### PR TITLE
Fix GUI reconnect flow and suppress replayed turn noise

### DIFF
--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -126,7 +126,25 @@ describe("threadActions", () => {
     });
   });
 
-  it("marks inactive GUI threads launching when reopening", () => {
+  it("queues terminal reconnects as launching when reopening", () => {
+    const thread = makeThread({
+      status: "inactive",
+      sessionRef: {
+        providerSessionId: "session-1",
+        discoveredAt: "2026-03-22T00:00:00.000Z",
+      },
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    reopenStoredThread(thread.id);
+
+    const reopened = useAppStore.getState().threads[0];
+    expect(reopened?.status).toBe("launching");
+    expect(reopened?.attention).toBe("none");
+    expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
+  });
+
+  it("queues inactive GUI reconnects without marking them launching", () => {
     const thread = makeThread({
       presentationMode: "gui",
       status: "inactive",
@@ -140,7 +158,7 @@ describe("threadActions", () => {
     reopenStoredThread(thread.id);
 
     const reopened = useAppStore.getState().threads[0];
-    expect(reopened?.status).toBe("launching");
+    expect(reopened?.status).toBe("idle");
     expect(reopened?.attention).toBe("none");
     expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
   });

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -117,9 +117,10 @@ export function reopenStoredThread(threadId: string): void {
     return;
   }
 
+  const isGuiReconnect = thread.presentationMode === "gui" && thread.sessionRef !== undefined;
   startTransition(() => {
     store.updateThreadRuntime(thread.id, {
-      status: "launching",
+      status: isGuiReconnect ? "idle" : "launching",
       attention: "none",
       ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
       canResumeWithConfig: thread.canResumeWithConfig || thread.sessionRef !== undefined,

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -578,7 +578,7 @@ describe("App", () => {
     expect(bridge.startThread).not.toHaveBeenCalled();
   });
 
-  it("queues reconnect for an inactive GUI thread without marking it as working", async () => {
+  it("queues reconnect for an inactive GUI thread without marking it as launching", async () => {
     useAppStore.persist.hasHydrated = vi.fn<() => boolean>().mockReturnValue(true);
     useAppStore.persist.onHydrate = vi.fn<() => () => void>(() => () => undefined);
     useAppStore.persist.onFinishHydration = vi.fn<() => () => void>(() => () => undefined);
@@ -627,10 +627,7 @@ describe("App", () => {
     fireEvent.click(await screen.findByText("open-thread-1"));
 
     await waitFor(() => {
-      expect(screen.getByTestId("thread-view-thread-1")).toHaveAttribute(
-        "data-status",
-        "launching",
-      );
+      expect(screen.getByTestId("thread-view-thread-1")).toHaveAttribute("data-status", "idle");
       expect(screen.getByTestId("thread-view-thread-1")).toHaveAttribute("data-pending-launch", "");
     });
     expect(bridge.startThread).not.toHaveBeenCalled();

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -868,6 +868,34 @@ describe("ChatPane", () => {
     expect(text.indexOf("Worked for 1m 15s")).toBeLessThan(text.indexOf("Follow-up prompt"));
   });
 
+  it("ignores sub-second duplicate completed turns when rendering a rehydrated footer", () => {
+    const thread = {
+      ...makeThread(),
+      status: "idle" as const,
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:10:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:10:00.700Z",
+    };
+    seedAssistantMessage(thread.id, "Final answer");
+    useAppStore.getState().hydrateThreadCompletedTurns(thread.id, [
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:07:50.000Z").getTime(),
+        anchorItemId: ASSISTANT_ITEM_ID,
+      },
+      {
+        startedAt: new Date("2026-05-01T12:10:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:10:00.700Z").getTime(),
+        anchorItemId: ASSISTANT_ITEM_ID,
+      },
+    ]);
+
+    renderChatPane(thread);
+
+    expect(screen.getAllByText("Worked for 7m 50s")).toHaveLength(1);
+    expect(screen.queryByText("Worked for 0s")).not.toBeInTheDocument();
+  });
+
   it("shows checkpoint buttons on later user messages and reverts to before that prompt", async () => {
     const thread = { ...makeThread(), status: "idle" as const };
     seedUserMessage(thread.id, "Initial prompt", "user-1");

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -203,17 +203,20 @@ export function ChatPane(props: ChatPaneProps) {
   // `item.started` arriving, even though the runtime was still working the
   // turn.
   const turn = resolveTurnTiming(thread);
-  const mostRecentCompletedTurnAnchor = useAppStore((s) => {
-    if (isLive || turn?.endedAt == null) return null;
-    const records = s.runtimeCompletedTurnsByThread[threadId];
-    return records && records.length > 0
-      ? (records[records.length - 1]?.anchorItemId ?? null)
-      : null;
-  });
+  const mostRecentDisplayableCompletedTurn = useAppStore((s) =>
+    isLive
+      ? null
+      : selectMostRecentDisplayableCompletedTurn(s.runtimeCompletedTurnsByThread[threadId]),
+  );
+  const mostRecentCompletedTurnAnchor = mostRecentDisplayableCompletedTurn?.anchorItemId ?? null;
   const completedTurnCanRenderInTail =
     !isLive &&
-    turn?.endedAt != null &&
+    (turn?.endedAt != null || mostRecentDisplayableCompletedTurn !== null) &&
     isCompletedTurnAnchorAtTimelineTail(mostRecentCompletedTurnAnchor, timelineEntries);
+  const tailTurn =
+    completedTurnCanRenderInTail && mostRecentDisplayableCompletedTurn
+      ? mostRecentDisplayableCompletedTurn
+      : turn;
   const showTailLoader = isLive || completedTurnCanRenderInTail;
   // The agent is not actually working while it waits for a user answer, so the
   // tail loader keeps rendering but its elapsed-time counter freezes for the
@@ -289,8 +292,8 @@ export function ChatPane(props: ChatPaneProps) {
                     checkpointGuard={checkpointGuard}
                     projectLocation={isHomeScope ? undefined : targetContext?.projectLocation}
                   />
-                  {showTailLoader && turn ? (
-                    <ChatTailLoader turn={turn} isPaused={isTurnPaused} />
+                  {showTailLoader && tailTurn ? (
+                    <ChatTailLoader turn={tailTurn} isPaused={isTurnPaused} />
                   ) : null}
                 </>
               )}
@@ -604,6 +607,11 @@ interface TurnTiming {
   endedAt: number | null;
 }
 
+interface CompletedTurnTiming extends TurnTiming {
+  anchorItemId: string | null;
+  endedAt: number;
+}
+
 function parseTurnTimestamp(iso: string | undefined): number | null {
   if (!iso) return null;
   const ms = new Date(iso).getTime();
@@ -632,6 +640,17 @@ function resolveTurnTiming(thread: Thread): TurnTiming | null {
     startedAt,
     endedAt: Math.max(startedAt, endedAt),
   };
+}
+
+function selectMostRecentDisplayableCompletedTurn(
+  records: readonly CompletedTurnTiming[] | undefined,
+): CompletedTurnTiming | null {
+  if (!records) return null;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    if (record.endedAt - record.startedAt >= 1000) return record;
+  }
+  return null;
 }
 
 function ChatTailLoader({ turn, isPaused }: { turn: TurnTiming; isPaused: boolean }) {

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -393,7 +393,9 @@ export function selectCompletedTurnsByAnchorItem(
   if (cached) return cached;
   const map = new Map<string, CompletedTurnRecord>();
   for (const record of records) {
-    if (record.anchorItemId) map.set(record.anchorItemId, record);
+    if (record.anchorItemId && record.endedAt - record.startedAt >= 1000) {
+      map.set(record.anchorItemId, record);
+    }
   }
   completedTurnsByAnchorCache.set(records, map);
   return map;

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -783,6 +783,44 @@ describe("appStore runtime config sync", () => {
     expect(useAppStore.getState().threads[0]?.activeTurnStartedAt).toBe("2026-05-01T12:00:00.000Z");
   });
 
+  it("closes an offscreen GUI thread when the transcript has not been hydrated", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "a",
+      presentationMode: "gui",
+    });
+
+    useAppStore.setState((state) => ({ ...state, view: { kind: "home" } }));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "working",
+      attention: "working",
+      canResumeWithConfig: false,
+    });
+
+    vi.setSystemTime(new Date("2026-05-01T12:00:05.000Z"));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+    });
+
+    expect(useAppStore.getState().threads[0]).toMatchObject({
+      status: "finished",
+      attention: "none",
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:00:05.000Z",
+    });
+  });
+
   it("lets a forced GUI idle close an interrupted turn before assistant output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
@@ -875,6 +913,38 @@ describe("appStore runtime config sync", () => {
     expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]?.[0]).toMatchObject({
       anchorItemId: "assistant-1",
     });
+  });
+
+  it("does not add sub-second completed turns", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "a",
+      presentationMode: "gui",
+    });
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "assistant-1",
+      itemType: "assistant_message",
+    });
+
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.700Z"));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+    });
+
+    expect(useAppStore.getState().threads[0]?.status).toBe("idle");
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]).toBeUndefined();
   });
 });
 

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -127,6 +127,7 @@ function appendCompletedTurnIfClosed(
   const startedAt = parseTurnIso(nextTurnTiming.lastTurnStartedAt);
   const endedAt = parseTurnIso(nextTurnTiming.lastTurnEndedAt);
   if (startedAt === null || endedAt === null) return unchanged;
+  if (endedAt - startedAt < 1000) return unchanged;
   if (
     prevThread.lastTurnStartedAt === nextTurnTiming.lastTurnStartedAt &&
     prevThread.lastTurnEndedAt === nextTurnTiming.lastTurnEndedAt
@@ -392,6 +393,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
           thread.presentationMode === "gui" &&
           isThreadLiveStatus(thread.status) &&
           input.forceCloseActiveTurn !== true &&
+          (isVisible ||
+            Object.prototype.hasOwnProperty.call(state.runtimeItemIdsByThread, thread.id)) &&
           resolveCompletedTurnAnchorItemId(state, thread.id) === null
         ) {
           effectiveStatus = thread.status;

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -553,6 +553,34 @@ describe("ACP client protocol helpers", () => {
     expect(connection.loadSession).not.toHaveBeenCalled();
   });
 
+  it("does not surface session/resume history replay as new work", async () => {
+    const { connection, listener, session } = makeConfigSyncSession();
+    (session as unknown as Record<string, unknown>)["agentSessionCapabilities"] = { resume: {} };
+    const sessionRef = {
+      providerSessionId: "session-resume",
+      discoveredAt: new Date().toISOString(),
+    };
+    connection.resumeSession.mockImplementationOnce(async () => {
+      session.handleSessionUpdate({
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-1",
+          title: "Read file",
+          kind: "read",
+        },
+      });
+      return { modes: { availableModes: [] }, configOptions: [] };
+    });
+
+    await session.openThread({ model: "model-a" }, sessionRef);
+
+    expect(listener.onUpdate).not.toHaveBeenCalledWith({
+      status: "working",
+      attention: "working",
+    });
+    expect(listener.onRuntimeEvent).not.toHaveBeenCalled();
+  });
+
   it("falls back to session/load for known sessions when resume is not advertised", async () => {
     const { connection, session } = makeConfigSyncSession();
     const sessionRef = {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -927,6 +927,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     if (sessionRef) {
       if (this.agentSessionCapabilities?.resume !== undefined) {
         console.log("[acp] resuming session:", sessionRef.providerSessionId);
+        this.isReplayingHistory = true;
+        this.replayHistoryUntil = Infinity;
         try {
           const result = await this.connection.resumeSession({
             sessionId: sessionRef.providerSessionId,
@@ -938,6 +940,9 @@ export class AcpStructuredSession implements StructuredSessionHandle {
           configOptions = result.configOptions ?? [];
         } catch (error) {
           throw this.loadSessionErrorRewriter(error, sessionRef.providerSessionId);
+        } finally {
+          this.isReplayingHistory = false;
+          this.replayHistoryUntil = Date.now() + 500;
         }
       } else {
         console.log("[acp] loading session:", sessionRef.providerSessionId);
@@ -1576,7 +1581,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     // path below stays in place — terminal-mode threads still get all the
     // existing behaviour, and the canonical channel runs in parallel.
     //
-    // During `loadSession` the agent replays persisted history as
+    // During session resume/load the agent may replay persisted history as
     // `session/update` notifications. Lightcode already has those messages
     // in its own DB, so we skip canonical mapping for the replay window to
     // avoid duplicating every message in the chat pane.


### PR DESCRIPTION
- Tickets: none
- Prevent inactive GUI threads from being marked as launching on reopen by queuing reconnects while leaving them idle until real runtime work resumes.
- Filter out sub-second completed turns so rehydrated history does not surface duplicate 0s/near-zero turn artifacts in thread tail rendering.
- Use displayable completed-turn data for tail loaders on resumed threads to keep elapsed-time and tail state accurate after hydration.
- Treat ACP session resume/load history as replay-only during reconnect, preventing resumed history events from triggering fake runtime “working” activity.
- Tighten GUI thread close behavior to account for visibility/runtime attachment so offscreen threads don’t incorrectly remain active, with lifecycle expectations captured by updated tests.