### PR TITLE
Animate sidebar terminal icons when shells stream output

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -10,6 +10,7 @@ import {
 } from "./notifications";
 
 import { useAppStore } from "./state/appStore";
+import { useDevTerminalStore } from "./state/devTerminalStore";
 import { useAgentStatusesStore } from "./state/agentStatusesStore";
 import { useUpdateStore } from "./state/updateStore";
 import { installRuntimeItemsPersister } from "./state/chatRuntimePersister";
@@ -81,6 +82,9 @@ function flushPendingRuntimeEventsSync(): void {
 
 const unsubSupervisor = readBridge().onSupervisorEvent((event) => {
   if ("threadId" in event && event.threadId.startsWith("shell:")) {
+    if (event.type === "thread-output") {
+      useDevTerminalStore.getState().noteShellOutput(event.threadId);
+    }
     return;
   }
 

--- a/src/renderer/components/common/AnimatedTerminalIcon.tsx
+++ b/src/renderer/components/common/AnimatedTerminalIcon.tsx
@@ -1,0 +1,38 @@
+import type { SVGProps } from "react";
+
+interface AnimatedTerminalIconProps extends SVGProps<SVGSVGElement> {
+  isBusy?: boolean | undefined;
+}
+
+export function AnimatedTerminalIcon({ isBusy, className, ...props }: AnimatedTerminalIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      {isBusy && (
+        <style>{`
+          @keyframes terminal-cursor-breath {
+            0%, 100% { opacity: 0.15; }
+            50% { opacity: 1; }
+          }
+          .anim-cursor-breath {
+            animation: terminal-cursor-breath 1s infinite ease-in-out;
+          }
+        `}</style>
+      )}
+      <rect width="20" height="20" x="2" y="2" rx="2" />
+      <path d="m7 8 3 3-3 3" />
+      <path d="m12 14 h4" className={isBusy ? "anim-cursor-breath" : undefined} />
+    </svg>
+  );
+}

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -114,6 +114,28 @@ export function useIsWorktreeTerminalOpen(worktreePath: string | null | undefine
   });
 }
 
