### PR TITLE
Add worktree-based new thread creation flow from sidebar thread contexts

### DIFF
--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -51,6 +51,30 @@ export function openNewThreadSideBySide(projectId: string): void {
   });
 }
 
+export function openNewThreadInWorktree(input: {
+  projectId: string;
+  worktreePath: string;
+  worktreeBranch: string;
+}): void {
+  openThreadRequestId += 1;
+  startTransition(() => {
+    const store = useAppStore.getState();
+    store.setPendingDraftWorktreeSelection(input.projectId, {
+      branch: input.worktreeBranch,
+      baseBranch: input.worktreeBranch,
+      isWorktree: true,
+      worktreePath: input.worktreePath,
+    });
+    const mode = useSharedSettings.getState().newThreadMode;
+    const view = useAppStore.getState().view;
+    if (mode === "panel" && view.kind === "thread" && view.panes.length > 0) {
+      useAppStore.getState().openDraftSideBySide(input.projectId);
+    } else {
+      useAppStore.getState().openDraft(input.projectId);
+    }
+  });
+}
+
 export function openThread(threadId: string, options?: { focusComposer?: boolean }): void {
   const thread = useAppStore.getState().threads.find((item) => item.id === threadId);
   const requestId = ++openThreadRequestId;

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -99,7 +99,9 @@ export function ThreadDraftComposerArea(props: {
     }
   }, [pendingPickedAttachments, inboxKey]);
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  const [branchSelection, setBranchSelection] = useState<BranchSelection | null>(null);
+  const [branchSelection, setBranchSelection] = useState<BranchSelection | null>(
+    () => useAppStore.getState().pendingDraftWorktreeSelections[props.project.id] ?? null,
+  );
   const [slashQuery, setSlashQuery] = useState<string | null>(null);
   const [slashActiveIndex, setSlashActiveIndex] = useState(0);
   const [controlOpenRequest, setControlOpenRequest] = useState<{
@@ -256,6 +258,10 @@ export function ThreadDraftComposerArea(props: {
     clearDraftContent(props.project.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time mount restore
   }, []);
+
+  useEffect(() => {
+    useAppStore.getState().clearPendingDraftWorktreeSelection(props.project.id);
+  }, [props.project.id]);
 
   useEffect(() => {
     const pid = props.project.id;

--- a/src/renderer/state/slices/draftSlice.ts
+++ b/src/renderer/state/slices/draftSlice.ts
@@ -1,14 +1,21 @@
-import type { DraftContent } from "./types";
+import type { DraftContent, PendingDraftWorktreeSelection } from "./types";
 import type { SliceCreator } from "./shared";
 
 export interface DraftSlice {
   draftContents: Record<string, DraftContent>;
+  pendingDraftWorktreeSelections: Record<string, PendingDraftWorktreeSelection>;
   saveDraftContent: (projectId: string, content: DraftContent) => void;
   clearDraftContent: (projectId: string) => void;
+  setPendingDraftWorktreeSelection: (
+    projectId: string,
+    selection: PendingDraftWorktreeSelection,
+  ) => void;
+  clearPendingDraftWorktreeSelection: (projectId: string) => void;
 }
 
 export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
   draftContents: {},
+  pendingDraftWorktreeSelections: {},
   saveDraftContent: (projectId, content) =>
     set((state) => ({
       draftContents: { ...state.draftContents, [projectId]: content },
@@ -18,5 +25,18 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
       if (!(projectId in state.draftContents)) return {};
       const { [projectId]: _, ...rest } = state.draftContents;
       return { draftContents: rest };
+    }),
+  setPendingDraftWorktreeSelection: (projectId, selection) =>
+    set((state) => ({
+      pendingDraftWorktreeSelections: {
+        ...state.pendingDraftWorktreeSelections,
+        [projectId]: selection,
+      },
+    })),
+  clearPendingDraftWorktreeSelection: (projectId) =>
+    set((state) => {
+      if (!(projectId in state.pendingDraftWorktreeSelections)) return {};
+      const { [projectId]: _, ...rest } = state.pendingDraftWorktreeSelections;
+      return { pendingDraftWorktreeSelections: rest };
     }),
 });

--- a/src/renderer/state/slices/types.ts
+++ b/src/renderer/state/slices/types.ts
@@ -7,6 +7,13 @@ export interface DraftContent {
   attachments: Attachment[];
 }
 
+export interface PendingDraftWorktreeSelection {
+  branch: string;
+  baseBranch: string;
+  isWorktree: true;
+  worktreePath: string;
+}
+
 export interface SavedGroupLayout {
   panes: string[];
   paneLayout?: PaneLayout;

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -1,4 +1,4 @@
-import { GitFork, Play, Trash2 } from "lucide-react";
+import { GitFork, Play, Plus, Trash2 } from "lucide-react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import type { Project } from "@/shared/contracts";
 import { ContextMenu } from "@/renderer/components/common";
@@ -20,10 +20,12 @@ import {
 import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
 import { openWorktreeTerminal, runProjectAction } from "@/renderer/actions/terminalActions";
 import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
+import { openNewThreadInWorktree } from "@/renderer/actions/threadActions";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useIsWorktreeCollapsed, useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
+import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { gitMenuIcons } from "./gitMenuIcons";
 import type { WorktreeThreadGroup } from "./groupThreads";
 import { useWorktreeGitItems } from "./useWorktreeActions";
@@ -69,6 +71,11 @@ export function SidebarWorktreeGroup(props: {
       <ContextMenu
         items={[
           {
+            id: "new-thread-in-worktree",
+            label: "New Thread in Worktree",
+            icon: <Plus className="size-3.5" />,
+          },
+          {
             type: "submenu" as const,
             id: "git",
             label: "Git",
@@ -98,6 +105,14 @@ export function SidebarWorktreeGroup(props: {
           },
         ]}
         onAction={(key) => {
+          if (key === "new-thread-in-worktree")
+            openNewThreadInWorktree({
+              projectId: project.id,
+              worktreePath: group.worktreePath,
+              worktreeBranch:
+                resolveWorktreeBranch(project.id, group.worktreePath, group.worktreeBranch) ??
+                group.worktreeBranch,
+            });
           if (key === "git-review") openGitReview(project.id, group.worktreePath);
           if (key === "delete-worktree")
             deleteWorktreeGroup(project.id, group.worktreePath, groupThreadIds);

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -8,6 +8,7 @@ import {
   GitFork,
   Pencil,
   Play,
+  Plus,
   Star,
   Trash2,
 } from "lucide-react";
@@ -47,8 +48,10 @@ import {
   deleteThread,
   renameThread,
   continueInProvider,
+  openNewThreadInWorktree,
 } from "@/renderer/actions/threadActions";
 import { runProjectAction } from "@/renderer/actions/terminalActions";
+import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 
 export function SortableThreadItem(props: {
   thread: Thread;
@@ -121,6 +124,11 @@ export function SortableThreadItem(props: {
         items={[
           ...(thread.worktreePath
             ? [
+                {
+                  id: "new-thread-in-worktree",
+                  label: "New Thread in Worktree",
+                  icon: <Plus className="size-3.5" />,
+                },
                 {
                   type: "submenu" as const,
                   id: "git",
@@ -215,6 +223,17 @@ export function SortableThreadItem(props: {
           },
         ]}
         onAction={(key) => {
+          if (key === "new-thread-in-worktree" && thread.worktreePath)
+            openNewThreadInWorktree({
+              projectId: thread.projectId,
+              worktreePath: thread.worktreePath,
+              worktreeBranch:
+                resolveWorktreeBranch(
+                  thread.projectId,
+                  thread.worktreePath,
+                  thread.worktreeBranch,
+                ) ?? thread.worktreePath,
+            });
           if (key === "git-review") openGitReview(thread.projectId, thread.worktreePath);
           if (key === "git-sync" && thread.worktreePath)
             gitSync(thread.projectId, thread.worktreePath);


### PR DESCRIPTION
- [Feature] Add a new `openNewThreadInWorktree` action so new threads can be created directly within a selected worktree and opened in the correct draft mode.
- Persist pending worktree thread context in `src/renderer/state/slices/types.ts` and `src/renderer/state/slices/draftSlice.ts` to carry branch/base branch/path selection through the draft-open flow.
- Initialize and clear pending worktree draft context in `src/renderer/components/thread/ThreadDraftComposerArea.tsx` so branch selection is preloaded correctly for the new thread and does not leak across drafts.
- Extend worktree UI actions in `src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx` and `.../SortableThreadItem/SortableThreadItem.tsx` with a dedicated “New Thread in Worktree” command that resolves the active worktree branch before opening the composer.