### PR TITLE
Bugfix: Prevent interrupted Claude turns from surfacing failure states

### DIFF
--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1401,6 +1401,31 @@ describe("sdkCanonicalMapping — turn completion", () => {
       state: "failed",
     });
   });
+
+  it("maps an interrupted turn (error_during_execution + is_error) to interrupted, not failed", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-stop", "do the thing", undefined);
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        errors: ["[ede_diagnostic] turn interrupted before assistant content"],
+        session_id: "claude-session",
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    // Pressing stop (or steering) must not surface a spurious error event.
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events).toContainEqual({
+      type: "turn.completed",
+      threadId: "thread-1",
+      turnId: "turn-stop",
+      state: "interrupted",
+    });
+  });
 });
 
 describe("sdkCanonicalMapping — requests", () => {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -1075,12 +1075,19 @@ export function nonDiagnosticErrors(message: SDKMessage): string[] {
  * claude.exe can emit subtype "success" while still surfacing an upstream API
  * failure (e.g. 401/429) via `is_error: true` and `api_error_status`. Treat
  * those as failures so the turn doesn't quietly resolve to idle.
+ *
+ * `is_error: true` alone is NOT sufficient — an interrupted/aborted turn is
+ * reported as `error_during_execution` with `is_error: true` and only a
+ * `[ede_diagnostic]` line, and must not be misread as an API failure (that
+ * surfaced a spurious "Claude turn failed." on every stop/steer). So the
+ * `is_error` signal is scoped to the documented subtype-"success" quirk; an
+ * explicit `api_error_status >= 400` remains unambiguous on its own.
  */
 export function isApiErrorResult(message: SDKMessage): boolean {
   if (message.type !== "result") return false;
-  const m = message as { is_error?: unknown; api_error_status?: unknown };
-  if (m.is_error === true) return true;
-  return typeof m.api_error_status === "number" && m.api_error_status >= 400;
+  const m = message as { is_error?: unknown; api_error_status?: unknown; subtype?: unknown };
+  if (typeof m.api_error_status === "number" && m.api_error_status >= 400) return true;
+  return m.is_error === true && m.subtype === "success";
 }
 
 export function extractResultErrorMessage(message: SDKMessage): string | undefined {

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -713,4 +713,52 @@ describe("ClaudeSdkSession", () => {
 
     await session.dispose();
   });
+
+  it("treats a steered/interrupted turn as idle rather than a failed turn", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const updates: StructuredSessionUpdate[] = [];
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-steer",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: () => {},
+      onUpdate: (update) => updates.push(update),
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    const openedSessionId = await session.openThread(config);
+    await flushAsyncWork();
+
+    await session.startTurn("do the thing", config);
+    // The user steers → the runtime fires interruptTurn() before the turn settles.
+    await session.interruptTurn();
+    expect(
+      (fake.runtime as unknown as { interrupt: ReturnType<typeof vi.fn> }).interrupt,
+    ).toHaveBeenCalledTimes(1);
+
+    // claude.exe reports an interrupted turn as `error_during_execution` with
+    // `is_error: true` and only a `[ede_diagnostic]` line. This must resolve to
+    // idle — surfacing "Claude turn failed." on every steer is the bug.
+    fake.emitMessage({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["[ede_diagnostic] turn interrupted before assistant content"],
+      session_id: openedSessionId,
+    } as unknown as SDKMessage);
+    await flushAsyncWork();
+
+    const resultUpdate = updates.at(-1);
+    expect(resultUpdate?.status).toBe("idle");
+    expect(resultUpdate?.attention).toBe("none");
+    expect(resultUpdate?.errorMessage).toBeUndefined();
+    expect(updates.some((update) => update.status === "error")).toBe(false);
+
+    await session.dispose();
+  });
 });

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -998,16 +998,19 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       const remaining = nonDiagnosticErrors(message);
       // claude.exe surfaces upstream API failures (e.g. 401 auth, 429 rate
       // limit) as subtype "success" with `is_error: true` / `api_error_status`
-      // set — the failure text lives in `result`, not `errors[]`. Treat those
-      // as failures regardless of subtype/interrupt state so the composer can
-      // show the error and stop the spinner.
+      // set — the failure text lives in `result`, not `errors[]`.
       const apiErrored = isApiErrorResult(message);
-      // Only diagnostic lines remained → treat as interrupted, matching
-      // `mapResultState`. claude.exe emits `[ede_diagnostic] ...` whenever a
-      // turn ends before the assistant produced content, including external
-      // (in-CLI) Esc interrupts where `interruptInFlight` is false.
+      // An interrupt always wins. A steered/aborted turn comes back as
+      // `error_during_execution` with `is_error: true` and only
+      // `[ede_diagnostic]` lines — that would otherwise trip both the API-error
+      // and non-success checks below and surface a spurious "Claude turn
+      // failed." every time the user steers. Genuine API failures (401/429)
+      // arrive with `wasInterrupted` false, so they still surface. The
+      // diagnostic-only case is itself treated as an interrupt via
+      // `isInterruptedResult`, covering external (in-CLI) Esc interrupts where
+      // `interruptInFlight` is false.
       const failed =
-        apiErrored || (message.subtype !== "success" && !wasInterrupted && remaining.length > 0);
+        !wasInterrupted && (apiErrored || (message.subtype !== "success" && remaining.length > 0));
       const errorMessage = failed
         ? (extractResultErrorMessage(message) ?? "Claude turn failed.")
         : undefined;

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -492,6 +492,150 @@ describe("SupervisorRuntime thread input", () => {
     );
   });
 
