### PR TITLE
Fix terminal login handoff and auth detection

### DIFF
--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -99,6 +99,9 @@ export function createLocalIpcHandlers(
       }
       await shell.openExternal(safeUrl);
     },
+    openExternalNative: async (url) => {
+      await shell.openExternal(assertSafeExternalUrl(url));
+    },
     focusWindow: () => {
       const win = options.getMainWindow();
       if (!win) return;

--- a/src/renderer/actions/agentLoginActions.test.ts
+++ b/src/renderer/actions/agentLoginActions.test.ts
@@ -14,6 +14,7 @@ const supervisorHandlers = vi.hoisted(() => [] as Array<(event: SupervisorEvent)
 const loginTerminalStore = vi.hoisted(() => ({
   open: vi.fn<(input: { shellId: string }) => void>(),
   close: vi.fn<() => void>(),
+  markFailed: vi.fn<(shellId: string, exitCode: number) => void>(),
   active: undefined as { onForceClose?: () => void; shellId: string } | undefined,
 }));
 const writeScriptToShellMock = vi.hoisted(() => vi.fn<(shellId: string, script: string) => void>());
@@ -110,6 +111,7 @@ describe("runAgentLoginCommand", () => {
     });
     loginTerminalStore.open.mockReset();
     loginTerminalStore.close.mockReset();
+    loginTerminalStore.markFailed.mockReset();
     loginTerminalStore.active = undefined;
     writeScriptToShellMock.mockReset();
   });
@@ -226,7 +228,30 @@ describe("runAgentLoginCommand", () => {
     );
   });
 
