### PR TITLE
Fix existing worktree selection when disabling new-worktree mode

### DIFF
--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -906,6 +906,7 @@ describe("App", () => {
       "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-x",
     );
     expect(threads[0]?.worktreeBranch).toBe("feature/x");
+    expect(useAppStore.getState().projects[0]?.lastDraftConfig?.worktreeMode).toBe(true);
     expect(bridge.gitWatchWorktrees).toHaveBeenCalledWith({
       projectId: "project-1",
       worktreePaths: ["C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-x"],
@@ -952,6 +953,7 @@ describe("App", () => {
     });
 
     expect(bridge.gitAddWorktree).not.toHaveBeenCalled();
+    expect(useAppStore.getState().projects[0]?.lastDraftConfig?.worktreeMode).toBe(false);
   });
 
   it("uses a sibling thread branch when merge and remove is triggered from a worktree thread without branch metadata", async () => {

--- a/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.test.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BranchFooterActions } from "./BranchFooterActions";
+import type { BranchSelection } from "./types";
+
+describe("BranchFooterActions", () => {
+  it("keeps a selected existing worktree when disabling new-worktree mode from the row", async () => {
+    const onSelect = vi.fn<(selection: BranchSelection) => void>();
+    const onWorktreeModeChange = vi.fn<(value: boolean) => void>();
+
+    render(
+      <BranchFooterActions
+        isCreating={false}
+        setIsCreating={vi.fn<(value: boolean) => void>()}
+        newBranchName=""
+        setNewBranchName={vi.fn<(value: string) => void>()}
+        createRef={{ current: null }}
+        searchRef={{ current: null }}
+        handleCreateBranch={vi.fn<() => void>()}
+        hideWorktreeToggle={false}
+        worktreeMode
+        onWorktreeModeChange={onWorktreeModeChange}
+        baseBranch="feature/x"
+        value="feature/x"
+        isWorktree
+        branchWorktreePath={
+          new Map([["feature/x", "C:\\Users\\demo\\.lightcode\\worktrees\\repo\\feature-x"]])
+        }
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("New worktree"));
+
+    await waitFor(() => {
+      expect(onWorktreeModeChange).toHaveBeenCalledWith(false);
+      expect(onSelect).toHaveBeenCalledWith({
+        branch: "feature/x",
+        baseBranch: "feature/x",
+        isWorktree: true,
+        worktreePath: "C:\\Users\\demo\\.lightcode\\worktrees\\repo\\feature-x",
+      });
+    });
+  });
+});

--- a/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
@@ -102,7 +102,17 @@ export function BranchFooterActions(props: {
               const base = baseBranch ?? value;
               onSelect?.({ branch: base, baseBranch: base, isWorktree: true });
             } else if (isWorktree && baseBranch) {
-              onSelect?.({ branch: baseBranch, isWorktree: false });
+              const existingWorktreePath = branchWorktreePath.get(baseBranch);
+              if (existingWorktreePath) {
+                onSelect?.({
+                  branch: baseBranch,
+                  baseBranch,
+                  isWorktree: true,
+                  worktreePath: existingWorktreePath,
+                });
+              } else {
+                onSelect?.({ branch: baseBranch, isWorktree: false });
+              }
             }
           }}
         >

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -88,7 +88,7 @@ export function AppContent() {
       buildProjectDraftConfig({
         agentKind,
         config,
-        worktreeMode: !isHomeScope && Boolean(worktreeBranch || existingWorktreePath),
+        worktreeMode: !isHomeScope && worktreeIsNewBranch === true,
       }),
     );
 


### PR DESCRIPTION
Tickets: None

- Keep an existing worktree branch selected when turning off `New worktree` mode from the branch selector.
- Preserve the existing worktree path in the branch selection instead of converting the selection into a normal branch.
- Drive saved draft `worktreeMode` from the explicit new-branch state so existing worktree selections are not treated as new-worktree drafts.
- Add regression coverage for `BranchFooterActions` toggle behavior and draft worktree-mode state updates.