### PR TITLE
Tighten panel header project name line height

### DIFF
--- a/src/renderer/components/layout/PanelHeaderProjectName.tsx
+++ b/src/renderer/components/layout/PanelHeaderProjectName.tsx
@@ -13,7 +13,7 @@ export function PanelHeaderProjectName(props: {
       <Tooltip.Trigger
         className={`${panelHeaderTooltipTriggerResetClass} ${props.maxWidthClass}${triggerClassName}`}
       >
-        <span className="min-w-0 truncate text-left text-xs font-medium leading-none text-foreground @max-[400px]:text-[11px]">
+        <span className="min-w-0 truncate text-left text-xs font-medium leading-tight text-foreground @max-[400px]:text-[11px]">
           {props.name}
         </span>
       </Tooltip.Trigger>


### PR DESCRIPTION
- Bugfix: keep the panel header project name compact and easier to read in tight layouts.
- Adjust the project name label line height so it sits better inside the header without changing the overall layout.