### PR TITLE
Include thread worktrees in git watch and status refresh

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - "."
   - "website"
 
+# Share the virtual store across worktrees/checkouts via symlinks instead of
+# hardlinking every package into each node_modules/.pnpm (see pnpm.io/git-worktrees).
+enableGlobalVirtualStore: true
+
 allowBuilds:
   "@sentry/cli": true
   better-sqlite3: true

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -919,6 +919,60 @@ describe("App", () => {
     });
   });
 
+  it("keeps existing thread worktrees watched when creating another worktree", async () => {
+    useAppStore.persist.hasHydrated = vi.fn<() => boolean>().mockReturnValue(true);
+    useAppStore.persist.onHydrate = vi.fn<() => () => void>(() => () => undefined);
+    useAppStore.persist.onFinishHydration = vi.fn<() => () => void>(() => () => undefined);
+
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [
+        {
+          id: "project-1",
+          name: "Repo",
+          location: {
+            kind: "windows",
+            path: "C:\\repo",
+          },
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      threads: [
+        {
+          id: "thread-existing",
+          projectId: "project-1",
+          title: "Existing worktree",
+          agentKind: "codex",
+          config: { model: "gpt-5.4" },
+          status: "idle",
+          attention: "none",
+          canResumeWithConfig: false,
+          worktreePath: "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-y",
+          worktreeBranch: "feature/y",
+          archived: false,
+          done: false,
+          starred: false,
+          createdAt: "2026-03-22T00:00:00.000Z",
+          updatedAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      view: { kind: "draft", projectId: "project-1" },
+    }));
+
+    render(<App />);
+    fireEvent.click(screen.getByText("start-worktree"));
+
+    await waitFor(() => {
+      expect(bridge.gitWatchWorktrees).toHaveBeenCalledWith({
+        projectId: "project-1",
+        worktreePaths: [
+          "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-x",
+          "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-y",
+        ],
+      });
+    });
+  });
+
   it("attaches a new thread to an existing worktree without creating another one", async () => {
     useAppStore.persist.hasHydrated = vi.fn<() => boolean>().mockReturnValue(true);
     useAppStore.persist.onHydrate = vi.fn<() => () => void>(() => () => undefined);

--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -11,8 +11,10 @@ import { useAppStore } from "./appStore";
 import { useGitStore } from "./gitStore";
 import { buildBranchPrKey } from "./gitSelectors";
 import {
+  cleanupGitRefreshProjects,
   PR_PENDING_REFRESH_INTERVAL_MS,
   PR_POST_PUSH_STATUS_POLL_MS,
+  refreshGitProject,
   stopPendingPrRefresh,
   startPostPushPrStatusRefresh,
   syncPendingPrRefreshProjects,
@@ -313,5 +315,144 @@ describe("pending PR refresh", () => {
     await vi.advanceTimersByTimeAsync(PR_POST_PUSH_STATUS_POLL_MS);
 
     expect(ghGetPrForBranchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("watcher git status refresh", () => {
+  beforeEach(() => {
+    cleanupGitRefreshProjects(new Set());
+    useGitStore.setState({
+      statuses: {},
+      worktreeStatuses: {},
+      worktrees: {},
+      branches: {},
+      ghAvailable: {},
+      prData: {},
+      worktreeSourceInfo: {},
+      prDetails: {},
+      prFiles: {},
+      prDiffs: {},
+    });
+    useAppStore.setState({ projects: [project], threads: [] });
+  });
+
+  afterEach(() => {
+    cleanupGitRefreshProjects(new Set());
+  });
+
+  it("refreshes thread worktree statuses before the full worktree cache catches up", async () => {
+    const getGitStatus = vi.fn<() => Promise<GitStatusResult>>().mockResolvedValue(status);
+    const worktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      unstaged: [
+        {
+          path: "src/changed.ts",
+          status: "M",
+          staged: false,
+          insertions: 3,
+          deletions: 1,
+        },
+      ],
+      totalInsertions: 3,
+      totalDeletions: 1,
+    };
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockResolvedValue({ statuses: { "/repo-wt": worktreeStatus } });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        getGitStatus,
+        gitWorktreeStatusBatch,
+      },
+    });
+    useGitStore.getState().setWorktrees("p1", [
+      {
+        path: "/repo",
+        branch: "main",
+        commit: "abc123",
+        isMain: true,
+      },
+    ]);
+    useAppStore.setState({ threads: [worktreeThread] });
+
+    await refreshGitProject(project, "watcher", "status");
+
+    expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
+      projectLocation: location,
+      worktreePaths: ["/repo-wt"],
+    });
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
+  });
+
+  it("keeps thread worktrees watched when a stale full refresh has not listed them yet", async () => {
+    const worktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      unstaged: [
+        {
+          path: "src/changed.ts",
+          status: "M",
+          staged: false,
+          insertions: 3,
+          deletions: 1,
+        },
+      ],
+      totalInsertions: 3,
+      totalDeletions: 1,
+    };
+    const gitWatchWorktrees = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockResolvedValue({ statuses: { "/repo-wt": worktreeStatus } });
+    const gitProjectSnapshot = vi
+      .fn<
+        () => Promise<{
+          status: GitStatusResult;
+          branches: { current: string; branches: unknown[] };
+          worktrees: { path: string; branch: string; commit: string; isMain: boolean }[];
+          ghAvailable: boolean;
+        }>
+      >()
+      .mockResolvedValue({
+        status,
+        branches: { current: "main", branches: [] },
+        worktrees: [{ path: "/repo", branch: "main", commit: "abc123", isMain: true }],
+        ghAvailable: false,
+      });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        gitProjectSnapshot,
+        gitWatchWorktrees,
+        gitWorktreeStatusBatch,
+      },
+    });
+    useAppStore.setState({ threads: [worktreeThread] });
+
+    await refreshGitProject(project, "initial", "full");
+
+    expect(gitWatchWorktrees).toHaveBeenCalledWith({
+      projectId: "p1",
+      worktreePaths: ["/repo-wt"],
+    });
+    expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
+      projectLocation: location,
+      worktreePaths: ["/repo-wt"],
+    });
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
   });
 });

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -301,9 +301,17 @@ async function refreshProjectStatusOnly(
     useGitStore.getState().setStatus(project.id, statusResult);
   }
 
