### PR TITLE
Fix Droid ApplyPatch classification and edit rendering in chat

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
@@ -170,7 +170,12 @@ function isEditLikeToolPayload(payload: ToolCallPayload): boolean {
     case "move":
       return true;
   }
-  if (["Edit", "Write", "MultiEdit", "NotebookEdit", "Patch"].includes(payload.name)) return true;
+  if (
+    ["Edit", "Write", "MultiEdit", "NotebookEdit", "Patch", "ApplyPatch", "apply_patch"].includes(
+      payload.name,
+    )
+  )
+    return true;
   const title = payload.title?.trim() || payload.name.trim();
   return /^(?:edit|editing|write|writing|patch|patching|create|creating|delete|deleting|remove|removing)(?:\s|:|$)/i.test(
     title,

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -164,6 +164,25 @@ describe("ToolCallGroup", () => {
     expect(screen.queryByText("result")).not.toBeInTheDocument();
   });
 
+  it("renders Droid ApplyPatch tool-call edits with diff counts and rich diff body", async () => {
+    const threadId = "thread-1";
+    const item = makeDroidApplyPatchToolItem("tool-droid-applypatch");
+    seedThread(threadId, [item]);
+
+    renderToolCallGroup(threadId, [item.id]);
+
+    expect(screen.getByText("+1")).toHaveClass("text-success");
+    expect(screen.getByText("-1")).toHaveClass("text-danger");
+    fireEvent.click(screen.getByText("droidFile.ts"));
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent(/old droid/);
+      expect(document.body).toHaveTextContent(/new droid/);
+    });
+    expect(screen.queryByText("args")).not.toBeInTheDocument();
+    expect(screen.queryByText("result")).not.toBeInTheDocument();
+  });
+
   it("renders read tool-call results as highlighted file content", async () => {
     const threadId = "thread-1";
     const item = makeReadToolItem("tool-read");
@@ -259,6 +278,22 @@ describe("ToolCallGroup", () => {
 
     expect(screen.getByText("2 commands")).toBeInTheDocument();
     expect(screen.getByText("1 edit")).toBeInTheDocument();
+  });
+
+  it("categorizes ApplyPatch tool calls as edits in the group heading", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeDroidApplyPatchToolItem("droid-patch-1", "src/alpha.ts"),
+      makeDroidApplyPatchToolItem("droid-patch-2", "src/beta.ts"),
+    ];
+    seedThread(threadId, items);
+
+    renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    expect(screen.getByText("2 edits")).toBeInTheDocument();
   });
 
   it("renders semantic tool-like item buckets as tool rows", () => {
@@ -433,6 +468,33 @@ function makeApplyPatchToolItem(id: string): RuntimeChatItem {
       },
       result:
         "Success. Updated the following files:\nM src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts",
+    },
+    streams: {},
+  };
+}
+
+function makeDroidApplyPatchToolItem(id: string, filePath?: string): RuntimeChatItem {
+  const path = filePath ?? "src/renderer/components/thread/ChatPane/parts/items/droidFile.ts";
+  return {
+    id,
+    type: "tool_call",
+    state: "completed",
+    payload: {
+      name: "ApplyPatch",
+      title: "ApplyPatch",
+      kind: "other",
+      status: "success",
+      args: {
+        patch: [
+          "*** Begin Patch",
+          `*** Update File: ${path}`,
+          "@@",
+          "-old droid",
+          "+new droid",
+          "*** End Patch",
+        ].join("\n"),
+      },
+      result: `Success. Updated the following files:\nM ${path}`,
     },
     streams: {},
   };

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -782,6 +782,8 @@ function categorizeToolName(name: string): GroupCategory {
     case "MultiEdit":
     case "NotebookEdit":
     case "Patch":
+    case "ApplyPatch":
+    case "apply_patch":
       return "edited";
     case "Bash":
     case "BashOutput":

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
@@ -193,4 +193,32 @@ describe("deriveToolDisplay", () => {
     expect(display.title).toBe("Workflow: Run the release checklist");
     expect(display.Icon).toBe(GitBranch);
   });
+
+  it("labels Droid ApplyPatch as edit even when kind is other", () => {
+    const display = deriveToolDisplay(
+      makePayload({
+        name: "ApplyPatch",
+        title: "ApplyPatch",
+        kind: "other",
+        args: {
+          patch: [
+            "*** Begin Patch",
+            "*** Update File: src/renderer/notifications.ts",
+            "@@",
+            "-before",
+            "+after",
+            "*** End Patch",
+          ].join("\n"),
+        },
+      }),
+    );
+
+    expect(display.title).toBe("Edit: src/renderer/notifications.ts");
+    expect(display.parts).toEqual({
+      prefix: "Edit: ",
+      path: "src/renderer/notifications.ts",
+      filePath: true,
+    });
+    expect(display.Icon).toBe(Pencil);
+  });
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -304,18 +304,26 @@ function readSubAgentType(args: Record<string, unknown> | undefined): string | u
   return readStr(args, "subagent_type", "agent_type", "agentType");
 }
 
+/** Recognise Droid/Codex `ApplyPatch`, `apply_patch`, `apply-patch` tool names. */
+function isApplyPatchToolName(name: string): boolean {
+  return /^(apply[_-]?patch)$/i.test(name.trim());
+}
+
 function mapAcpTool(
   payload: ToolCallPayload,
   args: Record<string, unknown> | undefined,
 ): ToolDisplay | null {
   const kind = payload.kind?.trim().toLowerCase();
   const title = payload.title?.trim() || payload.name.trim();
+  const isEditByName = isApplyPatchToolName(payload.name) || isApplyPatchToolName(title);
   const locations = payload.locations ?? [];
   const locationPath = pickAcpLocationPath(kind, locations);
   const titlePath = extractLeadingPath(title);
   const argsPath = readPathArg(args);
   const patchPath =
-    kind === "edit" || kind === "delete" ? extractAcpPatchTargetPath(payload) : undefined;
+    kind === "edit" || kind === "delete" || isEditByName
+      ? extractAcpPatchTargetPath(payload)
+      : undefined;
   const path = locationPath ?? argsPath ?? patchPath ?? titlePath;
 
   switch (kind) {
@@ -340,8 +348,10 @@ function mapAcpTool(
       };
     case "think":
     case "other":
+      if (isEditByName) return formatAcpPathDisplay("Edit", path, title, Pencil);
       return title ? { title, Icon: pickIconByVerbPrefix(title) } : null;
     default:
+      if (isEditByName) return formatAcpPathDisplay("Edit", path, title, Pencil);
       return null;
   }
 }

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -557,6 +557,31 @@ describe("mapAcpSessionUpdate", () => {
     expect(started.payload.changeKind).toBe("edit");
   });
 
+  it("classifies Droid ApplyPatch as file_change even when kind is not edit", () => {
+    // Droid's ACP adapter emits `ApplyPatch` (camelCase, no underscore) as the
+    // tool title/name. The word-boundary regex `\bpatch\b` does NOT match
+    // "ApplyPatch" because there is no boundary between "Apply" and "Patch",
+    // so the mapper must recognise the name explicitly.
+    const state = createAcpMapperState("t-fc-droid-applypatch");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-fc-droid",
+        title: "ApplyPatch",
+        kind: "other",
+        status: "in_progress",
+        rawInput: {
+          patch: "*** Begin Patch\n*** Update File: src/bar.ts\n@@\n-old\n+new\n*** End Patch",
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const started = events[0] as { itemType: string; payload: Record<string, unknown> };
+    expect(started.itemType).toBe("file_change");
+    expect(started.payload.path).toBe("src/bar.ts");
+    expect(started.payload.changeKind).toBe("edit");
+  });
+
   it("classifies ACP write content payloads as creates", () => {
     const state = createAcpMapperState("t-fc-write-create");
     const rawInput = {
@@ -1284,5 +1309,30 @@ describe("mapAcpPermissionRequest", () => {
         ],
       },
     });
+  });
+
+  it("classifies Droid ApplyPatch approvals as apply_patch_approval", () => {
+    const state = createAcpMapperState("t-perm-applypatch");
+
+    const event = mapAcpPermissionRequest(
+      {
+        sessionId: "s1",
+        toolCall: {
+          title: "ApplyPatch",
+          kind: "other",
+          rawInput: {
+            patch: "*** Begin Patch\n*** Update File: src/foo.ts\n@@\n-old\n+new\n*** End Patch",
+          },
+        },
+        options: [
+          { optionId: "allow", name: "Allow", kind: "allow_once" },
+          { optionId: "reject", name: "Reject", kind: "reject_once" },
+        ],
+      } as Parameters<typeof mapAcpPermissionRequest>[0],
+      state,
+      "acp-perm-applypatch-0",
+    );
+
+    expect(event).toMatchObject({ requestType: "apply_patch_approval" });
   });
 });

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -1110,6 +1110,11 @@ function readStringAllowEmpty(input: Record<string, unknown>, key: string): stri
   return typeof value === "string" ? value : undefined;
 }
 
