### PR TITLE
Refresh git project after creating worktree

### DIFF
--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -21,6 +21,7 @@ import {
   useAgentStatusesStore,
 } from "@/renderer/state/agentStatusesStore";
 import { useAppStore } from "@/renderer/state/appStore";
+import { refreshGitProject } from "@/renderer/state/gitRefresh";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
   useInitialProjectDraftConfig,
@@ -104,6 +105,14 @@ export function AppContent() {
           startPoint: worktreeBaseBranch,
         });
         worktreePath = result.path;
+
+        // Full refresh so the new worktree enters the cache and gets a file
+        // watcher (status-mode refreshes only walk cached worktrees), and so
+        // any new branch from createBranch shows up in BranchSelectors and
+        // worktreeSourceInfo without lagging a refresh cycle. Without this,
+        // the sidebar diff badge stays empty until the Git review panel
+        // mounts and runs its own one-shot fetch.
+        void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
 
         const setupScript = project.scripts?.setupScript;
         if (setupScript) {


### PR DESCRIPTION
- Bugfix: force a full git project refresh immediately after a new worktree is created.
- Ensures the new worktree is cached and picked up by file watchers right away.
- Keeps branch selectors, worktree metadata, and sidebar diff badges in sync without waiting for the review panel to mount.