### PR TITLE
Fix terminal paste clipboard access

### DIFF
--- a/src/main/browser/permissions.ts
+++ b/src/main/browser/permissions.ts
@@ -1,6 +1,10 @@
 import type { WebContents, Session } from "electron";
 
-const ALLOWED_PERMISSIONS = new Set<string>(["clipboard-sanitized-write", "fullscreen"]);
+const ALLOWED_PERMISSIONS = new Set<string>([
+  "clipboard-read",
+  "clipboard-sanitized-write",
+  "fullscreen",
+]);
 
 const BLOCKED_NAVIGATION_PROTOCOLS = new Set<string>([
   "file:",

--- a/src/renderer/components/terminal/XTermSurface.tsx
+++ b/src/renderer/components/terminal/XTermSurface.tsx
@@ -430,11 +430,16 @@ export const XTermSurface = forwardRef<
       // ── Paste: Ctrl+V / Cmd+V ───────────────────────────────────
       if (event.code === "KeyV" && !readOnly) {
         event.preventDefault();
-        void navigator.clipboard.readText().then((text) => {
-          if (text) {
-            terminal.paste(text);
-          }
-        });
+        navigator.clipboard.readText().then(
+          (text) => {
+            if (text) {
+              terminal.paste(text);
+            }
+          },
+          // Swallow NotAllowedError (e.g. window not focused) — paste is a
+          // best-effort UX action; failure must not crash the renderer.
+          () => {},
+        );
         return false;
       }
 
@@ -550,11 +555,15 @@ export const XTermSurface = forwardRef<
       void navigator.clipboard.writeText(terminal.getSelection());
       terminal.clearSelection();
     } else if (key === "paste") {
-      void navigator.clipboard.readText().then((text) => {
-        if (text) {
-          terminal.paste(text);
-        }
-      });
+      navigator.clipboard.readText().then(
+        (text) => {
+          if (text) {
+            terminal.paste(text);
+          }
+        },
+        // See keydown handler above — silent failure is intentional.
+        () => {},
+      );
     } else if (key === "paste-in-input") {
       if (!terminal.hasSelection()) return;
       window.dispatchEvent(


### PR DESCRIPTION
- Allow terminal surfaces to read from the clipboard so paste works under Electron’s permission model.
- Treat clipboard read failures as non-fatal in the renderer so paste remains best-effort instead of breaking terminal input.
- Keep clipboard write and selection behavior unchanged.