-  it("keeps the login overlay open when the command exits unsuccessfully", () => {
+  it("opens Cursor WSL browser login URLs", () => {
+    runAgentLoginCommand({
+      label: "Cursor",
+      command: "cursor-agent login",
+      env: { NO_OPEN_BROWSER: "1" },
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const url =
+      "https://cursor.com/loginDeepControl?challenge=C_7tIakH9LsaJ5eBDQVlz6IYoQvg93TP5qmAkdBFFY&uuid=801340c1-2708-4d80-afaa-197f054a7e58&mode=login&redirectTarget=cli";
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `Open a browser and navigate to this link: ${url}\n`,
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledWith(url);
+  });
+
+  it("marks the login overlay as failed when the command exits unsuccessfully", () => {
     runAgentLoginCommand({
       label: "Grok",
       command: "grok login",
@@ -247,7 +272,8 @@ describe("runAgentLoginCommand", () => {
     vi.advanceTimersByTime(1200);
 
     expect(loginTerminalStore.close).not.toHaveBeenCalled();
-    expect(toast.danger).toHaveBeenCalledWith("Grok login exited with code 1.");
+    expect(loginTerminalStore.markFailed).toHaveBeenCalledWith(shellId, 1);
+    expect(toast.danger).not.toHaveBeenCalled();
   });
 
   it("auto-closes the login overlay after a successful command exit", () => {

--- a/src/renderer/actions/agentLoginActions.test.ts
+++ b/src/renderer/actions/agentLoginActions.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc";
+
+const bridge = vi.hoisted(() => ({
+  startShell: vi.fn<() => Promise<void>>(),
+  closeThread: vi.fn<() => Promise<void>>(),
+  onSupervisorEvent: vi.fn<(handler: (event: SupervisorEvent) => void) => () => void>(),
+  openExternal: vi.fn<(url: string) => Promise<void>>(),
+  openExternalNative: vi.fn<(url: string) => Promise<void>>(),
+}));
+
+const supervisorHandlers = vi.hoisted(() => [] as Array<(event: SupervisorEvent) => void>);
+const loginTerminalStore = vi.hoisted(() => ({
+  open: vi.fn<(input: { shellId: string }) => void>(),
+  close: vi.fn<() => void>(),
+  active: undefined as { onForceClose?: () => void; shellId: string } | undefined,
+}));
+const writeScriptToShellMock = vi.hoisted(() => vi.fn<(shellId: string, script: string) => void>());
+
+vi.mock("@heroui/react", () => ({
+  toast: {
+    danger: vi.fn<(message: string) => void>(),
+    success: vi.fn<(message: string) => void>(),
+    warning: vi.fn<(message: string) => void>(),
+  },
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+vi.mock("@/renderer/state/appStore", () => ({
+  useAppStore: {
+    getState: () => ({ projects: [], threads: [], view: { kind: "draft", projectId: "project" } }),
+  },
+}));
+
+vi.mock("@/renderer/state/devTerminalStore", () => ({
+  useDevTerminalStore: {
+    getState: () => ({ activeProjectId: undefined }),
+  },
+}));
+
+vi.mock("@/renderer/state/loginTerminalStore", () => ({
+  useLoginTerminalStore: {
+    getState: () => loginTerminalStore,
+  },
+}));
+
+vi.mock("@/renderer/state/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({ setRightPanelTab: vi.fn<(tab: string) => void>() }),
+  },
+}));
+
+vi.mock("@/renderer/state/sharedSettingsStore", () => ({
+  useSharedSettings: {
+    getState: () => ({ terminalPosition: "bottom" }),
+  },
+}));
+
+vi.mock("@/renderer/utils/shellUtils", () => ({
+  writeScriptToShell: writeScriptToShellMock,
+}));
+
+import { toast } from "@heroui/react";
+import { runAgentLoginCommand } from "./agentLoginActions";
+
+const wslProject: Project = {
+  id: "project",
+  name: "Project",
+  location: {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/home/demo/project",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+  },
+  createdAt: new Date(0).toISOString(),
+};
+
+const windowsProject: Project = {
+  id: "windows-project",
+  name: "Windows Project",
+  location: {
+    kind: "windows",
+    path: "C:\\repo",
+  },
+  createdAt: new Date(0).toISOString(),
+};
+
+function emit(event: SupervisorEvent) {
+  for (const handler of supervisorHandlers) handler(event);
+}
+
+describe("runAgentLoginCommand", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    supervisorHandlers.length = 0;
+    bridge.startShell.mockReset().mockResolvedValue(undefined);
+    bridge.closeThread.mockReset().mockResolvedValue(undefined);
+    bridge.openExternal.mockReset().mockResolvedValue(undefined);
+    bridge.openExternalNative.mockReset().mockResolvedValue(undefined);
+    bridge.onSupervisorEvent.mockReset().mockImplementation((handler) => {
+      supervisorHandlers.push(handler);
+      return () => {
+        const index = supervisorHandlers.indexOf(handler);
+        if (index >= 0) supervisorHandlers.splice(index, 1);
+      };
+    });
+    loginTerminalStore.open.mockReset();
+    loginTerminalStore.close.mockReset();
+    loginTerminalStore.active = undefined;
+    writeScriptToShellMock.mockReset();
+  });
+
+  it("opens hard-wrapped WSL auth URLs in the native browser", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    expect(shellId).toBeTruthy();
+    const script = writeScriptToShellMock.mock.calls[0]?.[1] ?? "";
+    expect(script).not.toContain("cmd.exe /c start");
+    expect(script).toContain("clear; BROWSER='/bin/true' grok login");
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: "Open https://auth.x.ai/oauth2/authorize?response_type=code\n",
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+    expect(bridge.openExternalNative).not.toHaveBeenCalled();
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: "&client_id=grok-build\n&redirect_uri=http%3A%2F%2F127.0.0.1%3A3000%2Fcallback\n",
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledWith(
+      "https://auth.x.ai/oauth2/authorize?response_type=code&client_id=grok-build&redirect_uri=http%3A%2F%2F127.0.0.1%3A3000%2Fcallback",
+    );
+  });
+
+  it("opens complete long WSL auth URLs after suppressing the agent browser", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const url =
+      "https://auth.x.ai/oauth2/authorize?response_type=code&client_id=b1a00492-073a-47ea-816f-4c329264a828&redirect_uri=http%3A%2F%2F127.0.0.1%3A45417%2Fcallback&scope=openid%20profile%20email%20offline_access%20grok-cli%3Aaccess%20api%3Aaccess&code_challenge=MDPixKrsA5K4QIgvDtSEPlQniofqpd2Rr8wT5HEzo5I&code_challenge_method=S256&state=019e5ddb-3198-7542-8504-714899198f01&nonce=019e5ddb-3198-7542-8504-7154a7bf6c98";
+
+    expect(writeScriptToShellMock.mock.calls[0]?.[1] ?? "").toContain(
+      "clear; BROWSER='/bin/true' grok login",
+    );
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `Open this URL to sign in:\n  ${url}\n`,
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledWith(url);
+  });
+
+  it("does not intercept login URLs on native Windows so the CLI's own browser opener wins", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login",
+      project: windowsProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const url =
+      "https://auth.x.ai/oauth2/authorize?response_type=code&client_id=b1a00492-073a-47ea-816f-4c329264a828&redirect_uri=http%3A%2F%2F127.0.0.1%3A37155%2Fcallback&scope=openid%20profile%20email%20offline_access%20grok-cli%3Aaccess%20api%3Aaccess&code_challenge=XZGsVbiV8w8TRiC3gHnWDKL8TsuK2tFNeVR9md4tA34&code_challenge_method=S256&state=019e5e1e-040a-78c1-bbd6-1585cd381488&nonce=019e5e1e-040a-78c1-bbd6-159774c2afa3";
+
+    // BROWSER override is WSL-only; Clear-Host runs as-is on native Windows.
+    expect(writeScriptToShellMock.mock.calls[0]?.[1] ?? "").toContain("Clear-Host; grok login");
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `\r\nSigning in with Grok...\r\n\r\nOpen this URL to sign in:\r\n  ${url}\r\n\r\nPaste the URL here if it doesn't connect:\r\n`,
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).not.toHaveBeenCalled();
+  });
+
+  it("does not append following prompt text to xAI device auth URLs", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login --device-auth",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: [
+        "To sign in, open this URL in your browser:\n\n",
+        "  https://accounts.x.ai/oauth2/device?user_code=E9YP-N7CQIf prompted, confirm this code:\n\n",
+        "  E9YP-N7CQ\n",
+      ].join(""),
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledWith(
+      "https://accounts.x.ai/oauth2/device?user_code=E9YP-N7CQ",
+    );
+  });
+
+  it("keeps the login overlay open when the command exits unsuccessfully", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const script = writeScriptToShellMock.mock.calls[0]?.[1] ?? "";
+    const token = /lightcode-login-complete=([^:]+):/u.exec(script)?.[1];
+    expect(token).toBeTruthy();
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `\u001B]777;lightcode-login-complete=${token}:1\u0007`,
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(1200);
+
+    expect(loginTerminalStore.close).not.toHaveBeenCalled();
+    expect(toast.danger).toHaveBeenCalledWith("Grok login exited with code 1.");
+  });
+
+  it("auto-closes the login overlay after a successful command exit", () => {
+    runAgentLoginCommand({
+      label: "Grok",
+      command: "grok login",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const script = writeScriptToShellMock.mock.calls[0]?.[1] ?? "";
+    const token = /lightcode-login-complete=([^:]+):/u.exec(script)?.[1];
+    expect(token).toBeTruthy();
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `\u001B]777;lightcode-login-complete=${token}:0\u0007`,
+      outputLength: 0,
+    });
+
+    expect(loginTerminalStore.close).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1200);
+    expect(loginTerminalStore.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/actions/agentLoginActions.test.ts
+++ b/src/renderer/actions/agentLoginActions.test.ts
@@ -228,6 +228,49 @@ describe("runAgentLoginCommand", () => {
     );
   });
 
+  it("normalizes Codex device auth URLs when auto-opening from WSL output", () => {
+    runAgentLoginCommand({
+      label: "Codex",
+      command: "codex login --device-auth",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: "1. Open this link in your browser and sign in to your account\n   https://auth.openai.com/codex/device2. Enter this one-time code\n",
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledWith("https://auth.openai.com/codex/device");
+  });
+
+  it("does not auto-open Codex's local callback server URL", () => {
+    runAgentLoginCommand({
+      label: "Codex",
+      command: "codex login",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    const authUrl =
+      "https://auth.openai.com/oauth/authorize?response_type=code&client_id=app&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback";
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: `Starting local login server on http://localhost:1455.\nIf your browser did not open, navigate to this URL to authenticate:\n\n${authUrl}\n`,
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).toHaveBeenCalledTimes(1);
+    expect(bridge.openExternalNative).toHaveBeenCalledWith(authUrl);
+  });
+
   it("opens Cursor WSL browser login URLs", () => {
     runAgentLoginCommand({
       label: "Cursor",

--- a/src/renderer/actions/agentLoginActions.ts
+++ b/src/renderer/actions/agentLoginActions.ts
@@ -153,7 +153,9 @@ export function runAgentLoginCommand(input: {
       // can read any final success line before it slides away.
       window.setTimeout(() => useLoginTerminalStore.getState().close(), 1200);
     } else {
-      toast.danger(`${input.label} login exited with code ${exitCode}.`);
+      // Leave the overlay open so the user can read the failure output, but
+      // flag the session so the header switches to a failed state.
+      useLoginTerminalStore.getState().markFailed(shellId, exitCode);
     }
   });
 
@@ -206,7 +208,7 @@ function isCompleteLoginUrl(text: string): boolean {
     }
     // Device-code flow: provider prints a code-entry URL the user opens manually.
     if (url.pathname.includes("/device") && url.searchParams.has("user_code")) return true;
-    return false;
+    return true;
   } catch {
     return false;
   }

--- a/src/renderer/actions/agentLoginActions.ts
+++ b/src/renderer/actions/agentLoginActions.ts
@@ -226,10 +226,23 @@ function normalizeLoginUrl(text: string): string {
         return url.toString();
       }
     }
+    if (url.hostname === "auth.openai.com" && /^\/codex\/device\d+$/u.test(url.pathname)) {
+      url.pathname = "/codex/device";
+      return url.toString();
+    }
   } catch {
     return text;
   }
   return text;
+}
+
+function isLoopbackUrl(text: string): boolean {
+  try {
+    const { hostname } = new URL(text);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
 }
 
 function watchUrlsInNativeBrowser(shellId: string): (flushPending?: boolean) => void {
@@ -240,6 +253,7 @@ function watchUrlsInNativeBrowser(shellId: string): (flushPending?: boolean) => 
   const opened = new Set<string>();
 
   const openUrl = (url: string) => {
+    if (isLoopbackUrl(url)) return;
     const normalizedUrl = normalizeLoginUrl(url);
     if (opened.has(normalizedUrl) || !isCompleteLoginUrl(normalizedUrl)) return;
     opened.add(normalizedUrl);

--- a/src/renderer/actions/agentLoginActions.ts
+++ b/src/renderer/actions/agentLoginActions.ts
@@ -1,5 +1,6 @@
 import { toast } from "@heroui/react";
 import type { Project } from "@/shared/contracts";
+import { stripAnsi } from "@/shared/ansi";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
@@ -74,15 +75,19 @@ export function runAgentTerminalCommand(input: {
           : `Unable to open ${input.label} ${input.toastPurpose ?? purpose}.`,
       ),
     );
+  const interceptWslUrls =
+    project.location.kind === "wsl" && input.openUrlsInNativeBrowser === true;
   const command = buildTerminalCommand({
     command: typeof input.command === "function" ? input.command(project) : input.command,
-    env: input.env,
-    openUrlsInNativeBrowser: input.openUrlsInNativeBrowser === true,
-    project,
+    env: interceptWslUrls ? { BROWSER: "/bin/true", ...(input.env ?? {}) } : input.env,
   });
+  const stopOpeningUrls = interceptWslUrls ? watchUrlsInNativeBrowser(tab.id) : undefined;
   const completionToken = input.onCommandComplete ? createCompletionToken() : undefined;
   if (completionToken && input.onCommandComplete) {
-    watchCommandCompletion(tab.id, completionToken, input.onCommandComplete);
+    watchCommandCompletion(tab.id, completionToken, (exitCode) => {
+      stopOpeningUrls?.(true);
+      input.onCommandComplete?.(exitCode);
+    });
   }
   writeScriptToShell(
     tab.id,
@@ -115,19 +120,21 @@ export function runAgentLoginCommand(input: {
   }
 
   const shellId = `login:${crypto.randomUUID()}`;
+  // On WSL the agent CLI can't reach the Windows browser on its own, so we
+  // suppress its opener (BROWSER=/bin/true) and watch stdout for auth URLs to
+  // hand off via the Windows shell. Native macOS / Windows CLIs already open
+  // their own browser, so a renderer-side watcher would just double-launch.
+  const interceptWslUrls = project.location.kind === "wsl";
   // Wipe the bash prompt + echoed script line that briefly appear before the
   // TUI takes over. `clear` (POSIX) / `Clear-Host` (PowerShell) gives the
   // overlay a clean canvas so the user only sees the agent's own UI.
-  const cleared =
-    project.location.kind === "windows"
-      ? `Clear-Host; ${input.command}`
-      : `clear; ${input.command}`;
-  const command = buildTerminalCommand({
-    command: cleared,
-    env: input.env,
-    openUrlsInNativeBrowser: true,
-    project,
+  const loginCommand = buildTerminalCommand({
+    command: input.command,
+    env: interceptWslUrls ? { BROWSER: "/bin/true", ...(input.env ?? {}) } : input.env,
   });
+  const command =
+    project.location.kind === "windows" ? `Clear-Host; ${loginCommand}` : `clear; ${loginCommand}`;
+  const stopOpeningUrls = interceptWslUrls ? watchUrlsInNativeBrowser(shellId) : undefined;
   const completionToken = createCompletionToken();
   const script = appendCompletionSignal(command, project, completionToken);
 
@@ -139,10 +146,15 @@ export function runAgentLoginCommand(input: {
   };
 
   const stopWatching = watchCommandCompletion(shellId, completionToken, (exitCode) => {
+    stopOpeningUrls?.(true);
     fireOnce(exitCode);
-    // Auto-dismiss the overlay shortly after the command exits so the user
-    // can read any final success line before it slides away.
-    window.setTimeout(() => useLoginTerminalStore.getState().close(), 1200);
+    if (exitCode === 0) {
+      // Auto-dismiss the overlay shortly after the command exits so the user
+      // can read any final success line before it slides away.
+      window.setTimeout(() => useLoginTerminalStore.getState().close(), 1200);
+    } else {
+      toast.danger(`${input.label} login exited with code ${exitCode}.`);
+    }
   });
 
   useLoginTerminalStore.getState().open({
@@ -151,6 +163,7 @@ export function runAgentLoginCommand(input: {
     projectLocation: project.location,
     onForceClose: () => {
       stopWatching();
+      stopOpeningUrls?.();
       fireOnce(-1);
     },
   });
@@ -177,28 +190,102 @@ function shellEnvPrefix(env: Record<string, string> | undefined): string {
     .join(" ");
 }
 
-function openWslUrlsInNativeBrowser(command: string): string {
-  const script = [
-    `${command} 2>&1 | while IFS= read -r line; do`,
-    'printf "%s\\n" "$line";',
-    'url=$(printf "%s\\n" "$line" | sed -n "s/.*\\(https\\?:\\/\\/[^[:space:]]*\\).*/\\1/p" | head -n 1);',
-    'cmd_url=$(printf "%s" "$url" | sed "s/&/^\\\\&/g");',
-    'if [ -n "$cmd_url" ]; then cmd.exe /c start "" "$cmd_url" >/dev/null 2>&1 || true; fi;',
-    "done",
-  ].join(" ");
-  return `sh -lc ${quotePosixShellArg(script)}`;
-}
-
 function buildTerminalCommand(input: {
   command: string;
   env: Record<string, string> | undefined;
-  openUrlsInNativeBrowser: boolean;
-  project: Project;
 }): string {
   const envPrefix = shellEnvPrefix(input.env);
-  const command = envPrefix ? `${envPrefix} ${input.command}` : input.command;
-  if (input.project.location.kind !== "wsl" || !input.openUrlsInNativeBrowser) return command;
-  return openWslUrlsInNativeBrowser(command);
+  return envPrefix ? `${envPrefix} ${input.command}` : input.command;
+}
+
+function isCompleteLoginUrl(text: string): boolean {
+  try {
+    const url = new URL(text);
+    if (url.pathname.includes("/authorize") && url.searchParams.has("response_type")) {
+      return url.searchParams.has("client_id") && url.searchParams.has("redirect_uri");
+    }
+    // Device-code flow: provider prints a code-entry URL the user opens manually.
+    if (url.pathname.includes("/device") && url.searchParams.has("user_code")) return true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeLoginUrl(text: string): string {
+  try {
+    const url = new URL(text);
+    if (url.hostname === "accounts.x.ai" && url.pathname === "/oauth2/device") {
+      const code = url.searchParams.get("user_code");
+      const match = code ? /^([A-Z0-9]{4}-[A-Z0-9]{4})/u.exec(code) : null;
+      const normalizedCode = match?.[1];
+      if (normalizedCode) {
+        url.searchParams.set("user_code", normalizedCode);
+        return url.toString();
+      }
+    }
+  } catch {
+    return text;
+  }
+  return text;
+}
+
+function watchUrlsInNativeBrowser(shellId: string): (flushPending?: boolean) => void {
+  let buffer = "";
+  let done = false;
+  let flushTimer = 0;
+  let unsubscribe: () => void = () => undefined;
+  const opened = new Set<string>();
+
+  const openUrl = (url: string) => {
+    const normalizedUrl = normalizeLoginUrl(url);
+    if (opened.has(normalizedUrl) || !isCompleteLoginUrl(normalizedUrl)) return;
+    opened.add(normalizedUrl);
+    void readBridge()
+      .openExternalNative(normalizedUrl)
+      .catch(() => undefined);
+  };
+
+  const scan = () => {
+    const text = buffer.replace(/\s+(?=[/?#&=])/gu, "");
+    for (const match of text.matchAll(/https?:\/\/[^\s"'<>`]+/giu)) {
+      openUrl(match[0].replace(/[),.;:!?]+$/u, ""));
+    }
+  };
+
+  const flush = () => {
+    flushTimer = 0;
+    scan();
+  };
+
+  const scheduleFlush = () => {
+    if (flushTimer !== 0) window.clearTimeout(flushTimer);
+    flushTimer = window.setTimeout(flush, 250);
+  };
+
+  const timeout = window.setTimeout(() => {
+    if (done) return;
+    done = true;
+    if (flushTimer !== 0) window.clearTimeout(flushTimer);
+    unsubscribe();
+  }, 10 * 60_000);
+
+  unsubscribe = readBridge().onSupervisorEvent((event) => {
+    if (done || event.type !== "thread-output" || event.threadId !== shellId) return;
+    buffer = `${buffer}${stripAnsi(event.data).replace(/\r\n?/gu, "\n")}`.slice(-8192);
+    scheduleFlush();
+  });
+
+  return (flushPending = false) => {
+    if (done) return;
+    if (flushPending) {
+      flush();
+    }
+    done = true;
+    window.clearTimeout(timeout);
+    if (flushTimer !== 0) window.clearTimeout(flushTimer);
+    unsubscribe();
+  };
 }
 
 function createCompletionToken(): string {

--- a/src/renderer/components/terminal/TerminalLinkProvider.test.ts
+++ b/src/renderer/components/terminal/TerminalLinkProvider.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { TerminalLinkProvider } from "./TerminalLinkProvider";
+
+type LinkProviderProbe = {
+  _getWindowedLineStrings(lineIndex: number): [string[], number];
+};
+
+function makeLine(text: string, isWrapped = false) {
+  return {
+    isWrapped,
+    translateToString: () => text,
+  };
+}
+
+function makeProvider(lines: ReturnType<typeof makeLine>[]): LinkProviderProbe {
+  return new TerminalLinkProvider(
+    {
+      buffer: {
+        active: {
+          getLine: (index: number) => lines[index],
+          getNullCell: () => ({}),
+        },
+      },
+    } as never,
+    () => undefined,
+  ) as unknown as LinkProviderProbe;
+}
+
+describe("TerminalLinkProvider", () => {
+  it("does not append numbered instruction lines to URL links", () => {
+    const provider = makeProvider([
+      makeLine("  https://auth.openai.com/codex/device"),
+      makeLine("2. Enter this one-time code"),
+    ]);
+
+    const [lines] = provider._getWindowedLineStrings(0);
+
+    expect(lines.join("")).toBe("  https://auth.openai.com/codex/device");
+  });
+
+  it("keeps stitching hard-wrapped URL continuation lines", () => {
+    const provider = makeProvider([
+      makeLine("https://auth.x.ai/oauth2/authorize?response_type=code&clie"),
+      makeLine("nt_id=grok-build&redirect_uri=http%3A%2F%2F127.0.0.1%3A3000%2Fcallback"),
+    ]);
+
+    const [lines] = provider._getWindowedLineStrings(0);
+
+    expect(lines.join("")).toContain("client_id=grok-build");
+    expect(lines.join("")).toContain("redirect_uri=http%3A%2F%2F127.0.0.1%3A3000%2Fcallback");
+  });
+});

--- a/src/renderer/components/terminal/TerminalLinkProvider.ts
+++ b/src/renderer/components/terminal/TerminalLinkProvider.ts
@@ -132,6 +132,7 @@ export class TerminalLinkProvider implements ILinkProvider {
 
       content = stripAnsi(nextLine.translateToString(true));
       if (!content || /^\s/.test(content)) break;
+      if (/^\d+[.)]\s/u.test(content)) break;
 
       // Take only the URL-legal prefix of the continuation line.
       const continuationMatch = URL_LEGAL_TAIL.exec(content.split(/\s/)[0] ?? "");

--- a/src/renderer/components/terminal/XTermSurface.test.tsx
+++ b/src/renderer/components/terminal/XTermSurface.test.tsx
@@ -13,6 +13,8 @@ const { state } = vi.hoisted(() => ({
       readTerminalScrollback: vi.fn<() => Promise<string>>().mockResolvedValue(""),
       writeTerminal: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       resizeTerminal: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      openExternal: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      openExternalNative: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       onSupervisorEvent: vi.fn<(listener: (e: SupervisorEvent) => void) => () => void>(),
     },
   },
@@ -186,6 +188,20 @@ describe("XTermSurface", () => {
     render(<XTermSurface terminalId="test-1" />);
     expect(state.bridge.onSupervisorEvent).toHaveBeenCalled();
     expect(state.eventListeners).toHaveLength(1);
+  });
+
+  it("opens login terminal links in the native browser when requested", () => {
+    render(<XTermSurface terminalId="test-1" openLinksInNativeBrowser />);
+
+    const linkHandler = state.terminalOptions?.linkHandler as
+      | { activate: (event: MouseEvent, uri: string) => void }
+      | undefined;
+    linkHandler?.activate(new MouseEvent("click"), "https://auth.openai.com/codex/device");
+
+    expect(state.bridge.openExternalNative).toHaveBeenCalledWith(
+      "https://auth.openai.com/codex/device",
+    );
+    expect(state.bridge.openExternal).not.toHaveBeenCalled();
   });
 
   it("hydrates the terminal from supervisor scrollback on mount", async () => {

--- a/src/renderer/components/terminal/XTermSurface.tsx
+++ b/src/renderer/components/terminal/XTermSurface.tsx
@@ -73,6 +73,7 @@ export const XTermSurface = forwardRef<
     onTerminalResize?: (size: TerminalSize) => void;
     className?: string;
     baseFontSize?: number;
+    openLinksInNativeBrowser?: boolean;
   }
 >(function XTermSurface(props, ref) {
   const {
@@ -86,6 +87,7 @@ export const XTermSurface = forwardRef<
     onTerminalResize,
     className,
     baseFontSize = 12,
+    openLinksInNativeBrowser = false,
   } = props;
   const appearance = useResolvedAppearance();
   const mountRef = useRef<HTMLDivElement | null>(null);
@@ -108,6 +110,10 @@ export const XTermSurface = forwardRef<
   const baseFontSizeRef = useRef(baseFontSize);
   baseFontSizeRef.current = baseFontSize;
   const requestRefitRef = useRef<(() => void) | null>(null);
+  const openLink = (uri: string) => {
+    const bridge = readBridge();
+    void (openLinksInNativeBrowser ? bridge.openExternalNative(uri) : bridge.openExternal(uri));
+  };
   const [hasSelection, setHasSelection] = useState(false);
   const [showScrollDown, setShowScrollDown] = useState(false);
   const [scrollbar, setScrollbar] = useState({
@@ -228,7 +234,7 @@ export const XTermSurface = forwardRef<
       // back to a browser confirm() dialog; we route to the default browser.
       linkHandler: {
         activate: (_event, uri) => {
-          void readBridge().openExternal(uri);
+          openLink(uri);
         },
       },
     });
@@ -319,7 +325,7 @@ export const XTermSurface = forwardRef<
     terminal.loadAddon(search);
     const linkDisposable = terminal.registerLinkProvider(
       new TerminalLinkProvider(terminal, (_event, uri) => {
-        void readBridge().openExternal(uri);
+        openLink(uri);
       }),
     );
 

--- a/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+++ b/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
@@ -33,6 +33,10 @@ function preventFocusSteal(event: React.MouseEvent<HTMLElement>): void {
   event.preventDefault();
 }
 
+function shouldPreferTerminalLogin(status: AgentStatus): boolean {
+  return status.kind === "grok" && Boolean(status.loginCommand);
+}
+
 export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; project?: Project }) {
   const { agentStatus, project } = props;
   const [pendingAction, setPendingAction] = useState<"login" | "refresh" | undefined>();
@@ -41,7 +45,9 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
   const canUseAgentAuth = agentAuthMethod !== undefined;
   const canUseTerminalLogin = Boolean(agentStatus.loginCommand);
   const hasDirectLogin = canUseAgentAuth || canUseTerminalLogin;
-  const description = agentStatus.loginCommand
+  const preferTerminalLogin = shouldPreferTerminalLogin(agentStatus);
+  const useTerminalLogin = canUseTerminalLogin && (preferTerminalLogin || !canUseAgentAuth);
+  const description = useTerminalLogin
     ? `Run ${agentStatus.loginCommand} before this thread can run.`
     : agentAuthMethod
       ? `Complete ${agentAuthMethod.name} sign-in before this thread can run.`
@@ -50,7 +56,7 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
   async function handleLogin() {
     if (pendingAction) return;
 
-    if (agentStatus.loginCommand) {
+    if (useTerminalLogin && agentStatus.loginCommand) {
       setPendingAction("login");
       const opened = runAgentLoginCommand({
         label: agentStatus.label,

--- a/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+++ b/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
@@ -58,6 +58,9 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
         ...(terminalAuthMethod?.env ? { env: terminalAuthMethod.env } : {}),
         ...(project ? { project } : {}),
         onCommandComplete: (exitCode) => {
+          // Unlock the button as soon as the command exits so the user can
+          // retry without waiting for the (post-exit) status refresh.
+          setPendingAction(undefined);
           void refreshAgentStatus(agentStatus)
             .then(() => {
               if (exitCode === 0) toast.success(`${agentStatus.label} authenticated.`);
@@ -68,8 +71,7 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
                   ? error.message
                   : `Unable to refresh ${agentStatus.label} status.`,
               );
-            })
-            .finally(() => setPendingAction(undefined));
+            });
         },
       });
       if (!opened) setPendingAction(undefined);

--- a/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+++ b/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
@@ -41,34 +41,14 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
   const canUseAgentAuth = agentAuthMethod !== undefined;
   const canUseTerminalLogin = Boolean(agentStatus.loginCommand);
   const hasDirectLogin = canUseAgentAuth || canUseTerminalLogin;
-  const description = agentAuthMethod
-    ? `Complete ${agentAuthMethod.name} sign-in before this thread can run.`
-    : agentStatus.loginCommand
-      ? `Run ${agentStatus.loginCommand} before this thread can run.`
+  const description = agentStatus.loginCommand
+    ? `Run ${agentStatus.loginCommand} before this thread can run.`
+    : agentAuthMethod
+      ? `Complete ${agentAuthMethod.name} sign-in before this thread can run.`
       : "Add credentials before this thread can run.";
 
   async function handleLogin() {
     if (pendingAction) return;
-    if (canUseAgentAuth) {
-      setPendingAction("login");
-      try {
-        await readBridge().authenticateAcpAgent({
-          agentKind: agentStatus.kind,
-          methodId: agentAuthMethod.id,
-          ...agentAuthTarget(agentStatus),
-        });
-        void readBridge().focusWindow();
-        await refreshAgentStatus(agentStatus);
-        toast.success(`${agentStatus.label} authenticated.`);
-      } catch (error) {
-        toast.danger(
-          error instanceof Error ? error.message : `Unable to authenticate ${agentStatus.label}.`,
-        );
-      } finally {
-        setPendingAction(undefined);
-      }
-      return;
-    }
 
     if (agentStatus.loginCommand) {
       setPendingAction("login");
@@ -93,6 +73,28 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
         },
       });
       if (!opened) setPendingAction(undefined);
+      return;
+    }
+
+    if (canUseAgentAuth) {
+      setPendingAction("login");
+      try {
+        await readBridge().authenticateAcpAgent({
+          agentKind: agentStatus.kind,
+          methodId: agentAuthMethod.id,
+          ...agentAuthTarget(agentStatus),
+        });
+        void readBridge().focusWindow();
+        await refreshAgentStatus(agentStatus);
+        toast.success(`${agentStatus.label} authenticated.`);
+      } catch (error) {
+        toast.danger(
+          error instanceof Error ? error.message : `Unable to authenticate ${agentStatus.label}.`,
+        );
+      } finally {
+        setPendingAction(undefined);
+      }
+      return;
     }
   }
 

--- a/src/renderer/state/loginTerminalStore.ts
+++ b/src/renderer/state/loginTerminalStore.ts
@@ -16,16 +16,25 @@ export interface LoginTerminalSession {
   label: string;
   projectLocation: ProjectLocation;
   onForceClose?: () => void;
+  /** Set when the login command exits non-zero so the overlay can render a failed state. */
+  failedExitCode?: number;
 }
 
 interface LoginTerminalState {
   active: LoginTerminalSession | null;
   open: (session: LoginTerminalSession) => void;
   close: () => void;
+  markFailed: (shellId: string, exitCode: number) => void;
 }
 
 export const useLoginTerminalStore = create<LoginTerminalState>((set) => ({
   active: null,
   open: (session) => set({ active: session }),
   close: () => set((state) => (state.active === null ? {} : { active: null })),
+  markFailed: (shellId, exitCode) =>
+    set((state) =>
+      state.active && state.active.shellId === shellId
+        ? { active: { ...state.active, failedExitCode: exitCode } }
+        : state,
+    ),
 }));

--- a/src/renderer/utils/acpRegistryAuth.ts
+++ b/src/renderer/utils/acpRegistryAuth.ts
@@ -24,16 +24,19 @@ export function registryAdapterKind(agentId: string): string {
 export function isEnvVarAuthMethod(
   method: StatusAuthMethod | undefined,
 ): method is AgentEnvVarAuthMethod {
-  return (
-    method !== undefined &&
-    (method.type === "env_var" || ("vars" in method && Array.isArray(method.vars)))
-  );
+  return method !== undefined && method.type === "env_var";
 }
 
 export function isAgentAuthMethod(
   method: StatusAuthMethod | undefined,
 ): method is AgentOwnedAuthMethod {
-  return method !== undefined && !isEnvVarAuthMethod(method) && method.type !== "terminal";
+  return (
+    method !== undefined &&
+    !isEnvVarAuthMethod(method) &&
+    method.type !== "terminal" &&
+    !("vars" in method) &&
+    !/\b(api[-_\s]*key|token|secret)\b/iu.test(`${method.id} ${method.name}`)
+  );
 }
 
 export function isTerminalAuthMethod(

--- a/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
+++ b/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
@@ -145,6 +145,7 @@ export function LoginTerminalOverlay() {
             ref={xtermRef}
             terminalId={renderedSession.shellId}
             className="h-full"
+            openLinksInNativeBrowser
           />
         </div>
       </div>

--- a/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
+++ b/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
@@ -115,11 +115,18 @@ export function LoginTerminalOverlay() {
       >
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-foreground">
+            <p
+              className={`truncate text-sm font-medium ${
+                renderedSession.failedExitCode !== undefined ? "text-danger" : "text-foreground"
+              }`}
+            >
               {renderedSession.label} login
+              {renderedSession.failedExitCode !== undefined ? " failed" : ""}
             </p>
             <p className="text-xs text-muted">
-              Complete the prompts in this terminal. Closes when finished.
+              {renderedSession.failedExitCode !== undefined
+                ? `Exited with code ${renderedSession.failedExitCode}. Close to retry.`
+                : "Complete the prompts in this terminal. Closes when finished."}
             </p>
           </div>
           <Button

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -637,7 +637,7 @@ describe("SingleAgentSettings", () => {
     expect(toastMock.success).toHaveBeenCalledWith("SSO Agent authenticated.");
   });
 
-  it("prefers terminal login when an agent advertises both ACP and a loginCommand", async () => {
+  it("prefers terminal login for Grok when it advertises both ACP and a loginCommand", async () => {
     statusesState.agentStatuses = [
       makeStatus("grok", {
         label: "Grok Build",
@@ -657,6 +657,27 @@ describe("SingleAgentSettings", () => {
       onCommandComplete: expect.any(Function),
     });
     expect(authenticateAcpAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps ACP auth preferred for non-Grok agents that also expose loginCommand", async () => {
+    statusesState.agentStatuses = [
+      makeStatus("acp-generic:sso-agent", {
+        label: "SSO Agent",
+        authState: "missing",
+        loginCommand: "sso-agent login",
+        authMethods: [{ id: "browser-login", name: "Browser login" }],
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="acp-generic:sso-agent" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+
+    expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
+      agentKind: "acp-generic:sso-agent",
+      methodId: "browser-login",
+    });
+    expect(runAgentLoginCommandMock).not.toHaveBeenCalled();
   });
 
   it("hides malformed ACP API key methods while keeping browser login available", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentStatus, Project } from "@/shared/contracts";
@@ -397,7 +397,13 @@ describe("SingleAgentSettings", () => {
     });
   });
 
-  it("shows terminal auth login actions per environment", () => {
+  it("shows terminal auth login actions per environment", async () => {
+    let resolveRefresh!: () => void;
+    refreshAgentStatusesMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
     const windowsProject = makeProject({
       id: "windows-project",
       name: "Windows Project",
@@ -462,11 +468,24 @@ describe("SingleAgentSettings", () => {
     });
     expect(screen.getByRole("status", { name: /logging in/i })).toBeInTheDocument();
 
-    loginInput?.onCommandComplete?.(0);
+    await act(async () => {
+      loginInput?.onCommandComplete?.(0);
+    });
+    expect(screen.getByRole("status", { name: /logging in/i })).toBeInTheDocument();
+    expect(
+      screen.getByText("Refreshing WSL (Ubuntu) Cursor authentication status."),
+    ).toBeInTheDocument();
     expect(refreshAgentStatusesMock).toHaveBeenCalledWith(["Ubuntu"], {
       agentKinds: ["cursor"],
       envs: [{ kind: "wsl", distro: "Ubuntu" }],
     });
+    await act(async () => {
+      resolveRefresh();
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(screen.queryByRole("status", { name: /logging in/i })).not.toBeInTheDocument(),
+    );
   });
 
   it("saves ACP env-var auth through the supervisor and refreshes detection", async () => {
@@ -618,12 +637,12 @@ describe("SingleAgentSettings", () => {
     expect(toastMock.success).toHaveBeenCalledWith("SSO Agent authenticated.");
   });
 
-  it("prefers terminal login when an agent also advertises ACP auth", async () => {
+  it("prefers terminal login when an agent advertises both ACP and a loginCommand", async () => {
     statusesState.agentStatuses = [
       makeStatus("grok", {
         label: "Grok Build",
         authState: "missing",
-        loginCommand: "grok login",
+        loginCommand: "grok login --device-auth",
         authMethods: [{ id: "grok.com", name: "Grok" }],
       }),
     ];
@@ -634,13 +653,13 @@ describe("SingleAgentSettings", () => {
 
     expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
       label: "Grok Build",
-      command: "grok login",
+      command: "grok login --device-auth",
       onCommandComplete: expect.any(Function),
     });
     expect(authenticateAcpAgentMock).not.toHaveBeenCalled();
   });
 
-  it("keeps browser login available when an ACP agent also advertises API key auth", async () => {
+  it("hides malformed ACP API key methods while keeping browser login available", async () => {
     statusesState.agentStatuses = [
       makeStatus("acp-generic:factory-droid", {
         label: "Factory Droid",
@@ -658,7 +677,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:factory-droid" />);
 
-    expect(screen.getByLabelText("Factory API Key")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Factory API Key")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Factory API Key" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Login" }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
@@ -685,7 +705,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:factory-droid" />);
 
-    expect(screen.getByLabelText("Factory API Key")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Factory API Key")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Factory API Key" })).toBeNull();
     expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -618,6 +618,28 @@ describe("SingleAgentSettings", () => {
     expect(toastMock.success).toHaveBeenCalledWith("SSO Agent authenticated.");
   });
 
+  it("prefers terminal login when an agent also advertises ACP auth", async () => {
+    statusesState.agentStatuses = [
+      makeStatus("grok", {
+        label: "Grok Build",
+        authState: "missing",
+        loginCommand: "grok login",
+        authMethods: [{ id: "grok.com", name: "Grok" }],
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="grok" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+
+    expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
+      label: "Grok Build",
+      command: "grok login",
+      onCommandComplete: expect.any(Function),
+    });
+    expect(authenticateAcpAgentMock).not.toHaveBeenCalled();
+  });
+
   it("keeps browser login available when an ACP agent also advertises API key auth", async () => {
     statusesState.agentStatuses = [
       makeStatus("acp-generic:factory-droid", {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentStatus, Project } from "@/shared/contracts";
@@ -266,6 +266,14 @@ function makeProject(input: { id: string; name: string; location: Project["locat
   };
 }
 
+function envRow(label: string): HTMLElement {
+  const row = screen.getByText(label).closest('[class*="group/env"]');
+  if (!(row instanceof HTMLElement)) {
+    throw new Error(`Unable to find ${label} environment row`);
+  }
+  return row;
+}
+
 describe("SingleAgentSettings", () => {
   beforeEach(() => {
     statusesState.agentStatuses = [];
@@ -306,7 +314,9 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="claude" />);
 
-    expect(screen.getByText("user@example.com · Yieldmo · Team Subscription")).toBeInTheDocument();
+    expect(screen.getByText(/user@example.com/)).toBeInTheDocument();
+    expect(screen.getByText(/Yieldmo/)).toBeInTheDocument();
+    expect(screen.getByText(/Team Subscription/)).toBeInTheDocument();
     // Auth method is intentionally omitted from the summary when richer
     // identity fields are available.
     expect(screen.queryByText("Auth method")).not.toBeInTheDocument();
@@ -328,7 +338,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="opencode" />);
 
-    expect(screen.getByText("2 providers · Copilot, OpenAI")).toBeInTheDocument();
+    expect(screen.getByText(/2 providers/)).toBeInTheDocument();
+    expect(screen.getByText(/Copilot, OpenAI/)).toBeInTheDocument();
   });
 
   it("falls back to the auth method when no identity is available", () => {
@@ -344,7 +355,7 @@ describe("SingleAgentSettings", () => {
     expect(screen.getByText("via ChatGPT")).toBeInTheDocument();
   });
 
-  it("shows a login action when the agent reports missing auth", () => {
+  it("shows a login action when the agent reports missing auth", async () => {
     statusesState.agentStatuses = [
       makeStatus("gemini", {
         label: "Gemini",
@@ -355,7 +366,7 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="gemini" />);
 
-    expect(screen.getByText("Login required")).toBeInTheDocument();
+    expect(screen.getAllByText("Login required").length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole("button", { name: /login/i }));
     expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
       label: "Gemini",
@@ -364,7 +375,7 @@ describe("SingleAgentSettings", () => {
     });
   });
 
-  it("opens WSL login actions in the matching project distro", () => {
+  it("opens WSL login actions in the matching project distro", async () => {
     const wslProject = makeProject({
       id: "wsl-project",
       name: "WSL Project",
@@ -452,11 +463,13 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="cursor" />);
 
-    expect(screen.getByRole("button", { name: /login windows/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /login wsl \(ubuntu\)/i })).toBeInTheDocument();
+    const windowsRow = envRow("Windows");
+    const wslRow = envRow("WSL (Ubuntu)");
+    expect(within(windowsRow).getByRole("button", { name: /login/i })).toBeInTheDocument();
+    expect(within(wslRow).getByRole("button", { name: /login/i })).toBeInTheDocument();
     expect(screen.queryByText(/Windows, WSL \(Ubuntu\) needs authentication/u)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /login wsl \(ubuntu\)/i }));
+    fireEvent.click(within(wslRow).getByRole("button", { name: /login/i }));
 
     const loginInput = runAgentLoginCommandMock.mock.calls[0]?.[0];
     expect(loginInput).toEqual({
@@ -536,7 +549,7 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:glm-acp-agent" />);
 
-    expect(screen.getByText("Authentication")).toBeInTheDocument();
+    expect(screen.getByText("Z.AI API key")).toBeInTheDocument();
     const input = screen.getByLabelText("Z.AI API key");
     expect(input).toHaveValue("***********");
     expect(input).toHaveAttribute("type", "text");
@@ -626,7 +639,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:sso-agent" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+    const row = envRow("Default");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "acp-generic:sso-agent",
@@ -649,7 +663,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="grok" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+    const row = envRow("Default");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
       label: "Grok Build",
@@ -671,7 +686,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:sso-agent" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+    const row = envRow("Default");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "acp-generic:sso-agent",
@@ -700,7 +716,8 @@ describe("SingleAgentSettings", () => {
 
     expect(screen.queryByLabelText("Factory API Key")).toBeNull();
     expect(screen.queryByRole("button", { name: "Factory API Key" })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+    const row = envRow("Default");
+    fireEvent.click(within(row).getByRole("button", { name: "Login" }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "acp-generic:factory-droid",
@@ -728,7 +745,8 @@ describe("SingleAgentSettings", () => {
 
     expect(screen.queryByLabelText("Factory API Key")).toBeNull();
     expect(screen.queryByRole("button", { name: "Factory API Key" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+    const row = envRow("Default");
+    expect(within(row).getByRole("button", { name: "Login" })).toBeInTheDocument();
   });
 
   it("offers logout (not re-login) for an authenticated ACP agent env", async () => {
@@ -743,7 +761,8 @@ describe("SingleAgentSettings", () => {
     render(<SingleAgentSettings agentKind="acp-generic:sso-agent" />);
 
     expect(screen.queryByRole("button", { name: /re-login/i })).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: /logout/i }));
+    const row = envRow("Default");
+    fireEvent.click(within(row).getByRole("button", { name: /logout/i }));
 
     expect(logoutAcpAgentMock).toHaveBeenCalledWith({ agentKind: "acp-generic:sso-agent" });
   });
@@ -769,7 +788,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:sso-agent" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /login wsl \(ubuntu\)/i }));
+    const row = envRow("WSL (Ubuntu)");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "acp-generic:sso-agent",
@@ -798,7 +818,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:factory-droid" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /login/i }));
+    const row = envRow("WSL (Ubuntu)");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(
       screen.getByText(/Waiting for WSL \(Ubuntu\) Login authentication/u),
@@ -828,10 +849,12 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:factory-droid" />);
 
-    expect(screen.getByText(/Windows · Login required/u)).toBeInTheDocument();
+    expect(screen.getByText("Windows")).toBeInTheDocument();
+    expect(screen.getAllByText("Login required").length).toBeGreaterThan(0);
     expect(screen.getByText(/Complete Login sign-in for Windows\./u)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /login windows/i })).toBeInTheDocument();
-    expect(screen.getByText(/WSL \(Ubuntu\) · Signed in/u)).toBeInTheDocument();
+    const windowsRow = envRow("Windows");
+    expect(within(windowsRow).getByRole("button", { name: /login/i })).toBeInTheDocument();
+    expect(screen.getByText("WSL (Ubuntu)")).toBeInTheDocument();
     expect(screen.queryByText(/Windows · Authentication/u)).toBeNull();
   });
 
@@ -858,11 +881,13 @@ describe("SingleAgentSettings", () => {
 
     // Per-env rows: Windows env gets its own logout action, WSL env gets
     // its own login action. No combined Re-login button across envs.
-    expect(screen.getByRole("button", { name: /logout windows/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /login wsl \(ubuntu\)/i })).toBeInTheDocument();
+    const windowsRow = envRow("Windows");
+    const wslRow = envRow("WSL (Ubuntu)");
+    expect(within(windowsRow).getByRole("button", { name: /logout/i })).toBeInTheDocument();
+    expect(within(wslRow).getByRole("button", { name: /login/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /re-login/i })).toBeNull();
     expect(screen.getByText(/Complete Login sign-in for WSL \(Ubuntu\)\./u)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /login wsl \(ubuntu\)/i }));
+    fireEvent.click(within(wslRow).getByRole("button", { name: /login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "acp-generic:factory-droid",
@@ -900,7 +925,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="acp-generic:factory-droid" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /logout windows/i }));
+    const windowsRow = envRow("Windows");
+    fireEvent.click(within(windowsRow).getByRole("button", { name: /logout/i }));
 
     expect(screen.getByRole("status", { name: /logging out/i })).toBeInTheDocument();
     expect(logoutAcpAgentMock).toHaveBeenCalledWith({
@@ -938,7 +964,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="copilot" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^re-login$/i }));
+    const row = envRow("Windows");
+    fireEvent.click(within(row).getByRole("button", { name: /re-login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "copilot",
@@ -960,7 +987,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="gemini" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^login$/i }));
+    const row = envRow("Windows");
+    fireEvent.click(within(row).getByRole("button", { name: /login/i }));
 
     expect(authenticateAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "gemini",
@@ -983,7 +1011,8 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="gemini" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /^logout$/i }));
+    const row = envRow("Windows");
+    fireEvent.click(within(row).getByRole("button", { name: /logout/i }));
 
     expect(logoutAcpAgentMock).toHaveBeenCalledWith({
       agentKind: "gemini",
@@ -1018,18 +1047,20 @@ describe("SingleAgentSettings", () => {
 
     render(<SingleAgentSettings agentKind="cursor" />);
 
+    const wslRow = envRow("WSL (Ubuntu)");
     await waitFor(() =>
       expect(
-        screen.getByRole("button", {
-          name: "Update to v2026.05.16-0338208 for Cursor (WSL (Ubuntu))",
+        within(wslRow).getByRole("button", {
+          name: /Update to v2026\.05\.16-0338208/i,
         }),
       ).toBeInTheDocument(),
     );
-    expect(screen.queryByRole("button", { name: /for Cursor \(Windows\)/ })).toBeNull();
+    const windowsRow = envRow("Windows");
+    expect(within(windowsRow).queryByRole("button", { name: /Update to v/i })).toBeNull();
 
     fireEvent.click(
-      screen.getByRole("button", {
-        name: "Update to v2026.05.16-0338208 for Cursor (WSL (Ubuntu))",
+      within(wslRow).getByRole("button", {
+        name: /Update to v2026\.05\.16-0338208/i,
       }),
     );
 
@@ -1053,9 +1084,8 @@ describe("SingleAgentSettings", () => {
     });
 
     render(<SingleAgentSettings agentKind="claude" />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: /Update to v1\.1\.0 for Claude Code/ }),
-    );
+    const row = envRow("Default");
+    fireEvent.click(await within(row).findByRole("button", { name: /Update to v1\.1\.0/i }));
 
     await waitFor(() =>
       expect(toastMock.success).toHaveBeenCalledWith("Claude Code updated to v1.1.0."),
@@ -1069,9 +1099,8 @@ describe("SingleAgentSettings", () => {
     getLatestAgentVersionMock.mockResolvedValueOnce({ version: "1.1.0", source: "npm" });
 
     render(<SingleAgentSettings agentKind="claude" />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: /Update to v1\.1\.0 for Claude Code/ }),
-    );
+    const row = envRow("Default");
+    fireEvent.click(await within(row).findByRole("button", { name: /Update to v1\.1\.0/i }));
 
     await waitFor(() =>
       expect(toastMock.success).toHaveBeenCalledWith("Claude Code is already up to date."),

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -4,7 +4,6 @@ import {
   AlertTriangle,
   ArrowUpCircle,
   Check,
-  Download,
   LogIn,
   LogOut,
   Minus,
@@ -62,14 +61,17 @@ function AgentSettingRow(props: { agentKind: string; def: AgentSettingDef }) {
   if (def.type !== "toggle" && def.type !== "select") return null;
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="min-w-0">
+    <div className="flex items-center justify-between gap-4 py-2 border-b border-border/10 last:border-0 group">
+      <div className="flex flex-col min-w-0 flex-1">
         <p className="text-sm font-medium text-foreground">{def.label}</p>
-        <p className="text-xs text-muted">{def.description}</p>
+        <p className="text-[11px] text-muted line-clamp-1 group-hover:line-clamp-none transition-all">
+          {def.description}
+        </p>
       </div>
       {def.type === "toggle" ? (
         <Switch
           isSelected={value as boolean}
+          size="sm"
           onChange={(selected) => {
             startTransition(() => {
               setAgentSetting(agentKind, def.key, selected);
@@ -83,7 +85,7 @@ function AgentSettingRow(props: { agentKind: string; def: AgentSettingDef }) {
       ) : (
         <Select
           aria-label={def.label}
-          className="w-[160px] shrink-0"
+          className="w-[140px] shrink-0"
           options={def.options}
           value={String(value)}
           onChange={(v) => {
@@ -172,10 +174,12 @@ function ModelVisibilityDropdown(props: {
   }
 
   return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="min-w-0">
+    <div className="flex items-center justify-between gap-4 py-2 border-b border-border/10 last:border-0 group">
+      <div className="flex flex-col min-w-0 flex-1">
         <p className="text-sm font-medium text-foreground">Visible models</p>
-        <p className="text-xs text-muted">Toggle models off to hide them from the selector.</p>
+        <p className="text-[11px] text-muted line-clamp-1 group-hover:line-clamp-none transition-all">
+          Toggle models off to hide them from the selector.
+        </p>
       </div>
       <Popover isOpen={isOpen} onOpenChange={setIsOpen}>
         <Popover.Trigger>
@@ -381,19 +385,6 @@ function formatAgentMetadataSummary(
   return undefined;
 }
 
-function AgentMetadataLine(props: {
-  status: AgentStatus;
-  showEnvironmentLabel: boolean;
-  includeAuthFallback: boolean;
-}) {
-  const summary = formatAgentMetadataSummary(props.status, {
-    includeAuthFallback: props.includeAuthFallback,
-  });
-  if (!summary) return null;
-  const prefix = props.showEnvironmentLabel ? `${envLabel(props.status)} · ` : "";
-  return <p className="truncate text-xs text-muted">{`${prefix}${summary}`}</p>;
-}
-
 function formatStatusList(statuses: readonly AgentStatus[]): string {
   return statuses
     .map((status) => envLabel(status))
@@ -439,68 +430,137 @@ function shouldPreferTerminalLogin(status: AgentStatus): boolean {
   return status.kind === "grok" && Boolean(status.loginCommand);
 }
 
-function AcpAgentAuthEnvRow(props: {
+function AgentEnvironmentRow(props: {
+  agentLabel: string;
   status: AgentStatus;
   authMethods: ReadonlyArray<AgentOwnedAuthMethod | AgentTerminalAuthMethod>;
   canLogout: boolean;
   authPending: boolean;
   pendingMessage: string | undefined;
-  showEnvironmentLabel: boolean;
   onLogin: (method: AgentOwnedAuthMethod | AgentTerminalAuthMethod) => void;
   onLogout: () => void;
+
+  latestNpmVersion: string | undefined;
+  newestInstalledVersion: string | undefined;
+  binaryUpdatePending: boolean;
+  isRedetecting: boolean;
+  onUpdate: (status: AgentStatus) => void;
+
+  includeAuthFallback: boolean;
+  acpInstanceId: string | undefined;
 }) {
-  const { status, authMethods, showEnvironmentLabel } = props;
+  const { status, authMethods } = props;
   const hasAnyMethod = authMethods.length > 0;
   const isAuthenticated = status.authState === "authenticated";
   const isMissing =
     status.authState === "missing" || (status.authState === "unknown" && hasAnyMethod);
   const env = envLabel(status);
-  const envSuffix = showEnvironmentLabel && env ? ` ${env}` : "";
-  const envScope = env ? ` for ${env}` : "";
-  const envSubject = env || "Agent";
+  const envSuffix = env ? ` ${env}` : "";
   const canLogout = isAuthenticated && props.canLogout;
   const canReLogin = isAuthenticated && !canLogout && hasAnyMethod;
   const canLogin = (isMissing || canReLogin) && hasAnyMethod;
   const loginLabel = canReLogin ? "Re-login" : "Login";
   const pendingLabel = canLogout ? "Logging out" : "Logging in";
-  const headerLabel = isMissing
-    ? "Login required"
-    : isAuthenticated
-      ? "Signed in"
-      : "Authentication";
-  const headerPrefix = env ? `${env} · ` : "";
+
   const hasMultipleMethods = authMethods.length > 1;
   const singleMethod = !hasMultipleMethods ? authMethods[0] : undefined;
+
+  const metadataSummary = formatAgentMetadataSummary(status, {
+    includeAuthFallback: props.includeAuthFallback,
+  });
+
+  const installedVer = status.version;
+  const registryTargetVersion =
+    props.latestNpmVersion !== undefined &&
+    installedVer !== undefined &&
+    isNewerVersion(props.latestNpmVersion, installedVer)
+      ? props.latestNpmVersion
+      : undefined;
+  const peerTargetVersion =
+    props.newestInstalledVersion !== undefined &&
+    installedVer !== undefined &&
+    isNewerVersion(props.newestInstalledVersion, installedVer)
+      ? props.newestInstalledVersion
+      : undefined;
+  const targetVersion = registryTargetVersion ?? peerTargetVersion;
+  const updateLabel = targetVersion ? `v${targetVersion}` : "";
+  const showUpdateButton =
+    !props.isRedetecting &&
+    props.acpInstanceId === undefined &&
+    status.installed &&
+    targetVersion !== undefined;
+
+  const previewScope = statusUpdateScope(status);
+  const previewCommand = showUpdateButton
+    ? resolveSharedUpdateCommand({
+        update: status.update,
+        executablePath: status.executablePath,
+        envKind: previewScope.envKind,
+      })
+    : undefined;
+  const previewCommandLine = previewCommand ? formatUpdateCommandLine(previewCommand) : undefined;
+
   const description = isMissing
     ? hasMultipleMethods
-      ? `Choose how to sign in${envScope}.`
+      ? `Choose how to sign in${env ? ` for ${env}` : ""}.`
       : singleMethod
-        ? `Complete ${singleMethod.name} sign-in${envScope}.`
-        : `${envSubject} needs authentication.`
-    : isAuthenticated
-      ? `${envSubject} credentials are configured.`
-      : "";
-  const detail = props.pendingMessage ?? description;
+        ? `Complete ${singleMethod.name} sign-in${env ? ` for ${env}` : ""}.`
+        : `${env || "Agent"} needs authentication.`
+    : "";
 
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div className="flex min-w-0 items-start gap-2">
-        <div className="min-w-0 flex-1">
-          <p className={`text-sm font-medium ${isMissing ? "text-warning" : ""}`}>
-            {isMissing ? (
-              <AlertTriangle className="mr-1.5 inline size-4 -translate-y-px text-warning" />
-            ) : null}
-            {headerPrefix}
-            {headerLabel}
-          </p>
-          {detail ? <p className="text-xs text-muted">{detail}</p> : null}
+    <div className="flex flex-col py-1.5 px-2 -mx-2 hover:bg-surface-secondary/40 rounded-lg transition-colors group/env">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <span className="shrink-0 text-foreground/90">{env || "Default"}</span>
+          {props.isRedetecting ? (
+            <PixelLoader size="xs" />
+          ) : (
+            <span className="shrink-0 tabular-nums text-muted/60 font-normal text-xs">
+              {installedVer ? `v${installedVer}` : "—"}
+            </span>
+          )}
+          {showUpdateButton && (
+            <Tooltip delay={0}>
+              <Tooltip.Trigger>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-5 min-h-5 gap-1 px-1.5 py-0 text-[10px] text-muted hover:text-foreground"
+                  aria-label={`Update to ${updateLabel} for ${props.agentLabel}${env ? ` (${env})` : ""}`}
+                  onPress={() => props.onUpdate(status)}
+                >
+                  <ArrowUpCircle className="size-3" />
+                  Update to {updateLabel}
+                </Button>
+              </Tooltip.Trigger>
+              <Tooltip.Content placement="right" className="max-w-[440px]">
+                {previewCommandLine ? (
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-[11px] text-muted">
+                      Will run in {env || "this environment"}:
+                    </span>
+                    <code className="font-mono text-[11px]">{previewCommandLine}</code>
+                  </div>
+                ) : (
+                  <span className="text-[11px]">
+                    Update {props.agentLabel} to {updateLabel}
+                  </span>
+                )}
+              </Tooltip.Content>
+            </Tooltip>
+          )}
+          {isMissing && (
+            <span className="text-warning flex items-center gap-1.5 whitespace-nowrap text-[11px] font-normal">
+              <AlertTriangle className="size-3" />
+              Login required
+            </span>
+          )}
         </div>
-      </div>
-      {canLogin || canLogout ? (
-        <div className="flex shrink-0 flex-row items-center gap-2">
-          {props.authPending ? (
+        <div className="flex shrink-0 items-center gap-2">
+          {props.authPending || props.binaryUpdatePending ? (
             <div
-              className="flex h-8 w-8 items-center justify-center"
+              className="flex h-6 w-6 items-center justify-center"
               role="status"
               aria-label={pendingLabel}
             >
@@ -514,10 +574,10 @@ function AcpAgentAuthEnvRow(props: {
                       key={method.id}
                       size="sm"
                       variant="tertiary"
+                      className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
                       aria-label={`${loginLabel} ${method.name}${envSuffix}`}
                       onPress={() => props.onLogin(method)}
                     >
-                      <LogIn className="size-4" />
                       {method.name}
                     </Button>
                   ))
@@ -526,28 +586,41 @@ function AcpAgentAuthEnvRow(props: {
                 <Button
                   size="sm"
                   variant="tertiary"
-                  isIconOnly
+                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
                   aria-label={`${loginLabel}${envSuffix}`}
                   onPress={() => props.onLogin(singleMethod)}
                 >
-                  <LogIn className="size-4" />
+                  {loginLabel}
                 </Button>
               ) : null}
               {canLogout ? (
                 <Button
                   size="sm"
                   variant="tertiary"
-                  isIconOnly
+                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
                   aria-label={`Logout${envSuffix}`}
                   onPress={props.onLogout}
                 >
-                  <LogOut className="size-4 text-danger" />
+                  Logout
                 </Button>
               ) : null}
             </>
           )}
         </div>
-      ) : null}
+      </div>
+      <div className="flex flex-col min-w-0 h-4 justify-center">
+        {props.pendingMessage ? (
+          <span className="min-w-0 truncate text-[11px] font-normal text-muted/60 italic">
+            {props.pendingMessage}
+          </span>
+        ) : metadataSummary ? (
+          <span className="min-w-0 truncate text-[11px] font-normal text-muted/60 group-hover/env:text-muted/80 transition-colors">
+            {metadataSummary}
+          </span>
+        ) : description ? (
+          <p className="text-[10px] text-muted/50 truncate">{description}</p>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -682,7 +755,6 @@ export function SingleAgentSettings(props: { agentKind: string }) {
     for (const s of installedHere)
       versionRows.push({ label: envLabel(s) || "Installed", status: s });
   }
-  const showEnvironmentMetadataLabels = installedStatuses.length > 1;
   const missingAuthStatuses = installedStatuses.filter((status) => status.authState === "missing");
   const envVarAuthMethod =
     findEnvVarAuthMethod(installedStatuses) ?? findEnvVarAuthMethod(missingAuthStatuses);
@@ -871,18 +943,11 @@ export function SingleAgentSettings(props: { agentKind: string }) {
     logoutStatuses.length > 0 ||
     hasAdvertisedAuthMethods;
   const includeAuthFallbackMetadata = !hasAuthSettings;
-  const metadataStatuses = installedStatuses.filter(
-    (status) =>
-      formatAgentMetadataSummary(status, {
-        includeAuthFallback: includeAuthFallbackMetadata,
-      }) !== undefined,
-  );
   const authMissing =
     missingAuthStatuses.length > 0 ||
     (hasAdvertisedAuthMethods &&
       !installedStatuses.some((status) => status.authState === "authenticated"));
   const missingAuthLabel = formatStatusList(missingAuthStatuses);
-  const showAuthEnvironmentLabels = installedStatuses.length > 1;
   const showEnvVarOnly = envVarAuthMethod !== undefined && !authMissing;
   // Interactive auth (browser/CLI sign-in) is per-env — Windows and each WSL
   // distro hold their own sessions. We split the auth panel into one row per
@@ -956,10 +1021,6 @@ export function SingleAgentSettings(props: { agentKind: string }) {
       })
       .then(async (result) => {
         if (result.ok) {
-          // Switch the row to a loader while we wait for the supervisor to
-          // re-detect the new installed version. The store updates via the
-          // `agent-status-updated` events emitted during refresh; once the row
-          // re-renders with the fresh version, we clear the loader.
           setRedetectingEnvKey(envKey);
           try {
             await readBridge().refreshAgentStatuses(wslDistros, {
@@ -969,9 +1030,6 @@ export function SingleAgentSettings(props: { agentKind: string }) {
           } finally {
             setRedetectingEnvKey(undefined);
           }
-          // Many built-in updaters exit 0 even when there's nothing to do.
-          // Compare the freshly-detected version to the pre-update value so
-          // the toast reflects what actually happened.
           const store = useAgentStatusesStore.getState();
           const pool = status.envKind === "wsl" ? store.wslAgentStatuses : store.agentStatuses;
           const newVersion = pool.find(
@@ -1008,143 +1066,114 @@ export function SingleAgentSettings(props: { agentKind: string }) {
     <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
       <div className="mx-auto max-w-[720px]">
         <div className="mb-6">
-          <div className="flex items-center gap-2">
-            <ProviderIcon
-              kind={agent.kind}
-              icon={agent.icon}
-              fallbackLabel={agent.label}
-              className="size-5"
-            />
-            <h1 className="text-lg font-semibold text-foreground">{agent.label}</h1>
-            {updateAvailable ? (
-              <Button
+          <div className="flex items-center justify-between gap-4 mb-4">
+            <div className="flex items-center gap-3">
+              <ProviderIcon
+                kind={agent.kind}
+                icon={agent.icon}
+                fallbackLabel={agent.label}
+                className="size-8"
+              />
+              <div className="flex flex-col">
+                <h1 className="text-lg font-semibold text-foreground leading-tight">
+                  {agent.label}
+                </h1>
+                <p className="text-[11px] text-muted">
+                  {isDisabled ? "Agent is currently disabled" : "Agent is active and ready"}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              {updateAvailable && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                  isPending={updatePending}
+                  onPress={performUpdate}
+                >
+                  <ArrowUpCircle className="size-3" />
+                  Update to v{latestRegistryVersion}
+                </Button>
+              )}
+              <Switch
+                isSelected={!isDisabled}
                 size="sm"
-                variant="ghost"
-                className="h-6 min-h-6 gap-1 px-2 text-[11px]"
-                isPending={updatePending}
-                onPress={performUpdate}
+                aria-label="Enabled"
+                onChange={(selected) => {
+                  startTransition(() => {
+                    setAgentDisabled(agent.kind, !selected);
+                  });
+                  if (selected) {
+                    void readBridge()
+                      .refreshAgentStatuses(wslDistros, { agentKinds: [agent.kind] })
+                      .catch(() => undefined);
+                  }
+                }}
               >
-                <ArrowUpCircle className="size-3" />
-                Update to v{latestRegistryVersion}
-              </Button>
-            ) : null}
+                <Switch.Control>
+                  <Switch.Thumb />
+                </Switch.Control>
+              </Switch>
+            </div>
           </div>
-          {versionRows.length > 0 ? (
-            <div className="mt-1 space-y-0.5">
-              {versionRows.map((row, i) => {
-                const envKey = statusEnvKey(row.status);
-                const isPending = binaryUpdatePendingEnvKey === envKey;
-                const installedVer = row.status.version;
-                const isRedetecting = redetectingEnvKey === envKey;
-                const registryTargetVersion =
-                  latestNpmVersion !== undefined &&
-                  installedVer !== undefined &&
-                  isNewerVersion(latestNpmVersion, installedVer)
-                    ? latestNpmVersion
-                    : undefined;
-                const peerTargetVersion =
-                  newestInstalledVersion !== undefined &&
-                  installedVer !== undefined &&
-                  isNewerVersion(newestInstalledVersion, installedVer)
-                    ? newestInstalledVersion
-                    : undefined;
-                const targetVersion = registryTargetVersion ?? peerTargetVersion;
-                const updateLabel = targetVersion ? `Update to v${targetVersion}` : "";
-                const showUpdateButton =
-                  !isRedetecting &&
-                  acpInstanceId === undefined &&
-                  row.status.installed &&
-                  targetVersion !== undefined;
-                // Resolve the update command client-side from the same shared
-                // module the supervisor uses, so the tooltip always has the
-                // exact command we're about to run — no extra IPC roundtrip
-                // and no stale-supervisor edge case.
-                const previewScope = statusUpdateScope(row.status);
-                const previewCommand = showUpdateButton
-                  ? resolveSharedUpdateCommand({
-                      update: row.status.update,
-                      executablePath: row.status.executablePath,
-                      envKind: previewScope.envKind,
-                    })
-                  : undefined;
-                const previewCommandLine = previewCommand
-                  ? formatUpdateCommandLine(previewCommand)
-                  : undefined;
-                return (
-                  <div
-                    key={`${row.label}-${i}`}
-                    // Fixed row height so the per-env Update button can appear
-                    // without shifting siblings down. Height matches the
-                    // button's `h-5` so the row looks identical whether the
-                    // button is present or not.
-                    className="flex h-5 items-center gap-2 text-xs text-muted"
-                  >
-                    <span className="w-[120px] shrink-0">{row.label}</span>
-                    {isRedetecting ? (
-                      <PixelLoader size="xs" />
-                    ) : (
-                      <span className="tabular-nums">
-                        {installedVer ? `v${installedVer}` : "—"}
-                      </span>
-                    )}
-                    {showUpdateButton ? (
-                      <Tooltip delay={0}>
-                        <Tooltip.Trigger>
-                          <Button
-                            size="sm"
-                            variant="tertiary"
-                            className="ml-1 h-5 min-h-5 gap-1 px-2 py-0 text-[11px] leading-none"
-                            aria-label={`${updateLabel} for ${agent.label}${row.label ? ` (${row.label})` : ""}`}
-                            isPending={isPending}
-                            isDisabled={
-                              binaryUpdatePendingEnvKey !== undefined &&
-                              binaryUpdatePendingEnvKey !== envKey
-                            }
-                            onPress={() => performBinaryUpdate(row.status)}
-                          >
-                            <Download className="size-3" />
-                            {updateLabel}
-                          </Button>
-                        </Tooltip.Trigger>
-                        <Tooltip.Content placement="right" className="max-w-[440px]">
-                          {previewCommandLine ? (
-                            <div className="flex flex-col gap-0.5">
-                              <span className="text-[11px] text-muted">
-                                Will run in {row.label || "this environment"}:
-                              </span>
-                              <code className="font-mono text-[11px]">{previewCommandLine}</code>
-                            </div>
-                          ) : (
-                            <span className="text-[11px]">
-                              Update {agent.label} to v{targetVersion}
-                            </span>
-                          )}
-                        </Tooltip.Content>
-                      </Tooltip>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            agent.version && <p className="mt-0.5 text-xs text-muted">v{agent.version}</p>
-          )}
-          {metadataStatuses.length > 0 ? (
-            <div className="mt-1 space-y-0.5">
-              {metadataStatuses.map((status, index) => (
-                <AgentMetadataLine
-                  key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}`}
-                  status={status}
-                  showEnvironmentLabel={showEnvironmentMetadataLabels}
+
+          <div className="space-y-0.5 border-t border-border/10 pt-3">
+            {installedStatuses.map((status) => {
+              const envKey = statusEnvKey(status);
+              const agentMethods =
+                status.authMethods?.filter(isAgentAuthMethod) ??
+                (sharedAgentAuthMethod ? [sharedAgentAuthMethod] : []);
+              const terminalMethod = status.loginCommand
+                ? (findTerminalAuthMethodForStatus(status) ??
+                  sharedTerminalAuthMethod ?? {
+                    id: "terminal-login",
+                    name: "Login",
+                    type: "terminal" as const,
+                  })
+                : undefined;
+              const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> =
+                usePerEnvAuthRows
+                  ? shouldPreferTerminalLogin(status) && terminalMethod
+                    ? [terminalMethod]
+                    : agentMethods.length > 0
+                      ? agentMethods
+                      : terminalMethod
+                        ? [terminalMethod]
+                        : []
+                  : [];
+              return (
+                <AgentEnvironmentRow
+                  key={`${status.kind}-${envKey}`}
+                  acpInstanceId={acpInstanceId}
+                  agentLabel={agent.label}
+                  authMethods={methods}
+                  authPending={authPendingEnvKey === envKey}
+                  binaryUpdatePending={binaryUpdatePendingEnvKey === envKey}
+                  canLogout={supportsAcpLogoutStatus(status, acpInstanceId)}
                   includeAuthFallback={includeAuthFallbackMetadata}
+                  isRedetecting={redetectingEnvKey === envKey}
+                  latestNpmVersion={latestNpmVersion}
+                  newestInstalledVersion={newestInstalledVersion}
+                  pendingMessage={authPendingEnvKey === envKey ? authPendingMessage : undefined}
+                  status={status}
+                  onLogin={(method) => {
+                    if (isAgentAuthMethod(method)) {
+                      authenticateAgent({ status, method });
+                      return;
+                    }
+                    runTerminalLogin(status, method);
+                  }}
+                  onLogout={() => logoutAgent(status)}
+                  onUpdate={() => performBinaryUpdate(status)}
                 />
-              ))}
-            </div>
-          ) : null}
+              );
+            })}
+          </div>
         </div>
 
         <div className="space-y-4">
-          {hasAuthSettings && usePerEnvAuthRows ? (
+          {hasAuthSettings && (
             <div className="space-y-2">
               {envVarAuthMethod && acpInstanceId ? (
                 <div className="flex items-start justify-between gap-4 rounded-xl border border-border bg-surface-secondary px-3 py-2 text-foreground">
@@ -1232,148 +1261,78 @@ export function SingleAgentSettings(props: { agentKind: string }) {
                     >
                       <Save className="size-4" />
                     </Button>
-                  </div>
-                </div>
-              ) : null}
-              {installedStatuses.map((status) => {
-                const envKey = statusEnvKey(status);
-                const agentMethods =
-                  status.authMethods?.filter(isAgentAuthMethod) ??
-                  (sharedAgentAuthMethod ? [sharedAgentAuthMethod] : []);
-                const terminalMethod = status.loginCommand
-                  ? (findTerminalAuthMethodForStatus(status) ??
-                    sharedTerminalAuthMethod ?? {
-                      id: "terminal-login",
-                      name: "Login",
-                      type: "terminal" as const,
-                    })
-                  : undefined;
-                const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> =
-                  shouldPreferTerminalLogin(status) && terminalMethod
-                    ? [terminalMethod]
-                    : agentMethods.length > 0
-                      ? agentMethods
-                      : terminalMethod
-                        ? [terminalMethod]
-                        : [];
-                const isAuthenticated = status.authState === "authenticated";
-                const needsInteractiveRow =
-                  isAuthenticated ||
-                  status.authState === "missing" ||
-                  (status.authState === "unknown" && methods.length > 0);
-                if (!needsInteractiveRow) return null;
-                return (
-                  <AcpAgentAuthEnvRow
-                    key={`${status.kind}-${envKey}-auth-row`}
-                    status={status}
-                    authMethods={methods}
-                    canLogout={supportsAcpLogoutStatus(status, acpInstanceId)}
-                    authPending={authPendingEnvKey === envKey}
-                    pendingMessage={authPendingEnvKey === envKey ? authPendingMessage : undefined}
-                    showEnvironmentLabel={showAuthEnvironmentLabels}
-                    onLogin={(method) => {
-                      if (isAgentAuthMethod(method)) {
-                        authenticateAgent({ status, method });
-                        return;
-                      }
-                      runTerminalLogin(status, method);
-                    }}
-                    onLogout={() => logoutAgent(status)}
-                  />
-                );
-              })}
-            </div>
-          ) : hasAuthSettings ? (
-            <div className="space-y-3">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex min-w-0 items-start gap-2">
-                  <div className="min-w-0 flex-1">
-                    <p className={`text-sm font-medium ${authMissing ? "text-warning" : ""}`}>
-                      {authMissing ? (
-                        <AlertTriangle className="mr-1.5 inline size-4 -translate-y-px text-warning" />
-                      ) : null}
-                      {authMissing ? "Login required" : "Authentication"}
-                    </p>
-                    <p className="text-xs text-muted">
-                      {authPendingMessage ??
-                        (authMissing
-                          ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
-                              envVarAuthMethod
-                                ? agentAuth
-                                  ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
-                                  : `Save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
-                                : agentAuth
-                                  ? `Complete ${agentAuth.method.name} sign-in, then detected agents will refresh.`
-                                  : loginCommand
-                                    ? `Run ${loginCommand} to sign in.`
-                                    : "Sign in with the agent CLI, then refresh detected agents."
-                            }`
-                          : envVarAuthMethod
-                            ? `Saved ${envVarAuthMethod.name} credentials are configured. Enter a new value to replace them.`
-                            : agentAuth
-                              ? `Sign in again with ${agentAuth.method.name}.`
-                              : loginCommand
-                                ? `Run ${loginCommand} again to refresh credentials.`
-                                : "Credentials are configured.")}
-                    </p>
-                  </div>
-                </div>
-                {showEnvVarOnly && acpInstanceId ? (
-                  <div className="flex shrink-0 flex-row items-center gap-2">
-                    <Button
-                      size="sm"
-                      variant="tertiary"
-                      isIconOnly
-                      aria-label="Save"
-                      isDisabled={!canSaveEnvAuth}
-                      isPending={authPending}
-                      data-acp-auth-save=""
-                      onPress={saveEnvAuth}
-                    >
-                      <Save className="size-4" />
-                    </Button>
-                    {/* Env-var credentials are shared across envs — a single
-                      "Logout" clears them for all environments. */}
-                    <Button
-                      size="sm"
-                      variant="tertiary"
-                      isIconOnly
-                      aria-label="Logout"
-                      isPending={authPending}
-                      onPress={clearEnvVarCredentials}
-                    >
-                      <LogOut className="size-4 text-danger" />
-                    </Button>
-                  </div>
-                ) : agentAuth && supportsAcpAgentAuth ? (
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    {(agentAuthEntries.length > 0 ? agentAuthEntries : [agentAuth]).map(
-                      (entry, index) => (
-                        <Button
-                          key={`${entry.status.kind}-${entry.status.envKind ?? "native"}-${entry.status.envDistro ?? index}`}
-                          size="sm"
-                          variant="tertiary"
-                          isPending={authPending}
-                          onPress={() => authenticateAgent(entry)}
-                        >
-                          <LogIn className="size-4" />
-                          {authMissing ? "Login" : "Re-login"}
-                          {showAuthEnvironmentLabels ? ` ${envLabel(entry.status)}` : ""}
-                        </Button>
-                      ),
-                    )}
-                    {envVarAuthMethod ? (
+                    {!usePerEnvAuthRows && (
                       <Button
                         size="sm"
                         variant="tertiary"
                         isIconOnly
-                        aria-label="Save"
-                        isDisabled={!canSaveEnvAuth}
+                        aria-label="Logout"
                         isPending={authPending}
-                        data-acp-auth-save=""
-                        onPress={saveEnvAuth}
+                        onPress={clearEnvVarCredentials}
                       >
-                        <Save className="size-4" />
+                        <LogOut className="size-4 text-danger" />
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ) : null}
+
+              {!usePerEnvAuthRows &&
+              !showEnvVarOnly &&
+              (agentAuth || loginStatus || logoutStatuses.length > 0) ? (
+                <div className="flex items-start justify-between gap-4 py-1">
+                  <div className="flex min-w-0 items-start gap-2">
+                    <div className="min-w-0 flex-1">
+                      <p className={`text-sm font-medium ${authMissing ? "text-warning" : ""}`}>
+                        {authMissing ? (
+                          <AlertTriangle className="mr-1.5 inline size-4 -translate-y-px text-warning" />
+                        ) : null}
+                        {authMissing ? "Login required" : "Authentication"}
+                      </p>
+                      <p className="text-xs text-muted truncate">
+                        {authPendingMessage ??
+                          (authMissing
+                            ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
+                                envVarAuthMethod
+                                  ? agentAuth
+                                    ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials.`
+                                    : `Save ${envVarAuthMethod.name} credentials.`
+                                  : agentAuth
+                                    ? `Complete ${agentAuth.method.name} sign-in.`
+                                    : loginCommand
+                                      ? `Run ${loginCommand} to sign in.`
+                                      : "Sign in with the agent CLI."
+                              }`
+                            : "Credentials are configured.")}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-2">
+                    {agentAuth && supportsAcpAgentAuth ? (
+                      (agentAuthEntries.length > 0 ? agentAuthEntries : [agentAuth]).map(
+                        (entry, index) => (
+                          <Button
+                            key={`${entry.status.kind}-${entry.status.envKind ?? "native"}-${entry.status.envDistro ?? index}`}
+                            size="sm"
+                            variant="tertiary"
+                            className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                            isPending={authPending}
+                            onPress={() => authenticateAgent(entry)}
+                          >
+                            <LogIn className="size-3" />
+                            {authMissing ? "Login" : "Re-login"}
+                          </Button>
+                        ),
+                      )
+                    ) : loginStatus && loginCommand ? (
+                      <Button
+                        size="sm"
+                        variant="tertiary"
+                        className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                        onPress={() => runTerminalLogin(loginStatus, terminalLoginMethod)}
+                      >
+                        <LogIn className="size-3" />
+                        {authMissing ? "Login" : "Re-login"}
                       </Button>
                     ) : null}
                     {logoutStatuses.map((status, index) => (
@@ -1381,176 +1340,24 @@ export function SingleAgentSettings(props: { agentKind: string }) {
                         key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
                         size="sm"
                         variant="tertiary"
+                        className="h-7 min-h-7 gap-1 px-2 text-[11px]"
                         isPending={authPending}
                         onPress={() => logoutAgent(status)}
                       >
-                        <LogOut className="size-4" />
+                        <LogOut className="size-3 text-danger" />
                         Logout
-                        {showAuthEnvironmentLabels ? ` ${envLabel(status)}` : ""}
                       </Button>
                     ))}
                   </div>
-                ) : envVarAuthMethod && acpInstanceId ? (
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    <Button
-                      size="sm"
-                      variant="tertiary"
-                      isIconOnly
-                      aria-label="Save"
-                      isDisabled={!canSaveEnvAuth}
-                      isPending={authPending}
-                      data-acp-auth-save=""
-                      onPress={saveEnvAuth}
-                    >
-                      <Save className="size-4" />
-                    </Button>
-                    {logoutStatuses.map((status, index) => (
-                      <Button
-                        key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
-                        size="sm"
-                        variant="tertiary"
-                        isPending={authPending}
-                        onPress={() => logoutAgent(status)}
-                      >
-                        <LogOut className="size-4" />
-                        Logout
-                        {showAuthEnvironmentLabels ? ` ${envLabel(status)}` : ""}
-                      </Button>
-                    ))}
-                  </div>
-                ) : loginStatus && loginCommand ? (
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    <Button
-                      size="sm"
-                      variant="tertiary"
-                      onPress={() => runTerminalLogin(loginStatus, terminalLoginMethod)}
-                    >
-                      <LogIn className="size-4" />
-                      {authMissing ? "Login" : "Re-login"}
-                    </Button>
-                    {logoutStatuses.map((status, index) => (
-                      <Button
-                        key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
-                        size="sm"
-                        variant="tertiary"
-                        isPending={authPending}
-                        onPress={() => logoutAgent(status)}
-                      >
-                        <LogOut className="size-4" />
-                        Logout
-                        {showAuthEnvironmentLabels ? ` ${envLabel(status)}` : ""}
-                      </Button>
-                    ))}
-                  </div>
-                ) : logoutStatuses.length > 0 ? (
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    {logoutStatuses.map((status, index) => (
-                      <Button
-                        key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
-                        size="sm"
-                        variant="tertiary"
-                        isPending={authPending}
-                        onPress={() => logoutAgent(status)}
-                      >
-                        <LogOut className="size-4" />
-                        Logout
-                        {showAuthEnvironmentLabels ? ` ${envLabel(status)}` : ""}
-                      </Button>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-              {envVarAuthMethod && acpInstanceId ? (
-                <div className="flex flex-col gap-2">
-                  {envVarAuthMethod.vars.map((variable) => {
-                    const hasAuthValue = Object.prototype.hasOwnProperty.call(
-                      authValues,
-                      variable.name,
-                    );
-                    return (
-                      <Input
-                        key={variable.name}
-                        aria-label={variable.label ?? variable.name}
-                        className="w-full"
-                        placeholder={variable.label ?? variable.name}
-                        type={
-                          variable.secret === false || (!hasAuthValue && !authMissing)
-                            ? "text"
-                            : "password"
-                        }
-                        value={
-                          hasAuthValue
-                            ? (authValues[variable.name] ?? "")
-                            : authMissing
-                              ? ""
-                              : SAVED_SECRET_MASK
-                        }
-                        onFocus={() => {
-                          if (!authMissing && !hasAuthValue) {
-                            setAuthValues((current) => ({ ...current, [variable.name]: "" }));
-                          }
-                        }}
-                        onBlur={(event) => {
-                          if (authMissing) return;
-                          if (
-                            event.relatedTarget instanceof HTMLElement &&
-                            event.relatedTarget.closest("[data-acp-auth-save]")
-                          ) {
-                            return;
-                          }
-                          setAuthValues((current) => {
-                            if (!Object.prototype.hasOwnProperty.call(current, variable.name)) {
-                              return current;
-                            }
-                            const next = { ...current };
-                            delete next[variable.name];
-                            return next;
-                          });
-                        }}
-                        onChange={(event) =>
-                          setAuthValues((current) => ({
-                            ...current,
-                            [variable.name]: event.target.value,
-                          }))
-                        }
-                      />
-                    );
-                  })}
                 </div>
               ) : null}
             </div>
-          ) : null}
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Enabled</p>
-              <p className="text-xs text-muted">
-                Show this agent in the agent picker when creating threads.
-              </p>
-            </div>
-            <Switch
-              isSelected={!isDisabled}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setAgentDisabled(agent.kind, !selected);
-                });
-                if (selected) {
-                  void readBridge()
-                    .refreshAgentStatuses(wslDistros, { agentKinds: [agent.kind] })
-                    .catch(() => undefined);
-                }
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
+          )}
         </div>
 
         <div className={`transition-opacity ${isDisabled ? "pointer-events-none opacity-40" : ""}`}>
           {defs.length > 0 && (
-            <div className="mt-8 space-y-4">
+            <div className="mt-6">
               {defs.map((def) => (
                 <AgentSettingRow key={def.key} agentKind={agent.kind} def={def} />
               ))}
@@ -1558,7 +1365,7 @@ export function SingleAgentSettings(props: { agentKind: string }) {
           )}
 
           {hasSelectableModels && (
-            <div className="mt-8 space-y-4">
+            <div className="mt-6">
               <ModelVisibilityDropdown agentKind={agent.kind} provider={menuProvider} />
             </div>
           )}

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -435,6 +435,10 @@ function supportsAcpLogoutStatus(status: AgentStatus, acpInstanceId: string | un
   return status.authLogoutSupported === true || acpInstanceId !== undefined;
 }
 
+function shouldPreferTerminalLogin(status: AgentStatus): boolean {
+  return status.kind === "grok" && Boolean(status.loginCommand);
+}
+
 function AcpAgentAuthEnvRow(props: {
   status: AgentStatus;
   authMethods: ReadonlyArray<AgentOwnedAuthMethod | AgentTerminalAuthMethod>;
@@ -1245,7 +1249,13 @@ export function SingleAgentSettings(props: { agentKind: string }) {
                     })
                   : undefined;
                 const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> =
-                  terminalMethod ? [terminalMethod] : agentMethods;
+                  shouldPreferTerminalLogin(status) && terminalMethod
+                    ? [terminalMethod]
+                    : agentMethods.length > 0
+                      ? agentMethods
+                      : terminalMethod
+                        ? [terminalMethod]
+                        : [];
                 const isAuthenticated = status.authState === "authenticated";
                 const needsInteractiveRow =
                   isAuthenticated ||

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -1229,10 +1229,16 @@ export function SingleAgentSettings(props: { agentKind: string }) {
                 const agentMethods =
                   status.authMethods?.filter(isAgentAuthMethod) ??
                   (sharedAgentAuthMethod ? [sharedAgentAuthMethod] : []);
-                const terminalMethod =
-                  findTerminalAuthMethodForStatus(status) ?? sharedTerminalAuthMethod;
+                const terminalMethod = status.loginCommand
+                  ? (findTerminalAuthMethodForStatus(status) ??
+                    sharedTerminalAuthMethod ?? {
+                      id: "terminal-login",
+                      name: "Login",
+                      type: "terminal" as const,
+                    })
+                  : undefined;
                 const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> =
-                  agentMethods.length > 0 ? agentMethods : terminalMethod ? [terminalMethod] : [];
+                  terminalMethod ? [terminalMethod] : agentMethods;
                 const isAuthenticated = status.authState === "authenticated";
                 const needsInteractiveRow =
                   isAuthenticated ||

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -476,6 +476,7 @@ function AcpAgentAuthEnvRow(props: {
     : isAuthenticated
       ? `${envSubject} credentials are configured.`
       : "";
+  const detail = props.pendingMessage ?? description;
 
   return (
     <div className="flex items-start justify-between gap-4">
@@ -488,10 +489,7 @@ function AcpAgentAuthEnvRow(props: {
             {headerPrefix}
             {headerLabel}
           </p>
-          {description ? <p className="text-xs text-muted">{description}</p> : null}
-          {props.pendingMessage ? (
-            <p className="mt-1 text-xs text-muted">{props.pendingMessage}</p>
-          ) : null}
+          {detail ? <p className="text-xs text-muted">{detail}</p> : null}
         </div>
       </div>
       {canLogin || canLogout ? (
@@ -793,7 +791,16 @@ export function SingleAgentSettings(props: { agentKind: string }) {
       command: status.loginCommand,
       ...(method?.env ? { env: method.env } : {}),
       ...(project ? { project } : {}),
-      onCommandComplete: () => {
+      onCommandComplete: (exitCode) => {
+        if (exitCode !== 0) {
+          setAuthPending(false);
+          setAuthPendingMessage(undefined);
+          setAuthPendingEnvKey(undefined);
+          return;
+        }
+        setAuthPendingMessage(
+          `Refreshing ${env ? `${env} ` : ""}${status.label} authentication status.`,
+        );
         void readBridge()
           .refreshAgentStatuses(wslDistros, {
             agentKinds: [props.agentKind],
@@ -1278,29 +1285,27 @@ export function SingleAgentSettings(props: { agentKind: string }) {
                       {authMissing ? "Login required" : "Authentication"}
                     </p>
                     <p className="text-xs text-muted">
-                      {authMissing
-                        ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
-                            envVarAuthMethod
-                              ? agentAuth
-                                ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
-                                : `Save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
-                              : agentAuth
-                                ? `Complete ${agentAuth.method.name} sign-in, then detected agents will refresh.`
-                                : loginCommand
-                                  ? `Run ${loginCommand} to sign in.`
-                                  : "Sign in with the agent CLI, then refresh detected agents."
-                          }`
-                        : envVarAuthMethod
-                          ? `Saved ${envVarAuthMethod.name} credentials are configured. Enter a new value to replace them.`
-                          : agentAuth
-                            ? `Sign in again with ${agentAuth.method.name}.`
-                            : loginCommand
-                              ? `Run ${loginCommand} again to refresh credentials.`
-                              : "Credentials are configured."}
+                      {authPendingMessage ??
+                        (authMissing
+                          ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
+                              envVarAuthMethod
+                                ? agentAuth
+                                  ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
+                                  : `Save ${envVarAuthMethod.name} credentials, then detected agents will refresh.`
+                                : agentAuth
+                                  ? `Complete ${agentAuth.method.name} sign-in, then detected agents will refresh.`
+                                  : loginCommand
+                                    ? `Run ${loginCommand} to sign in.`
+                                    : "Sign in with the agent CLI, then refresh detected agents."
+                            }`
+                          : envVarAuthMethod
+                            ? `Saved ${envVarAuthMethod.name} credentials are configured. Enter a new value to replace them.`
+                            : agentAuth
+                              ? `Sign in again with ${agentAuth.method.name}.`
+                              : loginCommand
+                                ? `Run ${loginCommand} again to refresh credentials.`
+                                : "Credentials are configured.")}
                     </p>
-                    {authPendingMessage ? (
-                      <p className="mt-1 text-xs text-muted">{authPendingMessage}</p>
-                    ) : null}
                   </div>
                 </div>
                 {showEnvVarOnly && acpInstanceId ? (

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -52,6 +52,7 @@ export const MAIN_LOCAL_PROCEDURE_NAMES = [
   "saveClipboardImage",
   "saveHandoffContext",
   "openExternal",
+  "openExternalNative",
   "focusWindow",
   "getHomeScopeLocation",
   "getKeybindings",

--- a/src/shared/ipc/procedures/app.ts
+++ b/src/shared/ipc/procedures/app.ts
@@ -41,6 +41,12 @@ export const appProcedures = {
     openExternalPayloadSchema,
     (url) => openExternalPayloadSchema.parse(url),
   ),
+  openExternalNative: defineIpcProcedure<[string], string, void, "main-local">(
+    "openExternalNative",
+    "main-local",
+    openExternalPayloadSchema,
+    (url) => openExternalPayloadSchema.parse(url),
+  ),
   focusWindow: defineNoArgProcedure<void, "main-local">("focusWindow", "main-local"),
   getHomeScopeLocation: defineNoArgProcedure<ProjectLocation, "main-local">(
     "getHomeScopeLocation",

--- a/src/supervisor/agents/acp-generic/index.test.ts
+++ b/src/supervisor/agents/acp-generic/index.test.ts
@@ -230,7 +230,7 @@ describe("createAcpGenericAdapter", () => {
     expect(status.providerMetadata?.authMethod).toBe("Example API key");
   });
 
-  it("does not report agent-owned login methods as provider metadata", async () => {
+  it("drops malformed env-var auth methods without showing them as login methods", async () => {
     vi.mocked(probeAcpCapabilities).mockResolvedValue({
       authMethods: [
         { id: "login", name: "Login" },
@@ -243,7 +243,8 @@ describe("createAcpGenericAdapter", () => {
     });
     const adapter = createAcpGenericAdapter(baseInstance);
     const status = await adapter.detectInstall();
-    expect(status.providerMetadata?.authMethod).toBe("Factory API Key");
+    expect(status.authMethods).toEqual([{ id: "login", name: "Login" }]);
+    expect(status.providerMetadata?.authMethod).toBeUndefined();
   });
 
   it("reports ACP terminal auth as missing until a session probe succeeds", async () => {

--- a/src/supervisor/agents/acp/authMethods.ts
+++ b/src/supervisor/agents/acp/authMethods.ts
@@ -13,7 +13,7 @@ type AcpTerminalAuthMethod = Extract<AcpAuthMethod, { type: "terminal" }>;
 type AcpAgentAuthMethod = Exclude<AcpAuthMethod, AcpEnvVarAuthMethod | AcpTerminalAuthMethod>;
 
 export function isAcpEnvVarAuthMethod(method: AcpAuthMethod): method is AcpEnvVarAuthMethod {
-  return ("type" in method && method.type === "env_var") || "vars" in method;
+  return "type" in method && method.type === "env_var";
 }
 
 export function isAcpTerminalAuthMethod(method: AcpAuthMethod): method is AcpTerminalAuthMethod {
@@ -21,7 +21,16 @@ export function isAcpTerminalAuthMethod(method: AcpAuthMethod): method is AcpTer
 }
 
 export function isAcpAgentAuthMethod(method: AcpAuthMethod): method is AcpAgentAuthMethod {
-  return !isAcpEnvVarAuthMethod(method) && !isAcpTerminalAuthMethod(method);
+  return !isAcpEnvVarAuthMethod(method) && !isAcpTerminalAuthMethod(method) && !hasVars(method);
+}
+
+function hasVars(method: AcpAuthMethod): boolean {
+  return "vars" in method;
+}
+
+function isKeyLikeAgentMethod(method: AcpAuthMethod): boolean {
+  if (!isAcpAgentAuthMethod(method)) return false;
+  return /\b(api[-_\s]*key|token|secret)\b/iu.test(`${method.id} ${method.name}`);
 }
 
 /**
@@ -33,6 +42,9 @@ export function isAcpAgentAuthMethod(method: AcpAuthMethod): method is AcpAgentA
 export function dedupeAcpAuthMethods(methods: readonly AcpAuthMethod[]): AcpAuthMethod[] {
   const envVarNames = new Set(methods.filter(isAcpEnvVarAuthMethod).map((method) => method.name));
   return methods.filter(
-    (method) => !(isAcpAgentAuthMethod(method) && envVarNames.has(method.name)),
+    (method) =>
+      (isAcpEnvVarAuthMethod(method) || !hasVars(method)) &&
+      !isKeyLikeAgentMethod(method) &&
+      !(isAcpAgentAuthMethod(method) && envVarNames.has(method.name)),
   );
 }

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -620,6 +620,8 @@ export async function detectAgentInstall(
     statusProbeResult = nextStatusProbeResult;
   }
 
+  const probeCtx: DetectProbeCtx = { location, executablePath, version };
+
   let authState: AuthState;
   if (!executablePath) {
     authState = "missing";
@@ -632,7 +634,6 @@ export async function detectAgentInstall(
     authState = probedAuthState;
   } else {
     authState = statusProbeResult?.authState ?? "unknown";
-    const probeCtx: DetectProbeCtx = { location, executablePath, version };
     if (authState !== "authenticated") {
       for (const probe of spec.authProbes ?? []) {
         const result = await probe(probeCtx);
@@ -649,11 +650,14 @@ export async function detectAgentInstall(
 
   const providerMetadata = statusProbeResult?.providerMetadata ?? probedProviderMetadata;
 
+  const loginCommand =
+    typeof spec.loginCommand === "function" ? spec.loginCommand(probeCtx) : spec.loginCommand;
+
   return {
     kind: spec.kind,
     label: spec.label,
     installed: executablePath !== undefined,
-    ...(spec.loginCommand ? { loginCommand: spec.loginCommand } : {}),
+    ...(loginCommand ? { loginCommand } : {}),
     ...(executablePath ? { executablePath } : {}),
     ...(version ? { version } : {}),
     ...(spec.update ? { update: spec.update } : {}),

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -170,7 +170,7 @@ export interface DetectionSpec {
   kind: AgentKind;
   label: string;
   binary: string;
-  loginCommand?: string;
+  loginCommand?: string | ((ctx: DetectProbeCtx) => string | undefined);
   capabilities: AgentCapability;
   update?: AgentUpdateInfo;
   versionArgs?: string[];

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -587,10 +587,12 @@ describe("createCodexAdapter buildAcpLogoutCommand", () => {
     const adapter = createCodexAdapter();
     const command = await adapter.buildAcpLogoutCommand?.();
     expect(command).toBeDefined();
-    // `buildAgentCommand` wraps the argv in a login shell (`sh -c "exec
-    // 'codex' 'logout'"`) on posix and in `wsl.exe -d <distro> --` on WSL —
-    // assert on the substring so both platforms pass.
-    expect(command?.args.join(" ")).toContain("'codex' 'logout'");
+    const args = command?.args ?? [];
+    const rendered = args.includes("-EncodedCommand")
+      ? Buffer.from(args.at(-1) ?? "", "base64").toString("utf16le")
+      : args.join(" ");
+    expect(rendered).toMatch(/codex/i);
+    expect(rendered).toContain("logout");
   });
 });
 

--- a/src/supervisor/agents/cursor/cursor.test.ts
+++ b/src/supervisor/agents/cursor/cursor.test.ts
@@ -506,6 +506,17 @@ Options:
     ).toBe(true);
   });
 
+  it("detects the cursor-agent logout command help", () => {
+    expect(
+      parseCursorLogoutHelpOutput(`Usage: cursor-agent logout [options]
+
+Sign out of Cursor
+
+Options:
+  -h, --help  Display help for command`),
+    ).toBe(true);
+  });
+
   it("does not treat root help as logout command support", () => {
     expect(
       parseCursorLogoutHelpOutput(`Usage: agent [options] [command]

--- a/src/supervisor/agents/cursor/detection.ts
+++ b/src/supervisor/agents/cursor/detection.ts
@@ -97,7 +97,10 @@ async function readCursorProbeOutputAsync(
 
 export function parseCursorLogoutHelpOutput(output: string): boolean {
   const text = stripAnsi(output);
-  return /Usage:\s+agent\s+logout\b/i.test(text) && /clear stored authentication/i.test(text);
+  return (
+    /Usage:\s+(?:agent|cursor-agent)\s+logout\b/i.test(text) &&
+    /(?:clear stored authentication|sign out)/i.test(text)
+  );
 }
 
 async function probeCursorLogoutSupport(

--- a/src/supervisor/agents/grok/detection.ts
+++ b/src/supervisor/agents/grok/detection.ts
@@ -137,21 +137,20 @@ function formatGrokAuthMode(mode: string): string {
 }
 
 /**
- * Grok stores auth in ~/.grok/auth.json (or the dir presence after login).
+ * Grok stores auth in ~/.grok/auth.json.
  */
-async function grokConfigDirAuthProbe(
+async function grokAuthFileProbe(
   ctx: Parameters<NonNullable<DetectionSpec["statusProbe"]>>[0],
 ): Promise<"authenticated" | "unknown"> {
   const check = (home: string) => {
     if (existsSync(join(home, ".grok", "auth.json"))) return "authenticated";
-    if (existsSync(join(home, ".grok"))) return "authenticated";
     return "unknown";
   };
   if (ctx.location.kind !== "wsl") {
     return check(homedir());
   }
   const [r] = await batchWslCommandsAsync(ctx.location.distro, [
-    "test -f ~/.grok/auth.json && echo yes || test -d ~/.grok && echo yes || echo no",
+    "test -f ~/.grok/auth.json && echo yes || echo no",
   ]);
   return r?.ok && r.stdout.trim() === "yes" ? "authenticated" : "unknown";
 }
@@ -160,7 +159,8 @@ export const grokDetectionSpec: DetectionSpec = {
   kind: "grok",
   label: "Grok Build",
   binary: "grok",
-  loginCommand: "grok login",
+  loginCommand: ({ location }) =>
+    location.kind === "wsl" ? "grok login --device-auth" : "grok login",
   capabilities: grokDefaultCapabilities,
   update: {
     builtIn: { binary: "grok", args: ["update"] },
@@ -168,7 +168,7 @@ export const grokDetectionSpec: DetectionSpec = {
   // Auth detection prefers XAI_API_KEY / GROK_API_KEY (for "xai.api_key" ACP method)
   // then falls back to ~/.grok/auth.json (populated by `grok login` → "cached_token").
   // See https://docs.x.ai/build/enterprise#authentication
-  authProbes: [envVarAuthProbe(["GROK_API_KEY", "XAI_API_KEY"]), grokConfigDirAuthProbe],
+  authProbes: [envVarAuthProbe(["GROK_API_KEY", "XAI_API_KEY"]), grokAuthFileProbe],
   async capabilitiesProbe(ctx) {
     if (!ctx.executablePath) return undefined;
     return probeCapabilities(ctx.location, ctx.executablePath);

--- a/src/supervisor/agents/grok/grok.test.ts
+++ b/src/supervisor/agents/grok/grok.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OscNotification, OscTitle } from "@/shared/osc";
+import { grokDetectionSpec } from "./detection";
 import { createGrokAdapter } from "./index";
 
 function oscTitle(text: string, code: 0 | 1 | 2 = 0): OscTitle {
@@ -76,6 +77,38 @@ describe("createGrokAdapter OSC plumbing", () => {
   it("keeps OSC parsing active alongside the L1 hook plugin", () => {
     const adapter = createGrokAdapter();
     expect(adapter.oscHintsDeferToHookPlugin).toBeUndefined();
+  });
+});
+
+describe("grokDetectionSpec", () => {
+  it("uses device auth for WSL login to avoid localhost callback nonce mismatches", () => {
+    expect(typeof grokDetectionSpec.loginCommand).toBe("function");
+    const loginCommand =
+      typeof grokDetectionSpec.loginCommand === "function"
+        ? grokDetectionSpec.loginCommand({
+            location: {
+              kind: "wsl",
+              distro: "Ubuntu",
+              linuxPath: "/home/demo/project",
+              uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+            },
+            executablePath: "grok",
+          })
+        : grokDetectionSpec.loginCommand;
+
+    expect(loginCommand).toBe("grok login --device-auth");
+  });
+
+  it("keeps normal OAuth login for native Windows", () => {
+    const loginCommand =
+      typeof grokDetectionSpec.loginCommand === "function"
+        ? grokDetectionSpec.loginCommand({
+            location: { kind: "windows", path: "C:\\repo" },
+            executablePath: "grok",
+          })
+        : grokDetectionSpec.loginCommand;
+
+    expect(loginCommand).toBe("grok login");
   });
 });
 

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -46,6 +46,7 @@ describe("agent status cache", () => {
     writeFileSync(
       statusCachePath,
       JSON.stringify({
+        version: 2,
         windows: [
           {
             kind: "claude",
@@ -174,6 +175,7 @@ describe("agent status cache", () => {
     writeFileSync(
       statusCachePath,
       JSON.stringify({
+        version: 2,
         windows: [
           {
             kind: "codex",

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -31,7 +31,7 @@ const execFileAsync = promisify(execFile);
  * coincides with `DetectionSpec.loginCommand` becoming a function that depends
  * on the project location (e.g. `grok login --device-auth` on WSL).
  */
-const STATUS_CACHE_VERSION = 2;
+const STATUS_CACHE_VERSION = 3;
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
   if (definition.type === "toggle" || definition.type === "select") {

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -31,7 +31,7 @@ const execFileAsync = promisify(execFile);
  * coincides with `DetectionSpec.loginCommand` becoming a function that depends
  * on the project location (e.g. `grok login --device-auth` on WSL).
  */
-const STATUS_CACHE_VERSION = 3;
+const STATUS_CACHE_VERSION = 2;
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
   if (definition.type === "toggle" || definition.type === "select") {

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -25,6 +25,14 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Bump whenever a cached `AgentStatus` field's shape or derivation changes so
+ * that previously-saved caches are invalidated and a fresh detection runs. v2
+ * coincides with `DetectionSpec.loginCommand` becoming a function that depends
+ * on the project location (e.g. `grok login --device-auth` on WSL).
+ */
+const STATUS_CACHE_VERSION = 2;
+
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
   if (definition.type === "toggle" || definition.type === "select") {
     return definition;
@@ -365,9 +373,19 @@ export class AgentStatusService {
     try {
       const raw = readFileSync(this.options.statusCachePath, "utf8");
       const cache = JSON.parse(raw) as {
+        version?: number;
         windows?: unknown[];
         wsl?: unknown[];
       };
+
+      // Cache version is bumped whenever derived fields like `loginCommand`
+      // change shape (e.g. when an adapter's static string becomes a function
+      // that depends on the project location). Stale caches would otherwise
+      // hand back pre-bump values that no longer match what fresh detection
+      // would compute.
+      if (cache.version !== STATUS_CACHE_VERSION) {
+        return { windows: [], wsl: [], fromCache: false };
+      }
 
       const windows = parseCachedStatuses(cache.windows)
         .filter((status) => status.envKind !== "wsl")
@@ -408,7 +426,12 @@ export class AgentStatusService {
     try {
       writeFileSync(
         this.options.statusCachePath,
-        JSON.stringify({ windows, wsl, savedAt: new Date().toISOString() }),
+        JSON.stringify({
+          version: STATUS_CACHE_VERSION,
+          windows,
+          wsl,
+          savedAt: new Date().toISOString(),
+        }),
         "utf8",
       );
     } catch {


### PR DESCRIPTION
- Add a native-browser path for WSL login URLs, keep failed login sessions visible, and stop wrapped CLI output from opening the wrong link.
- Tighten auth detection for ACP, Cursor, Grok, and Codex so malformed env-var methods are ignored, logout support is recognized, and Grok uses the WSL device-auth flow.
- Refresh the auth-required dock and single-agent settings so the UI matches the updated login path and auth labels.
- Invalidate cached agent status after the auth-shape change, and add tests around login actions, link parsing, and auth detection to lock in the behavior.