### PR TITLE
Split terminal login/install flows and add Grok Build registry entry

### DIFF
--- a/src/renderer/actions/agentLoginActions.ts
+++ b/src/renderer/actions/agentLoginActions.ts
@@ -5,8 +5,6 @@ import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useLoginTerminalStore } from "@/renderer/state/loginTerminalStore";
-import { usePanelStore } from "@/renderer/state/panelStore";
-import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { writeScriptToShell } from "@/renderer/utils/shellUtils";
 
 function resolveLoginProject(): Project | undefined {
@@ -36,65 +34,6 @@ function resolveLoginProject(): Project | undefined {
   }
 
   return app.projects[0];
-}
-
-export function runAgentTerminalCommand(input: {
-  label: string;
-  command: string | ((project: Project) => string);
-  env?: Record<string, string>;
-  onCommandComplete?: (exitCode: number) => void;
-  openUrlsInNativeBrowser?: boolean;
-  project?: Project;
-  tabPurpose?: string;
-  toastPurpose?: string;
-}): boolean {
-  const project = input.project ?? resolveLoginProject();
-  if (!project) {
-    toast.warning("Add a project before opening an agent terminal.");
-    return false;
-  }
-
-  const terminal = useDevTerminalStore.getState();
-  const purpose = input.tabPurpose ?? "login";
-  const tab = terminal.addTab(project.id, `${input.label} ${purpose}`);
-  terminal.openPanel(project.id);
-  terminal.setActiveTab(tab.id);
-  if (useSharedSettings.getState().terminalPosition !== "bottom") {
-    usePanelStore.getState().setRightPanelTab("terminal");
-  }
-
-  void readBridge()
-    .startShell({
-      shellId: tab.id,
-      projectLocation: project.location,
-    })
-    .catch((error) =>
-      toast.danger(
-        error instanceof Error
-          ? error.message
-          : `Unable to open ${input.label} ${input.toastPurpose ?? purpose}.`,
-      ),
-    );
-  const interceptWslUrls =
-    project.location.kind === "wsl" && input.openUrlsInNativeBrowser === true;
-  const command = buildTerminalCommand({
-    command: typeof input.command === "function" ? input.command(project) : input.command,
-    env: interceptWslUrls ? { BROWSER: "/bin/true", ...(input.env ?? {}) } : input.env,
-  });
-  const stopOpeningUrls = interceptWslUrls ? watchUrlsInNativeBrowser(tab.id) : undefined;
-  const completionToken = input.onCommandComplete ? createCompletionToken() : undefined;
-  if (completionToken && input.onCommandComplete) {
-    watchCommandCompletion(tab.id, completionToken, (exitCode) => {
-      stopOpeningUrls?.(true);
-      input.onCommandComplete?.(exitCode);
-    });
-  }
-  writeScriptToShell(
-    tab.id,
-    completionToken ? appendCompletionSignal(command, project, completionToken) : command,
-  );
-  toast.success(`Opened ${input.label} ${input.toastPurpose ?? purpose} in terminal.`);
-  return true;
 }
 
 export function runAgentLoginCommand(input: {
@@ -172,9 +111,95 @@ export function runAgentLoginCommand(input: {
   });
 
   void readBridge()
-    .startShell({ shellId, projectLocation: project.location })
+    // Auth is global (writes to ~/.<agent>), so run login in the user's home
+    // directory rather than the (possibly ephemeral) project worktree.
+    .startShell({ shellId, projectLocation: project.location, startInHome: true })
     .catch((error) => {
+      // The shell never started, so the completion watcher would otherwise leak
+      // (and leave callers' pending UI stuck). Tear it down and report failure.
+      stopWatching();
+      fireOnce(-1);
       toast.danger(error instanceof Error ? error.message : `Unable to open ${input.label} login.`);
+      useLoginTerminalStore.getState().close();
+    });
+  writeScriptToShell(shellId, script);
+  return true;
+}
+
+/**
+ * Run an agent installer inside the transient terminal overlay (the same
+ * surface as {@link runAgentLoginCommand}) rather than a dev-terminal tab.
+ *
+ * Shows no success toast: progress is visible in the overlay, which auto-closes
+ * on success and stays open on failure. Callers drive their own pending UI via
+ * `onCommandComplete`.
+ */
+export function runAgentInstallCommand(input: {
+  label: string;
+  command: string | ((project: Project) => string);
+  env?: Record<string, string>;
+  onCommandComplete?: (exitCode: number) => void;
+  project?: Project;
+}): boolean {
+  const project = input.project ?? resolveLoginProject();
+  if (!project) {
+    toast.warning("Add a project before installing an agent.");
+    return false;
+  }
+
+  // Replace any active overlay session — only one terminal overlay at a time.
+  const previous = useLoginTerminalStore.getState().active;
+  if (previous) {
+    previous.onForceClose?.();
+    void readBridge()
+      .closeThread({ threadId: previous.shellId })
+      .catch(() => undefined);
+  }
+
+  const shellId = `install:${crypto.randomUUID()}`;
+  const command = buildTerminalCommand({
+    command: typeof input.command === "function" ? input.command(project) : input.command,
+    env: input.env,
+  });
+  const completionToken = createCompletionToken();
+  const script = appendCompletionSignal(command, project, completionToken);
+
+  let fired = false;
+  const fireOnce = (exitCode: number) => {
+    if (fired) return;
+    fired = true;
+    input.onCommandComplete?.(exitCode);
+  };
+
+  const stopWatching = watchCommandCompletion(shellId, completionToken, (exitCode) => {
+    fireOnce(exitCode);
+    if (exitCode === 0) {
+      // Let the user read the final success line before the overlay slides away.
+      window.setTimeout(() => useLoginTerminalStore.getState().close(), 1200);
+    } else {
+      useLoginTerminalStore.getState().markFailed(shellId, exitCode);
+    }
+  });
+
+  useLoginTerminalStore.getState().open({
+    shellId,
+    label: input.label,
+    projectLocation: project.location,
+    purpose: "install",
+    onForceClose: () => {
+      stopWatching();
+      fireOnce(-1);
+    },
+  });
+
+  void readBridge()
+    // Installers shouldn't run inside the (possibly ephemeral) project
+    // worktree — launch the shell in the user's home directory instead.
+    .startShell({ shellId, projectLocation: project.location, startInHome: true })
+    .catch((error) => {
+      stopWatching();
+      fireOnce(-1);
+      toast.danger(error instanceof Error ? error.message : `Unable to install ${input.label}.`);
       useLoginTerminalStore.getState().close();
     });
   writeScriptToShell(shellId, script);

--- a/src/renderer/state/loginTerminalStore.ts
+++ b/src/renderer/state/loginTerminalStore.ts
@@ -15,8 +15,10 @@ export interface LoginTerminalSession {
   shellId: string;
   label: string;
   projectLocation: ProjectLocation;
+  /** Drives the overlay header copy. Defaults to "login". */
+  purpose?: "login" | "install";
   onForceClose?: () => void;
-  /** Set when the login command exits non-zero so the overlay can render a failed state. */
+  /** Set when the command exits non-zero so the overlay can render a failed state. */
   failedExitCode?: number;
 }
 

--- a/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
+++ b/src/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay.tsx
@@ -93,6 +93,9 @@ export function LoginTerminalOverlay() {
 
   if (!renderedSession) return null;
 
+  const isInstall = renderedSession.purpose === "install";
+  const purposeNoun = isInstall ? "install" : "login";
+
   return (
     <div className="fixed inset-0 z-[60]">
       <div
@@ -120,20 +123,22 @@ export function LoginTerminalOverlay() {
                 renderedSession.failedExitCode !== undefined ? "text-danger" : "text-foreground"
               }`}
             >
-              {renderedSession.label} login
+              {renderedSession.label} {purposeNoun}
               {renderedSession.failedExitCode !== undefined ? " failed" : ""}
             </p>
             <p className="text-xs text-muted">
               {renderedSession.failedExitCode !== undefined
                 ? `Exited with code ${renderedSession.failedExitCode}. Close to retry.`
-                : "Complete the prompts in this terminal. Closes when finished."}
+                : isInstall
+                  ? "Installing in this terminal. Closes when finished."
+                  : "Complete the prompts in this terminal. Closes when finished."}
             </p>
           </div>
           <Button
             size="sm"
             variant="ghost"
             isIconOnly
-            aria-label="Close login terminal"
+            aria-label={`Close ${purposeNoun} terminal`}
             onPress={closeSession}
           >
             <X className="size-4" />

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -46,7 +46,7 @@ const bridge = {
   openExternal: vi.fn<(url: string) => Promise<void>>(),
 };
 
-const runAgentTerminalCommandMock = vi.hoisted(() => vi.fn<(input: unknown) => void>());
+const runAgentInstallCommandMock = vi.hoisted(() => vi.fn<(input: unknown) => void>());
 const runAgentLoginCommandMock = vi.hoisted(() => vi.fn<(input: unknown) => void>());
 const resetDiscoveredAgentsMock = vi.hoisted(() => vi.fn<() => void>());
 
@@ -82,7 +82,7 @@ vi.mock("@/renderer/bridge", () => ({
 
 vi.mock("@/renderer/actions/agentLoginActions", () => ({
   runAgentLoginCommand: runAgentLoginCommandMock,
-  runAgentTerminalCommand: runAgentTerminalCommandMock,
+  runAgentInstallCommand: runAgentInstallCommandMock,
 }));
 
 vi.mock("@/renderer/components/common", () => ({
@@ -192,7 +192,7 @@ describe("AcpRegistrySettings", () => {
     bridge.focusWindow.mockReset().mockResolvedValue(undefined);
     bridge.openExternal.mockReset().mockResolvedValue(undefined);
     runAgentLoginCommandMock.mockReset();
-    runAgentTerminalCommandMock.mockReset();
+    runAgentInstallCommandMock.mockReset();
     resetDiscoveredAgentsMock.mockReset();
     settingsState.syncAcpRegistryInstalledAgents.mockReset().mockImplementation((installed) => {
       settingsState.acpRegistryInstalledAgents = Object.fromEntries(
@@ -244,10 +244,9 @@ describe("AcpRegistrySettings", () => {
     fireEvent.click(within(codexCard as HTMLElement).getByRole("button", { name: "Install" }));
 
     await waitFor(() => {
-      expect(runAgentTerminalCommandMock).toHaveBeenCalledWith(
+      expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
         expect.objectContaining({
           label: "Codex",
-          tabPurpose: "install",
         }),
       );
     });
@@ -367,11 +366,10 @@ describe("AcpRegistrySettings", () => {
     );
 
     await waitFor(() => {
-      expect(runAgentTerminalCommandMock).toHaveBeenCalledWith(
+      expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
         expect.objectContaining({
           label: "Codex",
           project: wslProject,
-          tabPurpose: "install",
         }),
       );
     });
@@ -486,11 +484,14 @@ describe("AcpRegistrySettings", () => {
 
     fireEvent.click(within(codexCard as HTMLElement).getByRole("button", { name: "Login" }));
 
-    expect(runAgentLoginCommandMock).toHaveBeenCalledWith({
-      label: "Codex WSL",
-      command: "codex login",
-      project: wslProject,
-    });
+    expect(runAgentLoginCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Codex WSL",
+        command: "codex login",
+        project: wslProject,
+        onCommandComplete: expect.any(Function),
+      }),
+    );
   });
 
   it("runs ACP agent-owned auth from registry cards", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
@@ -21,10 +21,7 @@ import type {
   RefreshAgentScope,
 } from "@/shared/contracts";
 import { isWindows, readBridge } from "@/renderer/bridge";
-import {
-  runAgentLoginCommand,
-  runAgentTerminalCommand,
-} from "@/renderer/actions/agentLoginActions";
+import { runAgentInstallCommand, runAgentLoginCommand } from "@/renderer/actions/agentLoginActions";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
@@ -288,6 +285,41 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
       .finally(() => setPendingAuthAgentId(undefined));
   };
 
+  // Terminal-based login (CLI `login` command run in the overlay). Unlike the
+  // ACP method auth above, the CLI exit doesn't update detection on its own, so
+  // we re-probe the scoped agent on success — matching the Agent Settings login
+  // flow — and keep the button pending through the probe.
+  const runTerminalLogin = (input: {
+    agentKind: string;
+    agentId: string;
+    status: AgentStatus;
+    loginCommand: string;
+    env?: Record<string, string>;
+    project?: Project;
+  }) => {
+    setError(undefined);
+    setPendingAuthAgentId(input.agentId);
+    const clearPending = () =>
+      setPendingAuthAgentId((current) => (current === input.agentId ? undefined : current));
+    const opened = runAgentLoginCommand({
+      label: input.status.label ?? input.agentId,
+      command: input.loginCommand,
+      ...(input.env ? { env: input.env } : {}),
+      ...(input.project ? { project: input.project } : {}),
+      onCommandComplete: (exitCode) => {
+        if (exitCode !== 0) {
+          clearPending();
+          return;
+        }
+        void refreshStatuses({
+          reset: false,
+          scope: { agentKinds: [input.agentKind], envs: [scopeEnvForStatus(input.status)] },
+        }).finally(clearPending);
+      },
+    });
+    if (!opened) clearPending();
+  };
+
   const renderTag = (label: string) => (
     <span className="rounded border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted">
       {label}
@@ -347,10 +379,11 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
     const loginCommand = missingAuthStatus?.loginCommand;
     const terminalAuthMethod = findTerminalAuthMethodForStatus(missingAuthStatus);
     const loginProject = projectForStatus(missingAuthStatus);
+    const supportsNativeWindows = agent.supportsWindows !== false;
     const installTargets: InstallTarget[] = [];
     const shouldOfferWslTargets = isWindowsPlatform && wslProjectsByDistro.size > 0;
     if (shouldOfferWslTargets) {
-      if (!nativeStatus && firstWindowsProject) {
+      if (supportsNativeWindows && !nativeStatus && firstWindowsProject) {
         installTargets.push({
           id: "windows",
           label: "Install on Windows",
@@ -365,38 +398,72 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
           project,
         });
       }
-    } else if (!nativeStatus) {
+    } else if (!nativeStatus && (supportsNativeWindows || !isWindowsPlatform)) {
       installTargets.push({ id: "default", label: "Install" });
     }
+    // Native Windows without WSL available, for an agent that has no Windows
+    // installer (e.g. Grok Build): nothing to install here yet.
+    const showWindowsUnsupportedNotice =
+      !isInstalled && !supportsNativeWindows && isWindowsPlatform && installTargets.length === 0;
 
     const runInstallTarget = (target: InstallTarget | undefined) => {
-      runAgentTerminalCommand({
+      setError(undefined);
+      setPendingAgentId(agent.id);
+      runAgentInstallCommand({
         label: agent.label,
         command: agent.installCommand,
         ...(target?.project ? { project: target.project } : {}),
-        tabPurpose: "install",
-        toastPurpose: "install",
+        // Re-detect once the installer exits so the card flips to "Detected"
+        // without the user manually refreshing, mirroring the ACP install flow.
+        // Keep the loader on through the probe so it doesn't flicker back to
+        // "Install" before detection confirms the binary.
+        onCommandComplete: (exitCode) => {
+          const clearPending = () =>
+            setPendingAgentId((current) => (current === agent.id ? undefined : current));
+          if (exitCode === 0) {
+            void refreshStatuses({ reset: false, scope: { agentKinds: [agent.id] } }).finally(
+              clearPending,
+            );
+          } else {
+            clearPending();
+          }
+        },
       });
     };
+
+    const isNativePending = pendingAgentId === agent.id;
 
     const renderInstallControl = () => {
       if (installTargets.length === 0) return null;
       if (installTargets.length === 1) {
         const target = installTargets[0];
         return (
-          <Button size="sm" variant="tertiary" onPress={() => runInstallTarget(target)}>
-            <Download className="size-4" />
-            {target?.label ?? "Install"}
+          <Button
+            size="sm"
+            variant="tertiary"
+            isPending={isNativePending}
+            onPress={() => runInstallTarget(target)}
+          >
+            {({ isPending }) => (
+              <>
+                {isPending ? <PixelLoader size="xs" /> : <Download className="size-4" />}
+                {isPending ? "Installing" : (target?.label ?? "Install")}
+              </>
+            )}
           </Button>
         );
       }
       const targetsById = new Map(installTargets.map((target) => [target.id, target]));
       return (
         <Dropdown>
-          <Button size="sm" variant="tertiary">
-            <Download className="size-4" />
-            Install
-            <ChevronDown className="size-3.5" />
+          <Button size="sm" variant="tertiary" isPending={isNativePending}>
+            {({ isPending }) => (
+              <>
+                {isPending ? <PixelLoader size="xs" /> : <Download className="size-4" />}
+                {isPending ? "Installing" : "Install"}
+                {isPending ? null : <ChevronDown className="size-3.5" />}
+              </>
+            )}
           </Button>
           <Dropdown.Popover placement="bottom end">
             <Dropdown.Menu
@@ -464,9 +531,14 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                   </div>
                 ) : null}
                 {renderInstallControl()}
+                {showWindowsUnsupportedNotice ? (
+                  <span className="max-w-[13rem] text-right text-xs text-muted">
+                    Windows is not supported yet. Install inside WSL or on macOS/Linux.
+                  </span>
+                ) : null}
                 {isInstalled && missingAuthStatus ? (
-                  <div className="flex max-w-[13rem] flex-col items-end gap-1 text-right text-xs text-warning">
-                    <span className="inline-flex items-center gap-1">
+                  <div className="flex items-center gap-2 text-xs text-warning">
+                    <span className="inline-flex items-center gap-1 whitespace-nowrap">
                       <AlertTriangle className="size-3.5" />
                       Sign in required
                     </span>
@@ -474,17 +546,24 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                       <Button
                         size="sm"
                         variant="tertiary"
+                        isPending={pendingAuthAgentId === agent.id}
                         onPress={() =>
-                          runAgentLoginCommand({
-                            label: missingAuthStatus.label ?? agent.label,
-                            command: loginCommand,
+                          runTerminalLogin({
+                            agentKind: agent.id,
+                            agentId: agent.id,
+                            status: missingAuthStatus,
+                            loginCommand,
                             ...(terminalAuthMethod?.env ? { env: terminalAuthMethod.env } : {}),
                             ...(loginProject ? { project: loginProject } : {}),
                           })
                         }
                       >
-                        <LogIn className="size-3.5" />
-                        Login
+                        {({ isPending }) => (
+                          <>
+                            {isPending ? <PixelLoader size="xs" /> : <LogIn className="size-3.5" />}
+                            {isPending ? "Signing in" : "Login"}
+                          </>
+                        )}
                       </Button>
                     ) : null}
                   </div>
@@ -659,21 +738,28 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                           </Button>
                         ))}
                       </div>
-                    ) : loginCommand ? (
+                    ) : loginCommand && localStatus ? (
                       <Button
                         size="sm"
                         variant="tertiary"
+                        isPending={pendingAuthAgentId === agent.id}
                         onPress={() =>
-                          runAgentLoginCommand({
-                            label: localStatus?.label ?? agent.name,
-                            command: loginCommand,
+                          runTerminalLogin({
+                            agentKind: adapterKind,
+                            agentId: agent.id,
+                            status: localStatus,
+                            loginCommand,
                             ...(terminalAuthMethod?.env ? { env: terminalAuthMethod.env } : {}),
                             ...(loginProject ? { project: loginProject } : {}),
                           })
                         }
                       >
-                        <LogIn className="size-3.5" />
-                        Login
+                        {({ isPending }) => (
+                          <>
+                            {isPending ? <PixelLoader size="xs" /> : <LogIn className="size-3.5" />}
+                            {isPending ? "Signing in" : "Login"}
+                          </>
+                        )}
                       </Button>
                     ) : null}
                   </div>

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -6,6 +6,12 @@ export interface NativeAgentRegistryEntry {
   description: string;
   installCommand: (project: Project) => string;
   docsUrl: string;
+  /**
+   * Whether the agent can be installed on native Windows. Defaults to `true`.
+   * When `false`, native Windows installs are hidden (only WSL/macOS/Linux are
+   * offered) since the upstream installer does not support Windows yet.
+   */
+  supportsWindows?: boolean;
 }
 
 const POSIX_MISSING_NPM_MESSAGE =
@@ -63,6 +69,18 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
           "; fi",
         "if (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g opencode-ai } elseif (Get-Command choco -ErrorAction SilentlyContinue) { choco install opencode } elseif (Get-Command scoop -ErrorAction SilentlyContinue) { scoop install opencode } else { Write-Host 'No supported installer found. Install Node.js/npm, Chocolatey, or Scoop first, then refresh detected agents.' }",
       ),
+  },
+  {
+    id: "grok",
+    label: "Grok Build",
+    description: "First-class Grok Build CLI integration using Lightcode's native runtime.",
+    docsUrl: "https://x.ai/cli",
+    // Grok Build only ships a macOS/Linux installer; native Windows is unsupported.
+    // On Windows the install button is hidden and WSL targets are offered instead.
+    supportsWindows: false,
+    installCommand: () =>
+      "if command -v curl >/dev/null 2>&1; then curl -fsSL https://x.ai/cli/install.sh | bash; " +
+      "else printf 'curl is required to install Grok Build. Install curl, then refresh detected agents.\\n'; fi",
   },
 ];
 

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -190,5 +190,11 @@ export const startShellPayloadSchema = z.object({
   projectLocation: projectLocationSchema,
   worktreePath: z.string().min(1).optional(),
   initialSize: terminalSizeSchema.optional(),
+  /**
+   * Start the shell in the user's home directory instead of the project path.
+   * Used by one-shot installers that shouldn't run inside a (possibly
+   * ephemeral) worktree.
+   */
+  startInHome: z.boolean().optional(),
 });
 export type StartShellPayload = z.infer<typeof startShellPayloadSchema>;

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -1,5 +1,6 @@
 import { accessSync, constants as fsConstants, existsSync, readFileSync, statSync } from "node:fs";
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { spawn } from "node-pty";
@@ -701,7 +702,9 @@ export class ThreadSessionManager {
       await primeProjectShellEnv(payload.projectLocation.path);
     }
 
-    const shellCommand = this.buildShellCommand(payload.projectLocation);
+    const shellCommand = this.buildShellCommand(payload.projectLocation, {
+      startInHome: payload.startInHome === true,
+    });
     this.options.emit({ type: "thread-reset", threadId: payload.shellId });
     const terminalEnv = resolveTerminalColorEnv(payload.projectLocation);
 
@@ -2060,15 +2063,20 @@ export class ThreadSessionManager {
     session.pty.kill();
   }
 
-  private buildShellCommand(location: ProjectLocation): {
+  private buildShellCommand(
+    location: ProjectLocation,
+    options?: { startInHome?: boolean },
+  ): {
     command: string;
     args: string[];
     cwd?: string;
   } {
+    const startInHome = options?.startInHome === true;
     if (location.kind === "wsl") {
+      // `wsl --cd ~` lands in the distro's Linux home; otherwise the worktree.
       return {
         command: getWslCommand(),
-        args: ["-d", location.distro, "--cd", location.linuxPath],
+        args: ["-d", location.distro, "--cd", startInHome ? "~" : location.linuxPath],
       };
     }
 
@@ -2076,7 +2084,7 @@ export class ThreadSessionManager {
       return {
         command: this.options.windowsShell.shell,
         args: [...this.options.windowsShell.args],
-        cwd: location.path,
+        cwd: startInHome ? homedir() : location.path,
       };
     }
 
@@ -2084,7 +2092,7 @@ export class ThreadSessionManager {
     return {
       command: shell,
       args: ["-l"],
-      cwd: location.path,
+      cwd: startInHome ? homedir() : location.path,
     };
   }
 


### PR DESCRIPTION
Tickets: none

- Add a separate terminal action path for installs and keep login terminals distinct with purpose-aware state, so the overlay accurately communicates whether the user is installing or logging in.
- Update installer/login handling in Settings so terminal-based login now re-checks agent auth status after successful completion, improving post-login detection reliability.
- Introduce a new Grok Build native registry entry with OS-aware install visibility, hiding Windows-native installs while still supporting supported platforms.
- Extend the shell-start contract and session manager to support `startInHome`, allowing one-shot installer shells to run from stable home directories instead of transient project worktrees.