### PR TITLE
Add thread rollback with provider recovery and watcher resubscribe

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -673,6 +673,24 @@ describe("ChatPane", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("copies user message text from the inline action", async () => {
+    const thread = makeThread();
+    seedUserMessage(thread.id, "Copy this prompt");
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    expect(writeText).toHaveBeenCalledWith("Copy this prompt");
+    await screen.findByRole("button", { name: "Copied" });
+  });
+
   it("updates user message collapse state when resize changes visual overflow", async () => {
     const thread = makeThread();
     seedUserMessage(thread.id, "Resize can wrap this prompt into more visual rows.");
@@ -868,8 +886,53 @@ describe("ChatPane", () => {
     expect(text.indexOf("Worked for 1m 15s")).toBeLessThan(text.indexOf("Follow-up prompt"));
   });
 
+  it("waits for a base file checkpoint before finalizing a completed turn", async () => {
+    const thread = { ...makeThread(), status: "idle" as const };
+    useAppStore.setState({ projects: [project] });
+    seedUserMessage(thread.id, "Initial prompt", "user-1");
+    seedAssistantMessage(thread.id, "First answer", "assistant-1");
+    useAppStore.getState().hydrateThreadCompletedTurns(thread.id, [
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:00:05.000Z").getTime(),
+        anchorItemId: "assistant-1",
+      },
+    ]);
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    expect(finalizeFileCheckpoint).not.toHaveBeenCalled();
+
+    act(() => {
+      useAppStore.getState().upsertThreadFileCheckpoint(thread.id, {
+        threadId: thread.id,
+        checkpointItemId: "user-1",
+        ref: "refs/lightcode/checkpoints/thread/user-1",
+        commit: "abc123",
+        capturedAt: "2026-05-01T12:00:00.000Z",
+      });
+    });
+
+    await waitFor(() =>
+      expect(finalizeFileCheckpoint).toHaveBeenCalledWith({
+        threadId: thread.id,
+        checkpointItemId: "assistant-1",
+        baseCheckpointItemId: "user-1",
+        projectLocation: project.location,
+      }),
+    );
+  });
+
   it("shows checkpoint buttons on later user messages and reverts to before that prompt", async () => {
     const thread = { ...makeThread(), status: "idle" as const };
+    const rollbackThreadConversation = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    Object.assign(window, {
+      lightcode: {
+        rollbackThreadConversation,
+        setWindowChrome: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      },
+    });
     seedUserMessage(thread.id, "Initial prompt", "user-1");
     seedAssistantMessage(thread.id, "First answer", "assistant-1");
     seedUserMessage(thread.id, "Follow-up prompt", "user-2");
@@ -884,13 +947,90 @@ describe("ChatPane", () => {
 
     fireEvent.click(buttons[0]!);
     expect(await screen.findByText("Revert to checkpoint?")).toBeInTheDocument();
-    expect(screen.getByText(/Workspace files are not changed/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/restores files when a checkpoint snapshot is available/),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Revert" }));
 
+    await waitFor(() =>
+      expect(rollbackThreadConversation).toHaveBeenCalledWith({
+        threadId: thread.id,
+        numTurns: 1,
+      }),
+    );
     await waitFor(() => expect(screen.queryByText("Follow-up prompt")).not.toBeInTheDocument());
     expect(screen.getByText("Initial prompt")).toBeInTheDocument();
     expect(screen.getByText("First answer")).toBeInTheDocument();
+    expect(screen.queryByText("Second answer")).not.toBeInTheDocument();
+  });
+
+  it("rolls back provider by completed turns instead of assistant message count", async () => {
+    const thread = { ...makeThread(), status: "idle" as const };
+    const rollbackThreadConversation = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    Object.assign(window, {
+      lightcode: {
+        rollbackThreadConversation,
+        setWindowChrome: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      },
+    });
+    seedUserMessage(thread.id, "Initial prompt", "user-1");
+    seedAssistantMessage(thread.id, "First answer", "assistant-1");
+    seedUserMessage(thread.id, "Follow-up prompt", "user-2");
+    seedAssistantMessage(thread.id, "Second answer part one", "assistant-2a");
+    seedAssistantMessage(thread.id, "Second answer part two", "assistant-2b");
+    useAppStore.getState().hydrateThreadCompletedTurns(thread.id, [
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:00:05.000Z").getTime(),
+        anchorItemId: "assistant-1",
+      },
+      {
+        startedAt: new Date("2026-05-01T12:01:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:01:05.000Z").getTime(),
+        anchorItemId: "assistant-2b",
+      },
+    ]);
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    fireEvent.click(screen.getByRole("button", { name: "Revert to this checkpoint" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Revert" }));
+
+    await waitFor(() =>
+      expect(rollbackThreadConversation).toHaveBeenCalledWith({
+        threadId: thread.id,
+        numTurns: 1,
+      }),
+    );
+  });
+
+  it("continues local checkpoint revert when provider rollback fails", async () => {
+    const thread = { ...makeThread(), status: "idle" as const };
+    Object.assign(window, {
+      lightcode: {
+        rollbackThreadConversation: vi
+          .fn<() => Promise<void>>()
+          .mockRejectedValue(new Error("Codex does not support checkpoint rollback.")),
+        setWindowChrome: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      },
+    });
+    seedUserMessage(thread.id, "Initial prompt", "user-1");
+    seedAssistantMessage(thread.id, "First answer", "assistant-1");
+    seedUserMessage(thread.id, "Follow-up prompt", "user-2");
+    seedAssistantMessage(thread.id, "Second answer", "assistant-2");
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    fireEvent.click(screen.getByRole("button", { name: "Revert to this checkpoint" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(screen.queryByText("Follow-up prompt")).not.toBeInTheDocument());
+    expect(
+      screen.queryByText("Codex does not support checkpoint rollback."),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Second answer")).not.toBeInTheDocument();
   });
 
@@ -912,8 +1052,9 @@ describe("ChatPane", () => {
 
     fireEvent.click(screen.getAllByRole("button", { name: "Revert to this checkpoint" })[0]!);
 
-    expect(await screen.findByText("Chat only")).toBeInTheDocument();
-    expect(screen.getByText("Chat and files")).toBeInTheDocument();
+    expect(await screen.findByText("Revert to checkpoint?")).toBeInTheDocument();
+    expect(screen.queryByText("Chat only")).not.toBeInTheDocument();
+    expect(screen.queryByText("Chat and files")).not.toBeInTheDocument();
     expect(screen.getByText(/No file checkpoint is stored/)).toBeInTheDocument();
     expect(screen.getByText(/Another chat uses this same tree/)).toBeInTheDocument();
   });

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -58,6 +58,9 @@ const EMPTY_ITEM_IDS: readonly string[] = [];
 const EMPTY_FILE_CHECKPOINT_TURNS: NonNullable<
   ReturnType<typeof useAppStore.getState>["fileCheckpointTurnsByThread"][string]
 > = {};
+const EMPTY_FILE_CHECKPOINTS: NonNullable<
+  ReturnType<typeof useAppStore.getState>["fileCheckpointsByThread"][string]
+> = {};
 
 /**
  * Renderer-native chat surface for `presentationMode === "gui"` threads.
@@ -163,6 +166,9 @@ export function ChatPane(props: ChatPaneProps) {
   const fileCheckpointTurns = useAppStore(
     (s) => s.fileCheckpointTurnsByThread[threadId] ?? EMPTY_FILE_CHECKPOINT_TURNS,
   );
+  const fileCheckpoints = useAppStore(
+    (s) => s.fileCheckpointsByThread[threadId] ?? EMPTY_FILE_CHECKPOINTS,
+  );
   const finalizingFileCheckpointIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
@@ -181,6 +187,7 @@ export function ChatPane(props: ChatPaneProps) {
         checkpointItemId,
       );
       if (!baseCheckpointItemId) continue;
+      if (!fileCheckpoints[baseCheckpointItemId]) continue;
       finalizingFileCheckpointIdsRef.current.add(checkpointItemId);
       void finalizeFileCheckpoint({
         threadId,
@@ -191,7 +198,7 @@ export function ChatPane(props: ChatPaneProps) {
         finalizingFileCheckpointIdsRef.current.delete(checkpointItemId);
       });
     }
-  }, [completedTurns, fileCheckpointTurns, isHomeScope, targetContext, threadId]);
+  }, [completedTurns, fileCheckpoints, fileCheckpointTurns, isHomeScope, targetContext, threadId]);
 
   const isEmpty = timelineEntries.length === 0 && !hasSupplementaryContent;
   const isLive = isThreadTurnActive(status);

--- a/src/renderer/components/thread/ChatPane/parts/CheckpointRevertControls.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/CheckpointRevertControls.tsx
@@ -1,14 +1,5 @@
-import {
-  AlertDialog,
-  Checkbox,
-  Description,
-  Label,
-  Radio,
-  RadioGroup,
-  Tooltip,
-} from "@heroui/react";
+import { AlertDialog, Checkbox, Tooltip } from "@heroui/react";
 import { RotateCcw } from "lucide-react";
-import type { FileCheckpointRecord } from "@/shared/contracts";
 import { Button } from "@/renderer/components/common/Button";
 
 export interface CheckpointGuard {
@@ -16,8 +7,6 @@ export interface CheckpointGuard {
   hasSharedTree: boolean;
   sharedThreadCount: number;
 }
-
-export type RevertScope = "transcript" | "files";
 
 export const DEFAULT_CHECKPOINT_GUARD: CheckpointGuard = {
   scopeLabel: "this tree",
@@ -31,20 +20,20 @@ export function CheckpointRevertButton(props: {
 }) {
   return (
     <Tooltip delay={300}>
-      <Tooltip.Trigger className="absolute right-2 top-2 z-10 opacity-0 transition-opacity group-hover/checkpoint:opacity-100 focus-within:opacity-100">
+      <Tooltip.Trigger>
         <button
           type="button"
           aria-label="Revert to this checkpoint"
-          className="flex size-6 items-center justify-center rounded text-muted/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
+          className="flex size-5 items-center justify-center rounded text-muted/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
           onClick={(event) => {
             event.stopPropagation();
             props.onRequestRevert(props.itemId);
           }}
         >
-          <RotateCcw className="size-3.5" />
+          <RotateCcw className="size-3" />
         </button>
       </Tooltip.Trigger>
-      <Tooltip.Content placement="left">Revert to this checkpoint</Tooltip.Content>
+      <Tooltip.Content placement="top">Revert to this checkpoint</Tooltip.Content>
     </Tooltip>
   );
 }
@@ -52,16 +41,13 @@ export function CheckpointRevertButton(props: {
 export function RevertCheckpointDialog(props: {
   isOpen: boolean;
   dontAskAgain: boolean;
-  revertScope: RevertScope;
   checkpointGuard: CheckpointGuard;
-  fileCheckpoint?: FileCheckpointRecord | undefined;
   canRestoreFiles: boolean;
+  errorMessage?: string | undefined;
   onDontAskAgainChange: (value: boolean) => void;
-  onRevertScopeChange: (value: RevertScope) => void;
   onClose: () => void;
   onConfirm: () => void;
 }) {
-  const filesDisabled = !props.canRestoreFiles;
   return (
     <AlertDialog.Backdrop isOpen={props.isOpen} onOpenChange={(open) => !open && props.onClose()}>
       <AlertDialog.Container size="sm">
@@ -69,50 +55,26 @@ export function RevertCheckpointDialog(props: {
           <AlertDialog.Header className="gap-1">
             <AlertDialog.Heading>Revert to checkpoint?</AlertDialog.Heading>
             <p className="text-sm leading-5 text-muted">
-              Choose what to revert for this checkpoint.
+              This removes later messages and restores files when a checkpoint snapshot is
+              available.
             </p>
           </AlertDialog.Header>
           <AlertDialog.Body>
-            <RadioGroup
-              aria-label="Revert scope"
-              className="gap-1.5"
-              value={props.revertScope}
-              onChange={(value) => props.onRevertScopeChange(value as RevertScope)}
-            >
-              <Radio value="transcript" className="items-start rounded-lg px-2 py-1.5">
-                <Radio.Control className="mt-0.5">
-                  <Radio.Indicator />
-                </Radio.Control>
-                <Radio.Content>
-                  <Label className="text-sm font-medium">Chat only</Label>
-                  <Description className="text-xs text-muted">
-                    Remove later messages from this chat. Workspace files are not changed.
-                  </Description>
-                </Radio.Content>
-              </Radio>
-              <Radio
-                value="files"
-                className="items-start rounded-lg px-2 py-1.5"
-                isDisabled={filesDisabled}
-              >
-                <Radio.Control className="mt-0.5">
-                  <Radio.Indicator />
-                </Radio.Control>
-                <Radio.Content>
-                  <Label className="text-sm font-medium">Chat and files</Label>
-                  <Description className="text-xs text-muted">
-                    {props.fileCheckpoint
-                      ? `Restore ${props.checkpointGuard.scopeLabel} to this checkpoint snapshot.`
-                      : "No file checkpoint is stored for this message."}
-                  </Description>
-                </Radio.Content>
-              </Radio>
-            </RadioGroup>
+            {!props.canRestoreFiles ? (
+              <div className="rounded-lg border border-border bg-surface-container/70 px-2.5 py-2 text-xs leading-5 text-muted">
+                No file checkpoint is stored for this message.
+              </div>
+            ) : null}
             {props.checkpointGuard.hasSharedTree ? (
               <div className="mt-2 rounded-lg border border-warning-soft-foreground/20 bg-warning-soft/60 px-2.5 py-2 text-xs leading-5 text-warning-soft-foreground">
                 {props.checkpointGuard.sharedThreadCount === 1
                   ? "Another chat uses this same tree. File restore could overwrite that chat's changes."
                   : `${props.checkpointGuard.sharedThreadCount} other chats use this same tree. File restore could overwrite their changes.`}
+              </div>
+            ) : null}
+            {props.errorMessage ? (
+              <div className="mt-2 rounded-lg border border-danger-soft-foreground/20 bg-danger-soft/60 px-2.5 py-2 text-xs leading-5 text-danger-soft-foreground">
+                {props.errorMessage}
               </div>
             ) : null}
             <div className="mt-2">

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -11,7 +11,6 @@ import {
   DEFAULT_CHECKPOINT_GUARD,
   RevertCheckpointDialog,
   type CheckpointGuard,
-  type RevertScope,
 } from "./CheckpointRevertControls";
 import { formatElapsed } from "../formatElapsed";
 import {
@@ -71,7 +70,7 @@ export function MessageList({
   const [measureEpoch, setMeasureEpoch] = useState(0);
   const [pendingRevertItemId, setPendingRevertItemId] = useState<string | null>(null);
   const [dontAskAgain, setDontAskAgain] = useState(false);
-  const [revertScope, setRevertScope] = useState<RevertScope>("transcript");
+  const [revertError, setRevertError] = useState<string | null>(null);
   const virtualizer = useVirtualizer({
     count: entries.length,
     getScrollElement: useCallback(() => scrollElement, [scrollElement]),
@@ -192,15 +191,37 @@ export function MessageList({
   );
 
   const performRevert = useCallback(
-    async (itemId: string, scope: RevertScope) => {
-      if (scope === "files" && projectLocation) {
+    async (itemId: string) => {
+      const state = useAppStore.getState();
+      const itemIds = state.runtimeItemIdsByThread[threadId];
+      const itemsById = state.runtimeItemsByIdByThread[threadId];
+      const completedTurns = state.runtimeCompletedTurnsByThread[threadId] ?? [];
+      const checkpoint = state.fileCheckpointsByThread[threadId]?.[itemId];
+      const rollbackTurns =
+        itemIds && itemsById
+          ? countRollbackTurnsAfterCheckpoint(itemIds, itemsById, completedTurns, itemId)
+          : 0;
+      if (rollbackTurns > 0) {
+        try {
+          await readBridge().rollbackThreadConversation({
+            threadId,
+            numTurns: rollbackTurns,
+          });
+        } catch (error) {
+          console.warn(
+            "[checkpoint] provider rollback failed; continuing with local revert",
+            error,
+          );
+        }
+      }
+      if (projectLocation && checkpoint) {
         await readBridge().restoreFileCheckpoint({
           threadId,
           checkpointItemId: itemId,
           projectLocation,
         });
       }
-      useAppStore.getState().truncateThreadRuntimeAfter(threadId, itemId);
+      state.truncateThreadRuntimeAfter(threadId, itemId);
       parentActions?.onContentHeightChange();
     },
     [parentActions, projectLocation, threadId],
@@ -209,11 +230,13 @@ export function MessageList({
   const requestRevert = useCallback(
     (itemId: string) => {
       if (localStorage.getItem(SKIP_REVERT_CONFIRM_PREF_KEY) === "1") {
-        void performRevert(itemId, "transcript");
+        void performRevert(itemId).catch((error) => {
+          console.warn("[checkpoint] failed to revert checkpoint", error);
+        });
         return;
       }
       setDontAskAgain(false);
-      setRevertScope("transcript");
+      setRevertError(null);
       setPendingRevertItemId(itemId);
     },
     [performRevert],
@@ -221,14 +244,20 @@ export function MessageList({
 
   const confirmRevert = useCallback(() => {
     if (!pendingRevertItemId) return;
-    if (dontAskAgain) {
-      localStorage.setItem(SKIP_REVERT_CONFIRM_PREF_KEY, "1");
-    }
-    void performRevert(pendingRevertItemId, revertScope);
-    setPendingRevertItemId(null);
-    setDontAskAgain(false);
-    setRevertScope("transcript");
-  }, [dontAskAgain, pendingRevertItemId, performRevert, revertScope]);
+    setRevertError(null);
+    void performRevert(pendingRevertItemId)
+      .then(() => {
+        if (dontAskAgain) {
+          localStorage.setItem(SKIP_REVERT_CONFIRM_PREF_KEY, "1");
+        }
+        setPendingRevertItemId(null);
+        setDontAskAgain(false);
+      })
+      .catch((error) => {
+        console.warn("[checkpoint] failed to revert checkpoint", error);
+        setRevertError(error instanceof Error ? error.message : String(error));
+      });
+  }, [dontAskAgain, pendingRevertItemId, performRevert]);
 
   const pendingCheckpoint = useAppStore((state) =>
     pendingRevertItemId
@@ -301,16 +330,14 @@ export function MessageList({
       <RevertCheckpointDialog
         isOpen={pendingRevertItemId !== null}
         dontAskAgain={dontAskAgain}
-        revertScope={revertScope}
         checkpointGuard={checkpointGuard ?? DEFAULT_CHECKPOINT_GUARD}
-        fileCheckpoint={pendingCheckpoint}
         canRestoreFiles={projectLocation !== undefined && pendingCheckpoint !== undefined}
+        errorMessage={revertError ?? undefined}
         onDontAskAgainChange={setDontAskAgain}
-        onRevertScopeChange={setRevertScope}
         onClose={() => {
           setPendingRevertItemId(null);
           setDontAskAgain(false);
-          setRevertScope("transcript");
+          setRevertError(null);
         }}
         onConfirm={confirmRevert}
       />
@@ -528,4 +555,30 @@ function findCheckpointBeforeUserMessage(
   }
 
   return null;
+}
+
+function countRollbackTurnsAfterCheckpoint(
+  itemIds: readonly string[],
+  itemsById: ReturnType<typeof useAppStore.getState>["runtimeItemsByIdByThread"][string],
+  completedTurns: ReadonlyArray<CompletedTurnRecord>,
+  checkpointItemId: string,
+): number {
+  const checkpointIndex = itemIds.indexOf(checkpointItemId);
+  if (checkpointIndex < 0) return 0;
+
+  if (completedTurns.length > 0) {
+    let count = 0;
+    for (const turn of completedTurns) {
+      if (!turn.anchorItemId) continue;
+      if (itemIds.indexOf(turn.anchorItemId) > checkpointIndex) count += 1;
+    }
+    return count;
+  }
+
+  let count = 0;
+  for (let idx = checkpointIndex + 1; idx < itemIds.length; idx += 1) {
+    const itemId = itemIds[idx]!;
+    if (itemsById[itemId]?.type === "assistant_message") count += 1;
+  }
+  return count;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
@@ -55,7 +55,11 @@ export function QuestionAnswer({ item, checkpointRevertControl }: QuestionAnswer
           </div>
         ))}
       </div>
-      {checkpointRevertControl}
+      {checkpointRevertControl ? (
+        <div className="absolute right-2 top-1/2 z-10 -translate-y-1/2 opacity-0 transition-opacity group-hover/checkpoint:opacity-100 focus-within:opacity-100">
+          {checkpointRevertControl}
+        </div>
+      ) : null}
     </Surface>
   );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactNode, useEffectEvent, useLayoutEffect, useRef, useState } from "react";
 import { Surface, Tooltip } from "@heroui/react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, Copy } from "lucide-react";
 import type { CanonicalContentBlock, MessageItemPayload } from "@/shared/contracts";
 import { AttachmentBar, ImageLightbox, type Attachment } from "@/renderer/components/composer";
 import { fileNameFromPath } from "@/shared/promptContent";
@@ -88,7 +88,7 @@ export const UserMessage = memo(function UserMessage({
     : isCollapsible
       ? "max-h-[50vh] overflow-y-auto"
       : "";
-  const baseBodyClass = `min-w-0 leading-snug ${checkpointRevertControl ? "pr-7" : ""} ${collapseClass}`;
+  const baseBodyClass = `min-w-0 leading-snug ${checkpointRevertControl ? "pr-12" : "pr-7"} ${collapseClass}`;
   const inlineBodyClass = `${baseBodyClass} lightcode-user-message-inline-content whitespace-pre-wrap break-words text-[length:var(--lc-chat-font-size)] text-foreground`;
 
   let bodyContent: ReactNode = null;
@@ -151,7 +151,10 @@ export const UserMessage = memo(function UserMessage({
           </Tooltip>
         </>
       ) : null}
-      {checkpointRevertControl}
+      <div className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-hover/checkpoint:opacity-100 focus-within:opacity-100">
+        {checkpointRevertControl}
+        <CopyUserMessageButton text={rawText} />
+      </div>
       {lightboxIndex !== null ? (
         <ImageLightbox
           images={imageAttachments}
@@ -162,6 +165,62 @@ export const UserMessage = memo(function UserMessage({
     </Surface>
   );
 });
+
+function CopyUserMessageButton({ text }: { text: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
+  const labelResetTimerRef = useRef<number | null>(null);
+
+  useLayoutEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
+      if (labelResetTimerRef.current !== null) window.clearTimeout(labelResetTimerRef.current);
+    },
+    [],
+  );
+
+  return (
+    <Tooltip delay={300} isOpen={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          aria-label={copyState === "copied" ? "Copied" : "Copy message"}
+          className="flex size-5 items-center justify-center rounded text-muted/70 transition-colors hover:bg-foreground/5 hover:text-foreground"
+          onClick={(event) => {
+            event.stopPropagation();
+            navigator.clipboard
+              .writeText(text)
+              .then(() => {
+                setCopyState("copied");
+                setIsTooltipOpen(true);
+                if (resetTimerRef.current !== null) {
+                  window.clearTimeout(resetTimerRef.current);
+                }
+                if (labelResetTimerRef.current !== null) {
+                  window.clearTimeout(labelResetTimerRef.current);
+                }
+                resetTimerRef.current = window.setTimeout(() => {
+                  setIsTooltipOpen(false);
+                  resetTimerRef.current = null;
+                  labelResetTimerRef.current = window.setTimeout(() => {
+                    setCopyState("idle");
+                    labelResetTimerRef.current = null;
+                  }, 200);
+                }, 1200);
+              })
+              .catch(() => {});
+          }}
+        >
+          <Copy className="size-3" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content placement="top">
+        {copyState === "copied" ? "Copied" : "Copy message"}
+      </Tooltip.Content>
+    </Tooltip>
+  );
+}
 
 const LEADING_SLASH_COMMAND_RE = /^\/([A-Za-z][A-Za-z0-9_-]*)(\s+|$)/;
 

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ThreadConfig, ThreadServerRequestId } from "@/shared/contracts";
+import type { Thread, ThreadConfig, ThreadServerRequestId } from "@/shared/contracts";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { ThreadView } from "./ThreadView";
 
-const { bridge } = vi.hoisted(() => ({
+const { bridge, captureFileCheckpoint } = vi.hoisted(() => ({
   bridge: {
     startThread: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     interruptThread: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
@@ -18,12 +18,21 @@ const { bridge } = vi.hoisted(() => ({
       .fn<() => Promise<{ entries: unknown[]; totalIndexed: number }>>()
       .mockResolvedValue({ entries: [], totalIndexed: 0 }),
     dbGetThreadRuntimeItems: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+    dbGetThreadCompletedTurns: vi.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+    dbGetThreadContextUsage: vi.fn<() => Promise<unknown | null>>().mockResolvedValue(null),
   },
+  captureFileCheckpoint: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../bridge", () => ({
   readBridge: () => bridge,
   isDevApp: () => false,
+}));
+
+vi.mock("@/renderer/state/fileCheckpointActions", () => ({
+  captureFileCheckpoint,
+  hydrateFileCheckpoints: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  finalizeFileCheckpoint: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }));
 
 vi.mock("./TerminalPane", () => ({
@@ -262,6 +271,79 @@ describe("ThreadView", () => {
         },
       });
     });
+  });
+
+  it("renders a GUI launch prompt and marks working before awaiting the file checkpoint", async () => {
+    let resolveCapture!: () => void;
+    captureFileCheckpoint.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveCapture = resolve;
+      }),
+    );
+    const thread: Thread = {
+      id: "thread-gui-launch",
+      projectId: "project-1",
+      title: "Queued chat thread",
+      agentKind: "codex",
+      config: {
+        model: "gpt-5.4",
+      },
+      status: "launching",
+      attention: "none",
+      canResumeWithConfig: false,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "gui",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    useAppStore.setState({ threads: [thread] });
+
+    renderThreadView({
+      thread,
+      agentStatus: {
+        kind: "codex",
+        label: "Codex",
+        installed: true,
+        authState: "authenticated",
+        capabilities: {
+          models: [{ id: "gpt-5.4", label: "5.4" }],
+          efforts: ["low"],
+          modelEfforts: {},
+          modes: ["agent"],
+          approvalPolicies: [{ id: "on-request", label: "On Request" }],
+          sandboxModes: [{ id: "read-only", label: "Read Only" }],
+          supportsResume: true,
+          supportsDirectInput: true,
+          liveInputMode: "server",
+          presentationMode: "gui",
+          settingDefs: [],
+        },
+      },
+      projectLocation: {
+        kind: "windows",
+        path: "C:\\repo",
+      },
+      pendingLaunchPrompt: "hi",
+      onConfigChange: () => undefined,
+      onLaunchConsumed: () => undefined,
+      onResolveServerRequest: async () => undefined,
+      onSubmitInput: async () => undefined,
+    });
+
+    await waitFor(() => expect(captureFileCheckpoint).toHaveBeenCalled());
+
+    const optimisticItemId = useAppStore.getState().runtimeItemIdsByThread[thread.id]?.[0];
+    expect(optimisticItemId).toEqual(expect.stringMatching(/^user-/));
+    expect(useAppStore.getState().threads.find((item) => item.id === thread.id)?.status).toBe(
+      "working",
+    );
+    expect(bridge.startThread).not.toHaveBeenCalled();
+
+    resolveCapture();
+
+    await waitFor(() => expect(bridge.startThread).toHaveBeenCalled());
   });
 
   it("forwards launch rejection messages to the launch failure callback", async () => {

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -275,11 +275,17 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         threadId: thread.id,
         itemId: optimisticUserMessageItemId,
       });
+      useAppStore.getState().updateThreadRuntime(thread.id, {
+        status: "working",
+        attention: "working",
+        canResumeWithConfig: thread.canResumeWithConfig,
+        ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
+      });
     }
 
     void (async () => {
       if (optimisticUserMessageItemId && !isHomeProjectId(thread.projectId)) {
-        void captureFileCheckpoint({
+        await captureFileCheckpoint({
           threadId: thread.id,
           checkpointItemId: optimisticUserMessageItemId,
           projectLocation,
@@ -321,6 +327,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     launchTerminalSize,
     thread.agentKind,
     thread.agentInstanceId,
+    thread.canResumeWithConfig,
     thread.config,
     thread.id,
     thread.presentationMode,

--- a/src/renderer/hooks/useGitRefresh.ts
+++ b/src/renderer/hooks/useGitRefresh.ts
@@ -11,6 +11,8 @@ import {
   GIT_FETCH_BACKGROUND_INTERVAL_MS,
 } from "@/renderer/utils/gitHelpers";
 
+const WSL_STATUS_POLL_INTERVAL_MS = 3_000;
+
 export function useGitRefresh(storeHydrated: boolean) {
   // Subscribe only to the active-project identity/location key so draft config
   // writes do not invalidate the whole shell.
@@ -148,6 +150,17 @@ export function useGitRefresh(storeHydrated: boolean) {
       );
     }
 
+    function pollPriorityWslStatus() {
+      if (!isActive) return;
+      if (typeof document !== "undefined" && !document.hasFocus()) return;
+      const priorityProjectIds = getPriorityProjectIds();
+      for (const project of activeProjects) {
+        if (project.location.kind !== "wsl") continue;
+        if (!priorityProjectIds.has(project.id)) continue;
+        void refreshGitProject(project, "poll", "status", { isActive: isActiveCheck });
+      }
+    }
+
     // Defer the first remote fetch until after the initial refresh batch has
     // had a chance to paint UI. Running them concurrently means git fetch's
     // ref updates (legitimate `.git/refs/...` writes) trigger watcher events
@@ -158,11 +171,13 @@ export function useGitRefresh(storeHydrated: boolean) {
       () => void fetchRemotes(),
       Math.min(GIT_FETCH_PRIORITY_INTERVAL_MS, GIT_FETCH_BACKGROUND_INTERVAL_MS),
     );
+    const wslStatusPollIntervalId = setInterval(pollPriorityWslStatus, WSL_STATUS_POLL_INTERVAL_MS);
 
     return () => {
       isActive = false;
       clearTimeout(initialFetchTimer);
       clearInterval(fetchIntervalId);
+      clearInterval(wslStatusPollIntervalId);
       for (const timer of watcherDebounceTimers.values()) clearTimeout(timer);
       watcherDebounceTimers.clear();
       unsubWatcher();

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -4,7 +4,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
 
-export type GitRefreshReason = "initial" | "watcher" | "fetch" | "manual";
+export type GitRefreshReason = "initial" | "watcher" | "fetch" | "manual" | "poll";
 export type GitRefreshMode = "status" | "full";
 
 export interface GitRefreshOptions {

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -149,6 +149,7 @@ export function ThreadPane(props: {
         // dropped by the renderer's per-id dedupe in `applyRuntimeEvent`.
         const presentation = thread.presentationMode ?? "terminal";
         let optimisticUserMessageItemId: string | undefined;
+        let markedWorking = false;
         if (presentation === "gui" && prompt.length > 0) {
           optimisticUserMessageItemId = `user-${crypto.randomUUID()}`;
           useAppStore.getState().applyRuntimeEvent(thread.id, {
@@ -163,23 +164,43 @@ export function ThreadPane(props: {
             threadId: thread.id,
             itemId: optimisticUserMessageItemId,
           });
+          updateThreadRuntime(thread.id, {
+            status: "working",
+            attention: "working",
+            canResumeWithConfig: thread.canResumeWithConfig,
+            ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
+          });
+          markedWorking = true;
           if (!isHomeProjectId(thread.projectId)) {
-            void captureFileCheckpoint({
+            await captureFileCheckpoint({
               threadId: thread.id,
               checkpointItemId: optimisticUserMessageItemId,
               projectLocation,
             });
           }
         }
-        await readBridge().sendThreadInput({
-          threadId: thread.id,
-          prompt,
-          ...(segments ? { segments } : {}),
-          config: thread.config,
-          ...(optimisticUserMessageItemId
-            ? { userMessageItemId: optimisticUserMessageItemId }
-            : {}),
-        });
+        try {
+          await readBridge().sendThreadInput({
+            threadId: thread.id,
+            prompt,
+            ...(segments ? { segments } : {}),
+            config: thread.config,
+            ...(optimisticUserMessageItemId
+              ? { userMessageItemId: optimisticUserMessageItemId }
+              : {}),
+          });
+        } catch (error) {
+          if (markedWorking) {
+            updateThreadRuntime(thread.id, {
+              status: thread.status,
+              attention: thread.attention,
+              canResumeWithConfig: thread.canResumeWithConfig,
+              forceCloseActiveTurn: true,
+              ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
+            });
+          }
+          throw error;
+        }
         captureThreadInputSubmitted(thread, segments);
         touchThread(thread.id);
       }}

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -119,6 +119,14 @@ export const interruptThreadPayloadSchema = z.object({
 });
 export type InterruptThreadPayload = z.infer<typeof interruptThreadPayloadSchema>;
 
+export const rollbackThreadConversationPayloadSchema = z.object({
+  threadId: z.string().min(1),
+  numTurns: z.number().int().min(0),
+});
+export type RollbackThreadConversationPayload = z.infer<
+  typeof rollbackThreadConversationPayloadSchema
+>;
+
 export const setPendingSteerPayloadSchema = z.object({
   threadId: z.string().min(1),
   prompt: z.string().min(1),

--- a/src/shared/ipc/procedures/thread.ts
+++ b/src/shared/ipc/procedures/thread.ts
@@ -10,6 +10,7 @@ import {
   removeAcpRegistryAgentPayloadSchema,
   resizeTerminalPayloadSchema,
   resolveThreadServerRequestPayloadSchema,
+  rollbackThreadConversationPayloadSchema,
   sendThreadInputPayloadSchema,
   setAcpRegistryAgentAuthPayloadSchema,
   setPendingSteerPayloadSchema,
@@ -37,6 +38,7 @@ import type {
   RemoveAcpRegistryAgentPayload,
   ResizeTerminalPayload,
   ResolveThreadServerRequestPayload,
+  RollbackThreadConversationPayload,
   SendThreadInputPayload,
   SetAcpRegistryAgentAuthPayload,
   SetPendingSteerPayload,
@@ -142,6 +144,11 @@ export const threadProcedures = {
     "supervisor",
     interruptThreadPayloadSchema,
   ),
+  rollbackThreadConversation: definePayloadProcedure<
+    RollbackThreadConversationPayload,
+    void,
+    "supervisor"
+  >("rollbackThreadConversation", "supervisor", rollbackThreadConversationPayloadSchema),
   setPendingSteer: definePayloadProcedure<SetPendingSteerPayload, void, "supervisor">(
     "setPendingSteer",
     "supervisor",

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -7,6 +7,7 @@ import type { CreateStructuredSessionInput } from "../base";
 import type { ThreadConfig } from "@/shared/contracts";
 import {
   AcpStructuredSession,
+  resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
   rewriteLoadSessionError,
   shouldSpawnAcpSession,
@@ -307,6 +308,34 @@ describe("ACP resource path helpers", () => {
         ".agents/docs/ui patterns.md",
       ),
     ).toBe("file:///home/me/repo/.agents/docs/ui%20patterns.md");
+  });
+
+  it("allows read-only access to user agent skill files outside a WSL project", () => {
+    expect(
+      resolveAcpReadableHostFsPath(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/home/me/repo",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\repo",
+        },
+        "/home/me/.agents/skills/agent-browser/SKILL.md",
+      ),
+    ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\me\\.agents\\skills\\agent-browser\\SKILL.md");
+  });
+
+  it("rejects user agent skill paths that escape through parent segments", () => {
+    expect(() =>
+      resolveAcpReadableHostFsPath(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/home/me/repo",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\repo",
+        },
+        "/home/me/.agents/skills/../secret.txt",
+      ),
+    ).toThrow("Invalid params");
   });
 });
 

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -108,6 +108,7 @@ import {
   guessMimeType,
   resolveAcpHostFsPath,
   resolveAcpProjectPath,
+  resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
   resolveSessionCwd,
   resolveSpawnCwd,
@@ -115,7 +116,7 @@ import {
   toAcpResourceUri,
 } from "./sessionPaths";
 
-export { resolveAcpResourcePath, toAcpResourceUri };
+export { resolveAcpReadableHostFsPath, resolveAcpResourcePath, toAcpResourceUri };
 
 /**
  * Convert Lightcode `PromptSegment[]` + prompt text into ACP `ContentBlock[]`.
@@ -1208,7 +1209,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
   private async handleReadTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
     this.assertRequestSession(params.sessionId);
-    const path = resolveAcpHostFsPath(this.projectLocation, params.path);
+    const path = resolveAcpReadableHostFsPath(this.projectLocation, params.path);
     const fullContent = await readFile(path, "utf8");
     const content = sliceTextFileContent(fullContent, params.line, params.limit);
     return { content };

--- a/src/supervisor/agents/acp/sessionPaths.ts
+++ b/src/supervisor/agents/acp/sessionPaths.ts
@@ -2,6 +2,7 @@ import { posix, win32 } from "node:path";
 import { pathToFileURL } from "node:url";
 import { RequestError } from "@agentclientprotocol/sdk";
 import type { ProjectLocation } from "@/shared/contracts";
+import { toWslUncPath } from "@/shared/wsl";
 
 /** CWD to pass into the ACP session (the agent's working directory). */
 export function resolveSessionCwd(location: ProjectLocation): string {
@@ -87,6 +88,21 @@ export function resolveAcpHostFsPath(location: ProjectLocation, rawPath: string)
     : win32.join(location.uncPath, ...relative.split("/").filter(Boolean));
 }
 
+export function resolveAcpReadableHostFsPath(location: ProjectLocation, rawPath: string): string {
+  const absolutePath = resolveAcpResourcePath(location, rawPath);
+  if (isProjectRelativePath(location, absolutePath)) {
+    return resolveAcpHostFsPath(location, rawPath);
+  }
+  const normalizedPath = normalizeAcpPath(location, absolutePath);
+  if (!isAgentSkillReadPath(location, normalizedPath)) {
+    throw RequestError.invalidParams({ message: `Path is outside the project: ${rawPath}` });
+  }
+  if (location.kind === "wsl" && !isWindowsAbsolutePath(normalizedPath)) {
+    return toWslUncPath(location.distro, normalizedPath);
+  }
+  return normalizedPath;
+}
+
 export function toAcpResourceUri(location: ProjectLocation, rawPath: string): string {
   const absolutePath = resolveAcpResourcePath(location, rawPath);
   if (isWindowsAbsolutePath(absolutePath)) {
@@ -141,4 +157,36 @@ export function sliceTextFileContent(
     maxLines === undefined ? undefined : startLine - 1 + maxLines,
   );
   return selected.join("\n");
+}
+
+function isAgentSkillReadPath(location: ProjectLocation, absolutePath: string): boolean {
+  switch (location.kind) {
+    case "windows": {
+      const match =
+        /^([A-Za-z]:[\\/]Users[\\/][^\\/]+[\\/]\\.agents[\\/]skills)(?:[\\/].*)?$/i.exec(
+          absolutePath,
+        );
+      if (!match) return false;
+      const root = match[1]!;
+      const relative = win32.relative(root, absolutePath);
+      return relative !== "" && !relative.startsWith("..") && !win32.isAbsolute(relative);
+    }
+    case "wsl":
+    case "posix": {
+      const match = /^(\/(?:home\/[^/]+|Users\/[^/]+|root)\/\.agents\/skills)(?:\/.*)?$/.exec(
+        absolutePath,
+      );
+      if (!match) return false;
+      const root = match[1]!;
+      const relative = posix.relative(root, absolutePath);
+      return relative !== "" && !relative.startsWith("..") && !posix.isAbsolute(relative);
+    }
+  }
+}
+
+function normalizeAcpPath(location: ProjectLocation, absolutePath: string): string {
+  if (isWindowsAbsolutePath(absolutePath)) return win32.normalize(absolutePath);
+  return location.kind === "windows"
+    ? win32.normalize(absolutePath)
+    : posix.normalize(absolutePath);
 }

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -67,6 +67,7 @@ vi.mock("../binaryResolver", () => ({
 function createFakeQuery(initCommands: Array<Record<string, string>> = []) {
   let closed = false;
   let resolveNext: ((result: IteratorResult<SDKMessage>) => void) | undefined;
+  const queuedMessages: SDKMessage[] = [];
   const setModel = vi.fn<(model?: string) => Promise<void>>().mockResolvedValue(undefined);
   const setPermissionMode = vi
     .fn<(mode: PermissionMode) => Promise<void>>()
@@ -91,6 +92,8 @@ function createFakeQuery(initCommands: Array<Record<string, string>> = []) {
   const runtime = {
     async next(): Promise<IteratorResult<SDKMessage>> {
       if (closed) return { done: true, value: undefined };
+      const queued = queuedMessages.shift();
+      if (queued) return { done: false, value: queued };
       return new Promise<IteratorResult<SDKMessage>>((resolve) => {
         resolveNext = resolve;
       });
@@ -132,7 +135,11 @@ function createFakeQuery(initCommands: Array<Record<string, string>> = []) {
     emitMessage(message: SDKMessage): void {
       const resolve = resolveNext;
       resolveNext = undefined;
-      resolve?.({ done: false, value: message });
+      if (resolve) {
+        resolve({ done: false, value: message });
+      } else {
+        queuedMessages.push(message);
+      }
     },
   };
 }
@@ -152,6 +159,28 @@ function sdkSystemMessage(
     uuid: `uuid-${subtype}`,
     session_id: sessionId,
     ...extra,
+  } as unknown as SDKMessage;
+}
+
+function sdkAssistantMessage(sessionId: string, uuid: string, text: string): SDKMessage {
+  return {
+    type: "assistant",
+    uuid,
+    session_id: sessionId,
+    parent_tool_use_id: null,
+    message: {
+      id: uuid,
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  } as unknown as SDKMessage;
+}
+
+function sdkSuccessResult(sessionId: string): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    session_id: sessionId,
   } as unknown as SDKMessage;
 }
 
@@ -453,6 +482,56 @@ describe("ClaudeSdkSession", () => {
       );
     });
     expect(updates.some((update) => update.status === "working")).toBe(false);
+
+    await session.dispose();
+  });
+
+  it("rolls back SDK sessions by reopening Claude at the target assistant UUID", async () => {
+    mockSdk.query.mockClear();
+    const firstQuery = createFakeQuery();
+    const resumedQuery = createFakeQuery();
+    mockSdk.query.mockReturnValueOnce(firstQuery.runtime).mockReturnValueOnce(resumedQuery.runtime);
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-rollback",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: () => {},
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    const openedSessionId = await session.openThread(config);
+    await flushAsyncWork();
+
+    await session.startTurn("first", config);
+    firstQuery.emitMessage(sdkAssistantMessage(openedSessionId, "assistant-uuid-1", "first"));
+    await flushAsyncWork();
+    firstQuery.emitMessage(sdkSuccessResult(openedSessionId));
+    await flushAsyncWork();
+
+    await session.startTurn("second", config);
+    firstQuery.emitMessage(sdkAssistantMessage(openedSessionId, "assistant-uuid-2", "second"));
+    await flushAsyncWork();
+    firstQuery.emitMessage(sdkSuccessResult(openedSessionId));
+    await flushAsyncWork();
+
+    await expect(session.rollbackThread(1)).resolves.toEqual({
+      providerSessionId: openedSessionId,
+      messages: [],
+    });
+
+    expect(firstQuery.runtime.close).toHaveBeenCalledTimes(1);
+    expect(mockSdk.query).toHaveBeenCalledTimes(2);
+    const queryInput = mockSdk.query.mock.calls[1]?.[0] as { options?: Record<string, unknown> };
+    expect(queryInput.options).toMatchObject({
+      resume: openedSessionId,
+      resumeSessionAt: "assistant-uuid-1",
+    });
+    expect(queryInput.options).not.toHaveProperty("sessionId");
 
     await session.dispose();
   });

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -41,6 +41,7 @@ import {
   type StructuredSessionHandle,
   type StructuredSessionListener,
   type StructuredSessionUpdate,
+  type ThreadHistory,
 } from "../base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import { resolveAgentBinaryPath } from "../binaryResolver";
@@ -87,6 +88,10 @@ type PendingQuestion = {
 };
 
 type PendingRequest = PendingPermission | PendingQuestion;
+
+type CompletedClaudeTurn = {
+  resumeSessionAt: string | undefined;
+};
 
 class AsyncPromptQueue implements AsyncIterable<SDKUserMessage> {
   private items: SDKUserMessage[] = [];
@@ -415,6 +420,9 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
   private currentAttention: ThreadAttention = "none";
   private currentSlashCommands: AgentSlashCommand[] | undefined;
   private pendingRequests = new Map<ThreadServerRequestId, PendingRequest>();
+  private completedTurns: CompletedClaudeTurn[] = [];
+  private currentTurnAssistantUuid: string | undefined;
+  private currentTurnInFlight = false;
   // openThread() fires `startQuery` as a fire-and-forget IIFE and returns
   // synchronously, but the runtime calls `setListener` only afterwards from
   // `spawnThread`. Anything emitted in that window — early SDK system/stream
@@ -530,6 +538,8 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     if (this.disposed) return;
     this.currentConfig = config;
     const turnId = `turn-${randomUUID()}`;
+    this.currentTurnAssistantUuid = undefined;
+    this.currentTurnInFlight = true;
     this.emitRuntimeEvents(
       startClaudeTurn(this.mapperState, turnId, prompt, segments, options?.userMessageItemId),
     );
@@ -557,6 +567,47 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
 
     const message = await buildSdkUserMessage(prompt, segments);
     this.promptQueue.push(message);
+  }
+
+  async rollbackThread(numTurns: number): Promise<ThreadHistory> {
+    if (!Number.isInteger(numTurns) || numTurns <= 0) {
+      throw new Error(`rollbackThread: numTurns must be a positive integer (got ${numTurns}).`);
+    }
+    if (this.currentStatus === "working" || this.currentAttention === "working") {
+      throw new Error("Claude SDK rollback is unavailable while a turn is running.");
+    }
+    if (this.pendingRequests.size > 0) {
+      throw new Error("Claude SDK rollback is unavailable while a request is pending.");
+    }
+    if (!this.sessionId) {
+      throw new Error("Claude SDK rollback requires an open session.");
+    }
+    if (numTurns > this.completedTurns.length) {
+      throw new Error("Claude SDK rollback only supports turns completed in this runtime.");
+    }
+
+    const nextTurns = this.completedTurns.slice(0, this.completedTurns.length - numTurns);
+    const resumeSessionAt = nextTurns.at(-1)?.resumeSessionAt;
+    if (!resumeSessionAt) {
+      throw new Error("Claude SDK rollback requires an assistant resume point.");
+    }
+
+    this.completedTurns = nextTurns;
+    this.currentTurnAssistantUuid = undefined;
+    this.currentTurnInFlight = false;
+    this.openedResumeSessionId = this.sessionId;
+    this.promptQueue.close();
+    this.queryRuntime?.close();
+    this.promptQueue = new AsyncPromptQueue();
+    this.queryRuntime = undefined;
+    this.queryReady = undefined;
+    this.streamStarted = false;
+    this.appliedModel = undefined;
+    this.appliedPermissionMode = undefined;
+    this.startQuery(this.sessionId, resumeSessionAt);
+    await this.requireQuery();
+
+    return { providerSessionId: this.sessionId, messages: [] };
   }
 
   async interruptTurn(): Promise<void> {
@@ -692,7 +743,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     return this.queryReady;
   }
 
-  private startQuery(resumeSessionId: string | undefined): void {
+  private startQuery(resumeSessionId: string | undefined, resumeSessionAt?: string): void {
     if (this.streamStarted) return;
     this.streamStarted = true;
 
@@ -785,6 +836,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
           ? { allowDangerouslySkipPermissions: true }
           : {}),
         ...(resumeSessionId ? { resume: resumeSessionId } : {}),
+        ...(resumeSessionAt ? { resumeSessionAt } : {}),
         ...(!resumeSessionId && this.sessionId ? { sessionId: this.sessionId } : {}),
         includePartialMessages: true,
         forwardSubagentText: true,
@@ -931,11 +983,16 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.emitUpdate(mapped);
     }
 
+    if (message.type === "assistant") {
+      this.currentTurnAssistantUuid = message.uuid;
+    }
+
     const events = mapClaudeSdkMessage(message, this.mapperState);
     this.emitRuntimeEvents(events);
     if (message.type === "result") {
       void this.refreshContextUsage();
-      const wasInterrupted = this.interruptInFlight || isInterruptedResult(message);
+      const wasInterrupted =
+        this.interruptInFlight || (message.subtype !== "success" && isInterruptedResult(message));
       this.interruptInFlight = false;
       const remaining = nonDiagnosticErrors(message);
       // claude.exe surfaces upstream API failures (e.g. 401 auth, 429 rate
@@ -953,6 +1010,11 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       const errorMessage = failed
         ? (extractResultErrorMessage(message) ?? "Claude turn failed.")
         : undefined;
+      if (this.currentTurnInFlight && !failed && !wasInterrupted) {
+        this.completedTurns.push({ resumeSessionAt: this.currentTurnAssistantUuid });
+      }
+      this.currentTurnAssistantUuid = undefined;
+      this.currentTurnInFlight = false;
       this.emitUpdate({
         status: failed ? "error" : "idle",
         attention: failed ? "error" : "none",

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -23,6 +23,7 @@ import {
   type StartTurnOptions,
   type StructuredSessionHandle,
   type StructuredSessionListener,
+  type ThreadHistory,
 } from "../base";
 import { buildCodexAppServerCommand } from "./argv";
 import {
@@ -531,6 +532,24 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       threadId,
       turnId: this.activeTurnId,
     });
+  }
+
+  async rollbackThread(numTurns: number): Promise<ThreadHistory> {
+    if (!Number.isInteger(numTurns) || numTurns <= 0) {
+      throw new Error(`rollbackThread: numTurns must be a positive integer (got ${numTurns}).`);
+    }
+    const threadId = await this.waitForRemoteThreadId();
+    await this.request("thread/rollback", {
+      threadId,
+      numTurns,
+    });
+    this.pendingTurnInterrupt = false;
+    this.activeTurnId = undefined;
+    await this.syncRemoteThreadState(threadId, toSessionRef(threadId));
+    return {
+      providerSessionId: threadId,
+      messages: [],
+    };
   }
 
   async resolveServerRequest(requestId: ThreadServerRequestId, response: unknown): Promise<void> {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -319,6 +319,21 @@ describe("CodexStructuredSession", () => {
     });
   });
 
+  it("rolls back Codex app-server threads with thread/rollback", async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const structuredSession = makeStructuredSession(requests);
+
+    await structuredSession.rollbackThread(2);
+
+    expect(requests[0]).toEqual({
+      method: "thread/rollback",
+      params: {
+        threadId: "provider-thread",
+        numTurns: 2,
+      },
+    });
+  });
+
   it("requests Codex reasoning summaries for GUI turns", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);

--- a/src/supervisor/agents/opencode/opencodeErrors.ts
+++ b/src/supervisor/agents/opencode/opencodeErrors.ts
@@ -33,6 +33,15 @@ export function readOpenCodeErrorText(cause: unknown): string {
   return String(cause ?? "").toLowerCase();
 }
 
+export function isOpenCodeConnectionLoss(cause: unknown): boolean {
+  const text = readOpenCodeErrorText(cause);
+  return (
+    /(econnrefused|connection refused|fetch failed|networkerror|socket hang up|aborted)/.test(
+      text,
+    ) && !/aborted by user/.test(text)
+  );
+}
+
 /**
  * Convert a raw failure into a user-facing summary. The original message is
  * still appended after a colon when no classification matched, so power users

--- a/src/supervisor/agents/opencode/sdkClient.test.ts
+++ b/src/supervisor/agents/opencode/sdkClient.test.ts
@@ -1,0 +1,108 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import type { CommandSpec } from "../base";
+import type { OpenCodeServerHandle } from "./sdkServer";
+
+const mocks = vi.hoisted(() => ({
+  buildOpenCodeServerCommand: vi.fn<() => CommandSpec>(),
+  createOpencodeClient: vi.fn<() => unknown>(),
+  resolveAgentBinaryPath: vi.fn<() => string>(),
+  spawnOpenCodeServer: vi.fn<() => OpenCodeServerHandle>(),
+}));
+
+vi.mock("../binaryResolver", () => ({
+  resolveAgentBinaryPath: mocks.resolveAgentBinaryPath,
+}));
+
+vi.mock("./argv", () => ({
+  buildOpenCodeServerCommand: mocks.buildOpenCodeServerCommand,
+}));
+
+vi.mock("./sdkServer", () => ({
+  spawnOpenCodeServer: mocks.spawnOpenCodeServer,
+}));
+
+vi.mock("@opencode-ai/sdk/v2/client", () => ({
+  createOpencodeClient: mocks.createOpencodeClient,
+}));
+
+function makeHandle(baseUrl: string) {
+  return {
+    child: new EventEmitter() as ChildProcess,
+    baseUrl: Promise.resolve(baseUrl),
+    formatOutput: () => "",
+    dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  } satisfies OpenCodeServerHandle;
+}
+
+describe("acquireOpenCodeServer", () => {
+  const oldBrowserMcpUrl = process.env.LIGHTCODE_BROWSER_MCP_URL;
+  const oldBrowserMcpToken = process.env.LIGHTCODE_BROWSER_MCP_TOKEN;
+
+  beforeEach(() => {
+    mocks.buildOpenCodeServerCommand.mockReset().mockReturnValue({
+      command: "opencode",
+      args: ["serve"],
+      cwd: "/repo",
+      env: {},
+    });
+    mocks.createOpencodeClient.mockReset();
+    mocks.resolveAgentBinaryPath.mockReset().mockReturnValue("opencode");
+    mocks.spawnOpenCodeServer.mockReset();
+    process.env.LIGHTCODE_BROWSER_MCP_URL = "http://127.0.0.1:9321";
+    process.env.LIGHTCODE_BROWSER_MCP_TOKEN = "test-token";
+  });
+
+  afterEach(() => {
+    if (oldBrowserMcpUrl === undefined) {
+      delete process.env.LIGHTCODE_BROWSER_MCP_URL;
+    } else {
+      process.env.LIGHTCODE_BROWSER_MCP_URL = oldBrowserMcpUrl;
+    }
+    if (oldBrowserMcpToken === undefined) {
+      delete process.env.LIGHTCODE_BROWSER_MCP_TOKEN;
+    } else {
+      process.env.LIGHTCODE_BROWSER_MCP_TOKEN = oldBrowserMcpToken;
+    }
+  });
+
+  it("respawns once when Browser MCP sync hits a dead OpenCode server", async () => {
+    const firstHandle = makeHandle("http://127.0.0.1:4096");
+    const secondHandle = makeHandle("http://127.0.0.1:4097");
+    const firstAdd = vi.fn<() => Promise<void>>().mockRejectedValue(new Error("fetch failed"));
+    const secondAdd = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const secondConnect = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    mocks.spawnOpenCodeServer.mockReturnValueOnce(firstHandle).mockReturnValueOnce(secondHandle);
+    mocks.createOpencodeClient
+      .mockReturnValueOnce({
+        mcp: {
+          add: firstAdd,
+          connect: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        },
+      })
+      .mockReturnValueOnce({
+        mcp: {
+          add: secondAdd,
+          connect: secondConnect,
+        },
+      });
+
+    const { acquireOpenCodeServer } = await import("./sdkClient");
+    const acquired = await acquireOpenCodeServer({
+      projectLocation: { kind: "posix", path: "/repo" },
+      browserMcpEnabled: true,
+    });
+
+    expect(mocks.spawnOpenCodeServer).toHaveBeenCalledTimes(2);
+    expect(firstAdd).toHaveBeenCalledTimes(1);
+    expect(firstHandle.dispose).toHaveBeenCalledTimes(1);
+    expect(secondAdd).toHaveBeenCalledTimes(1);
+    expect(secondConnect).toHaveBeenCalledTimes(1);
+    expect(acquired.baseUrl).toBe("http://127.0.0.1:4097");
+
+    await acquired.dispose();
+    expect(secondHandle.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -4,6 +4,7 @@ import { resolveAgentBinaryPath } from "../binaryResolver";
 import { BROWSER_MCP_SERVER_NAME } from "../browserMcp";
 import { buildOpenCodeServerCommand } from "./argv";
 import { buildOpenCodeBrowserMcp } from "./mcpBrowser";
+import { isOpenCodeConnectionLoss } from "./opencodeErrors";
 import { spawnOpenCodeServer, type OpenCodeServerHandle } from "./sdkServer";
 
 /** Agent-side cwd that the SDK passes through to the server's session config. */
@@ -128,12 +129,21 @@ async function syncBrowserMcp(
 
   await client.mcp
     .add({ directory, name: BROWSER_MCP_SERVER_NAME, config: browser })
-    .catch(() => undefined);
+    .catch((err) => {
+      if (isOpenCodeConnectionLoss(err)) throw err;
+    });
   await client.mcp.connect({ directory, name: BROWSER_MCP_SERVER_NAME });
 }
 
 export async function acquireOpenCodeServer(
   input: AcquireOpenCodeServerInput,
+): Promise<AcquiredOpenCodeServer> {
+  return acquireOpenCodeServerInner(input, true);
+}
+
+async function acquireOpenCodeServerInner(
+  input: AcquireOpenCodeServerInput,
+  retryMcpConnectionLoss: boolean,
 ): Promise<AcquiredOpenCodeServer> {
   const key = poolKey(input.projectLocation);
   let entry = pool.get(key);
@@ -179,9 +189,19 @@ export async function acquireOpenCodeServer(
 
   let released = false;
   const idleCloseDelayMs = input.idleCloseDelayMs;
-  await syncBrowserMcp(input, snapshot.client).catch((error) => {
-    console.warn("[opencode] failed to sync Browser MCP:", error);
-  });
+  try {
+    await syncBrowserMcp(input, snapshot.client);
+  } catch (error) {
+    if (!retryMcpConnectionLoss || !isOpenCodeConnectionLoss(error)) {
+      console.warn("[opencode] failed to sync Browser MCP:", error);
+    } else {
+      released = true;
+      acquiringEntry.refCount -= 1;
+      if (pool.get(key) === acquiringEntry) pool.delete(key);
+      await snapshot.handle.dispose().catch(() => undefined);
+      return acquireOpenCodeServerInner(input, false);
+    }
+  }
 
   return {
     client: snapshot.client,

--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -88,6 +88,63 @@ describe("OpencodeSdkSession", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("restarts the OpenCode server once when session.create loses its connection", async () => {
+    const firstDispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const secondDispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const firstCreate = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(new Error("fetch failed"));
+    const secondCreate = vi
+      .fn<() => Promise<{ data: { id: string } }>>()
+      .mockResolvedValue({ data: { id: "ses_retry" } });
+    const commandList = vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] });
+    mocks.acquireOpenCodeServer
+      .mockResolvedValueOnce({
+        client: {
+          global: { event: vi.fn<() => Promise<{ stream: AsyncGenerator<Event> }>>() },
+          command: { list: commandList },
+          session: { create: firstCreate },
+        },
+        baseUrl: "http://127.0.0.1:1",
+        handle: { formatOutput: () => "first server output" },
+        dispose: firstDispose,
+      })
+      .mockResolvedValueOnce({
+        client: {
+          global: { event: vi.fn<() => Promise<{ stream: AsyncGenerator<Event> }>>() },
+          command: { list: commandList },
+          session: { create: secondCreate },
+        },
+        baseUrl: "http://127.0.0.1:2",
+        handle: { formatOutput: () => "" },
+        dispose: secondDispose,
+      });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "terminal",
+    });
+    session.setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: () => {},
+      onRuntimeEvent: () => {},
+    });
+
+    await session.activate();
+    await expect(session.openThread(config)).resolves.toBe("ses_retry");
+
+    expect(mocks.acquireOpenCodeServer).toHaveBeenCalledTimes(2);
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(firstCreate).toHaveBeenCalledTimes(1);
+    expect(secondCreate).toHaveBeenCalledTimes(1);
+
+    await session.dispose();
+    expect(secondDispose).toHaveBeenCalledTimes(1);
+  });
+
   it("unwraps global payload events and ignores sync duplicates", async () => {
     const updates: StructuredSessionUpdate[] = [];
     const runtimeEvents: RuntimeEvent[] = [];

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -47,7 +47,11 @@ import {
   type QuestionAnswerSourceQuestion,
 } from "../questionAnswerEvents";
 import { mapOpenCodeSlashCommands } from "./detection";
-import { classifyOpenCodeError, readOpenCodeErrorText } from "./opencodeErrors";
+import {
+  classifyOpenCodeError,
+  isOpenCodeConnectionLoss,
+  readOpenCodeErrorText,
+} from "./opencodeErrors";
 import { buildOpenCodePermissionRules } from "./permissionRules";
 import { syncOpenCodeBrowserMcpConfigFile } from "./plugin/install";
 import {
@@ -355,6 +359,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
   private disposed = false;
   private pendingRequests = new Map<ThreadServerRequestId, PendingRequest>();
   private currentSlashCommands: AgentSlashCommand[] | undefined;
+  private browserMcpEnabled = false;
 
   private constructor(input: CreateStructuredSessionInput) {
     this.input = input;
@@ -404,11 +409,11 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     this.activated = true;
 
     try {
-      const browserMcpEnabled = isOpenCodeBrowserMcpEnabled(this.input.agentSettings);
-      syncOpenCodeBrowserMcpConfigFile(this.input.projectLocation, browserMcpEnabled);
+      this.browserMcpEnabled = isOpenCodeBrowserMcpEnabled(this.input.agentSettings);
+      syncOpenCodeBrowserMcpConfigFile(this.input.projectLocation, this.browserMcpEnabled);
       this.acquired = await acquireOpenCodeServer({
         projectLocation: this.input.projectLocation,
-        browserMcpEnabled,
+        browserMcpEnabled: this.browserMcpEnabled,
       });
     } catch (cause) {
       // Surface server-startup failures (sandbox blocks, ENOENT, port races,
@@ -460,7 +465,22 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         ...(permission ? { permission } : {}),
       });
     } catch (cause) {
-      throw new Error(classifyOpenCodeError({ cause, operation: "session.create" }), { cause });
+      if (!isOpenCodeConnectionLoss(cause)) {
+        throw new Error(this.classifyOpenCodeError(cause, "session.create"), { cause });
+      }
+      await this.reacquireOpenCodeServer();
+      const retryAcquired = this.requireAcquired();
+      try {
+        created = await retryAcquired.client.session.create({
+          directory: this.sdkDirectory,
+          title: `lightcode/${this.threadId.slice(0, 8)}`,
+          ...(permission ? { permission } : {}),
+        });
+      } catch (retryCause) {
+        throw new Error(this.classifyOpenCodeError(retryCause, "session.create"), {
+          cause: retryCause,
+        });
+      }
     }
     const id = created.data?.id;
     if (!id) throw new Error("opencode session.create returned no id");
@@ -828,6 +848,29 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         ]);
       }
     })();
+  }
+
+  private async reacquireOpenCodeServer(): Promise<void> {
+    const previous = this.acquired;
+    this.sseAbort?.abort();
+    this.sseAbort = undefined;
+    this.acquired = undefined;
+    await previous?.dispose().catch(() => undefined);
+    this.acquired = await acquireOpenCodeServer({
+      projectLocation: this.input.projectLocation,
+      browserMcpEnabled: this.browserMcpEnabled,
+    });
+    if (this.isGui) this.startEventStream();
+  }
+
+  private classifyOpenCodeError(cause: unknown, operation: string): string {
+    const message = classifyOpenCodeError({
+      cause,
+      operation,
+      serverUrl: this.acquired?.baseUrl,
+    });
+    const output = this.acquired?.handle.formatOutput().trim();
+    return output ? `${message}\n${output}` : message;
   }
 
   private handleSseEvent(event: Event): void {

--- a/src/supervisor/git/checkpointService.test.ts
+++ b/src/supervisor/git/checkpointService.test.ts
@@ -89,4 +89,18 @@ describe.skipIf(!hasGit())("GitCheckpointService", () => {
       "?? new.txt",
     ]);
   }, 15_000);
+
+  it("reports a missing base checkpoint without surfacing raw git ref errors", async () => {
+    const { location } = makeRepo();
+    const service = new GitCheckpointService();
+
+    await expect(
+      service.finalize({
+        threadId: "thread-1",
+        checkpointItemId: "assistant-1",
+        baseCheckpointItemId: "user-1",
+        projectLocation: location,
+      }),
+    ).rejects.toThrow("No file checkpoint exists for item user-1.");
+  });
 });

--- a/src/supervisor/git/checkpointService.ts
+++ b/src/supervisor/git/checkpointService.ts
@@ -186,9 +186,14 @@ export class GitCheckpointService {
     projectLocation: ProjectLocation,
     ref: string,
   ): Promise<CheckpointMetadata | null> {
-    const commit = (
-      await execGit(projectLocation, ["rev-parse", "--verify", `${ref}^{commit}`])
-    ).trim();
+    let commit: string;
+    try {
+      commit = (
+        await execGit(projectLocation, ["rev-parse", "--verify", `${ref}^{commit}`])
+      ).trim();
+    } catch {
+      return null;
+    }
     const body = await execGit(projectLocation, ["log", "-1", "--format=%B", ref]);
     const jsonLine = body
       .split(/\r?\n/)

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -19,6 +19,7 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
     startThread: (payload) => runtime.startThread(payload),
     sendThreadInput: (payload) => runtime.sendThreadInput(payload),
     interruptThread: (payload) => runtime.interruptThread(payload),
+    rollbackThreadConversation: (payload) => runtime.rollbackThreadConversation(payload),
     setPendingSteer: (payload) => runtime.setPendingSteer(payload),
     clearPendingSteer: (payload) => runtime.clearPendingSteer(payload),
     writeTerminal: (payload) => runtime.writeTerminal(payload),

--- a/src/supervisor/projectWatcher.test.ts
+++ b/src/supervisor/projectWatcher.test.ts
@@ -91,4 +91,39 @@ describe("ProjectWatcher WSL worktrees", () => {
     await vi.waitFor(() => expect(onTreeChanged).toHaveBeenCalledWith("project-1"));
     await watcher.dispose();
   });
+
+  it("resubscribes WSL project watchers after the bridge exits", async () => {
+    const unsubscribe = vi.fn<() => Promise<void>>(async () => undefined);
+    let subscriptionCount = 0;
+    const watch = vi.fn<WslBridgeClient["watch"]>(async () => ({
+      subscriptionId: `sub-${subscriptionCount++}`,
+      unsubscribe,
+    }));
+    const client = {
+      readFile: vi.fn<WslBridgeClient["readFile"]>(async () => {
+        throw new Error("missing");
+      }),
+      stat: vi.fn<WslBridgeClient["stat"]>(async () => ({ stats: [] })),
+      watch,
+    } as unknown as WslBridgeClient;
+    const watcher = new ProjectWatcher({
+      onGitChanged: vi.fn<(projectId: string) => void>(),
+      onTreeChanged: vi.fn<(projectId: string) => void>(),
+    });
+    watcher.setWslClient(client);
+
+    watcher.watch("project-1", makeLocation("/home/demo/work/repo"));
+
+    await vi.waitFor(() => expect(watch).toHaveBeenCalledTimes(1));
+    watcher.handleWslBridgeExit("Ubuntu");
+
+    await vi.waitFor(() => expect(watch).toHaveBeenCalledTimes(2));
+    expect(watch.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        paths: [{ path: "/home/demo/work/repo", scope: "worktree" }],
+      }),
+    );
+    expect(unsubscribe).not.toHaveBeenCalled();
+    await watcher.dispose();
+  });
 });

