### PR TITLE
Bugfix: Show web-search rows when query is missing

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -292,6 +292,21 @@ describe("ToolCallGroup", () => {
     expect(screen.getByText("Tool search: deploy")).toBeInTheDocument();
   });
 
+  it("keeps web searches visible when Codex omits the query", () => {
+    const threadId = "thread-1";
+    const item = makeWebSearchItem("web-search-1", {
+      query: "",
+      name: "WebSearch",
+      args: { type: "other" },
+      status: "success",
+    });
+    seedThread(threadId, [item]);
+
+    renderToolCallGroup(threadId, [item.id]);
+
+    expect(screen.getByText("Web search")).toBeInTheDocument();
+  });
+
   it("categorizes sub-agent tools as commands", () => {
     const threadId = "thread-1";
     const items = [makeAgentItem("agent-1")];
@@ -366,6 +381,16 @@ function makeSemanticToolItem(
   return {
     id,
     type,
+    state: "completed",
+    payload,
+    streams: {},
+  };
+}
+
+function makeWebSearchItem(id: string, payload: RuntimeChatItem["payload"]): RuntimeChatItem {
+  return {
+    id,
+    type: "web_search",
     state: "completed",
     payload,
     streams: {},

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -544,7 +544,8 @@ function getFileChangeRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow
 
 function getWebSearchRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow | null {
   const payload = getRuntimeItemPayload<WebSearchPayload>(item, "web_search");
-  if (!payload?.query) return null;
+  if (!payload) return null;
+  const title = payload.query || formatWebSearchName(readPayloadString(payload, "name"));
   const sections: ToolCallSection[] =
     isExpanded && hasAuxFields(payload)
       ? [
@@ -561,12 +562,16 @@ function getWebSearchRow(item: RuntimeChatItem, isExpanded: boolean): InlineRow 
   ) : undefined;
   return {
     Icon: Globe,
-    title: payload.query,
+    title,
     rightLabel,
     rightLabelClassName: "text-[color:var(--muted)]",
     hasDetails: hasAuxFields(payload),
     sections,
   };
+}
+
+function formatWebSearchName(name: string | undefined): string {
+  return name === "WebSearch" || !name ? "Web search" : name;
 }
 
 type GroupCategory = "viewed" | "searched" | "edited" | "executed" | "other";

--- a/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
@@ -23,7 +23,8 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
       { label: "results", part: extractAcpResultPart(payload) },
     ];
   }, [isExpanded, payload]);
-  if (!payload?.query) return null;
+  if (!payload) return null;
+  const title = payload.query || formatWebSearchName(readPayloadString(payload, "name"));
   const hasDetails = hasAuxFields(payload);
   const resultCount = payload.resultCount ?? deriveResultCount(payload);
   const right =
@@ -32,7 +33,7 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
   return (
     <ChatItemAccordion
       icon={<Globe className="size-3" />}
-      title={payload.query}
+      title={title}
       rightLabel={right}
       hasBody={hasDetails}
       isExpanded={isExpanded}
@@ -47,6 +48,16 @@ function hasAuxFields(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") return false;
   const p = payload as Record<string, unknown>;
   return p.args !== undefined || p.result !== undefined;
+}
+
+function readPayloadString(payload: unknown, key: string): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const v = (payload as Record<string, unknown>)[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function formatWebSearchName(name: string | undefined): string {
+  return name === "WebSearch" || !name ? "Web search" : name;
 }
 
 /**


### PR DESCRIPTION
Tickets: n/a
- Fixes a regression where web-search tool rows were hidden whenever the tool payload omitted a `query` field.
- Restores web-search visibility in `ToolCallGroup` by using a resilient title fallback based on the tool name metadata.
- Aligns standalone `WebSearchItem` rendering with the same fallback behavior so query-less web-search tool calls still display with normal details.
- Adds focused test coverage for empty-query web-search items to prevent this visibility issue from reappearing.