### PR TITLE
Expand browser MCP tools and add @Browser composer mention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/icons/
 tmp/
 .agent/
 lightcode-diff.patch
+review.diff
 .spec-workflow/
 **/worktrees/
 .cursor/

--- a/src/main/browser/BrowserMcpIngress.test.ts
+++ b/src/main/browser/BrowserMcpIngress.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BrowserMcpIngress } from "./BrowserMcpIngress";
+import type { BrowserPanelManager } from "./BrowserPanelManager";
+
+let ingress: BrowserMcpIngress | null = null;
+
+afterEach(() => {
+  ingress?.dispose();
+  ingress = null;
+});
+
+describe("BrowserMcpIngress", () => {
+  it("advertises browser instructions and API discovery on initialize", async () => {
+    ingress = new BrowserMcpIngress();
+    const info = await ingress.start();
+
+    const response = await fetch(`${info.url}/mcp`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${info.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
+    });
+
+    const body = (await response.json()) as {
+      result: {
+        serverInfo: { name: string };
+        instructions: string;
+      };
+    };
+
+    expect(body.result.serverInfo.name).toBe("browser");
+    expect(body.result.instructions).toContain("Use the browser MCP server");
+    expect(body.result.instructions).toContain("browser.api");
+    expect(body.result.instructions).toContain("@e refs");
+  });
+
+  it("routes MCP reload, get_url, and fill through the browser panel tab", async () => {
+    ingress = new BrowserMcpIngress();
+    const send = vi.fn<(method: string, params?: Record<string, unknown>) => Promise<unknown>>(
+      async (method) => {
+        if (method === "Runtime.evaluate") {
+          return { result: { type: "boolean", value: true } };
+        }
+        return {};
+      },
+    );
+    const revealPanel = vi.fn<() => void>();
+    const tab = {
+      tabId: "tab-1",
+      snapshot: () => ({ url: "https://example.test/page", title: "Example Page" }),
+      webContents: {
+        focus: vi.fn<() => void>(),
+        executeJavaScript: vi
+          .fn<(script: string, userGesture?: boolean) => Promise<unknown>>()
+          .mockResolvedValue(true),
+      },
+      cdp: {
+        attach: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        send,
+      },
+    };
+    ingress.setManagerAccessor(
+      () =>
+        ({
+          revealPanel,
+          snapshot: () => ({
+            tabs: [
+              {
+                tabId: "tab-1",
+                url: "https://example.test/page",
+                title: "Example Page",
+                loading: false,
+                canGoBack: false,
+                canGoForward: false,
+                devToolsOpen: false,
+              },
+            ],
+            activeTabId: "tab-1",
+          }),
+          getActiveTab: () => tab,
+          getTab: () => tab,
+          createTab: vi.fn<() => Promise<unknown>>().mockResolvedValue({ tabId: "tab-1" }),
+          reload: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        }) as unknown as BrowserPanelManager,
+    );
+    const info = await ingress.start();
+
+    const callTool = async (name: string, args: Record<string, unknown>) => {
+      const response = await fetch(`${info.url}/mcp`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${info.token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: name,
+          method: "tools/call",
+          params: { name, arguments: args },
+        }),
+      });
+      return (await response.json()) as {
+        result: { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+      };
+    };
+
+    const api = await callTool("api", {});
+    expect(api.result.isError).toBeUndefined();
+
+    const reload = await callTool("reload", {});
+    expect(reload.result.isError).toBeUndefined();
+    await expect(callTool("get_url", {})).resolves.toMatchObject({
+      result: { content: [{ type: "text", text: '{\n  "url": "https://example.test/page"\n}' }] },
+    });
+    const fill = await callTool("fill", { selector: "input", text: "hello", submit: true });
+    expect(fill.result.isError).toBeUndefined();
+    const click = await callTool("click", { selector: "button" });
+    expect(click.result.isError).toBeUndefined();
+    const type = await callTool("type", { selector: "input", text: "hello" });
+    expect(type.result.isError).toBeUndefined();
+    const press = await callTool("press", { selector: "input", key: "Enter" });
+    expect(press.result.isError).toBeUndefined();
+
+    expect(revealPanel).toHaveBeenCalledTimes(5);
+    expect(send).not.toHaveBeenCalledWith("Input.insertText", { text: "hello" });
+    expect(send.mock.calls.some(([method]) => String(method).startsWith("Input."))).toBe(false);
+    expect(tab.webContents.executeJavaScript).toHaveBeenCalled();
+    expect(
+      tab.webContents.executeJavaScript.mock.calls.some(([script]) =>
+        String(script).includes('press("Enter", "input", false)'),
+      ),
+    ).toBe(true);
+    expect(tab.webContents.focus).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/browser/BrowserMcpIngress.ts
+++ b/src/main/browser/BrowserMcpIngress.ts
@@ -2,11 +2,13 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { randomBytes, randomUUID } from "node:crypto";
 import type { BrowserPanelManager } from "./BrowserPanelManager";
 import {
+  BROWSER_MCP_INSTRUCTIONS,
   TOOLS,
   dispatchTool,
   formatToolResult,
   isKnownToolName,
   type McpToolResult,
+  normalizeToolName,
   type ToolContext,
 } from "./mcp/toolRegistry";
 
@@ -18,6 +20,7 @@ export interface BrowserMcpIngressInfo {
 
 const MAX_BODY = 1024 * 1024;
 const MCP_PROTOCOL_VERSION = "2025-03-26";
+const PASSIVE_TOOLS = new Set(["api", "list_tabs", "get_url", "get_title"]);
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -248,6 +251,7 @@ export class BrowserMcpIngress {
             protocolVersion: MCP_PROTOCOL_VERSION,
             capabilities: { tools: {} },
             serverInfo: { name: "browser", version: "2.0.0" },
+            instructions: BROWSER_MCP_INSTRUCTIONS,
           },
         };
       }
@@ -285,7 +289,9 @@ export class BrowserMcpIngress {
             },
           };
         }
-        ctx.manager.revealPanel();
+        if (shouldRevealPanelForTool(name)) {
+          ctx.manager.revealPanel();
+        }
         let raw: unknown;
         try {
           raw = await dispatchTool(name, args, ctx);
@@ -324,4 +330,8 @@ function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
     (value as { jsonrpc?: unknown }).jsonrpc === "2.0" &&
     typeof (value as { method?: unknown }).method === "string"
   );
+}
+
+function shouldRevealPanelForTool(name: string): boolean {
+  return !PASSIVE_TOOLS.has(normalizeToolName(name));
 }

--- a/src/main/browser/BrowserPanelManager.test.ts
+++ b/src/main/browser/BrowserPanelManager.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveWebContentsById = vi.hoisted(() => vi.fn<(id: number) => unknown>());
+
+vi.mock("electron", () => ({
+  BrowserWindow: class BrowserWindow {},
+  shell: { openExternal: vi.fn<(url: string) => Promise<void>>() },
+}));
+
+vi.mock("../db", () => ({
+  dbGetState: vi.fn<(key: string) => string | null>(),
+  dbSetState: vi.fn<(key: string, value: string) => void>(),
+}));
+
+vi.mock("../sharedSettingsFile", () => ({
+  readSharedSettingsFile: vi.fn<(path: string) => unknown>(),
+}));
+
+vi.mock("../attachments/localFiles", () => ({
+  saveClipboardImageFile: vi.fn<() => string>(),
+}));
+
+vi.mock("@/shared/ipc", () => ({
+  IPC_EVENT_CHANNELS: { browserEvent: "browser-event" },
+}));
+
+vi.mock("./picker/pickerProtocol", () => ({
+  PICKER_COMMIT_ORIGIN: "lightcode-picker",
+  onPickerCommit: vi.fn<() => () => void>(() => vi.fn<() => void>()),
+}));
+
+vi.mock("./picker/pickerScript", () => ({
+  buildPickerScript: vi.fn<() => string>(),
+}));
+
+vi.mock("./BrowserTab", () => ({
+  BrowserTab: class BrowserTab {},
+  resolveWebContentsById,
+}));
+
+function createManagerWithTab() {
+  const tab = {
+    tabId: "tab-1",
+    attach: vi.fn<(webContents: unknown) => void>(),
+  };
+  const hostWebContents = {
+    id: 42,
+    on: vi.fn<() => void>(),
+    send: vi.fn<() => void>(),
+  };
+  const host = {
+    webContents: hostWebContents,
+    once: vi.fn<() => void>(),
+    isDestroyed: () => false,
+  };
+  return { tab, host, hostWebContents };
+}
+
+describe("BrowserPanelManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects the host window WebContents as a browser tab target", async () => {
+    const { BrowserPanelManager } = await import("./BrowserPanelManager");
+    const manager = new BrowserPanelManager({ settingsPath: "settings.json" } as never);
+    const { tab, host } = createManagerWithTab();
+
+    manager.bindHost(host as never);
+    (manager as unknown as { tabs: (typeof tab)[] }).tabs = [tab];
+    manager.attachWebContents("tab-1", 42);
+
+    expect(resolveWebContentsById).not.toHaveBeenCalled();
+    expect(tab.attach).not.toHaveBeenCalled();
+  });
+
+  it("attaches a non-host WebContents to the browser tab", async () => {
+    const { BrowserPanelManager } = await import("./BrowserPanelManager");
+    const manager = new BrowserPanelManager({ settingsPath: "settings.json" } as never);
+    const { tab, host } = createManagerWithTab();
+    const guestWebContents = { id: 99 };
+    resolveWebContentsById.mockReturnValue(guestWebContents);
+
+    manager.bindHost(host as never);
+    (manager as unknown as { tabs: (typeof tab)[] }).tabs = [tab];
+    manager.attachWebContents("tab-1", 99);
+
+    expect(resolveWebContentsById).toHaveBeenCalledWith(99);
+    expect(tab.attach).toHaveBeenCalledWith(guestWebContents);
+  });
+});

