### PR TITLE
Fix agent discovery, ACP auth, and result rendering

### DIFF
--- a/src/renderer/actions/agentLoginActions.test.ts
+++ b/src/renderer/actions/agentLoginActions.test.ts
@@ -294,6 +294,29 @@ describe("runAgentLoginCommand", () => {
     expect(bridge.openExternalNative).toHaveBeenCalledWith(url);
   });
 
+  it("does not auto-open Gemini WSL login links", () => {
+    runAgentLoginCommand({
+      label: "Gemini",
+      command: "gemini /auth",
+      project: wslProject,
+    });
+
+    const shellId = loginTerminalStore.open.mock.calls[0]?.[0].shellId;
+    expect(writeScriptToShellMock.mock.calls[0]?.[1] ?? "").toContain(
+      "clear; BROWSER='/bin/true' gemini /auth",
+    );
+
+    emit({
+      type: "thread-output",
+      threadId: shellId!,
+      data: "https://geminicli.com/docs/resources/tos-privacy/%E2%94%82\n",
+      outputLength: 0,
+    });
+    vi.advanceTimersByTime(250);
+
+    expect(bridge.openExternalNative).not.toHaveBeenCalled();
+  });
+
   it("marks the login overlay as failed when the command exits unsuccessfully", () => {
     runAgentLoginCommand({
       label: "Grok",

--- a/src/renderer/actions/agentLoginActions.ts
+++ b/src/renderer/actions/agentLoginActions.ts
@@ -124,13 +124,14 @@ export function runAgentLoginCommand(input: {
   // suppress its opener (BROWSER=/bin/true) and watch stdout for auth URLs to
   // hand off via the Windows shell. Native macOS / Windows CLIs already open
   // their own browser, so a renderer-side watcher would just double-launch.
-  const interceptWslUrls = project.location.kind === "wsl";
+  const suppressWslBrowser = project.location.kind === "wsl";
+  const interceptWslUrls = suppressWslBrowser && !isGeminiLoginCommand(input);
   // Wipe the bash prompt + echoed script line that briefly appear before the
   // TUI takes over. `clear` (POSIX) / `Clear-Host` (PowerShell) gives the
   // overlay a clean canvas so the user only sees the agent's own UI.
   const loginCommand = buildTerminalCommand({
     command: input.command,
-    env: interceptWslUrls ? { BROWSER: "/bin/true", ...(input.env ?? {}) } : input.env,
+    env: suppressWslBrowser ? { BROWSER: "/bin/true", ...(input.env ?? {}) } : input.env,
   });
   const command =
     project.location.kind === "windows" ? `Clear-Host; ${loginCommand}` : `clear; ${loginCommand}`;
@@ -198,6 +199,10 @@ function buildTerminalCommand(input: {
 }): string {
   const envPrefix = shellEnvPrefix(input.env);
   return envPrefix ? `${envPrefix} ${input.command}` : input.command;
+}
+
+function isGeminiLoginCommand(input: { label: string; command: string }): boolean {
+  return input.label.trim().toLowerCase() === "gemini" || /^\s*gemini(?:\s|$)/u.test(input.command);
 }
 
 function isCompleteLoginUrl(text: string): boolean {

--- a/src/renderer/components/thread/AgentDiscoveryScreen.tsx
+++ b/src/renderer/components/thread/AgentDiscoveryScreen.tsx
@@ -1,7 +1,10 @@
+import { Button } from "@heroui/react";
+import { X } from "lucide-react";
 import { PixelLoader } from "@/renderer/components/common";
 import { getRegisteredProviders, ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import type { AgentStatus, ProjectLocation } from "@/shared/contracts";
+import type { CSSProperties } from "react";
 
 function readyBadge(status: AgentStatus): { label: string; toneClass: string } | null {
   if (!status.installed) return null;
@@ -20,16 +23,117 @@ function statusLine(scopedCount: number, installedCount: number, wslDistro: stri
   return `${installedCount} agents ready`;
 }
 
-export function AgentDiscoveryScreen(props: { location?: ProjectLocation }) {
+function combinedStatusLine(discovered: readonly AgentStatus[]): string {
+  if (discovered.length === 0) return "Warming up shell environments...";
+  const readyKinds = new Set(
+    discovered.filter((status) => status.installed).map((status) => status.kind),
+  );
+  if (readyKinds.size === 0) return "No providers ready yet";
+  if (readyKinds.size === 1) return "1 provider ready";
+  return `${readyKinds.size} providers ready`;
+}
+
+function statusRank(status: AgentStatus): number {
+  if (!status.installed) return 0;
+  return status.authState === "missing" ? 1 : 2;
+}
+
+interface ScanTarget {
+  key: string;
+  label: string;
+  matches(status: AgentStatus): boolean;
+}
+
+function statusForTarget(
+  statuses: readonly AgentStatus[],
+  target: ScanTarget | undefined,
+): AgentStatus | undefined {
+  const matching = target ? statuses.filter((status) => target.matches(status)) : statuses;
+  return matching.toSorted((left, right) => statusRank(right) - statusRank(left))[0];
+}
+
+function statusLabel(status: AgentStatus | undefined): { label: string; toneClass: string } {
+  if (!status) return { label: "Searching...", toneClass: "text-muted/60" };
+  const badge = readyBadge(status);
+  if (badge) return badge;
+  return { label: "Not found", toneClass: "text-muted/55" };
+}
+
+export function AgentDiscoveryScreen(props: {
+  location?: ProjectLocation;
+  onCancel?: () => void;
+  wslDistros?: string[];
+}) {
   // `discoveredAgents` is already scoped by `pushDiscoveredAgent` to the active
   // discovery scope, so no additional location filtering is needed here.
   const discovered = useAgentStatusesStore((s) => s.discoveredAgents);
-  const byKind = new Map(discovered.map((status) => [status.kind, status]));
+  const discoveryScope = useAgentStatusesStore((s) => s.discoveryScope);
+  const byKind = new Map<AgentStatus["kind"], AgentStatus>();
+  const statusesByKind = new Map<AgentStatus["kind"], AgentStatus[]>();
+  for (const status of discovered) {
+    const current = byKind.get(status.kind);
+    if (!current || statusRank(status) >= statusRank(current)) {
+      byKind.set(status.kind, status);
+    }
+    statusesByKind.set(status.kind, [...(statusesByKind.get(status.kind) ?? []), status]);
+  }
   const installedCount = discovered.reduce((n, s) => n + (s.installed ? 1 : 0), 0);
   const wslDistro = props.location?.kind === "wsl" ? props.location.distro : undefined;
+  const scanTargets: ScanTarget[] =
+    wslDistro !== undefined
+      ? [
+          {
+            key: `wsl:${wslDistro}`,
+            label: `WSL: ${wslDistro}`,
+            matches: (status) => status.envKind === "wsl" && status.envDistro === wslDistro,
+          },
+        ]
+      : props.wslDistros !== undefined
+        ? [
+            {
+              key: "native",
+              label: "Windows",
+              matches: (status) => status.envKind !== "wsl",
+            },
+            ...props.wslDistros.map((distro) => ({
+              key: `wsl:${distro}`,
+              label: `WSL: ${distro}`,
+              matches: (status: AgentStatus) =>
+                status.envKind === "wsl" && status.envDistro === distro,
+            })),
+          ]
+        : discoveryScope?.kind === "all"
+          ? [
+              {
+                key: "native",
+                label: "Windows",
+                matches: (status) => status.envKind !== "wsl",
+              },
+              ...discoveryScope.wslDistros.map((distro) => ({
+                key: `wsl:${distro}`,
+                label: `WSL: ${distro}`,
+                matches: (status: AgentStatus) =>
+                  status.envKind === "wsl" && status.envDistro === distro,
+              })),
+            ]
+          : [];
   // Provider plugins self-register at module-load time; reading the registry
   // each render keeps this screen in sync as new agent kinds are added.
   const providers = getRegisteredProviders();
+  const useMatrixLayout = scanTargets.length > 1;
+  const statusTargets: ScanTarget[] =
+    scanTargets.length > 0
+      ? scanTargets
+      : [
+          {
+            key: "system",
+            label: "System",
+            matches: () => true,
+          },
+        ];
+  const matrixGridStyle = {
+    "--agent-target-count": statusTargets.length,
+  } as CSSProperties;
 
   return (
     <div className="agent-discovery-screen flex h-full flex-col items-center justify-center gap-8 px-6 text-center">
@@ -39,42 +143,79 @@ export function AgentDiscoveryScreen(props: { location?: ProjectLocation }) {
         <p className="max-w-sm text-sm text-muted">
           {wslDistro
             ? `Scanning ${wslDistro} for installed CLIs. This usually takes a couple of seconds.`
-            : "Scanning your system for installed CLIs. This usually takes a couple of seconds."}
+            : scanTargets.length > 1
+              ? "Scanning Windows and WSL for installed CLIs. This usually takes a couple of seconds."
+              : "Scanning your system for installed CLIs. This usually takes a couple of seconds."}
         </p>
+        {scanTargets.length > 1 ? (
+          <div className="flex flex-wrap items-center justify-center gap-1.5">
+            {scanTargets.map((target) => (
+              <span
+                key={target.key}
+                className="rounded border border-border/70 bg-surface/60 px-2 py-0.5 text-[0.6875rem] font-medium text-muted"
+              >
+                {target.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
       </div>
 
-      <div className="flex w-full max-w-[36rem] flex-wrap items-start justify-center gap-x-10 gap-y-6">
-        {providers.map(({ kind, label }) => {
-          const status = byKind.get(kind);
-          const probed = status !== undefined;
-          const isInstalled = status?.installed === true;
-          const badge = status ? readyBadge(status) : null;
-          return (
-            <div
-              key={kind}
-              data-found={isInstalled ? "true" : "false"}
-              data-probed={probed ? "true" : "false"}
-              className="agent-discovery-item flex w-24 flex-col items-center gap-2"
-            >
-              <ProviderIcon kind={kind} className="agent-discovery-item__icon size-12" />
-              <div className="text-sm font-medium leading-tight">{label}</div>
-              <div
-                className={`min-h-[1rem] text-xs leading-tight ${badge ? badge.toneClass : "text-muted/60"}`}
-              >
-                {badge ? (
-                  badge.label
-                ) : !probed ? (
-                  <span className="opacity-60">Searching…</span>
-                ) : null}
-              </div>
+      <div className="w-full max-w-[42rem] overflow-hidden rounded border border-border/60 bg-background/25 text-left">
+        <div
+          className="grid grid-cols-[minmax(11rem,1fr)_repeat(var(--agent-target-count),minmax(7rem,8rem))] border-b border-border/60 px-3 py-2 text-[0.6875rem] font-medium uppercase text-muted/70"
+          style={matrixGridStyle}
+        >
+          <div>Provider</div>
+          {statusTargets.map((target) => (
+            <div key={target.key} className="text-center">
+              {target.label}
             </div>
-          );
-        })}
+          ))}
+        </div>
+        <div>
+          {providers.map(({ kind, label }) => {
+            const statuses = statusesByKind.get(kind) ?? [];
+            return (
+              <div
+                key={kind}
+                className="grid min-h-14 grid-cols-[minmax(11rem,1fr)_repeat(var(--agent-target-count),minmax(7rem,8rem))] items-center border-b border-border/40 px-3 py-2 last:border-b-0"
+                style={matrixGridStyle}
+              >
+                <div className="flex min-w-0 items-center gap-3">
+                  <ProviderIcon kind={kind} className="agent-discovery-item__icon size-7" />
+                  <div className="truncate text-sm font-medium">{label}</div>
+                </div>
+                {statusTargets.map((target) => {
+                  const rowStatus = statusForTarget(statuses, target);
+                  const labelInfo = statusLabel(rowStatus);
+                  return (
+                    <div
+                      key={target.key}
+                      className={`text-center text-xs font-medium ${labelInfo.toneClass}`}
+                    >
+                      {labelInfo.label}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       <div className="text-xs text-muted/70" aria-live="polite">
-        {statusLine(discovered.length, installedCount, wslDistro)}
+        {useMatrixLayout
+          ? combinedStatusLine(discovered)
+          : statusLine(discovered.length, installedCount, wslDistro)}
       </div>
+
+      {props.onCancel ? (
+        <Button size="sm" variant="tertiary" onPress={props.onCancel}>
+          <X className="size-3.5" />
+          Cancel
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
@@ -78,6 +78,18 @@ describe("ItemMarkdownInner", () => {
     expect(container.querySelector("pre > code")).toHaveTextContent("plain block");
   });
 
+  it("treats range/path fence info as a code fence header, not visible body text", () => {
+    const { container } = render(
+      <AppProvider>
+        <ItemMarkdownInner text={"```1:30:AGENTS.md\n# AGENTS.md\n\nBody\n```"} />
+      </AppProvider>,
+    );
+
+    expect(screen.getByTestId("code-block")).toHaveAttribute("data-lang", "markdown");
+    expect(screen.getByTestId("code-block")).toHaveTextContent("# AGENTS.md Body");
+    expect(container).not.toHaveTextContent("1:30:AGENTS.md");
+  });
+
   it("hides browser selector metadata fences", () => {
     const payload = JSON.stringify({
       selector: "svg.lnXdpd > path",

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCall.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCall.test.tsx
@@ -92,6 +92,46 @@ describe("ToolCall — Claude View (Read) rich rendering", () => {
     expect(resultViewport.tagName.toLowerCase()).toBe("pre");
     expect(resultViewport.classList.contains("lc-shiki")).toBe(false);
   });
+
+  it("renders standalone Grok edit tool calls as rich diffs with counts", async () => {
+    const item: RuntimeChatItem = {
+      id: "toolu_grok_edit",
+      type: "tool_call",
+      state: "completed",
+      payload: {
+        name: "Edit: src/App.tsx",
+        status: "success",
+        args: {
+          file_path: "src/App.tsx",
+          old_string: "const title = 'old';",
+          new_string: "const title = 'new';",
+        },
+        result: {
+          type: "SearchReplace",
+          tool_output_for_prompt: "The file src/App.tsx has been updated successfully.",
+        },
+      },
+      streams: {},
+    };
+
+    render(
+      <AppProvider>
+        <ToolCall item={item} />
+      </AppProvider>,
+    );
+
+    expect(document.body).toHaveTextContent("+1");
+    expect(document.body).toHaveTextContent("-1");
+
+    fireEvent.click(getDisclosureTrigger());
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent(/const title = 'old'/);
+      expect(document.body).toHaveTextContent(/const title = 'new'/);
+    });
+    expect(findSectionHeader("args")).toBeNull();
+    expect(findSectionHeader("result")).toBeNull();
+  });
 });
 
 function getDisclosureTrigger(): HTMLElement {

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
@@ -12,9 +12,14 @@ import { PlanProposal, isPlanProposalToolCall } from "./PlanProposal";
 import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
 import {
   extractAcpArgsPart,
+  extractAcpDiffResultPart,
+  extractAcpDiffSummary,
   extractAcpResultPart,
   extractReadFileResultPart,
+  readAcpContentEditTexts,
 } from "./acpToolPayload";
+import { formatDiffSummaryLabel } from "./FileChange";
+import { InlineDiffView } from "./InlineDiffView";
 import { deriveToolDisplay, isSkillTool } from "./toolDisplay";
 import { FileContentPlaceholder, useReadAbsoluteFile } from "./useReadAbsoluteFile";
 
@@ -33,11 +38,17 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
       : null;
   const fetched = useReadAbsoluteFile(isExpanded ? fetchTarget : null);
   const readResultPart =
-    payload?.kind === "read" && !lazyReadPath ? extractReadFileResultPart(payload) : undefined;
+    payload && isReadLikeToolPayload(payload) && !lazyReadPath
+      ? extractReadFileResultPart(payload)
+      : undefined;
   const hasReadResult = !!readResultPart && readResultPart.text.length > 0;
+  const diffPart =
+    payload && isEditLikeToolPayload(payload) ? extractAcpDiffResultPart(payload) : undefined;
+  const diffText = diffPart?.text ? diffPart.text : undefined;
+  const contentEdit = readAcpContentEditTexts(payload);
   const sections = useMemo<ToolCallSection[]>(() => {
     if (!isExpanded || !payload) return [];
-    if (lazyReadPath || hasReadResult) return [];
+    if (lazyReadPath || hasReadResult || diffText !== undefined) return [];
     const isSkill = isSkillTool(payload);
     return [
       { label: "args", part: extractAcpArgsPart(payload) },
@@ -47,15 +58,23 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
         ...(isSkill ? { renderAsMarkdown: true } : {}),
       },
     ];
-  }, [isExpanded, payload, lazyReadPath, hasReadResult]);
+  }, [isExpanded, payload, lazyReadPath, hasReadResult, diffText]);
   if (!payload?.name) return null;
   if (isContextCompactionToolCall(item)) return <ContextCompaction item={item} />;
   if (isPlanProposalToolCall(item)) return <PlanProposal item={item} />;
   const hasDetails =
-    payload.args !== undefined || payload.result !== undefined || fetchTarget !== null;
+    payload.args !== undefined ||
+    payload.result !== undefined ||
+    fetchTarget !== null ||
+    diffText !== undefined ||
+    hasReadResult;
   const display = deriveToolDisplay(payload);
   const Icon = display.Icon;
-  const status = resolveToolStatus(item, payload);
+  const status = resolveToolStatus(
+    item,
+    payload,
+    diffText ? extractAcpDiffSummary(payload) : undefined,
+  );
 
   return (
     <ChatItemAccordion
@@ -79,6 +98,12 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
         )
       ) : readResultPart && hasReadResult ? (
         <CommandOutputViewport text={readResultPart.text} language={readResultPart.language} />
+      ) : diffText !== undefined ? (
+        <InlineDiffView
+          diffText={diffText}
+          filePath={display.parts?.filePath ? display.parts.path : ""}
+          {...(contentEdit ? { oldText: contentEdit.oldText, newText: contentEdit.newText } : {})}
+        />
       ) : (
         <ToolCallSections sections={sections} />
       )}
@@ -94,7 +119,7 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
  * read-file result extractor instead.
  */
 function pickLazyReadPath(payload: ToolCallPayload | undefined): string | undefined {
-  if (!payload || payload.kind !== "read") return undefined;
+  if (!payload || !isReadLikeToolPayload(payload)) return undefined;
   if (payload.result !== undefined) return undefined;
   return payload.locations?.find((location) => location.path.length > 0)?.path;
 }
@@ -104,7 +129,11 @@ interface ToolStatusDisplay {
   rightLabelClassName: string;
 }
 
-function resolveToolStatus(item: RuntimeChatItem, payload: ToolCallPayload): ToolStatusDisplay {
+function resolveToolStatus(
+  item: RuntimeChatItem,
+  payload: ToolCallPayload,
+  diffSummary?: ReturnType<typeof extractAcpDiffSummary>,
+): ToolStatusDisplay {
   const isRunning = item.state !== "completed" || payload.status === "running";
   if (isRunning) {
     return {
@@ -118,5 +147,32 @@ function resolveToolStatus(item: RuntimeChatItem, payload: ToolCallPayload): Too
       rightLabelClassName: "text-danger",
     };
   }
+  if (diffSummary) {
+    return {
+      rightLabel: formatDiffSummaryLabel(diffSummary),
+      rightLabelClassName: "!text-[color:var(--muted)]",
+    };
+  }
   return { rightLabel: null, rightLabelClassName: "!text-[color:var(--muted)]" };
+}
+
+function isReadLikeToolPayload(payload: ToolCallPayload): boolean {
+  if (payload.kind === "read") return true;
+  if (payload.name === "Read" || payload.name === "NotebookRead") return true;
+  const title = payload.title?.trim() || payload.name.trim();
+  return /^(?:view|read)(?:ing)?(?:\s|:|$)/i.test(title);
+}
+
+function isEditLikeToolPayload(payload: ToolCallPayload): boolean {
+  switch (payload.kind) {
+    case "edit":
+    case "delete":
+    case "move":
+      return true;
+  }
+  if (["Edit", "Write", "MultiEdit", "NotebookEdit", "Patch"].includes(payload.name)) return true;
+  const title = payload.title?.trim() || payload.name.trim();
+  return /^(?:edit|editing|write|writing|patch|patching|create|creating|delete|deleting|remove|removing)(?:\s|:|$)/i.test(
+    title,
+  );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -179,6 +179,28 @@ describe("ToolCallGroup", () => {
     expect(screen.queryByText("result")).not.toBeInTheDocument();
   });
 
+  it("renders Grok structured read results as highlighted file content", async () => {
+    const threadId = "thread-1";
+    const item = makeGrokReadToolItem("tool-grok-read");
+    seedThread(threadId, [item]);
+
+    renderToolCallGroup(threadId, [item.id]);
+    fireEvent.click(screen.getByText("store.js"));
+
+    const viewport = await waitFor(() => {
+      const rich = findRichViewport();
+      if (!rich.textContent?.includes("export function subscribe")) {
+        throw new Error("read viewport not populated yet");
+      }
+      return rich;
+    });
+
+    expect(viewport.textContent).toContain("let todos = [];");
+    expect(viewport.textContent).not.toContain('"type": "ReadFile"');
+    expect(screen.queryByText("args")).not.toBeInTheDocument();
+    expect(screen.queryByText("result")).not.toBeInTheDocument();
+  });
+
   it("renders changes-array creates as highlighted file content", async () => {
     const threadId = "thread-1";
     const item = makeChangesArrayFileChangeItem("file-changes-array-create", "create");
@@ -409,6 +431,34 @@ function makeReadToolItem(id: string): RuntimeChatItem {
   };
 }
 
+function makeGrokReadToolItem(id: string): RuntimeChatItem {
+  return {
+    id,
+    type: "tool_call",
+    state: "completed",
+    payload: {
+      name: "View 1:80: store.js",
+      title: "View 1:80: store.js",
+      kind: "read",
+      args: { file_path: "/home/sdsleon/work/todo-app/js/store.js", offset: 1, limit: 80 },
+      result: {
+        type: "ReadFile",
+        content: [
+          "1: import { STORAGE_KEY } from './constants.js';",
+          "2: let todos = [];",
+          "3: export function subscribe(fn) {",
+          "4:   return () => {};",
+          "5: }",
+        ].join("\n"),
+        content_concise: "1: import { STORAGE_KEY } from './constants.js';",
+        absolute_path: "/home/sdsleon/work/todo-app/js/store.js",
+      },
+      status: "success",
+    },
+    streams: {},
+  };
+}
+
 function makeFileChangeItem(
   id: string,
   diffSummary: { added: number; removed: number } = { added: 1, removed: 1 },
@@ -533,4 +583,10 @@ function getViewport(container: HTMLElement): HTMLDivElement {
     throw new Error("missing tool call group viewport");
   }
   return element;
+}
+
+function findRichViewport(): HTMLElement {
+  const viewport = document.querySelector(".lc-shiki, pre");
+  if (!(viewport instanceof HTMLElement)) throw new Error("rich viewport not found");
+  return viewport;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -39,6 +39,7 @@ import {
   readAcpContentEditTexts,
   extractAcpResultPart,
   extractAcpResultText,
+  extractReadFileResultPart,
   readAcpStringField,
 } from "./acpToolPayload";
 import { commandIntentDisplay } from "./commandSummary";
@@ -360,13 +361,16 @@ function getToolCallRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow |
   const diffPart = isEditLikeToolPayload(payload) ? extractAcpDiffResultPart(payload) : undefined;
   const diffText = diffPart?.text || undefined;
   const lazyReadPath = pickLazyReadPath(payload);
-  const readText = payload.kind === "read" && !lazyReadPath ? extractAcpResultText(payload) : "";
-  const readPath =
-    payload.kind === "read"
-      ? display.parts?.filePath
-        ? display.parts.path
-        : pickFirstLocationPath(payload)
+  const readPart =
+    isReadLikeToolPayload(payload) && !lazyReadPath
+      ? extractReadFileResultPart(payload)
       : undefined;
+  const readText = readPart?.text ?? "";
+  const readPath = isReadLikeToolPayload(payload)
+    ? display.parts?.filePath
+      ? display.parts.path
+      : pickFirstLocationPath(payload)
+    : undefined;
   const hasDetails =
     payload.args !== undefined ||
     payload.result !== undefined ||
@@ -399,7 +403,7 @@ function getToolCallRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow |
     hasDetails,
     sections,
     bodyText: isExpanded ? (diffText ?? (readText.length > 0 ? readText : undefined)) : undefined,
-    bodyLanguage: readPath ? detectLanguageFromPath(readPath) : undefined,
+    bodyLanguage: readPart?.language ?? (readPath ? detectLanguageFromPath(readPath) : undefined),
     bodyKind: diffText ? "diff" : "text",
     bodyFilePath: display.parts?.filePath ? display.parts.path : readPath,
     fetchPath: lazyReadPath,
@@ -413,7 +417,7 @@ function getToolCallRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow |
  * the payload already contains a result — those use the existing result path.
  */
 function pickLazyReadPath(payload: ToolCallPayload): string | undefined {
-  if (payload.kind !== "read") return undefined;
+  if (!isReadLikeToolPayload(payload)) return undefined;
   if (payload.result !== undefined) return undefined;
   return payload.locations?.find((location) => location.path.length > 0)?.path;
 }
@@ -430,6 +434,15 @@ function isEditLikeToolPayload(payload: ToolCallPayload): boolean {
       return true;
   }
   return categorizeToolName(payload.name) === "edited";
+}
+
+function isReadLikeToolPayload(payload: ToolCallPayload): boolean {
+  const kind = payload.kind?.trim().toLowerCase();
+  if (kind === "read" || kind === "readfile") return true;
+  if (payload.name === "Read" || payload.name === "NotebookRead" || payload.name === "ReadFile")
+    return true;
+  const title = payload.title?.trim() || payload.name.trim();
+  return /^(?:view|read)(?:ing)?(?:\s|:|$)/i.test(title);
 }
 
 function ErrorIcon() {

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
@@ -155,6 +155,62 @@ describe("acpToolPayload", () => {
         language: "plain",
       });
     });
+
+    it("unwraps structured Grok read results", () => {
+      expect(
+        extractReadFileResultPart({
+          kind: "read",
+          result: {
+            type: "ReadFile",
+            file: {
+              path: "src/App.tsx",
+              content: "1: export function App() {\n2:   return null;\n3: }",
+            },
+          },
+        }),
+      ).toEqual({
+        text: "export function App() {\n  return null;\n}",
+        language: "tsx",
+      });
+    });
+
+    it("unwraps Grok ReadFile FileContent results", () => {
+      expect(
+        extractReadFileResultPart({
+          kind: "read",
+          result: {
+            type: "ReadFile",
+            FileContent: {
+              content: "1→prefixed content should not win",
+              content_concise: "1→prefixed content should not win",
+              absolute_path: "/home/sdsleon/work/todo-app/js/main.js",
+              raw_output: "import { FILTERS } from './constants.js';\nexport function init() {}",
+            },
+          },
+        }),
+      ).toEqual({
+        text: "import { FILTERS } from './constants.js';\nexport function init() {}",
+        language: "javascript",
+      });
+    });
+
+    it("strips Grok arrow line prefixes when raw output is absent", () => {
+      expect(
+        extractReadFileResultPart({
+          kind: "read",
+          result: {
+            type: "ReadFile",
+            FileContent: {
+              content: "1→const a = 1;\n2→const b = 2;",
+              absolute_path: "/home/sdsleon/work/todo-app/js/main.js",
+            },
+          },
+        }),
+      ).toEqual({
+        text: "const a = 1;\nconst b = 2;",
+        language: "javascript",
+      });
+    });
   });
 
   it("prefers OpenCode's metadata.changes diff over synthesizing from oldString/newString", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
@@ -80,9 +80,11 @@ export function extractAcpResultPart(payload: unknown): ExtractedPart {
  * Falls back to {@link extractAcpResultPart} for shapes we don't recognise.
  */
 export function extractReadFileResultPart(payload: unknown): ExtractedPart {
-  const base = extractAcpResultPart(payload);
+  const structured = extractStructuredReadResult(payload);
+  const base = structured ? asPart(structured.text) : extractAcpResultPart(payload);
   if (base.text.length === 0) return base;
   const pathFromPayload =
+    structured?.path ??
     readPayloadString(payload, "path") ??
     readAcpStringField(payload, "filePath") ??
     readAcpStringField(payload, "file_path") ??
@@ -95,6 +97,51 @@ export function extractReadFileResultPart(payload: unknown): ExtractedPart {
   const stripped = stripLineNumberPrefix(text);
   const language = detectLanguageFromPath(path);
   return { text: stripped, language };
+}
+
+function extractStructuredReadResult(
+  payload: unknown,
+): { path: string | undefined; text: string } | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const result = (payload as Record<string, unknown>).result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) return undefined;
+  const record = result as Record<string, unknown>;
+  const nested =
+    readNestedReadText(record.file) ??
+    readNestedReadText(record.output) ??
+    readNestedReadText(record.FileContent) ??
+    readNestedReadText(record.fileContent);
+  const text =
+    nested?.text ??
+    readString(record.content) ??
+    readString(record.text) ??
+    readString(record.tool_output_for_prompt);
+  if (text === undefined) return undefined;
+  const path =
+    nested?.path ??
+    readString(record.path) ??
+    readString(record.file_path) ??
+    readString(record.filePath) ??
+    readString(record.absolute_path) ??
+    readString(record.absolutePath);
+  return { path, text };
+}
+
+function readNestedReadText(
+  value: unknown,
+): { path: string | undefined; text: string } | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const text =
+    readString(record.raw_output) ?? readString(record.content) ?? readString(record.text);
+  if (text === undefined) return undefined;
+  const path =
+    readString(record.path) ??
+    readString(record.file_path) ??
+    readString(record.filePath) ??
+    readString(record.absolute_path) ??
+    readString(record.absolutePath);
+  return { path, text };
 }
 
 function unwrapReadFileWrapper(
@@ -121,7 +168,7 @@ function stripLineNumberPrefix(text: string): string {
   for (const line of lines) {
     const trimmed = line.trim();
     if (trimmed.length > 0) nonEmpty += 1;
-    const match = /^\s*\d+:\s?(.*)$/.exec(line);
+    const match = /^\s*\d+(?::|>|→)\s?(.*)$/.exec(line);
     if (match) {
       prefixed += 1;
       out.push(match[1] ?? "");

--- a/src/renderer/components/thread/ChatPane/parts/items/languageDetect.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/languageDetect.test.ts
@@ -7,6 +7,8 @@ describe("normalizeHighlightLanguage", () => {
     expect(normalizeHighlightLanguage("language-js")).toBe("javascript");
     expect(normalizeHighlightLanguage("lang-yml")).toBe("yaml");
     expect(normalizeHighlightLanguage("foo language-tsx")).toBe("tsx");
+    expect(normalizeHighlightLanguage("language-1:30:AGENTS.md")).toBe("markdown");
+    expect(normalizeHighlightLanguage("language-src/App.tsx")).toBe("tsx");
   });
 
   it("returns null for empty and unsupported language tokens", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/languageDetect.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/languageDetect.ts
@@ -80,8 +80,18 @@ export function normalizeHighlightLanguage(
     if (token.length === 0) continue;
     const language = LANGUAGE_ALIASES[token];
     if (language) return language;
+    const pathLanguage = inferLanguageFromFencePath(token);
+    if (pathLanguage) return pathLanguage;
   }
   return null;
+}
+
+function inferLanguageFromFencePath(token: string): HighlightLanguage | null {
+  const path = token.replace(/^\d+(?::\d+)?:/, "");
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return null;
+  const ext = path.slice(dot + 1).toLowerCase();
+  return LANGUAGE_ALIASES[ext] ?? null;
 }
 
 export function detectLanguageFromPath(path: string | undefined): ViewportLanguage {

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -9,10 +9,14 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { TuxIcon } from "@/renderer/components/common/TuxIcon";
 
 function LocationIcon(props: { kind: Project["location"]["kind"]; className?: string }) {
-  const className = `${props.className ?? "size-4"} shrink-0 text-muted`;
   if (props.kind === "wsl") {
-    return <TuxIcon className={className} />;
+    return (
+      <span className={`${props.className ?? "size-3.5"} relative shrink-0 text-muted`}>
+        <TuxIcon className="absolute left-1/2 top-1/2 h-3.5 w-6 -translate-x-1/2 -translate-y-1/2" />
+      </span>
+    );
   }
+  const className = `${props.className ?? "size-4"} shrink-0 text-muted`;
   if (props.kind === "windows") {
     return <Monitor className={className} />;
   }

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -158,6 +158,16 @@ describe("beginFirstLaunchDiscovery", () => {
     expect(state.discoveryScope).toEqual({ kind: "wsl", distro: "Ubuntu" });
     expect(state.wslLoaded).toBe(false);
   });
+
+  it("can start combined discovery after statuses are already loaded", () => {
+    useAgentStatusesStore.setState({ windowsLoaded: true, wslLoaded: true });
+    useAgentStatusesStore
+      .getState()
+      .beginFirstLaunchDiscovery({ kind: "all", wslDistros: ["Ubuntu"] });
+    const state = useAgentStatusesStore.getState();
+    expect(state.inFirstLaunchDiscovery).toBe(true);
+    expect(state.discoveryScope).toEqual({ kind: "all", wslDistros: ["Ubuntu"] });
+  });
 });
 
 describe("pushDiscoveredAgent", () => {
@@ -186,6 +196,22 @@ describe("pushDiscoveredAgent", () => {
     expect(useAgentStatusesStore.getState().discoveredAgents.map((status) => status.kind)).toEqual([
       "gemini",
     ]);
+  });
+
+  it("appends native and matching WSL agents during combined discovery", () => {
+    useAgentStatusesStore
+      .getState()
+      .beginFirstLaunchDiscovery({ kind: "all", wslDistros: ["Ubuntu"] });
+    useAgentStatusesStore.getState().pushDiscoveredAgent(makeStatus({ kind: "codex" }));
+    useAgentStatusesStore
+      .getState()
+      .pushDiscoveredAgent(makeStatus({ kind: "codex", envKind: "wsl", envDistro: "Ubuntu" }));
+    useAgentStatusesStore
+      .getState()
+      .pushDiscoveredAgent(makeStatus({ kind: "gemini", envKind: "wsl", envDistro: "Debian" }));
+    expect(
+      useAgentStatusesStore.getState().discoveredAgents.map((status) => status.envKind),
+    ).toEqual([undefined, "wsl"]);
   });
 });
 
@@ -305,5 +331,15 @@ describe("isDiscoveryActiveForLocation", () => {
         loc,
       ),
     ).toBe(false);
+  });
+
+  it("matches combined discovery to every project location", () => {
+    const loc: ProjectLocation = { kind: "windows", path: "C:\\tmp" };
+    expect(
+      isDiscoveryActiveForLocation(
+        { inFirstLaunchDiscovery: true, discoveryScope: { kind: "all", wslDistros: ["Ubuntu"] } },
+        loc,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -6,7 +6,10 @@ import {
   type ProjectLocation,
 } from "@/shared/contracts";
 
-export type AgentDiscoveryScope = { kind: "native" } | { kind: "wsl"; distro: string };
+export type AgentDiscoveryScope =
+  | { kind: "native" }
+  | { kind: "wsl"; distro: string }
+  | { kind: "all"; wslDistros: string[] };
 
 interface AgentStatusesStore {
   agentStatuses: AgentStatus[];
@@ -85,6 +88,9 @@ function isStatusInDiscoveryScope(
   status: AgentStatus,
   scope: AgentDiscoveryScope | undefined,
 ): boolean {
+  if (scope?.kind === "all") {
+    return status.envKind !== "wsl" || scope.wslDistros.includes(status.envDistro ?? "");
+  }
   if (scope?.kind === "wsl") {
     return status.envKind === "wsl" && status.envDistro === scope.distro;
   }
@@ -102,7 +108,9 @@ function buildStatusUpdatePatch(
   const equal = statusesEqual(currentList, incoming);
   const endsDiscovery =
     prev.inFirstLaunchDiscovery &&
-    (isWsl ? prev.discoveryScope?.kind === "wsl" : prev.discoveryScope?.kind !== "wsl");
+    (isWsl
+      ? prev.discoveryScope?.kind === "wsl"
+      : prev.discoveryScope?.kind === undefined || prev.discoveryScope.kind === "native");
   const discoveryPatch: Partial<AgentStatusesStore> = endsDiscovery
     ? { inFirstLaunchDiscovery: false, discoveryScope: undefined }
     : {};
@@ -165,7 +173,14 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()((set) => ({
       if (!isStatusInDiscoveryScope(status, prev.discoveryScope)) {
         return prev;
       }
-      if (prev.discoveredAgents.some((existing) => existing.kind === status.kind)) {
+      if (
+        prev.discoveredAgents.some(
+          (existing) =>
+            existing.kind === status.kind &&
+            existing.envKind === status.envKind &&
+            existing.envDistro === status.envDistro,
+        )
+      ) {
         return prev;
       }
       return { discoveredAgents: [...prev.discoveredAgents, status] };
@@ -211,6 +226,7 @@ export function isDiscoveryActiveForLocation(
   location: ProjectLocation,
 ): boolean {
   if (!state.inFirstLaunchDiscovery) return false;
+  if (state.discoveryScope?.kind === "all") return true;
   if (location.kind === "wsl") {
     return state.discoveryScope?.kind === "wsl" && state.discoveryScope.distro === location.distro;
   }

--- a/src/renderer/views/HomeView.test.tsx
+++ b/src/renderer/views/HomeView.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Project, Thread } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { HomeView } from "./HomeView";
+
+describe("HomeView", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSharedSettings.setState({ homeScopeEnabled: true });
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [makeProject()],
+      threads: [],
+      view: { kind: "home" },
+    }));
+  });
+
+  it("does not show archived threads in recent threads", () => {
+    useAppStore.setState({
+      threads: [
+        makeThread({ id: "active", title: "Keep me visible", archived: false }),
+        makeThread({ id: "archived", title: "Archived thread", archived: true }),
+      ],
+    });
+
+    render(<HomeView />);
+
+    expect(screen.getByText("Keep me visible")).toBeInTheDocument();
+    expect(screen.queryByText("Archived thread")).not.toBeInTheDocument();
+  });
+});
+
+function makeProject(): Project {
+  return {
+    id: "project-1",
+    name: "todo-app",
+    location: { kind: "windows", path: "C:\\repo" },
+    createdAt: "2026-05-26T00:00:00.000Z",
+  };
+}
+
+function makeThread(overrides: Partial<Thread>): Thread {
+  return {
+    id: "thread-1",
+    projectId: "project-1",
+    title: "Thread",
+    agentKind: "codex",
+    config: { model: "gpt-5" },
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: "2026-05-26T00:00:00.000Z",
+    updatedAt: "2026-05-26T00:00:00.000Z",
+    ...overrides,
+  };
+}

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -18,7 +18,9 @@ export function HomeView() {
   const recentThreads = useAppStore(
     useShallow((state) =>
       state.threads
-        .filter((t) => !t.done && (homeScopeEnabled || !isHomeProjectId(t.projectId)))
+        .filter(
+          (t) => !t.done && !t.archived && (homeScopeEnabled || !isHomeProjectId(t.projectId)),
+        )
         .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
         .slice(0, 8),
     ),

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -9,6 +9,7 @@ const statusesState = {
 };
 
 const resetDiscoveredAgentsMock = vi.fn<() => void>();
+const beginFirstLaunchDiscoveryMock = vi.fn<(scope?: unknown) => void>();
 const refreshAgentStatusesMock = vi.fn<(wslDistros?: string[]) => Promise<void>>();
 
 const appState = {
@@ -20,14 +21,17 @@ vi.mock("@/renderer/state/agentStatusesStore", () => {
     selector: (state: {
       agentStatuses: AgentStatus[];
       wslAgentStatuses: AgentStatus[];
+      beginFirstLaunchDiscovery: (scope?: unknown) => void;
       resetDiscoveredAgents: () => void;
     }) => unknown,
   ) =>
     selector({
       ...statusesState,
+      beginFirstLaunchDiscovery: beginFirstLaunchDiscoveryMock,
       resetDiscoveredAgents: resetDiscoveredAgentsMock,
     });
   useAgentStatusesStore.getState = () => ({
+    beginFirstLaunchDiscovery: beginFirstLaunchDiscoveryMock,
     resetDiscoveredAgents: resetDiscoveredAgentsMock,
   });
   return { useAgentStatusesStore };
@@ -90,7 +94,16 @@ vi.mock("@/renderer/bridge", () => ({
 }));
 
 vi.mock("@/renderer/components/thread/AgentDiscoveryScreen", () => ({
-  AgentDiscoveryScreen: () => <div>Discovering coding agents…</div>,
+  AgentDiscoveryScreen: (props: { onCancel?: () => void }) => (
+    <div>
+      Discovering coding agents…
+      {props.onCancel ? (
+        <button type="button" onClick={props.onCancel}>
+          Cancel
+        </button>
+      ) : null}
+    </div>
+  ),
 }));
 
 vi.mock("./parts/GeneralSettings", () => ({
@@ -162,6 +175,7 @@ describe("SettingsOverlay", () => {
     statusesState.agentStatuses = [];
     statusesState.wslAgentStatuses = [];
     appState.projects = [];
+    beginFirstLaunchDiscoveryMock.mockReset();
     resetDiscoveredAgentsMock.mockReset();
     refreshAgentStatusesMock.mockReset();
     refreshAgentStatusesMock.mockResolvedValue(undefined);
@@ -262,7 +276,11 @@ describe("SettingsOverlay", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Refresh detected agents" }));
 
-    expect(resetDiscoveredAgentsMock).toHaveBeenCalledTimes(1);
+    expect(beginFirstLaunchDiscoveryMock).toHaveBeenCalledWith({
+      kind: "all",
+      wslDistros: ["Ubuntu"],
+    });
+    expect(resetDiscoveredAgentsMock).not.toHaveBeenCalled();
     expect(refreshAgentStatusesMock).toHaveBeenCalledWith(["Ubuntu"]);
     expect(screen.getByText("Discovering coding agents…")).toBeInTheDocument();
 
@@ -274,5 +292,20 @@ describe("SettingsOverlay", () => {
       },
       { timeout: 2500 },
     );
+    expect(resetDiscoveredAgentsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the visible agent refresh overlay", () => {
+    refreshAgentStatusesMock.mockReturnValueOnce(new Promise<void>(() => undefined));
+
+    render(<SettingsOverlay onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh detected agents" }));
+    expect(screen.getByText("Discovering coding agents…")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Discovering coding agents…")).not.toBeInTheDocument();
+    expect(resetDiscoveredAgentsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { AgentDiscoveryScreen } from "@/renderer/components/thread/AgentDiscoveryScreen";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
@@ -52,6 +52,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
   const { onClose } = props;
   const [activeSection, setActiveSection] = useState<SettingsSection>("general");
   const [isRefreshingAgents, setIsRefreshingAgents] = useState(false);
+  const refreshRunRef = useRef(0);
   const agentStatuses = useAgentStatusesStore((s) => s.agentStatuses);
   const wslAgentStatuses = useAgentStatusesStore((s) => s.wslAgentStatuses);
   const wslProjectDistrosKey = useAppStore((state) => buildWslProjectDistrosKey(state.projects));
@@ -75,16 +76,28 @@ export function SettingsOverlay(props: { onClose: () => void }) {
       const firstInstalled = installedAgents[0];
       return firstInstalled ? `agents:${firstInstalled.kind}` : "agents";
     });
-    useAgentStatusesStore.getState().resetDiscoveredAgents();
+    const refreshRun = refreshRunRef.current + 1;
+    refreshRunRef.current = refreshRun;
+    useAgentStatusesStore.getState().beginFirstLaunchDiscovery({ kind: "all", wslDistros });
     setIsRefreshingAgents(true);
     void readBridge()
       .refreshAgentStatuses(wslDistros)
       .catch(() => undefined)
       .finally(() => {
         setTimeout(() => {
+          if (refreshRunRef.current !== refreshRun) {
+            return;
+          }
           setIsRefreshingAgents(false);
+          useAgentStatusesStore.getState().resetDiscoveredAgents();
         }, 1000);
       });
+  };
+
+  const cancelRefreshAgents = () => {
+    refreshRunRef.current += 1;
+    setIsRefreshingAgents(false);
+    useAgentStatusesStore.getState().resetDiscoveredAgents();
   };
 
   return (
@@ -106,7 +119,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
           {renderSection(activeSection, setActiveSection)}
           {isAgentsSectionActive && isRefreshingAgents ? (
             <div className="absolute inset-0 z-20 bg-background/90 backdrop-blur-sm">
-              <AgentDiscoveryScreen />
+              <AgentDiscoveryScreen wslDistros={wslDistros} onCancel={cancelRefreshAgents} />
             </div>
           ) : null}
         </div>

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -975,6 +975,46 @@ describe("SingleAgentSettings", () => {
     await waitFor(() => expect(focusWindowMock).toHaveBeenCalled());
   });
 
+  it("runs terminal re-login for authenticated native ACP terminal auth agents", () => {
+    const windowsProject = makeProject({
+      id: "windows-project",
+      name: "Windows Project",
+      location: { kind: "windows", path: "C:\\project" },
+    });
+    appState.projects = [windowsProject];
+    runAgentLoginCommandMock.mockReturnValue(true);
+    statusesState.agentStatuses = [
+      makeStatus("copilot", {
+        label: "GitHub Copilot",
+        authState: "authenticated",
+        loginCommand: "copilot login",
+        authMethods: [
+          {
+            type: "terminal",
+            id: "copilot-login",
+            name: "Log in with Copilot CLI",
+            args: ["login"],
+          },
+        ],
+        envKind: "windows",
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="copilot" />);
+
+    const row = envRow("Windows");
+    fireEvent.click(within(row).getByRole("button", { name: /re-login/i }));
+
+    expect(authenticateAcpAgentMock).not.toHaveBeenCalled();
+    expect(runAgentLoginCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "GitHub Copilot",
+        command: "copilot login",
+        project: windowsProject,
+      }),
+    );
+  });
+
   it("runs native ACP agent-owned auth in the selected environment", async () => {
     statusesState.agentStatuses = [
       makeStatus("gemini", {

--- a/src/supervisor/agents/acp-generic/index.test.ts
+++ b/src/supervisor/agents/acp-generic/index.test.ts
@@ -264,6 +264,34 @@ describe("createAcpGenericAdapter", () => {
     expect(status.loginCommand).toBe("my-acp --stdio login");
   });
 
+  it("treats ACP terminal-auth metadata as terminal auth", async () => {
+    vi.mocked(probeAcpCapabilities).mockResolvedValue({
+      authMethods: [
+        {
+          id: "copilot-login",
+          name: "Log in with Copilot CLI",
+          _meta: {
+            "terminal-auth": {
+              args: ["login"],
+              env: { BROWSER: "/bin/true" },
+            },
+          },
+        },
+      ],
+    });
+    const adapter = createAcpGenericAdapter(baseInstance);
+    const status = await adapter.detectInstall();
+    expect(status.authState).toBe("missing");
+    expect(status.loginCommand).toBe("my-acp --stdio login");
+    expect(status.authMethods?.[0]).toMatchObject({
+      type: "terminal",
+      id: "copilot-login",
+      name: "Log in with Copilot CLI",
+      args: ["login"],
+      env: { BROWSER: "/bin/true" },
+    });
+  });
+
   it("drops agent-owned methods that duplicate an env-var method name", async () => {
     // Some agents advertise both an agent-typed stub and the real env_var
     // method under the same display name. The stub's authenticate() just acks,

--- a/src/supervisor/agents/acp/authMethods.ts
+++ b/src/supervisor/agents/acp/authMethods.ts
@@ -24,6 +24,40 @@ export function isAcpAgentAuthMethod(method: AcpAuthMethod): method is AcpAgentA
   return !isAcpEnvVarAuthMethod(method) && !isAcpTerminalAuthMethod(method) && !hasVars(method);
 }
 
+function terminalAuthMeta(
+  method: AcpAuthMethod,
+): Pick<AcpTerminalAuthMethod, "args" | "env"> | undefined {
+  const terminalAuth = method._meta?.["terminal-auth"];
+  if (typeof terminalAuth !== "object" || terminalAuth === null) return undefined;
+  const candidate = terminalAuth as { args?: unknown; env?: unknown };
+  const args = Array.isArray(candidate.args)
+    ? candidate.args.filter((arg): arg is string => typeof arg === "string")
+    : undefined;
+  const env =
+    typeof candidate.env === "object" && candidate.env !== null && !Array.isArray(candidate.env)
+      ? Object.fromEntries(
+          Object.entries(candidate.env).filter(
+            (entry): entry is [string, string] => typeof entry[1] === "string",
+          ),
+        )
+      : undefined;
+  return {
+    ...(args?.length ? { args } : {}),
+    ...(env && Object.keys(env).length > 0 ? { env } : {}),
+  };
+}
+
+function normalizeAcpAuthMethod(method: AcpAuthMethod): AcpAuthMethod {
+  if (isAcpTerminalAuthMethod(method)) return method;
+  const terminalMeta = terminalAuthMeta(method);
+  if (!terminalMeta) return method;
+  return {
+    ...method,
+    ...terminalMeta,
+    type: "terminal",
+  };
+}
+
 function hasVars(method: AcpAuthMethod): boolean {
   return "vars" in method;
 }
@@ -40,8 +74,11 @@ function isKeyLikeAgentMethod(method: AcpAuthMethod): boolean {
  * real flow.
  */
 export function dedupeAcpAuthMethods(methods: readonly AcpAuthMethod[]): AcpAuthMethod[] {
-  const envVarNames = new Set(methods.filter(isAcpEnvVarAuthMethod).map((method) => method.name));
-  return methods.filter(
+  const normalized = methods.map(normalizeAcpAuthMethod);
+  const envVarNames = new Set(
+    normalized.filter(isAcpEnvVarAuthMethod).map((method) => method.name),
+  );
+  return normalized.filter(
     (method) =>
       (isAcpEnvVarAuthMethod(method) || !hasVars(method)) &&
       !isKeyLikeAgentMethod(method) &&

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -393,6 +393,28 @@ function looksLikeAcpSessionNotification(params: unknown): params is SessionNoti
   return typeof (p.update as { sessionUpdate?: unknown }).sessionUpdate === "string";
 }
 
+function filterAcpInboundNoise(
+  stream: ReturnType<typeof ndJsonStream>,
+): ReturnType<typeof ndJsonStream> {
+  return {
+    writable: stream.writable,
+    readable: stream.readable.pipeThrough(
+      new TransformStream({
+        transform(message, controller) {
+          if (isStraySkillsReloadResponse(message)) return;
+          controller.enqueue(message);
+        },
+      }),
+    ) as ReturnType<typeof ndJsonStream>["readable"],
+  };
+}
+
+function isStraySkillsReloadResponse(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const record = message as Record<string, unknown>;
+  return !("method" in record) && record.id === "skills-reload";
+}
+
 function childExitStatus(code: number | null, signal: NodeJS.Signals | null): TerminalExitStatus {
   return {
     ...(typeof code === "number" ? { exitCode: code } : {}),
@@ -748,7 +770,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     // tsgo's strict generics require explicit casts.
     const toAgent = Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>;
     const fromAgent = Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>;
-    const stream = ndJsonStream(toAgent, fromAgent);
+    const stream = filterAcpInboundNoise(ndJsonStream(toAgent, fromAgent));
 
     let session: AcpStructuredSession;
 
@@ -1526,11 +1548,9 @@ export class AcpStructuredSession implements StructuredSessionHandle {
    */
   private handleExtNotification(method: string, params: Record<string, unknown>): void {
     if (looksLikeAcpSessionNotification(params)) {
-      console.log("[acp] forwarding extension notification to session/update:", method);
       this.handleSessionUpdate(params as unknown as SessionNotification);
       return;
     }
-    console.log("[acp] ignoring extension notification:", method);
   }
 
   /**

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentStatus } from "@/shared/contracts";
 import { resolveLightcodePaths } from "@/shared/lightcodePaths";
+import type { AgentAdapter } from "../agents/base";
 import { detectWslAgentStatuses, SupervisorRuntime } from "../runtime";
 
 const tempDirs: string[] = [];
@@ -31,6 +32,7 @@ afterEach(() => {
   } else {
     process.env.LIGHTCODE_DATA_DIR = lightcodeDataDirBeforeTests;
   }
+  vi.useRealTimers();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -219,6 +221,20 @@ describe("agent status cache", () => {
 });
 
 describe("detectWslAgentStatuses", () => {
+  const capabilities: AgentStatus["capabilities"] = {
+    models: [],
+    efforts: [],
+    modelEfforts: {},
+    modes: [],
+    approvalPolicies: [],
+    sandboxModes: [],
+    supportsResume: true,
+    supportsDirectInput: true,
+    liveInputMode: "server",
+    presentationMode: "terminal",
+    settingDefs: [],
+  };
+
   it("detects statuses for every adapter in every distro", async () => {
     const detectInstall = vi.fn<
       (ctx?: { envKind: "windows" | "wsl"; wslDistro?: string }) => Promise<{
@@ -300,5 +316,65 @@ describe("detectWslAgentStatuses", () => {
       expect.objectContaining({ envKind: "wsl", envDistro: "Ubuntu", installed: true }),
       expect.objectContaining({ envKind: "wsl", envDistro: "Debian", installed: false }),
     ]);
+  });
+
+  it("times out a stalled WSL adapter without blocking the status batch", async () => {
+    vi.useFakeTimers();
+    const stalledDetect = vi.fn<AgentAdapter["detectInstall"]>(
+      () => new Promise<AgentStatus>(() => {}),
+    );
+    const readyDetect = vi.fn<AgentAdapter["detectInstall"]>().mockResolvedValue({
+      kind: "codex",
+      label: "Codex",
+      installed: true,
+      authState: "authenticated",
+      capabilities,
+    });
+    const onStatus = vi.fn<(status: AgentStatus) => void>();
+
+    const statusesPromise = detectWslAgentStatuses(
+      [
+        {
+          kind: "opencode",
+          label: "OpenCode",
+          capabilities,
+          detectInstall: stalledDetect,
+          buildLaunchArgv: vi.fn<AgentAdapter["buildLaunchArgv"]>(),
+          buildResumeArgv: vi.fn<AgentAdapter["buildResumeArgv"]>(),
+          createInitialSessionRef: vi.fn<AgentAdapter["createInitialSessionRef"]>(),
+        } as AgentAdapter,
+        {
+          kind: "codex",
+          label: "Codex",
+          capabilities,
+          detectInstall: readyDetect,
+          buildLaunchArgv: vi.fn<AgentAdapter["buildLaunchArgv"]>(),
+          buildResumeArgv: vi.fn<AgentAdapter["buildResumeArgv"]>(),
+          createInitialSessionRef: vi.fn<AgentAdapter["createInitialSessionRef"]>(),
+        } as AgentAdapter,
+      ],
+      ["Ubuntu"],
+      undefined,
+      onStatus,
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const statuses = await statusesPromise;
+    expect(statuses).toEqual([
+      expect.objectContaining({
+        kind: "opencode",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+        installed: false,
+      }),
+      expect.objectContaining({
+        kind: "codex",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+        installed: true,
+      }),
+    ]);
+    expect(onStatus).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -32,6 +32,7 @@ const execFileAsync = promisify(execFile);
  * on the project location (e.g. `grok login --device-auth` on WSL).
  */
 const STATUS_CACHE_VERSION = 2;
+const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
   if (definition.type === "toggle" || definition.type === "select") {
@@ -158,7 +159,22 @@ export async function detectWslAgentStatuses(
             };
           } else {
             try {
-              const detected = await adapter.detectInstall(ctx);
+              let timeout: NodeJS.Timeout | undefined;
+              const detected = await Promise.race([
+                adapter.detectInstall(ctx),
+                new Promise<never>((_, reject) => {
+                  timeout = setTimeout(() => {
+                    reject(
+                      new Error(
+                        `detectInstall(${adapter.kind}, wsl:${distro}) timed out after ${WSL_AGENT_DETECTION_TIMEOUT_MS}ms`,
+                      ),
+                    );
+                  }, WSL_AGENT_DETECTION_TIMEOUT_MS);
+                  if (typeof timeout.unref === "function") timeout.unref();
+                }),
+              ]).finally(() => {
+                if (timeout) clearTimeout(timeout);
+              });
               status = { ...detected, envKind: "wsl" as const, envDistro: distro };
             } catch (error) {
               console.error(


### PR DESCRIPTION
- Keep first-launch discovery working after statuses are already loaded, and keep WSL indicators aligned across the discovery/settings UI.
- Prevent Gemini WSL logins from auto-opening a browser, while treating ACP terminal-auth metadata as terminal auth.
- Render structured ACP/Grok read and edit results as readable file content and inline diffs, and ignore fence/path tokens when inferring code block language.
- Exclude archived threads from Home recent threads, keep WSL agent detection responsive with a timeout, and add regression coverage for the updated paths.