### PR TITLE
Fix overlay Escape capture for empty stack and focused inputs

### DIFF
--- a/src/renderer/components/layout/overlayEscapeStack.ts
+++ b/src/renderer/components/layout/overlayEscapeStack.ts
@@ -5,7 +5,9 @@
  *
  * Each overlay pushes a close handler on mount/open and pops it on
  * unmount/close. A single window-level capture listener routes the keypress
- * to the top of the stack.
+ * to the top of the stack. The listener is installed only while the stack is
+ * non-empty so that Escape reaches terminals, editors, and inputs unimpeded
+ * when no overlay is visible.
  */
 
 type Handler = () => void;
@@ -13,8 +15,31 @@ type Handler = () => void;
 const stack: Handler[] = [];
 let listenerInstalled = false;
 
+function installListener(): void {
+  if (listenerInstalled) return;
+  window.addEventListener("keydown", onKeyDown, { capture: true });
+  listenerInstalled = true;
+}
+
+function uninstallListener(): void {
+  if (!listenerInstalled) return;
+  window.removeEventListener("keydown", onKeyDown, { capture: true });
+  listenerInstalled = false;
+}
+
+/**
+ * Elements that must receive Escape presses directly even while an overlay is
+ * visible — e.g. a terminal inside a login overlay, a Monaco editor inside the
+ * file-editor overlay, or an open mention popover inside a sub-agent drawer.
+ */
+const FOCUS_RETAINS_ESCAPE = ".xterm, .monaco-editor, .lightcode-mention-input";
+
 function onKeyDown(event: KeyboardEvent): void {
   if (event.key !== "Escape") return;
+
+  const target = event.target as HTMLElement | null;
+  if (target?.closest(FOCUS_RETAINS_ESCAPE)) return;
+
   const handler = stack[stack.length - 1];
   if (!handler) return;
   event.preventDefault();
@@ -23,13 +48,11 @@ function onKeyDown(event: KeyboardEvent): void {
 }
 
 export function pushEscapeHandler(handler: Handler): () => void {
-  if (!listenerInstalled) {
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    listenerInstalled = true;
-  }
   stack.push(handler);
+  installListener();
   return () => {
     const idx = stack.lastIndexOf(handler);
     if (idx >= 0) stack.splice(idx, 1);
+    if (stack.length === 0) uninstallListener();
   };
 }


### PR DESCRIPTION
**Type:** Bugfix

- Install the window-level Escape listener only while the overlay stack has handlers, so Escape reaches terminals, editors, and other controls when no overlay is open
- When an overlay is open, still pass Escape through to focused xterm, Monaco, and mention-input surfaces instead of closing the overlay
- Prevents capture-phase handling from stealing Escape from nested interactive UI (e.g. terminal in a login overlay, editor in the file overlay)