### PR TITLE
Fix completed GUI goal dock visibility and Codex goal restarts

### DIFF
--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -130,18 +130,6 @@ export function GuiThreadContent(
     lastGoalItemRef.current = goalItem;
   }, [dismissedGoalItemId, goalItem]);
 
-  // Track goals seen as non-complete during this mount so completed-in-session
-  // goals keep showing their "Complete" state, but a thread reopened with an
-  // already-complete goal hides the dock.
-  const seenActiveGoalIdsRef = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    if (goalDockState && goalDockState.status !== "complete") {
-      seenActiveGoalIdsRef.current.add(goalDockState.sourceItemId);
-    }
-  }, [goalDockState]);
-  const goalWasActiveThisMount =
-    goalDockState !== null && seenActiveGoalIdsRef.current.has(goalDockState.sourceItemId);
-
   const errorItem = useAppStore((s) => selectThreadLatestErrorItem(s, props.threadId));
   const [dismissedErrorItemId, setDismissedErrorItemId] = useState<string | null>(null);
   const errorDockState =
@@ -149,10 +137,7 @@ export function GuiThreadContent(
       ? getThreadErrorDockStateForItem(errorItem)
       : null;
   const showTodoDock = todoDockState !== null && todoDockState.sourceItemId !== retiredSourceItemId;
-  const showGoalDock =
-    goalDockState !== null &&
-    goalDockState.sourceItemId !== dismissedGoalItemId &&
-    (goalDockState.status !== "complete" || goalWasActiveThisMount);
+  const showGoalDock = goalDockState !== null && goalDockState.sourceItemId !== dismissedGoalItemId;
   const showTodoInRightRail = showTodoDock && todoDockPlacement === "right";
   const showThreadSideRail = runtimeDebugOpen || showTodoInRightRail;
   const hiddenRuntimeItemId = showTodoDock ? todoDockState?.sourceItemId : undefined;

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1205,6 +1205,87 @@ describe("ThreadView", () => {
     expect(screen.queryByText("No messages yet")).not.toBeInTheDocument();
   });
 
+  it("keeps a completed GUI goal in the composer dock", () => {
+    useAppStore.setState({
+      runtimeItemIdsByThread: {
+        "thread-gui-goal-complete": ["goal-1"],
+      },
+      runtimeItemsByIdByThread: {
+        "thread-gui-goal-complete": {
+          "goal-1": {
+            id: "goal-1",
+            type: "goal",
+            state: "completed",
+            payload: {
+              action: "updated",
+              objective: "Ship completed GUI goal dock",
+              status: "complete",
+              tokensUsed: 120,
+              timeUsedSeconds: 5,
+              updatedAt: Date.now() / 1000,
+            },
+            streams: {},
+          },
+        },
+      },
+    });
+
+    renderThreadView({
+      thread: {
+        id: "thread-gui-goal-complete",
+        projectId: "project-1",
+        title: "GUI completed goal thread",
+        agentKind: "claude",
+        config: {
+          model: "sonnet",
+        },
+        status: "idle",
+        attention: "none",
+        canResumeWithConfig: true,
+        archived: false,
+        done: false,
+        starred: false,
+        presentationMode: "gui",
+        sessionRef: {
+          providerSessionId: "session-gui-goal-complete",
+          discoveredAt: new Date().toISOString(),
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      agentStatus: {
+        kind: "claude",
+        label: "Claude Code",
+        installed: true,
+        authState: "authenticated",
+        capabilities: {
+          models: [{ id: "sonnet", label: "Sonnet" }],
+          efforts: ["low"],
+          modelEfforts: {},
+          modes: ["agent"],
+          approvalPolicies: [{ id: "default", label: "Default" }],
+          sandboxModes: [],
+          supportsResume: true,
+          supportsDirectInput: true,
+          liveInputMode: "server",
+          presentationMode: "gui",
+          settingDefs: [],
+        },
+      },
+      projectLocation: {
+        kind: "windows",
+        path: "C:\\repo",
+      },
+      onConfigChange: () => undefined,
+      onResolveServerRequest: async () => undefined,
+      onSubmitInput: async () => undefined,
+    });
+
+    expect(screen.getByLabelText("Thread goal dock")).toHaveAttribute("data-placement", "composer");
+    expect(screen.getByText("Ship completed GUI goal dock")).toBeInTheDocument();
+    expect(screen.getByText("Complete · 120 tokens")).toBeInTheDocument();
+  });
+
   it("moves the pinned todo dock to the right rail and supports collapse", () => {
     useAppStore.setState({
       runtimeItemIdsByThread: {

--- a/src/supervisor/agents/codex/canonicalMapping.test.ts
+++ b/src/supervisor/agents/codex/canonicalMapping.test.ts
@@ -281,6 +281,64 @@ describe("mapCodexNotification — goals", () => {
       { type: "item.completed", threadId: "t-codex", itemId: goalItemId },
     ]);
   });
+
+  it("starts a new Codex goal item when the provider reports a new goal", () => {
+    const state = createCodexMapperState("t-codex");
+    const first = mapCodexNotification(
+      "thread/goal/updated",
+      {
+        threadId: "provider-thread",
+        goal: {
+          objective: "ship initial goal",
+          status: "active",
+          tokensUsed: 120,
+          timeUsedSeconds: 30,
+          createdAt: 1778570000,
+          updatedAt: 1778570030,
+        },
+      },
+      state,
+    );
+    const firstGoalItemId = first[0]?.type === "item.started" ? first[0].itemId : "";
+
+    const next = mapCodexNotification(
+      "thread/goal/updated",
+      {
+        threadId: "provider-thread",
+        goal: {
+          objective: "ship next goal",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          createdAt: 1778570100,
+          updatedAt: 1778570100,
+        },
+      },
+      state,
+    );
+    const nextGoalItemId = next[0]?.type === "item.started" ? next[0].itemId : "";
+
+    expect(next).toEqual([
+      {
+        type: "item.started",
+        threadId: "t-codex",
+        itemId: expect.stringMatching(/^goal-/u),
+        itemType: "goal",
+        payload: {
+          action: "set",
+          objective: "ship next goal",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 0,
+          timeUsedSeconds: 0,
+          updatedAt: 1778570100,
+        },
+      },
+      { type: "item.completed", threadId: "t-codex", itemId: nextGoalItemId },
+    ]);
+    expect(nextGoalItemId).not.toBe(firstGoalItemId);
+  });
 });
 
 describe("mapCodexNotification — plan updates", () => {

--- a/src/supervisor/agents/codex/canonicalMapping.ts
+++ b/src/supervisor/agents/codex/canonicalMapping.ts
@@ -328,6 +328,7 @@ function readCodexGoal(params: Record<string, unknown> | undefined): ProviderGoa
     ...(typeof record.timeUsedSeconds === "number"
       ? { timeUsedSeconds: record.timeUsedSeconds }
       : {}),
+    ...(typeof record.createdAt === "number" ? { createdAt: record.createdAt } : {}),
     ...(typeof record.updatedAt === "number" ? { updatedAt: record.updatedAt } : {}),
   };
 }
@@ -343,6 +344,22 @@ function readCodexGoalStatus(status: unknown): ProviderGoalState["status"] | und
     default:
       return undefined;
   }
+}
+
+function isNewCodexGoal(goal: ProviderGoalState, state: CodexMapperState): boolean {
+  if (goal.createdAt !== undefined && state.goalCreatedAt !== undefined) {
+    return goal.createdAt !== state.goalCreatedAt;
+  }
+  return (
+    goal.objective !== undefined &&
+    state.goalObjective !== undefined &&
+    goal.objective !== state.goalObjective
+  );
+}
+
+function updateCodexGoalIdentity(goal: ProviderGoalState, state: CodexMapperState): void {
+  if (goal.createdAt !== undefined) state.goalCreatedAt = goal.createdAt;
+  if (goal.objective !== undefined) state.goalObjective = goal.objective;
 }
 
 export function mapCodexNotification(
@@ -447,14 +464,16 @@ export function mapCodexNotification(
   if (method === "thread/goal/updated") {
     const goal = readCodexGoal(params);
     if (!goal) return [];
-    if (!state.goalItemId) {
+    if (!state.goalItemId || isNewCodexGoal(goal, state)) {
       state.goalItemId = newItemId("goal");
+      updateCodexGoalIdentity(goal, state);
       const payload = goalPayloadFromProviderState(
         goal,
         goal.status === "active" ? "set" : "updated",
       );
       return startGoalItemEvents(threadId, state.goalItemId, payload);
     }
+    updateCodexGoalIdentity(goal, state);
     const payload = goalPayloadFromProviderState(goal, "updated");
     return updateGoalItemEvents(threadId, state.goalItemId, payload);
   }
@@ -471,6 +490,8 @@ export function mapCodexNotification(
       "cleared",
     );
     delete state.goalItemId;
+    delete state.goalCreatedAt;
+    delete state.goalObjective;
     if (existingGoalItemId) return updateGoalItemEvents(threadId, goalItemId, payload);
     return startGoalItemEvents(threadId, goalItemId, payload);
   }

--- a/src/supervisor/agents/codex/canonicalMappingState.ts
+++ b/src/supervisor/agents/codex/canonicalMappingState.ts
@@ -19,6 +19,10 @@ export interface CodexMapperState {
   fileChangePathMap: Map<string, string>;
   /** Current chat item that mirrors the provider's active goal state. */
   goalItemId?: string;
+  /** Provider-created timestamp for the current goal, when reported. */
+  goalCreatedAt?: number;
+  /** Objective for the current goal, used as a fallback identity. */
+  goalObjective?: string;
   /** Current plan item sourced from `turn/plan/updated` notifications. */
   turnPlanItemId?: string;
 }

--- a/src/supervisor/agents/goalRuntime.ts
+++ b/src/supervisor/agents/goalRuntime.ts
@@ -7,6 +7,7 @@ export interface ProviderGoalState {
   tokenBudget?: number | null;
   tokensUsed?: number;
   timeUsedSeconds?: number;
+  createdAt?: number;
   updatedAt?: number;
 }
 


### PR DESCRIPTION
- Tickets: none
- Preserve the completed GUI goal dock in composer view so completed goals stay visible when reopening threads.
- Keep completed goals visible regardless of prior active-state tracking, preventing missing dock state across sessions.
- Detect new Codex goals by identity (`createdAt`/objective) and start a fresh goal item whenever identity changes.
- Clear and track goal identity state through Codex goal lifecycle so updates apply to the correct goal instance.
- Add coverage for both surfaces: renderer behavior for completed goal dock persistence and canonical mapping behavior for new goal restart events.