### PR TITLE
Bugfix: Use remote-tracked refs when syncing PR branches

### DIFF
--- a/src/renderer/hooks/usePrWriteActions.ts
+++ b/src/renderer/hooks/usePrWriteActions.ts
@@ -9,6 +9,7 @@ const ADMIN_BYPASS_RX = /--admin|base branch policy|not mergeable/i;
 
 export interface UsePrWriteActionsArgs {
   projectLocation: ProjectLocation;
+  localSyncLocation?: ProjectLocation | undefined;
   prKey: string | undefined;
   onRefresh: () => void;
 }
@@ -28,7 +29,7 @@ export interface UsePrWriteActionsResult {
  * stay in lockstep across surfaces.
  */
 export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteActionsResult {
-  const { projectLocation, prKey, onRefresh } = args;
+  const { projectLocation, localSyncLocation, prKey, onRefresh } = args;
   const [prLoading, setPrLoading] = useState(false);
 
   function getCurrentPrData() {
@@ -120,6 +121,12 @@ export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteAction
         prNumber: prData.number,
         rebase,
       });
+      const syncPayload = {
+        projectLocation: localSyncLocation ?? projectLocation,
+        remote: "origin",
+      };
+      if (rebase) await readBridge().gitPullRebase(syncPayload);
+      else await readBridge().gitPull(syncPayload);
       onRefresh();
     } catch (err) {
       console.error("[git] update PR branch failed", err);

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
@@ -116,6 +116,7 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
 
   const writeActions = usePrWriteActions({
     projectLocation: project.location,
+    localSyncLocation: getWorktreeLocation(),
     prKey: effectivePrKey,
     onRefresh,
   });

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -857,6 +857,7 @@ describe("GitService.pullFromSource", () => {
 
   it("fast-forwards when HEAD is ancestor of source branch", async () => {
     mockGitCommands((args) => {
+      if (args[0] === "remote") return { stdout: "origin\n" };
       if (args[0] === "merge-base") return { stdout: "" };
       if (args[0] === "merge") return { stdout: "" };
       return { stdout: "" };
@@ -869,6 +870,13 @@ describe("GitService.pullFromSource", () => {
       (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
     );
     expect(mergeCall![1]).toContain("--ff-only");
+    expect(mergeCall![1]).toContain("origin/main");
+    expect(
+      execFileMock.mock.calls.some(
+        (c: unknown[]) =>
+          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "fetch origin --prune",
+      ),
+    ).toBe(true);
   });
 
   it("uses --no-ff when fast-forward is not possible", async () => {
@@ -885,6 +893,21 @@ describe("GitService.pullFromSource", () => {
       (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
     );
     expect(mergeCall![1]).toContain("--no-ff");
+  });
+
+  it("does not merge a stale source branch when fetch fails", async () => {
+    mockGitCommands((args) => {
+      if (args[0] === "remote") return { stdout: "origin\n" };
+      if (args[0] === "fetch") return { error: new Error("fetch failed") };
+      return { stdout: "" };
+    });
+
+    await expect(new GitService().pullFromSource(location, "main")).rejects.toThrow("fetch failed");
+    expect(
+      execFileMock.mock.calls.some(
+        (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[])[0] === "merge",
+      ),
+    ).toBe(false);
   });
 
   it("returns conflicting: true without aborting when merge has conflicts", async () => {
@@ -931,7 +954,7 @@ describe("GitService.pullFromSource", () => {
     expect(result).toEqual({ merged: true, fastForward: true });
     const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
     expect(commands).toContain("stash push -u -m Lightcode: before pull from main");
-    expect(commands).toContain("merge --ff-only main");
+    expect(commands).toContain("merge --ff-only origin/main");
     expect(commands).toContain("stash pop");
   });
 
@@ -1129,6 +1152,7 @@ describe("GitService.getWorktreeSourceBranch", () => {
       if (args[0] === "merge-base") return { stdout: "base123\n" };
       if (args[0] === "config") return { stdout: "" };
       if (args[0] === "rev-list") return { stdout: "1\t1\n" };
+      if (args[0] === "remote") return { stdout: "origin\n" };
       return { stdout: "" };
     });
 
@@ -1152,6 +1176,10 @@ describe("GitService.getWorktreeSourceBranch", () => {
     );
     expect(configCall).toBeDefined();
     expect(configCall![1]).toContain("master");
+    const revListCall = execFileMock.mock.calls.find(
+      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[])[0] === "rev-list",
+    );
+    expect(revListCall![1]).toContain("origin/master...lightcode/brave-heron");
   });
 });
 

--- a/src/supervisor/git/mergeService.ts
+++ b/src/supervisor/git/mergeService.ts
@@ -107,9 +107,13 @@ export class GitMergeService {
     worktreeLocation: ProjectLocation,
     sourceBranch: string,
   ): Promise<GitPullFromSourceResult> {
+    const sourceRef = await this.worktreeService.resolveFetchedSourceRef(
+      worktreeLocation,
+      sourceBranch,
+    );
     let canFastForward = false;
     try {
-      await execGit(worktreeLocation, ["merge-base", "--is-ancestor", "HEAD", sourceBranch]);
+      await execGit(worktreeLocation, ["merge-base", "--is-ancestor", "HEAD", sourceRef]);
       canFastForward = true;
     } catch {
       // not an ancestor
@@ -117,7 +121,7 @@ export class GitMergeService {
 
     if (canFastForward) {
       try {
-        await execGit(worktreeLocation, ["merge", "--ff-only", sourceBranch]);
+        await execGit(worktreeLocation, ["merge", "--ff-only", sourceRef]);
         return { merged: true, fastForward: true };
       } catch (error: unknown) {
         return {
@@ -129,7 +133,7 @@ export class GitMergeService {
     }
 
     try {
-      await execGit(worktreeLocation, ["merge", sourceBranch, "--no-ff", "--no-edit"], {
+      await execGit(worktreeLocation, ["merge", sourceRef, "--no-ff", "--no-edit"], {
         timeout: GIT_HOOK_TIMEOUT,
       });
     } catch (mergeError: unknown) {

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -297,11 +297,12 @@ export class GitWorktreeService {
     let sourceAhead = 0;
     if (sourceBranch) {
       try {
+        const sourceRef = await this.resolveFetchedSourceRef(location, sourceBranch);
         const output = await execGit(location, [
           "rev-list",
           "--left-right",
           "--count",
-          `${sourceBranch}...${branch}`,
+          `${sourceRef}...${branch}`,
         ]);
         const parts = output.trim().split(/\s+/);
         sourceAhead = parseInt(parts[0]!, 10) || 0;
@@ -311,6 +312,19 @@ export class GitWorktreeService {
       }
     }
     return { sourceBranch, commitsAhead, sourceAhead };
+  }
+
+  async resolveFetchedSourceRef(location: ProjectLocation, sourceBranch: string): Promise<string> {
+    await this.fetch(location, "origin", true);
+    if (sourceBranch.startsWith("origin/")) return sourceBranch;
+
+    const remoteRef = `origin/${sourceBranch}`;
+    try {
+      await execGit(location, ["rev-parse", "--verify", "--quiet", `refs/remotes/${remoteRef}`]);
+      return remoteRef;
+    } catch {
+      return sourceBranch;
+    }
   }
 
   async writeWorktreeSourceBranch(


### PR DESCRIPTION
Tickets: none
- Updated PR write actions to use a dedicated local sync location during PR update/rebase flows so review surfaces stay consistent with the sync target.
- Fixed merge execution to resolve and merge against fetched remote-tracked source refs (`origin/...`) in `mergeService`, ensuring PR updates use the latest remote source state.
- Updated worktree source-branch analysis to compute ahead/behind against fetched remote refs, avoiding decisions based on stale local branch pointers.
- Expanded Git supervisor tests to cover fetch-before-merge behavior, explicit `origin/main` merge targets, and to block merge attempts when fetch fails.