### PR TITLE
Show completed state for thread and worktree sidebar groups

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "@heroui/react";
-import { Archive, ChevronRight, CircleCheck, Columns2, Pencil } from "lucide-react";
+import { Archive, Check, ChevronRight, CircleCheck, Columns2, Pencil } from "lucide-react";
 import type { Project } from "@/shared/contracts";
 import { ContextMenu } from "@/renderer/components/common";
 import { archiveThread, toggleMarkThreadDone } from "@/renderer/actions/threadActions";
@@ -20,6 +20,7 @@ export function SidebarThreadGroup(props: {
   const isGroupCollapsed = useIsWorktreeCollapsed(collapseKey);
   const toggleWorktreeCollapsed = useSidebarUiStore((s) => s.toggleWorktreeCollapsed);
   const activeThreads = entry.group.threads.filter((t) => !t.done);
+  const isDone = activeThreads.length === 0;
   const isRenamingGroup = editingThreadId === collapseKey;
 
   return (
@@ -86,6 +87,7 @@ export function SidebarThreadGroup(props: {
                 isGroupCollapsed ? "" : "rotate-90"
               }`}
             />
+            {isDone && <Check className="size-3.5 shrink-0 text-success" strokeWidth={4} />}
             {isRenamingGroup ? (
               <InlineRenameInput
                 initialValue={entry.group.groupName}
@@ -101,8 +103,12 @@ export function SidebarThreadGroup(props: {
               />
             ) : (
               <>
-                <span className="truncate">{entry.group.groupName}</span>
-                <span className="shrink-0 text-muted/60">{entry.group.threads.length}</span>
+                <span className={`truncate ${isDone ? "opacity-50 line-through" : ""}`}>
+                  {entry.group.groupName}
+                </span>
+                <span className={`shrink-0 text-muted/60 ${isDone ? "opacity-50" : ""}`}>
+                  {entry.group.threads.length}
+                </span>
               </>
             )}
           </button>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -45,6 +45,7 @@ export function SidebarWorktreeGroup(props: {
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
   const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
   const groupThreadIds = group.threads.map((t) => t.id);
+  const isDone = group.threads.every((t) => t.done);
 
   const { ref } = useSortable({
     id: `wt:${group.worktreePath}`,
@@ -131,6 +132,7 @@ export function SidebarWorktreeGroup(props: {
           onOpenTerminal={() => openWorktreeTerminal(project.id, group.worktreePath)}
           isDragging={isDragging}
           isDraggingAnything={!!source}
+          isDone={isDone}
         />
       </ContextMenu>
     </div>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -1,4 +1,4 @@
-import { FolderOpen, GitFork, TerminalSquare } from "lucide-react";
+import { Check, FolderOpen, GitFork, TerminalSquare } from "lucide-react";
 import { SidebarButton } from "@/renderer/components/common";
 import { GitBadge } from "./GitBadge";
 import { SidebarPanelDragButton } from "./SidebarPanelDragButton";
@@ -20,6 +20,7 @@ export function WorktreeGroupHeader(props: {
   onOpenTerminal: () => void;
   isDragging?: boolean;
   isDraggingAnything?: boolean;
+  isDone?: boolean;
   onContextMenu?: React.MouseEventHandler | undefined;
 }) {
   return (
@@ -27,13 +28,29 @@ export function WorktreeGroupHeader(props: {
       {...(props.ref != null ? { ref: props.ref } : {})}
       onContextMenu={props.onContextMenu}
       icon={
-        <GitFork
-          className={`size-3 shrink-0 transition-colors ${
-            props.isCollapsed ? "text-muted/60" : "text-foreground"
-          }`}
-        />
+        props.isDone ? (
+          <span className="relative size-3.5 shrink-0 text-muted">
+            <GitFork className="size-3.5 opacity-40" />
+            <Check
+              className="absolute left-[15%] top-[15%] size-[70%] text-success"
+              strokeWidth={4}
+            />
+          </span>
+        ) : (
+          <GitFork
+            className={`size-3 shrink-0 transition-colors ${
+              props.isCollapsed ? "text-muted/60" : "text-foreground"
+            }`}
+          />
+        )
       }
-      label={<span className="font-medium text-foreground/80">{props.worktreeBranch}</span>}
+      label={
+        <span
+          className={`font-medium ${props.isDone ? "opacity-50 line-through" : "text-foreground/80"}`}
+        >
+          {props.worktreeBranch}
+        </span>
+      }
       tooltip={`Worktree: ${props.worktreeBranch}`}
       size="xs"
       liveText


### PR DESCRIPTION
- Tickets: None
- Mark thread groups as completed in the sidebar when all active threads are finished, so users can immediately see finalized thread work.
- Compute and propagate a worktree-level completion state from thread statuses so each worktree header reflects whether its contained threads are done.
- Render completed worktree headers with a check-marked icon and muted/struck styling on the branch label and count to improve visual recognition of finished areas.