### PR TITLE
Fix sidebar git badge fallback for clean worktrees

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatusResult } from "@/shared/contracts";
 import { useGitStore } from "@/renderer/state/gitStore";
@@ -7,6 +8,14 @@ import { GitBadge } from "./GitBadge";
 vi.mock("@dnd-kit/react", () => ({
   useDraggable: () => undefined,
 }));
+
+vi.mock("@heroui/react", () => {
+  const Tooltip = Object.assign((props: { children: ReactNode }) => <>{props.children}</>, {
+    Trigger: (props: { children: ReactNode }) => <>{props.children}</>,
+    Content: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  });
+  return { Tooltip };
+});
 
 function makeStatus(overrides: Partial<GitStatusResult> = {}): GitStatusResult {
   return {
@@ -54,5 +63,37 @@ describe("GitBadge", () => {
 
     expect(icon).not.toBeNull();
     expect(icon).toHaveClass("text-muted/60");
+    expect(icon).toHaveClass("lucide-git-pull-request");
+  });
+
+  it("falls back to a worktree fork icon when a clean worktree has no PR", () => {
+    useGitStore.setState({
+      worktreeStatuses: { "/wt/feature": makeStatus() },
+    });
+
+    render(
+      <GitBadge
+        projectId="project-1"
+        projectName="feature/pr"
+        worktreePath="/wt/feature"
+        fallbackToWorktreeIcon
+      />,
+    );
+
+    const badge = screen.getByRole("button", { name: "Git status for feature/pr" });
+    const icon = badge.querySelector("svg");
+
+    expect(icon).not.toBeNull();
+    expect(icon).toHaveClass("lucide-git-fork");
+  });
+
+  it("renders nothing for a clean worktree without the fallback", () => {
+    useGitStore.setState({
+      worktreeStatuses: { "/wt/feature": makeStatus() },
+    });
+
+    render(<GitBadge projectId="project-1" projectName="feature/pr" worktreePath="/wt/feature" />);
+
+    expect(screen.queryByRole("button", { name: "Git status for feature/pr" })).toBeNull();
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -1,5 +1,6 @@
 import { useId, useRef } from "react";
-import { GitPullRequest } from "lucide-react";
+import { GitFork, GitPullRequest } from "lucide-react";
+import { Tooltip } from "@heroui/react";
 import { useDraggable } from "@dnd-kit/react";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
@@ -19,6 +20,13 @@ export function GitBadge(props: {
   onPress?: () => void;
   worktreePath?: string;
   isActive?: boolean;
+  /**
+   * When set, a worktree with no PR (and no PR to create) falls back to a
+   * `GitFork` marker in this slot instead of rendering nothing, so the row keeps
+   * a single git glyph that reflects state (PR icon when a PR exists, fork
+   * otherwise). The `projectName` is used as the branch name in its tooltip.
+   */
+  fallbackToWorktreeIcon?: boolean;
 }) {
   const elementRef = useRef<HTMLDivElement>(null);
   const dragId = useId();
@@ -67,7 +75,8 @@ export function GitBadge(props: {
   const hasVisiblePr =
     prState !== undefined && prState !== "closed" && (prState !== "merged" || isWorktree);
   const showPrIcon = hasVisiblePr || canCreatePr;
-  if (!isRepo || (!hasChanges && !showPrIcon)) return null;
+  const showWorktreeFork = (props.fallbackToWorktreeIcon ?? false) && isWorktree && !showPrIcon;
+  if (!isRepo || (!hasChanges && !showPrIcon && !showWorktreeFork)) return null;
   const prIconColor = canCreatePr
     ? "text-muted/60"
     : PR_TONE_TEXT_CLASS[getPrStatusTone(prState, checksStatus)];
@@ -88,6 +97,16 @@ export function GitBadge(props: {
     >
       <span className="flex items-center gap-1 text-[10px] font-medium">
         {showPrIcon && <GitPullRequest className={`size-3 ${prIconColor}`} />}
+        {showWorktreeFork && (
+          <Tooltip delay={150}>
+            <Tooltip.Trigger tabIndex={-1} role="none">
+              <span className="flex items-center">
+                <GitFork className="size-3" />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content placement="right">Worktree: {props.projectName}</Tooltip.Content>
+          </Tooltip>
+        )}
         {hasChanges && (
           <span className="flex items-center gap-0.5">
             {totalInsertions > 0 && <span className="text-success">+{totalInsertions}</span>}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
@@ -1,5 +1,4 @@
-import { Tooltip } from "@heroui/react";
-import { Archive, FolderOpen, GitFork, Star, TerminalSquare, Trash2 } from "lucide-react";
+import { Archive, FolderOpen, Star, TerminalSquare, Trash2 } from "lucide-react";
 import type { Thread } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { GitBadge } from "@/renderer/views/MainView/parts/Sidebar/parts/GitBadge";
@@ -70,15 +69,8 @@ export function ThreadItemSuffix(props: {
             worktreePath={thread.worktreePath}
             onPress={() => openGitReview(thread.projectId, thread.worktreePath)}
             isActive={isGitActive}
+            fallbackToWorktreeIcon
           />
-          <Tooltip delay={150}>
-            <Tooltip.Trigger tabIndex={-1} role="none">
-              <div className="flex shrink-0 items-center">
-                <GitFork className="size-3 text-muted/60" />
-              </div>
-            </Tooltip.Trigger>
-            <Tooltip.Content placement="right">Worktree: {thread.worktreeBranch}</Tooltip.Content>
-          </Tooltip>
         </>
       )}
       <span className="relative w-[2.4ch] shrink-0">


### PR DESCRIPTION
- Tickets: none
- Type: Bugfix
- Keep sidebar thread rows visually stateful by showing a fork marker for clean worktrees that have no PR instead of rendering no git badge.
- Preserve existing PR and changed-files behavior so PR badges still show for active PRs while clean worktrees now have a consistent fallback glyph.
- Centralize the fallback behavior in `GitBadge` via `fallbackToWorktreeIcon`, and remove the duplicate fork tooltip/icon rendering from `ThreadItemSuffix`.
- Update `GitBadge.test.tsx` coverage for PR icon behavior, clean-worktree fallback rendering, and disabled-fallback behavior.