### PR TITLE
docs: add community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SDSLeon

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by using GitHub's
+private vulnerability reporting for this repository or by contacting the
+repository maintainers through GitHub. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Lightcode
+
+Thanks for thinking about contributing! Bug reports, docs fixes, new providers, and features are all welcome.
+
+By contributing, you agree your work is licensed under the [Apache License 2.0](../LICENSE).
+
+## Before you start
+
+- For anything non-trivial, [open an issue](https://github.com/SDSLeon/lightcode/issues/new/choose) first so we can align on scope.
+- Search [existing issues](https://github.com/SDSLeon/lightcode/issues) and [PRs](https://github.com/SDSLeon/lightcode/pulls) to avoid duplicates.
+
+## Local setup
+
+You'll need Node `>= 24.10.0` (see `.nvmrc`) and pnpm `11.x` (pinned in `package.json`).
+
+```bash
+git clone https://github.com/<your-username>/lightcode.git
+cd lightcode
+pnpm install
+pnpm run dev
+```
+
+Handy scripts:
+
+| Script               | What it does                      |
+| -------------------- | --------------------------------- |
+| `pnpm run dev`       | Run the Electron app in dev mode  |
+| `pnpm run typecheck` | Type-check with `tsgo`            |
+| `pnpm run lint`      | Lint with `oxlint`                |
+| `pnpm run fmt`       | Format with `oxfmt`               |
+| `pnpm run test`      | Run the test suite (`vitest`)     |
+| `pnpm run build`     | Build renderer + electron bundles |
+
+## Pull request flow
+
+1. Fork the repo and create a branch: `feat/...`, `fix/...`, `docs/...`, etc.
+2. Keep the change scoped to one thing.
+3. Run `pnpm run typecheck`, `pnpm run lint`, `pnpm run fmt:check`, and `pnpm run test` before pushing.
+4. Open a PR against `master` and fill in the template: what changed, why, and how you tested.
+5. CI (`ci`) must pass and review threads must be resolved before merge.
+
+Rebase on the latest `master` before requesting review. Husky runs `lint-staged` on commit, so formatting fixes apply automatically.
+
+## Code style & deeper docs
+
+`oxlint` and `oxfmt` are the source of truth for style. For architecture, agent adapters, UI patterns, and editing rules, read [`AGENTS.md`](../AGENTS.md) and `.agents/docs/`; please skim the relevant one before changing those areas.
+
+## Reporting issues
+
+Use the [issue templates](https://github.com/SDSLeon/lightcode/issues/new/choose). Include OS, Lightcode version, the agent(s) involved, and reproduction steps.
+
+For security issues, don't open a public issue. See [SECURITY.md](SECURITY.md).
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Tell us what broke and how to reproduce it.
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Clear repro steps help us fix it faster.
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      description: Which OS and version are you using?
+      placeholder: macOS 15.5, Windows 11, Ubuntu 24.04, etc.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Lightcode version
+      description: Paste the app version, commit, or build you are running.
+      placeholder: v1.0.0
+    validations:
+      required: true
+  - type: input
+    id: agents
+    attributes:
+      label: Agents involved
+      description: Which providers or agents were active?
+      placeholder: Claude Code, Codex, OpenCode, Gemini, Cursor, Copilot, etc.
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: What should we do to see the bug?
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs, terminal output, screenshots, or screen recordings if you can.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question or start a discussion
+    url: https://github.com/SDSLeon/lightcode/discussions
+    about: Use Discussions for questions, ideas, and open-ended topics.
+  - name: Lightcode website
+    url: https://www.lightcodeapp.com
+    about: Learn more about Lightcode.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an improvement for Lightcode.
+title: "feat: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. A clear problem statement helps us decide what to build.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what makes it hard today?
+      placeholder: I want to ... but ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like Lightcode to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other workflows, tools, or designs you tried?
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, examples, links, or notes that would help.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Summary
+
+What changed?
+
+# Motivation
+
+Why is this useful or needed?
+
+# Testing
+
+- [ ] `pnpm run typecheck`
+- [ ] `pnpm run lint`
+- [ ] `pnpm run fmt:check`
+- [ ] `pnpm run test`
+- [ ] Not run; reason:
+
+# Screenshots
+
+Add screenshots or screen recordings for UI changes.
+
+# Linked issue
+
+Closes #

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+Thanks for helping keep Lightcode users safe.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security reports.
+
+Use GitHub's **Report a vulnerability** button on this repository so we can
+coordinate privately with you. Include as much as you can:
+
+- What is affected
+- Steps to reproduce
+- Expected impact
+- Any logs, screenshots, or proof-of-concept details that are safe to share
+
+We will review the report, follow up through GitHub, and coordinate a fix and
+disclosure timeline when needed.
+
+## Supported versions
+
+Security fixes target the latest released version of Lightcode unless a
+maintainer says otherwise in the report thread.


### PR DESCRIPTION
## Summary
- Add contribution, security, code of conduct, CODEOWNERS, issue form, and PR template files.
- Point security reports to GitHub private vulnerability reporting.

## Testing
- pnpm run fmt:check
- pre-commit hook ran pnpm exec tsgo --noEmit -p tsconfig.json