### PR TITLE
Surface ACP subagent progress updates and result text in chat

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
@@ -33,6 +33,13 @@ describe("acpToolPayload", () => {
     });
   });
 
+  it("unwraps markdown text fields from ACP result objects", () => {
+    expect(extractAcpResultPart({ result: { text: "# Report\n\n- done" } })).toEqual({
+      text: "# Report\n\n- done",
+      language: "plain",
+    });
+  });
+
   it("synthesizes a unified diff from replacement-style edit args", () => {
     expect(
       extractAcpDiffResultPart({

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
@@ -15,6 +15,8 @@ import { buildLineUnifiedDiff, countLineChangeStats } from "@/shared/lineUnified
 import { detectLanguageFromPath, type ViewportLanguage } from "./languageDetect";
 
 export interface AcpToolResult {
+  /** Markdown/plain text result used by ACP servers such as Factory Droid. */
+  text?: unknown;
   /** Short preview text. */
   content?: unknown;
   /** Full output (may be larger than `content`). */
@@ -59,6 +61,7 @@ export function extractAcpResultPart(payload: unknown): ExtractedPart {
   const r = result as AcpToolResult;
   if (typeof r.detailedContent === "string" && r.detailedContent.length > 0)
     return asPart(prettyIfJson(r.detailedContent));
+  if (typeof r.text === "string" && r.text.length > 0) return asPart(prettyIfJson(r.text));
   if (typeof r.content === "string" && r.content.length > 0) return asPart(prettyIfJson(r.content));
   if (Array.isArray(r.contents)) {
     const parts = r.contents

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
@@ -221,4 +221,19 @@ describe("deriveToolDisplay", () => {
     });
     expect(display.Icon).toBe(Pencil);
   });
+
+  it("prefers live ACP subagent update titles over the launch description", () => {
+    const payload = makePayload({
+      name: "Reading README.md",
+      title: "Reading README.md",
+      isSubAgent: true,
+      args: {
+        description: "Explore worktree watcher",
+        subagent_type: "worker",
+        prompt: "Trace watcher flow",
+      },
+    });
+
+    expect(deriveToolDisplay(payload).title).toBe("Agent (worker): Reading README.md");
+  });
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -93,7 +93,9 @@ export function deriveToolDisplay(payload: ToolCallPayload): ToolDisplay {
 
   if (payload.isSubAgent === true) {
     return {
-      title: formatAgentTitle(args, payload.title?.trim() || payload.name.trim()),
+      title: formatAgentTitle(args, payload.title?.trim() || payload.name.trim(), {
+        preferFallback: payload.title !== undefined,
+      }),
       Icon: Bot,
     };
   }
@@ -291,8 +293,12 @@ function formatGrepDisplay(args: Record<string, unknown> | undefined): ToolDispl
 function formatAgentTitle(
   args: Record<string, unknown> | undefined,
   fallbackDescription?: string,
+  options?: { preferFallback?: boolean },
 ): string {
-  const description = readStr(args, "description") ?? fallbackDescription;
+  const argsDescription = readStr(args, "description");
+  const description = options?.preferFallback
+    ? (fallbackDescription ?? argsDescription)
+    : (argsDescription ?? fallbackDescription);
   const subagent = readSubAgentType(args);
   if (description) {
     return subagent ? `Agent (${subagent}): ${description}` : `Agent: ${description}`;

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -781,6 +781,78 @@ describe("mapAcpSessionUpdate", () => {
     ]);
   });
 
+  it("surfaces ACP subagent tool_call_update progress as title metadata and child markdown", () => {
+    const state = createAcpMapperState("t-subagent-progress");
+    const started = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-subagent-progress",
+        title: "Explore worktree watcher",
+        status: "in_progress",
+        rawInput: {
+          description: "Explore worktree watcher",
+          subagent_type: "worker",
+          prompt: "Trace watcher flow",
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const parentItemId = (started[0] as { itemId: string }).itemId;
+
+    const update = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-subagent-progress",
+        title: "Reading README.md",
+        status: "in_progress",
+        rawOutput: {
+          text: "Reading README.md\n\nFound the watcher initialization path.",
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+
+    expect(update).toMatchObject([
+      {
+        type: "item.updated",
+        threadId: "t-subagent-progress",
+        itemId: parentItemId,
+        payload: {
+          title: "Reading README.md",
+          isSubAgent: true,
+          progress: {
+            description: "Reading README.md",
+            summary: "Reading README.md",
+          },
+        },
+      },
+      {
+        type: "item.started",
+        threadId: "t-subagent-progress",
+        itemType: "assistant_message",
+        parentItemId,
+      },
+      {
+        type: "content.delta",
+        threadId: "t-subagent-progress",
+        stream: "assistant_text",
+        delta: "Reading README.md\n\nFound the watcher initialization path.",
+      },
+      {
+        type: "item.updated",
+        threadId: "t-subagent-progress",
+        itemId: parentItemId,
+        payload: {
+          isSubAgent: true,
+          progress: {
+            description: "Reading README.md",
+            stepCount: 1,
+          },
+        },
+      },
+    ]);
+  });
+
   it("switches the inferred ACP parent for nested subagents", () => {
     const state = createAcpMapperState("t-nested-subagent");
     const outer = mapAcpSessionUpdate(

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -45,6 +45,8 @@ interface AcpToolCallItemState {
   itemType: CanonicalItemType;
   payload: Record<string, unknown>;
   isSubAgent: boolean;
+  subAgentProgressItemId?: string;
+  subAgentProgressText?: string;
   /**
    * ACP `Terminal` id that hosts this tool's output, if any. Captured on the
    * first `tool_call`/`tool_call_update` whose `content` references a terminal,
@@ -440,13 +442,33 @@ export function mapAcpSessionUpdate(
         state.resolveTerminalOutput,
         state.resolveTerminalOutputByCommand,
       );
-      item.payload = mergeToolPayload(item.payload, payload);
+      const subAgentProgress = item.isSubAgent
+        ? buildSubAgentProgress(toolCall, payload, status)
+        : undefined;
+      const nextPayload = subAgentProgress?.label
+        ? mergeToolPayload(payload, {
+            progress: {
+              description: subAgentProgress.label,
+              ...(subAgentProgress.summary ? { summary: subAgentProgress.summary } : {}),
+            },
+          })
+        : payload;
+      item.payload = mergeToolPayload(item.payload, nextPayload);
       events.push({
         type: isTerminal ? "item.completed" : "item.updated",
         threadId,
         itemId: item.itemId,
-        payload,
+        payload: nextPayload,
       });
+      if (subAgentProgress?.text) {
+        events.push(...buildSubAgentProgressEvents(state, item, subAgentProgress.text, isTerminal));
+      } else if (isTerminal && item.subAgentProgressItemId) {
+        events.push({
+          type: "item.completed",
+          threadId,
+          itemId: item.subAgentProgressItemId,
+        });
+      }
       if (isTerminal) {
         state.toolCallItems.delete(toolCall.toolCallId);
         if (item.isSubAgent) {
@@ -741,6 +763,99 @@ function resolveTerminalOutputForCommandPayload(
   const command = typeof payload.command === "string" ? payload.command : undefined;
   if (!command || !resolveTerminalOutputByCommand) return undefined;
   return resolveTerminalOutputByCommand(command);
+}
+
+function buildSubAgentProgress(
+  toolCall: {
+    title?: string | null;
+    kind?: string | null;
+    rawOutput?: unknown;
+    content?: unknown;
+  },
+  payload: Record<string, unknown>,
+  status: "running" | "success" | "error",
+): { label: string | undefined; text: string | undefined; summary: string | undefined } {
+  const title = normalizeToolText(toolCall.title);
+  const kind = normalizeToolText(toolCall.kind);
+  const result = payload.result;
+  const outputText = readSubAgentText(result) ?? readSubAgentText(toolCall.rawOutput);
+  const outputSummary = outputText ? firstNonEmptyLine(outputText) : undefined;
+  const label = status === "running" ? (title ?? kind ?? outputSummary) : undefined;
+  const text = outputText ?? label;
+  const summary = outputSummary ?? label;
+  return { label, text, summary };
+}
+
+function buildSubAgentProgressEvents(
+  state: AcpMapperState,
+  item: AcpToolCallItemState,
+  text: string,
+  isTerminal: boolean,
+): RuntimeEvent[] {
+  const normalized = text.trim();
+  if (!normalized || normalized === item.subAgentProgressText) return [];
+  const events: RuntimeEvent[] = [];
+  if (!item.subAgentProgressItemId) {
+    item.subAgentProgressItemId = newItemId("subagent");
+    item.subAgentProgressText = "";
+    events.push({
+      type: "item.started",
+      threadId: state.threadId,
+      itemId: item.subAgentProgressItemId,
+      itemType: "assistant_message",
+    });
+  }
+  const previous = item.subAgentProgressText ?? "";
+  const delta = normalized.startsWith(previous)
+    ? normalized.slice(previous.length)
+    : `${previous ? "\n\n" : ""}${normalized}`;
+  item.subAgentProgressText = previous + delta;
+  if (delta.length > 0) {
+    events.push({
+      type: "content.delta",
+      threadId: state.threadId,
+      itemId: item.subAgentProgressItemId,
+      stream: "assistant_text",
+      delta,
+    });
+  }
+  if (isTerminal) {
+    events.push({
+      type: "item.completed",
+      threadId: state.threadId,
+      itemId: item.subAgentProgressItemId,
+    });
+  }
+  return events;
+}
+
+function readSubAgentText(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim().length > 0 ? value : undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ["text", "markdown", "message", "summary", "content", "detailedContent"]) {
+    const text = record[key];
+    if (typeof text === "string" && text.trim().length > 0) return text;
+  }
+  const contents = record.contents;
+  if (Array.isArray(contents)) {
+    const parts = contents
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return "";
+        const text = (entry as Record<string, unknown>).text;
+        return typeof text === "string" ? text : "";
+      })
+      .filter((text) => text.trim().length > 0);
+    if (parts.length > 0) return parts.join("\n\n");
+  }
+  return undefined;
+}
+
+function firstNonEmptyLine(text: string): string | undefined {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
 }
 
 function getActiveSubAgent(state: AcpMapperState): ActiveAcpSubAgent | undefined {


### PR DESCRIPTION
**Type:** Bugfix

- Map ACP subagent `tool_call_update` events to live progress titles, step metadata, and streamed markdown output so long-running subagents stay visible in the thread
- Extract `result.text` from ACP tool payloads so markdown/plain results (e.g. Factory Droid) render in the chat instead of being dropped
- Prefer runtime subagent titles over the static launch description in tool cards when the provider sends progress updates
- Add supervisor and renderer tests for subagent progress mapping, result text extraction, and display title derivation