### PR TITLE
fix(file-change): infer create diffs from content payloads

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
@@ -270,6 +270,32 @@ describe("acpToolPayload", () => {
     });
   });
 
+  it("synthesizes diffs and summaries from create content args", () => {
+    const payload = {
+      name: "Write",
+      path: "src/app.js",
+      changeKind: "create",
+      args: {
+        file_path: "src/app.js",
+        content: "const root = document.querySelector('#app');\nroot.textContent = 'hi';\n",
+      },
+    };
+
+    expect(extractAcpDiffSummary(payload)).toEqual({ added: 2, removed: 0 });
+    expect(extractAcpDiffResultPart(payload)).toEqual({
+      text: [
+        "diff --git a/src/app.js b/src/app.js",
+        "--- /dev/null",
+        "+++ b/src/app.js",
+        "@@ -0,0 +1,2 @@",
+        "+const root = document.querySelector('#app');",
+        "+root.textContent = 'hi';",
+        "",
+      ].join("\n"),
+      language: "diff",
+    });
+  });
+
   it("prefers normalized metadata changes over range-less apply_patch text", () => {
     const patch = [
       "Index: /Users/serhiivecherenko/work/site-search-ui/README.md",

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
@@ -283,6 +283,8 @@ function synthesizeEditDiff(payload: unknown): string | undefined {
   if (changesDiff) return changesDiff;
   const applyPatchDiff = synthesizeApplyPatchDiff(payload);
   if (applyPatchDiff) return applyPatchDiff;
+  const createDiff = synthesizeCreateContentDiff(payload);
+  if (createDiff) return createDiff;
 
   const args = p.args;
   if (!args || typeof args !== "object" || Array.isArray(args)) return undefined;
@@ -306,6 +308,18 @@ function synthesizeEditDiff(payload: unknown): string | undefined {
     ...newLines.map((line) => `+${line}`),
     "",
   ].join("\n");
+}
+
+function synthesizeCreateContentDiff(payload: unknown): string | undefined {
+  const content = readCreateContent(payload);
+  if (content === undefined) return undefined;
+  const path =
+    readAcpStringField(payload, "filePath") ??
+    readAcpStringField(payload, "file_path") ??
+    readAcpStringField(payload, "path") ??
+    readPayloadString(payload, "path");
+  if (!path) return undefined;
+  return buildLineUnifiedDiff(path, "", content);
 }
 
 interface StructuredFileChange {
@@ -559,6 +573,18 @@ function summarizeDiffText(diff: string): DiffSummary | undefined {
     }
   }
   return sawLine ? { added, removed } : undefined;
+}
+
+function readCreateContent(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const record = payload as Record<string, unknown>;
+  const changeKind = (readString(record.changeKind) ?? "").toLowerCase();
+  const toolName = (readString(record.name) ?? "").toLowerCase();
+  const args = record.args;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return undefined;
+  const content = readString((args as Record<string, unknown>).content);
+  if (content === undefined) return undefined;
+  return changeKind === "create" || toolName === "write" ? content : undefined;
 }
 
 function readPayloadString(payload: unknown, key: string): string | undefined {

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -444,6 +444,66 @@ describe("mapAcpSessionUpdate", () => {
     expect(started.payload.result).toContain("+const x = 2;");
   });
 
+  it("classifies empty-old-text ACP content diffs as creates", () => {
+    const state = createAcpMapperState("t-fc-content-create");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-content-create",
+        title: "Edit File",
+        kind: "edit",
+        status: "completed",
+        rawInput: {},
+        content: [
+          {
+            type: "diff",
+            path: "index.html",
+            oldText: "",
+            newText: "<!DOCTYPE html>\n<html></html>\n",
+          },
+        ],
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const started = events[0] as { itemType: string; payload: Record<string, unknown> };
+    expect(started.itemType).toBe("file_change");
+    expect(started.payload).toMatchObject({
+      path: "index.html",
+      changeKind: "create",
+      diffSummary: { added: 2, removed: 0 },
+    });
+  });
+
+  it("drops fake removed-line counts from ACP content creates", () => {
+    const state = createAcpMapperState("t-fc-content-create-blank-old");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-content-create-blank-old",
+        title: "Create file",
+        kind: "edit",
+        status: "completed",
+        rawInput: {},
+        content: [
+          {
+            type: "diff",
+            path: "index.html",
+            oldText: "\n",
+            newText: "<!DOCTYPE html>\n<html></html>\n",
+          },
+        ],
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const started = events[0] as { itemType: string; payload: Record<string, unknown> };
+    expect(started.itemType).toBe("file_change");
+    expect(started.payload).toMatchObject({
+      path: "index.html",
+      changeKind: "create",
+      diffSummary: { added: 2, removed: 0 },
+    });
+  });
+
   it("extracts file_change path from apply_patch text args", () => {
     const state = createAcpMapperState("t-fc");
     const events = mapAcpSessionUpdate(
@@ -461,6 +521,33 @@ describe("mapAcpSessionUpdate", () => {
     expect(started.itemType).toBe("file_change");
     expect(started.payload.path).toBe("src/foo.ts");
     expect(started.payload.changeKind).toBe("edit");
+  });
+
+  it("classifies ACP write content payloads as creates", () => {
+    const state = createAcpMapperState("t-fc-write-create");
+    const rawInput = {
+      filePath: "index.html",
+      content: "<!DOCTYPE html>\n<html></html>\n",
+    };
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-write-create",
+        title: "Write `index.html`",
+        kind: "edit",
+        status: "completed",
+        rawInput,
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const started = events[0] as { itemType: string; payload: Record<string, unknown> };
+    expect(started.itemType).toBe("file_change");
+    expect(started.payload).toMatchObject({
+      path: "index.html",
+      changeKind: "create",
+      diffSummary: { added: 2, removed: 0 },
+      args: rawInput,
+    });
   });
 
   it("extracts file_change metadata from file_path and changes arrays", () => {
@@ -808,6 +895,7 @@ describe("mapAcpSessionUpdate", () => {
     expect(terminal.type).toBe("item.completed");
     expect(terminal.payload).toMatchObject({
       path: "src/foo.ts",
+      changeKind: "edit",
       diffSummary: { added: 1, removed: 1 },
       result: {
         changes: [
@@ -818,6 +906,95 @@ describe("mapAcpSessionUpdate", () => {
           },
         ],
       },
+    });
+  });
+
+  it("keeps line removals inside an existing file as edits", () => {
+    const state = createAcpMapperState("t-fc-line-delete");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-line-delete",
+        title: "Delete line",
+        kind: "delete",
+        status: "in_progress",
+        rawInput: {},
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const diff = [
+      "diff --git a/index.html b/index.html",
+      "--- a/index.html",
+      "+++ b/index.html",
+      "@@ -51,7 +51,6 @@",
+      "     <span>${task.text}</span>",
+      "-    <button>bad</button>",
+      "   </li>",
+      "",
+    ].join("\n");
+    const completed = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-fc-line-delete",
+        kind: "delete",
+        rawOutput: diff,
+        status: "completed",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const terminal = completed[0] as { type: string; payload: Record<string, unknown> };
+    expect(terminal.type).toBe("item.completed");
+    expect(terminal.payload).toMatchObject({
+      path: "index.html",
+      changeKind: "edit",
+      diffSummary: { added: 0, removed: 1 },
+      result: diff,
+    });
+  });
+
+  it("uses update new-file diffs to heal file_change kind", () => {
+    const state = createAcpMapperState("t-fc-update-create-diff");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-update-create-diff",
+        title: "Edit File",
+        kind: "edit",
+        status: "in_progress",
+        rawInput: {},
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const diff = [
+      "diff --git a/index.html b/index.html",
+      "new file mode 100644",
+      "--- /dev/null",
+      "+++ b/index.html",
+      "@@ -0,0 +1,2 @@",
+      "+<!DOCTYPE html>",
+      "+<html></html>",
+      "",
+    ].join("\n");
+    const completed = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-fc-update-create-diff",
+        rawOutput: diff,
+        status: "completed",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    const terminal = completed[0] as { type: string; payload: Record<string, unknown> };
+    expect(terminal.type).toBe("item.completed");
+    expect(terminal.payload).toMatchObject({
+      path: "index.html",
+      changeKind: "create",
+      diffSummary: { added: 2, removed: 0 },
+      result: diff,
     });
   });
 

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -595,12 +595,19 @@ function buildAcpToolCallPayload(
     const diffSummary =
       summarizeAcpContentFileChanges(contentDiffs) ??
       readDiffSummary(toolCall.rawInput, contentDiffText);
+    const changeKind = classifyFileChangeKind(
+      kind,
+      title,
+      toolCall.rawInput,
+      primary,
+      contentDiffText,
+    );
     return {
       ...base,
       ...(contentDiffText ? { result: contentDiffText } : {}),
       path: path ?? "",
-      changeKind: classifyFileChangeKind(kind, title, toolCall.rawInput),
-      ...(diffSummary ? { diffSummary } : {}),
+      changeKind,
+      ...(diffSummary ? { diffSummary: normalizeDiffSummaryForKind(changeKind, diffSummary) } : {}),
       ...(primary ? { editOldText: primary.oldText, editNewText: primary.newText } : {}),
     };
   }
@@ -666,7 +673,16 @@ function buildAcpToolCallUpdatePayload(
     const diffSummary =
       summarizeAcpContentFileChanges(contentDiffs) ??
       readDiffSummary(toolCall.rawOutput, contentDiffText);
-    if (diffSummary) payload.diffSummary = diffSummary;
+    const changeKind = classifyFileChangeKind(
+      kind,
+      title,
+      toolCall.rawOutput,
+      primary,
+      contentDiffText,
+      item.payload,
+    );
+    if (diffSummary) payload.diffSummary = normalizeDiffSummaryForKind(changeKind, diffSummary);
+    payload.changeKind = changeKind;
     if (primary) {
       payload.editOldText = primary.oldText;
       payload.editNewText = primary.newText;
@@ -988,17 +1004,101 @@ function readToolLocationPath(
 function classifyFileChangeKind(
   kind: string | undefined,
   title: string | undefined,
-  input: unknown,
+  ...sources: unknown[]
 ): "create" | "edit" | "delete" {
   const k = (kind ?? "").toLowerCase();
   const t = (title ?? "").toLowerCase();
+  for (const source of sources) {
+    const inferred = inferFileChangeKindFromSource(source);
+    if (inferred) return inferred;
+  }
   if (k === "delete" || /\bdelete\b/.test(t)) return "delete";
   if (k === "create" || /\b(create|add)\b/.test(t)) return "create";
-  if (typeof input === "string") {
-    if (/^\*\*\*\s+Add File:/m.test(input)) return "create";
-    if (/^\*\*\*\s+Delete File:/m.test(input)) return "delete";
-  }
+  if ((k === "write" || /\bwrite\b/.test(t)) && sources.some(sourceHasFileContent)) return "create";
   return "edit";
+}
+
+function normalizeDiffSummaryForKind(
+  changeKind: "create" | "edit" | "delete",
+  summary: { added: number; removed: number },
+): { added: number; removed: number } {
+  if (changeKind === "create") return { added: summary.added, removed: 0 };
+  if (changeKind === "delete") return { added: 0, removed: summary.removed };
+  return summary;
+}
+
+function inferFileChangeKindFromSource(source: unknown): "create" | "edit" | "delete" | undefined {
+  if (typeof source === "string") {
+    if (/^\*\*\*\s+Add File:/m.test(source)) return "create";
+    if (/^\*\*\*\s+Delete File:/m.test(source)) return "delete";
+    if (/^\*\*\*\s+Update File:/m.test(source)) return "edit";
+    if (/^(?:new file mode|--- \/dev\/null\b)/m.test(source)) return "create";
+    if (/^(?:deleted file mode|\+\+\+ \/dev\/null\b)/m.test(source)) return "delete";
+    if (/^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/m.test(source)) return "edit";
+    return undefined;
+  }
+  if (!source || typeof source !== "object") return undefined;
+  const record = source as Record<string, unknown>;
+  const changesKind = inferStructuredChangesKind(record.changes);
+  if (changesKind) return changesKind;
+  const diffKind = inferFileChangeKindFromSource(record.diff);
+  if (diffKind) return diffKind;
+  const patchKind =
+    inferFileChangeKindFromSource(record.patchText) ??
+    inferFileChangeKindFromSource(record.patch_text) ??
+    inferFileChangeKindFromSource(record.patch);
+  if (patchKind) return patchKind;
+  const directKind =
+    readStringField(record, "changeKind") ?? readStringField(record, "change_kind");
+  const normalizedKind = directKind?.toLowerCase();
+  if (normalizedKind === "create" || normalizedKind === "add") return "create";
+  if (normalizedKind === "delete" || normalizedKind === "remove") return "delete";
+  if (normalizedKind === "edit" || normalizedKind === "update") return "edit";
+  const oldText =
+    readStringAllowEmpty(record, "oldText") ?? readStringAllowEmpty(record, "old_text");
+  const newText =
+    readStringAllowEmpty(record, "newText") ?? readStringAllowEmpty(record, "new_text");
+  if (oldText !== undefined && oldText.trim().length === 0 && newText && newText.length > 0) {
+    return "create";
+  }
+  if (newText !== undefined && newText.trim().length === 0 && oldText && oldText.length > 0) {
+    return "delete";
+  }
+  return undefined;
+}
+
+function inferStructuredChangesKind(changes: unknown): "create" | "edit" | "delete" | undefined {
+  if (!Array.isArray(changes) || changes.length === 0) return undefined;
+  const kinds = changes.flatMap((change) => {
+    if (!change || typeof change !== "object") return [];
+    const record = change as Record<string, unknown>;
+    const kind = record.kind && typeof record.kind === "object" ? record.kind : record;
+    const type =
+      readStringField(kind, "type") ??
+      readStringField(kind, "changeKind") ??
+      readStringField(kind, "change_kind");
+    if (!type) return [];
+    const normalized = type.toLowerCase();
+    if (normalized === "add" || normalized === "create") return ["create" as const];
+    if (normalized === "delete" || normalized === "remove") return ["delete" as const];
+    if (normalized === "edit" || normalized === "update") return ["edit" as const];
+    return [];
+  });
+  if (kinds.length === 0) return undefined;
+  const uniqueKinds = new Set(kinds);
+  return uniqueKinds.size === 1 ? kinds[0] : undefined;
+}
+
+function sourceHasFileContent(source: unknown): boolean {
+  if (!source || typeof source !== "object") return false;
+  const record = source as Record<string, unknown>;
+  if (typeof record.content === "string" && readFileChangePath(record)) return true;
+  return sourceHasFileContent(record.args) || sourceHasFileContent(record.input);
+}
+
+function readStringAllowEmpty(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === "string" ? value : undefined;
 }
 
 /**

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -869,6 +869,38 @@ describe("sdkCanonicalMapping — tool use", () => {
     ]);
   });
 
+  it("counts Claude Write content lines as create diff summary", () => {
+    const state = createClaudeMapperState("thread-1");
+    const args = {
+      file_path: "src/app.js",
+      content: "const root = document.querySelector('#app');\nroot.textContent = 'hi';\n",
+    };
+
+    const events = mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_write",
+          name: "Write",
+          input: args,
+        },
+      }),
+      state,
+    );
+
+    expect(events[0]).toMatchObject({
+      type: "item.started",
+      itemType: "file_change",
+      payload: {
+        path: "src/app.js",
+        changeKind: "create",
+        diffSummary: { added: 2, removed: 0 },
+      },
+    });
+  });
+
   // TodoWrite, TaskCreate, TaskUpdate, and TaskStop are routed through the
   // plan aggregator (see dedicated tests above) — their underlying tool_use
   // rows never produce a standalone chat item, so they're excluded from this

--- a/src/supervisor/agents/codex/canonicalMapping.test.ts
+++ b/src/supervisor/agents/codex/canonicalMapping.test.ts
@@ -617,6 +617,35 @@ describe("mapCodexNotification — item lifecycle (item/started, item/completed)
     );
   });
 
+  it("counts create content args as file_change diff summary", () => {
+    const state = createCodexMapperState("t-codex");
+    const args = {
+      path: "src/new-file.ts",
+      content: "export const value = 1;\nexport const other = 2;\n",
+    };
+    const events = mapCodexNotification(
+      "item/started",
+      {
+        threadId: "x",
+        itemId: "fc-create",
+        item: {
+          id: "fc-create",
+          type: "fileChange",
+          changeKind: "create",
+          args,
+        },
+      },
+      state,
+    );
+
+    expect((events[0] as { payload: Record<string, unknown> }).payload).toMatchObject({
+      path: "src/new-file.ts",
+      changeKind: "create",
+      diffSummary: { added: 2, removed: 0 },
+      args,
+    });
+  });
+
   it("extracts file_change metadata from real Codex app-server changes arrays", () => {
     const state = createCodexMapperState("t-codex");
     const events = mapCodexNotification(

--- a/src/supervisor/agents/fileChangeSummary.ts
+++ b/src/supervisor/agents/fileChangeSummary.ts
@@ -1,5 +1,6 @@
 import type { FileChangePayload } from "@/shared/contracts";
 import { extractLeadingPath } from "@/shared/extractLeadingPath";
+import { countLineChangeStats } from "@/shared/lineUnifiedDiff";
 
 type DiffSummary = NonNullable<FileChangePayload["diffSummary"]>;
 
@@ -21,6 +22,7 @@ function readDiffSummaryInner(source: unknown): DiffSummary | undefined {
     readDiffSummaryRecord(record.diffSummary) ??
     readDiffSummaryRecord(record.diff_summary) ??
     readStructuredChangesDiffSummary(record.changes) ??
+    readCreatedContentDiffSummary(record) ??
     readPatchTextDiffSummary(record.patchText) ??
     readPatchTextDiffSummary(record.patch_text) ??
     readPatchTextDiffSummary(record.patch) ??
@@ -72,6 +74,9 @@ function readFileChangePathInner(source: unknown): string | undefined {
   const patchPath = /^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s+(.+?)\s*$/m.exec(source);
   if (patchPath?.[1]) return patchPath[1].trim();
 
+  const diffPath = readUnifiedDiffPath(source);
+  if (diffPath) return diffPath;
+
   const leading = extractLeadingPath(source);
   if (leading) return leading;
 
@@ -98,6 +103,22 @@ function readPatchTextPath(source: unknown): string | undefined {
     .filter((path): path is string => !!path);
   const uniquePaths = new Set(paths);
   return uniquePaths.size === 1 ? paths[0] : undefined;
+}
+
+function readUnifiedDiffPath(source: string): string | undefined {
+  const newPath = /^\+\+\+\s+b\/(.+?)\s*$/m.exec(source)?.[1];
+  if (newPath && newPath !== "/dev/null") return stripDiffPathQuotes(newPath);
+  const oldPath = /^---\s+a\/(.+?)\s*$/m.exec(source)?.[1];
+  if (oldPath && oldPath !== "/dev/null") return stripDiffPathQuotes(oldPath);
+  const header = /^diff --git\s+(?:"a\/(.+?)"|a\/(\S+))\s+(?:"b\/(.+?)"|b\/(\S+))\s*$/m.exec(
+    source,
+  );
+  return stripDiffPathQuotes(header?.[3] ?? header?.[4] ?? header?.[1] ?? header?.[2]);
+}
+
+function stripDiffPathQuotes(path: string | undefined): string | undefined {
+  if (!path) return undefined;
+  return path.replace(/^"|"$/g, "").trim();
 }
 
 function readPathField(record: Record<string, unknown>): string | undefined {
@@ -158,6 +179,14 @@ function readStructuredChangesDiffSummary(changes: unknown): DiffSummary | undef
     }
   }
   return sawDiff ? { added, removed } : undefined;
+}
+
+function readCreatedContentDiffSummary(record: Record<string, unknown>): DiffSummary | undefined {
+  if (!readPathField(record)) return undefined;
+  const content = record.content;
+  if (typeof content !== "string") return undefined;
+  const { added } = countLineChangeStats("", content);
+  return added > 0 ? { added, removed: 0 } : undefined;
 }
 
 function readPatchTextDiffSummary(source: unknown): DiffSummary | undefined {

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
@@ -1024,6 +1024,7 @@ describe("sdkCanonicalMapping — tool parts", () => {
         name: "create",
         path: "src/new-file.ts",
         changeKind: "create",
+        diffSummary: { added: 1, removed: 0 },
         args,
         status: "running",
       },


### PR DESCRIPTION
- Add ACP payload synthesis for synthetic unified diffs when tool args include create content
- Update ACP canonical mapping to classify empty-old-text content updates as creates and normalize diff summaries by kind
- Extend shared file-change summary extraction to read created-content summaries and infer paths from unified diffs
- Add/adjust provider mapping tests for ACP, Claude, Codex, and Opencode create-content scenarios
