### PR TITLE
Surface Factory Droid ACP errors and fix registry icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ release/
 .vite/
 coverage/
 *.log
+logs/
 *.tsbuildinfo
 build/icon-trimmed.png
 build/icons/

--- a/scripts/probe-factory-droid-acp.mjs
+++ b/scripts/probe-factory-droid-acp.mjs
@@ -1,0 +1,194 @@
+/**
+ * Capture raw Factory Droid ACP session/update traffic (registry default).
+ *
+ * Usage:
+ *   node scripts/probe-factory-droid-acp.mjs
+ *   node scripts/probe-factory-droid-acp.mjs --model claude-opus-4-8 --prompt hi
+ */
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const MODEL = process.argv.includes("--model")
+  ? process.argv[process.argv.indexOf("--model") + 1]
+  : "claude-opus-4-8";
+const PROMPT = process.argv.includes("--prompt")
+  ? process.argv[process.argv.indexOf("--prompt") + 1]
+  : "hi";
+
+const OUT_DIR = join(process.cwd(), "logs");
+const OUT_FILE = join(OUT_DIR, "factory-droid-acp-probe.jsonl");
+
+const child = spawn("npx", ["-y", "droid@0.135.1", "exec", "--output-format", "acp-daemon"], {
+  stdio: ["pipe", "pipe", "pipe"],
+  shell: true,
+  env: {
+    ...process.env,
+    DROID_DISABLE_AUTO_UPDATE: "true",
+    FACTORY_DROID_AUTO_UPDATE_ENABLED: "false",
+  },
+});
+
+mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(OUT_FILE, "");
+
+function log(kind, payload) {
+  const line = JSON.stringify({ ts: new Date().toISOString(), kind, payload });
+  writeFileSync(OUT_FILE, `${line}\n`, { flag: "a" });
+  if (kind === "session/update") {
+    const update = payload?.update;
+    if (update?.sessionUpdate === "agent_message_chunk" && update?.content?.type === "text") {
+      process.stdout.write(update.content.text);
+    } else {
+      console.log(`\n[${update?.sessionUpdate ?? "update"}]`, JSON.stringify(update, null, 2));
+    }
+  } else if (kind === "response.error") {
+    console.log("\n[rpc error]", JSON.stringify(payload, null, 2));
+  } else if (kind !== "stderr") {
+    console.log(
+      `\n[${kind}]`,
+      typeof payload === "string" ? payload : JSON.stringify(payload, null, 2),
+    );
+  }
+}
+
+let requestId = 0;
+const pending = new Map();
+
+function send(method, params) {
+  const id = ++requestId;
+  const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+  log("request", { id, method, params });
+  child.stdin.write(`${msg}\n`);
+  return id;
+}
+
+function sendNotification(method, params) {
+  const msg = JSON.stringify({ jsonrpc: "2.0", method, params });
+  log("notification", { method, params });
+  child.stdin.write(`${msg}\n`);
+}
+
+function waitForResponse(id, timeoutMs = 120_000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`Timeout waiting for response ${id}`));
+    }, timeoutMs);
+    pending.set(id, { resolve, reject, timeout });
+  });
+}
+
+const rl = createInterface({ input: child.stdout });
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+  try {
+    const msg = JSON.parse(line);
+    if (msg.method === "session/update") {
+      log("session/update", msg.params);
+      return;
+    }
+    if ("id" in msg && pending.has(msg.id)) {
+      const { resolve, reject, timeout } = pending.get(msg.id);
+      clearTimeout(timeout);
+      pending.delete(msg.id);
+      if (msg.error) {
+        log("response.error", msg.error);
+        reject(new Error(JSON.stringify(msg.error)));
+      } else {
+        log("response", { id: msg.id, result: msg.result });
+        resolve(msg.result);
+      }
+    }
+  } catch (error) {
+    log("parse_error", { line, error: String(error) });
+  }
+});
+
+child.stderr?.on("data", (chunk) => {
+  const text = String(chunk);
+  if (text.trim()) log("stderr", text);
+});
+
+function findModelConfig(configOptions) {
+  if (!Array.isArray(configOptions)) return undefined;
+  for (const option of configOptions) {
+    if (option?.category === "model" || option?.id === "model") return option;
+  }
+  return undefined;
+}
+
+async function main() {
+  console.log(`Probing Factory Droid (model=${MODEL}, prompt="${PROMPT}")`);
+  console.log(`Logging to ${OUT_FILE}\n`);
+
+  const initResult = await waitForResponse(
+    send("initialize", {
+      protocolVersion: 1,
+      clientInfo: { name: "lightcode-probe", version: "0.1.0" },
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+        auth: { terminal: true },
+      },
+    }),
+  );
+  sendNotification("initialized", {});
+
+  if (initResult.authMethods?.length) {
+    const login = initResult.authMethods.find((m) => m.id === "login") ?? initResult.authMethods[0];
+    try {
+      await waitForResponse(send("authenticate", { methodId: login.id }), 180_000);
+    } catch (error) {
+      console.log("authenticate failed (continuing):", error.message);
+    }
+  }
+
+  const newResult = await waitForResponse(
+    send("session/new", { cwd: process.cwd(), mcpServers: [] }),
+  );
+  const sessionId = newResult.sessionId;
+  const modelConfig = findModelConfig(newResult.configOptions);
+  if (modelConfig?.id) {
+    try {
+      await waitForResponse(
+        send("session/set_config_option", {
+          sessionId,
+          configId: modelConfig.id,
+          value: MODEL,
+        }),
+      );
+      console.log(`\nSet model config to ${MODEL}`);
+    } catch (error) {
+      console.log("\nset_config_option failed:", error.message);
+      try {
+        await waitForResponse(
+          send("session/unstable_set_session_model", { sessionId, modelId: MODEL }),
+        );
+        console.log(`\nSet model via unstable_set_session_model to ${MODEL}`);
+      } catch (error2) {
+        console.log("\nunstable_set_session_model failed:", error2.message);
+      }
+    }
+  } else {
+    console.log("\nNo model config option in newSession — available models in modes only");
+  }
+
+  console.log(`\n--- prompt: "${PROMPT}" ---\n`);
+  const promptResult = await waitForResponse(
+    send("session/prompt", {
+      sessionId,
+      prompt: [{ type: "text", text: PROMPT }],
+    }),
+  );
+  console.log("\n\nstopReason:", promptResult.stopReason);
+  child.kill();
+}
+
+main().catch((error) => {
+  console.error("\nProbe failed:", error);
+  child.kill();
+  process.exit(1);
+});

