### PR TITLE
Bugfix: Fix remote branch deletion and tracking cleanup

### DIFF
--- a/src/renderer/components/common/BranchSelector/BranchSelector.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { ChevronDown, GitBranch, GitFork, Search } from "lucide-react";
-import { Popover, Tooltip } from "@heroui/react";
+import { Popover, toast, Tooltip } from "@heroui/react";
 import type { GitBranchInfo } from "@/shared/contracts";
+import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { Button } from "../Button";
@@ -128,14 +129,16 @@ export function BranchSelector(props: BranchSelectorProps) {
     if (!projectLocation) return;
     setDeletingBranch(branch.name);
     try {
-      const wtPath = branchWorktreePath.get(branch.name);
-      if (wtPath) {
-        await readBridge().gitRemoveWorktree({
-          projectLocation,
-          path: wtPath,
-          force: true,
-          deleteBranch: false,
-        });
+      if (!branch.isRemote) {
+        const wtPath = branchWorktreePath.get(branch.name);
+        if (wtPath) {
+          await readBridge().gitRemoveWorktree({
+            projectLocation,
+            path: wtPath,
+            force: true,
+            deleteBranch: false,
+          });
+        }
       }
       await readBridge().gitDeleteBranch({
         projectLocation,
@@ -143,8 +146,8 @@ export function BranchSelector(props: BranchSelectorProps) {
         force: true,
         ...(branch.remote ? { remote: branch.remote } : {}),
       });
-    } catch {
-      // best-effort — branch may already be deleted by removeWorktree
+    } catch (error) {
+      toast.danger(friendlyError(error));
     }
     try {
       const [branches, wts] = await Promise.all([

--- a/src/renderer/components/common/BranchSelector/parts/BranchListBox.test.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchListBox.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BranchListBox } from "./BranchListBox";
+
+describe("BranchListBox", () => {
+  it("fires delete for a remote branch row", () => {
+    const onDelete =
+      vi.fn<(branch: { name: string; remote?: string; isRemote?: boolean }) => void>();
+    const onSelect = vi.fn<(branchName: string) => void>();
+    const branch = {
+      name: "feature/x",
+      current: false,
+      commit: "abc123",
+      isRemote: true,
+      remote: "origin",
+    };
+
+    render(
+      <BranchListBox
+        items={[
+          { type: "header", id: "header-remote", name: "Remote" },
+          { type: "branch", id: branch.name, branch },
+        ]}
+        hasLocal={false}
+        hasRemote
+        currentBranch="main"
+        value="main"
+        baseBranch={undefined}
+        isWorktree={false}
+        worktreeMode={false}
+        deletingBranch={null}
+        activeWorktreeBranches={new Set()}
+        worktreeBranches={new Set()}
+        onSelect={onSelect}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete feature/x" }));
+
+    expect(onDelete).toHaveBeenCalledWith(branch);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
@@ -1,6 +1,5 @@
 import { Check, GitBranch, Globe, Trash2 } from "lucide-react";
 import { Header, Label, ListBox, ListLayout, Virtualizer } from "@heroui/react";
-import { handleKeyActivate } from "@/renderer/utils/a11y";
 import {
   COMPACT_DROPDOWN_ROW_HEIGHT,
   VIRTUALIZED_COMPACT_DROPDOWN_ITEM_CLASS,
@@ -86,6 +85,7 @@ export function BranchListBox(props: {
           const { branch } = item;
           const canDelete =
             branch.name !== currentBranch && !activeWorktreeBranches.has(branch.name);
+          const isDeleting = deletingBranch === branch.name;
           return (
             <ListBox.Item
               key={branch.name}
@@ -95,34 +95,10 @@ export function BranchListBox(props: {
             >
               <ListBox.ItemIndicator>
                 {({ isSelected }) => {
-                  const isDeleting = deletingBranch === branch.name;
                   if (isDeleting) {
                     return <PixelLoader size="xs" className="text-muted" />;
                   }
-                  return canDelete ? (
-                    <>
-                      {isSelected && <Check className="size-3 group-hover:hidden" />}
-                      <div
-                        role="button"
-                        tabIndex={0}
-                        aria-label={`Delete ${branch.name}`}
-                        className={`items-center justify-center rounded text-muted/55 transition hover:text-danger ${isSelected ? "hidden group-hover:flex" : "opacity-0 group-hover:opacity-100 flex"}`}
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onPointerUp={(e) => e.stopPropagation()}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onDelete(branch);
-                        }}
-                        onKeyDown={(e) =>
-                          handleKeyActivate(e, () => onDelete(branch), { stopPropagation: true })
-                        }
-                      >
-                        <Trash2 className="size-3.5" />
-                      </div>
-                    </>
-                  ) : isSelected ? (
-                    <Check className="size-3" />
-                  ) : null;
+                  return isSelected ? <Check className="size-3" /> : null;
                 }}
               </ListBox.ItemIndicator>
               {branch.isRemote ? (
@@ -136,6 +112,21 @@ export function BranchListBox(props: {
               )}
               {worktreeBranches.has(branch.name) && branch.name !== currentBranch && (
                 <span className="text-[10px] text-muted">worktree</span>
+              )}
+              {canDelete && !isDeleting && (
+                <button
+                  type="button"
+                  aria-label={`Delete ${branch.name}`}
+                  className="ms-auto flex items-center justify-center rounded border-0 bg-transparent p-0 text-muted/55 opacity-0 transition hover:text-danger group-hover:opacity-100"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onPointerUp={(e) => e.stopPropagation()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(branch);
+                  }}
+                >
+                  <Trash2 className="size-3.5" />
+                </button>
               )}
             </ListBox.Item>
           );

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -1422,6 +1422,28 @@ describe("GitService.deleteBranch", () => {
   });
 });
 
+describe("GitService.deleteRemoteBranch", () => {
+  const location = {
+    kind: "windows" as const,
+    path: "C:\\Users\\demo\\work\\repo",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the remote branch and removes the local remote-tracking ref", async () => {
+    mockGitCommands(() => ({ stdout: "" }));
+
+    await new GitService().deleteRemoteBranch(location, "origin", "feature/x");
+
+    expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
+      ["push", "origin", "--delete", "feature/x"],
+      ["update-ref", "-d", "refs/remotes/origin/feature/x"],
+    ]);
+  });
+});
+
 describe("GitService.abortMerge", () => {
   const location = {
     kind: "windows" as const,

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -240,6 +240,9 @@ export class GitWorktreeService {
     branch: string,
   ): Promise<void> {
     await execGit(location, ["push", remote, "--delete", branch], { timeout: GIT_NETWORK_TIMEOUT });
+    await execGit(location, ["update-ref", "-d", `refs/remotes/${remote}/${branch}`]).catch(
+      () => undefined,
+    );
   }
 
   async deleteBranch(location: ProjectLocation, branch: string, force: boolean): Promise<void> {


### PR DESCRIPTION
- Tickets: None
- Fix remote branch removal to fully complete cleanup by deleting both the remote branch and its local remote-tracking ref.
- Prevent branch deletion flow from invoking worktree removal for remote branches, which avoids invalid operations on non-local targets.
- Improve feedback by surfacing deletion failures via user-visible toast messaging instead of silently swallowing errors.
- Add coverage for the new supervisor and renderer behavior by testing remote delete command flow and remote-branch row deletion interaction.