--- a/src/main/browser/BrowserPanelManager.ts
+++ b/src/main/browser/BrowserPanelManager.ts
@@ -238,8 +238,10 @@ export class BrowserPanelManager {
   attachWebContents(tabId: string, webContentsId: number): void {
     const tab = this.findTab(tabId);
     if (!tab) return;
+    if (this.host?.webContents.id === webContentsId) return;
     const wc = resolveWebContentsById(webContentsId);
     if (!wc) return;
+    if (this.host?.webContents === wc) return;
     tab.attach(wc);
   }
 

--- a/src/main/browser/BrowserTab.ts
+++ b/src/main/browser/BrowserTab.ts
@@ -182,6 +182,18 @@ export class BrowserTab {
     wc.on("will-prevent-unload", onWillPreventUnload);
     this.wcCleanups.push(() => wc.removeListener("will-prevent-unload", onWillPreventUnload));
 
+    const onBeforeInputEvent = (event: Electron.Event, input: Electron.Input) => {
+      if (!isBrowserReloadKeyDown(input)) return;
+      event.preventDefault();
+      if (isBrowserHardReloadKeyDown(input)) {
+        this.hardReload();
+        return;
+      }
+      wc.reload();
+    };
+    wc.on("before-input-event", onBeforeInputEvent);
+    this.wcCleanups.push(() => wc.removeListener("before-input-event", onBeforeInputEvent));
+
     const onConsoleMessage = (
       event: Electron.Event<Electron.WebContentsConsoleMessageEventParams>,
     ) => {
@@ -410,4 +422,14 @@ function snapshotsEqual(a: BrowserTabSnapshot, b: BrowserTabSnapshot): boolean {
     a.devToolsOpen === b.devToolsOpen &&
     a.faviconUrl === b.faviconUrl
   );
+}
+
+function isBrowserReloadKeyDown(input: Electron.Input): boolean {
+  if (input.type !== "keyDown") return false;
+  if (input.key === "F5" || input.code === "F5") return true;
+  return (input.control || input.meta) && input.key.toLowerCase() === "r";
+}
+
+function isBrowserHardReloadKeyDown(input: Electron.Input): boolean {
+  return isBrowserReloadKeyDown(input) && input.shift === true;
 }

--- a/src/main/browser/cdp/tools.ts
+++ b/src/main/browser/cdp/tools.ts
@@ -57,14 +57,21 @@ export async function captureScreenshotPng(
   options: {
     fullPage?: boolean;
     clip?: { x: number; y: number; width: number; height: number };
+    format?: "png" | "jpeg";
+    quality?: number;
+    scale?: number;
     /** When true, allow the clip to reference document coordinates outside the
      *  current viewport so capture can happen without scrolling the page. */
     captureBeyondViewport?: boolean;
   },
 ): Promise<Buffer> {
-  const params: Record<string, unknown> = { format: "png" };
+  const params: Record<string, unknown> = { format: options.format ?? "png" };
+  if (options.format === "jpeg" && typeof options.quality === "number") {
+    params.quality = Math.max(1, Math.min(100, Math.floor(options.quality)));
+  }
+  const scale = Math.max(0.1, Math.min(1, options.scale ?? 1));
   if (options.clip) {
-    params.clip = { ...options.clip, scale: 1 };
+    params.clip = { ...options.clip, scale };
     if (options.captureBeyondViewport) {
       params.captureBeyondViewport = true;
     }
@@ -81,7 +88,7 @@ export async function captureScreenshotPng(
         y: Math.floor(size.y),
         width: Math.max(1, Math.ceil(size.width)),
         height: Math.max(1, Math.ceil(size.height)),
-        scale: 1,
+        scale,
       };
     }
     params.captureBeyondViewport = true;
@@ -125,51 +132,6 @@ export async function queryFirstDocumentRect(
   return await evalJs<{ x: number; y: number; width: number; height: number } | null>(cdp, expr);
 }
 
-export async function clickSelector(cdp: CdpClient, selector: string): Promise<void> {
-  const rect = await queryFirstRect(cdp, selector);
-  if (!rect || rect.width === 0 || rect.height === 0) {
-    throw new Error(`Selector not found or has zero size: ${selector}`);
-  }
-  const x = rect.x + rect.width / 2;
-  const y = rect.y + rect.height / 2;
-  await cdp.send("Input.dispatchMouseEvent", {
-    type: "mouseMoved",
-    x,
-    y,
-  });
-  await cdp.send("Input.dispatchMouseEvent", {
-    type: "mousePressed",
-    x,
-    y,
-    button: "left",
-    clickCount: 1,
-  });
-  await cdp.send("Input.dispatchMouseEvent", {
-    type: "mouseReleased",
-    x,
-    y,
-    button: "left",
-    clickCount: 1,
-  });
-}
-
-export async function typeIntoSelector(
-  cdp: CdpClient,
-  selector: string,
-  text: string,
-  submit: boolean,
-): Promise<void> {
-  await evalJs(
-    cdp,
-    `(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (el && el.focus) el.focus(); })()`,
-  );
-  await cdp.send("Input.insertText", { text });
-  if (submit) {
-    await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Enter", code: "Enter" });
-    await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Enter", code: "Enter" });
-  }
-}
-
 export async function waitForSelector(
   cdp: CdpClient,
   selector: string,
@@ -195,11 +157,25 @@ export async function waitForSelector(
  */
 export async function pageSnapshot(
   cdp: CdpClient,
-  options: { maxNodes?: number; includeHidden?: boolean } = {},
+  options: {
+    maxNodes?: number;
+    offset?: number;
+    mode?: "full" | "compact" | "summary";
+    maxTextLength?: number;
+    includeHidden?: boolean;
+    interactiveOnly?: boolean;
+    includeUrls?: boolean;
+    selector?: string;
+  } = {},
 ): Promise<{
   url: string;
   title: string;
   viewport: { width: number; height: number; scrollX: number; scrollY: number };
+  total: number;
+  offset: number;
+  limit: number;
+  nextOffset: number | null;
+  mode: "full" | "compact" | "summary";
   nodes: Array<{
     ref: string;
     tag: string;
@@ -212,11 +188,27 @@ export async function pageSnapshot(
     rect: { x: number; y: number; width: number; height: number };
   }>;
 }> {
-  const maxNodes = options.maxNodes ?? 200;
+  const maxNodes = Math.max(1, Math.min(500, options.maxNodes ?? 120));
+  const offset = Math.max(0, options.offset ?? 0);
+  const mode = options.mode === "compact" || options.mode === "summary" ? options.mode : "full";
+  const maxTextLength = Math.max(
+    20,
+    Math.min(1000, options.maxTextLength ?? (mode === "full" ? 200 : 80)),
+  );
   const includeHidden = options.includeHidden === true;
+  const interactiveOnly = options.interactiveOnly !== false;
+  const includeUrls = options.includeUrls === true;
   const expr = `(() => {
-    const out = { url: location.href, title: document.title || "", viewport: { width: innerWidth, height: innerHeight, scrollX: scrollX, scrollY: scrollY }, nodes: [] };
+    const mode = ${JSON.stringify(mode)};
+    const maxTextLength = ${maxTextLength};
+    const out = { url: location.href, title: document.title || "", viewport: { width: innerWidth, height: innerHeight, scrollX: scrollX, scrollY: scrollY }, total: 0, offset: ${offset}, limit: ${maxNodes}, nextOffset: null, mode, nodes: [] };
+    const root = ${JSON.stringify(options.selector ?? "")}
+      ? document.querySelector(${JSON.stringify(options.selector ?? "")})
+      : document;
+    if (!root) return out;
     const VALID = new Set(["a","button","input","textarea","select","option","label","h1","h2","h3","h4","h5","h6","li","summary","details","form","img","nav","main","section","article","aside","footer","header","dialog","menu","menuitem"]);
+    const STRUCTURAL = new Set(["h1","h2","h3","h4","h5","h6","li","form","nav","main","section","article","aside","footer","header"]);
+    const SUMMARY = new Set(["h1","h2","h3","h4","h5","h6","form","nav","main","section","article","aside","footer","header","dialog","summary","details"]);
     const isInteractive = (el) => {
       const tag = el.tagName.toLowerCase();
       if (VALID.has(tag)) return true;
@@ -252,16 +244,24 @@ export async function pageSnapshot(
       const text = (el.textContent || "").trim();
       return text.length > 0 && text.length < 120 ? text : "";
     };
-    const trim = (s) => s && s.length > 200 ? s.slice(0, 200) + "\\u2026" : s;
+    const trim = (s) => s && s.length > maxTextLength ? s.slice(0, maxTextLength) + "\\u2026" : s;
     const refs = (window.__lcRefs = window.__lcRefs || new Map());
     let counter = (window.__lcRefSeq = (window.__lcRefSeq || 0)) + 1;
-    const all = document.querySelectorAll("*");
+    const all = root === document
+      ? document.querySelectorAll("*")
+      : [root, ...root.querySelectorAll("*")];
     const include = ${includeHidden ? "() => true" : "isVisible"};
     for (const el of all) {
-      if (out.nodes.length >= ${maxNodes}) break;
-      if (!isInteractive(el) && el.tagName !== "BODY") continue;
+      const tag = el.tagName.toLowerCase();
+      if (tag === "body" && mode !== "full") continue;
+      if (mode === "summary") {
+        if (!isInteractive(el) && !SUMMARY.has(tag)) continue;
+      } else if (!isInteractive(el) && (${interactiveOnly ? "true" : "!STRUCTURAL.has(tag)"}) && el.tagName !== "BODY") continue;
       if (!include(el)) continue;
-      const ref = "node-" + (counter++);
+      const matchIndex = out.total++;
+      if (matchIndex < ${offset}) continue;
+      if (out.nodes.length >= ${maxNodes}) continue;
+      const ref = "@e" + (counter++);
       refs.set(ref, el);
       const r = el.getBoundingClientRect();
       const node = {
@@ -269,42 +269,20 @@ export async function pageSnapshot(
         tag: el.tagName.toLowerCase(),
         role: el.getAttribute("role") || undefined,
         name: trim(accessibleName(el)) || undefined,
-        text: trim((el.textContent || "").trim()) || undefined,
         visible: isVisible(el),
         rect: { x: r.left, y: r.top, width: r.width, height: r.height },
       };
+      const text = trim((el.textContent || "").trim());
+      if (text && !(mode === "compact" && tag === "body")) node.text = text;
       if ("value" in el && typeof el.value === "string") node.value = trim(el.value);
-      if (el.tagName === "A" && el.href) node.href = el.href;
+      if (${includeUrls ? "true" : "false"} && el.tagName === "A" && el.href) node.href = el.href;
       out.nodes.push(node);
     }
+    if (${offset} + out.nodes.length < out.total) out.nextOffset = ${offset} + out.nodes.length;
     window.__lcRefSeq = counter;
     return out;
   })()`;
   return await evalJs(cdp, expr);
-}
-
-export async function resolveRefToSelector(cdp: CdpClient, ref: string): Promise<string | null> {
-  return await evalJs<string | null>(
-    cdp,
-    `(() => {
-      const el = (window.__lcRefs || new Map()).get(${JSON.stringify(ref)});
-      if (!el) return null;
-      if (el.id && !/^\\d/.test(el.id)) return "#" + CSS.escape(el.id);
-      const path = [];
-      let n = el;
-      while (n && n.nodeType === 1 && n.tagName !== "HTML") {
-        let part = n.tagName.toLowerCase();
-        const p = n.parentElement;
-        if (p) {
-          const sibs = Array.from(p.children).filter((c) => c.tagName === n.tagName);
-          if (sibs.length > 1) part += ":nth-of-type(" + (sibs.indexOf(n) + 1) + ")";
-        }
-        path.unshift(part);
-        n = p;
-      }
-      return path.join(" > ");
-    })()`,
-  );
 }
 
 export async function getElementInfo(
@@ -365,33 +343,6 @@ export async function getElementState(
       return { exists: true, visible, enabled, checked, focused };
     })()`,
   );
-}
-
-export async function hoverSelector(cdp: CdpClient, selector: string): Promise<void> {
-  const rect = await queryFirstRect(cdp, selector);
-  if (!rect) throw new Error(`Selector not found: ${selector}`);
-  const x = rect.x + rect.width / 2;
-  const y = rect.y + rect.height / 2;
-  await cdp.send("Input.dispatchMouseEvent", { type: "mouseMoved", x, y });
-}
-
-export async function pressKey(cdp: CdpClient, key: string): Promise<void> {
-  await cdp.send("Input.dispatchKeyEvent", { type: "keyDown", key, code: key });
-  await cdp.send("Input.dispatchKeyEvent", { type: "keyUp", key, code: key });
-}
-
-export async function scrollPage(
-  cdp: CdpClient,
-  options: { selector?: string; x?: number; y?: number },
-): Promise<void> {
-  if (options.selector) {
-    await evalJs(
-      cdp,
-      `(() => { const el = document.querySelector(${JSON.stringify(options.selector)}); if (el) el.scrollIntoView({ block: "center", inline: "center" }); })()`,
-    );
-    return;
-  }
-  await evalJs(cdp, `(() => { window.scrollBy(${options.x ?? 0}, ${options.y ?? 0}); })()`);
 }
 
 export async function waitForJs(
@@ -460,6 +411,10 @@ export async function findByA11y(
     text?: string;
     testid?: string;
     nth?: number;
+    limit?: number;
+    visibleOnly?: boolean;
+    interactiveOnly?: boolean;
+    within?: string;
   },
 ): Promise<{
   found: boolean;
@@ -468,7 +423,22 @@ export async function findByA11y(
     selector: string;
     rect: { x: number; y: number; width: number; height: number };
     ref: string;
+    score: number;
+    reason: string[];
+    role?: string;
+    name?: string;
+    text?: string;
   };
+  candidates?: Array<{
+    selector: string;
+    rect: { x: number; y: number; width: number; height: number };
+    ref: string;
+    score: number;
+    reason: string[];
+    role?: string;
+    name?: string;
+    text?: string;
+  }>;
 }> {
   const expr = `(() => {
     const q = ${JSON.stringify(query)};
@@ -477,54 +447,176 @@ export async function findByA11y(
       const v = el.getAttribute(name);
       return v != null && (value ? v === value : true);
     };
-    const accName = (el) => (el.getAttribute("aria-label") || el.getAttribute("title") || el.getAttribute("alt") || (el.textContent || "").trim()).toLowerCase();
-    const all = document.querySelectorAll("*");
-    for (const el of all) {
-      if (q.testid && !matchAttr(el, "data-testid", q.testid)) continue;
-      if (q.role && (el.getAttribute("role") || el.tagName.toLowerCase()) !== q.role) continue;
-      if (q.placeholder && el.getAttribute("placeholder") !== q.placeholder) continue;
-      if (q.label) {
-        const labelText = (el.getAttribute("aria-label") || "").toLowerCase();
-        if (!labelText.includes(q.label.toLowerCase())) continue;
+    const isVisible = (el) => {
+      const style = getComputedStyle(el);
+      const r = el.getBoundingClientRect();
+      return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0" && r.width > 0 && r.height > 0;
+    };
+    const implicitRole = (el) => {
+      const tag = el.tagName.toLowerCase();
+      if (tag === "button") return "button";
+      if (tag === "a" && el.hasAttribute("href")) return "link";
+      if (tag === "select") return "combobox";
+      if (tag === "textarea") return "textbox";
+      if (tag === "input") {
+        const type = (el.getAttribute("type") || "text").toLowerCase();
+        if (type === "checkbox") return "checkbox";
+        if (type === "radio") return "radio";
+        if (type === "button" || type === "submit" || type === "reset") return "button";
+        return "textbox";
+      }
+      return tag;
+    };
+    const isInteractive = (el) => {
+      const tag = el.tagName.toLowerCase();
+      if (["a","button","input","textarea","select"].includes(tag)) return true;
+      if (el.getAttribute("role")) return true;
+      if (el.tabIndex >= 0) return true;
+      if (el.onclick || el.getAttribute("onclick")) return true;
+      return false;
+    };
+    const labelText = (el) => {
+      if (el.id) {
+        const lab = document.querySelector(\`label[for="\${CSS.escape(el.id)}"]\`);
+        if (lab) return (lab.textContent || "").trim();
+      }
+      const wrapping = el.closest("label");
+      return wrapping ? (wrapping.textContent || "").trim() : "";
+    };
+    const accName = (el) => (
+      el.getAttribute("aria-label") ||
+      el.getAttribute("title") ||
+      el.getAttribute("alt") ||
+      el.getAttribute("placeholder") ||
+      labelText(el) ||
+      (el.value && (el.tagName === "INPUT" || el.tagName === "BUTTON") ? String(el.value) : "") ||
+      (el.textContent || "").trim()
+    ).trim();
+    const trim = (s, n) => s && s.length > n ? s.slice(0, n) + "\\u2026" : s;
+    const selectorFor = (el) => {
+      const path = [];
+      let n = el;
+      while (n && n.nodeType === 1 && n.tagName !== "HTML") {
+        let part = n.tagName.toLowerCase();
+        const p = n.parentElement;
+        if (p) {
+          const sibs = Array.from(p.children).filter((c) => c.tagName === n.tagName);
+          if (sibs.length > 1) part += ":nth-of-type(" + (sibs.indexOf(n) + 1) + ")";
+        }
+        path.unshift(part);
+        n = p;
+      }
+      return path.join(" > ");
+    };
+    const score = (el) => {
+      let s = 0;
+      const reason = [];
+      const role = (el.getAttribute("role") || implicitRole(el)).toLowerCase();
+      const name = accName(el).toLowerCase();
+      const text = (el.textContent || "").trim().toLowerCase();
+      const childCount = el.children.length;
+      if (q.role && role === q.role.toLowerCase()) {
+        s += 80;
+        reason.push("role");
+      }
+      if (q.testid && matchAttr(el, "data-testid", q.testid)) {
+        s += 90;
+        reason.push("testid");
+      }
+      if (q.placeholder && el.getAttribute("placeholder") === q.placeholder) {
+        s += 70;
+        reason.push("placeholder");
+      }
+      if (q.label && labelText(el).toLowerCase().includes(q.label.toLowerCase())) {
+        s += 70;
+        reason.push("label");
       }
       if (q.name) {
-        if (!accName(el).includes(q.name.toLowerCase())) continue;
+        const needle = q.name.toLowerCase();
+        if (name === needle) {
+          s += 100;
+          reason.push("exact name");
+        } else if (name.includes(needle)) {
+          s += 60;
+          reason.push("name");
+        }
+      }
+      if (q.text) {
+        const needle = q.text.toLowerCase();
+        if (text === needle) {
+          s += 60;
+          reason.push("exact text");
+        } else if (text.includes(needle)) {
+          s += Math.max(5, 45 - childCount * 2);
+          reason.push("text");
+        }
+      }
+      if (["button","a","input","textarea","select"].includes(el.tagName.toLowerCase())) {
+        s += 15;
+        reason.push("native interactive");
+      }
+      if (el.tabIndex >= 0) {
+        s += 10;
+        reason.push("focusable");
+      }
+      if (["BODY","HTML","MAIN"].includes(el.tagName)) s -= 200;
+      if (text.length > 600 || childCount > 30) s -= 80;
+      return { score: s, reason };
+    };
+    const root = q.within ? document.querySelector(q.within) : document;
+    if (!root) return { found: false, count: 0 };
+    const all = root.querySelectorAll("*");
+    for (const el of all) {
+      if (q.visibleOnly !== false && !isVisible(el)) continue;
+      if (q.interactiveOnly === true && !isInteractive(el)) continue;
+      if (["SCRIPT","STYLE","NOSCRIPT","HTML","BODY"].includes(el.tagName)) continue;
+      const role = (el.getAttribute("role") || implicitRole(el)).toLowerCase();
+      if (q.testid && !matchAttr(el, "data-testid", q.testid)) continue;
+      if (q.role && role !== q.role.toLowerCase()) continue;
+      if (q.placeholder && el.getAttribute("placeholder") !== q.placeholder) continue;
+      if (q.label) {
+        const text = labelText(el).toLowerCase();
+        if (!text.includes(q.label.toLowerCase())) continue;
+      }
+      if (q.name) {
+        if (!accName(el).toLowerCase().includes(q.name.toLowerCase())) continue;
       }
       if (q.text) {
         const t = (el.textContent || "").toLowerCase();
         if (!t.includes(q.text.toLowerCase())) continue;
       }
-      candidates.push(el);
+      const scored = score(el);
+      if (scored.score <= 0) continue;
+      candidates.push({ el, score: scored.score, reason: scored.reason, role, name: accName(el), text: trim((el.textContent || "").trim(), 120) });
     }
+    candidates.sort((a, b) => b.score - a.score);
     const refs = (window.__lcRefs = window.__lcRefs || new Map());
     let seq = (window.__lcRefSeq = (window.__lcRefSeq || 0));
     const idx = typeof q.nth === "number" ? q.nth : 0;
-    const el = candidates[idx];
-    if (!el) return { found: false, count: candidates.length };
-    const ref = "node-" + (++seq);
+    const limit = Math.max(idx + 1, Math.min(20, Math.max(1, typeof q.limit === "number" ? q.limit : 5)));
+    const results = candidates.slice(0, limit).map((candidate) => {
+      const ref = "@e" + (++seq);
+      refs.set(ref, candidate.el);
+      const r = candidate.el.getBoundingClientRect();
+      return {
+        selector: selectorFor(candidate.el),
+        ref,
+        score: candidate.score,
+        reason: candidate.reason,
+        role: candidate.role || undefined,
+        name: candidate.name || undefined,
+        text: candidate.text || undefined,
+        rect: { x: r.left, y: r.top, width: r.width, height: r.height },
+      };
+    });
     window.__lcRefSeq = seq;
-    refs.set(ref, el);
-    const path = [];
-    let n = el;
-    while (n && n.nodeType === 1 && n.tagName !== "HTML") {
-      let part = n.tagName.toLowerCase();
-      const p = n.parentElement;
-      if (p) {
-        const sibs = Array.from(p.children).filter((c) => c.tagName === n.tagName);
-        if (sibs.length > 1) part += ":nth-of-type(" + (sibs.indexOf(n) + 1) + ")";
-      }
-      path.unshift(part);
-      n = p;
-    }
-    const r = el.getBoundingClientRect();
+    const match = results[idx];
+    if (!match) return { found: false, count: candidates.length, candidates: results };
     return {
       found: true,
       count: candidates.length,
-      match: {
-        selector: path.join(" > "),
-        ref,
-        rect: { x: r.left, y: r.top, width: r.width, height: r.height },
-      },
+      match,
+      candidates: results,
     };
   })()`;
   return await evalJs(cdp, expr);
@@ -534,21 +626,30 @@ export async function querySelectorAllSnapshot(
   cdp: CdpClient,
   selector: string,
   limit: number = 20,
+  offset: number = 0,
 ): Promise<{
   count: number;
+  offset: number;
+  limit: number;
+  nextOffset: number | null;
   texts: string[];
   outerHtmls: string[];
   bounds: Array<{ x: number; y: number; width: number; height: number }>;
 }> {
   const expr = `(() => {
     const all = Array.from(document.querySelectorAll(${JSON.stringify(selector)}));
-    const lim = ${limit};
+    const off = ${Math.max(0, offset)};
+    const lim = ${Math.max(1, Math.min(100, limit))};
+    const slice = all.slice(off, off + lim);
     const truncate = (s, n) => s && s.length > n ? s.slice(0, n) + '\\u2026' : s;
     return {
       count: all.length,
-      texts: all.slice(0, lim).map((e) => truncate((e.textContent || '').trim(), 240)),
-      outerHtmls: all.slice(0, lim).map((e) => truncate(e.outerHTML || '', 1200)),
-      bounds: all.slice(0, lim).map((e) => {
+      offset: off,
+      limit: lim,
+      nextOffset: off + slice.length < all.length ? off + slice.length : null,
+      texts: slice.map((e) => truncate((e.textContent || '').trim(), 240)),
+      outerHtmls: slice.map((e) => truncate(e.outerHTML || '', 1200)),
+      bounds: slice.map((e) => {
         const r = e.getBoundingClientRect();
         return { x: r.left, y: r.top, width: r.width, height: r.height };
       }),

--- a/src/main/browser/mcp/toolRegistry.test.ts
+++ b/src/main/browser/mcp/toolRegistry.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BROWSER_MCP_INSTRUCTIONS,
+  TOOLS,
+  dispatchTool,
+  formatToolResult,
+  isKnownToolName,
+  type ToolContext,
+} from "./toolRegistry";
+
+function createContext(): ToolContext {
+  return {
+    allowDataAccess: false,
+    allowEval: false,
+    manager: {
+      snapshot: () => ({
+        tabs: [
+          {
+            tabId: "tab-1",
+            url: "https://example.com/",
+            title: "Example",
+            loading: false,
+            canGoBack: false,
+            canGoForward: false,
+            devToolsOpen: false,
+          },
+        ],
+        activeTabId: "tab-1",
+      }),
+    } as ToolContext["manager"],
+  };
+}
+
+function createDispatchContext(send: ReturnType<typeof vi.fn>): ToolContext {
+  const tab = {
+    tabId: "tab-1",
+    snapshot: () => ({ url: "https://example.test/page", title: "Example Page" }),
+    webContents: {
+      focus: vi.fn<() => void>(),
+      executeJavaScript: vi
+        .fn<(script: string, userGesture?: boolean) => Promise<unknown>>()
+        .mockResolvedValue(true),
+      capturePage: vi
+        .fn<
+          () => Promise<{
+            toPNG: () => Buffer;
+            toJPEG: (quality: number) => Buffer;
+            getSize: () => { width: number; height: number };
+            resize: () => unknown;
+          }>
+        >()
+        .mockResolvedValue({
+          toPNG: () => Buffer.from("png"),
+          toJPEG: () => Buffer.from("jpg"),
+          getSize: () => ({ width: 800, height: 600 }),
+          resize() {
+            return this;
+          },
+        }),
+    },
+    cdp: {
+      attach: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      send,
+    },
+    network: {
+      isEnabled: () => true,
+      enable: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      list: () => [],
+      clear: vi.fn<() => void>(),
+    },
+    dialogs: {
+      recent: () => [],
+      setNextDisposition: vi.fn<() => void>(),
+      waitForNext: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    },
+    getConsoleEntries: () => [],
+    clearConsole: vi.fn<() => void>(),
+    rememberInitScript: vi.fn<() => void>(),
+    forgetInitScript: vi.fn<() => void>(),
+    listInitScripts: () => ["script-1"],
+  };
+  return {
+    allowDataAccess: true,
+    allowEval: true,
+    manager: {
+      snapshot: () => ({
+        tabs: [
+          {
+            tabId: "tab-1",
+            url: "https://example.test/page",
+            title: "Example Page",
+            loading: false,
+            canGoBack: false,
+            canGoForward: false,
+            devToolsOpen: false,
+          },
+        ],
+        activeTabId: "tab-1",
+      }),
+      getActiveTab: () => tab,
+      getTab: () => tab,
+      createTab: vi.fn<() => Promise<unknown>>().mockResolvedValue({ tabId: "tab-1" }),
+      setActiveTab: vi.fn<() => void>(),
+      closeTab: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      navigate: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      reload: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    } as unknown as ToolContext["manager"],
+  };
+}
+
+function createRoutingSend(): ReturnType<typeof vi.fn> {
+  return vi.fn<(method: string, params?: Record<string, unknown>) => Promise<unknown>>(
+    async (method, params) => {
+      if (method === "Runtime.evaluate") {
+        const expression = String(params?.expression ?? "");
+        if (expression === "location.href") {
+          return { result: { type: "string", value: "https://example.test/page" } };
+        }
+        return { result: { type: "boolean", value: true } };
+      }
+      if (method === "Page.getNavigationHistory") {
+        return {
+          currentIndex: 1,
+          entries: [
+            { id: 1, url: "https://example.test/one", title: "One" },
+            { id: 2, url: "https://example.test/two", title: "Two" },
+            { id: 3, url: "https://example.test/three", title: "Three" },
+          ],
+        };
+      }
+      if (method === "Page.captureScreenshot") {
+        return { data: Buffer.from("png").toString("base64") };
+      }
+      if (method === "Page.getLayoutMetrics") {
+        return { cssContentSize: { x: 0, y: 0, width: 800, height: 600 } };
+      }
+      if (method === "Network.getCookies") {
+        return { cookies: [] };
+      }
+      if (method === "Network.setCookie") {
+        return { success: true };
+      }
+      if (method === "Page.getFrameTree") {
+        return { frameTree: { frame: { id: "main", url: "https://example.test/" } } };
+      }
+      if (method === "Page.addScriptToEvaluateOnNewDocument") {
+        return { identifier: "script-1" };
+      }
+      return {};
+    },
+  );
+}
+
+const ROUTING_ARGS: Record<string, Record<string, unknown>> = {
+  api: {},
+  list_tabs: {},
+  new_tab: { url: "https://example.test/", activate: true },
+  open: { url: "https://example.test/open" },
+  activate_tab: { tabId: "tab-1" },
+  close_tab: { tabId: "tab-1" },
+  navigate: { url: "https://example.test/nav" },
+  back: {},
+  forward: {},
+  reload: {},
+  get_url: {},
+  get_title: {},
+  screenshot: {},
+  query: { selector: "input" },
+  wait_for: { selector: "input", timeoutMs: 50 },
+  click: { selector: "button" },
+  dblclick: { selector: "button" },
+  focus: { selector: "input" },
+  type: { selector: "input", text: "abc" },
+  fill: { selector: "input", text: "abc" },
+  check: { selector: "input[type=checkbox]" },
+  uncheck: { selector: "input[type=checkbox]" },
+  select: { selector: "select", value: "pro" },
+  eval: { js: "true" },
+  snapshot: {},
+  inspect: {},
+  get: { selector: "input", fields: ["text"] },
+  is: { selector: "input" },
+  find: { text: "Example" },
+  hover: { selector: "button" },
+  press: { selector: "input", key: "Enter" },
+  wait: { selector: "input", timeoutMs: 50 },
+  scroll: { y: 100 },
+  wait_for_url: { pattern: "example.test", timeoutMs: 50 },
+  wait_for_text: { text: "Example", timeoutMs: 50 },
+  wait_for_js: { js: "true", timeoutMs: 50 },
+  console: {},
+  requests: {},
+  cookies: { op: "get" },
+  storage: { kind: "local", op: "getAll" },
+  dialog: { op: "recent" },
+  frames: {},
+  addscript: { op: "add", source: "window.__ok = true" },
+  addstyle: { op: "oneshot", css: "body { color: red; }" },
+};
+
+describe("browser MCP tool registry", () => {
+  it("surfaces an API map as the first tool", async () => {
+    expect(TOOLS[0]?.name).toBe("api");
+    expect(isKnownToolName("api")).toBe(true);
+
+    const result = (await dispatchTool("api", {}, createContext())) as {
+      guidance: string[];
+      workflows: Record<string, string[]>;
+      tools: Array<{ name: string }>;
+      tabs: { activeTabId: string | null };
+    };
+
+    expect(result.guidance.join(" ")).toContain("Prefer this MCP server");
+    expect(result.guidance.join(" ")).toContain("@e refs");
+    expect(result.workflows.inspect).toContain("snapshot");
+    expect(result.workflows.interact).toEqual(
+      expect.arrayContaining(["fill", "focus", "check", "uncheck", "select", "wait"]),
+    );
+    expect(result.tools.map((tool) => tool.name)).toContain("click");
+    expect(result.tools.map((tool) => tool.name)).toContain("fill");
+    expect(result.tabs.activeTabId).toBe("tab-1");
+  });
+
+  it("formats the API result for MCP clients", async () => {
+    const result = await dispatchTool("api", {}, createContext());
+    const formatted = formatToolResult("api", result);
+
+    expect(BROWSER_MCP_INSTRUCTIONS).toContain("call browser.api");
+    expect(formatted.content[0]?.type).toBe("text");
+    expect(formatted.content[0]?.text).toContain('"workflows"');
+    expect(formatted.content[0]?.text).toContain('"args"');
+    expect(formatted.content[0]?.text).not.toContain('"inputSchema"');
+    expect(formatted.content[0]?.text?.length).toBeLessThan(20_000);
+  });
+
+  it("recognizes agent-browser-style aliases", () => {
+    expect(isKnownToolName("goto")).toBe(true);
+    expect(isKnownToolName("key")).toBe(true);
+    expect(isKnownToolName("keyboard_type")).toBe(true);
+  });
+
+  it("dispatches optimized form and interaction commands", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+
+    await expect(
+      dispatchTool("fill", { selector: "#email", text: "test@example.com" }, ctx),
+    ).resolves.toEqual({ ok: true });
+    await expect(dispatchTool("focus", { selector: "#email" }, ctx)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(dispatchTool("click", { selector: "#submit" }, ctx)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(dispatchTool("type", { selector: "#email", text: "abc" }, ctx)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(dispatchTool("press", { selector: "#email", key: "Enter" }, ctx)).resolves.toEqual(
+      {
+        ok: true,
+      },
+    );
+    await expect(dispatchTool("check", { selector: "#remember" }, ctx)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(dispatchTool("select", { selector: "#plan", value: "pro" }, ctx)).resolves.toEqual(
+      { ok: true },
+    );
+
+    const activeTab = ctx.manager.getActiveTab() as unknown as {
+      webContents: {
+        executeJavaScript: ReturnType<typeof vi.fn>;
+        focus: ReturnType<typeof vi.fn>;
+      };
+      cdp: { attach: ReturnType<typeof vi.fn> };
+    };
+    expect(send).not.toHaveBeenCalledWith("Input.insertText", { text: "test@example.com" });
+    expect(send.mock.calls.some(([method]) => String(method).startsWith("Input."))).toBe(false);
+    expect(activeTab.webContents.executeJavaScript).toHaveBeenCalled();
+    expect(
+      activeTab.webContents.executeJavaScript.mock.calls.some(([script]) =>
+        String(script).includes('press("Enter", "#email", false)'),
+      ),
+    ).toBe(true);
+    expect(activeTab.cdp.attach).not.toHaveBeenCalled();
+    expect(activeTab.webContents.focus).not.toHaveBeenCalled();
+  });
+
+  it("dispatches every advertised browser tool through the browser context", async () => {
+    const toolNames = TOOLS.map((tool) => tool.name);
+    expect(Object.keys(ROUTING_ARGS).sort()).toEqual([...toolNames].sort());
+
+    for (const toolName of toolNames) {
+      const send = createRoutingSend();
+      const ctx = createDispatchContext(send);
+      await expect(dispatchTool(toolName, ROUTING_ARGS[toolName] ?? {}, ctx)).resolves.toBeTruthy();
+    }
+  });
+
+  it("routes reload, get_url, and fill to the active browser tab", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+
+    await expect(dispatchTool("reload", {}, ctx)).resolves.toEqual({ ok: true });
+    await expect(dispatchTool("get_url", {}, ctx)).resolves.toEqual({
+      url: "https://example.test/page",
+    });
+    await expect(
+      dispatchTool("fill", { selector: "input", text: "hello", submit: true }, ctx),
+    ).resolves.toEqual({ ok: true });
+
+    expect(ctx.manager.reload).toHaveBeenCalledWith("tab-1");
+    expect(send).not.toHaveBeenCalledWith("Input.insertText", { text: "hello" });
+    expect(send.mock.calls.some(([method]) => String(method).startsWith("Input."))).toBe(false);
+    expect(ctx.manager.getActiveTab()?.webContents.focus).not.toHaveBeenCalled();
+  });
+
+  it("falls back to jpeg for oversized full-page screenshots", async () => {
+    let screenshots = 0;
+    const send = vi.fn<(method: string, params?: Record<string, unknown>) => Promise<unknown>>(
+      async (method) => {
+        if (method === "Page.getLayoutMetrics") {
+          return { cssContentSize: { x: 0, y: 0, width: 800, height: 600 } };
+        }
+        if (method === "Page.captureScreenshot") {
+          screenshots++;
+          return {
+            data: Buffer.alloc(screenshots === 1 ? 3000 : 20).toString("base64"),
+          };
+        }
+        if (method === "Runtime.evaluate") {
+          return { result: { type: "boolean", value: true } };
+        }
+        return {};
+      },
+    );
+    const ctx = createDispatchContext(send);
+
+    await expect(
+      dispatchTool("screenshot", { fullPage: true, maxBytes: 2000 }, ctx),
+    ).resolves.toMatchObject({
+      mimeType: "image/jpeg",
+      format: "jpeg",
+      fallback: true,
+    });
+    expect(screenshots).toBeGreaterThan(1);
+  });
+
+  it("returns structured timeout metadata for a stuck viewport screenshot capture", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+    const tab = ctx.manager.getActiveTab() as unknown as {
+      webContents: {
+        capturePage: ReturnType<typeof vi.fn>;
+      };
+    };
+    tab.webContents.capturePage.mockReturnValueOnce(new Promise(() => {}));
+
+    await expect(dispatchTool("screenshot", { timeoutMs: 200 }, ctx)).resolves.toMatchObject({
+      timedOut: true,
+      reason: "timeout",
+      operation: "viewport screenshot",
+      timeoutMs: 200,
+    });
+  });
+
+  it("can hard-fail on screenshot timeout", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+    const tab = ctx.manager.getActiveTab() as unknown as {
+      webContents: {
+        capturePage: ReturnType<typeof vi.fn>;
+      };
+    };
+    tab.webContents.capturePage.mockReturnValueOnce(new Promise(() => {}));
+
+    await expect(
+      dispatchTool("screenshot", { timeoutMs: 200, failOnTimeout: true }, ctx),
+    ).rejects.toThrow("viewport screenshot timed out after 200ms");
+  });
+
+  it("includes screenshot metadata next to image content", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+    const raw = await dispatchTool("screenshot", {}, ctx);
+    const formatted = formatToolResult("screenshot", raw);
+
+    expect(formatted.content[0]?.type).toBe("text");
+    expect(formatted.content[0]?.text).toContain('"timedOut": false');
+    expect(formatted.content[1]?.type).toBe("image");
+  });
+
+  it("passes compact snapshot options through to the page snapshot", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+
+    await dispatchTool("snapshot", { mode: "compact", maxTextLength: 40 }, ctx);
+
+    expect(
+      send.mock.calls.some(
+        ([method, params]) =>
+          method === "Runtime.evaluate" &&
+          String(params?.expression).includes('const mode = "compact"') &&
+          String(params?.expression).includes("const maxTextLength = 40"),
+      ),
+    ).toBe(true);
+  });
+
+  it("passes ranked find options through to accessibility search", async () => {
+    const send = createRoutingSend();
+    const ctx = createDispatchContext(send);
+
+    await dispatchTool(
+      "find",
+      { text: "Submit", limit: 3, visibleOnly: false, interactiveOnly: true, within: "form" },
+      ctx,
+    );
+
+    expect(
+      send.mock.calls.some(
+        ([method, params]) =>
+          method === "Runtime.evaluate" &&
+          String(params?.expression).includes('"limit":3') &&
+          String(params?.expression).includes('"visibleOnly":false') &&
+          String(params?.expression).includes('"interactiveOnly":true') &&
+          String(params?.expression).includes('"within":"form"'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/main/browser/mcp/toolRegistry.ts
+++ b/src/main/browser/mcp/toolRegistry.ts
@@ -1,3 +1,4 @@
+import type { NativeImage } from "electron";
 import type { BrowserPanelManager } from "../BrowserPanelManager";
 import {
   addInitScript,
@@ -5,7 +6,6 @@ import {
   back,
   captureScreenshotPng,
   clearCookies,
-  clickSelector,
   evalJs,
   evaluateOneShotStyle,
   findByA11y,
@@ -14,29 +14,41 @@ import {
   getElementInfo,
   getElementState,
   getFrameTree,
-  hoverSelector,
   pageSnapshot,
-  pressKey,
   queryFirstDocumentRect,
   querySelectorAllSnapshot,
-  reload,
   removeInitScript,
-  resolveRefToSelector,
-  scrollPage,
   setCookie,
   storageClear,
   storageGet,
   storageGetAll,
   storageRemove,
   storageSet,
-  typeIntoSelector,
   waitForJs,
   waitForSelector,
   waitForText,
   waitForUrl,
 } from "../cdp/tools";
+import {
+  clickSelector,
+  doubleClickSelector,
+  fillSelector,
+  focusSelector,
+  hoverSelector,
+  pressKey,
+  resolveRefToSelector,
+  scrollPage,
+  selectOption,
+  setCheckedSelector,
+  typeIntoSelector,
+} from "../pageDriver";
 
 const MAX_EVAL_RESULT = 64 * 1024;
+const MAX_SCREENSHOT_BYTES = 6 * 1024 * 1024;
+const MAX_SCREENSHOT_DIMENSION = 2200;
+const SCREENSHOT_TIMEOUT_MS = 800;
+
+type ScreenshotFormat = "png" | "jpeg";
 
 export interface ToolContext {
   manager: BrowserPanelManager;
@@ -50,7 +62,16 @@ export interface ToolSpec {
   inputSchema: Record<string, unknown>;
 }
 
+export const BROWSER_MCP_INSTRUCTIONS =
+  "Use the browser MCP server for browsing, inspecting, clicking, typing, screenshots, network/console checks, and local web app verification inside Lightcode. Prefer browser.snapshot or browser.find before browser.click/fill/type, use @e refs from snapshots when possible, and call browser.api when you need the complete API map.";
+
 export const TOOLS: ToolSpec[] = [
+  {
+    name: "api",
+    description:
+      "Return the complete Browser MCP API, recommended workflows, and current tabs. Call this first if you need to browse, inspect, click, type, screenshot, or verify a web page.",
+    inputSchema: { type: "object", properties: {} },
+  },
   {
     name: "list_tabs",
     description: "List open tabs in the Lightcode in-app browser panel.",
@@ -130,24 +151,46 @@ export const TOOLS: ToolSpec[] = [
   },
   {
     name: "screenshot",
-    description: "Take a PNG screenshot of the tab (full page, viewport, or a CSS selector clip).",
+    description: "Take a screenshot of the tab (full page, viewport, or a CSS selector clip).",
     inputSchema: {
       type: "object",
       properties: {
         tabId: { type: "string" },
         selector: { type: "string", description: "If set, clip to this element." },
         fullPage: { type: "boolean", description: "Capture beyond the viewport." },
+        format: {
+          type: "string",
+          enum: ["png", "jpeg"],
+          description:
+            "Preferred image format. Defaults to png; may fall back to jpeg for maxBytes.",
+        },
+        quality: { type: "number", description: "JPEG quality, 1-100. Default 80." },
+        maxBytes: {
+          type: "number",
+          description: "Maximum image bytes before downscaling/returning an error.",
+        },
+        maxDimension: { type: "number", description: "Maximum width/height before downscaling." },
+        timeoutMs: { type: "number", description: "Capture timeout. Default 800ms." },
+        failOnTimeout: {
+          type: "boolean",
+          description: "Throw on timeout instead of returning { timedOut: true }.",
+        },
       },
     },
   },
   {
     name: "query",
     description:
-      "Run document.querySelectorAll and return up to 20 elements' text, outerHTML (truncated), and bounds.",
+      "Run document.querySelectorAll and return paginated elements' text, outerHTML (truncated), and bounds.",
     inputSchema: {
       type: "object",
       required: ["selector"],
-      properties: { tabId: { type: "string" }, selector: { type: "string" } },
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        limit: { type: "number" },
+        offset: { type: "number" },
+      },
     },
   },
   {
@@ -165,24 +208,107 @@ export const TOOLS: ToolSpec[] = [
   },
   {
     name: "click",
-    description: "Click the first element matching the selector.",
+    description: "Click an element matching a selector or @e ref.",
     inputSchema: {
       type: "object",
-      required: ["selector"],
-      properties: { tabId: { type: "string" }, selector: { type: "string" } },
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "dblclick",
+    description: "Double-click an element matching a selector or @e ref.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "focus",
+    description: "Focus an element matching a selector or @e ref.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+      },
     },
   },
   {
     name: "type",
-    description: "Focus a selector and type text. submit=true presses Enter at the end.",
+    description:
+      "Focus an element and append text using browser text insertion. submit=true presses Enter at the end. Use fill to clear existing text first.",
     inputSchema: {
       type: "object",
-      required: ["selector", "text"],
+      required: ["text"],
       properties: {
         tabId: { type: "string" },
         selector: { type: "string" },
+        ref: { type: "string" },
         text: { type: "string" },
         submit: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "fill",
+    description:
+      "Clear and fill an input, textarea, or contenteditable element. submit=true presses Enter at the end.",
+    inputSchema: {
+      type: "object",
+      required: ["text"],
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+        text: { type: "string" },
+        submit: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "check",
+    description: "Check a checkbox or radio input matching a selector or @e ref.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "uncheck",
+    description: "Uncheck a checkbox input matching a selector or @e ref.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "select",
+    description: "Select an option in a <select> by option value or visible text.",
+    inputSchema: {
+      type: "object",
+      required: ["value"],
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+        value: { type: "string" },
       },
     },
   },
@@ -205,7 +331,16 @@ export const TOOLS: ToolSpec[] = [
       properties: {
         tabId: { type: "string" },
         maxNodes: { type: "number" },
+        offset: { type: "number" },
+        mode: { type: "string", enum: ["full", "compact", "summary"] },
+        maxTextLength: { type: "number" },
         includeHidden: { type: "boolean" },
+        interactiveOnly: {
+          type: "boolean",
+          description: "Default true. Set false to include headings/sections/lists.",
+        },
+        includeUrls: { type: "boolean", description: "Include href values for links." },
+        selector: { type: "string", description: "Scope the snapshot to part of the page." },
       },
     },
   },
@@ -218,6 +353,9 @@ export const TOOLS: ToolSpec[] = [
       properties: {
         tabId: { type: "string" },
         maxNodes: { type: "number" },
+        offset: { type: "number" },
+        mode: { type: "string", enum: ["full", "compact", "summary"] },
+        maxTextLength: { type: "number" },
         includeHidden: { type: "boolean" },
       },
     },
@@ -265,6 +403,10 @@ export const TOOLS: ToolSpec[] = [
         text: { type: "string" },
         testid: { type: "string" },
         nth: { type: "number" },
+        limit: { type: "number" },
+        visibleOnly: { type: "boolean" },
+        interactiveOnly: { type: "boolean" },
+        within: { type: "string", description: "CSS selector to scope the search." },
       },
     },
   },
@@ -282,11 +424,35 @@ export const TOOLS: ToolSpec[] = [
   },
   {
     name: "press",
-    description: "Press a key (Enter, Tab, Escape, ArrowDown, etc.) globally on the page.",
+    description:
+      "Press a key (Enter, Tab, Escape, ArrowDown, etc.) on the page active element, or on a selector/ref when provided. Pass shift:true for Shift+Tab traversal.",
     inputSchema: {
       type: "object",
       required: ["key"],
-      properties: { tabId: { type: "string" }, key: { type: "string" } },
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        ref: { type: "string" },
+        key: { type: "string" },
+        shift: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "wait",
+    description:
+      "Wait for one condition: selector, text, url, js, or ms. Use this instead of guessing sleeps.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        tabId: { type: "string" },
+        selector: { type: "string" },
+        text: { type: "string" },
+        url: { type: "string", description: "Substring or /regex/ URL pattern." },
+        js: { type: "string", description: "JS expression; requires eval to be enabled." },
+        ms: { type: "number", description: "Plain delay in milliseconds." },
+        timeoutMs: { type: "number" },
+      },
     },
   },
   {
@@ -352,6 +518,7 @@ export const TOOLS: ToolSpec[] = [
       properties: {
         tabId: { type: "string" },
         limit: { type: "number" },
+        offset: { type: "number" },
         level: {
           type: "string",
           enum: ["log", "warn", "error", "info", "debug", "exception"],
@@ -370,6 +537,7 @@ export const TOOLS: ToolSpec[] = [
         tabId: { type: "string" },
         filter: { type: "string" },
         limit: { type: "number" },
+        offset: { type: "number" },
         clear: { type: "boolean" },
       },
     },
@@ -483,7 +651,10 @@ export const TOOL_NAMES = new Set(TOOLS.map((t) => t.name));
 
 const TOOL_ALIASES = new Map([
   ["open", "navigate"],
+  ["goto", "navigate"],
   ["inspect", "snapshot"],
+  ["key", "press"],
+  ["keyboard_type", "type"],
 ]);
 
 export function normalizeToolName(name: string): string {
@@ -492,6 +663,230 @@ export function normalizeToolName(name: string): string {
 
 export function isKnownToolName(name: string): boolean {
   return TOOL_NAMES.has(normalizeToolName(name));
+}
+
+function compactToolSpec(tool: ToolSpec): { name: string; description: string; args: string } {
+  const schema = tool.inputSchema as {
+    required?: unknown;
+    properties?: unknown;
+  };
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter((key): key is string => typeof key === "string")
+      : [],
+  );
+  const properties =
+    schema.properties && typeof schema.properties === "object"
+      ? Object.keys(schema.properties)
+      : [];
+  return {
+    name: tool.name,
+    description: tool.description,
+    args: properties.length
+      ? `{ ${properties.map((key) => `${key}${required.has(key) ? "" : "?"}`).join(", ")} }`
+      : "{}",
+  };
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function requestedMaxScreenshotBytes(payload: Record<string, unknown>): number {
+  return clampInteger(payload.maxBytes, MAX_SCREENSHOT_BYTES, 1024, 20 * 1024 * 1024);
+}
+
+function requestedScreenshotFormat(payload: Record<string, unknown>): ScreenshotFormat {
+  return payload.format === "jpeg" ? "jpeg" : "png";
+}
+
+function requestedScreenshotQuality(payload: Record<string, unknown>): number {
+  return clampInteger(payload.quality, 80, 1, 100);
+}
+
+function requestedMaxScreenshotDimension(payload: Record<string, unknown>): number {
+  return clampInteger(payload.maxDimension, MAX_SCREENSHOT_DIMENSION, 320, 5000);
+}
+
+function requestedScreenshotTimeoutMs(payload: Record<string, unknown>): number {
+  return clampInteger(payload.timeoutMs, SCREENSHOT_TIMEOUT_MS, 200, 30_000);
+}
+
+class ScreenshotTimeoutError extends Error {
+  constructor(
+    message: string,
+    readonly operation: string,
+    readonly timeoutMs: number,
+  ) {
+    super(message);
+    this.name = "ScreenshotTimeoutError";
+  }
+}
+
+async function withScreenshotTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(
+              new ScreenshotTimeoutError(
+                `${operation} timed out after ${timeoutMs}ms`,
+                operation,
+                timeoutMs,
+              ),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function screenshotTimeoutResult(error: ScreenshotTimeoutError): Record<string, unknown> {
+  return {
+    timedOut: true,
+    reason: "timeout",
+    operation: error.operation,
+    timeoutMs: error.timeoutMs,
+    message: error.message,
+    hint: "Retry with a larger timeoutMs, selector clip, smaller maxDimension, or failOnTimeout:true when a hard failure is preferred.",
+  };
+}
+
+function oversizedScreenshotError(
+  bytes: number,
+  maxBytes: number,
+  format: ScreenshotFormat,
+  size?: { width: number; height: number },
+): Record<string, unknown> {
+  return {
+    error: `screenshot is ${formatBytes(bytes)}, above maxBytes ${formatBytes(
+      maxBytes,
+    )}; retry with selector/fullPage:false or a higher maxBytes.`,
+    bytes,
+    maxBytes,
+    format,
+    ...(size ? { width: size.width, height: size.height } : {}),
+  };
+}
+
+function encodeNativeImage(image: NativeImage, format: ScreenshotFormat, quality: number): Buffer {
+  return format === "jpeg" ? image.toJPEG(quality) : image.toPNG();
+}
+
+function screenshotResultFromNativeImage(
+  image: NativeImage,
+  options: {
+    format: ScreenshotFormat;
+    quality: number;
+    maxBytes: number;
+    maxDimension: number;
+    allowJpegFallback: boolean;
+  },
+): Record<string, unknown> {
+  let current = image;
+  let format = options.format;
+  let quality = options.quality;
+  let bytes = encodeNativeImage(current, format, quality);
+  let size = current.getSize();
+  let downscaled = false;
+  let usedFallback = false;
+
+  while (
+    (bytes.length > options.maxBytes ||
+      size.width > options.maxDimension ||
+      size.height > options.maxDimension) &&
+    size.width > 1 &&
+    size.height > 1
+  ) {
+    const byteScale =
+      bytes.length > options.maxBytes ? Math.sqrt(options.maxBytes / bytes.length) * 0.92 : 1;
+    const dimensionScale = Math.min(1, options.maxDimension / Math.max(size.width, size.height));
+    const scale = Math.max(0.25, Math.min(0.9, byteScale, dimensionScale));
+    const width = Math.max(1, Math.floor(size.width * scale));
+    const height = Math.max(1, Math.floor(size.height * scale));
+    if (width === size.width && height === size.height) break;
+    current = current.resize({ width, height });
+    bytes = encodeNativeImage(current, format, quality);
+    size = current.getSize();
+    downscaled = true;
+  }
+
+  if (bytes.length > options.maxBytes && format === "png" && options.allowJpegFallback) {
+    format = "jpeg";
+    quality = Math.min(quality, 80);
+    bytes = encodeNativeImage(current, format, quality);
+    usedFallback = true;
+  }
+
+  if (format === "jpeg") {
+    while (bytes.length > options.maxBytes && quality > 35) {
+      quality = Math.max(35, quality - 10);
+      bytes = encodeNativeImage(current, format, quality);
+    }
+  }
+
+  while (bytes.length > options.maxBytes && size.width > 1 && size.height > 1) {
+    const scale = Math.max(0.25, Math.min(0.85, Math.sqrt(options.maxBytes / bytes.length) * 0.9));
+    const width = Math.max(1, Math.floor(size.width * scale));
+    const height = Math.max(1, Math.floor(size.height * scale));
+    if (width === size.width && height === size.height) break;
+    current = current.resize({ width, height });
+    bytes = encodeNativeImage(current, format, quality);
+    size = current.getSize();
+    downscaled = true;
+  }
+
+  if (bytes.length > options.maxBytes) {
+    return oversizedScreenshotError(bytes.length, options.maxBytes, format, size);
+  }
+  return {
+    mimeType: format === "jpeg" ? "image/jpeg" : "image/png",
+    base64: bytes.toString("base64"),
+    bytes: bytes.length,
+    format,
+    timedOut: false,
+    reason: "complete",
+    width: size.width,
+    height: size.height,
+    ...(format === "jpeg" ? { quality } : {}),
+    ...(downscaled ? { downscaled: true } : {}),
+    ...(usedFallback ? { fallback: true } : {}),
+  };
+}
+
+function screenshotResultFromBuffer(
+  bytes: Buffer,
+  maxBytes: number,
+  format: ScreenshotFormat,
+  quality?: number,
+): Record<string, unknown> {
+  if (bytes.length > maxBytes) return oversizedScreenshotError(bytes.length, maxBytes, format);
+  return {
+    mimeType: format === "jpeg" ? "image/jpeg" : "image/png",
+    base64: bytes.toString("base64"),
+    bytes: bytes.length,
+    format,
+    timedOut: false,
+    reason: "complete",
+    ...(format === "jpeg" && quality != null ? { quality } : {}),
+  };
 }
 
 async function resolveTabId(ctx: ToolContext, payload: Record<string, unknown>): Promise<string> {
@@ -513,8 +908,7 @@ async function resolveSelectorArg(
     return payload.selector;
   }
   if (typeof payload.ref === "string" && payload.ref.length > 0) {
-    await tab.cdp.attach();
-    return await resolveRefToSelector(tab.cdp, payload.ref);
+    return await resolveRefToSelector(tab.webContents, payload.ref);
   }
   return null;
 }
@@ -527,6 +921,54 @@ export async function dispatchTool(
   ctx: ToolContext,
 ): Promise<unknown> {
   switch (normalizeToolName(name)) {
+    case "api":
+      return {
+        server: "browser",
+        description:
+          "Controls the Lightcode in-app browser panel through tabs, navigation, inspection, input, screenshots, console, network, dialogs, cookies, and storage.",
+        guidance: [
+          "Prefer this MCP server over shell-driven browser automation when a page is visible in Lightcode.",
+          "Start with snapshot or find to identify @e refs before click, fill, type, hover, get, is, or scroll.",
+          "Use fill for form fields when replacing text; use type only when appending text to the current value.",
+          "Use wait after navigation or mutations instead of fixed sleeps unless a plain ms delay is intentional.",
+          "Use requests and console after actions to verify web app behavior and diagnose failures.",
+          "Use eval, cookies, and storage only when the corresponding Lightcode setting allows it.",
+        ],
+        workflows: {
+          inspect: ["list_tabs", "snapshot", "find", "get", "is"],
+          navigate: ["new_tab", "open", "navigate", "back", "forward", "reload"],
+          interact: [
+            "click",
+            "dblclick",
+            "focus",
+            "fill",
+            "type",
+            "check",
+            "uncheck",
+            "select",
+            "press",
+            "hover",
+            "scroll",
+            "wait",
+          ],
+          verify: ["screenshot", "console", "requests", "wait_for_url", "frames"],
+          advanced: ["dialog", "addscript", "addstyle", "eval", "cookies", "storage"],
+        },
+        conventions: {
+          refs: "snapshot/find return @e refs. Prefer passing ref over fragile CSS selectors.",
+          aliases: {
+            open: "navigate",
+            goto: "navigate",
+            inspect: "snapshot",
+            key: "press",
+            keyboard_type: "type",
+          },
+          snapshot:
+            "Use interactiveOnly/includeUrls/selector to reduce output before handing page state to the model.",
+        },
+        tools: TOOLS.filter((tool) => tool.name !== "api").map(compactToolSpec),
+        tabs: ctx.manager.snapshot(),
+      };
     case "list_tabs":
       return ctx.manager.snapshot();
     case "new_tab": {
@@ -562,9 +1004,8 @@ export async function dispatchTool(
       return { ok: true };
     }
     case "reload": {
-      const { tab } = await requireTab(ctx, payload);
-      await tab.cdp.attach();
-      await reload(tab.cdp);
+      const tabId = await resolveTabId(ctx, payload);
+      await ctx.manager.reload(tabId);
       return { ok: true };
     }
     case "get_url": {
@@ -580,21 +1021,35 @@ export async function dispatchTool(
       await tab.cdp.attach();
       const selector = typeof payload.selector === "string" ? payload.selector : undefined;
       const fullPage = payload.fullPage === true;
+      const maxBytes = requestedMaxScreenshotBytes(payload);
+      const format = requestedScreenshotFormat(payload);
+      const quality = requestedScreenshotQuality(payload);
+      const maxDimension = requestedMaxScreenshotDimension(payload);
+      const timeoutMs = requestedScreenshotTimeoutMs(payload);
+      const failOnTimeout = payload.failOnTimeout === true;
+      const screenshotOptions = {
+        format,
+        quality,
+        maxBytes,
+        maxDimension,
+        allowJpegFallback: payload.format !== "png",
+      };
 
-      // Prefer `webContents.capturePage` for in-viewport captures — it reads
-      // the renderer's already-painted bitmap without resizing the page, so
-      // the user sees no jump. Fall back to CDP `captureBeyondViewport` only
-      // for `fullPage` or off-viewport selector captures (those genuinely
-      // need the page to be re-laid out beyond its current viewport).
-      if (selector && !fullPage) {
-        const viewport = await evalJs<{
-          rect: { x: number; y: number; width: number; height: number } | null;
-          inView: boolean;
-          vw: number;
-          vh: number;
-        }>(
-          tab.cdp,
-          `(() => {
+      try {
+        // Prefer `webContents.capturePage` for in-viewport captures — it reads
+        // the renderer's already-painted bitmap without resizing the page, so
+        // the user sees no jump. Fall back to CDP `captureBeyondViewport` only
+        // for `fullPage` or off-viewport selector captures (those genuinely
+        // need the page to be re-laid out beyond its current viewport).
+        if (selector && !fullPage) {
+          const viewport = await evalJs<{
+            rect: { x: number; y: number; width: number; height: number } | null;
+            inView: boolean;
+            vw: number;
+            vh: number;
+          }>(
+            tab.cdp,
+            `(() => {
             const el = document.querySelector(${JSON.stringify(selector)});
             const vw = window.innerWidth || document.documentElement.clientWidth || 0;
             const vh = window.innerHeight || document.documentElement.clientHeight || 0;
@@ -611,47 +1066,108 @@ export async function dispatchTool(
               vh,
             };
           })()`,
-        );
-        if (!viewport.rect) throw new Error(`selector not found: ${selector}`);
-        if (viewport.inView) {
-          const img = await tab.webContents.capturePage({
-            x: Math.max(0, Math.floor(viewport.rect.x)),
-            y: Math.max(0, Math.floor(viewport.rect.y)),
-            width: Math.max(1, Math.ceil(viewport.rect.width)),
-            height: Math.max(1, Math.ceil(viewport.rect.height)),
-          });
-          return { mimeType: "image/png", base64: img.toPNG().toString("base64") };
+          );
+          if (!viewport.rect) throw new Error(`selector not found: ${selector}`);
+          if (viewport.inView) {
+            const img = await withScreenshotTimeout(
+              tab.webContents.capturePage({
+                x: Math.max(0, Math.floor(viewport.rect.x)),
+                y: Math.max(0, Math.floor(viewport.rect.y)),
+                width: Math.max(1, Math.ceil(viewport.rect.width)),
+                height: Math.max(1, Math.ceil(viewport.rect.height)),
+              }),
+              timeoutMs,
+              "viewport selector screenshot",
+            );
+            return screenshotResultFromNativeImage(img, screenshotOptions);
+          }
+        } else if (!selector && !fullPage) {
+          const img = await withScreenshotTimeout(
+            tab.webContents.capturePage(),
+            timeoutMs,
+            "viewport screenshot",
+          );
+          return screenshotResultFromNativeImage(img, screenshotOptions);
         }
-      } else if (!selector && !fullPage) {
-        const img = await tab.webContents.capturePage();
-        return { mimeType: "image/png", base64: img.toPNG().toString("base64") };
-      }
 
-      // Off-viewport selector or fullPage — must use CDP, which will visibly
-      // re-lay out the page to capture content outside the current viewport.
-      let clip: { x: number; y: number; width: number; height: number } | undefined;
-      if (selector) {
-        const rect = await queryFirstDocumentRect(tab.cdp, selector);
-        if (!rect) throw new Error(`selector not found: ${selector}`);
-        clip = {
-          x: Math.max(0, Math.floor(rect.x)),
-          y: Math.max(0, Math.floor(rect.y)),
-          width: Math.max(1, Math.ceil(rect.width)),
-          height: Math.max(1, Math.ceil(rect.height)),
-        };
+        // Off-viewport selector or fullPage — must use CDP, which will visibly
+        // re-lay out the page to capture content outside the current viewport.
+        let clip: { x: number; y: number; width: number; height: number } | undefined;
+        if (selector) {
+          const rect = await queryFirstDocumentRect(tab.cdp, selector);
+          if (!rect) throw new Error(`selector not found: ${selector}`);
+          clip = {
+            x: Math.max(0, Math.floor(rect.x)),
+            y: Math.max(0, Math.floor(rect.y)),
+            width: Math.max(1, Math.ceil(rect.width)),
+            height: Math.max(1, Math.ceil(rect.height)),
+          };
+        }
+        const bytes = await withScreenshotTimeout(
+          captureScreenshotPng(tab.cdp, {
+            fullPage,
+            format,
+            quality,
+            ...(clip ? { clip, captureBeyondViewport: true } : {}),
+          }),
+          timeoutMs,
+          "cdp screenshot",
+        );
+        if (bytes.length <= maxBytes || payload.format === "png") {
+          return screenshotResultFromBuffer(
+            bytes,
+            maxBytes,
+            format,
+            format === "jpeg" ? quality : undefined,
+          );
+        }
+        for (const next of [
+          { format: "jpeg" as const, quality: Math.min(quality, 80), scale: 1 },
+          { format: "jpeg" as const, quality: 70, scale: 0.8 },
+          { format: "jpeg" as const, quality: 60, scale: 0.65 },
+          { format: "jpeg" as const, quality: 50, scale: 0.5 },
+          { format: "jpeg" as const, quality: 40, scale: 0.35 },
+        ]) {
+          const retry = await withScreenshotTimeout(
+            captureScreenshotPng(tab.cdp, {
+              fullPage,
+              format: next.format,
+              quality: next.quality,
+              scale: next.scale,
+              ...(clip ? { clip, captureBeyondViewport: true } : {}),
+            }),
+            timeoutMs,
+            "cdp screenshot retry",
+          );
+          if (retry.length <= maxBytes) {
+            return {
+              ...screenshotResultFromBuffer(retry, maxBytes, next.format, next.quality),
+              fallback: true,
+              downscaled: next.scale < 1,
+            };
+          }
+        }
+        return screenshotResultFromBuffer(
+          bytes,
+          maxBytes,
+          format,
+          format === "jpeg" ? quality : undefined,
+        );
+      } catch (err) {
+        if (err instanceof ScreenshotTimeoutError && !failOnTimeout) {
+          return screenshotTimeoutResult(err);
+        }
+        throw err;
       }
-      const bytes = await captureScreenshotPng(tab.cdp, {
-        fullPage,
-        ...(clip ? { clip, captureBeyondViewport: true } : {}),
-      });
-      return { mimeType: "image/png", base64: bytes.toString("base64") };
     }
     case "query": {
       const { tab } = await requireTab(ctx, payload);
       const selector = String(payload.selector ?? "");
       if (!selector) throw new Error("selector required");
       await tab.cdp.attach();
-      return await querySelectorAllSnapshot(tab.cdp, selector, 20);
+      const limit = clampInteger(payload.limit, 20, 1, 100);
+      const offset = clampInteger(payload.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+      return await querySelectorAllSnapshot(tab.cdp, selector, limit, offset);
     }
     case "wait_for": {
       const { tab } = await requireTab(ctx, payload);
@@ -664,20 +1180,64 @@ export async function dispatchTool(
     }
     case "click": {
       const { tab } = await requireTab(ctx, payload);
-      const selector = String(payload.selector ?? "");
-      if (!selector) throw new Error("selector required");
-      await tab.cdp.attach();
-      await clickSelector(tab.cdp, selector);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await clickSelector(tab.webContents, selector);
+      return { ok: true };
+    }
+    case "dblclick": {
+      const { tab } = await requireTab(ctx, payload);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await doubleClickSelector(tab.webContents, selector);
+      return { ok: true };
+    }
+    case "focus": {
+      const { tab } = await requireTab(ctx, payload);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await focusSelector(tab.webContents, selector);
       return { ok: true };
     }
     case "type": {
       const { tab } = await requireTab(ctx, payload);
-      const selector = String(payload.selector ?? "");
       const text = String(payload.text ?? "");
       const submit = payload.submit === true;
-      if (!selector) throw new Error("selector required");
-      await tab.cdp.attach();
-      await typeIntoSelector(tab.cdp, selector, text, submit);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await typeIntoSelector(tab.webContents, selector, text, submit);
+      return { ok: true };
+    }
+    case "fill": {
+      const { tab } = await requireTab(ctx, payload);
+      const text = String(payload.text ?? "");
+      const submit = payload.submit === true;
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await fillSelector(tab.webContents, selector, text, submit);
+      return { ok: true };
+    }
+    case "check": {
+      const { tab } = await requireTab(ctx, payload);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await setCheckedSelector(tab.webContents, selector, true);
+      return { ok: true };
+    }
+    case "uncheck": {
+      const { tab } = await requireTab(ctx, payload);
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await setCheckedSelector(tab.webContents, selector, false);
+      return { ok: true };
+    }
+    case "select": {
+      const { tab } = await requireTab(ctx, payload);
+      const value = String(payload.value ?? "");
+      if (!value) throw new Error("value required");
+      const selector = await resolveSelectorArg(tab, payload);
+      if (!selector) throw new Error("selector or ref required");
+      await selectOption(tab.webContents, selector, value);
       return { ok: true };
     }
     case "eval": {
@@ -702,9 +1262,24 @@ export async function dispatchTool(
     case "snapshot": {
       const { tab } = await requireTab(ctx, payload);
       await tab.cdp.attach();
-      const maxNodes = typeof payload.maxNodes === "number" ? payload.maxNodes : 200;
+      const maxNodes = clampInteger(payload.maxNodes, 120, 1, 500);
+      const offset = clampInteger(payload.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+      const mode = payload.mode === "compact" || payload.mode === "summary" ? payload.mode : "full";
+      const maxTextLength =
+        typeof payload.maxTextLength === "number"
+          ? clampInteger(payload.maxTextLength, mode === "full" ? 200 : 80, 20, 1000)
+          : undefined;
       const includeHidden = payload.includeHidden === true;
-      return await pageSnapshot(tab.cdp, { maxNodes, includeHidden });
+      return await pageSnapshot(tab.cdp, {
+        maxNodes,
+        offset,
+        mode,
+        ...(maxTextLength != null ? { maxTextLength } : {}),
+        includeHidden,
+        ...(payload.interactiveOnly === false ? { interactiveOnly: false } : {}),
+        ...(payload.includeUrls === true ? { includeUrls: true } : {}),
+        ...(typeof payload.selector === "string" ? { selector: payload.selector } : {}),
+      });
     }
     case "get": {
       const { tab } = await requireTab(ctx, payload);
@@ -738,32 +1313,70 @@ export async function dispatchTool(
         ...(typeof payload.text === "string" ? { text: payload.text } : {}),
         ...(typeof payload.testid === "string" ? { testid: payload.testid } : {}),
         ...(typeof payload.nth === "number" ? { nth: payload.nth } : {}),
+        ...(typeof payload.limit === "number" ? { limit: payload.limit } : {}),
+        ...(typeof payload.visibleOnly === "boolean" ? { visibleOnly: payload.visibleOnly } : {}),
+        ...(typeof payload.interactiveOnly === "boolean"
+          ? { interactiveOnly: payload.interactiveOnly }
+          : {}),
+        ...(typeof payload.within === "string" ? { within: payload.within } : {}),
       });
     }
     case "hover": {
       const { tab } = await requireTab(ctx, payload);
-      await tab.cdp.attach();
       const selector = await resolveSelectorArg(tab, payload);
       if (!selector) throw new Error("selector or ref required");
-      await hoverSelector(tab.cdp, selector);
+      await hoverSelector(tab.webContents, selector);
       return { ok: true };
     }
     case "press": {
       const { tab } = await requireTab(ctx, payload);
       const key = String(payload.key ?? "");
       if (!key) throw new Error("key required");
-      await tab.cdp.attach();
-      await pressKey(tab.cdp, key);
+      const hasTarget = typeof payload.selector === "string" || typeof payload.ref === "string";
+      const selector = hasTarget ? await resolveSelectorArg(tab, payload) : undefined;
+      if (hasTarget && !selector) throw new Error("selector or ref required");
+      const shift = payload.shift === true;
+      await pressKey(tab.webContents, key, selector ?? undefined, { shift });
       return { ok: true };
+    }
+    case "wait": {
+      const timeoutMs = typeof payload.timeoutMs === "number" ? payload.timeoutMs : 5000;
+      if (typeof payload.ms === "number") {
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.max(0, Math.min(60_000, payload.ms as number))),
+        );
+        return { ok: true };
+      }
+      const { tab } = await requireTab(ctx, payload);
+      await tab.cdp.attach();
+      if (typeof payload.selector === "string" && payload.selector.length > 0) {
+        const found = await waitForSelector(tab.cdp, payload.selector, timeoutMs);
+        return { found };
+      }
+      if (typeof payload.text === "string" && payload.text.length > 0) {
+        await waitForText(tab.cdp, payload.text, timeoutMs);
+        return { ok: true };
+      }
+      if (typeof payload.url === "string" && payload.url.length > 0) {
+        const url = await waitForUrl(tab.cdp, payload.url, timeoutMs);
+        return { url };
+      }
+      if (typeof payload.js === "string" && payload.js.length > 0) {
+        if (!ctx.allowEval) {
+          return { error: "wait.js requires eval to be enabled in settings" };
+        }
+        const result = await waitForJs(tab.cdp, payload.js, timeoutMs);
+        return { result };
+      }
+      throw new Error("wait requires selector, text, url, js, or ms");
     }
     case "scroll": {
       const { tab } = await requireTab(ctx, payload);
-      await tab.cdp.attach();
       const selector =
         typeof payload.selector === "string" || typeof payload.ref === "string"
           ? await resolveSelectorArg(tab, payload)
           : undefined;
-      await scrollPage(tab.cdp, {
+      await scrollPage(tab.webContents, {
         ...(selector ? { selector } : {}),
         ...(typeof payload.x === "number" ? { x: payload.x } : {}),
         ...(typeof payload.y === "number" ? { y: payload.y } : {}),
@@ -802,15 +1415,23 @@ export async function dispatchTool(
     }
     case "console": {
       const { tab } = await requireTab(ctx, payload);
-      const limit = typeof payload.limit === "number" ? payload.limit : 50;
+      const limit = clampInteger(payload.limit, 50, 1, 100);
+      const offset = clampInteger(payload.offset, 0, 0, Number.MAX_SAFE_INTEGER);
       const level =
         typeof payload.level === "string"
           ? (payload.level as "log" | "warn" | "error" | "info" | "debug" | "exception")
           : undefined;
-      let entries = tab.getConsoleEntries(limit);
+      let entries = tab.getConsoleEntries();
       if (level) entries = entries.filter((e) => e.level === level);
+      const page = entries.slice(offset, offset + limit);
       if (payload.clear === true) tab.clearConsole();
-      return { entries };
+      return {
+        count: entries.length,
+        offset,
+        limit,
+        nextOffset: offset + page.length < entries.length ? offset + page.length : null,
+        entries: page,
+      };
     }
     case "requests": {
       const { tab } = await requireTab(ctx, payload);
@@ -819,10 +1440,18 @@ export async function dispatchTool(
         await tab.network.enable(tab.cdp);
       }
       const filter = typeof payload.filter === "string" ? payload.filter : undefined;
-      const limit = typeof payload.limit === "number" ? payload.limit : 100;
-      const entries = tab.network.list({ ...(filter ? { filter } : {}), limit });
+      const limit = clampInteger(payload.limit, 50, 1, 100);
+      const offset = clampInteger(payload.offset, 0, 0, Number.MAX_SAFE_INTEGER);
+      const entries = tab.network.list({ ...(filter ? { filter } : {}), limit: 500 });
+      const page = entries.slice(offset, offset + limit);
       if (payload.clear === true) tab.network.clear();
-      return { count: entries.length, requests: entries };
+      return {
+        count: entries.length,
+        offset,
+        limit,
+        nextOffset: offset + page.length < entries.length ? offset + page.length : null,
+        requests: page,
+      };
     }
     case "cookies": {
       if (!ctx.allowDataAccess) {
@@ -1010,8 +1639,14 @@ export function formatToolResult(name: string, result: unknown): McpToolResult {
     "base64" in result
   ) {
     const r = result as { base64: string; mimeType?: string };
+    const metadata = { ...(result as Record<string, unknown>) };
+    delete metadata.base64;
     return {
       content: [
+        {
+          type: "text",
+          text: JSON.stringify(metadata, null, 2),
+        },
         {
           type: "image",
           data: r.base64,

--- a/src/main/browser/pageDriver.ts
+++ b/src/main/browser/pageDriver.ts
@@ -1,0 +1,399 @@
+import type { WebContents } from "electron";
+
+type PageExecutor = Pick<WebContents, "executeJavaScript">;
+
+const DRIVER_GLOBAL = "__lightcodeBrowserDriver";
+
+const DRIVER_SOURCE = `(() => {
+  if (window.${DRIVER_GLOBAL}) return true;
+
+  const bySelector = (selector) => document.querySelector(selector);
+  const isVisible = (el) => {
+    const r = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+  };
+  const centerInit = (el, extra = {}) => {
+    const r = el.getBoundingClientRect();
+    return {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      view: window,
+      clientX: r.left + r.width / 2,
+      clientY: r.top + r.height / 2,
+      ...extra,
+    };
+  };
+  const valueSetterFor = (el) => {
+    const proto = el instanceof HTMLTextAreaElement
+      ? HTMLTextAreaElement.prototype
+      : el instanceof HTMLInputElement
+        ? HTMLInputElement.prototype
+        : null;
+    return proto ? Object.getOwnPropertyDescriptor(proto, "value")?.set : null;
+  };
+  const dispatchTextEvents = (el, text) => {
+    const inputEvent = typeof InputEvent === "function"
+      ? new InputEvent("input", { bubbles: true, inputType: "insertText", data: text })
+      : new Event("input", { bubbles: true });
+    el.dispatchEvent(inputEvent);
+    el.dispatchEvent(new Event("change", { bubbles: true }));
+  };
+  const focusElement = (el) => {
+    if (!el || typeof el.focus !== "function") return false;
+    el.scrollIntoView({ block: "center", inline: "center" });
+    el.focus();
+    return document.activeElement === el;
+  };
+  const submitFrom = (el) => {
+    const down = new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true });
+    const shouldSubmit = el.dispatchEvent(down);
+    el.dispatchEvent(new KeyboardEvent("keyup", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));
+    const form = el.form instanceof HTMLFormElement ? el.form : el.closest("form");
+    if (shouldSubmit && form && typeof form.requestSubmit === "function") {
+      form.requestSubmit();
+    }
+  };
+  const isEditableValueElement = (el) => {
+    if (el instanceof HTMLTextAreaElement) return true;
+    if (!(el instanceof HTMLInputElement)) return false;
+    const TEXT_TYPES = new Set([
+      "text", "search", "url", "tel", "email", "password", "number",
+      "date", "datetime-local", "month", "time", "week",
+    ]);
+    return TEXT_TYPES.has((el.type || "text").toLowerCase());
+  };
+  const writeText = (selector, text, submit, append) => {
+    const el = bySelector(selector);
+    if (!focusElement(el)) return false;
+    if (isEditableValueElement(el)) {
+      if (append) {
+        const value = String(el.value ?? "");
+        const start = typeof el.selectionStart === "number" ? el.selectionStart : value.length;
+        const end = typeof el.selectionEnd === "number" ? el.selectionEnd : value.length;
+        const next = value.slice(0, start) + text + value.slice(end);
+        const setter = valueSetterFor(el);
+        if (setter) setter.call(el, next);
+        else el.value = next;
+        if (typeof el.setSelectionRange === "function") {
+          try { el.setSelectionRange(start + text.length, start + text.length); } catch {}
+        }
+      } else {
+        const setter = valueSetterFor(el);
+        if (setter) setter.call(el, text);
+        else el.value = text;
+        if (typeof el.setSelectionRange === "function") {
+          try { el.setSelectionRange(text.length, text.length); } catch {}
+        }
+      }
+    } else if (el.isContentEditable) {
+      if (append) {
+        const selection = window.getSelection();
+        const range = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : document.createRange();
+        if (!selection || !el.contains(range.commonAncestorContainer)) {
+          range.selectNodeContents(el);
+          range.collapse(false);
+        }
+        range.deleteContents();
+        range.insertNode(document.createTextNode(text));
+        range.collapse(false);
+        const nextSelection = window.getSelection();
+        if (nextSelection) {
+          nextSelection.removeAllRanges();
+          nextSelection.addRange(range);
+        }
+      } else {
+        el.textContent = text;
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const selection = window.getSelection();
+        if (selection) {
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
+    } else {
+      return false;
+    }
+    dispatchTextEvents(el, text);
+    if (submit) submitFrom(el);
+    return true;
+  };
+
+  window.${DRIVER_GLOBAL} = {
+    click(selector, clickCount) {
+      const el = bySelector(selector);
+      if (!el) return false;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      if (!isVisible(el)) return false;
+      const init = centerInit(el, { button: 0, buttons: 1, detail: clickCount });
+      if (typeof PointerEvent === "function") {
+        el.dispatchEvent(new PointerEvent("pointerover", init));
+        el.dispatchEvent(new PointerEvent("pointerenter", init));
+        el.dispatchEvent(new PointerEvent("pointerdown", init));
+      }
+      el.dispatchEvent(new MouseEvent("mouseover", init));
+      el.dispatchEvent(new MouseEvent("mouseenter", init));
+      el.dispatchEvent(new MouseEvent("mousedown", init));
+      if (typeof el.focus === "function") el.focus();
+      if (typeof PointerEvent === "function") {
+        el.dispatchEvent(new PointerEvent("pointerup", init));
+      }
+      el.dispatchEvent(new MouseEvent("mouseup", init));
+      el.dispatchEvent(new MouseEvent("click", init));
+      if (clickCount === 2) el.dispatchEvent(new MouseEvent("dblclick", init));
+      return true;
+    },
+    focus(selector) {
+      return focusElement(bySelector(selector));
+    },
+    type(selector, text, submit) {
+      return writeText(selector, text, submit, true);
+    },
+    fill(selector, text, submit) {
+      return writeText(selector, text, submit, false);
+    },
+    setChecked(selector, checked) {
+      const el = bySelector(selector);
+      if (!el || !("checked" in el)) return false;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      if (el.checked !== checked) {
+        el.checked = checked;
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+        el.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      return true;
+    },
+    select(selector, value) {
+      const el = bySelector(selector);
+      if (!el || el.tagName !== "SELECT") return false;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      const options = Array.from(el.options);
+      const option = options.find((opt) => opt.value === value) ||
+        options.find((opt) => (opt.textContent || "").trim() === value);
+      if (!option) return false;
+      el.value = option.value;
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+      return true;
+    },
+    resolveRefToSelector(ref) {
+      const el = (window.__lcRefs || new Map()).get(ref);
+      if (!el) return null;
+      if (el.id && !/^\\d/.test(el.id)) return "#" + CSS.escape(el.id);
+      const path = [];
+      let n = el;
+      while (n && n.nodeType === 1 && n.tagName !== "HTML") {
+        let part = n.tagName.toLowerCase();
+        const p = n.parentElement;
+        if (p) {
+          const sibs = Array.from(p.children).filter((c) => c.tagName === n.tagName);
+          if (sibs.length > 1) part += ":nth-of-type(" + (sibs.indexOf(n) + 1) + ")";
+        }
+        path.unshift(part);
+        n = p;
+      }
+      return path.join(" > ");
+    },
+    hover(selector) {
+      const el = bySelector(selector);
+      if (!el) return false;
+      el.scrollIntoView({ block: "center", inline: "center" });
+      if (!isVisible(el)) return false;
+      const init = centerInit(el);
+      if (typeof PointerEvent === "function") {
+        el.dispatchEvent(new PointerEvent("pointerover", init));
+        el.dispatchEvent(new PointerEvent("pointermove", init));
+      }
+      el.dispatchEvent(new MouseEvent("mouseover", init));
+      el.dispatchEvent(new MouseEvent("mousemove", init));
+      return true;
+    },
+    press(rawKey, selector, shiftKey) {
+      const keyMap = { Esc: "Escape", Space: " " };
+      const codeMap = { " ": "Space", Escape: "Escape", Enter: "Enter", Tab: "Tab", Backspace: "Backspace", Delete: "Delete", ArrowUp: "ArrowUp", ArrowDown: "ArrowDown", ArrowLeft: "ArrowLeft", ArrowRight: "ArrowRight" };
+      const normalizedKey = keyMap[rawKey] || rawKey;
+      const code = codeMap[normalizedKey] || rawKey;
+      let target;
+      if (selector) {
+        target = bySelector(selector);
+        if (!target) return false;
+        focusElement(target);
+      } else {
+        target = document.activeElement && document.activeElement !== document.body
+          ? document.activeElement
+          : document;
+      }
+      const init = { key: normalizedKey, code, shiftKey: !!shiftKey, bubbles: true, cancelable: true, composed: true };
+      const down = new KeyboardEvent("keydown", init);
+      const proceed = target.dispatchEvent(down);
+      if (proceed) {
+        if (normalizedKey === "Enter") {
+          if (target instanceof HTMLButtonElement || target instanceof HTMLAnchorElement) {
+            target.click();
+          } else {
+            const form = "form" in target && target.form instanceof HTMLFormElement
+              ? target.form
+              : target instanceof Element
+                ? target.closest("form")
+                : null;
+            if (form && typeof form.requestSubmit === "function") form.requestSubmit();
+          }
+        } else if (normalizedKey === " " && target instanceof HTMLElement && (target instanceof HTMLButtonElement || target instanceof HTMLInputElement)) {
+          target.click();
+        } else if (normalizedKey === "Tab") {
+          const focusable = Array.from(document.querySelectorAll("a[href], button, input, textarea, select, details, [tabindex]:not([tabindex='-1'])"))
+            .filter((el) => {
+              if (!(el instanceof HTMLElement)) return false;
+              if ("disabled" in el && el.disabled) return false;
+              return isVisible(el);
+            });
+          if (focusable.length > 0) {
+            const idx = focusable.indexOf(target);
+            const step = shiftKey ? -1 : 1;
+            const nextIdx = idx < 0
+              ? (shiftKey ? focusable.length - 1 : 0)
+              : (idx + step + focusable.length) % focusable.length;
+            const next = focusable[nextIdx];
+            if (next instanceof HTMLElement) next.focus();
+          }
+        }
+      }
+      target.dispatchEvent(new KeyboardEvent("keyup", init));
+      return true;
+    },
+    scroll(selector, x, y) {
+      if (selector) {
+        const el = bySelector(selector);
+        if (!el) return false;
+        el.scrollIntoView({ block: "center", inline: "center" });
+        return true;
+      }
+      window.scrollBy(x || 0, y || 0);
+      return true;
+    },
+  };
+  return true;
+})()`;
+
+async function callDriver<T = unknown>(page: PageExecutor, expression: string): Promise<T> {
+  await page.executeJavaScript(DRIVER_SOURCE, true);
+  return (await page.executeJavaScript(expression, true)) as T;
+}
+
+export async function clickSelector(page: PageExecutor, selector: string): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.click(${JSON.stringify(selector)}, 1)`,
+  );
+  if (!ok) throw new Error(`Selector not found or has zero size: ${selector}`);
+}
+
+export async function doubleClickSelector(page: PageExecutor, selector: string): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.click(${JSON.stringify(selector)}, 2)`,
+  );
+  if (!ok) throw new Error(`Selector not found or has zero size: ${selector}`);
+}
+
+export async function focusSelector(page: PageExecutor, selector: string): Promise<void> {
+  const focused = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.focus(${JSON.stringify(selector)})`,
+  );
+  if (!focused) throw new Error(`Selector not found or not focusable: ${selector}`);
+}
+
+export async function typeIntoSelector(
+  page: PageExecutor,
+  selector: string,
+  text: string,
+  submit: boolean,
+): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.type(${JSON.stringify(selector)}, ${JSON.stringify(text)}, ${submit ? "true" : "false"})`,
+  );
+  if (!ok) throw new Error(`Selector not found or not typeable: ${selector}`);
+}
+
+export async function fillSelector(
+  page: PageExecutor,
+  selector: string,
+  text: string,
+  submit: boolean,
+): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.fill(${JSON.stringify(selector)}, ${JSON.stringify(text)}, ${submit ? "true" : "false"})`,
+  );
+  if (!ok) throw new Error(`Selector not found or not fillable: ${selector}`);
+}
+
+export async function setCheckedSelector(
+  page: PageExecutor,
+  selector: string,
+  checked: boolean,
+): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.setChecked(${JSON.stringify(selector)}, ${checked ? "true" : "false"})`,
+  );
+  if (!ok) throw new Error(`Selector not found or not checkable: ${selector}`);
+}
+
+export async function selectOption(
+  page: PageExecutor,
+  selector: string,
+  value: string,
+): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.select(${JSON.stringify(selector)}, ${JSON.stringify(value)})`,
+  );
+  if (!ok) throw new Error(`Selector not found or option not available: ${selector}`);
+}
+
+export async function resolveRefToSelector(
+  page: PageExecutor,
+  ref: string,
+): Promise<string | null> {
+  return await callDriver<string | null>(
+    page,
+    `window.${DRIVER_GLOBAL}.resolveRefToSelector(${JSON.stringify(ref)})`,
+  );
+}
+
+export async function hoverSelector(page: PageExecutor, selector: string): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.hover(${JSON.stringify(selector)})`,
+  );
+  if (!ok) throw new Error(`Selector not found: ${selector}`);
+}
+
+export async function pressKey(
+  page: PageExecutor,
+  key: string,
+  selector?: string,
+  options: { shift?: boolean } = {},
+): Promise<void> {
+  const ok = await callDriver<boolean>(
+    page,
+    `window.${DRIVER_GLOBAL}.press(${JSON.stringify(key)}, ${selector ? JSON.stringify(selector) : "null"}, ${options.shift ? "true" : "false"})`,
+  );
+  if (!ok) throw new Error(`Selector not found: ${selector}`);
+}
+
+export async function scrollPage(
+  page: PageExecutor,
+  options: { selector?: string; x?: number; y?: number },
+): Promise<void> {
+  await callDriver(
+    page,
+    `window.${DRIVER_GLOBAL}.scroll(${options.selector ? JSON.stringify(options.selector) : "null"}, ${options.x ?? 0}, ${options.y ?? 0})`,
+  );
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,7 @@
 import { watch } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, Menu } from "electron";
 import { closeDatabase, dbGetThreads, initDatabase } from "./db";
 import { cleanupOrphanedAttachments, prepareLightcodeDataRoot } from "./lightcodeData";
 import { createLocalIpcHandlers } from "./ipc/localHandlers";
@@ -146,6 +146,8 @@ if (!hasSingleInstanceLock) {
   });
 
   app.whenReady().then(async () => {
+    Menu.setApplicationMenu(null);
+
     installLocalFileProtocolHandler();
     installPickerProtocolHandler();
 

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -41,6 +41,7 @@ export function BrowserChip(props: {
       role={onRemove ? "group" : "img"}
     >
       <Globe className="size-3 text-muted" aria-hidden="true" />
+      <span className="lightcode-attachment-chip__name">Browser</span>
       {onRemove ? (
         <button
           type="button"

--- a/src/renderer/components/composer/MentionInput.test.ts
+++ b/src/renderer/components/composer/MentionInput.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildMentionResults } from "./MentionInput";
+
+describe("buildMentionResults", () => {
+  const fileResults = [{ type: "file" as const, path: "README.md", name: "README.md" }];
+
+  it("shows Browser when typing an empty @ mention", () => {
+    expect(buildMentionResults(fileResults, "", true)).toEqual([
+      { type: "browser", path: "browser", name: "Browser" },
+      ...fileResults,
+    ]);
+  });
+
+  it("shows Browser when the query matches browser", () => {
+    expect(buildMentionResults(fileResults, "browser", true)).toEqual([
+      { type: "browser", path: "browser", name: "Browser" },
+      ...fileResults,
+    ]);
+  });
+
+  it("does not show Browser until the composer allows it", () => {
+    expect(buildMentionResults(fileResults, "browser", false)).toEqual(fileResults);
+  });
+});

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -3,9 +3,22 @@ import type { FileEntry, ProjectLocation, PromptSegment } from "@/shared/contrac
 import { fileNameFromPath } from "@/shared/promptContent";
 import { createChipElement, type FileMentionData } from "./FileMentionChip";
 import { createSlashCommandChipElement } from "./SlashCommandChip";
-import { MentionPopover } from "./MentionPopover";
+import { MentionPopover, type MentionEntry } from "./MentionPopover";
 import { useDebouncedFileSearch } from "./useDebouncedFileSearch";
 import { serializeToSegments, flattenSegments } from "./serializeMentions";
+
+const BROWSER_MENTION_ENTRY: MentionEntry = { type: "browser", path: "browser", name: "Browser" };
+
+export function buildMentionResults(
+  fileResults: FileEntry[],
+  query: string,
+  showBrowserMention: boolean,
+): MentionEntry[] {
+  const q = query.trim().toLowerCase();
+  const browserResults =
+    showBrowserMention && "browser".startsWith(q) ? [BROWSER_MENTION_ENTRY] : [];
+  return [...browserResults, ...fileResults];
+}
 
 export interface MentionInputHandle {
   /** Get structured segments (text + file mentions) for the adapter pipeline. */
@@ -131,6 +144,8 @@ export const MentionInput = forwardRef<
     onTextChange: (hasText: boolean) => void;
     onSubmit: (segments: PromptSegment[]) => void;
     onPasteImage?: (file: File) => void;
+    showBrowserMention?: boolean;
+    onBrowserMentionSelect?: () => void;
     onSlashCommandChange?: (query: string | null) => void;
     /**
      * Called before MentionInput's own key handling (after the mention popover
@@ -150,6 +165,8 @@ export const MentionInput = forwardRef<
     onTextChange,
     onSubmit,
     onPasteImage,
+    showBrowserMention,
+    onBrowserMentionSelect,
     onSlashCommandChange,
     onInterceptKey,
   } = props;
@@ -158,16 +175,21 @@ export const MentionInput = forwardRef<
   const [mention, setMention] = useState<MentionState | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
-  const results = useDebouncedFileSearch(
+  const fileResults = useDebouncedFileSearch(
     projectLocation,
     mention?.query ?? "",
     mention !== null,
     projectId,
   );
+  const results = buildMentionResults(
+    fileResults,
+    mention?.query ?? "",
+    showBrowserMention === true,
+  );
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [results]);
+  }, [mention?.query, fileResults, showBrowserMention]);
 
   useImperativeHandle(ref, () => ({
     serializeSegments() {
@@ -299,11 +321,23 @@ export const MentionInput = forwardRef<
     onTextChange(hasEditorContent(editor));
   }
 
-  function insertMention(entry: FileEntry) {
+  function insertMention(entry: MentionEntry) {
     if (!editorRef.current) return;
 
     const range = detectTriggerRange("@");
     if (!range) return;
+
+    if (entry.type === "browser") {
+      const sel = window.getSelection();
+      if (!sel) return;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      range.deleteContents();
+      setMention(null);
+      onBrowserMentionSelect?.();
+      notifyTextChange();
+      return;
+    }
 
     const mentionData: FileMentionData = {
       path: entry.path,

--- a/src/renderer/components/composer/MentionPopover.tsx
+++ b/src/renderer/components/composer/MentionPopover.tsx
@@ -1,7 +1,16 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { Globe } from "lucide-react";
 import type { FileEntry } from "@/shared/contracts";
 import { getEntryIconUrl } from "@/renderer/components/common/fileIcons";
+
+export type BrowserMentionEntry = {
+  type: "browser";
+  path: "browser";
+  name: "Browser";
+};
+
+export type MentionEntry = FileEntry | BrowserMentionEntry;
 
 function getParentDir(path: string): string {
   const lastSlash = path.lastIndexOf("/");
@@ -9,11 +18,11 @@ function getParentDir(path: string): string {
 }
 
 export function MentionPopover(props: {
-  results: FileEntry[];
+  results: MentionEntry[];
   activeIndex: number;
   editorEl: HTMLDivElement | null;
   mentionRange: Range;
-  onSelect: (entry: FileEntry) => void;
+  onSelect: (entry: MentionEntry) => void;
   onActiveIndexChange: (index: number) => void;
 }) {
   const { results, activeIndex, editorEl, mentionRange, onSelect, onActiveIndexChange } = props;
@@ -52,6 +61,7 @@ export function MentionPopover(props: {
         {results.map((entry, index) => {
           const dir = getParentDir(entry.path);
           const isActive = index === activeIndex;
+          const isBrowser = entry.type === "browser";
           return (
             <div
               key={`${entry.type}:${entry.path}`}
@@ -64,14 +74,26 @@ export function MentionPopover(props: {
                 onSelect(entry);
               }}
             >
-              <img
-                className="lightcode-mention-popover__icon"
-                src={getEntryIconUrl(entry.name, entry.type === "directory")}
-                alt=""
-                draggable={false}
-              />
-              <span className="truncate">{entry.name}</span>
-              {dir && <span className="ml-auto shrink-0 text-xs text-[var(--muted)]">{dir}</span>}
+              {isBrowser ? (
+                <Globe className="lightcode-mention-popover__icon text-muted" aria-hidden="true" />
+              ) : (
+                <img
+                  className="lightcode-mention-popover__icon"
+                  src={getEntryIconUrl(entry.name, entry.type === "directory")}
+                  alt=""
+                  draggable={false}
+                />
+              )}
+              <span className="lightcode-mention-popover__label truncate">{entry.name}</span>
+              {isBrowser ? (
+                <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
+                  Browser MCP
+                </span>
+              ) : dir ? (
+                <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
+                  {dir}
+                </span>
+              ) : null}
             </div>
           );
         })}

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -367,8 +367,11 @@ export function ThreadDraftComposerArea(props: {
             {...(!isHomeScope ? { projectId: props.project.id } : {})}
             onTextChange={(hasText) => {
               setHasContent(hasText);
-              latestSegmentsRef.current = mentionRef.current?.serializeSegments() ?? [];
+              const segments = mentionRef.current?.serializeSegments() ?? [];
+              latestSegmentsRef.current = segments;
             }}
+            showBrowserMention={browserMcpScope !== "none" && props.config.browserMcp !== true}
+            onBrowserMentionSelect={() => props.onConfigChange({ browserMcp: true })}
             onPasteImage={(file) => {
               void attachments.addClipboardImage(file, `draft:${props.project.id}`);
             }}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1995,11 +1995,9 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
 }
 
 .lightcode-browser-chip {
-  justify-content: center;
-  width: 1.35rem;
+  padding: 0.25em 0.45em;
   height: 1.35rem;
-  gap: 0;
-  padding: 0;
+  gap: 0.3rem;
   border-radius: 0.35rem;
   font-size: 0.6875rem;
   line-height: 1.25;
@@ -2222,8 +2220,17 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   padding: 0.45rem 0.65rem;
   border-radius: 0.5rem;
   font-size: 0.8125rem;
+  line-height: 1.125rem;
   cursor: var(--interactive-cursor);
   color: var(--foreground);
+}
+
+.lightcode-mention-popover__label,
+.lightcode-mention-popover__detail {
+  display: flex;
+  align-items: center;
+  min-height: 1.125rem;
+  transform: translateY(-1px);
 }
 
 .lightcode-mention-popover__item--active {

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.test.tsx
@@ -1,8 +1,15 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { BrowserPanel } from "./BrowserPanel";
+
+const bridge = vi.hoisted(() => ({
+  browserCreateTab: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  browserAttachWebContents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  browserReload: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  browserHardReload: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
 
 vi.mock("./hooks/useElementPicker", () => ({
   useElementPicker: () => ({
@@ -26,13 +33,16 @@ vi.mock("./parts/BrowserTabStrip", () => ({
 vi.mock("@/renderer/bridge", () => ({
   isMac: () => false,
   readBridge: () => ({
-    browserCreateTab: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-    browserAttachWebContents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    browserCreateTab: bridge.browserCreateTab,
+    browserAttachWebContents: bridge.browserAttachWebContents,
+    browserReload: bridge.browserReload,
+    browserHardReload: bridge.browserHardReload,
   }),
 }));
 
 describe("BrowserPanel", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     useBrowserPanelStore.setState({
       tabs: [],
       activeTabId: null,
@@ -74,7 +84,60 @@ describe("BrowserPanel", () => {
     const { container } = render(<BrowserPanel visible />);
     const webviews = container.querySelectorAll("webview");
     expect(webviews).toHaveLength(2);
+    expect(webviews[0]?.getAttribute("partition")).toBe("persist:lightcode-browser");
     expect((webviews[0] as HTMLElement).style.display).toBe("flex");
     expect((webviews[1] as HTMLElement).style.display).toBe("none");
+  });
+
+  it("attaches the right-panel webview contents to the browser tab", () => {
+    useBrowserPanelStore.setState({
+      tabs: [
+        {
+          tabId: "tab-1",
+          url: "https://example.com/",
+          title: "Example",
+          loading: false,
+          canGoBack: false,
+          canGoForward: false,
+        },
+      ],
+      activeTabId: "tab-1",
+    });
+    const { container } = render(<BrowserPanel visible />);
+    const webview = container.querySelector("webview") as HTMLElement & {
+      getWebContentsId(): number;
+    };
+    webview.getWebContentsId = vi.fn<() => number>().mockReturnValue(42);
+
+    fireEvent(webview, new Event("dom-ready"));
+
+    expect(bridge.browserAttachWebContents).toHaveBeenCalledWith({
+      tabId: "tab-1",
+      webContentsId: 42,
+    });
+  });
+
+  it("routes browser panel reload shortcuts to the active tab", () => {
+    useBrowserPanelStore.setState({
+      tabs: [
+        {
+          tabId: "tab-1",
+          url: "https://example.com/",
+          title: "Example",
+          loading: false,
+          canGoBack: false,
+          canGoForward: false,
+        },
+      ],
+      activeTabId: "tab-1",
+    });
+    const { container } = render(<BrowserPanel visible />);
+    const panel = container.firstElementChild as HTMLElement;
+
+    fireEvent.keyDown(panel, { key: "r", ctrlKey: true });
+    expect(bridge.browserReload).toHaveBeenCalledWith({ tabId: "tab-1" });
+
+    fireEvent.keyDown(panel, { key: "R", ctrlKey: true, shiftKey: true });
+    expect(bridge.browserHardReload).toHaveBeenCalledWith({ tabId: "tab-1" });
   });
 });

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { Maximize2, Minimize2, X } from "lucide-react";
 import { isMac, readBridge } from "@/renderer/bridge";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
@@ -41,6 +41,18 @@ export function BrowserPanel(props: { visible: boolean }) {
     } catch {}
   }, []);
 
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!activeTabId || !isBrowserReloadShortcut(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const bridge = readBridge();
+    if (event.shiftKey) {
+      bridge.browserHardReload({ tabId: activeTabId }).catch(() => {});
+      return;
+    }
+    bridge.browserReload({ tabId: activeTabId }).catch(() => {});
+  };
+
   const onPick = useCallback(() => {
     void startPicker();
   }, [startPicker]);
@@ -68,7 +80,12 @@ export function BrowserPanel(props: { visible: boolean }) {
     isFullscreenOverlay ? "lightcode-overlay-header__controls " : ""
   }${panelHeaderIconButtonClass}`;
   return (
-    <div className="flex h-full min-h-0 flex-col bg-[var(--content-background)]">
+    <div
+      role="group"
+      aria-label="Browser"
+      className="flex h-full min-h-0 flex-col bg-[var(--content-background)]"
+      onKeyDown={onKeyDown}
+    >
       {browserOverlayOpen ? (
         <div
           className={`${
@@ -191,10 +208,16 @@ function BrowserTabWebview(props: { tabId: string; initialSrc: string; visible: 
     <webview
       ref={ref}
       data-tab-id={props.tabId}
+      partition="persist:lightcode-browser"
       src={initialSrcRef.current || "about:blank"}
       allowpopups={true}
       className="absolute inset-0 size-full"
       style={{ display: props.visible ? "flex" : "none" }}
     />
   );
+}
+
+function isBrowserReloadShortcut(event: KeyboardEvent): boolean {
+  if (event.key === "F5") return true;
+  return (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "r";
 }


### PR DESCRIPTION
- **Feature:** Broaden the in-app browser MCP server with more automation tools, server instructions, passive read-only tools, and a dedicated page driver for clicks, fills, and form actions so agents can drive the embedded browser reliably.
- Add an **@Browser** mention in the thread composer (when browser MCP is available but not yet enabled) so users can turn on browser scope from the draft without digging through settings.
- Improve browser panel behavior with keyboard reload shortcuts, safer tab/webContents attachment, and screenshot options (format, quality, scale) for agent captures.
- Polish composer UI with a labeled Browser attachment chip and mention popover alignment for the new browser entry.
- Add unit tests for MCP ingress, tool registry, panel manager, mention filtering, and browser panel reload handling.