### PR TITLE
Fix GitHub PR selection and worktree PR badge visibility

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -47,8 +47,10 @@ export function GitBadge(props: {
     }),
   );
   const hasChanges = totalInsertions > 0 || totalDeletions > 0;
-  const hasOpenPr = prState !== undefined && prState !== "closed" && prState !== "merged";
-  if (!isRepo || (!hasChanges && !hasOpenPr)) return null;
+  const isWorktree = props.worktreePath !== undefined;
+  const hasVisiblePr =
+    prState !== undefined && prState !== "closed" && (prState !== "merged" || isWorktree);
+  if (!isRepo || (!hasChanges && !hasVisiblePr)) return null;
   const prIconColor = PR_TONE_TEXT_CLASS[getPrStatusTone(prState, checksStatus)];
   return (
     <div
@@ -66,7 +68,7 @@ export function GitBadge(props: {
       onKeyDown={(e) => handleKeyActivate(e, () => props.onPress?.(), { stopPropagation: true })}
     >
       <span className="flex items-center gap-1 text-[10px] font-medium">
-        {hasOpenPr && <GitPullRequest className={`size-3 ${prIconColor}`} />}
+        {hasVisiblePr && <GitPullRequest className={`size-3 ${prIconColor}`} />}
         {hasChanges && (
           <span className="flex items-center gap-0.5">
             {totalInsertions > 0 && <span className="text-success">+{totalInsertions}</span>}

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -114,6 +114,35 @@ describe("GitHubService", () => {
       });
     });
 
+    it("returns the latest PR when multiple PRs match a branch", async () => {
+      const prJson = JSON.stringify([
+        {
+          number: 42,
+          url: "https://github.com/owner/repo/pull/42",
+          state: "MERGED",
+          title: "Old PR",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-03T10:00:00Z",
+        },
+        {
+          number: 45,
+          url: "https://github.com/owner/repo/pull/45",
+          state: "CLOSED",
+          title: "Latest PR",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-02T10:00:00Z",
+        },
+      ]);
+      execFileAsyncMock.mockResolvedValue({ stdout: prJson });
+
+      const result = await new GitHubService().getPrForBranch(location, "feature/x");
+
+      expect(result?.number).toBe(45);
+      expect(result?.state).toBe("closed");
+    });
+
     it("returns null when no PRs match", async () => {
       execFileAsyncMock.mockResolvedValue({ stdout: "[]" });
 
@@ -539,6 +568,15 @@ describe("GitHubService", () => {
       const jsonIdx = ghArgs.indexOf("--json");
       expect(jsonIdx).toBeGreaterThan(-1);
       expect(ghArgs[jsonIdx + 1]).toContain("statusCheckRollup");
+    });
+
+    it("fetches enough branch PRs to choose the latest one locally", async () => {
+      execFileAsyncMock.mockResolvedValue({ stdout: "[]" });
+
+      await new GitHubService().getPrForBranch(location, "feature/x");
+
+      const ghArgs = buildAgentCommandMock.mock.calls[0]![2] as string[];
+      expect(ghArgs).toContain("20");
     });
   });
 

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -33,6 +33,16 @@ const CREATE_PR_STATUS_POLL_MS = 1_000;
 const PR_VIEW_FIELDS =
   "number,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus,author";
 
+function selectLatestPr(items: unknown[]): Record<string, unknown> | null {
+  return items.reduce<Record<string, unknown> | null>((latest, item) => {
+    if (!item || typeof item !== "object") return latest;
+    const pr = item as Record<string, unknown>;
+    const number = typeof pr.number === "number" ? pr.number : 0;
+    const latestNumber = typeof latest?.number === "number" ? latest.number : 0;
+    return number > latestNumber ? pr : latest;
+  }, null);
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -437,7 +447,7 @@ export class GitHubService {
       "--state",
       "all",
       "--limit",
-      "1",
+      "20",
       "--json",
       PR_VIEW_FIELDS,
     ];
@@ -469,7 +479,8 @@ export class GitHubService {
         }
         const items = JSON.parse(prResult.stdout);
         if (!Array.isArray(items) || items.length === 0) return null;
-        return mapPrData(items[0], viewerLogin);
+        const latest = selectLatestPr(items);
+        return latest ? mapPrData(latest, viewerLogin) : null;
       } catch (err) {
         throw classifyError(err, "pr list");
       }
@@ -483,7 +494,8 @@ export class GitHubService {
       ]);
       const items = JSON.parse(stdout);
       if (!Array.isArray(items) || items.length === 0) return null;
-      return mapPrData(items[0], viewerLogin);
+      const latest = selectLatestPr(items);
+      return latest ? mapPrData(latest, viewerLogin) : null;
     } catch (err) {
       if (isRepoNotFoundError(err)) return null;
       throw classifyError(err, "pr list");


### PR DESCRIPTION
- Tickets: None
- Ensures branch PR lookup uses the latest matching PR, avoiding stale or outdated PRs being shown for active worktree branches.
- Expands PR query scope so branch lookup can consistently return the correct latest PR when multiple PRs exist.
- Keeps PR badges visible for worktrees in relevant merged/closed states while preserving normal non-worktree behavior.
- Adds focused tests in `src/supervisor/github.test.ts` to lock in latest-PR selection and fetch-limit behavior.