### PR TITLE
Add local voice input to composer with Whisper and audio settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@git-diff-view/react": "^0.1.3",
     "@heroui/react": "^3.0.3",
     "@heroui/styles": "^3.0.3",
+    "@huggingface/transformers": "^4.2.0",
     "@monaco-editor/react": "^4.7.0",
     "@opencode-ai/sdk": "^1.14.48",
     "@sentry/electron": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@heroui/styles':
         specifier: ^3.0.3
         version: 3.0.3(tailwind-merge@3.4.0)(tailwindcss@4.2.4)
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -895,6 +898,16 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -1664,6 +1677,36 @@ packages:
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -2793,6 +2836,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3815,6 +3862,9 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
@@ -3943,6 +3993,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -4376,6 +4429,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4786,6 +4842,19 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
+
   oxfmt@0.47.0:
     resolution: {integrity: sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4883,6 +4952,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
@@ -4952,6 +5024,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -6676,6 +6752,18 @@ snapshots:
     dependencies:
       hono: 4.12.21
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.3':
@@ -6684,8 +6772,7 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -7302,6 +7389,28 @@ snapshots:
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -8483,6 +8592,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -8661,8 +8772,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  boolean@3.2.0:
-    optional: true
+  boolean@3.2.0: {}
 
   brace-expansion@1.1.13:
     dependencies:
@@ -9141,14 +9251,12 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
 
   defu@6.1.7: {}
 
@@ -9164,8 +9272,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0:
-    optional: true
+  detect-node@2.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -9383,8 +9490,7 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  es6-error@4.1.1:
-    optional: true
+  es6-error@4.1.1: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -9419,8 +9525,7 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@4.0.0:
-    optional: true
+  escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -9539,6 +9644,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  flatbuffers@25.9.23: {}
 
   follow-redirects@1.15.11: {}
 
@@ -9663,13 +9770,11 @@ snapshots:
       roarr: 2.15.4
       semver: 7.7.4
       serialize-error: 7.0.1
-    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
 
   gopd@1.2.0: {}
 
@@ -9689,6 +9794,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  guid-typescript@1.0.9: {}
+
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
@@ -9696,7 +9803,6 @@ snapshots:
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
 
@@ -10034,8 +10140,7 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
 
@@ -10169,6 +10274,8 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -10218,7 +10325,6 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
-    optional: true
 
   material-icon-theme@5.34.0:
     dependencies:
@@ -10757,8 +10863,7 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   obug@2.1.1: {}
 
@@ -10781,6 +10886,25 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.17
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.1
 
   oxfmt@0.47.0:
     dependencies:
@@ -10902,6 +11026,8 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  platform@1.3.6: {}
+
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.12
@@ -10985,6 +11111,21 @@ snapshots:
       signal-exit: 3.0.7
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.9.1
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -11285,7 +11426,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
-    optional: true
 
   robust-predicates@3.0.3: {}
 
@@ -11391,8 +11531,7 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semver-compare@1.0.0:
-    optional: true
+  semver-compare@1.0.0: {}
 
   semver@5.7.2: {}
 
@@ -11419,7 +11558,6 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
-    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -11462,7 +11600,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -11560,8 +11697,7 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  sprintf-js@1.1.3:
-    optional: true
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
 
@@ -11827,8 +11963,7 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
-  type-fest@0.13.1:
-    optional: true
+  type-fest@0.13.1: {}
 
   type-is@2.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,8 @@ allowBuilds:
   electron-winstaller: true
   esbuild: true
   node-pty: true
+  onnxruntime-node: false
+  protobufjs: false
   sharp: true
 onlyBuiltDependencies:
   - "@sentry/cli"

--- a/scripts/build-desktop-artifact.mjs
+++ b/scripts/build-desktop-artifact.mjs
@@ -457,6 +457,8 @@ mac:
   artifactName: ${prefix}-\${version}-\${arch}.\${ext}
   hardenedRuntime: true
   gatekeeperAssess: false
+  extendInfo:
+    NSMicrophoneUsageDescription: Lightcode uses the microphone for local voice input in the composer.
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   notarize: true

--- a/src/main/browser/permissions.ts
+++ b/src/main/browser/permissions.ts
@@ -25,11 +25,20 @@ export function isNavigationUrlAllowed(url: string): boolean {
   }
 }
 