-  const cachedWorktrees = useGitStore.getState().worktrees[project.id];
-  if (!cachedWorktrees || cachedWorktrees.length === 0) return;
-  const childWorktreePaths = cachedWorktrees.filter((wt) => !wt.isMain).map((wt) => wt.path);
+  const cachedWorktreePaths =
+    useGitStore
+      .getState()
+      .worktrees[project.id]?.filter((wt) => !wt.isMain)
+      .map((wt) => wt.path) ?? [];
+  const threadWorktreePaths = useAppStore
+    .getState()
+    .threads.flatMap((thread) =>
+      thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
+    );
+  const childWorktreePaths = [...new Set([...cachedWorktreePaths, ...threadWorktreePaths])];
   if (childWorktreePaths.length === 0) return;
   const batch = await readBridge()
     .gitWorktreeStatusBatch({
@@ -406,17 +414,21 @@ export async function refreshGitProject(
           if (!worktrees) return;
           if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
           const childWorktrees = worktrees.filter((wt) => !wt.isMain);
+          const childWorktreePaths = childWorktrees.map((wt) => wt.path);
+          const threadWorktreePaths = useAppStore
+            .getState()
+            .threads.flatMap((thread) =>
+              thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
+            );
+          const watchWorktreePaths = [...new Set([...childWorktreePaths, ...threadWorktreePaths])];
 
-          const wtPaths = childWorktrees
-            .map((wt) => wt.path)
-            .sort()
-            .join("\0");
+          const wtPaths = [...watchWorktreePaths].sort().join("\0");
           if (wtPaths !== watchedWorktreePaths.get(project.id)) {
             watchedWorktreePaths.set(project.id, wtPaths);
             readBridge()
               .gitWatchWorktrees({
                 projectId: project.id,
-                worktreePaths: childWorktrees.map((wt) => wt.path),
+                worktreePaths: watchWorktreePaths,
               })
               .catch(() => undefined);
           }
@@ -424,7 +436,7 @@ export async function refreshGitProject(
           const statusesPromise = readBridge()
             .gitWorktreeStatusBatch({
               projectLocation: project.location,
-              worktreePaths: childWorktrees.map((wt) => wt.path),
+              worktreePaths: watchWorktreePaths,
             })
             .then((batch) => {
               if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -93,11 +93,11 @@ export function AppContent() {
     );
 
     let worktreePath: string | undefined;
+    let newWorktreeSetupPath: string | undefined;
     if (isHomeScope) {
       worktreePath = undefined;
     } else if (existingWorktreePath) {
       worktreePath = existingWorktreePath;
-      await primeWorktreeGitState(project, existingWorktreePath);
     } else if (worktreeBranch) {
       try {
         const result = await readBridge().gitAddWorktree({
@@ -107,35 +107,7 @@ export function AppContent() {
           startPoint: worktreeBaseBranch,
         });
         worktreePath = result.path;
-        await primeWorktreeGitState(project, result.path);
-
-        // Full refresh so the new worktree enters the cache and gets a file
-        // watcher (status-mode refreshes only walk cached worktrees), and so
-        // any new branch from createBranch shows up in BranchSelectors and
-        // worktreeSourceInfo without lagging a refresh cycle. Without this,
-        // the sidebar diff badge stays empty until the Git review panel
-        // mounts and runs its own one-shot fetch.
-        void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
-
-        const setupScript = project.scripts?.setupScript;
-        if (setupScript) {
-          const wtLocation = buildWorktreeLocation(project.location, result.path);
-          const store = useDevTerminalStore.getState();
-          const tab = store.addTab(project.id, "setup", result.path);
-          if (useSharedSettings.getState().autoShowTerminalPanel) {
-            store.openWorktreePanel(project.id, result.path);
-          }
-          store.setActiveTab(tab.id);
-          startShellWithToast(
-            {
-              shellId: tab.id,
-              projectLocation: wtLocation,
-              worktreePath: result.path,
-            },
-            "setup shell",
-          );
-          writeScriptToShell(tab.id, setupScript);
-        }
+        newWorktreeSetupPath = result.path;
       } catch (err) {
         console.error("[renderer] failed to create worktree:", err);
         return;
@@ -179,6 +151,19 @@ export function AppContent() {
     });
     queueThreadLaunch(thread.id, prompt, segments);
     generateTitleAsync(thread.id, project.location, projectAgentStatuses, titlePrompt);
+    if (worktreePath) {
+      void primeWorktreeGitState(project, worktreePath);
+      // Full refresh so the new worktree enters the cache and any new branch
+      // from createBranch shows up in BranchSelectors and worktreeSourceInfo
+      // without waiting for the next background refresh.
+      void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+    }
+    if (newWorktreeSetupPath) {
+      const setupScript = project.scripts?.setupScript;
+      if (setupScript) {
+        runWorktreeSetupScript(project, newWorktreeSetupPath, setupScript);
+      }
+    }
   }
 
   async function handleContinueInProvider(
@@ -393,7 +378,14 @@ async function primeWorktreeGitState(project: Project, worktreePath: string): Pr
       .getState()
       .worktrees[project.id]?.filter((worktree) => !worktree.isMain)
       .map((worktree) => worktree.path) ?? [];
-  const worktreePaths = [...new Set([...cachedWorktreePaths, worktreePath])];
+  const threadWorktreePaths = useAppStore
+    .getState()
+    .threads.flatMap((thread) =>
+      thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
+    );
+  const worktreePaths = [
+    ...new Set([...cachedWorktreePaths, ...threadWorktreePaths, worktreePath]),
+  ].sort();
   const watchWorktrees = readBridge()
     .gitWatchWorktrees({ projectId: project.id, worktreePaths })
     .catch(() => undefined);
@@ -403,6 +395,25 @@ async function primeWorktreeGitState(project: Project, worktreePath: string): Pr
     .getGitStatus({ projectLocation: buildWorktreeLocation(project.location, worktreePath) })
     .then((status) => useGitStore.getState().setWorktreeStatus(worktreePath, status))
     .catch(() => undefined);
+}
+
+function runWorktreeSetupScript(project: Project, worktreePath: string, setupScript: string): void {
+  const wtLocation = buildWorktreeLocation(project.location, worktreePath);
+  const store = useDevTerminalStore.getState();
+  const tab = store.addTab(project.id, "setup", worktreePath);
+  if (useSharedSettings.getState().autoShowTerminalPanel) {
+    store.openWorktreePanel(project.id, worktreePath);
+  }
+  store.setActiveTab(tab.id);
+  startShellWithToast(
+    {
+      shellId: tab.id,
+      projectLocation: wtLocation,
+      worktreePath,
+    },
+    "setup shell",
+  );
+  writeScriptToShell(tab.id, setupScript);
 }
 
 /**

--- a/src/supervisor/agents/opencode/sdkClient.test.ts
+++ b/src/supervisor/agents/opencode/sdkClient.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   createOpencodeClient: vi.fn<() => unknown>(),
   resolveAgentBinaryPath: vi.fn<() => string>(),
   spawnOpenCodeServer: vi.fn<() => OpenCodeServerHandle>(),
+  disposeSpawnedOpenCodeServerHandles: vi.fn<() => void>(),
 }));
 
 vi.mock("../binaryResolver", () => ({
@@ -21,6 +22,7 @@ vi.mock("./argv", () => ({
 
 vi.mock("./sdkServer", () => ({
   spawnOpenCodeServer: mocks.spawnOpenCodeServer,
+  disposeSpawnedOpenCodeServerHandles: mocks.disposeSpawnedOpenCodeServerHandles,
 }));
 
 vi.mock("@opencode-ai/sdk/v2/client", () => ({
@@ -104,5 +106,30 @@ describe("acquireOpenCodeServer", () => {
 
     await acquired.dispose();
     expect(secondHandle.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shutdownSpawnedOpenCodeServers clears pool bookkeeping and disposes tracked spawns only", async () => {
+    const { acquireOpenCodeServer, shutdownSpawnedOpenCodeServers } = await import("./sdkClient");
+    const handle = makeHandle("http://127.0.0.1:4096");
+    mocks.spawnOpenCodeServer.mockReturnValue(handle);
+
+    const acquired = await acquireOpenCodeServer({
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      browserMcpEnabled: false,
+    });
+    expect(acquired.baseUrl).toBe("http://127.0.0.1:4096");
+
+    shutdownSpawnedOpenCodeServers();
+
+    expect(mocks.disposeSpawnedOpenCodeServerHandles).toHaveBeenCalledTimes(1);
+    expect(handle.dispose).not.toHaveBeenCalled();
+
+    await expect(
+      acquireOpenCodeServer({
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        browserMcpEnabled: false,
+      }),
+    ).resolves.toBeDefined();
+    expect(mocks.spawnOpenCodeServer).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -6,7 +6,11 @@ import { BROWSER_MCP_SERVER_NAME } from "../browserMcp";
 import { buildOpenCodeServerCommand } from "./argv";
 import { buildOpenCodeBrowserMcp } from "./mcpBrowser";
 import { isOpenCodeConnectionLoss } from "./opencodeErrors";
-import { spawnOpenCodeServer, type OpenCodeServerHandle } from "./sdkServer";
+import {
+  disposeSpawnedOpenCodeServerHandles,
+  spawnOpenCodeServer,
+  type OpenCodeServerHandle,
+} from "./sdkServer";
 
 /** Agent-side cwd that the SDK passes through to the server's session config. */
 export function resolveOpenCodeSessionDirectory(location: ProjectLocation): string {
@@ -239,4 +243,21 @@ async function acquireOpenCodeServerInner(
       }
     },
   };
+}
+
+/**
+ * Supervisor shutdown helper. Releases pool bookkeeping, then terminates
+ * only Lightcode-spawned `opencode serve` processes still tracked in
+ * {@link disposeSpawnedOpenCodeServerHandles}. Does not touch unrelated
+ * `opencode.exe` processes the user started outside the app.
+ */
+export function shutdownSpawnedOpenCodeServers(): void {
+  for (const entry of pool.values()) {
+    if (entry.idleCloseTimer) {
+      clearTimeout(entry.idleCloseTimer);
+      entry.idleCloseTimer = undefined;
+    }
+  }
+  pool.clear();
+  disposeSpawnedOpenCodeServerHandles();
 }

--- a/src/supervisor/agents/opencode/sdkServer.ts
+++ b/src/supervisor/agents/opencode/sdkServer.ts
@@ -44,17 +44,21 @@ function terminateOpenCodeServerChildNow(child: ChildProcess): void {
   }
 }
 
-export function disposeOpenCodeServerHandlesForShutdown(): void {
+/** Terminate only `opencode serve` children spawned through {@link spawnOpenCodeServer}. */
+export function disposeSpawnedOpenCodeServerHandles(): void {
   for (const child of activeServerChildren) {
     terminateOpenCodeServerChildNow(child);
   }
   activeServerChildren.clear();
 }
 
+/** @deprecated Use {@link disposeSpawnedOpenCodeServerHandles}. */
+export const disposeOpenCodeServerHandlesForShutdown = disposeSpawnedOpenCodeServerHandles;
+
 function registerProcessExitCleanup(): void {
   if (processExitCleanupRegistered) return;
   processExitCleanupRegistered = true;
-  process.once("exit", disposeOpenCodeServerHandlesForShutdown);
+  process.once("exit", disposeSpawnedOpenCodeServerHandles);
 }
 
 export function spawnOpenCodeServer(commandSpec: CommandSpec): OpenCodeServerHandle {

--- a/src/supervisor/index.ts
+++ b/src/supervisor/index.ts
@@ -22,14 +22,21 @@ const runtime = new SupervisorRuntime((event) => {
 const handlers = createSupervisorIpcHandlers(runtime);
 
 let isShuttingDown = false;
+const SUPERVISOR_SHUTDOWN_TIMEOUT_MS = 5_000;
 
-function shutdownSupervisor(exitCode = 0): void {
+async function shutdownSupervisor(exitCode = 0): Promise<void> {
   if (isShuttingDown) {
     return;
   }
   isShuttingDown = true;
-  runtime.dispose();
-  process.exit(exitCode);
+  try {
+    await Promise.race([
+      runtime.disposeAsync(),
+      new Promise<void>((resolve) => setTimeout(resolve, SUPERVISOR_SHUTDOWN_TIMEOUT_MS)),
+    ]);
+  } finally {
+    process.exit(exitCode);
+  }
 }
 
 async function handleRequest(request: SupervisorRequest): Promise<unknown> {
@@ -59,15 +66,15 @@ process.on("message", async (message: SupervisorRequest) => {
 });
 
 process.on("disconnect", () => {
-  shutdownSupervisor(0);
+  void shutdownSupervisor(0);
 });
 
 process.on("SIGINT", () => {
-  shutdownSupervisor(0);
+  void shutdownSupervisor(0);
 });
 
 process.on("SIGTERM", () => {
-  shutdownSupervisor(0);
+  void shutdownSupervisor(0);
 });
 
 process.on("uncaughtException", (error) => {

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -1277,11 +1277,17 @@ export class SupervisorRuntime {
   }
 
   dispose(): void {
+    void this.disposeAsync();
+  }
+
+  async disposeAsync(): Promise<void> {
     this.lspManager.dispose();
-    this._projectWatcher?.dispose();
-    this.threadSessionManager.dispose();
+    await this._projectWatcher?.dispose();
+    await this.threadSessionManager.dispose();
     this.sharedSettingsCache.dispose();
-    void this.cliHookPluginCoordinator.dispose();
+    await this.cliHookPluginCoordinator.dispose().catch(() => undefined);
+    const { shutdownSpawnedOpenCodeServers } = await import("./agents/opencode/sdkClient");
+    shutdownSpawnedOpenCodeServers();
   }
 
   private requireAdapter(kind: AgentKind) {

--- a/src/supervisor/runtime/threadSessionManager.startClose.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.startClose.test.ts
@@ -145,9 +145,9 @@ const guardedStructuredProviders = ["codex", "opencode"] as const;
 const managersToDispose: ThreadSessionManager[] = [];
 const tempDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
   for (const manager of managersToDispose.splice(0)) {
-    manager.dispose();
+    await manager.dispose();
   }
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -814,18 +814,20 @@ export class ThreadSessionManager {
     this.outputPipeline.handlePtyData(session, data);
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     this.disposed = true;
     for (const threadId of this.startLocks.keys()) {
       this.pendingStartAborts.add(threadId);
     }
 
     this.flushRuntimeEvents();
-    for (const session of this.sessions.values()) {
-      session.ignoreExit = true;
-      void session.structuredSession?.dispose();
-      this.safePtyKill(session);
-    }
+    await Promise.allSettled(
+      [...this.sessions.values()].map(async (session) => {
+        session.ignoreExit = true;
+        await session.structuredSession?.dispose();
+        this.safePtyKill(session);
+      }),
+    );
     this.sessions.clear();
     this.sessionsBySessionId.clear();
 


### PR DESCRIPTION
- **Bugfix:** Git watch and status refresh now include worktree paths from threads, not only paths already in the worktree cache, so existing thread worktrees stay watched when another is created.
- Fixes stale or missing sidebar diff badges when file watchers run before a full worktree list refresh catches up.
- Defers new-worktree git priming and full refresh until after the thread is created so the watcher set includes all thread worktrees.
- Enables pnpm `enableGlobalVirtualStore` so multiple checkouts/worktrees can share the virtual store via symlinks.
- Adds regression tests for multi-worktree watch registration and watcher-driven status refresh.