### PR TITLE
Fix stale PR checks by prioritizing live detail status

### DIFF
--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -190,6 +190,23 @@ describe("pending PR refresh", () => {
     expect(ghGetPrDetailsMock).not.toHaveBeenCalled();
   });
 
+  it("polls when the PR summary is stale failed but loaded check details are pending", async () => {
+    const prKey = buildBranchPrKey("p1");
+    useGitStore.getState().setStatus("p1", status);
+    useGitStore.getState().setPrData(prKey, { ...basePr, checksStatus: "FAILURE" });
+    useGitStore.getState().setPrDetails("p1#42", baseDetails);
+    ghGetPrForBranchMock.mockResolvedValue({ ...basePr, checksStatus: "PENDING" });
+    ghGetPrDetailsMock.mockResolvedValue({ details: baseDetails });
+
+    syncPendingPrRefreshProjects([{ id: "p1", location }]);
+
+    expect(ghGetPrForBranchMock).toHaveBeenCalledWith({
+      projectLocation: location,
+      branch: "feature/pr-checks",
+    });
+    expect(ghGetPrDetailsMock).toHaveBeenCalledWith({ projectLocation: location, prNumber: 42 });
+  });
+
   it("stops polling when the worktree thread is removed", async () => {
     useAppStore.setState({ threads: [worktreeThread] });
     useGitStore.getState().setPrData("/repo-wt", basePr);

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -48,8 +48,8 @@ export function combineChecksStatus(
 ): PrChecksStatus | undefined {
   const normalizedDetails = normalizeChecksStatus(detailsStatus);
   const normalizedPr = normalizeChecksStatus(prStatus);
-  if (normalizedDetails === "FAILURE" || normalizedPr === "FAILURE") return "FAILURE";
   if (normalizedDetails === "PENDING" || normalizedPr === "PENDING") return "PENDING";
+  if (normalizedDetails === "FAILURE" || normalizedPr === "FAILURE") return "FAILURE";
   if (normalizedDetails === "SUCCESS" || normalizedPr === "SUCCESS") return "SUCCESS";
   return undefined;
 }

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -22,7 +22,6 @@ import {
 import { readBridge } from "@/renderer/bridge";
 import { PixelLoader } from "@/renderer/components/common";
 import {
-  usePrChecksStatus,
   usePrMergeStateStatus,
   usePrMergeable,
   usePrNumber,
@@ -31,6 +30,7 @@ import {
   usePrUrl,
 } from "@/renderer/state/gitSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { usePrCombinedChecksStatus } from "@/renderer/hooks/usePrCombinedChecksStatus";
 import { getPrStatusTone, PR_TONE_BG_CLASS } from "@/renderer/utils/prStatus";
 import { GitReviewSection } from "./GitReviewSection";
 
@@ -66,12 +66,13 @@ export function PrSection(props: {
   const number = usePrNumber(prKey);
   const title = usePrTitle(prKey);
   const url = usePrUrl(prKey);
-  const checksStatus = usePrChecksStatus(prKey);
+  const cacheKey = number !== undefined ? `${projectId}#${number}` : undefined;
+  const combinedChecksStatus = usePrCombinedChecksStatus(prKey, cacheKey);
   const mergeStateStatus = usePrMergeStateStatus(prKey);
   const mergeable = usePrMergeable(prKey);
   const [bypass, setBypass] = useState(false);
 
-  const indicatorColor = PR_TONE_BG_CLASS[getPrStatusTone(state, checksStatus)];
+  const indicatorColor = PR_TONE_BG_CLASS[getPrStatusTone(state, combinedChecksStatus)];
 
   const reasonKey = mergeable === "CONFLICTING" ? "DIRTY" : mergeStateStatus;
   const isBlocked =

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -5,7 +5,12 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
 import { useShallow } from "zustand/shallow";
 import { handleKeyActivate } from "@/renderer/utils/a11y";
-import { getPrStatusTone, PR_TONE_TEXT_CLASS } from "@/renderer/utils/prStatus";
+import {
+  aggregatePrChecksStatus,
+  combineChecksStatus,
+  getPrStatusTone,
+  PR_TONE_TEXT_CLASS,
+} from "@/renderer/utils/prStatus";
 import type { DragSourceData } from "@/renderer/dnd";
 
 export function GitBadge(props: {
@@ -37,12 +42,14 @@ export function GitBadge(props: {
       const pr = props.worktreePath
         ? s.prData[props.worktreePath]
         : s.prData[buildBranchPrKey(props.projectId)];
+      const details = pr?.number ? s.prDetails[`${props.projectId}#${pr.number}`] : undefined;
+      const detailsStatus = aggregatePrChecksStatus(details?.checks);
       return {
         isRepo: gitStatus?.isRepo ?? false,
         totalInsertions: gitStatus?.totalInsertions ?? 0,
         totalDeletions: gitStatus?.totalDeletions ?? 0,
         prState: pr?.state,
-        checksStatus: pr?.checksStatus,
+        checksStatus: combineChecksStatus(detailsStatus, pr?.checksStatus),
       };
     }),
   );

--- a/src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+++ b/src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
@@ -1,7 +1,8 @@
 import { GitBranch, GitMerge } from "lucide-react";
 import { Chip } from "@heroui/react";
-import { usePrChecksStatus, usePrState } from "@/renderer/state/gitSelectors";
+import { usePrState } from "@/renderer/state/gitSelectors";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { usePrCombinedChecksStatus } from "@/renderer/hooks/usePrCombinedChecksStatus";
 import { getPrStatusTone, PR_TONE_BG_CLASS, PR_TONE_TEXT_CLASS } from "@/renderer/utils/prStatus";
 
 const STATE_LABEL: Record<NonNullable<ReturnType<typeof usePrState>>, string> = {
@@ -15,7 +16,7 @@ const STATE_LABEL: Record<NonNullable<ReturnType<typeof usePrState>>, string> = 
 export function PrMetaRow(props: { prKey: string; cacheKey: string }) {
   const { prKey, cacheKey } = props;
   const state = usePrState(prKey);
-  const checksStatus = usePrChecksStatus(prKey);
+  const checksStatus = usePrCombinedChecksStatus(prKey, cacheKey);
   const details = useGitStore((s) => s.prDetails[cacheKey]);
 
   const tone = getPrStatusTone(state, checksStatus);


### PR DESCRIPTION
Tickets: None

- Bugfix: Normalize combined PR check status so pending check details take precedence over stale summary failures, preventing false-negative PR status during active runs.
- Bugfix: Align PR review sidebar and PR meta row status indicators with the combined checks result for consistent color/tone behavior in both surfaces.
- Bugfix: Update the main Git sidebar badge to merge summary and detail check data before rendering check status text/color.
- Tests: Add coverage for the scenario where PR summary is stale (failure) while details are pending, ensuring pending detail state continues polling and drives status correctly.