### PR TITLE
Adjust branch selector dropdown spacing

### DIFF
--- a/src/renderer/components/common/BranchSelector/BranchSelector.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.tsx
@@ -206,9 +206,9 @@ export function BranchSelector(props: BranchSelectorProps) {
           )}
         </Popover.Trigger>
         <Popover.Content placement={popoverPlacement} className="w-80 p-0">
-          <Popover.Dialog className="flex max-h-[24rem] flex-col overflow-hidden !p-0">
+          <Popover.Dialog className="flex max-h-[24rem] flex-col overflow-hidden !p-0 !pb-1.5">
             {/* Search */}
-            <div className="flex items-center gap-2 border-b border-border px-1.5 py-1.5">
+            <div className="flex items-center gap-2 border-b border-border px-3 py-2">
               <Search className="size-3.5 shrink-0 text-muted" />
               <input
                 ref={searchRef}
@@ -230,7 +230,7 @@ export function BranchSelector(props: BranchSelectorProps) {
               />
             </div>
 
-            <div className="flex-1 overflow-hidden">
+            <div className="flex-1 overflow-hidden pb-1.5">
               <BranchListBox
                 items={items}
                 hasLocal={hasLocal}

--- a/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
@@ -39,11 +39,11 @@ export function BranchFooterActions(props: {
   } = props;
 
   return (
-    <div className="border-t border-border">
+    <div className="border-t border-border px-1.5 pt-1.5">
       {/* Create new branch */}
       <ListBox
         aria-label="Actions"
-        className="lightcode-menu px-1.5 py-1.5"
+        className="lightcode-menu"
         selectionMode="none"
         onAction={() => {
           setIsCreating(true);
@@ -93,7 +93,7 @@ export function BranchFooterActions(props: {
       {!hideWorktreeToggle && (
         <ListBox
           aria-label="Options"
-          className="lightcode-menu px-1.5 py-1.5"
+          className="lightcode-menu"
           selectionMode="none"
           onAction={() => {
             const next = !worktreeMode;

--- a/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
@@ -46,7 +46,7 @@ export function BranchListBox(props: {
   return (
     <Virtualizer
       layout={ListLayout}
-      layoutOptions={{ rowHeight: COMPACT_DROPDOWN_ROW_HEIGHT, padding: 6 }}
+      layoutOptions={{ rowHeight: COMPACT_DROPDOWN_ROW_HEIGHT, padding: 8 }}
     >
       <ListBox
         aria-label="Branches"


### PR DESCRIPTION
- Tighten the branch selector popover layout so the search bar, branch list, and footer actions feel more balanced.
- Add a bit more breathing room around list rows and footer controls to improve readability and click comfort.
- Keep the dropdown compact while preserving the existing branch-selection behavior.