### PR TITLE
Bugfix: Use provider version URLs for grok update detection

### DIFF
--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -64,6 +64,7 @@ export const agentUpdateInfoSchema = z.object({
   homebrewCask: z.string().min(1).optional(),
   brew: z.string().min(1).optional(),
   winget: z.string().min(1).optional(),
+  latestVersionUrls: z.array(z.string().url()).optional(),
 });
 export type AgentUpdateInfo = z.infer<typeof agentUpdateInfoSchema>;
 
@@ -382,7 +383,7 @@ export const getLatestAgentVersionResultSchema = z.object({
   /** Latest published version reported by the upstream registry, undefined when probing failed. */
   version: z.string().min(1).optional(),
   /** Where the version came from, surfaced for telemetry / debug. */
-  source: z.enum(["npm", "homebrew-cask", "unknown"]).optional(),
+  source: z.enum(["npm", "homebrew-cask", "version-url", "unknown"]).optional(),
 });
 export type GetLatestAgentVersionResult = z.infer<typeof getLatestAgentVersionResultSchema>;
 

--- a/src/supervisor/agents/grok/detection.ts
+++ b/src/supervisor/agents/grok/detection.ts
@@ -164,6 +164,10 @@ export const grokDetectionSpec: DetectionSpec = {
   capabilities: grokDefaultCapabilities,
   update: {
     builtIn: { binary: "grok", args: ["update"] },
+    latestVersionUrls: [
+      "https://x.ai/cli/stable",
+      "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",
+    ],
   },
   // Auth detection prefers XAI_API_KEY / GROK_API_KEY (for "xai.api_key" ACP method)
   // then falls back to ~/.grok/auth.json (populated by `grok login` → "cached_token").

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -29,6 +29,13 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
     builtIn: { binary: "cursor-agent", args: ["update"] },
     homebrewCask: "cursor-cli",
   },
+  grok: {
+    builtIn: { binary: "grok", args: ["update"] },
+    latestVersionUrls: [
+      "https://x.ai/cli/stable",
+      "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",
+    ],
+  },
 };
 
 function makeStatus(overrides: Partial<AgentStatus>): AgentStatus {
@@ -228,6 +235,35 @@ describe("getLatestVersionForAdapter", () => {
     const callUrl = fetchSpy.mock.calls[0]?.[0] as string;
     expect(callUrl).toContain("raw.githubusercontent.com/Homebrew/homebrew-cask");
     expect(callUrl).toContain("Casks/c/cursor-cli.rb");
+  });
+
+  it("fetches the latest version from provider version URLs", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      text: async () => "0.2.3\n",
+    } as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getLatestVersionForAdapter(makeAdapter("grok"));
+    expect(result).toEqual({ version: "0.2.3", source: "version-url" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://x.ai/cli/stable");
+  });
+
+  it("falls back to the next provider version URL", async () => {
+    const fetchSpy = vi.fn<typeof fetch>();
+    fetchSpy.mockResolvedValueOnce({ ok: false, status: 404 } as Response).mockResolvedValueOnce({
+      ok: true,
+      text: async () => "0.2.4",
+    } as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getLatestVersionForAdapter(makeAdapter("grok"));
+    expect(result).toEqual({ version: "0.2.4", source: "version-url" });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[1]?.[0]).toBe(
+      "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",
+    );
   });
 
   it("returns version: undefined for adapters without update metadata", async () => {

--- a/src/supervisor/agents/updateAgent.ts
+++ b/src/supervisor/agents/updateAgent.ts
@@ -213,6 +213,34 @@ async function fetchHomebrewCaskLatestVersion(cask: string): Promise<string | un
   }
 }
 
+async function fetchLatestVersionFromUrls(urls: readonly string[]): Promise<string | undefined> {
+  for (const url of urls) {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      const controller = new AbortController();
+      timer = setTimeout(() => controller.abort(), 8000);
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { accept: "text/plain" },
+      });
+      if (!response.ok) {
+        console.warn(`[updateAgent] version URL probe failed for ${url}: HTTP ${response.status}`);
+        continue;
+      }
+      const version = (await response.text()).trim();
+      if (version) return version;
+      console.warn(`[updateAgent] version URL probe for ${url} returned no version`);
+    } catch (error) {
+      console.warn(
+        `[updateAgent] version URL probe for ${url} threw: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+  return undefined;
+}
+
 /**
  * Resolve the latest published version for an agent kind. Used by the UI to
  * decide whether to surface the update button. Cached for `LATEST_VERSION_TTL_MS`
@@ -233,7 +261,12 @@ export async function getLatestVersionForAdapter(
 
   const npmName = getNpmPackageNameForUpdate(adapter.update);
   let result: GetLatestAgentVersionResult = { source: "unknown" };
-  if (adapter.update?.homebrewCask) {
+  if (adapter.update?.latestVersionUrls?.length) {
+    const version = await fetchLatestVersionFromUrls(adapter.update.latestVersionUrls);
+    if (version) {
+      result = { version, source: "version-url" };
+    }
+  } else if (adapter.update?.homebrewCask) {
     const version = await fetchHomebrewCaskLatestVersion(adapter.update.homebrewCask);
     if (version) {
       result = { version, source: "homebrew-cask" };


### PR DESCRIPTION
- Tickets: none
- Updates shared agent contracts to support provider-defined `latestVersionUrls` and a new `version-url` source for latest-version checks.
- Adds provider-specific stable version endpoints to Grok’s detection config so updates can be resolved from upstream URL sources.
- Updates version resolution logic to attempt provider version URL checks first, including timeout-aware probing and fallback across URLs before Homebrew-based checks.
- Extends update-result semantics to report URL-based detection as the source of truth for version discovery.
- Adds tests that validate Grok URL-based version fetch behavior and fallback handling between multiple version endpoints.