### PR TITLE
Update GitHub repository URL in About settings

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
@@ -7,7 +7,7 @@ import { productNameFor } from "@/shared/channel";
 import { formatBytes } from "@/shared/formatBytes";
 import appIconUrl from "../../../../../build/icon.png";
 
-const GITHUB_REPO = "https://github.com/nicepkg/lightcode";
+const GITHUB_REPO = "https://github.com/SDSLeon/lightcode";
 const WEBSITE_URL = "https://www.lightcodeapp.com/";
 
 function AboutLink(props: { href: string; children: React.ReactNode }) {


### PR DESCRIPTION
- **Type:** Chore
- Update the GitHub repository URL referenced in the About settings panel to point to the correct repository owner (`SDSLeon/lightcode`).
- Ensure users are directed to the correct active repository when clicking the GitHub link in the About page.