+function isPermissionAllowed(webContents: WebContents | null, permission: string): boolean {
+  if (permission === "media") {
+    return webContents?.getType() === "window";
+  }
+  return ALLOWED_PERMISSIONS.has(permission);
+}
+
 export function installSessionPermissions(session: Session): void {
-  session.setPermissionRequestHandler((_wc, permission, callback) => {
-    callback(ALLOWED_PERMISSIONS.has(permission));
+  session.setPermissionRequestHandler((webContents, permission, callback) => {
+    callback(isPermissionAllowed(webContents, permission));
   });
-  session.setPermissionCheckHandler((_wc, permission) => ALLOWED_PERMISSIONS.has(permission));
+  session.setPermissionCheckHandler((webContents, permission) =>
+    isPermissionAllowed(webContents, permission),
+  );
 }
 
 export function installNavigationGuards(

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -89,6 +89,12 @@ describe("sharedSettingsFile", () => {
         linkOpenTarget: "internal",
         linkPresentationMode: "panel",
       },
+      audio: {
+        microphoneDeviceId: "",
+        transcriptionLanguage: "en",
+        transcriptionModel: "tiny",
+        useWebGpu: true,
+      },
     });
 
     expect(readSharedSettingsFile(settingsPath)).toEqual({
@@ -153,6 +159,12 @@ describe("sharedSettingsFile", () => {
         allowDataAccess: false,
         linkOpenTarget: "internal",
         linkPresentationMode: "panel",
+      },
+      audio: {
+        microphoneDeviceId: "",
+        transcriptionLanguage: "en",
+        transcriptionModel: "tiny",
+        useWebGpu: true,
       },
     });
     expect(readFileSync(settingsPath, "utf8")).toContain('"themeMode": "dark"');
@@ -241,6 +253,46 @@ describe("sharedSettingsFile", () => {
       allowDataAccess: true,
       linkOpenTarget: "internal",
       linkPresentationMode: "panel",
+    });
+  });
+
+  it("normalizes older audio settings without dropping existing values", () => {
+    const settingsPath = join(makeTempDir(), "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        audio: { microphoneDeviceId: "mic-1" },
+      }),
+      "utf8",
+    );
+
+    expect(readSharedSettingsFile(settingsPath).audio).toEqual({
+      microphoneDeviceId: "mic-1",
+      transcriptionLanguage: "en",
+      transcriptionModel: "tiny",
+      useWebGpu: true,
+    });
+  });
+
+  it("normalizes removed audio models without dropping existing values", () => {
+    const settingsPath = join(makeTempDir(), "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        audio: {
+          microphoneDeviceId: "mic-1",
+          transcriptionLanguage: "es",
+          transcriptionModel: "small",
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readSharedSettingsFile(settingsPath).audio).toEqual({
+      microphoneDeviceId: "mic-1",
+      transcriptionLanguage: "es",
+      transcriptionModel: "tiny",
+      useWebGpu: true,
     });
   });
 });

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -90,6 +90,7 @@ describe("sharedSettingsFile", () => {
         linkPresentationMode: "panel",
       },
       audio: {
+        showVoiceInputButton: true,
         microphoneDeviceId: "",
         transcriptionLanguage: "en",
         transcriptionModel: "tiny",
@@ -161,6 +162,7 @@ describe("sharedSettingsFile", () => {
         linkPresentationMode: "panel",
       },
       audio: {
+        showVoiceInputButton: true,
         microphoneDeviceId: "",
         transcriptionLanguage: "en",
         transcriptionModel: "tiny",
@@ -267,6 +269,7 @@ describe("sharedSettingsFile", () => {
     );
 
     expect(readSharedSettingsFile(settingsPath).audio).toEqual({
+      showVoiceInputButton: true,
       microphoneDeviceId: "mic-1",
       transcriptionLanguage: "en",
       transcriptionModel: "tiny",
@@ -289,6 +292,7 @@ describe("sharedSettingsFile", () => {
     );
 
     expect(readSharedSettingsFile(settingsPath).audio).toEqual({
+      showVoiceInputButton: true,
       microphoneDeviceId: "mic-1",
       transcriptionLanguage: "es",
       transcriptionModel: "tiny",

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -1,6 +1,7 @@
 import { dbGetState, dbSetState } from "../db";
 import { BrowserWindow, screen, type RenderProcessGoneDetails } from "electron";
 import type { LightcodeChannel } from "@/shared/channel";
+import { installSessionPermissions } from "../browser/permissions";
 
 interface WindowBounds {
   x?: number;
@@ -109,6 +110,7 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
       ],
     },
   });
+  installSessionPermissions(window.webContents.session);
 
   window.once("ready-to-show", () => {
     if (saved?.isMaximized) {

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -16,6 +16,10 @@ export interface MentionInputHandle {
   restoreFromSegments(segments: PromptSegment[]): void;
   focus(): void;
   clear(): void;
+  insertText(text: string): void;
+  previewVoiceTranscript(text: string): void;
+  commitVoiceTranscript(text: string): void;
+  clearVoiceTranscriptPreview(): void;
   insertSlashCommand(id: string): void;
 }
 
@@ -119,6 +123,17 @@ function normalizeEmptyEditor(editor: HTMLDivElement): void {
   editor.innerHTML = "";
 }
 
+function placeCaretAtEnd(editor: HTMLDivElement): Range | null {
+  const sel = window.getSelection();
+  if (!sel) return null;
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(false);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  return range;
+}
+
 export const MentionInput = forwardRef<
   MentionInputHandle,
   {
@@ -155,6 +170,7 @@ export const MentionInput = forwardRef<
   } = props;
   const editorRef = useRef<HTMLDivElement>(null);
   const lastSlashQueryRef = useRef<string | null>(null);
+  const voicePreviewRef = useRef<HTMLSpanElement | null>(null);
   const [mention, setMention] = useState<MentionState | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -169,6 +185,43 @@ export const MentionInput = forwardRef<
     setActiveIndex(0);
   }, [results]);
 
+  function insertPlainText(text: string) {
+    const editor = editorRef.current;
+    const trimmed = text.trim();
+    if (!editor || !trimmed) return;
+
+    editor.focus();
+    const sel = window.getSelection();
+    const selectionInsideEditor =
+      sel?.rangeCount && sel.anchorNode ? editor.contains(sel.anchorNode) : false;
+    const range = selectionInsideEditor ? sel!.getRangeAt(0) : placeCaretAtEnd(editor);
+    if (!range) return;
+
+    const precedingRange = document.createRange();
+    precedingRange.selectNodeContents(editor);
+    precedingRange.setEnd(range.startContainer, range.startOffset);
+    const prefix =
+      precedingRange.toString().length > 0 && !/\s$/.test(precedingRange.toString()) ? " " : "";
+    const node = document.createTextNode(prefix + trimmed);
+    range.deleteContents();
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.collapse(true);
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    checkMentionState();
+    notifyTextChange();
+  }
+
+  function clearVoicePreviewNode() {
+    const preview = voicePreviewRef.current;
+    if (preview?.isConnected) {
+      preview.remove();
+    }
+    voicePreviewRef.current = null;
+    notifyTextChange();
+  }
+
   useImperativeHandle(ref, () => ({
     serializeSegments() {
       if (!editorRef.current) return [];
@@ -181,6 +234,7 @@ export const MentionInput = forwardRef<
     restoreFromSegments(segments: PromptSegment[]) {
       const editor = editorRef.current;
       if (!editor) return;
+      voicePreviewRef.current = null;
       editor.innerHTML = "";
       for (const seg of segments) {
         if (seg.kind === "text") {
@@ -206,6 +260,7 @@ export const MentionInput = forwardRef<
     },
     clear() {
       if (editorRef.current) {
+        voicePreviewRef.current = null;
         editorRef.current.innerHTML = "";
         setMention(null);
         if (lastSlashQueryRef.current !== null) {
@@ -213,6 +268,79 @@ export const MentionInput = forwardRef<
           onSlashCommandChange?.(null);
         }
       }
+    },
+    insertText(text: string) {
+      insertPlainText(text);
+    },
+    previewVoiceTranscript(text: string) {
+      const editor = editorRef.current;
+      const trimmed = text.trim();
+      if (!editor) return;
+      if (!trimmed) {
+        clearVoicePreviewNode();
+        return;
+      }
+
+      const existing = voicePreviewRef.current;
+      if (existing?.isConnected) {
+        existing.textContent = `${existing.dataset.voicePrefix ?? ""}${trimmed}`;
+        notifyTextChange();
+        return;
+      }
+
+      editor.focus();
+      const sel = window.getSelection();
+      const selectionInsideEditor =
+        sel?.rangeCount && sel.anchorNode ? editor.contains(sel.anchorNode) : false;
+      const range = selectionInsideEditor ? sel!.getRangeAt(0) : placeCaretAtEnd(editor);
+      if (!range) return;
+
+      const precedingRange = document.createRange();
+      precedingRange.selectNodeContents(editor);
+      precedingRange.setEnd(range.startContainer, range.startOffset);
+      const prefix =
+        precedingRange.toString().length > 0 && !/\s$/.test(precedingRange.toString()) ? " " : "";
+      const node = document.createElement("span");
+      node.dataset.voiceTranscriptPreview = "true";
+      node.dataset.voicePrefix = prefix;
+      node.textContent = prefix + trimmed;
+      range.deleteContents();
+      range.insertNode(node);
+      range.setStartAfter(node);
+      range.collapse(true);
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      voicePreviewRef.current = node;
+      checkMentionState();
+      notifyTextChange();
+    },
+    commitVoiceTranscript(text: string) {
+      const trimmed = text.trim();
+      const preview = voicePreviewRef.current;
+      if (!preview?.isConnected) {
+        insertPlainText(trimmed);
+        return;
+      }
+
+      if (!trimmed) {
+        clearVoicePreviewNode();
+        return;
+      }
+
+      const node = document.createTextNode(`${preview.dataset.voicePrefix ?? ""}${trimmed}`);
+      preview.replaceWith(node);
+      voicePreviewRef.current = null;
+      const sel = window.getSelection();
+      const range = document.createRange();
+      range.setStartAfter(node);
+      range.collapse(true);
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      checkMentionState();
+      notifyTextChange();
+    },
+    clearVoiceTranscriptPreview() {
+      clearVoicePreviewNode();
     },
     insertSlashCommand(id: string) {
       const editor = editorRef.current;

--- a/src/renderer/components/composer/VoiceInputButton.tsx
+++ b/src/renderer/components/composer/VoiceInputButton.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useRef, useState } from "react";
+import { Mic, Square } from "lucide-react";
+import { toast, Tooltip } from "@heroui/react";
+import { Button, PixelLoader } from "@/renderer/components/common";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { friendlyError } from "@/shared/messages";
+import {
+  prepareVoiceAudio,
+  subscribeVoiceTranscriptionProgress,
+  transcribeVoiceAudio,
+  warmupVoiceTranscription,
+} from "@/renderer/speech/voiceTranscription";
+import type { VoiceTranscriptionProgress } from "@/renderer/speech/voiceTranscriptionWorker";
+
+type VoiceInputState = "idle" | "starting" | "recording" | "transcribing";
+
+const AUTO_TRANSCRIBE_PAUSE_MS = 1400;
+const AUTO_TRANSCRIBE_SPEECH_RMS = 0.01;
+
+interface AudioCapture {
+  autoStopping: boolean;
+  context: AudioContext;
+  chunks: Float32Array[];
+  heardSpeech: boolean;
+  lastSpeechAt: number;
+  processor: ScriptProcessorNode;
+  source: MediaStreamAudioSourceNode;
+  stream: MediaStream;
+}
+
+function createAudioContext(): AudioContext {
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as typeof window & { webkitAudioContext?: new () => AudioContext }).webkitAudioContext;
+  if (!AudioContextCtor) {
+    throw new Error("Voice input requires audio support.");
+  }
+  return new AudioContextCtor();
+}
+
+function formatVoiceError(error: unknown): string {
+  if (error instanceof DOMException) {
+    if (error.name === "NotAllowedError" || error.name === "SecurityError") {
+      return "Microphone permission was denied.";
+    }
+    if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
+      return "No microphone found.";
+    }
+  }
+  return friendlyError(error);
+}
+
+function formatDownloadProgress(progress: VoiceTranscriptionProgress): string {
+  if (typeof progress.progress === "number") {
+    return `Downloading voice model ${Math.round(progress.progress)}%`;
+  }
+  return "Downloading voice model...";
+}
+
+export function VoiceInputButton(props: {
+  isDisabled?: boolean;
+  onTranscript: (text: string) => void;
+  onTranscriptPreview?: (text: string) => void;
+  onTranscriptCancel?: () => void;
+}) {
+  const { isDisabled = false, onTranscript, onTranscriptPreview, onTranscriptCancel } = props;
+  const [downloadProgress, setDownloadProgress] = useState<VoiceTranscriptionProgress | null>(null);
+  const [state, setState] = useState<VoiceInputState>("idle");
+  const microphoneDeviceId = useSharedSettings((s) => s.audio.microphoneDeviceId);
+  const transcriptionLanguage = useSharedSettings((s) => s.audio.transcriptionLanguage);
+  const transcriptionModel = useSharedSettings((s) => s.audio.transcriptionModel);
+  const useWebGpu = useSharedSettings((s) => s.audio.useWebGpu);
+  const captureRef = useRef<AudioCapture | null>(null);
+  const disposedRef = useRef(false);
+
+  function stopCapture(): AudioCapture | null {
+    const capture = captureRef.current;
+    if (!capture) return null;
+    captureRef.current = null;
+    capture.processor.onaudioprocess = null;
+    capture.processor.disconnect();
+    capture.source.disconnect();
+    capture.stream.getTracks().forEach((track) => track.stop());
+    void capture.context.close();
+    return capture;
+  }
+
+  useEffect(
+    () => () => {
+      disposedRef.current = true;
+      stopCapture();
+    },
+    [],
+  );
+
+  useEffect(
+    () =>
+      subscribeVoiceTranscriptionProgress((progress) => {
+        if (progress.language !== transcriptionLanguage || progress.model !== transcriptionModel) {
+          return;
+        }
+        setDownloadProgress(progress.phase === "ready" ? null : progress);
+      }),
+    [transcriptionLanguage, transcriptionModel],
+  );
+
+  async function transcribeSamples(samples: Float32Array) {
+    if (samples.length === 0) {
+      toast.danger("No speech detected.");
+      onTranscriptCancel?.();
+      setState("idle");
+      return;
+    }
+
+    setState("transcribing");
+    try {
+      const text = (
+        await transcribeVoiceAudio(
+          samples,
+          {
+            language: transcriptionLanguage,
+            model: transcriptionModel,
+            useWebGpu,
+          },
+          {
+            onPartial: (partial) => {
+              if (!disposedRef.current) {
+                onTranscriptPreview?.(partial);
+              }
+            },
+          },
+        )
+      ).trim();
+      if (disposedRef.current) return;
+      if (text) {
+        onTranscript(text);
+      } else {
+        onTranscriptCancel?.();
+        toast.danger("No speech detected.");
+      }
+    } catch (error) {
+      if (!disposedRef.current) {
+        onTranscriptCancel?.();
+        toast.danger(formatVoiceError(error));
+      }
+    } finally {
+      if (!disposedRef.current) {
+        setState("idle");
+      }
+    }
+  }
+
+  async function startRecording() {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      toast.danger("Voice input is not available in this environment.");
+      return;
+    }
+
+    setState("starting");
+    setDownloadProgress(null);
+    onTranscriptCancel?.();
+    let context: AudioContext | null = null;
+    let stream: MediaStream | null = null;
+    try {
+      context = createAudioContext();
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          ...(microphoneDeviceId ? { deviceId: { exact: microphoneDeviceId } } : {}),
+        },
+      });
+      if (disposedRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        void context.close();
+        return;
+      }
+      if (context.state === "suspended") {
+        await context.resume();
+      }
+
+      const source = context.createMediaStreamSource(stream);
+      const processor = context.createScriptProcessor(4096, 1, 1);
+      const chunks: Float32Array[] = [];
+      processor.onaudioprocess = (event) => {
+        const input = event.inputBuffer.getChannelData(0);
+        chunks.push(new Float32Array(input));
+        event.outputBuffer.getChannelData(0).fill(0);
+        const capture = captureRef.current;
+        if (!capture || capture.autoStopping) return;
+
+        let sumSquares = 0;
+        for (const sample of input) {
+          sumSquares += sample * sample;
+        }
+
+        const now = performance.now();
+        if (Math.sqrt(sumSquares / input.length) >= AUTO_TRANSCRIBE_SPEECH_RMS) {
+          capture.heardSpeech = true;
+          capture.lastSpeechAt = now;
+        } else if (capture.heardSpeech && now - capture.lastSpeechAt >= AUTO_TRANSCRIBE_PAUSE_MS) {
+          capture.autoStopping = true;
+          stopRecording();
+        }
+      };
+      source.connect(processor);
+      processor.connect(context.destination);
+      captureRef.current = {
+        autoStopping: false,
+        context,
+        chunks,
+        heardSpeech: false,
+        lastSpeechAt: performance.now(),
+        processor,
+        source,
+        stream,
+      };
+      setState("recording");
+      warmupVoiceTranscription({
+        language: transcriptionLanguage,
+        model: transcriptionModel,
+        useWebGpu,
+      });
+    } catch (error) {
+      stream?.getTracks().forEach((track) => track.stop());
+      void context?.close();
+      setState("idle");
+      toast.danger(formatVoiceError(error));
+    }
+  }
+
+  function stopRecording() {
+    const capture = stopCapture();
+    if (!capture) return;
+    const samples = prepareVoiceAudio(capture.chunks, capture.context.sampleRate);
+    void transcribeSamples(samples);
+  }
+
+  const isRecording = state === "recording";
+  const isStarting = state === "starting";
+  const isTranscribing = state === "transcribing";
+  const downloadLabel =
+    downloadProgress && isTranscribing ? formatDownloadProgress(downloadProgress) : null;
+  const label =
+    downloadLabel ??
+    (isRecording
+      ? "Stop voice input"
+      : isStarting
+        ? "Starting voice input"
+        : isTranscribing
+          ? "Transcribing voice"
+          : "Start voice input");
+
+  return (
+    <Tooltip delay={300}>
+      <Button
+        isIconOnly
+        aria-label={label}
+        className={`lightcode-composer-menu min-w-9 px-2 ${isRecording ? "text-danger" : ""}`}
+        isDisabled={(isDisabled && !isRecording) || isStarting || isTranscribing}
+        onPress={() => {
+          if (isRecording) {
+            stopRecording();
+          } else {
+            void startRecording();
+          }
+        }}
+        size="sm"
+        variant="ghost"
+      >
+        {isStarting || isTranscribing ? (
+          <PixelLoader size="xs" />
+        ) : isRecording ? (
+          <Square className="size-3.5 fill-current" />
+        ) : (
+          <Mic className="size-4" />
+        )}
+      </Button>
+      <Tooltip.Content placement="top">{label}</Tooltip.Content>
+    </Tooltip>
+  );
+}

--- a/src/renderer/components/composer/index.ts
+++ b/src/renderer/components/composer/index.ts
@@ -1,6 +1,7 @@
 export { MentionInput, type MentionInputHandle } from "./MentionInput";
 export { AttachmentBar, BrowserChip } from "./AttachmentBar";
 export { ComposerAddMenu } from "./ComposerAddMenu";
+export { VoiceInputButton } from "./VoiceInputButton";
 export { ImageLightbox } from "./ImageLightbox";
 export { useAttachments, type Attachment } from "./useAttachments";
 export { toLocalFileUrl } from "@/shared/promptContent";

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -297,6 +297,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   } = props;
   const [prompt, setPrompt] = useState("");
   const [hasContent, setHasContent] = useState(false);
+  const showVoiceInputButton = useSharedSettings((s) => s.audio.showVoiceInputButton);
   const mentionRef = useRef<MentionInputHandle>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInterrupting, setIsInterrupting] = useState(false);
@@ -978,24 +979,25 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         ) : null}
                       </>
                     );
-                    const renderVoiceInput = () => (
-                      <VoiceInputButton
-                        isDisabled={
-                          authRequired ||
-                          isSubmitting ||
-                          !(showServerComposer || showTerminalComposer)
-                        }
-                        onTranscript={(text) => {
-                          mentionRef.current?.commitVoiceTranscript(text);
-                        }}
-                        onTranscriptPreview={(text) => {
-                          mentionRef.current?.previewVoiceTranscript(text);
-                        }}
-                        onTranscriptCancel={() => {
-                          mentionRef.current?.clearVoiceTranscriptPreview();
-                        }}
-                      />
-                    );
+                    const renderVoiceInput = () =>
+                      showVoiceInputButton ? (
+                        <VoiceInputButton
+                          isDisabled={
+                            authRequired ||
+                            isSubmitting ||
+                            !(showServerComposer || showTerminalComposer)
+                          }
+                          onTranscript={(text) => {
+                            mentionRef.current?.commitVoiceTranscript(text);
+                          }}
+                          onTranscriptPreview={(text) => {
+                            mentionRef.current?.previewVoiceTranscript(text);
+                          }}
+                          onTranscriptCancel={() => {
+                            mentionRef.current?.clearVoiceTranscriptPreview();
+                          }}
+                        />
+                      ) : null;
                     return isCliThread
                       ? { leadingControls: renderExtras, afterControls: renderVoiceInput }
                       : {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -16,6 +16,7 @@ import {
   ComposerAddMenu,
   ImageLightbox,
   MentionInput,
+  VoiceInputButton,
   useAttachments,
 } from "../composer";
 import type { MentionInputHandle } from "../composer";
@@ -977,9 +978,34 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         ) : null}
                       </>
                     );
+                    const renderVoiceInput = () => (
+                      <VoiceInputButton
+                        isDisabled={
+                          authRequired ||
+                          isSubmitting ||
+                          !(showServerComposer || showTerminalComposer)
+                        }
+                        onTranscript={(text) => {
+                          mentionRef.current?.commitVoiceTranscript(text);
+                        }}
+                        onTranscriptPreview={(text) => {
+                          mentionRef.current?.previewVoiceTranscript(text);
+                        }}
+                        onTranscriptCancel={() => {
+                          mentionRef.current?.clearVoiceTranscriptPreview();
+                        }}
+                      />
+                    );
                     return isCliThread
-                      ? { leadingControls: renderExtras }
-                      : { afterControls: renderExtras };
+                      ? { leadingControls: renderExtras, afterControls: renderVoiceInput }
+                      : {
+                          afterControls: (level: number) => (
+                            <>
+                              {renderExtras(level)}
+                              {renderVoiceInput()}
+                            </>
+                          ),
+                        };
                   })()}
                   onPromptChange={setPrompt}
                   onSubmit={() => {

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -27,6 +27,7 @@ import {
   type BranchSelection,
 } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { ThreadCommandPanel } from "./ThreadCommandPanel";
 import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
 import { ThreadAuthRequiredDock } from "./ThreadAuthRequiredDock";
@@ -77,6 +78,7 @@ export function ThreadDraftComposerArea(props: {
   // either binary, which is a confusing state to debug.
   const [agentUpdating, setAgentUpdating] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const showVoiceInputButton = useSharedSettings((s) => s.audio.showVoiceInputButton);
   const mentionRef = useRef<MentionInputHandle>(null);
   const attachments = useAttachments();
   const inboxKey = props.paneId ?? `draft:${props.project.id}`;
@@ -434,18 +436,20 @@ export function ThreadDraftComposerArea(props: {
                 iconOnly={level >= 3}
               />
             ) : null}
-            <VoiceInputButton
-              isDisabled={authRequired || agentUpdating || isSubmitting}
-              onTranscript={(text) => {
-                mentionRef.current?.commitVoiceTranscript(text);
-              }}
-              onTranscriptPreview={(text) => {
-                mentionRef.current?.previewVoiceTranscript(text);
-              }}
-              onTranscriptCancel={() => {
-                mentionRef.current?.clearVoiceTranscriptPreview();
-              }}
-            />
+            {showVoiceInputButton ? (
+              <VoiceInputButton
+                isDisabled={authRequired || agentUpdating || isSubmitting}
+                onTranscript={(text) => {
+                  mentionRef.current?.commitVoiceTranscript(text);
+                }}
+                onTranscriptPreview={(text) => {
+                  mentionRef.current?.previewVoiceTranscript(text);
+                }}
+                onTranscriptCancel={() => {
+                  mentionRef.current?.clearVoiceTranscriptPreview();
+                }}
+              />
+            ) : null}
           </>
         )}
       />

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -14,6 +14,7 @@ import {
   ComposerAddMenu,
   ImageLightbox,
   MentionInput,
+  VoiceInputButton,
   type MentionInputHandle,
   useAttachments,
 } from "@/renderer/components/composer";
@@ -433,6 +434,18 @@ export function ThreadDraftComposerArea(props: {
                 iconOnly={level >= 3}
               />
             ) : null}
+            <VoiceInputButton
+              isDisabled={authRequired || agentUpdating || isSubmitting}
+              onTranscript={(text) => {
+                mentionRef.current?.commitVoiceTranscript(text);
+              }}
+              onTranscriptPreview={(text) => {
+                mentionRef.current?.previewVoiceTranscript(text);
+              }}
+              onTranscriptCancel={() => {
+                mentionRef.current?.clearVoiceTranscriptPreview();
+              }}
+            />
           </>
         )}
       />

