### PR TITLE
Bugfix: Respect PR state when deleting worktree branches

### DIFF
--- a/src/renderer/actions/worktreeActions.ts
+++ b/src/renderer/actions/worktreeActions.ts
@@ -64,11 +64,19 @@ export async function performWorktreeRemoval(
   }
 
   if (resolvedWorktreeBranch) {
+    // Force-delete unless an unmerged PR exists. A merged PR (the purple badge)
+    // is safe to drop even when git's local history doesn't show it as merged
+    // (squash/rebase merges), and a branch with no PR at all shouldn't nag the
+    // user with a "not fully merged" error. Only an open/draft/closed PR -- work
+    // that was meant to land but hasn't -- soft-deletes so the user is prompted
+    // before discarding it.
+    const prState = useGitStore.getState().prData[worktreePath]?.state;
+    const hasUnmergedPr = prState !== undefined && prState !== "merged";
     try {
       await readBridge().gitDeleteBranch({
         projectLocation: project.location,
         branch: resolvedWorktreeBranch,
-        force: false,
+        force: !hasUnmergedPr,
       });
     } catch (err: unknown) {
       const detail = errorDetail(err);

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -1035,7 +1035,7 @@ describe("App", () => {
       expect(bridge.gitDeleteBranch).toHaveBeenCalledWith({
         projectLocation: { kind: "windows", path: "C:\\repo" },
         branch: "lightcode/brave-heron",
-        force: false,
+        force: true,
       });
     });
   });

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -1378,34 +1378,28 @@ describe("GitService.deleteBranch", () => {
     vi.clearAllMocks();
   });
 
-  it("force-deletes a worktree branch that is merged into its configured source branch", async () => {
-    let softDeleteAttempted = false;
+  it("force-deletes a branch with -D when force is requested", async () => {
+    let forceDeleteAttempted = false;
     mockGitCommands((args) => {
-      if (args[0] === "branch" && args[1] === "-d") {
-        softDeleteAttempted = true;
-        return { error: new Error("error: The branch 'feature/x' is not fully merged.") };
+      if (args[0] === "branch" && args[1] === "-D") {
+        forceDeleteAttempted = true;
+        return { stdout: "" };
       }
-      if (args[0] === "branch" && args[1] === "-D") return { stdout: "" };
-      if (args[0] === "config") return { stdout: "main\n" };
-      if (args[0] === "merge-base") return { stdout: "" };
       return { stdout: "" };
     });
 
-    await new GitService().deleteBranch(location, "feature/x", false);
+    await new GitService().deleteBranch(location, "feature/x", true);
 
-    expect(softDeleteAttempted).toBe(true);
-    const forceDeleteCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("-D"),
+    expect(forceDeleteAttempted).toBe(true);
+    const softDeleteCall = execFileMock.mock.calls.find(
+      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("-d"),
     );
-    expect(forceDeleteCall).toBeDefined();
+    expect(softDeleteCall).toBeUndefined();
   });
 
   it("prunes stale worktree metadata before retrying a force delete", async () => {
     let forceDeleteAttempts = 0;
     mockGitCommands((args) => {
-      if (args[0] === "branch" && args[1] === "-d") {
-        return { error: new Error("error: The branch 'feature/x' is not fully merged.") };
-      }
       if (args[0] === "branch" && args[1] === "-D") {
         forceDeleteAttempts += 1;
         if (forceDeleteAttempts === 1) {
@@ -1417,13 +1411,11 @@ describe("GitService.deleteBranch", () => {
         }
         return { stdout: "" };
       }
-      if (args[0] === "config") return { stdout: "main\n" };
-      if (args[0] === "merge-base") return { stdout: "" };
       if (args[0] === "worktree" && args[1] === "prune") return { stdout: "" };
       return { stdout: "" };
     });
 
-    await new GitService().deleteBranch(location, "feature/x", false);
+    await new GitService().deleteBranch(location, "feature/x", true);
 
     expect(forceDeleteAttempts).toBe(2);
     const pruneCall = execFileMock.mock.calls.find(
@@ -1435,18 +1427,21 @@ describe("GitService.deleteBranch", () => {
     expect(pruneCall).toBeDefined();
   });
 
-  it("preserves the not-fully-merged failure when the branch is not merged into its source branch", async () => {
+  it("surfaces the not-fully-merged failure on a soft delete without escalating", async () => {
     mockGitCommands((args) => {
-      if (args[0] === "branch")
+      if (args[0] === "branch" && args[1] === "-d") {
         return { error: new Error("error: The branch 'feature/x' is not fully merged.") };
-      if (args[0] === "config") return { stdout: "main\n" };
-      if (args[0] === "merge-base") return { error: new Error("not ancestor") };
+      }
       return { stdout: "" };
     });
 
     await expect(new GitService().deleteBranch(location, "feature/x", false)).rejects.toThrow(
       "not fully merged",
     );
+    const forceDeleteCall = execFileMock.mock.calls.find(
+      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("-D"),
+    );
+    expect(forceDeleteCall).toBeUndefined();
   });
 });
 

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -246,19 +246,10 @@ export class GitWorktreeService {
   }
 
   async deleteBranch(location: ProjectLocation, branch: string, force: boolean): Promise<void> {
-    if (force) {
-      await this.deleteBranchWithPruneRetry(location, branch, true);
-      return;
-    }
-
-    try {
-      await this.deleteBranchWithPruneRetry(location, branch, false);
-    } catch (error) {
-      if (!(await this.canForceDeleteMergedWorktreeBranch(location, branch, error))) {
-        throw error;
-      }
-      await this.deleteBranchWithPruneRetry(location, branch, true);
-    }
+    // The caller decides whether a force delete is safe (e.g. the PR is merged).
+    // We intentionally don't second-guess that here: a soft delete simply
+    // surfaces git's "not fully merged" error so the UI can offer a force option.
+    await this.deleteBranchWithPruneRetry(location, branch, force);
   }
 
   async switchBranch(
@@ -353,27 +344,6 @@ export class GitWorktreeService {
       if (isManaged && !isActive) {
         await this.removeWorktree(location, worktree.path, true).catch(() => undefined);
       }
-    }
-  }
-
-  private async canForceDeleteMergedWorktreeBranch(
-    location: ProjectLocation,
-    branch: string,
-    error: unknown,
-  ): Promise<boolean> {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!/not fully merged/i.test(message)) {
-      return false;
-    }
-    const sourceBranch = await this.readWorktreeSourceBranch(location, branch);
-    if (!sourceBranch) {
-      return false;
-    }
-    try {
-      await execGit(location, ["merge-base", "--is-ancestor", branch, sourceBranch]);
-      return true;
-    } catch {
-      return false;
     }
   }
 


### PR DESCRIPTION
- In `src/renderer/actions/worktreeActions.ts`, worktree branch deletion now bases the `force` flag on PR state, using force deletion for merged or non-PR branches and preserving soft-delete behavior for active/unmerged PR branches.
- In `src/supervisor/git/worktreeService.ts`, `deleteBranch` now trusts the caller’s `force` decision and executes only the requested mode, removing internal merge-ancestor detection that could overrule UI intent.
- This change prevents incorrectly blocking deletion of branches that are already effectively done (including squash/rebase merge scenarios) while still protecting branches with unresolved PR context.
- Updated `src/renderer/app.test.tsx` and `src/supervisor/git.test.ts` to assert the new deletion contract, including forced `-D` behavior and prune-retry flow during forced branch removal.