### PR TITLE
Prune old nightly prereleases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -112,6 +112,20 @@ jobs:
       - name: List release assets
         run: ls -lh release-assets
 
+      - name: Remove previous nightly prereleases for this version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ needs.prepare.outputs.tag }}
+          NIGHTLY_PREFIX: v${{ needs.prepare.outputs.base_version }}-nightly.
+        run: |
+          gh release list --json tagName,isPrerelease --limit 1000 \
+            --jq ".[] | select(.isPrerelease and .tagName != env.CURRENT_TAG and (.tagName | startswith(env.NIGHTLY_PREFIX))) | .tagName" |
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "Deleting previous nightly release $tag"
+            gh release delete "$tag" --yes --cleanup-tag
+          done
+
       - name: Create GitHub prerelease
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
- Delete prior prereleases for the same base version before publishing a new nightly build.
- Keep nightly release lists and tags from accumulating stale duplicates.
- Make nightly release automation cleaner and less error-prone.