--- a/src/main/attachments/localFiles.ts
+++ b/src/main/attachments/localFiles.ts
@@ -56,7 +56,17 @@ export function registerLocalFileProtocolScheme(): void {
   protocol.registerSchemesAsPrivileged([
     {
       scheme: "lightcode-local",
-      privileges: { standard: false, secure: true, supportFetchAPI: true, stream: true },
+      // `standard: true` is required so Chromium can load cached ACP registry
+      // icons in CSS `mask-image` (ProviderIcon external glyphs). With
+      // `standard: false` the scheme behaves like `file://` and mask sources
+      // fail cross-origin from the renderer document.
+      privileges: {
+        standard: true,
+        secure: true,
+        corsEnabled: true,
+        supportFetchAPI: true,
+        stream: true,
+      },
     },
   ]);
 }

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -113,7 +113,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -159,7 +159,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -223,7 +223,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -314,7 +314,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -391,7 +391,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -460,7 +460,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}
@@ -543,7 +543,7 @@ describe("ThreadComposerSection", () => {
         todoDockPlacement="composer"
         todoDockState={null}
         goalDockState={null}
-        errorDockState={null}
+        errorDockStates={[]}
         onGoalDockDismiss={() => undefined}
         onDismissError={() => undefined}
         onConfigChange={() => undefined}

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -264,9 +264,9 @@ type ThreadComposerSectionProps = {
   todoDockPlacement: "composer" | "right";
   todoDockState: ThreadTodoDockState | null;
   goalDockState: ThreadGoalDockState | null;
-  errorDockState: ThreadErrorDockState | null;
+  errorDockStates: ThreadErrorDockState[];
   onGoalDockDismiss: () => void;
-  onDismissError: () => void;
+  onDismissError: (sourceItemId: string) => void;
   onConfigChange: (config: ThreadConfig) => void;
   onResolveServerRequest: (input: {
     requestId: ThreadServerRequestId;
@@ -294,7 +294,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     todoDockPlacement,
     todoDockState,
     goalDockState,
-    errorDockState,
+    errorDockStates,
   } = props;
   const [prompt, setPrompt] = useState("");
   const [hasContent, setHasContent] = useState(false);
@@ -355,11 +355,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const showCommandPanel = filteredCommands.length > 0;
   // A stale runtime auth error (e.g. a 401 from before the user signed in)
   // must not keep the auth dock visible once detection confirms the agent is
-  // authenticated again — otherwise the dock sticks until the user sends a
-  // new message and the error item scrolls off `selectThreadLatestErrorItem`.
+  // authenticated again — otherwise the dock sticks until the user retries.
   const isAgentAuthenticated = agentStatus?.authState === "authenticated";
   const hasRuntimeAuthError =
-    !isAgentAuthenticated && errorDockState !== null && isAuthErrorMessage(errorDockState.message);
+    !isAgentAuthenticated && errorDockStates.some((state) => isAuthErrorMessage(state.message));
   const authRequired = agentStatus?.authState === "missing" || hasRuntimeAuthError;
   const isServerControlled =
     agentStatus?.capabilities.liveInputMode === "server" || !usesTerminalPresentation;
@@ -392,7 +391,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     !usesTerminalPresentation && todoDockState !== null && todoDockPlacement === "composer";
   const showGoalInComposer = !usesTerminalPresentation && goalDockState !== null;
   const showErrorInComposer =
-    !usesTerminalPresentation && errorDockState !== null && !hasRuntimeAuthError;
+    !usesTerminalPresentation && errorDockStates.length > 0 && !hasRuntimeAuthError;
   const hasActiveSubAgent = useAppStore(
     (s) => !usesTerminalPresentation && selectActiveSubAgentParentItemIds(s, thread.id).length > 0,
   );
@@ -749,12 +748,15 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                             onClose={() => setContextDockOpen(false)}
                           />
                         ) : null}
-                        {showErrorInComposer ? (
-                          <ThreadErrorDock
-                            state={errorDockState!}
-                            onDismiss={props.onDismissError}
-                          />
-                        ) : null}
+                        {showErrorInComposer
+                          ? errorDockStates.map((state) => (
+                              <ThreadErrorDock
+                                key={state.sourceItemId}
+                                state={state}
+                                onDismiss={() => props.onDismissError(state.sourceItemId)}
+                              />
+                            ))
+                          : null}
                         {showGoalInComposer ? (
                           <ThreadGoalDock
                             state={goalDockState!}

--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useShallow } from "zustand/react/shallow";
 import type {
   AgentStatus,
   ProjectLocation,
@@ -18,7 +19,7 @@ import { guiChatFontCssVars } from "./ChatPane/chatFontVars";
 import { TerminalPane, type TerminalPaneHandle } from "./TerminalPane";
 import { ThreadComposerSection } from "./ThreadComposerSection";
 import { ThreadTodoDock } from "./ThreadTodoDock";
-import { getThreadErrorDockStateForItem, selectThreadLatestErrorItem } from "./threadErrorState";
+import { selectThreadErrorDockStates } from "./threadErrorState";
 import { selectThreadGoalDockItem, selectThreadGoalDockState } from "./threadGoalState";
 import { selectThreadTodoDockItem, selectThreadTodoDockState } from "./threadTodoState";
 
@@ -43,7 +44,7 @@ const emptyTodoComposerProps = {
   todoDockPlacement: "composer" as const,
   todoDockState: null,
   goalDockState: null,
-  errorDockState: null,
+  errorDockStates: [],
   onGoalDockDismiss: () => undefined,
   onTodoDockCollapsedChange: () => undefined,
   onTodoDockPlacementChange: () => undefined,
@@ -130,12 +131,19 @@ export function GuiThreadContent(
     lastGoalItemRef.current = goalItem;
   }, [dismissedGoalItemId, goalItem]);
 
-  const errorItem = useAppStore((s) => selectThreadLatestErrorItem(s, props.threadId));
-  const [dismissedErrorItemId, setDismissedErrorItemId] = useState<string | null>(null);
-  const errorDockState =
-    errorItem && errorItem.id !== dismissedErrorItemId
-      ? getThreadErrorDockStateForItem(errorItem)
-      : null;
+  const errorDockStatesRaw = useAppStore(
+    useShallow((s) => selectThreadErrorDockStates(s, props.threadId)),
+  );
+  const [dismissedErrorItemIds, setDismissedErrorItemIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  useEffect(() => {
+    setDismissedErrorItemIds(new Set());
+  }, [props.threadId]);
+  const errorDockStates = useMemo(
+    () => errorDockStatesRaw.filter((state) => !dismissedErrorItemIds.has(state.sourceItemId)),
+    [dismissedErrorItemIds, errorDockStatesRaw],
+  );
   const showTodoDock = todoDockState !== null && todoDockState.sourceItemId !== retiredSourceItemId;
   const showGoalDock = goalDockState !== null && goalDockState.sourceItemId !== dismissedGoalItemId;
   const showTodoInRightRail = showTodoDock && todoDockPlacement === "right";
@@ -202,11 +210,13 @@ export function GuiThreadContent(
         todoDockPlacement={todoDockPlacement}
         todoDockState={showTodoDock ? todoDockState : null}
         goalDockState={showGoalDock ? goalDockState : null}
-        errorDockState={errorDockState}
+        errorDockStates={errorDockStates}
         onGoalDockDismiss={() =>
           goalDockState && setDismissedGoalItemId(goalDockState.sourceItemId)
         }
-        onDismissError={() => errorItem && setDismissedErrorItemId(errorItem.id)}
+        onDismissError={(sourceItemId) =>
+          setDismissedErrorItemIds((prev) => new Set([...prev, sourceItemId]))
+        }
         onTodoDockCollapsedChange={(collapsed) => setTodoDockCollapsed(thread.id, collapsed)}
         onTodoDockPlacementChange={(placement) => setTodoDockPlacement(thread.id, placement)}
         onTodoDockRetire={() =>

--- a/src/renderer/components/thread/threadErrorState.test.ts
+++ b/src/renderer/components/thread/threadErrorState.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
-import { getThreadErrorDockStateForItem, isAuthErrorMessage } from "./threadErrorState";
+import type { AppStoreState } from "@/renderer/state/slices/shared";
+import {
+  getThreadErrorDockStateForItem,
+  isAuthErrorMessage,
+  selectThreadErrorDockStates,
+} from "./threadErrorState";
 
-function errorItem(message: string): RuntimeChatItem {
+function errorItem(id: string, message: string): RuntimeChatItem {
   return {
-    id: "err-1",
+    id,
     type: "error",
     state: "completed",
     payload: { message },
@@ -14,15 +19,62 @@ function errorItem(message: string): RuntimeChatItem {
 
 describe("threadErrorState", () => {
   it("suppresses abort-only composer errors", () => {
-    expect(getThreadErrorDockStateForItem(errorItem("Aborted"))).toBeNull();
-    expect(getThreadErrorDockStateForItem(errorItem("AbortError: aborted"))).toBeNull();
+    expect(getThreadErrorDockStateForItem(errorItem("err-1", "Aborted"))).toBeNull();
+    expect(getThreadErrorDockStateForItem(errorItem("err-2", "AbortError: aborted"))).toBeNull();
   });
 
   it("keeps non-abort composer errors", () => {
-    expect(getThreadErrorDockStateForItem(errorItem("Network error: request failed"))).toEqual({
+    expect(
+      getThreadErrorDockStateForItem(errorItem("err-1", "Network error: request failed")),
+    ).toEqual({
       sourceItemId: "err-1",
       message: "Network error: request failed",
     });
+  });
+
+  it("returns a stable empty array when there are no errors", () => {
+    const state = {
+      runtimeItemIdsByThread: { "t-1": ["user-1"] },
+      runtimeItemsByIdByThread: {
+        "t-1": {
+          "user-1": {
+            id: "user-1",
+            type: "user_message",
+            state: "completed",
+            payload: {},
+            streams: {},
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+    expect(selectThreadErrorDockStates(state, "t-1")).toBe(
+      selectThreadErrorDockStates(state, "t-1"),
+    );
+  });
+
+  it("returns all errors since the latest user message in order", () => {
+    const state = {
+      runtimeItemIdsByThread: {
+        "t-1": ["user-1", "err-a", "err-b"],
+      },
+      runtimeItemsByIdByThread: {
+        "t-1": {
+          "user-1": {
+            id: "user-1",
+            type: "user_message",
+            state: "completed",
+            payload: {},
+            streams: {},
+          },
+          "err-a": errorItem("err-a", "Usage limit reached."),
+          "err-b": errorItem("err-b", "Internal error"),
+        },
+      },
+    } as unknown as AppStoreState;
+    expect(selectThreadErrorDockStates(state, "t-1")).toEqual([
+      { sourceItemId: "err-a", message: "Usage limit reached." },
+      { sourceItemId: "err-b", message: "Internal error" },
+    ]);
   });
 });
 

--- a/src/renderer/components/thread/threadErrorState.ts
+++ b/src/renderer/components/thread/threadErrorState.ts
@@ -10,30 +10,46 @@ export interface ThreadErrorDockState {
   message: string;
 }
 
-export function selectThreadErrorDockState(
-  state: AppStoreState,
-  threadId: string,
-): ThreadErrorDockState | null {
-  const item = selectThreadLatestErrorItem(state, threadId);
-  return item ? getThreadErrorDockStateForItem(item) : null;
-}
+const EMPTY_ERROR_DOCK_STATES: ThreadErrorDockState[] = [];
 
-export function selectThreadLatestErrorItem(
+const errorDockStatesCache = new Map<
+  string,
+  {
+    itemIds: readonly string[] | undefined;
+    result: ThreadErrorDockState[];
+  }
+>();
+
+const errorDockStateByItem = new WeakMap<RuntimeChatItem, ThreadErrorDockState>();
+
+/** Errors since the latest user message, oldest → newest (composer order). */
+export function selectThreadErrorDockStates(
   state: AppStoreState,
   threadId: string,
-): RuntimeChatItem | null {
+): ThreadErrorDockState[] {
   const itemIds = state.runtimeItemIdsByThread[threadId];
-  if (!itemIds?.length) return null;
+  const cached = errorDockStatesCache.get(threadId);
+  if (cached && cached.itemIds === itemIds) {
+    return cached.result;
+  }
+
+  if (!itemIds?.length) {
+    errorDockStatesCache.set(threadId, { itemIds, result: EMPTY_ERROR_DOCK_STATES });
+    return EMPTY_ERROR_DOCK_STATES;
+  }
+
   const itemsById = state.runtimeItemsByIdByThread[threadId];
-  // Walk newest → oldest. If we hit a user_message before any error, the user
-  // has already retried since the last error, so suppress the dock.
+  const sinceLastUser: ThreadErrorDockState[] = [];
   for (let index = itemIds.length - 1; index >= 0; index -= 1) {
     const item = itemsById?.[itemIds[index]!];
     if (!item) continue;
-    if (item.type === "user_message") return null;
-    if (item.type === "error" && getThreadErrorDockStateForItem(item)) return item;
+    if (item.type === "user_message") break;
+    const dock = item.type === "error" ? getThreadErrorDockStateForItem(item) : null;
+    if (dock) sinceLastUser.push(dock);
   }
-  return null;
+  const result = sinceLastUser.length === 0 ? EMPTY_ERROR_DOCK_STATES : sinceLastUser.reverse();
+  errorDockStatesCache.set(threadId, { itemIds, result });
+  return result;
 }
 
 export function getThreadErrorDockStateForItem(item: RuntimeChatItem): ThreadErrorDockState | null {
@@ -42,7 +58,11 @@ export function getThreadErrorDockStateForItem(item: RuntimeChatItem): ThreadErr
   const message = payload?.message?.trim();
   if (!message) return null;
   if (isAbortOnlyErrorMessage(message)) return null;
-  return { sourceItemId: item.id, message };
+  const cached = errorDockStateByItem.get(item);
+  if (cached && cached.message === message) return cached;
+  const dock = { sourceItemId: item.id, message };
+  errorDockStateByItem.set(item, dock);
+  return dock;
 }
 
 function isAbortOnlyErrorMessage(message: string): boolean {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@/renderer/components/providers", () => ({
 
 vi.mock("@/renderer/hooks/uiSelectors", () => ({
   useCurrentThreadIdsCount: () => 1,
-  useInstalledAgents: () => [],
+  useProjectAgentStatuses: () => [],
   useIsCurrentThread: () => false,
 }));
 

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -27,8 +27,8 @@ import { InlineRenameInput } from "../InlineRenameInput";
 import { ThreadItemSuffix } from "./parts/ThreadItemSuffix";
 import {
   useCurrentThreadIdsCount,
-  useInstalledAgents,
   useIsCurrentThread,
+  useProjectAgentStatuses,
 } from "@/renderer/hooks/uiSelectors";
 import { openGitReview } from "@/renderer/actions/panelActions";
 import {
@@ -77,8 +77,8 @@ export function SortableThreadItem(props: {
   } = props;
   const isCurrentThread = useIsCurrentThread(thread.id);
   const currentThreadCount = useCurrentThreadIdsCount();
-  const installedAgents = useInstalledAgents();
-  const threadAgent = installedAgents.find((agent) => agent.kind === thread.agentKind);
+  const projectAgents = useProjectAgentStatuses(project.location);
+  const threadAgent = projectAgents.find((agent) => agent.kind === thread.agentKind);
   const worktreeGitItems = useWorktreeGitItems(
     thread.projectId,
     thread.worktreePath ?? "",
@@ -181,9 +181,9 @@ export function SortableThreadItem(props: {
             icon: <ArrowRightLeft className="size-3.5" />,
             isDisabled:
               !thread.sessionRef ||
-              installedAgents.filter((a) => a.kind !== thread.agentKind).length === 0,
+              projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0,
             ...(!thread.sessionRef ||
-            installedAgents.filter((a) => a.kind !== thread.agentKind).length === 0
+            projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0
               ? {
                   disabledReason: !thread.sessionRef
                     ? "No active session"

--- a/src/supervisor/agents/acp/acpUserVisibleErrors.test.ts
+++ b/src/supervisor/agents/acp/acpUserVisibleErrors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { parseAcpAgentMessageApiError } from "./acpUserVisibleErrors";
+
+describe("parseAcpAgentMessageApiError", () => {
+  it("extracts detail from Factory Droid usage-limit payloads", () => {
+    const text =
+      'Error: 402 {"detail":"You\'ve reached your 5-hour Droid Core usage limit (resets in 0h 3min).\\nReload Extra Usage credits or wait for your limits to reset.","status":402,"title":"Payment Required","displayToUser":true}';
+    expect(parseAcpAgentMessageApiError(text)).toBe(
+      "You've reached your 5-hour Droid Core usage limit (resets in 0h 3min).\nReload Extra Usage credits or wait for your limits to reset.",
+    );
+  });
+
+  it("maps plain HTTP no-body errors to actionable messages", () => {
+    expect(parseAcpAgentMessageApiError("Error: 403 status code (no body)")).toBe(
+      "Access denied (HTTP 403). Your Factory account may lack permission for this model or workspace.",
+    );
+  });
+
+  it("returns undefined for normal assistant text", () => {
+    expect(parseAcpAgentMessageApiError("Here is the fix for your bug.")).toBeUndefined();
+    expect(parseAcpAgentMessageApiError("Error: something went wrong")).toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/acp/acpUserVisibleErrors.ts
+++ b/src/supervisor/agents/acp/acpUserVisibleErrors.ts
@@ -1,0 +1,67 @@
+/**
+ * Parse API failures Factory Droid surfaces as `agent_message_chunk` text before
+ * `session/prompt` rejects with a generic JSON-RPC error.
+ *
+ * Observed wire format (Factory Droid `exec --output-format acp-daemon`):
+ *   Error: 402 {"detail":"…","status":402,"title":"Payment Required","displayToUser":true,…}
+ *   Error: 403 status code (no body)
+ */
+export function parseAcpAgentMessageApiError(text: string): string | undefined {
+  const trimmed = text.trim();
+  const jsonMatch = /^Error:\s*(\d{3})\s*(\{[\s\S]*\})\s*$/i.exec(trimmed);
+  const statusCode = jsonMatch?.[1];
+  const jsonBody = jsonMatch?.[2];
+  if (statusCode && jsonBody) {
+    return parseJsonApiError(statusCode, jsonBody);
+  }
+
+  const noBodyMatch = /^Error:\s*(\d{3})\s+status code\s*\(no body\)\s*$/i.exec(trimmed);
+  const noBodyStatus = noBodyMatch?.[1];
+  if (noBodyStatus) {
+    return httpStatusUserMessage(noBodyStatus);
+  }
+
+  const plainMatch = /^Error:\s*(\d{3})\s+(.+)$/i.exec(trimmed);
+  const plainStatus = plainMatch?.[1];
+  const plainDetail = plainMatch?.[2];
+  if (plainStatus && plainDetail && !plainDetail.trimStart().startsWith("{")) {
+    const detail = plainDetail.trim();
+    if (detail.length > 0 && !/^status code\b/i.test(detail)) {
+      return detail;
+    }
+    return httpStatusUserMessage(plainStatus);
+  }
+
+  return undefined;
+}
+
+function parseJsonApiError(statusCode: string, jsonText: string): string | undefined {
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(jsonText) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+
+  const detail = typeof payload.detail === "string" ? payload.detail.trim() : undefined;
+  const title = typeof payload.title === "string" ? payload.title.trim() : undefined;
+  if (detail) return detail;
+  if (title && payload.displayToUser === true) return title;
+  if (payload.displayToUser === true) return httpStatusUserMessage(statusCode);
+  return undefined;
+}
+
+function httpStatusUserMessage(code: string): string {
+  switch (code) {
+    case "401":
+      return "Authentication failed (HTTP 401). Sign in to Factory or refresh your credentials.";
+    case "402":
+      return "Payment or usage limit reached (HTTP 402). Check your Factory account billing or usage.";
+    case "403":
+      return "Access denied (HTTP 403). Your Factory account may lack permission for this model or workspace.";
+    case "429":
+      return "Rate limit exceeded (HTTP 429). Wait and retry, or switch models.";
+    default:
+      return `Request failed (HTTP ${code}).`;
+  }
+}

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -46,6 +46,40 @@ describe("mapAcpSessionUpdate", () => {
     expect((second[0] as { delta: string }).delta).toBe(" world");
   });
 
+  it("maps Factory Droid API failures in agent_message_chunk to runtime errors", () => {
+    const state = createAcpMapperState("t-droid-limit");
+    const text =
+      'Error: 402 {"detail":"Usage limit reached.","status":402,"title":"Payment Required","displayToUser":true}';
+    const events = mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text } }),
+      state,
+    );
+    expect(events).toEqual([
+      { type: "error", threadId: "t-droid-limit", message: "Usage limit reached." },
+    ]);
+    expect(state.openAssistantItemId).toBeUndefined();
+  });
+
+  it("maps plain HTTP no-body agent errors to runtime errors", () => {
+    const state = createAcpMapperState("t-droid-403");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "Error: 403 status code (no body)" },
+      }),
+      state,
+    );
+    expect(events).toEqual([
+      {
+        type: "error",
+        threadId: "t-droid-403",
+        message:
+          "Access denied (HTTP 403). Your Factory account may lack permission for this model or workspace.",
+      },
+    ]);
+    expect(state.openAssistantItemId).toBeUndefined();
+  });
+
   it("drops [MODE_UPDATE] agent text echoes — mode is chosen in the launcher, not chat", () => {
     // Gemini's ACP server emits `[MODE_UPDATE] <mode>` as a fresh
     // agent_message_chunk every time a session starts (or switches) into a

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -38,6 +38,7 @@ import {
   readNonNegativeInteger,
   usageFromTokenCounts,
 } from "../contextUsage";
+import { parseAcpAgentMessageApiError } from "./acpUserVisibleErrors";
 
 interface AcpToolCallItemState {
   itemId: string;
@@ -216,6 +217,14 @@ export function mapAcpSessionUpdate(
         /^\[MODE_UPDATE\]/.test(content.text)
       ) {
         break;
+      }
+      if (content?.type === "text") {
+        const apiError = parseAcpAgentMessageApiError(content.text);
+        if (apiError) {
+          events.push(...closeOpenContentItems(state));
+          events.push({ type: "error", threadId, message: apiError });
+          break;
+        }
       }
       // Open an assistant item on first chunk; emit deltas thereafter.
       if (!state.openAssistantItemId) {

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -13,6 +13,7 @@ import {
   shouldSpawnAcpSession,
   toAcpResourceUri,
 } from "./session";
+import { resolveAcpPromptFailureMessage, shouldEmitAcpPromptRpcErrorItem } from "./sessionErrors";
 
 function makeInput(
   overrides: Partial<CreateStructuredSessionInput> = {},
@@ -207,6 +208,36 @@ describe("shouldSpawnAcpSession — shared resume/presentation gate for all ACP 
     expect(shouldSpawnAcpSession(makeInput({ presentationMode: "gui" }))).toBe(true);
     expect(shouldSpawnAcpSession(makeInput({ presentationMode: "terminal" }))).toBe(true);
     expect(shouldSpawnAcpSession(makeInput())).toBe(true);
+  });
+});
+
+describe("resolveAcpPromptFailureMessage — prompt rejection after agent-surfaced errors", () => {
+  it("prefers the usage-limit detail streamed in agent_message_chunk", () => {
+    const usage =
+      "You've reached your weekly standard usage limit (resets in 2 days).\nSwitch to Droid Core or enable Extra Usage to continue.";
+    const out = resolveAcpPromptFailureMessage(
+      RequestError.internalError({ details: "Internal error: Agent error" }),
+      usage,
+    );
+    expect(out).toBe(usage);
+  });
+
+  it("falls back to the JSON-RPC error when no agent-surfaced message exists", () => {
+    expect(
+      resolveAcpPromptFailureMessage(RequestError.internalError({ details: "Agent error" })),
+    ).toBe("Internal error");
+  });
+
+  it("suppresses a generic Internal error row when usage detail was already streamed", () => {
+    const usage = "Usage limit reached.";
+    const transport = RequestError.internalError({ details: "Internal error: Agent error" });
+    expect(shouldEmitAcpPromptRpcErrorItem(transport, usage)).toBe(false);
+    expect(resolveAcpPromptFailureMessage(transport, usage)).toBe(usage);
+  });
+
+  it("still emits the RPC error row when no agent-surfaced message exists", () => {
+    const transport = RequestError.internalError({ details: "Agent error" });
+    expect(shouldEmitAcpPromptRpcErrorItem(transport, undefined)).toBe(true);
   });
 });
 

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -187,7 +187,10 @@ import {
   appendInterruptAckTextTail,
   createAcpPromptUsageEvent,
   normalizeAcpStopReason,
+  resolveAcpPromptFailureMessage,
+  resolveAcpPromptRpcErrorMessage,
   rewriteLoadSessionError,
+  shouldEmitAcpPromptRpcErrorItem,
 } from "./sessionErrors";
 import {
   buildAcpElicitationAnswerEvents,
@@ -482,6 +485,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private pendingPromptInterrupt = false;
   private currentTurnInterruptRequested = false;
   private recentInterruptAckTextTail = "";
+  /** User-visible error text from an `agent_message_chunk` before `prompt()` settles. */
+  private agentSurfacedErrorMessage: string | undefined;
   private availableModeIds: string[] = [];
   private currentConfigOptions: unknown[] = [];
   private modeConfigId: string | undefined;
@@ -1014,6 +1019,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     }
     this.currentTurnInterruptRequested = false;
     this.recentInterruptAckTextTail = "";
+    this.agentSurfacedErrorMessage = undefined;
 
     await this.applyTurnConfig(config);
 
@@ -1070,44 +1076,24 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         interruptRequested: this.currentTurnInterruptRequested,
         recentAgentText: this.recentInterruptAckTextTail,
       });
-      const { status, attention } = this.mapStopReason(normalizedStopReason);
-      this.emitListenerUpdate({ status, attention });
-
-      // Close any items still open at end-of-turn and emit turn.completed.
-      const mapperState = this.ensureMapperState();
-      this.emitRuntimeEvents([
-        ...closeOpenTurnItems(mapperState),
-        {
-          type: "turn.completed",
-          threadId: this.threadId,
-          turnId: this.currentTurnId,
-          state: normalizedStopReason === "cancelled" ? "cancelled" : "completed",
-        },
-      ]);
+      this.emitTurnStatusAfterPrompt(normalizedStopReason);
+      this.completeTurn(
+        this.ensureMapperState(),
+        this.agentSurfacedErrorMessage
+          ? "failed"
+          : normalizedStopReason === "cancelled"
+            ? "cancelled"
+            : "completed",
+      );
     } catch (error) {
       if (this.isDisposed) return;
-      const message = error instanceof Error ? error.message : String(error);
-      this.emitListenerUpdate({ status: "error", attention: "error", errorMessage: message });
-      const mapperState = this.ensureMapperState();
-      this.emitRuntimeEvents([
-        ...closeOpenTurnItems(mapperState),
-        { type: "error", threadId: this.threadId, message },
-        ...(this.currentTurnId
-          ? ([
-              {
-                type: "turn.completed",
-                threadId: this.threadId,
-                turnId: this.currentTurnId,
-                state: "failed",
-              },
-            ] as RuntimeEvent[])
-          : []),
-      ]);
+      this.emitPromptFailure(error);
     } finally {
       this.promptInFlight = false;
       this.pendingPromptInterrupt = false;
       this.currentTurnInterruptRequested = false;
       this.recentInterruptAckTextTail = "";
+      this.agentSurfacedErrorMessage = undefined;
       // The mapper's per-turn item state has been cleared via
       // `closeOpenTurnItems`, so any output snapshots from terminals that
       // belonged to this turn are no longer reachable. Drop them so the cache
@@ -1597,7 +1583,10 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     // avoid duplicating every message in the chat pane.
     if (!this.isReplayingHistory && Date.now() >= (this.replayHistoryUntil || 0)) {
       const events = mapAcpSessionUpdate(params, this.ensureMapperState());
-      if (events.length > 0) this.emitRuntimeEvents(events);
+      if (events.length > 0) {
+        this.recordAgentSurfacedError(events);
+        this.emitRuntimeEvents(events);
+      }
     } else {
       return;
     }
@@ -1690,6 +1679,72 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       default:
         break;
     }
+  }
+
+  private recordAgentSurfacedError(events: RuntimeEvent[]): void {
+    for (const event of events) {
+      if (event.type !== "error") continue;
+      this.agentSurfacedErrorMessage = event.message;
+      this.emitListenerUpdate({
+        status: "error",
+        attention: "error",
+        errorMessage: event.message,
+      });
+      return;
+    }
+  }
+
+  private emitTurnStatusAfterPrompt(normalizedStopReason: string): void {
+    if (this.agentSurfacedErrorMessage) {
+      this.emitListenerUpdate({
+        status: "error",
+        attention: "error",
+        errorMessage: this.agentSurfacedErrorMessage,
+      });
+      return;
+    }
+    const { status, attention } = this.mapStopReason(normalizedStopReason);
+    this.emitListenerUpdate({ status, attention });
+  }
+
+  private completeTurn(
+    mapperState: AcpMapperState,
+    turnState: "completed" | "cancelled" | "failed",
+  ): void {
+    if (!this.currentTurnId) return;
+    this.emitRuntimeEvents([
+      ...closeOpenTurnItems(mapperState),
+      {
+        type: "turn.completed",
+        threadId: this.threadId,
+        turnId: this.currentTurnId,
+        state: turnState,
+      },
+    ]);
+  }
+
+  private emitPromptFailure(error: unknown): void {
+    const headerMessage = resolveAcpPromptFailureMessage(error, this.agentSurfacedErrorMessage);
+    const rpcMessage = resolveAcpPromptRpcErrorMessage(error);
+    this.emitListenerUpdate({
+      status: "error",
+      attention: "error",
+      errorMessage: headerMessage,
+    });
+    const mapperState = this.ensureMapperState();
+    const events: RuntimeEvent[] = [...closeOpenTurnItems(mapperState)];
+    if (shouldEmitAcpPromptRpcErrorItem(error, this.agentSurfacedErrorMessage)) {
+      events.push({ type: "error", threadId: this.threadId, message: rpcMessage });
+    }
+    if (this.currentTurnId) {
+      events.push({
+        type: "turn.completed",
+        threadId: this.threadId,
+        turnId: this.currentTurnId,
+        state: "failed",
+      });
+    }
+    this.emitRuntimeEvents(events);
   }
 
   private mapStopReason(stopReason: string): { status: ThreadStatus; attention: ThreadAttention } {

--- a/src/supervisor/agents/acp/sessionErrors.ts
+++ b/src/supervisor/agents/acp/sessionErrors.ts
@@ -67,6 +67,59 @@ export function appendInterruptAckTextTail(current: string, next: string): strin
   return combined.slice(-INTERRUPT_ACK_TEXT_TAIL_LIMIT);
 }
 
+/**
+ * Factory Droid streams a user-visible `agent_message_chunk` (402/403 detail),
+ * then `session/prompt` rejects with JSON-RPC -32603 "Internal error". Prefer
+ * the message we already parsed from the chunk.
+ */
+export function resolveAcpPromptFailureMessage(
+  error: unknown,
+  agentSurfacedMessage?: string,
+): string {
+  if (agentSurfacedMessage) return agentSurfacedMessage;
+  return resolveAcpPromptRpcErrorMessage(error);
+}
+
+/**
+ * After Factory Droid streams a specific `agent_message_chunk` error, `prompt()`
+ * often rejects with JSON-RPC -32603 / "Internal error". Skip that redundant
+ * composer row when we already have the real message.
+ */
+export function shouldEmitAcpPromptRpcErrorItem(
+  error: unknown,
+  agentSurfacedMessage?: string,
+): boolean {
+  if (!agentSurfacedMessage) return true;
+  if (isGenericAcpPromptTransportError(error)) return false;
+  const rpcMessage = resolveAcpPromptRpcErrorMessage(error);
+  return rpcMessage !== agentSurfacedMessage && !isGenericAcpPromptRpcErrorMessage(rpcMessage);
+}
+
+function isGenericAcpPromptTransportError(error: unknown): boolean {
+  if (error instanceof RequestError && error.code === -32603) return true;
+  return isGenericAcpPromptRpcErrorMessage(resolveAcpPromptRpcErrorMessage(error));
+}
+
+function isGenericAcpPromptRpcErrorMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase();
+  return normalized === "internal error" || normalized.startsWith("internal error:");
+}
+
+/** JSON-RPC error from `session/prompt` — may follow a separate agent_message_chunk. */
+export function resolveAcpPromptRpcErrorMessage(error: unknown): string {
+  if (error instanceof RequestError) {
+    if (error.message.trim().length > 0) return error.message;
+    const data = error.data as { details?: unknown; detail?: unknown } | undefined;
+    if (typeof data?.details === "string" && data.details.trim().length > 0) {
+      return data.details.trim();
+    }
+    if (typeof data?.detail === "string" && data.detail.trim().length > 0) {
+      return data.detail.trim();
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function normalizeAcpStopReason(
   stopReason: string,
   input: { interruptRequested: boolean; recentAgentText?: string },

--- a/src/supervisor/agents/acpRegistryIcons.ts
+++ b/src/supervisor/agents/acpRegistryIcons.ts
@@ -7,8 +7,10 @@
  * where ACP agent tiles render with no glyph until the network round-trip completes.
  *
  * This helper downloads the SVG once at install / backfill time and returns a
- * `lightcode-local://` URL pointing at the cached file. The renderer can then paint
- * the icon synchronously on every subsequent app start.
+ * `lightcode-local://` URL pointing at the cached file. The renderer paints the
+ * icon via CSS `mask-image` in `ProviderIcon`; the `lightcode-local` scheme must
+ * be registered as a standard+cors-enabled protocol in the main process for those
+ * masks to load.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -69,6 +71,18 @@ export function isRemoteIconUrl(url: string): boolean {
   return /^https?:\/\//i.test(url);
 }
 
+/** Registry SVGs use `fill="currentColor"`; standalone mask sources need opaque alpha. */
+function normalizeSvgForMask(filePath: string): void {
+  if (!filePath.endsWith(".svg")) return;
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    if (!/currentColor/i.test(raw)) return;
+    writeFileSync(filePath, raw.replaceAll(/currentColor/gi, "#000"), "utf8");
+  } catch {
+    // Best-effort; a broken SVG still falls back to the remote URL on cache miss.
+  }
+}
+
 /**
  * Cache a remote ACP registry icon to disk and return a `lightcode-local://`
  * URL pointing at the cached file. Reuses an existing cache entry when the
@@ -90,11 +104,13 @@ export async function cacheAcpRegistryIcon(input: {
   const fileName = iconFileName(input.agentId, input.iconUrl);
   const filePath = join(input.iconsDir, fileName);
   if (index.entries[input.agentId] === input.iconUrl && existsSync(filePath)) {
+    normalizeSvgForMask(filePath);
     return toLocalFileUrl(filePath);
   }
   try {
     mkdirSync(input.iconsDir, { recursive: true });
     await downloadToFile(input.iconUrl, filePath);
+    normalizeSvgForMask(filePath);
   } catch (error) {
     console.warn(
       `[acp-registry] icon cache failed for ${input.agentId}:`,

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -36,9 +36,15 @@ vi.mock("./binaryResolver", async (importActual) => {
 
 vi.mock("./base/processRuntime", async (importActual) => {
   const actual = await importActual<typeof import("./base/processRuntime")>();
+  const shellBinaries = new Set(["pwsh.exe", "pwsh", "powershell.exe", "powershell"]);
   return {
     ...actual,
     resolveWslShellPath: () => "/bin/bash",
+    // Keep shell detection real, but skip PATH resolution for agent CLIs so
+    // Windows tests assert argv shaping (`codex`, `copilot`) instead of fnm
+    // node.exe / .cmd shim expansion on the host machine.
+    resolveExecutablePath: (binary: string) =>
+      shellBinaries.has(binary) ? actual.resolveExecutablePath(binary) : undefined,
   };
 });
 

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -447,6 +447,21 @@ export class SupervisorRuntime {
     if (changed) {
       this.sharedSettingsCache.invalidate();
       this.refreshAgentRegistryAdapters();
+      const settings = readAcpRegistrySettings(this.settingsPath);
+      const acpKinds = Object.entries(settings.agentInstances)
+        .filter(([, instance]) => instance.driver === "acp-generic")
+        .map(([id]) => acpGenericKind(id));
+      if (acpKinds.length > 0) {
+        try {
+          const wslDistros = await this.agentStatusService.listWslDistros();
+          await this.agentStatusService.refreshAgentStatuses({
+            wslDistros,
+            scope: { agentKinds: acpKinds },
+          });
+        } catch (error) {
+          console.warn("[supervisor] refresh after ACP icon backfill failed", error);
+        }
+      }
     }
     return registry;
   }


### PR DESCRIPTION
- **Bugfix:** Parse Factory Droid usage-limit and HTTP failures from ACP `agent_message_chunk` traffic into clear runtime errors, and prefer them over generic JSON-RPC prompt failures so users see actionable messages
- **Bugfix:** Show all composer error docks since the latest user message (oldest first), with per-item dismiss, so stacked ACP failures are not hidden behind a single “latest error” slot
- **Bugfix:** Restore ACP registry agent icons in the sidebar and provider UI by normalizing cached SVGs for CSS masks and registering `lightcode-local` as a standard, CORS-enabled protocol
- Refresh scoped agent install status after icon backfill so sidebar tiles pick up cached glyphs without a manual reload
- Add a Factory Droid ACP probe script (output under `logs/`) for capturing raw session traffic during diagnosis