### PR TITLE
Fix chat markdown tables to render native HTML structure

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
@@ -184,6 +184,44 @@ describe("ItemMarkdownInner", () => {
     expect(rawParagraph).toBeUndefined();
   });
 
+  it("renders a markdown table with thead, tbody, th and td elements", () => {
+    const mdTable = [
+      "| Name | Role |",
+      "|------|------|",
+      "| Alice | Engineer |",
+      "| Bob | Designer |",
+      "",
+    ].join("\n");
+
+    const { container } = render(
+      <AppProvider>
+        <ItemMarkdownInner text={mdTable} />
+      </AppProvider>,
+    );
+
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+
+    const thead = table!.querySelector("thead");
+    expect(thead).not.toBeNull();
+
+    const ths = thead!.querySelectorAll("th");
+    expect(ths).toHaveLength(2);
+    expect(ths[0]).toHaveTextContent("Name");
+    expect(ths[1]).toHaveTextContent("Role");
+
+    const tbody = table!.querySelector("tbody");
+    expect(tbody).not.toBeNull();
+
+    const rows = tbody!.querySelectorAll("tr");
+    expect(rows).toHaveLength(2);
+
+    const firstRowCells = rows[0]!.querySelectorAll("td");
+    expect(firstRowCells).toHaveLength(2);
+    expect(firstRowCells[0]).toHaveTextContent("Alice");
+    expect(firstRowCells[1]).toHaveTextContent("Engineer");
+  });
+
   it("does not render incomplete absolute markdown hrefs as browser links", () => {
     const { container } = render(
       <AppProvider>

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
@@ -1,4 +1,4 @@
-import { Link, Table } from "@heroui/react";
+import { Link } from "@heroui/react";
 import { ExternalLink } from "lucide-react";
 import {
   Children,
@@ -131,8 +131,37 @@ const MD_COMPONENTS: StreamdownComponents = {
   a({ href, children }) {
     return <MdAnchor href={href ?? ""}>{children}</MdAnchor>;
   },
+  // Render a clean native table with HeroUI-themed styling. Override
+  // Streamdown's default wrapper (which includes copy/download/fullscreen
+  // controls) and replace its memoized sub-components with native HTML
+  // elements so `<thead>`, `<tr>`, etc. compose correctly.
   table({ children }) {
-    return <MdTable>{children}</MdTable>;
+    return (
+      <div className="not-prose my-4 min-w-0 max-w-full overflow-x-auto rounded-2xl border border-border bg-[var(--surface-secondary)]/50">
+        <table className="w-full border-collapse text-[length:var(--lc-chat-font-size)] leading-snug">
+          {children}
+        </table>
+      </div>
+    );
+  },
+  thead({ children }) {
+    return <thead className="[&_th]:border-b [&_th]:border-foreground/10">{children}</thead>;
+  },
+  tbody({ children }) {
+    return (
+      <tbody className="[&_tr:not(:last-child)_td]:border-b [&_tr:not(:last-child)_td]:border-foreground/5">
+        {children}
+      </tbody>
+    );
+  },
+  tr({ children }) {
+    return <tr>{children}</tr>;
+  },
+  th({ children }) {
+    return <th className="px-4 py-1 text-left font-medium text-muted">{children}</th>;
+  },
+  td({ children }) {
+    return <td className="px-4 py-1 align-middle text-foreground">{children}</td>;
   },
 };
 
@@ -337,111 +366,6 @@ function renderPathChip(
       onShowInExplorer={actions.showProjectEntryInExplorer}
     />
   );
-}
-
-function MdTable({ children }: { children?: ReactNode }) {
-  const { headerCells, bodyRows } = extractTableParts(children);
-  if (headerCells.length === 0 && bodyRows.length === 0) {
-    return null;
-  }
-  // React Aria's Table is strict: every Row must have exactly one Cell per
-  // Column. Malformed markdown (mismatched separator dash count, ragged rows,
-  // partial streaming chunks) routinely produces rows whose lengths drift from
-  // the header. Normalize everything to the widest row so the table renders
-  // instead of falling over.
-  const columnCount = Math.max(headerCells.length, ...bodyRows.map((r) => r.length), 1);
-  const paddedHeader: ReactNode[] = Array.from(
-    { length: columnCount },
-    (_, i) => headerCells[i] ?? "",
-  );
-  const paddedRows: ReactNode[][] = bodyRows.map((row) =>
-    Array.from({ length: columnCount }, (_, i) => row[i] ?? ""),
-  );
-  return (
-    <div className="not-prose my-2 min-w-0 max-w-full overflow-hidden">
-      <Table className="min-w-0 max-w-full">
-        <Table.ScrollContainer className="min-w-0 max-w-full overflow-x-auto">
-          <Table.Content
-            aria-label="Table"
-            className="text-[length:var(--lc-chat-font-size-command)]"
-          >
-            <Table.Header>
-              {paddedHeader.map((cell, i) => (
-                <Table.Column key={`col-${i}`} id={`col-${i}`} isRowHeader={i === 0}>
-                  {cell}
-                </Table.Column>
-              ))}
-            </Table.Header>
-            <Table.Body>
-              {paddedRows.map((row, ri) => (
-                <Table.Row key={`row-${ri}`} id={`row-${ri}`}>
-                  {row.map((cell, ci) => (
-                    <Table.Cell key={`cell-${ri}-${ci}`}>{cell}</Table.Cell>
-                  ))}
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table.Content>
-        </Table.ScrollContainer>
-      </Table>
-    </div>
-  );
-}
-
-export function extractTableParts(children: ReactNode): {
-  headerCells: ReactNode[];
-  bodyRows: ReactNode[][];
-} {
-  let headerCells: ReactNode[] = [];
-  const bodyRows: ReactNode[][] = [];
-  Children.forEach(children, (child) => {
-    if (!isValidElement(child)) return;
-    if (child.type === "thead") {
-      headerCells = collectCellsFromFirstRow(getElementChildren(child), "th");
-    } else if (child.type === "tbody") {
-      collectRowsInto(bodyRows, getElementChildren(child));
-    } else if (child.type === "tr") {
-      collectRowsInto(bodyRows, [child]);
-    }
-  });
-  return { headerCells, bodyRows };
-}
-
-function collectRowsInto(target: ReactNode[][], nodes: ReactNode) {
-  Children.forEach(nodes, (child) => {
-    if (!isValidElement(child) || child.type !== "tr") return;
-    const cells: ReactNode[] = [];
-    Children.forEach(getElementChildren(child), (cellNode) => {
-      if (!isValidElement(cellNode)) return;
-      if (cellNode.type === "td" || cellNode.type === "th") {
-        cells.push(getElementChildren(cellNode));
-      }
-    });
-    if (cells.length > 0) target.push(cells);
-  });
-}
-
-function collectCellsFromFirstRow(nodes: ReactNode, cellTag: "th" | "td"): ReactNode[] {
-  const cells: ReactNode[] = [];
-  let firstTr: ReactElement | undefined;
-  Children.forEach(nodes, (child) => {
-    if (!firstTr && isValidElement(child) && child.type === "tr") {
-      firstTr = child;
-    }
-  });
-  if (!firstTr) return cells;
-  Children.forEach(getElementChildren(firstTr), (cellNode) => {
-    if (!isValidElement(cellNode)) return;
-    if (cellNode.type === cellTag || cellNode.type === "td" || cellNode.type === "th") {
-      cells.push(getElementChildren(cellNode));
-    }
-  });
-  return cells;
-}
-
-function getElementChildren(element: ReactElement): ReactNode {
-  const props = element.props as { children?: ReactNode };
-  return props.children;
 }
 
 function flattenMdChildren(node: ReactNode): string {


### PR DESCRIPTION
**Type:** Bugfix

- Render markdown tables in chat with native `<table>`, `<thead>`, `<tbody>`, and cell elements so structure matches standard HTML instead of React Aria’s strict grid model
- Replace the HeroUI `Table` path and custom row/cell extraction with Streamdown overrides that compose correctly and drop the default copy/download/fullscreen table chrome
- Apply existing chat surface styling (scroll, border, typography tokens) on the native table wrapper
- Add regression test asserting header and body cells render with expected content in `ItemMarkdownInner`