+export function useIsProjectTerminalBusy(projectId: string): boolean {
+  return useDevTerminalStore((s) =>
+    s.tabs.some(
+      (t) =>
+        t.projectId === projectId &&
+        !t.worktreePath &&
+        (s.streamingTabs[t.id] || (t.splitId ? s.streamingTabs[t.splitId] : false)),
+    ),
+  );
+}
+
+export function useIsWorktreeTerminalBusy(worktreePath: string | null | undefined): boolean {
+  return useDevTerminalStore((s) => {
+    if (!worktreePath) return false;
+    return s.tabs.some(
+      (t) =>
+        t.worktreePath === worktreePath &&
+        (s.streamingTabs[t.id] || (t.splitId ? s.streamingTabs[t.splitId] : false)),
+    );
+  });
+}
+
 export function useIsProjectGitPanelActive(projectId: string): boolean {
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   return usePanelStore((s) => {

--- a/src/renderer/state/devTerminalStore.ts
+++ b/src/renderer/state/devTerminalStore.ts
@@ -21,6 +21,11 @@ interface DevTerminalState {
   focusRequestId: number;
   /** Tab IDs with unseen output. Ephemeral — not persisted. */
   tabActivity: Record<string, true>;
+  /**
+   * Shell IDs (tab `id` or `splitId`) currently streaming output. Set on PTY
+   * output, cleared after a short idle debounce. Ephemeral — not persisted.
+   */
+  streamingTabs: Record<string, true>;
 }
 
 interface DevTerminalActions {
@@ -40,7 +45,24 @@ interface DevTerminalActions {
   closeSplit: (tabId: string) => string | undefined;
   markTabActive: (tabId: string) => void;
   clearTabActivity: (tabId: string) => void;
+  /** Note PTY output for a shell, flagging it as streaming until output idles. */
+  noteShellOutput: (shellId: string) => void;
   updateTabTitle: (tabId: string, title: string) => void;
+}
+
+/** Idle window after the last PTY output before a shell is considered quiet. */
+const STREAMING_IDLE_MS = 700;
+
+/** Per-shell debounce timers backing `noteShellOutput`. Module-level so they
+ * never trigger store re-renders and survive across `set` calls. */
+const streamingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearStreaming(ids: string[]): void {
+  for (const id of ids) {
+    const timer = streamingTimers.get(id);
+    if (timer) clearTimeout(timer);
+    streamingTimers.delete(id);
+  }
 }
 
 export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>()((set, get) => ({
@@ -51,6 +73,7 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
   activeTabId: null,
   focusRequestId: 0,
   tabActivity: {},
+  streamingTabs: {},
 
   openPanel: (projectId) =>
     set((state) => ({
@@ -111,7 +134,11 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       const tabActivity = { ...state.tabActivity };
       delete tabActivity[tabId];
       if (removed?.splitId) delete tabActivity[removed.splitId];
-      return { tabs, activeTabId, tabActivity };
+      const streamingTabs = { ...state.streamingTabs };
+      delete streamingTabs[tabId];
+      if (removed?.splitId) delete streamingTabs[removed.splitId];
+      clearStreaming(removed?.splitId ? [tabId, removed.splitId] : [tabId]);
+      return { tabs, activeTabId, tabActivity, streamingTabs };
     }),
 
   setActiveTab: (tabId) => {
@@ -139,9 +166,17 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
         activeTabId = tabs.at(-1)?.id ?? null;
       }
       const tabActivity = { ...state.tabActivity };
-      for (const id of removed) delete tabActivity[id];
-      for (const id of splitIds) delete tabActivity[id];
-      return { tabs, activeTabId, tabActivity };
+      const streamingTabs = { ...state.streamingTabs };
+      for (const id of removed) {
+        delete tabActivity[id];
+        delete streamingTabs[id];
+      }
+      for (const id of splitIds) {
+        delete tabActivity[id];
+        delete streamingTabs[id];
+      }
+      clearStreaming([...removed, ...splitIds]);
+      return { tabs, activeTabId, tabActivity, streamingTabs };
     });
     return [...removed, ...splitIds];
   },
@@ -160,9 +195,17 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
         activeTabId = tabs.at(-1)?.id ?? null;
       }
       const tabActivity = { ...state.tabActivity };
-      for (const id of removed) delete tabActivity[id];
-      for (const id of splitIds) delete tabActivity[id];
-      return { tabs, activeTabId, tabActivity };
+      const streamingTabs = { ...state.streamingTabs };
+      for (const id of removed) {
+        delete tabActivity[id];
+        delete streamingTabs[id];
+      }
+      for (const id of splitIds) {
+        delete tabActivity[id];
+        delete streamingTabs[id];
+      }
+      clearStreaming([...removed, ...splitIds]);
+      return { tabs, activeTabId, tabActivity, streamingTabs };
     });
     return [...removed, ...splitIds];
   },
@@ -187,7 +230,10 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       });
       const tabActivity = { ...state.tabActivity };
       delete tabActivity[splitId];
-      return { tabs, tabActivity };
+      const streamingTabs = { ...state.streamingTabs };
+      delete streamingTabs[splitId];
+      clearStreaming([splitId]);
+      return { tabs, tabActivity, streamingTabs };
     });
     return splitId;
   },
@@ -205,6 +251,24 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
     const next = { ...tabActivity };
     delete next[tabId];
     set({ tabActivity: next });