--- a/src/renderer/speech/voiceTranscription.ts
+++ b/src/renderer/speech/voiceTranscription.ts
@@ -1,0 +1,207 @@
+import type {
+  VoiceTranscriptionProgress,
+  VoiceTranscriptionRequest,
+  VoiceTranscriptionResponse,
+} from "./voiceTranscriptionWorker";
+import type { AudioTranscriptionModel } from "@/shared/settings";
+
+const TARGET_SAMPLE_RATE = 16_000;
+const MIN_AUDIO_SECONDS = 0.25;
+const MIN_PEAK = 0.01;
+const MIN_RMS = 0.001;
+const SILENCE_FRAME_RMS = 0.003;
+
+let worker: Worker | null = null;
+let nextId = 0;
+const pending = new Map<
+  number,
+  {
+    onPartial?: (text: string) => void;
+    resolve: (text: string) => void;
+    reject: (error: Error) => void;
+  }
+>();
+const progressListeners = new Set<(progress: VoiceTranscriptionProgress) => void>();
+
+export interface VoiceTranscriptionOptions {
+  language: string;
+  model: AudioTranscriptionModel;
+  useWebGpu: boolean;
+}
+
+function getWorker(): Worker {
+  if (typeof Worker === "undefined") {
+    throw new Error("Voice input requires worker support.");
+  }
+  if (!worker) {
+    worker = new Worker(new URL("./voiceTranscriptionWorker.ts", import.meta.url), {
+      type: "module",
+    });
+    worker.onmessage = (event: MessageEvent<VoiceTranscriptionResponse>) => {
+      if (event.data.type === "progress") {
+        for (const listener of progressListeners) {
+          listener(event.data.progress);
+        }
+        return;
+      }
+      const entry = pending.get(event.data.id);
+      if (!entry) return;
+      if (event.data.type === "partial") {
+        entry.onPartial?.(event.data.text);
+        return;
+      }
+      pending.delete(event.data.id);
+      if (event.data.type === "result") {
+        entry.resolve(event.data.text);
+      } else {
+        entry.reject(new Error(event.data.error));
+      }
+    };
+    worker.onerror = (event) => {
+      const error = new Error(event.message || "Voice transcription worker failed.");
+      for (const entry of pending.values()) {
+        entry.reject(error);
+      }
+      pending.clear();
+      worker?.terminate();
+      worker = null;
+    };
+  }
+  return worker;
+}
+
+export function subscribeVoiceTranscriptionProgress(
+  listener: (progress: VoiceTranscriptionProgress) => void,
+): () => void {
+  progressListeners.add(listener);
+  return () => progressListeners.delete(listener);
+}
+
+/**
+ * Eagerly spin up the worker and start loading the speech model. Called when
+ * recording begins so the model init (and, on first ever use, the download)
+ * overlaps the seconds the user spends speaking. Safe to call repeatedly and a
+ * no-op where workers are unavailable.
+ */
+export function warmupVoiceTranscription(options: VoiceTranscriptionOptions): void {
+  try {
+    getWorker().postMessage({ type: "warmup", options } satisfies VoiceTranscriptionRequest);
+  } catch {
+    // Worker unsupported; the real error surfaces on transcribeVoiceAudio.
+  }
+}
+
+export function transcribeVoiceAudio(
+  samples: Float32Array,
+  options: VoiceTranscriptionOptions,
+  callbacks?: { onPartial?: (text: string) => void },
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, {
+      resolve,
+      reject,
+      ...(callbacks?.onPartial ? { onPartial: callbacks.onPartial } : {}),
+    });
+    try {
+      getWorker().postMessage(
+        {
+          type: "transcribe",
+          id,
+          samples,
+          options,
+          ...(callbacks?.onPartial ? { stream: true } : {}),
+        } satisfies VoiceTranscriptionRequest,
+        [samples.buffer as ArrayBuffer],
+      );
+    } catch (error) {
+      pending.delete(id);
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
+}
+
+export function prepareVoiceAudio(chunks: Float32Array[], inputSampleRate: number): Float32Array {
+  const merged = mergeAudioChunks(chunks);
+  const trimmed = trimSilence(merged, inputSampleRate);
+  if (!hasEnoughSignal(trimmed, inputSampleRate)) return new Float32Array();
+  return inputSampleRate === TARGET_SAMPLE_RATE
+    ? trimmed
+    : resampleLinear(trimmed, inputSampleRate, TARGET_SAMPLE_RATE);
+}
+
+function mergeAudioChunks(chunks: Float32Array[]): Float32Array {
+  let length = 0;
+  for (const chunk of chunks) {
+    length += chunk.length;
+  }
+
+  const merged = new Float32Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+function hasEnoughSignal(input: Float32Array, sampleRate: number): boolean {
+  if (input.length < sampleRate * MIN_AUDIO_SECONDS) return false;
+
+  let peak = 0;
+  let sumSquares = 0;
+  for (const sample of input) {
+    const absolute = Math.abs(sample);
+    peak = Math.max(peak, absolute);
+    sumSquares += sample * sample;
+  }
+
+  const rms = Math.sqrt(sumSquares / input.length);
+  return peak >= MIN_PEAK && rms >= MIN_RMS;
+}
+
+function trimSilence(input: Float32Array, sampleRate: number): Float32Array {
+  const frameSize = Math.max(1, Math.round(sampleRate * 0.02));
+  let firstFrame = -1;
+  let lastFrame = -1;
+
+  for (let frameStart = 0; frameStart < input.length; frameStart += frameSize) {
+    const frameEnd = Math.min(input.length, frameStart + frameSize);
+    let sumSquares = 0;
+    for (let i = frameStart; i < frameEnd; i++) {
+      const sample = input[i] ?? 0;
+      sumSquares += sample * sample;
+    }
+
+    if (Math.sqrt(sumSquares / (frameEnd - frameStart)) >= SILENCE_FRAME_RMS) {
+      if (firstFrame < 0) firstFrame = frameStart;
+      lastFrame = frameEnd;
+    }
+  }
+
+  if (firstFrame < 0) return new Float32Array();
+
+  const padding = Math.round(sampleRate * 0.15);
+  return input.slice(
+    Math.max(0, firstFrame - padding),
+    Math.min(input.length, lastFrame + padding),
+  );
+}
+
+function resampleLinear(input: Float32Array, inputRate: number, outputRate: number): Float32Array {
+  const ratio = inputRate / outputRate;
+  const outputLength = Math.max(1, Math.round(input.length / ratio));
+  const output = new Float32Array(outputLength);
+
+  for (let i = 0; i < output.length; i++) {
+    const position = i * ratio;
+    const index = Math.floor(position);
+    const nextIndex = Math.min(index + 1, input.length - 1);
+    const fraction = position - index;
+    const current = input[index] ?? 0;
+    const next = input[nextIndex] ?? current;
+    output[i] = current + (next - current) * fraction;
+  }
+
+  return output;
+}

--- a/src/renderer/speech/voiceTranscriptionWorker.ts
+++ b/src/renderer/speech/voiceTranscriptionWorker.ts
@@ -1,0 +1,228 @@
+import {
+  pipeline,
+  env,
+  WhisperTextStreamer,
+  type AutomaticSpeechRecognitionOutput,
+  type DeviceType,
+} from "@huggingface/transformers";
+import type { AudioTranscriptionModel } from "@/shared/settings";
+
+// Avoid quantized Whisper decoder graphs here: ONNX Runtime Web can fail
+// session creation on those with missing QDQ scale initializers.
+const SPEECH_DTYPE = "fp32";
+const TARGET_SAMPLE_RATE = 16_000;
+const MAX_UNCHUNKED_AUDIO_SECONDS = 29;
+const WASM_DEVICE: DeviceType = "wasm";
+const WEBGPU_DEVICE: DeviceType = "webgpu";
+
+// Models are fetched from the Hugging Face CDN, never from a local server path.
+// Skipping the local-model probe avoids a spurious 404 on first load.
+env.allowLocalModels = false;
+
+type SpeechPipeline = (
+  audio: Float32Array,
+  options?: {
+    chunk_length_s?: number;
+    language?: string;
+    stride_length_s?: number;
+    streamer?: unknown;
+    task?: string;
+  },
+) => Promise<AutomaticSpeechRecognitionOutput | AutomaticSpeechRecognitionOutput[]>;
+
+type SpeechPipelineOptions = NonNullable<Parameters<SpeechPipeline>[1]>;
+type WhisperTokenizerForStreamer = ConstructorParameters<typeof WhisperTextStreamer>[0];
+type SpeechPipelineWithTokenizer = SpeechPipeline & { tokenizer: unknown };
+
+type VoiceTranscriptionOptions = {
+  language: string;
+  model: AudioTranscriptionModel;
+  useWebGpu: boolean;
+};
+
+export type VoiceTranscriptionProgress = {
+  language: string;
+  loaded?: number;
+  model: AudioTranscriptionModel;
+  phase: "download" | "ready";
+  progress?: number;
+  total?: number;
+};
+
+export type VoiceTranscriptionRequest =
+  | { type: "warmup"; options: VoiceTranscriptionOptions }
+  | {
+      type: "transcribe";
+      id: number;
+      samples: Float32Array;
+      options: VoiceTranscriptionOptions;
+      stream?: boolean;
+    };
+
+export type VoiceTranscriptionResponse =
+  | {
+      type: "progress";
+      progress: VoiceTranscriptionProgress;
+    }
+  | {
+      id: number;
+      type: "partial";
+      text: string;
+    }
+  | {
+      id: number;
+      type: "result";
+      text: string;
+    }
+  | {
+      id: number;
+      type: "error";
+      error: string;
+    };
+
+const transcriberPromises = new Map<string, Promise<SpeechPipelineWithTokenizer>>();
+const disabledWebGpuModelIds = new Set<string>();
+
+function readProgressNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function postProgress(options: VoiceTranscriptionOptions, info: unknown) {
+  if (!info || typeof info !== "object" || !("status" in info)) return;
+  const status = info.status;
+  if (status === "ready") {
+    self.postMessage({
+      type: "progress",
+      progress: { language: options.language, model: options.model, phase: "ready" },
+    } satisfies VoiceTranscriptionResponse);
+    return;
+  }
+  if (status !== "download" && status !== "progress_total") return;
+
+  const progressInfo = info as { loaded?: unknown; progress?: unknown; total?: unknown };
+  const loaded = readProgressNumber(progressInfo.loaded);
+  const progress = readProgressNumber(progressInfo.progress);
+  const total = readProgressNumber(progressInfo.total);
+  self.postMessage({
+    type: "progress",
+    progress: {
+      language: options.language,
+      model: options.model,
+      phase: "download",
+      ...(loaded !== undefined ? { loaded } : {}),
+      ...(progress !== undefined ? { progress } : {}),
+      ...(total !== undefined ? { total } : {}),
+    },
+  } satisfies VoiceTranscriptionResponse);
+}
+
+function getModelId(options: VoiceTranscriptionOptions): string {
+  const modelSuffix = options.language === "en" ? `${options.model}.en` : options.model;
+  return `Xenova/whisper-${modelSuffix}`;
+}
+
+function getTranscriberCacheKey(modelId: string, device: DeviceType): string {
+  return `${modelId}:${device}`;
+}
+
+function getTranscriberForDevice(
+  options: VoiceTranscriptionOptions,
+  modelId: string,
+  device: DeviceType,
+): Promise<SpeechPipelineWithTokenizer> {
+  const cacheKey = getTranscriberCacheKey(modelId, device);
+  let transcriberPromise = transcriberPromises.get(cacheKey);
+  if (!transcriberPromise) {
+    transcriberPromise = (
+      pipeline("automatic-speech-recognition", modelId, {
+        device,
+        dtype: SPEECH_DTYPE,
+        progress_callback: (info: unknown) => postProgress(options, info),
+      }) as Promise<SpeechPipelineWithTokenizer>
+    ).catch((error: unknown) => {
+      transcriberPromises.delete(cacheKey);
+      throw error;
+    });
+    transcriberPromises.set(cacheKey, transcriberPromise);
+  }
+  return transcriberPromise;
+}
+
+function getTranscriber(options: VoiceTranscriptionOptions): Promise<SpeechPipelineWithTokenizer> {
+  const modelId = getModelId(options);
+  if (!options.useWebGpu || disabledWebGpuModelIds.has(modelId)) {
+    return getTranscriberForDevice(options, modelId, WASM_DEVICE);
+  }
+  return getTranscriberForDevice(options, modelId, WEBGPU_DEVICE).catch(() => {
+    disabledWebGpuModelIds.add(modelId);
+    return getTranscriberForDevice(options, modelId, WASM_DEVICE);
+  });
+}
+
+function getTranscriptionOptions(
+  options: VoiceTranscriptionOptions,
+  sampleCount: number,
+): SpeechPipelineOptions {
+  const pipelineOptions: SpeechPipelineOptions =
+    options.language === "en"
+      ? {}
+      : {
+          language: options.language,
+          task: "transcribe",
+        };
+
+  if (sampleCount > TARGET_SAMPLE_RATE * MAX_UNCHUNKED_AUDIO_SECONDS) {
+    pipelineOptions.chunk_length_s = 30;
+    pipelineOptions.stride_length_s = 5;
+  }
+
+  return pipelineOptions;
+}
+
+self.onmessage = (event: MessageEvent<VoiceTranscriptionRequest>) => {
+  const request = event.data;
+  if (request.type === "warmup") {
+    // Begin loading the model so it overlaps recording; errors are ignored here
+    // and surface on the actual transcription request instead.
+    void getTranscriber(request.options).catch(() => {});
+    return;
+  }
+
+  const { id, samples } = request;
+  void getTranscriber(request.options)
+    .then((transcriber) => {
+      const pipelineOptions = getTranscriptionOptions(request.options, samples.length);
+      if (request.stream) {
+        let partialText = "";
+        pipelineOptions.streamer = new WhisperTextStreamer(
+          transcriber.tokenizer as WhisperTokenizerForStreamer,
+          {
+            skip_prompt: true,
+            callback_function: (text) => {
+              partialText += text;
+              const trimmed = partialText.trim();
+              if (trimmed) {
+                self.postMessage({
+                  id,
+                  type: "partial",
+                  text: trimmed,
+                } satisfies VoiceTranscriptionResponse);
+              }
+            },
+          },
+        );
+      }
+      return transcriber(samples, pipelineOptions);
+    })
+    .then((output) => {
+      const text = Array.isArray(output) ? output.map((item) => item.text).join(" ") : output.text;
+      self.postMessage({ id, type: "result", text } satisfies VoiceTranscriptionResponse);
+    })
+    .catch((error: unknown) => {
+      self.postMessage({
+        id,
+        type: "error",
+        error: error instanceof Error ? error.message : String(error),
+      } satisfies VoiceTranscriptionResponse);
+    });
+};

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -7,6 +7,12 @@ describe("sharedSettingsStore", () => {
     useSharedSettings.setState({
       themeMode: "dark",
       staleThreadUnloadMinutes: 20,
+      audio: {
+        microphoneDeviceId: "",
+        transcriptionLanguage: "en",
+        transcriptionModel: "tiny",
+        useWebGpu: true,
+      },
       providerConfigs: {},
     });
   });
@@ -23,6 +29,11 @@ describe("sharedSettingsStore", () => {
   it("updates the stale thread unload timing", () => {
     useSharedSettings.getState().setStaleThreadUnloadMinutes(30);
     expect(useSharedSettings.getState().staleThreadUnloadMinutes).toBe(30);
+  });
+
+  it("updates audio settings", () => {
+    useSharedSettings.getState().setAudioSetting("transcriptionLanguage", "es");
+    expect(useSharedSettings.getState().audio.transcriptionLanguage).toBe("es");
   });
 
   it("updates provider config when only context size, fast, and thinking change", () => {

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -8,6 +8,7 @@ describe("sharedSettingsStore", () => {
       themeMode: "dark",
       staleThreadUnloadMinutes: 20,
       audio: {
+        showVoiceInputButton: true,
         microphoneDeviceId: "",
         transcriptionLanguage: "en",
         transcriptionModel: "tiny",

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -59,6 +59,10 @@ interface SharedSettingsState extends SharedSettings {
     key: K,
     value: SharedSettings["browser"][K],
   ) => void;
+  setAudioSetting: <K extends keyof SharedSettings["audio"]>(
+    key: K,
+    value: SharedSettings["audio"][K],
+  ) => void;
   setProviderConfig: (agentKind: string, config: ProviderDraftConfig) => void;
   setLastPresentationMode: (agentKind: string, mode: ThreadPresentationMode) => void;
   setNotificationsEnabled: (value: boolean) => void;
@@ -314,6 +318,12 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({ browser: { ...current, [key]: value } });
     persistSettings(selectSharedSettings(get()));
   },
+  setAudioSetting: (key, value) => {
+    const current = get().audio;
+    if (current[key] === value) return;
+    set({ audio: { ...current, [key]: value } });
+    persistSettings(selectSharedSettings(get()));
+  },
   setProviderConfig: (agentKind, config) => {
     if (!config.model.trim()) {
       return;
@@ -492,6 +502,7 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     favoriteModels: state.favoriteModels,
     recentModels: state.recentModels,
     browser: state.browser,
+    audio: state.audio,
   };
 }
 

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -7,6 +7,7 @@ import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
 import { PageLayout } from "@/renderer/components/layout/PageLayout";
 import { getSettingsInstalledAgents } from "@/shared/agentStatus";
 import { BrowserSettings } from "./parts/BrowserSettings";
+import { AudioSettings } from "./parts/AudioSettings";
 import { GeneralSettings } from "./parts/GeneralSettings";
 import { NotificationSettings } from "./parts/NotificationSettings";
 import { AISettings } from "./parts/AISettings";
@@ -22,6 +23,7 @@ import type { SettingsSection } from "./parts/types";
 
 const SECTION_VIEWS: Partial<Record<SettingsSection, () => ReactNode>> = {
   general: () => <GeneralSettings />,
+  audio: () => <AudioSettings />,
   notifications: () => <NotificationSettings />,
   ai: () => <AISettings />,
   search: () => <SearchSettings />,

--- a/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
@@ -66,6 +66,7 @@ export function AudioSettings() {
     { id: SYSTEM_MICROPHONE_ID, label: "System default" },
   ]);
   const microphoneDeviceId = useSharedSettings((s) => s.audio.microphoneDeviceId);
+  const showVoiceInputButton = useSharedSettings((s) => s.audio.showVoiceInputButton);
   const transcriptionLanguage = useSharedSettings((s) => s.audio.transcriptionLanguage);
   const transcriptionModel = useSharedSettings((s) => s.audio.transcriptionModel);
   const useWebGpu = useSharedSettings((s) => s.audio.useWebGpu);
@@ -98,6 +99,23 @@ export function AudioSettings() {
         <h1 className="mb-6 text-lg font-semibold text-foreground">Audio</h1>
 
         <div className="space-y-5">
+          <SettingRow
+            title="Show voice input button"
+            description="Show the microphone button in the composer."
+          >
+            <Switch
+              isSelected={showVoiceInputButton}
+              onChange={(selected) => {
+                startTransition(() => {
+                  setAudioSetting("showVoiceInputButton", selected);
+                });
+              }}
+            >
+              <Switch.Control>
+                <Switch.Thumb />
+              </Switch.Control>
+            </Switch>
+          </SettingRow>
           <SettingRow
             title="Microphone"
             description="Device used by the composer voice input button."

--- a/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
@@ -1,0 +1,309 @@
+import { startTransition, useEffect, useRef, useState } from "react";
+import { Switch, toast } from "@heroui/react";
+import { Button, Select } from "@/renderer/components/common";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { friendlyError } from "@/shared/messages";
+import type { AudioTranscriptionModel } from "@/shared/settings";
+
+const SYSTEM_MICROPHONE_ID = "system-default";
+
+const languageOptions = [
+  { id: "en", label: "English" },
+  { id: "es", label: "Spanish" },
+  { id: "fr", label: "French" },
+  { id: "de", label: "German" },
+  { id: "it", label: "Italian" },
+  { id: "pt", label: "Portuguese" },
+  { id: "nl", label: "Dutch" },
+  { id: "pl", label: "Polish" },
+  { id: "ru", label: "Russian" },
+  { id: "uk", label: "Ukrainian" },
+  { id: "tr", label: "Turkish" },
+  { id: "ar", label: "Arabic" },
+  { id: "zh", label: "Chinese" },
+  { id: "ja", label: "Japanese" },
+  { id: "ko", label: "Korean" },
+  { id: "hi", label: "Hindi" },
+  { id: "vi", label: "Vietnamese" },
+] as const;
+
+const modelOptions = [
+  { id: "tiny", label: "Fastest (Whisper tiny)" },
+  { id: "base", label: "Better (Whisper base)" },
+] as const;
+
+interface MicrophoneTest {
+  analyser: AnalyserNode;
+  context: AudioContext;
+  frame: number;
+  source: MediaStreamAudioSourceNode;
+  stream: MediaStream;
+}
+
+function createAudioContext(): AudioContext {
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as typeof window & { webkitAudioContext?: new () => AudioContext }).webkitAudioContext;
+  if (!AudioContextCtor) {
+    throw new Error("Audio input requires audio support.");
+  }
+  return new AudioContextCtor();
+}
+
+function buildMicrophoneOptions(devices: MediaDeviceInfo[]) {
+  const microphones = devices.filter((device) => device.kind === "audioinput");
+  return [
+    { id: SYSTEM_MICROPHONE_ID, label: "System default" },
+    ...microphones.map((device, index) => ({
+      id: device.deviceId,
+      label: device.label || `Microphone ${index + 1}`,
+    })),
+  ];
+}
+
+export function AudioSettings() {
+  const [microphoneOptions, setMicrophoneOptions] = useState([
+    { id: SYSTEM_MICROPHONE_ID, label: "System default" },
+  ]);
+  const microphoneDeviceId = useSharedSettings((s) => s.audio.microphoneDeviceId);
+  const transcriptionLanguage = useSharedSettings((s) => s.audio.transcriptionLanguage);
+  const transcriptionModel = useSharedSettings((s) => s.audio.transcriptionModel);
+  const useWebGpu = useSharedSettings((s) => s.audio.useWebGpu);
+  const setAudioSetting = useSharedSettings((s) => s.setAudioSetting);
+
+  useEffect(() => {
+    const mediaDevices = navigator.mediaDevices;
+    if (!mediaDevices?.enumerateDevices) return;
+
+    let disposed = false;
+    const refresh = () => {
+      void mediaDevices.enumerateDevices().then((devices) => {
+        if (!disposed) {
+          setMicrophoneOptions(buildMicrophoneOptions(devices));
+        }
+      });
+    };
+
+    refresh();
+    mediaDevices.addEventListener("devicechange", refresh);
+    return () => {
+      disposed = true;
+      mediaDevices.removeEventListener("devicechange", refresh);
+    };
+  }, []);
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
+      <div className="mx-auto max-w-[720px]">
+        <h1 className="mb-6 text-lg font-semibold text-foreground">Audio</h1>
+
+        <div className="space-y-5">
+          <SettingRow
+            title="Microphone"
+            description="Device used by the composer voice input button."
+          >
+            <Select
+              aria-label="Microphone"
+              className="w-[280px] shrink-0"
+              options={microphoneOptions}
+              value={microphoneDeviceId || SYSTEM_MICROPHONE_ID}
+              onChange={(value) => {
+                startTransition(() => {
+                  setAudioSetting(
+                    "microphoneDeviceId",
+                    value === SYSTEM_MICROPHONE_ID ? "" : value,
+                  );
+                });
+              }}
+            />
+          </SettingRow>
+          <SettingRow
+            title="Test microphone"
+            description="Check the live input level from the selected device."
+          >
+            <MicrophoneTestBar microphoneDeviceId={microphoneDeviceId} />
+          </SettingRow>
+          <SettingRow
+            title="Voice input language"
+            description="Language the speech model should expect when transcribing composer dictation."
+          >
+            <Select
+              aria-label="Voice input language"
+              className="w-[280px] shrink-0"
+              options={languageOptions}
+              value={transcriptionLanguage}
+              onChange={(value) => {
+                startTransition(() => {
+                  setAudioSetting("transcriptionLanguage", value);
+                });
+              }}
+            />
+          </SettingRow>
+          <SettingRow
+            title="Voice input model"
+            description="Fastest uses Whisper tiny; Better uses Whisper base."
+          >
+            <Select
+              aria-label="Voice input model"
+              className="w-[280px] shrink-0"
+              options={modelOptions}
+              value={transcriptionModel}
+              onChange={(value) => {
+                startTransition(() => {
+                  setAudioSetting("transcriptionModel", value as AudioTranscriptionModel);
+                });
+              }}
+            />
+          </SettingRow>
+          <SettingRow
+            title="Use WebGPU acceleration"
+            description="Run local transcription on the GPU when available."
+          >
+            <Switch
+              isSelected={useWebGpu}
+              onChange={(selected) => {
+                startTransition(() => {
+                  setAudioSetting("useWebGpu", selected);
+                });
+              }}
+            >
+              <Switch.Control>
+                <Switch.Thumb />
+              </Switch.Control>
+            </Switch>
+          </SettingRow>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MicrophoneTestBar(props: { microphoneDeviceId: string }) {
+  const { microphoneDeviceId } = props;
+  const [isStarting, setIsStarting] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [level, setLevel] = useState(0);
+  const testRef = useRef<MicrophoneTest | null>(null);
+
+  function stopTest() {
+    const test = testRef.current;
+    if (!test) return;
+    testRef.current = null;
+    cancelAnimationFrame(test.frame);
+    test.source.disconnect();
+    test.stream.getTracks().forEach((track) => track.stop());
+    void test.context.close();
+    setIsTesting(false);
+    setLevel(0);
+  }
+
+  useEffect(() => () => stopTest(), [microphoneDeviceId]);
+
+  async function startTest() {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      toast.danger("Microphone testing is not available in this environment.");
+      return;
+    }
+
+    setIsStarting(true);
+    let context: AudioContext | null = null;
+    let stream: MediaStream | null = null;
+    try {
+      context = createAudioContext();
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          ...(microphoneDeviceId ? { deviceId: { exact: microphoneDeviceId } } : {}),
+        },
+      });
+      if (context.state === "suspended") {
+        await context.resume();
+      }
+
+      const source = context.createMediaStreamSource(stream);
+      const analyser = context.createAnalyser();
+      analyser.fftSize = 1024;
+      source.connect(analyser);
+      const data = new Float32Array(analyser.fftSize);
+
+      const tick = () => {
+        analyser.getFloatTimeDomainData(data);
+        let sumSquares = 0;
+        for (const sample of data) {
+          sumSquares += sample * sample;
+        }
+        setLevel(Math.min(1, Math.sqrt(sumSquares / data.length) * 8));
+        const current = testRef.current;
+        if (current) {
+          current.frame = requestAnimationFrame(tick);
+        }
+      };
+
+      testRef.current = { analyser, context, frame: requestAnimationFrame(tick), source, stream };
+      setIsTesting(true);
+    } catch (error) {
+      stream?.getTracks().forEach((track) => track.stop());
+      void context?.close();
+      toast.danger(friendlyError(error));
+    } finally {
+      setIsStarting(false);
+    }
+  }
+
+  return (
+    <div className="flex w-[280px] shrink-0 items-center gap-3">
+      <Button
+        className="min-w-[5rem]"
+        isDisabled={isStarting}
+        onPress={() => {
+          if (isTesting) {
+            stopTest();
+          } else {
+            void startTest();
+          }
+        }}
+        size="sm"
+        variant={isTesting ? "danger" : "secondary"}
+      >
+        {isTesting ? "Stop" : isStarting ? "Starting" : "Start"}
+      </Button>
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-muted">
+          <span>Input level</span>
+          <span className="tabular-nums">{isTesting ? `${Math.round(level * 100)}%` : "Idle"}</span>
+        </div>
+        <div
+          aria-label="Microphone input level"
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={Math.round(level * 100)}
+          className="h-2.5 overflow-hidden rounded-full bg-surface-tertiary"
+          role="meter"
+        >
+          <div
+            className={`h-full rounded-full transition-[width] duration-75 ${isTesting ? "bg-success" : "bg-muted/35"}`}
+            style={{ width: `${Math.max(isTesting ? 3 : 0, Math.round(level * 100))}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SettingRow(props: {
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{props.title}</p>
+        <p className="text-xs text-muted">{props.description}</p>
+      </div>
+      {props.children}
+    </div>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -8,6 +8,7 @@ import {
   FlaskConical,
   Globe,
   Info,
+  Mic,
   PanelLeft,
   PanelLeftClose,
   RefreshCw,
@@ -73,6 +74,13 @@ export function SettingsSidebar(props: {
               label="General"
               isActive={activeSection === "general"}
               onPress={() => onSectionChange("general")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<Mic className="size-4" />}
+              label="Audio"
+              isActive={activeSection === "audio"}
+              onPress={() => onSectionChange("audio")}
             />
             <SidebarButton
               iconOnly
@@ -215,6 +223,12 @@ export function SettingsSidebar(props: {
               label="General"
               isActive={activeSection === "general"}
               onPress={() => onSectionChange("general")}
+            />
+            <SidebarButton
+              icon={<Mic className="size-4" />}
+              label="Audio"
+              isActive={activeSection === "audio"}
+              onPress={() => onSectionChange("audio")}
             />
             <SidebarButton
               icon={<Bell className="size-4" />}

--- a/src/renderer/views/SettingsOverlay/parts/types.ts
+++ b/src/renderer/views/SettingsOverlay/parts/types.ts
@@ -1,5 +1,6 @@
 export type SettingsSection =
   | "general"
+  | "audio"
   | "notifications"
   | "ai"
   | "acpRegistry"

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -63,6 +63,24 @@ const browserSettingsSchema = z.object({
   linkPresentationMode: browserLinkPresentationModeSchema.default("panel"),
 });
 
+export const audioTranscriptionModelSchema = z.preprocess(
+  (value) =>
+    value === "small" || value === "moonshine-tiny" || value === "moonshine-base" ? "tiny" : value,
+  z.enum(["tiny", "base"]),
+);
+export type AudioTranscriptionModel = z.infer<typeof audioTranscriptionModelSchema>;
+
+const audioSettingsSchema = z.object({
+  /** Empty string means the OS/browser default microphone. */
+  microphoneDeviceId: z.string().default(""),
+  /** Speech-to-text language code, for example "en", "es", or "fr". */
+  transcriptionLanguage: z.string().default("en"),
+  /** Model used for local composer dictation. */
+  transcriptionModel: audioTranscriptionModelSchema.default("tiny"),
+  /** Prefer WebGPU acceleration for local speech-to-text when available. */
+  useWebGpu: z.boolean().default(true),
+});
+
 export const sharedSettingsSchema = z.object({
   themeMode: themeModeSchema,
   terminalPosition: terminalPositionSchema,
@@ -193,6 +211,8 @@ export const sharedSettingsSchema = z.object({
    * not a global toggle.
    */
   browser: browserSettingsSchema,
+  /** Local audio capture and speech-to-text settings. */
+  audio: audioSettingsSchema,
 });
 export type SharedSettings = z.infer<typeof sharedSettingsSchema>;
 
@@ -265,6 +285,12 @@ export const defaultSharedSettings: SharedSettings = {
     allowDataAccess: false,
     linkOpenTarget: "internal",
     linkPresentationMode: "panel",
+  },
+  audio: {
+    microphoneDeviceId: "",
+    transcriptionLanguage: "en",
+    transcriptionModel: "tiny",
+    useWebGpu: true,
   },
 };
 

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -71,6 +71,8 @@ export const audioTranscriptionModelSchema = z.preprocess(
 export type AudioTranscriptionModel = z.infer<typeof audioTranscriptionModelSchema>;
 
 const audioSettingsSchema = z.object({
+  /** Show the composer microphone button. */
+  showVoiceInputButton: z.boolean().default(true),
   /** Empty string means the OS/browser default microphone. */
   microphoneDeviceId: z.string().default(""),
   /** Speech-to-text language code, for example "en", "es", or "fr". */
@@ -287,6 +289,7 @@ export const defaultSharedSettings: SharedSettings = {
     linkPresentationMode: "panel",
   },
   audio: {
+    showVoiceInputButton: true,
     microphoneDeviceId: "",
     transcriptionLanguage: "en",
     transcriptionModel: "tiny",


### PR DESCRIPTION
**Type:** Feature

- Add a composer microphone control for on-device dictation using Whisper in a web worker, with live preview and insertion into the prompt field in thread and draft composers.
- Introduce an Audio settings section to show or hide the voice button and configure microphone, transcription language, model size, and WebGPU acceleration.
- Persist audio preferences through shared settings schema, store, and settings file round-trip tests.
- Allow microphone access for the main app window in Electron and document macOS microphone usage in the desktop build.
- Add Hugging Face Transformers for speech recognition and adjust workspace/build packaging for the new runtime dependencies.