--- a/src/supervisor/projectWatcher.ts
+++ b/src/supervisor/projectWatcher.ts
@@ -14,6 +14,7 @@ export interface ProjectWatcherCallbacks {
 }
 
 type WslUnsubscribe = () => Promise<void>;
+type WslSchedule = { onGit: () => void; onTree: () => void };
 
 interface WatcherEntry {
   gitWatcher: FSWatcher | null;
@@ -23,6 +24,7 @@ interface WatcherEntry {
   treeDebounceTimer: ReturnType<typeof setTimeout> | null;
   projectId: string;
   location: ProjectLocation;
+  wslSchedule?: WslSchedule;
 }
 
 interface WorktreeWatcherEntry {
@@ -31,6 +33,9 @@ interface WorktreeWatcherEntry {
   gitDebounceTimer: ReturnType<typeof setTimeout> | null;
   treeDebounceTimer: ReturnType<typeof setTimeout> | null;
   projectId: string;
+  wslLocation?: WslLocation;
+  wslLinuxPath?: string;
+  wslSchedule?: WslSchedule;
 }
 
 const IGNORED_PREFIXES = [
@@ -167,11 +172,9 @@ export class ProjectWatcher {
     };
 
     if (location.kind === "wsl") {
+      entry.wslSchedule = { onGit: scheduleGitNotify, onTree: scheduleTreeNotify };
       this.watchers.set(projectId, entry);
-      void this.startWslSubscription(entry, location, location.linuxPath, {
-        onGit: scheduleGitNotify,
-        onTree: scheduleTreeNotify,
-      });
+      void this.startWslSubscription(entry, location, location.linuxPath, entry.wslSchedule);
       return;
     }
 
@@ -258,11 +261,11 @@ export class ProjectWatcher {
       };
 
       if (location?.kind === "wsl") {
+        entry.wslLocation = location;
+        entry.wslLinuxPath = wtPath;
+        entry.wslSchedule = { onGit: scheduleGitNotify, onTree: scheduleTreeNotify };
         this.worktreeWatchers.set(wtPath, entry);
-        void this.startWslWorktreeSubscription(entry, location, wtPath, {
-          onGit: scheduleGitNotify,
-          onTree: scheduleTreeNotify,
-        });
+        void this.startWslWorktreeSubscription(entry, location, wtPath, entry.wslSchedule);
         continue;
       }
 
@@ -330,6 +333,34 @@ export class ProjectWatcher {
   async dispose(): Promise<void> {
     for (const [projectId] of this.watchers) {
       await this.unwatch(projectId);
+    }
+  }
+
+  handleWslBridgeExit(distro: string): void {
+    for (const entry of this.watchers.values()) {
+      if (entry.location.kind !== "wsl" || entry.location.distro !== distro || !entry.wslSchedule) {
+        continue;
+      }
+      entry.wslUnsubscribe = null;
+      void this.startWslSubscription(
+        entry,
+        entry.location,
+        entry.location.linuxPath,
+        entry.wslSchedule,
+      );
+    }
+
+    for (const entry of this.worktreeWatchers.values()) {
+      if (entry.wslLocation?.distro !== distro || !entry.wslLinuxPath || !entry.wslSchedule) {
+        continue;
+      }
+      entry.wslUnsubscribe = null;
+      void this.startWslWorktreeSubscription(
+        entry,
+        entry.wslLocation,
+        entry.wslLinuxPath,
+        entry.wslSchedule,
+      );
     }
   }
 

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -327,6 +327,49 @@ describe("SupervisorRuntime thread input", () => {
     ]);
   });
 
+  it("rolls back provider conversation through the structured session", async () => {
+    const runtime = makeRuntime(() => undefined);
+    const rollbackThread = vi
+      .fn<(numTurns: number) => Promise<{ providerSessionId: string; messages: [] }>>()
+      .mockResolvedValue({ providerSessionId: "provider-session-1", messages: [] });
+    const session = createRuntimeSession({
+      sessionRef: { providerSessionId: "provider-session-1" },
+      structuredSession: {
+        launchOptions: {},
+        activate: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        startTurn: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        rollbackThread,
+        resolveServerRequest: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        setListener: vi.fn<(listener: unknown) => void>(),
+        dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      },
+    });
+
+    (runtime as unknown as { sessions: Map<string, typeof session> }).sessions.set(
+      session.threadId,
+      session,
+    );
+
+    await runtime.rollbackThreadConversation({ threadId: session.threadId, numTurns: 2 });
+
+    expect(rollbackThread).toHaveBeenCalledWith(2);
+  });
+
+  it("rejects checkpoint rollback when the provider does not support it", async () => {
+    const runtime = makeRuntime(() => undefined);
+    const session = createRuntimeSession();
+
+    (runtime as unknown as { sessions: Map<string, typeof session> }).sessions.set(
+      session.threadId,
+      session,
+    );
+
+    await expect(
+      runtime.rollbackThreadConversation({ threadId: session.threadId, numTurns: 1 }),
+    ).rejects.toThrow("Codex does not support checkpoint rollback.");
+    expect(session.structuredSession.startTurn).not.toHaveBeenCalled();
+  });
+
   it("stages GUI submit-while-working as a single pending steer with replace-latest, interrupts once, and drains the latest on idle", async () => {
     const runtime = makeRuntime(() => undefined);
     const startTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -120,6 +120,7 @@ import type {
   ResizeTerminalPayload,
   ResolveThreadServerRequestPayload,
   RestoreFileCheckpointPayload,
+  RollbackThreadConversationPayload,
   SearchProjectFilesPayload,
   SearchProjectFilesResult,
   SearchProjectTreePayload,
@@ -350,6 +351,7 @@ export class SupervisorRuntime {
     if (process.platform === "win32" && resolveWslHelpersDir()) {
       const bridge = new WslBridgeServer({
         onEvent: (envelope) => runHookDispatch(envelope, "wsl-bridge"),
+        onBridgeExit: (distro) => this._projectWatcher?.handleWslBridgeExit(distro),
         onError: (message, error) => {
           if (isLightcodeHookDebug()) {
             console.warn(`[supervisor] hook-debug: ${message}`, error);
@@ -634,6 +636,10 @@ export class SupervisorRuntime {
 
   async interruptThread(payload: InterruptThreadPayload): Promise<void> {
     return this.threadSessionManager.interruptThread(payload);
+  }
+
+  async rollbackThreadConversation(payload: RollbackThreadConversationPayload): Promise<void> {
+    return this.threadSessionManager.rollbackThreadConversation(payload);
   }
 
   async setPendingSteer(payload: SetPendingSteerPayload): Promise<void> {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -15,6 +15,7 @@ import {
   type ProjectLocation,
   type ResizeTerminalPayload,
   type ResolveThreadServerRequestPayload,
+  type RollbackThreadConversationPayload,
   type SendThreadInputPayload,
   type SessionRef,
   type SetPendingSteerPayload,
@@ -395,6 +396,29 @@ export class ThreadSessionManager {
       throw new Error(`Unknown thread session: ${payload.threadId}`);
     }
     await this.interruptStructuredTurn(session);
+  }
+
+  async rollbackThreadConversation(payload: RollbackThreadConversationPayload): Promise<void> {
+    if (payload.numTurns === 0) return;
+    const session = this.requireSession(payload.threadId);
+    if (session.status === "working") {
+      throw new Error("Cannot roll back a thread while the agent is working.");
+    }
+    if (!session.structuredSession?.rollbackThread) {
+      throw new Error(`${session.adapter.label} does not support checkpoint rollback.`);
+    }
+
+    const previousSessionId = session.sessionRef?.providerSessionId;
+    const history = await session.structuredSession.rollbackThread(payload.numTurns);
+    if (
+      history.providerSessionId &&
+      history.providerSessionId !== session.sessionRef?.providerSessionId
+    ) {
+      session.sessionRef = createKnownSessionRef(history.providerSessionId);
+      session.canResumeWithConfig = true;
+      this.indexSessionRef(session, previousSessionId);
+      this.outputPipeline.emitState(session);
+    }
   }
 
   async writeTerminal(payload: WriteTerminalPayload): Promise<void> {

--- a/src/supervisor/wsl/bridge/client.ts
+++ b/src/supervisor/wsl/bridge/client.ts
@@ -193,7 +193,7 @@ export class WslBridgeClient {
     onEvent: (event: WatchEvent) => void,
   ): Promise<{ subscriptionId: string; unsubscribe: () => Promise<void> }> {
     const subscriptionId = randomUUID();
-    this.server.registerWatchListener(subscriptionId, onEvent);
+    this.server.registerWatchListener(subscriptionId, location.distro, onEvent);
     try {
       await this.call(location, "/v1/watch/subscribe", {
         projectRoot: location.linuxPath,

--- a/src/supervisor/wsl/bridge/index.ts
+++ b/src/supervisor/wsl/bridge/index.ts
@@ -15,6 +15,8 @@ export interface WslBridgeServerOptions {
   onEvent: HookEventReceiver;
   /** Optional logger; defaults to no-op. */
   onError?: (message: string, error?: unknown) => void;
+  /** Called when a booted bridge child exits and callers should recreate subscriptions. */
+  onBridgeExit?: (distro: string) => void;
   /** Bearer secret shared with the Windows-side `HookIngress`. */
   secret: string;
   /** Supervisor's max protocol version, exposed to the in-WSL bridge. */
@@ -68,6 +70,10 @@ const DEFAULT_BOOT_TIMEOUT_MS = 10_000;
 export type WatchScope = "git" | "worktree" | "unknown";
 
 export type WatchEventListener = (event: WatchEvent) => void;
+interface WatchListenerEntry {
+  distro: string;
+  listener: WatchEventListener;
+}
 
 export interface WatchEvent {
   subscriptionId: string;
@@ -96,7 +102,7 @@ export class WslBridgeServer {
   private readonly inFlight = new Map<string, Promise<BridgeHandle | undefined>>();
   private readonly disposed = new WeakSet<BridgeState>();
   private readonly bootTimeoutMs: number;
-  private readonly watchListeners = new Map<string, WatchEventListener>();
+  private readonly watchListeners = new Map<string, WatchListenerEntry>();
   private isDisposed = false;
 
   constructor(private readonly options: WslBridgeServerOptions) {
@@ -107,12 +113,22 @@ export class WslBridgeServer {
    * Register a listener for a future `subscriptionId`. Must be called
    * BEFORE the HTTP subscribe call so the first event cannot race in.
    */
-  registerWatchListener(subscriptionId: string, listener: WatchEventListener): void {
-    this.watchListeners.set(subscriptionId, listener);
+  registerWatchListener(
+    subscriptionId: string,
+    distro: string,
+    listener: WatchEventListener,
+  ): void {
+    this.watchListeners.set(subscriptionId, { distro, listener });
   }
 
   unregisterWatchListener(subscriptionId: string): void {
     this.watchListeners.delete(subscriptionId);
+  }
+
+  private unregisterWatchListenersForDistro(distro: string): void {
+    for (const [subscriptionId, entry] of this.watchListeners) {
+      if (entry.distro === distro) this.watchListeners.delete(subscriptionId);
+    }
   }
 
   /**
@@ -154,6 +170,7 @@ export class WslBridgeServer {
       if (!state) continue;
       this.bridges.delete(distro);
       this.disposed.add(state);
+      this.unregisterWatchListenersForDistro(distro);
       try {
         terminateChildProcessTree(state.child);
       } catch {
@@ -292,15 +309,15 @@ export class WslBridgeServer {
         return;
       }
       if (type === "watch" && typeof message.subscriptionId === "string") {
-        const listener = this.watchListeners.get(message.subscriptionId);
-        if (listener) {
+        const entry = this.watchListeners.get(message.subscriptionId);
+        if (entry) {
           const scope: WatchScope =
             message.scope === "git" || message.scope === "worktree" ? message.scope : "unknown";
           const paths = Array.isArray(message.paths)
             ? (message.paths.filter((v): v is string => typeof v === "string") as string[])
             : [];
           try {
-            listener({ subscriptionId: message.subscriptionId, scope, paths });
+            entry.listener({ subscriptionId: message.subscriptionId, scope, paths });
           } catch (error) {
             this.options.onError?.("wsl bridge watch: listener threw", error);
           }
@@ -352,6 +369,7 @@ export class WslBridgeServer {
       if (state && state.child === child) {
         this.bridges.delete(distro);
       }
+      this.unregisterWatchListenersForDistro(distro);
       if (booted && isLightcodeHookDebug()) {
         console.log(
           "[supervisor] hook-debug: WSL bridge child exited (will respawn on next ensure)",
@@ -362,6 +380,8 @@ export class WslBridgeServer {
       }
       if (!booted) {
         rejectBoot(new Error(`wsl hook bridge[${distro}] exited before boot`));
+      } else if (!this.isDisposed) {
+        this.options.onBridgeExit?.(distro);
       }
     };
     child.once("exit", onExit);


### PR DESCRIPTION
Tickets: None

- Add end-to-end thread rollback support from renderer to supervisor via new shared contracts, IPC procedure, and runtime/thread session handling, so a reverted turn count can be applied consistently across providers.
- Introduce provider rollback execution for structured sessions (including Codex/OpenCode/ACP paths) and update conversation state transitions, enabling recovery behavior and continuity after rollback.
- Improve thread UX by integrating rollback controls into the chat message flow and adding inline prompt copy support in user messages, making recovery actions and workflow continuation easier for users.
- Harden runtime resilience for unstable provider backends by adding OpenCode connection-loss detection and restart behavior, plus WSL bridge reconnect-aware watch subscription handling to reduce dropped refresh/worktree events.
- Improve robustness of checkpoint and git lifecycle behavior (including missing base checkpoint handling and WSL watcher resubscribe semantics) and expand tests in supervisor and renderer areas to cover the new rollback/recovery paths.