+  },
+
+  noteShellOutput: (shellId) => {
+    const existing = streamingTimers.get(shellId);
+    if (existing) clearTimeout(existing);
+    streamingTimers.set(
+      shellId,
+      setTimeout(() => {
+        streamingTimers.delete(shellId);
+        const { streamingTabs } = get();
+        if (!streamingTabs[shellId]) return;
+        const next = { ...streamingTabs };
+        delete next[shellId];
+        set({ streamingTabs: next });
+      }, STREAMING_IDLE_MS),
+    );
+    if (get().streamingTabs[shellId]) return;
+    set((state) => ({ streamingTabs: { ...state.streamingTabs, [shellId]: true } }));
   },
 
   updateTabTitle: (tabId, rawTitle) => {

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8,10 +8,10 @@ import {
   RefreshCw,
   Search,
   Settings2,
-  TerminalSquare,
 } from "lucide-react";
 import { startTransition, useEffect } from "react";
 import { useShallow } from "zustand/shallow";
+import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { getAppName } from "@/shared/appName";
 import type { Thread } from "@/shared/contracts";
 import { formatBytes } from "@/shared/formatBytes";
@@ -36,6 +36,7 @@ import {
   useCurrentThreadIds,
   useCurrentWorktreePath,
   useIsProjectTerminalActive,
+  useIsProjectTerminalBusy,
   useIsProjectTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
 import { useScrollFade } from "@/renderer/hooks/useScrollFade";
@@ -120,6 +121,7 @@ function UpdateButtons(props: { iconOnly?: boolean }) {
 function HomeTerminalButton(props: { projectId: string; projectName: string }) {
   const hasTerminal = useIsProjectTerminalOpen(props.projectId);
   const isActiveTerminal = useIsProjectTerminalActive(props.projectId);
+  const isBusy = useIsProjectTerminalBusy(props.projectId);
   return (
     <SidebarPanelDragButton
       panel="terminal"
@@ -134,7 +136,7 @@ function HomeTerminalButton(props: { projectId: string; projectName: string }) {
       }`}
       onPress={() => openTerminal(props.projectId)}
     >
-      <TerminalSquare className="size-3.5" />
+      <AnimatedTerminalIcon className="size-3.5" isBusy={isBusy} />
     </SidebarPanelDragButton>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
@@ -8,7 +8,6 @@ import {
   PowerOff,
   RefreshCw,
   Settings2,
-  TerminalSquare,
   Trash2,
 } from "lucide-react";
 import type { Project } from "@/shared/contracts";
@@ -26,11 +25,13 @@ import {
   useIsProjectFilesPanelActive,
   useIsProjectGitPanelActive,
   useIsProjectTerminalActive,
+  useIsProjectTerminalBusy,
   useIsProjectTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { formatProjectLocation } from "./formatProjectLocation";
+import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { GitBadge } from "./GitBadge";
 import { SidebarPanelDragButton } from "./SidebarPanelDragButton";
 import { SyncBadge } from "./SyncBadge";
@@ -44,6 +45,7 @@ export function SidebarProjectHeader(props: {
   const toggleProjectCollapsed = useSidebarUiStore((s) => s.toggleProjectCollapsed);
   const hasTerminal = useIsProjectTerminalOpen(project.id);
   const isActiveTerminal = useIsProjectTerminalActive(project.id);
+  const isBusyTerminal = useIsProjectTerminalBusy(project.id);
   const isActiveGitPanel = useIsProjectGitPanelActive(project.id);
   const isActiveFilesPanel = useIsProjectFilesPanelActive(project.id);
   const projectLocation = formatProjectLocation(project);
@@ -172,7 +174,7 @@ export function SidebarProjectHeader(props: {
                 }`}
                 onPress={() => openTerminal(project.id)}
               >
-                <TerminalSquare className="size-3.5" />
+                <AnimatedTerminalIcon isBusy={isBusyTerminal} className="size-3.5" />
               </SidebarPanelDragButton>
               <SyncBadge projectId={project.id} />
               <GitBadge

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -7,6 +7,7 @@ import {
   useIsWorktreeFilesPanelActive,
   useIsWorktreeGitPanelActive,
   useIsWorktreeTerminalActive,
+  useIsWorktreeTerminalBusy,
   useIsWorktreeTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
 import {
@@ -44,6 +45,7 @@ export function SidebarWorktreeGroup(props: {
   const worktreeGitItems = useWorktreeGitItems(project.id, group.worktreePath, gitMenuIcons);
   const hasTerminal = useIsWorktreeTerminalOpen(group.worktreePath);
   const isActiveTerminal = useIsWorktreeTerminalActive(group.worktreePath);
+  const isBusyTerminal = useIsWorktreeTerminalBusy(group.worktreePath);
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
   const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
   const groupThreadIds = group.threads.map((t) => t.id);
@@ -139,6 +141,7 @@ export function SidebarWorktreeGroup(props: {
           isCollapsed={isGroupCollapsed}
           hasTerminal={hasTerminal}
           isActiveTerminal={isActiveTerminal}
+          isBusyTerminal={isBusyTerminal}
           isActiveFiles={isActiveFiles}
           isActiveGit={isActiveGit}
           onToggleCollapse={() => toggleWorktreeCollapsed(group.worktreePath)}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
@@ -1,4 +1,4 @@
-import { Archive, FolderOpen, Star, TerminalSquare, Trash2 } from "lucide-react";
+import { Archive, FolderOpen, Star, Trash2 } from "lucide-react";
 import type { Thread } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { GitBadge } from "@/renderer/views/MainView/parts/Sidebar/parts/GitBadge";
@@ -6,10 +6,12 @@ import { SyncBadge } from "@/renderer/views/MainView/parts/Sidebar/parts/SyncBad
 import { archiveThread, deleteThread } from "@/renderer/actions/threadActions";
 import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
 import { openWorktreeTerminal } from "@/renderer/actions/terminalActions";
+import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import {
   useIsWorktreeFilesPanelActive,
   useIsWorktreeGitPanelActive,
   useIsWorktreeTerminalActive,
+  useIsWorktreeTerminalBusy,
   useIsWorktreeTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
@@ -26,6 +28,7 @@ export function ThreadItemSuffix(props: {
   const isGitActive = useIsWorktreeGitPanelActive(thread.worktreePath);
   const isTerminalActive = useIsWorktreeTerminalActive(thread.worktreePath);
   const isTerminalOpen = useIsWorktreeTerminalOpen(thread.worktreePath);
+  const isTerminalBusy = useIsWorktreeTerminalBusy(thread.worktreePath);
 
   return (
     <>
@@ -60,7 +63,7 @@ export function ThreadItemSuffix(props: {
             }`}
             onPress={() => openWorktreeTerminal(thread.projectId, thread.worktreePath!)}
           >
-            <TerminalSquare className="size-3.5" />
+            <AnimatedTerminalIcon className="size-3.5" isBusy={isTerminalBusy} />
           </SidebarPanelDragButton>
           <SyncBadge projectId={thread.projectId} worktreePath={thread.worktreePath} />
           <GitBadge

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -1,5 +1,6 @@
-import { Check, FolderOpen, GitFork, TerminalSquare } from "lucide-react";
+import { Check, FolderOpen, GitFork } from "lucide-react";
 import { SidebarButton } from "@/renderer/components/common";
+import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { GitBadge } from "./GitBadge";
 import { SidebarPanelDragButton } from "./SidebarPanelDragButton";
 import { SyncBadge } from "./SyncBadge";
@@ -12,6 +13,7 @@ export function WorktreeGroupHeader(props: {
   isCollapsed: boolean;
   hasTerminal: boolean;
   isActiveTerminal: boolean;
+  isBusyTerminal?: boolean;
   isActiveFiles?: boolean;
   isActiveGit: boolean;
   onToggleCollapse: () => void;
@@ -90,7 +92,7 @@ export function WorktreeGroupHeader(props: {
             }`}
             onPress={props.onOpenTerminal}
           >
-            <TerminalSquare className="size-3.5" />
+            <AnimatedTerminalIcon className="size-3.5" isBusy={props.isBusyTerminal} />
           </SidebarPanelDragButton>
           <SyncBadge projectId={props.projectId} worktreePath={props.worktreePath} />
           <GitBadge


### PR DESCRIPTION
- **Feature:** Sidebar terminal icons pulse while a project or worktree shell is actively streaming PTY output, so users can spot busy terminals without opening the panel.
- Track shell streaming in `devTerminalStore` from supervisor `thread-output` events, with a short idle debounce before clearing the busy state.
- Add `useIsProjectTerminalBusy` and `useIsWorktreeTerminalBusy` selectors to drive icon state from project- and worktree-scoped terminal tabs.
- Introduce `AnimatedTerminalIcon` and use it across sidebar terminal buttons (home, project header, worktree group header, and thread item suffix) in place of static `TerminalSquare` icons.