+  it("drains a pending steer when the working turn fails with error status", async () => {
+    const runtime = makeRuntime(() => undefined);
+    const startTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const interruptTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    (
+      runtime as unknown as {
+        spawnThread: (input: Record<string, unknown>) => { status: string };
+      }
+    ).spawnThread({
+      threadId: "thread-gui-error",
+      agentKind: "codex",
+      adapter: {
+        kind: "codex",
+        label: "Codex",
+        capabilities: {
+          models: [{ id: "gpt-5.4", label: "5.4" }],
+          efforts: ["low"],
+          modelEfforts: {},
+          modes: ["agent"],
+          approvalPolicies: [{ id: "on-request", label: "On Request" }],
+          sandboxModes: [{ id: "read-only", label: "Read Only" }],
+          supportsResume: true,
+          supportsDirectInput: true,
+          liveInputMode: "server",
+          presentationMode: "gui",
+        },
+      },
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      config: { model: "gpt-5.4" },
+      initialSize: { cols: 120, rows: 30 },
+      launchPrompt: "",
+      structuredSession: {
+        launchOptions: {},
+        setListener: vi.fn<(listener: unknown) => void>(),
+        dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        startTurn,
+        interruptTurn,
+      },
+      presentationMode: "gui",
+    });
+
+    (
+      runtime as unknown as {
+        sessions: Map<string, { status: string }>;
+      }
+    ).sessions.get("thread-gui-error")!.status = "working";
+
+    await runtime.sendThreadInput({
+      threadId: "thread-gui-error",
+      prompt: "redirect",
+      config: { model: "gpt-5.4" },
+      userMessageItemId: "user-redirect",
+    });
+
+    expect(interruptTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn).not.toHaveBeenCalled();
+
+    const listener = (
+      (
+        runtime as unknown as {
+          sessions: Map<string, { structuredSession: { setListener: ReturnType<typeof vi.fn> } }>;
+        }
+      ).sessions.get("thread-gui-error")!.structuredSession.setListener as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as {
+      onUpdate: (update: { status: string; attention: string; errorMessage?: string }) => void;
+    };
+
+    // The turn fails instead of reaching idle. The steer must still drain —
+    // otherwise the strip sticks on "waiting for agent to stop" forever.
+    listener.onUpdate({ status: "error", attention: "error", errorMessage: "Claude turn failed." });
+    await Promise.resolve();
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn).toHaveBeenCalledWith("redirect", { model: "gpt-5.4" }, undefined, {
+      userMessageItemId: "user-redirect",
+    });
+  });
+
+  it("drains a steer staged after the turn already errored", async () => {
+    const runtime = makeRuntime(() => undefined);
+    const startTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const interruptTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    (
+      runtime as unknown as {
+        spawnThread: (input: Record<string, unknown>) => { status: string };
+      }
+    ).spawnThread({
+      threadId: "thread-gui-post-error",
+      agentKind: "codex",
+      adapter: {
+        kind: "codex",
+        label: "Codex",
+        capabilities: {
+          models: [{ id: "gpt-5.4", label: "5.4" }],
+          efforts: ["low"],
+          modelEfforts: {},
+          modes: ["agent"],
+          approvalPolicies: [{ id: "on-request", label: "On Request" }],
+          sandboxModes: [{ id: "read-only", label: "Read Only" }],
+          supportsResume: true,
+          supportsDirectInput: true,
+          liveInputMode: "server",
+          presentationMode: "gui",
+        },
+      },
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      config: { model: "gpt-5.4" },
+      initialSize: { cols: 120, rows: 30 },
+      launchPrompt: "",
+      structuredSession: {
+        launchOptions: {},
+        setListener: vi.fn<(listener: unknown) => void>(),
+        dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        startTurn,
+        interruptTurn,
+      },
+      presentationMode: "gui",
+    });
+
+    // The turn already failed before the user types their steer.
+    (
+      runtime as unknown as {
+        sessions: Map<string, { status: string }>;
+      }
+    ).sessions.get("thread-gui-post-error")!.status = "error";
+
+    await runtime.sendThreadInput({
+      threadId: "thread-gui-post-error",
+      prompt: "retry this",
+      config: { model: "gpt-5.4" },
+      userMessageItemId: "user-retry",
+    });
+
+    // Nothing to interrupt — the agent already stopped — so the steer drains
+    // immediately into a fresh turn rather than waiting on a stop that never comes.
+    expect(interruptTurn).not.toHaveBeenCalled();
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn).toHaveBeenCalledWith("retry this", { model: "gpt-5.4" }, undefined, {
+      userMessageItemId: "user-retry",
+    });
+  });
+
   it("does not emit runtime status updates for raw terminal writes", async () => {
     const emitted: unknown[] = [];
     const runtime = makeRuntime((event) => {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -25,6 +25,7 @@ import {
   type TerminalSize,
   type ThreadConfig,
   type ThreadRuntimeSnapshot,
+  type ThreadStatus,
   type WriteTerminalPayload,
   type RuntimeEvent,
   areAgentSlashCommandsEqual,
@@ -535,11 +536,21 @@ export class ThreadSessionManager {
     });
   }
 
+  /**
+   * Stopped states a staged steer can drain from. A failed turn ("error") still
+   * leaves the structured session alive and ready for a new turn, so the steer
+   * must flush there too — a turn that errors never reaches "idle"/"needs_reply",
+   * so without this the strip sticks on "waiting for agent to stop" forever.
+   */
+  private static isSteerDrainableStatus(status: ThreadStatus): boolean {
+    return status === "idle" || status === "needs_reply" || status === "error";
+  }
+
   private maybeDrainPendingSteer(session: SessionRuntime): void {
     if (session.presentationMode !== "gui") {
       return;
     }
-    if (session.status !== "idle" && session.status !== "needs_reply") {
+    if (!ThreadSessionManager.isSteerDrainableStatus(session.status)) {
       return;
     }
     const slot = session.pendingSteer;
@@ -1576,7 +1587,7 @@ export class ThreadSessionManager {
         if (
           session.presentationMode === "gui" &&
           (wasWorking || hadInterruptRequest) &&
-          (update.status === "idle" || update.status === "needs_reply")
+          ThreadSessionManager.isSteerDrainableStatus(update.status)
         ) {
           this.maybeDrainPendingSteer(session);
         }


### PR DESCRIPTION
- Tickets: none
- Treat interrupted Claude result messages as deliberate interruptions instead of API failures so stop/steer flows no longer appear as turn failures.
- Map interrupted result payloads to an idle recovery path in session handling, avoiding spurious “turn failed” error states and preserving normal attention state.
- Expand steer behavior to drain pending GUI steer requests from the `error` state as well as `idle`/`needs_reply`, preventing the strip from hanging on “waiting for agent to stop.”
- Add coverage across canonical mapping, SDK session lifecycle, and runtime thread management to lock in the interrupted-turn and failed-turn drain behavior.