### PR TITLE
Add Antigravity and platform-native agent install paths

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -94,6 +94,7 @@ vi.mock("@/renderer/components/providers/ProviderIcon", () => ({
 }));
 
 import { AcpRegistrySettings } from "./AcpRegistrySettings";
+import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
 
 const baseCapabilities = {
   models: [],
@@ -128,6 +129,16 @@ function makeProject(input: { id: string; name: string; location: Project["locat
     createdAt: new Date(0).toISOString(),
     location: input.location,
   };
+}
+
+function withProcessPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return run();
+  } finally {
+    if (descriptor) Object.defineProperty(process, "platform", descriptor);
+  }
 }
 
 const registry: AcpRegistryListResult = {
@@ -248,6 +259,98 @@ describe("AcpRegistrySettings", () => {
         expect.objectContaining({
           label: "Codex",
         }),
+      );
+    });
+  });
+
+  it("offers Antigravity as a native install", async () => {
+    render(<AcpRegistrySettings />);
+
+    await screen.findByRole("heading", { name: "Agent Registry" });
+    const antigravityCard = screen
+      .getByText(/First-class Antigravity CLI integration/u)
+      .closest(".rounded-lg");
+    expect(antigravityCard).toBeTruthy();
+
+    fireEvent.click(
+      within(antigravityCard as HTMLElement).getByRole("button", { name: "Install" }),
+    );
+
+    await waitFor(() => {
+      expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: "Antigravity",
+        }),
+      );
+    });
+    const installInput = runAgentInstallCommandMock.mock.calls[0]?.[0] as
+      | { command: (project: Project) => string }
+      | undefined;
+    expect(
+      installInput?.command(
+        makeProject({
+          id: "wsl-project",
+          name: "WSL Project",
+          location: {
+            kind: "wsl",
+            distro: "Ubuntu",
+            linuxPath: "/home/demo/project",
+            uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+          },
+        }),
+      ),
+    ).toContain("https://antigravity.google/cli/install.sh");
+  });
+
+  it("keeps brew install commands mac-only", () => {
+    const wslProject = makeProject({
+      id: "wsl-project",
+      name: "WSL Project",
+      location: {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/demo/project",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+      },
+    });
+    const macProject = makeProject({
+      id: "mac-project",
+      name: "Mac Project",
+      location: { kind: "posix", path: "/Users/demo/project" },
+    });
+    const entries = new Map(NATIVE_AGENT_REGISTRY_ENTRIES.map((entry) => [entry.id, entry]));
+
+    expect(entries.get("codex")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+    );
+    expect(entries.get("codex")?.installCommand(wslProject)).not.toContain("brew install");
+    expect(entries.get("codex")?.installCommand(wslProject)).toContain(
+      "npm install -g @openai/codex",
+    );
+    expect(entries.get("claude")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://claude.ai/install.sh | bash",
+    );
+    expect(entries.get("claude")?.installCommand(wslProject)).not.toContain("brew install");
+    expect(entries.get("opencode")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://opencode.ai/install | bash",
+    );
+    expect(entries.get("opencode")?.installCommand(wslProject)).not.toContain("brew install");
+    expect(entries.get("opencode")?.installCommand(wslProject)).toContain(
+      "npm install -g opencode-ai",
+    );
+    expect(entries.get("antigravity")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+    );
+
+    withProcessPlatform("darwin", () => {
+      expect(entries.get("codex")?.installCommand(macProject)).toContain(
+        "brew install --cask codex",
+      );
+      expect(entries.get("claude")?.installCommand(macProject)).toContain(
+        "brew install --cask claude-code",
+      );
+      expect(entries.get("opencode")?.installCommand(macProject)).toContain(
+        "brew install anomalyco/tap/opencode",
       );
     });
   });

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -14,8 +14,14 @@ export interface NativeAgentRegistryEntry {
   supportsWindows?: boolean;
 }
 
-const POSIX_MISSING_NPM_MESSAGE =
-  "printf 'No supported installer found. Install Node.js/npm first, then refresh detected agents.\\n'";
+const POSIX_MISSING_CURL_NPM_MESSAGE =
+  "printf 'No supported installer found. Install curl or Node.js/npm first, then refresh detected agents.\\n'";
+const MAC_MISSING_CURL_BREW_NPM_MESSAGE =
+  "printf 'No supported installer found. Install curl, Homebrew, or Node.js/npm first, then refresh detected agents.\\n'";
+const MAC_MISSING_CURL_BREW_MESSAGE =
+  "printf 'No supported installer found. Install curl or Homebrew first, then refresh detected agents.\\n'";
+const POSIX_MISSING_CURL_MESSAGE =
+  "printf 'curl is required to install this agent. Install curl, then refresh detected agents.\\n'";
 
 function isWslProject(project: Project): boolean {
   return project.location.kind === "wsl";
@@ -25,6 +31,15 @@ function posixOrWindows(project: Project, posix: string, windows: string): strin
   return isWslProject(project) || process.platform !== "win32" ? posix : windows;
 }
 
+function nativeInstallCommand(
+  project: Project,
+  commands: { mac: string; posix: string; windows: string },
+): string {
+  if (isWslProject(project)) return commands.posix;
+  if (process.platform === "win32") return commands.windows;
+  return process.platform === "darwin" ? commands.mac : commands.posix;
+}
+
 export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
   {
     id: "codex",
@@ -32,13 +47,21 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
     description: "First-class Codex CLI integration using Lightcode's native app-server runtime.",
     docsUrl: "https://developers.openai.com/codex/cli",
     installCommand: (project) =>
-      posixOrWindows(
-        project,
-        "if command -v npm >/dev/null 2>&1; then npm i -g @openai/codex; else " +
-          POSIX_MISSING_NPM_MESSAGE +
+      nativeInstallCommand(project, {
+        mac:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://chatgpt.com/codex/install.sh | sh; " +
+          "elif command -v brew >/dev/null 2>&1; then brew install --cask codex; " +
+          "elif command -v npm >/dev/null 2>&1; then npm install -g @openai/codex; else " +
+          MAC_MISSING_CURL_BREW_NPM_MESSAGE +
           "; fi",
-        "if (Get-Command npm -ErrorAction SilentlyContinue) { npm i -g @openai/codex } else { Write-Host 'No supported installer found. Install Node.js/npm first, then refresh detected agents.' }",
-      ),
+        posix:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://chatgpt.com/codex/install.sh | sh; " +
+          "elif command -v npm >/dev/null 2>&1; then npm install -g @openai/codex; else " +
+          POSIX_MISSING_CURL_NPM_MESSAGE +
+          "; fi",
+        windows:
+          "if (Get-Command powershell -ErrorAction SilentlyContinue) { powershell -ExecutionPolicy ByPass -c \"irm https://chatgpt.com/codex/install.ps1 | iex\" } elseif (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g @openai/codex } else { Write-Host 'No supported installer found. Install Windows PowerShell or Node.js/npm first, then refresh detected agents.' }",
+      }),
   },
   {
     id: "claude",
@@ -46,14 +69,19 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
     description: "First-class Claude Code integration using Lightcode's native SDK runtime.",
     docsUrl: "https://code.claude.com/docs/en/setup",
     installCommand: (project) =>
-      posixOrWindows(
-        project,
-        "if command -v curl >/dev/null 2>&1; then curl -fsSL https://claude.ai/install.sh | bash; " +
-          "elif command -v npm >/dev/null 2>&1; then npm install -g @anthropic-ai/claude-code; else " +
-          POSIX_MISSING_NPM_MESSAGE +
+      nativeInstallCommand(project, {
+        mac:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://claude.ai/install.sh | bash; " +
+          "elif command -v brew >/dev/null 2>&1; then brew install --cask claude-code; else " +
+          MAC_MISSING_CURL_BREW_MESSAGE +
           "; fi",
-        "if (Get-Command winget -ErrorAction SilentlyContinue) { winget install Anthropic.ClaudeCode } elseif (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g @anthropic-ai/claude-code } else { Write-Host 'No supported installer found. Install WinGet or Node.js/npm first, then refresh detected agents.' }",
-      ),
+        posix:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://claude.ai/install.sh | bash; else " +
+          POSIX_MISSING_CURL_MESSAGE +
+          "; fi",
+        windows:
+          "if (Get-Command irm -ErrorAction SilentlyContinue) { irm https://claude.ai/install.ps1 | iex } elseif (Get-Command curl.exe -ErrorAction SilentlyContinue) { cmd /c \"curl -fsSL https://claude.ai/install.cmd -o install.cmd && install.cmd && del install.cmd\" } elseif (Get-Command winget -ErrorAction SilentlyContinue) { winget install Anthropic.ClaudeCode } else { Write-Host 'No supported installer found. Install PowerShell Invoke-RestMethod, curl, or WinGet first, then refresh detected agents.' }",
+      }),
   },
   {
     id: "opencode",
@@ -61,14 +89,21 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
     description: "First-class OpenCode integration using Lightcode's native SDK runtime.",
     docsUrl: "https://opencode.ai/docs/",
     installCommand: (project) =>
-      posixOrWindows(
-        project,
-        "if command -v curl >/dev/null 2>&1; then curl -fsSL https://opencode.ai/install | bash; " +
+      nativeInstallCommand(project, {
+        mac:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://opencode.ai/install | bash; " +
+          "elif command -v brew >/dev/null 2>&1; then brew install anomalyco/tap/opencode; " +
           "elif command -v npm >/dev/null 2>&1; then npm install -g opencode-ai; else " +
-          POSIX_MISSING_NPM_MESSAGE +
+          MAC_MISSING_CURL_BREW_NPM_MESSAGE +
           "; fi",
-        "if (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g opencode-ai } elseif (Get-Command choco -ErrorAction SilentlyContinue) { choco install opencode } elseif (Get-Command scoop -ErrorAction SilentlyContinue) { scoop install opencode } else { Write-Host 'No supported installer found. Install Node.js/npm, Chocolatey, or Scoop first, then refresh detected agents.' }",
-      ),
+        posix:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://opencode.ai/install | bash; " +
+          "elif command -v npm >/dev/null 2>&1; then npm install -g opencode-ai; else " +
+          POSIX_MISSING_CURL_NPM_MESSAGE +
+          "; fi",
+        windows:
+          "if (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g opencode-ai } else { Write-Host 'No supported installer found. Install Node.js/npm first, then refresh detected agents.' }",
+      }),
   },
   {
     id: "grok",
@@ -81,6 +116,19 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
     installCommand: () =>
       "if command -v curl >/dev/null 2>&1; then curl -fsSL https://x.ai/cli/install.sh | bash; " +
       "else printf 'curl is required to install Grok Build. Install curl, then refresh detected agents.\\n'; fi",
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    description: "First-class Antigravity CLI integration using Lightcode's native runtime.",
+    docsUrl: "https://antigravity.google/docs/cli-getting-started",
+    installCommand: (project) =>
+      posixOrWindows(
+        project,
+        "if command -v curl >/dev/null 2>&1; then curl -fsSL https://antigravity.google/cli/install.sh | bash; " +
+          "else printf 'curl is required to install Antigravity. Install curl, then refresh detected agents.\\n'; fi",
+        "if (Get-Command irm -ErrorAction SilentlyContinue) { irm https://antigravity.google/cli/install.ps1 | iex } elseif (Get-Command curl.exe -ErrorAction SilentlyContinue) { cmd /c \"curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd\" } else { Write-Host 'No supported installer found. Install PowerShell Invoke-RestMethod or curl first, then refresh detected agents.' }",
+      ),
   },
 ];
 


### PR DESCRIPTION
**Type:** Feature

- Register **Antigravity** in the native agent registry so it can be installed from Settings alongside other first-class agents.
- Use each provider’s **official installers** (curl scripts, Homebrew casks, PowerShell/winget) for Codex, Claude Code, and OpenCode instead of relying on npm-only paths.
- Select install commands by **host platform** (macOS, Windows, Linux/WSL) so WSL projects always receive POSIX installers and users get clearer guidance when curl, brew, or npm is missing.
- Add settings overlay tests covering Antigravity install, WSL install URLs, and **mac-only** Homebrew fallbacks.