### PR TITLE
Preserve finished threads during stale thread cleanup

### DIFF
--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -161,11 +161,7 @@ export function sweepStaleThreads(): void {
   const staleBefore = Date.now() - staleThreadUnloadMinutes * 60_000;
 
   for (const thread of store.threads) {
-    if (
-      visibleThreadIds.has(thread.id) ||
-      (thread.status !== "idle" && thread.status !== "finished") ||
-      !thread.sessionRef
-    ) {
+    if (visibleThreadIds.has(thread.id) || thread.status !== "idle" || !thread.sessionRef) {
       continue;
     }
     const updatedAtMs = new Date(thread.updatedAt).getTime();

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -803,6 +803,27 @@ describe("App", () => {
             updatedAt: "2026-04-06T11:50:00.000Z",
           },
           {
+            id: "thread-4",
+            projectId: "project-1",
+            title: "Unchecked finished thread",
+            agentKind: "codex",
+            config: {
+              model: "gpt-5.4",
+            },
+            status: "finished",
+            attention: "none",
+            canResumeWithConfig: true,
+            archived: false,
+            done: false,
+            starred: false,
+            sessionRef: {
+              providerSessionId: "session-4",
+              discoveredAt: "2026-03-22T00:00:00.000Z",
+            },
+            createdAt: "2026-03-22T00:00:00.000Z",
+            updatedAt: "2026-04-06T11:00:00.000Z",
+          },
+          {
             id: "thread-2",
             projectId: "project-1",
             title: "Visible thread",
@@ -842,6 +863,9 @@ describe("App", () => {
     );
     expect(useAppStore.getState().threads.find((thread) => thread.id === "thread-3")?.status).toBe(
       "idle",
+    );
+    expect(useAppStore.getState().threads.find((thread) => thread.id === "thread-4")?.status).toBe(
+      "finished",
     );
   });
 


### PR DESCRIPTION
- Tickets: None
- Fixes a bug where threads with `status: "finished"` could still be swept out if stale, by preserving completed sessions during cleanup in `src/renderer/actions/threadActions.ts`.
- Keeps the stale-sweep behavior constrained to unload only idle threads with active session refs, while still protecting visible threads from removal in the same path.
- Adds regression coverage in `src/renderer/app.test.tsx` to validate a finished thread remains `finished` and is not incorrectly removed.