### PR TITLE
Close dev terminal panel when active worktree is removed

### DIFF
--- a/src/renderer/actions/worktreeActions.ts
+++ b/src/renderer/actions/worktreeActions.ts
@@ -27,8 +27,13 @@ export async function performWorktreeRemoval(
     });
   }
 
-  const removedTabIds = useDevTerminalStore.getState().removeTabsForWorktree(worktreePath);
+  const termStore = useDevTerminalStore.getState();
+  const removedTabIds = termStore.removeTabsForWorktree(worktreePath);
   await closeThreads(removedTabIds);
+
+  if (termStore.isOpen && termStore.activeWorktreePath === worktreePath) {
+    termStore.closePanel();
+  }
 
   useGitStore.getState().clearWorktreeStatus(worktreePath);
 


### PR DESCRIPTION
* Prevents the developer terminal panel from remaining open in an invalid state when its active worktree is deleted.
* Automatically closes the panel when the worktree being removed is the currently active one.
* Ensures the user interface remains clean and synchronized after worktree removal.