### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,12 @@ Terminal-native AI agent orchestrator — Electron desktop app managing Claude, 
 - WSL/codex/cursor hook install failures are expected on Linux — those are Windows-only features.
 - The app stores its SQLite database at `~/.lightcode-dev/state.sqlite` in dev mode.
 
+### Agent CLIs
+
+- For full end-to-end testing, install agent CLIs globally: `npm install -g @anthropic-ai/claude-code @google/gemini-cli`.
+- The supervisor detects agents via `command -v <binary>` in a login shell. Binary names: `claude`, `gemini`, `codex`, `copilot`, `cursor-agent`, `opencode`.
+- Gemini requires OAuth (a browser sign-in window opens on first detection). Claude requires `ANTHROPIC_API_KEY` for authenticated use but launches successfully without it.
+
 ### Testing caveats
 
 - 4 tests in `base.windows-path.test.ts` and `acp/session.test.ts` fail on Linux because they test Windows-specific path normalization. These are pre-existing and expected on non-Windows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,15 @@ Terminal-native AI agent orchestrator — Electron desktop app managing Claude, 
 - The supervisor detects agents via `command -v <binary>` in a login shell. Binary names: `claude`, `gemini`, `codex`, `copilot`, `cursor-agent`, `opencode`.
 - Gemini requires OAuth (a browser sign-in window opens on first detection). Claude requires `ANTHROPIC_API_KEY` for authenticated use but launches successfully without it.
 
+### Cursor Agent CLI (`cursor-agent`) and `CURSOR_API_KEY`
+
+- Install: `curl https://cursor.com/install -fsS | bash` (binary at `~/.local/bin/cursor-agent`; add that directory to `PATH` in `~/.bashrc` so Lightcode’s login-shell detection finds it).
+- **Remote / Cloud:** add **`CURSOR_API_KEY`** as a Cursor Cloud secret (Dashboard → Integrations → API Keys to generate the key). The CLI reads it from the environment; no browser login required on the VM.
+- **`cursor-agent status`** may still print `Not logged in` when only an API key is set; that reflects stored browser session, not key validity. Use **`cursor-agent models`** (or a `--print` run) to confirm the key works.
+- Smoke test (non-interactive):  
+  `cursor-agent --print --trust --workspace /workspace --model composer-2-fast "Reply with exactly: HELLO_WORLD_OK"`
+- Docs: [CLI authentication](https://cursor.com/docs/cli/reference/authentication).
+
 ### Testing caveats
 
 - 4 tests in `base.windows-path.test.ts` and `acp/session.test.ts` fail on Linux because they test Windows-specific path normalization. These are pre-existing and expected on non-Windows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,24 @@ Terminal-native AI agent orchestrator — Electron desktop app managing Claude, 
 - [Agent Adapter Rules](.agents/docs/agent-adapters.md)
 - [UI Patterns & Component Reuse](.agents/docs/ui-patterns.md)
 - [Editing & React Patterns](.agents/docs/editing-rules.md)
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Node.js 24.15+** is required (`engines.node` in `package.json` is `>=24.10.0`). Use `nvm` to install/activate: `nvm use 24` (the update script handles this).
+- **pnpm 10.33.0** is the package manager (declared via `packageManager` field). Activated through `corepack enable && corepack prepare pnpm@10.33.0 --activate`.
+- After `pnpm install`, the `postinstall` script automatically runs `electron-rebuild --only better-sqlite3` and `scripts/ensure-native-deps.mjs` to compile native addons (`better-sqlite3`, `node-pty`).
+
+### Running the app
+
+- `pnpm run dev` launches three concurrent processes (Vite renderer on port 3100, tsdown --watch for main/supervisor, and electronmon for hot-reloading Electron). The app requires `DISPLAY` to be set (Xvfb is fine).
+- D-Bus errors in the console are harmless in headless/container environments.
+- WSL/codex/cursor hook install failures are expected on Linux — those are Windows-only features.
+- The app stores its SQLite database at `~/.lightcode-dev/state.sqlite` in dev mode.
+
+### Testing caveats
+
+- 4 tests in `base.windows-path.test.ts` and `acp/session.test.ts` fail on Linux because they test Windows-specific path normalization. These are pre-existing and expected on non-Windows.
+- `pnpm run test` runs vitest; `pnpm run lint` runs oxlint; `pnpm run typecheck` runs tsgo.
+- The pre-commit hook runs `pnpm run lint:fix && pnpm run typecheck && git add -u`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Cursor Cloud instructions to AGENTS.md, including **`CURSOR_API_KEY`** usage for the Cursor Agent CLI, dev server notes, and agent CLI setup.

### Hello world (verified with user-provided secret)

`CURSOR_API_KEY` injected from Cursor Cloud secrets. Confirmed:

- `cursor-agent models` lists models successfully.
- Non-interactive smoke test:

  ```bash
  cursor-agent --print --trust --workspace /workspace --model composer-2-fast "Reply with exactly: HELLO_WORLD_OK"
  ```

  Output: `HELLO_WORLD_OK`

Note: `cursor-agent status` can still show `Not logged in` when using API-key-only auth; use `models` or `--print` to validate the key (documented in AGENTS.md).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-951c2832-de45-4124-a75e-a4729761b6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-951c2832-de45-4124-a75e-a4729761b6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

