### PR TITLE
Pass active Git panel state to worktree group header

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -5,6 +5,7 @@ import { ContextMenu } from "@/renderer/components/common";
 import { useDragSource, useIsDraggingWorktreeGroup, type DragSourceData } from "@/renderer/dnd";
 import {
   useIsWorktreeFilesPanelActive,
+  useIsWorktreeGitPanelActive,
   useIsWorktreeTerminalActive,
   useIsWorktreeTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
@@ -42,6 +43,7 @@ export function SidebarWorktreeGroup(props: {
   const hasTerminal = useIsWorktreeTerminalOpen(group.worktreePath);
   const isActiveTerminal = useIsWorktreeTerminalActive(group.worktreePath);
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
+  const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
   const groupThreadIds = group.threads.map((t) => t.id);
 
   const { ref } = useSortable({
@@ -122,6 +124,7 @@ export function SidebarWorktreeGroup(props: {
           hasTerminal={hasTerminal}
           isActiveTerminal={isActiveTerminal}
           isActiveFiles={isActiveFiles}
+          isActiveGit={isActiveGit}
           onToggleCollapse={() => toggleWorktreeCollapsed(group.worktreePath)}
           onOpenFiles={() => openFilesPanel(project.id, group.worktreePath)}
           onOpenGitReview={() => openGitReview(project.id, group.worktreePath)}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -13,6 +13,7 @@ export function WorktreeGroupHeader(props: {
   hasTerminal: boolean;
   isActiveTerminal: boolean;
   isActiveFiles?: boolean;
+  isActiveGit: boolean;
   onToggleCollapse: () => void;
   onOpenFiles: () => void;
   onOpenGitReview: () => void;
@@ -80,6 +81,7 @@ export function WorktreeGroupHeader(props: {
             projectName={props.worktreeBranch}
             worktreePath={props.worktreePath}
             onPress={props.onOpenGitReview}
+            isActive={props.isActiveGit}
           />
         </>
       }


### PR DESCRIPTION
- Enable the sidebar's worktree group header to track and display the active status of the Git review panel.
- Ensure the sidebar provides accurate visual feedback by highlighting the Git action button when active.