### PR TITLE
Show installed agent icons on home recent threads

### DIFF
--- a/src/renderer/views/HomeView.test.tsx
+++ b/src/renderer/views/HomeView.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import type { Project, Thread } from "@/shared/contracts";
+import type { AgentStatus, Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { HomeView } from "./HomeView";
 
@@ -15,6 +16,15 @@ describe("HomeView", () => {
       threads: [],
       view: { kind: "home" },
     }));
+    useAgentStatusesStore.setState({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+      inFirstLaunchDiscovery: false,
+      discoveryScope: undefined,
+      discoveredAgents: [],
+    });
   });
 
   it("does not show archived threads in recent threads", () => {
@@ -29,6 +39,32 @@ describe("HomeView", () => {
 
     expect(screen.getByText("Keep me visible")).toBeInTheDocument();
     expect(screen.queryByText("Archived thread")).not.toBeInTheDocument();
+  });
+
+  it("uses the installed ACP agent icon in recent threads", () => {
+    useAgentStatusesStore.setState({
+      agentStatuses: [
+        makeAgentStatus({
+          kind: "acp-generic:factory-droid",
+          label: "Factory Droid",
+          icon: "https://example.com/factory-droid.svg",
+        }),
+      ],
+    });
+    useAppStore.setState({
+      threads: [
+        makeThread({
+          title: "ACP thread",
+          agentKind: "acp-generic:factory-droid",
+        }),
+      ],
+    });
+
+    const { container } = render(<HomeView />);
+
+    expect(screen.getByText("ACP thread")).toBeInTheDocument();
+    expect(container.querySelector(".lightcode-provider-icon--external")).toBeInTheDocument();
+    expect(container.querySelector(".lightcode-provider-icon__generic")).not.toBeInTheDocument();
   });
 });
 
@@ -56,6 +92,29 @@ function makeThread(overrides: Partial<Thread>): Thread {
     starred: false,
     createdAt: "2026-05-26T00:00:00.000Z",
     updatedAt: "2026-05-26T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeAgentStatus(overrides: Partial<AgentStatus>): AgentStatus {
+  return {
+    kind: "codex",
+    label: "Codex",
+    installed: true,
+    authState: "authenticated",
+    capabilities: {
+      models: [{ id: "gpt-5", label: "GPT-5" }],
+      efforts: [],
+      modelEfforts: {},
+      modes: ["agent"],
+      approvalPolicies: [],
+      sandboxModes: [],
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: "terminal",
+      presentationMode: "terminal",
+      settingDefs: [],
+    },
     ...overrides,
   };
 }

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -1,7 +1,9 @@
 import { ArrowRight, FolderOpen, House, Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
+import { getProjectAgentStatuses } from "@/shared/agentStatus";
 import { isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { openThread } from "@/renderer/actions/threadActions";
 import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
@@ -24,6 +26,12 @@ export function HomeView() {
         .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
         .slice(0, 8),
     ),
+  );
+  const { agentStatuses, wslAgentStatuses } = useAgentStatusesStore(
+    useShallow((state) => ({
+      agentStatuses: state.agentStatuses,
+      wslAgentStatuses: state.wslAgentStatuses,
+    })),
   );
   const openDraft = useAppStore((state) => state.openDraft);
 
@@ -77,6 +85,12 @@ export function HomeView() {
                       const project = isHomeProjectId(thread.projectId)
                         ? homeProject
                         : projects.find((p) => p.id === thread.projectId);
+                      const availableAgents = project
+                        ? getProjectAgentStatuses(project.location, agentStatuses, wslAgentStatuses)
+                        : [...agentStatuses, ...wslAgentStatuses];
+                      const threadAgent = availableAgents.find(
+                        (agent) => agent.installed && agent.kind === thread.agentKind,
+                      );
                       return (
                         <button
                           key={thread.id}
@@ -86,6 +100,8 @@ export function HomeView() {
                         >
                           <ProviderIcon
                             kind={thread.agentKind}
+                            {...(threadAgent?.icon ? { icon: threadAgent.icon } : {})}
+                            fallbackLabel={threadAgent?.label}
                             tone={getStatusTone(thread)}
                             className="size-4 shrink-0"
                           />


### PR DESCRIPTION
- **Bugfix:** Recent threads on Home were rendering generic provider icons instead of icons from installed agent discovery (e.g. ACP agents with custom URLs).
- Home now reads Windows/WSL agent statuses and matches each thread’s `agentKind` to pass `icon` and `fallbackLabel` into `ProviderIcon`.
- Agent lookup respects project location via `getProjectAgentStatuses`, with a sensible fallback when the thread has no project context.
- Adds a HomeView test that asserts external agent icons render and the generic fallback is not used.