+/** Recognise Droid/Codex `ApplyPatch`, `apply_patch`, `apply-patch` tool names. */
+function isApplyPatchToolName(name: string): boolean {
+  return /^(apply[_-]?patch)$/i.test(name.trim());
+}
+
 /**
  * Classify ACP tool kind/title into a canonical item type for richer rendering.
  * - command-style tool calls → command_execution
@@ -1129,7 +1134,9 @@ function classifyToolCallItemType(
     k === "edit" ||
     k === "delete" ||
     k === "move" ||
-    /\b(edit|write|create|delete|patch|move|rename)\b/.test(t)
+    isApplyPatchToolName(k) ||
+    /\b(edit|write|create|delete|patch|move|rename)\b/.test(t) ||
+    isApplyPatchToolName(t)
   ) {
     return "file_change";
   }
@@ -1272,7 +1279,13 @@ function classifyApprovalRequestType(
   if (k === "execute" || k === "shell" || /^(run|exec|shell)\b/.test(t)) {
     return "command_execution_approval";
   }
-  if (k === "edit" || /\b(edit|patch)\b/.test(t)) return "apply_patch_approval";
+  if (
+    k === "edit" ||
+    isApplyPatchToolName(k) ||
+    /\b(edit|patch)\b/.test(t) ||
+    isApplyPatchToolName(t)
+  )
+    return "apply_patch_approval";
   if (k === "write" || /\bwrite\b/.test(t)) return "file_change_approval";
   return "tool_call_approval";
 }


### PR DESCRIPTION
**Type:** Bugfix

- Droid’s ACP adapter emits `ApplyPatch` with `kind: other`, so generic `\bpatch\b` matching never fired and patches were misclassified as generic tool calls.
- Supervisor ACP mapping now recognizes `ApplyPatch` / `apply_patch` / `apply-patch` as `file_change` edits and routes permission prompts to `apply_patch_approval`.
- Chat tool display, grouping, and edit-like rendering treat ApplyPatch like other patch tools (path labels, diff counts, rich diff body instead of raw args/result).
- Tests cover canonical mapping, display derivation, and ToolCallGroup UI for Droid ApplyPatch payloads.