### PR TITLE
Add random suffix to generated worktree branch names

### DIFF
--- a/src/renderer/components/common/BranchSelector/parts/generateWorktreeBranch.ts
+++ b/src/renderer/components/common/BranchSelector/parts/generateWorktreeBranch.ts
@@ -54,5 +54,8 @@ const NOUNS = [
 export function generateWorktreeBranch(): string {
   const adj = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)]!;
   const noun = NOUNS[Math.floor(Math.random() * NOUNS.length)]!;
-  return `lightcode/${adj}-${noun}`;
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const hash = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `lightcode/${adj}-${noun}-${hash}`;
 }

--- a/src/renderer/components/common/BranchSelector/parts/generateWorktreeBranch.ts
+++ b/src/renderer/components/common/BranchSelector/parts/generateWorktreeBranch.ts
@@ -23,6 +23,18 @@ const ADJECTIVES = [
   "clear",
   "fresh",
   "grand",
+  "bright",
+  "clever",
+  "cosmic",
+  "crisp",
+  "golden",
+  "honest",
+  "nimble",
+  "quick",
+  "silver",
+  "steady",
+  "sunny",
+  "tidy",
 ];
 const NOUNS = [
   "albatross",
@@ -49,6 +61,16 @@ const NOUNS = [
   "wren",
   "yak",
   "zebra",
+  "beacon",
+  "comet",
+  "ember",
+  "harbor",
+  "lantern",
+  "meteor",
+  "meadow",
+  "pixel",
+  "summit",
+  "willow",
 ];
 
 export function generateWorktreeBranch(): string {


### PR DESCRIPTION
- Bugfix: prevent collisions when generating default worktree branch names in BranchSelector flows.
- Branch names now include a short random hex suffix, reducing the chance of duplicate `lightcode/<adjective>-<noun>` outputs under repeated creation.
- Keeps the existing readable adjective/noun pattern while making auto-generated worktree names safely unique.
- Scope: `src/renderer/components/common/BranchSelector/parts/generateWorktreeBranch.ts`.