### PR TITLE
Grow one expanded sidebar project past thread list cap

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -46,6 +46,7 @@ import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useUpdateStore } from "@/renderer/state/updateStore";
 import { SidebarProjectThreadList } from "./parts/SidebarProjectThreadList";
+import { resolveGrowableProjectId } from "./parts/sidebarGrowLayout";
 
 function UpdateButtons(props: { iconOnly?: boolean }) {
   const { iconOnly = false } = props;
@@ -201,6 +202,11 @@ export function Sidebar() {
       state.projects.filter((project) => !isHomeProject(project)).map((project) => project.id),
     ),
   );
+  const projectExpansionTokens = useAppStore(
+    useShallow((state) =>
+      state.projects.flatMap((project) => [project.id, project.disabled ? 1 : 0]),
+    ),
+  );
   const homeProject = useAppStore((state) => state.projects.find(isHomeProject));
   const homeScopeEnabled = useSharedSettings((s) => s.homeScopeEnabled);
   const currentProjectId = useCurrentProjectId();
@@ -210,6 +216,20 @@ export function Sidebar() {
   const openThreadSearch = usePanelStore((s) => s.openThreadSearch);
   const isHomeProjectCollapsed = useSidebarUiStore((s) =>
     homeProject ? (s.collapsedProjects[homeProject.id] ?? false) : false,
+  );
+  const collapsedProjects = useSidebarUiStore((s) => s.collapsedProjects);
+  const collapsedWorktrees = useSidebarUiStore((s) => s.collapsedWorktrees);
+  const growableProjectId = useAppStore(
+    useShallow((state) =>
+      resolveGrowableProjectId({
+        projectExpansionTokens,
+        collapsedProjects,
+        collapsedWorktrees,
+        homeScopeEnabled,
+        sortMode,
+        threads: state.threads,
+      }),
+    ),
   );
   const setProjectCollapsed = useSidebarUiStore((s) => s.setProjectCollapsed);
   const toggleProjectCollapsed = useSidebarUiStore((s) => s.toggleProjectCollapsed);
@@ -311,7 +331,11 @@ export function Sidebar() {
                     }
                   />
                   {isHomeProjectCollapsed ? null : (
-                    <SidebarProjectThreadList project={homeProject} sortMode={sortMode} />
+                    <SidebarProjectThreadList
+                      project={homeProject}
+                      sortMode={sortMode}
+                      growableProjectId={growableProjectId}
+                    />
                   )}
                 </section>
               ) : null}
@@ -321,6 +345,7 @@ export function Sidebar() {
                   projectId={projectId}
                   projectIndex={projectIndex}
                   sortMode={sortMode}
+                  growableProjectId={growableProjectId}
                 />
               ))}
             </div>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectSection.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectSection.tsx
@@ -10,6 +10,7 @@ export function SidebarProjectSection(props: {
   projectId: string;
   projectIndex: number;
   sortMode: ThreadSortMode;
+  growableProjectId: string | null;
 }) {
   const project = useProject(props.projectId);
   const isProjectCollapsed = useIsProjectCollapsed(props.projectId);
@@ -34,7 +35,13 @@ export function SidebarProjectSection(props: {
         isCollapsed={isProjectCollapsed}
         isDragging={isDragging}
       />
-      {showBody ? <SidebarProjectThreadList project={project} sortMode={props.sortMode} /> : null}
+      {showBody ? (
+        <SidebarProjectThreadList
+          project={project}
+          sortMode={props.sortMode}
+          growableProjectId={props.growableProjectId}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { Project, Thread } from "@/shared/contracts";
+import type { Project } from "@/shared/contracts";
 import {
   useCurrentThreadIdsCount,
   useHasDraft,
@@ -11,7 +11,12 @@ import { useDragSource } from "@/renderer/dnd";
 import { openNewThread, openNewThreadSideBySide } from "@/renderer/actions/threadActions";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { NewThreadButton } from "./NewThreadButton";
-import { groupThreads, type ThreadListEntry, type WorktreeThreadGroup } from "./groupThreads";
+import { resolveProjectThreadListMaxHeight } from "./sidebarGrowLayout";
+import {
+  buildSidebarProjectRows,
+  estimateSidebarRowSize,
+  type SidebarVirtualRow,
+} from "./sidebarProjectRows";
 import type { ThreadSortMode } from "./sortMode";
 import { SidebarThreadGroup } from "./SidebarThreadGroup";
 import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
@@ -19,208 +24,12 @@ import { SortableThreadItem } from "./SortableThreadItem/SortableThreadItem";
 
 const VIRTUAL_OVERSCAN = 12;
 
-type SidebarVirtualRow =
-  | {
-      kind: "thread";
-      key: string;
-      thread: Thread;
-      threadIndex: number;
-      group: string;
-      showWorktreeBadge: boolean;
-      showWorktreeFilesButton?: boolean;
-      sortDisabled?: boolean;
-    }
-  | {
-      kind: "worktree-group";
-      key: string;
-      group: WorktreeThreadGroup;
-      entryIndex: number;
-      sortableGroup: string;
-      sortDisabled: boolean;
-    }
-  | {
-      kind: "thread-group";
-      key: string;
-      entry: Extract<ThreadListEntry, { kind: "thread-group" }>;
-    }
-  | { kind: "divider"; key: string }
-  | { kind: "section-label"; key: string; label: string };
-
-function isRecent(iso: string): boolean {
-  return Date.now() - new Date(iso).getTime() < 24 * 60 * 60 * 1000;
-}
-
-function getEntryDate(entry: ThreadListEntry, field: "updatedAt" | "createdAt"): string {
-  if (entry.kind === "thread") return entry.thread[field];
-  return entry.group.threads.reduce(
-    (latest, t) => (t[field] > latest ? t[field] : latest),
-    entry.group.threads[0]![field],
-  );
-}
-
-function entryIsStarred(entry: ThreadListEntry): boolean {
-  if (entry.kind === "thread") return entry.thread.starred;
-  return entry.group.threads.some((t) => t.starred);
-}
-
-function estimateRowSize(row: SidebarVirtualRow | undefined): number {
-  if (!row) return 32;
-  if (row.kind === "divider") return 10;
-  if (row.kind === "section-label") return 28;
-  if (row.kind === "worktree-group") return 34;
-  if (row.kind === "thread-group") return 30;
-  return 30;
-}
-
-function pushEntryRows(
-  rows: SidebarVirtualRow[],
-  entry: ThreadListEntry,
-  entryIndex: number,
-  input: {
-    projectId: string;
-    dndGroup: string;
-    dndDisabled: boolean;
-    collapsedWorktrees: Record<string, boolean>;
-    nextUngroupedIndex: () => number;
-  },
-) {
-  if (entry.kind === "thread") {
-    const idx = input.nextUngroupedIndex();
-    rows.push({
-      kind: "thread",
-      key: `thread:${entry.thread.id}`,
-      thread: entry.thread,
-      threadIndex: idx,
-      group: input.dndGroup,
-      showWorktreeBadge: true,
-      showWorktreeFilesButton: !!entry.thread.worktreePath,
-      sortDisabled: input.dndDisabled,
-    });
-    return;
-  }
-
-  if (entry.kind === "worktree-group") {
-    rows.push({
-      kind: "worktree-group",
-      key: `wt:${entry.group.worktreePath}`,
-      group: entry.group,
-      entryIndex,
-      sortableGroup: input.dndGroup,
-      sortDisabled: input.dndDisabled,
-    });
-    if (!(input.collapsedWorktrees[entry.group.worktreePath] ?? false)) {
-      entry.group.threads.forEach((thread, threadIndex) => {
-        rows.push({
-          kind: "thread",
-          key: `wt:${entry.group.worktreePath}:thread:${thread.id}`,
-          thread,
-          threadIndex,
-          group: `wt:${entry.group.worktreePath}`,
-          showWorktreeBadge: false,
-          showWorktreeFilesButton: false,
-        });
-      });
-    }
-    return;
-  }
-
-  const groupKey = entry.group.groupId;
-  rows.push({
-    kind: "thread-group",
-    key: `group:${groupKey}`,
-    entry,
-  });
-  if (!(input.collapsedWorktrees[`group:${groupKey}`] ?? false)) {
-    entry.group.threads.forEach((thread, threadIndex) => {
-      rows.push({
-        kind: "thread",
-        key: `group:${groupKey}:thread:${thread.id}`,
-        thread,
-        threadIndex,
-        group: `group:${groupKey}`,
-        showWorktreeBadge: !!thread.worktreePath,
-        sortDisabled: input.dndDisabled,
-      });
-    });
-  }
-}
-
-function buildRows(input: {
-  projectId: string;
-  projectThreads: Thread[];
+export function SidebarProjectThreadList(props: {
+  project: Project;
   sortMode: ThreadSortMode;
-  collapsedWorktrees: Record<string, boolean>;
-}): SidebarVirtualRow[] {
-  const rows: SidebarVirtualRow[] = [];
-  const dndGroup = `project-entries:${input.projectId}`;
-
-  if (input.sortMode === "manual") {
-    const orderedThreads = [...input.projectThreads].sort(
-      (a, b) => Number(b.starred) - Number(a.starred),
-    );
-    orderedThreads.forEach((thread, idx) => {
-      rows.push({
-        kind: "thread",
-        key: `thread:${thread.id}`,
-        thread,
-        threadIndex: idx,
-        group: dndGroup,
-        showWorktreeBadge: true,
-        showWorktreeFilesButton: !!thread.worktreePath,
-      });
-    });
-    return rows;
-  }
-
-  const dateField = input.sortMode === "created" ? "createdAt" : "updatedAt";
-  const entries = groupThreads(
-    [...input.projectThreads].sort((a, b) => b[dateField].localeCompare(a[dateField])),
-  );
-  const starredEntries = entries.filter(entryIsStarred);
-  const unstarredEntries = entries.filter((e) => !entryIsStarred(e));
-  const recentEntries = unstarredEntries.filter((e) => isRecent(getEntryDate(e, dateField)));
-  const olderEntries = unstarredEntries.filter((e) => !isRecent(getEntryDate(e, dateField)));
-  const hasBothSections = recentEntries.length > 0 && olderEntries.length > 0;
-  let ungroupedIndex = 0;
-
-  const nextUngroupedIndex = () => ungroupedIndex++;
-  const pushList = (list: ThreadListEntry[], offset = 0) => {
-    list.forEach((entry, i) => {
-      pushEntryRows(rows, entry, offset + i, {
-        projectId: input.projectId,
-        dndGroup,
-        dndDisabled: true,
-        collapsedWorktrees: input.collapsedWorktrees,
-        nextUngroupedIndex,
-      });
-      const isLast = i === list.length - 1;
-      if (isLast) return;
-      if (
-        entry.kind === "worktree-group" &&
-        !(input.collapsedWorktrees[entry.group.worktreePath] ?? false)
-      ) {
-        rows.push({ kind: "divider", key: `wt-divider:${entry.group.worktreePath}` });
-      } else if (
-        entry.kind === "thread-group" &&
-        !(input.collapsedWorktrees[`group:${entry.group.groupId}`] ?? false)
-      ) {
-        rows.push({ kind: "divider", key: `group-divider:${entry.group.groupId}` });
-      }
-    });
-  };
-
-  pushList(starredEntries);
-  pushList(recentEntries, starredEntries.length);
-  if (hasBothSections) {
-    rows.push({ kind: "section-label", key: "older-label", label: "Older" });
-  }
-  pushList(olderEntries, starredEntries.length + recentEntries.length);
-
-  return rows;
-}
-
-export function SidebarProjectThreadList(props: { project: Project; sortMode: ThreadSortMode }) {
-  const { project, sortMode } = props;
+  growableProjectId: string | null;
+}) {
+  const { project, sortMode, growableProjectId } = props;
   const { setScrollContainer, scrollRef, scrollFadeStyle } = useScrollFade<HTMLDivElement>({
     maxFadePx: 10,
   });
@@ -232,7 +41,8 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
   const currentThreadCount = useCurrentThreadIdsCount();
   const isDraftActive = useIsCurrentProjectDraft(project.id);
   const source = useDragSource();
-  const rows = buildRows({
+
+  const rows = buildSidebarProjectRows({
     projectId: project.id,
     projectThreads,
     sortMode,
@@ -241,7 +51,7 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: (index) => estimateRowSize(rows[index]),
+    estimateSize: (index) => estimateSidebarRowSize(rows[index]),
     getItemKey: (index) => rows[index]?.key ?? index,
     overscan: VIRTUAL_OVERSCAN,
     useFlushSync: false,
@@ -249,6 +59,11 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
   const virtualItems = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
   const firstVisibleStart = virtualItems[0]?.start ?? 0;
+  const maxHeight = resolveProjectThreadListMaxHeight({
+    growableProjectId,
+    projectId: project.id,
+    itemContentHeightPx: totalSize,
+  });
 
   return (
     <div className="space-y-0.5">
@@ -262,7 +77,14 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
         onOpenAsPanel={() => openNewThreadSideBySide(project.id)}
       />
 
-      <div ref={setScrollContainer} className="max-h-80 overflow-y-auto" style={scrollFadeStyle}>
+      <div
+        ref={setScrollContainer}
+        className="overflow-y-auto"
+        style={{
+          ...scrollFadeStyle,
+          ...(maxHeight ? { maxHeight } : {}),
+        }}
+      >
         <div className="relative w-full" style={{ height: totalSize }}>
           <div
             className="absolute top-0 left-0 w-full"

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarGrowLayout.test.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarGrowLayout.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveGrowableProjectId,
+  resolveProjectThreadListMaxHeight,
+  SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX,
+} from "./sidebarGrowLayout";
+
+describe("resolveGrowableProjectId", () => {
+  it("returns the only expanded project", () => {
+    expect(
+      resolveGrowableProjectId({
+        projectExpansionTokens: ["project-a", 0],
+        collapsedProjects: {},
+        collapsedWorktrees: {},
+        homeScopeEnabled: false,
+        sortMode: "manual",
+        threads: [],
+      }),
+    ).toBe("project-a");
+  });
+
+  it("returns the single overflowing project when multiple are expanded", () => {
+    const threads = Array.from({ length: 20 }, (_, index) => ({
+      id: `thread-${index}`,
+      projectId: "project-b",
+      archived: false,
+    })) as never[];
+
+    expect(
+      resolveGrowableProjectId({
+        projectExpansionTokens: ["project-a", 0, "project-b", 0],
+        collapsedProjects: {},
+        collapsedWorktrees: {},
+        homeScopeEnabled: false,
+        sortMode: "manual",
+        threads,
+      }),
+    ).toBe("project-b");
+  });
+
+  it("returns null when multiple expanded projects overflow", () => {
+    const threads = [
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: `a-${index}`,
+        projectId: "project-a",
+        archived: false,
+      })),
+      ...Array.from({ length: 20 }, (_, index) => ({
+        id: `b-${index}`,
+        projectId: "project-b",
+        archived: false,
+      })),
+    ] as never[];
+
+    expect(
+      resolveGrowableProjectId({
+        projectExpansionTokens: ["project-a", 0, "project-b", 0],
+        collapsedProjects: {},
+        collapsedWorktrees: {},
+        homeScopeEnabled: false,
+        sortMode: "manual",
+        threads,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when multiple expanded projects fit within the cap", () => {
+    const threads = [
+      { id: "a-1", projectId: "project-a", archived: false },
+      { id: "b-1", projectId: "project-b", archived: false },
+    ] as never[];
+
+    expect(
+      resolveGrowableProjectId({
+        projectExpansionTokens: ["project-a", 0, "project-b", 0],
+        collapsedProjects: {},
+        collapsedWorktrees: {},
+        homeScopeEnabled: false,
+        sortMode: "manual",
+        threads,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveProjectThreadListMaxHeight", () => {
+  it("uses natural height for short lists", () => {
+    expect(
+      resolveProjectThreadListMaxHeight({
+        growableProjectId: "project-a",
+        projectId: "project-a",
+        itemContentHeightPx: 30,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("caps non-grow targets at the default max height", () => {
+    expect(
+      resolveProjectThreadListMaxHeight({
+        growableProjectId: "project-b",
+        projectId: "project-a",
+        itemContentHeightPx: SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX + 40,
+      }),
+    ).toBe(`${SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX}px`);
+  });
+
+  it("expands grow targets to the measured item height", () => {
+    expect(
+      resolveProjectThreadListMaxHeight({
+        growableProjectId: "project-b",
+        projectId: "project-b",
+        itemContentHeightPx: SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX + 40,
+      }),
+    ).toBe(`${SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX + 40}px`);
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarGrowLayout.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarGrowLayout.ts
@@ -1,0 +1,89 @@
+import type { Thread } from "@/shared/contracts";
+import { isHomeProjectId } from "@/shared/homeScope";
+import { buildSidebarProjectRows, estimateSidebarProjectListHeightPx } from "./sidebarProjectRows";
+import type { ThreadSortMode } from "./sortMode";
+
+/** Matches Tailwind `max-h-80` / 20rem used for capped project thread lists. */
+export const SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX = 320;
+
+export function countProjectThreads(threads: Thread[], projectId: string): number {
+  return threads.filter((thread) => thread.projectId === projectId && !thread.archived).length;
+}
+
+function projectListHeightPx(input: {
+  projectId: string;
+  threads: Thread[];
+  sortMode: ThreadSortMode;
+  collapsedWorktrees: Record<string, boolean>;
+}): number {
+  const projectThreads = input.threads.filter(
+    (thread) => thread.projectId === input.projectId && !thread.archived,
+  );
+  const rows = buildSidebarProjectRows({
+    projectId: input.projectId,
+    projectThreads,
+    sortMode: input.sortMode,
+    collapsedWorktrees: input.collapsedWorktrees,
+  });
+  return estimateSidebarProjectListHeightPx(rows);
+}
+
+export function resolveGrowableProjectId(input: {
+  projectExpansionTokens: Array<string | number>;
+  collapsedProjects: Record<string, boolean>;
+  collapsedWorktrees: Record<string, boolean>;
+  homeScopeEnabled: boolean;
+  sortMode: ThreadSortMode;
+  threads: Thread[];
+}): string | null {
+  const expandedProjectIds: string[] = [];
+
+  for (let i = 0; i < input.projectExpansionTokens.length; i += 2) {
+    const projectId = input.projectExpansionTokens[i] as string;
+    const isDisabled = input.projectExpansionTokens[i + 1] === 1;
+    const isCollapsed = input.collapsedProjects[projectId] ?? false;
+
+    if (isHomeProjectId(projectId)) {
+      if (input.homeScopeEnabled && !isCollapsed) {
+        expandedProjectIds.push(projectId);
+      }
+      continue;
+    }
+
+    if (!isDisabled && !isCollapsed) {
+      expandedProjectIds.push(projectId);
+    }
+  }
+
+  if (expandedProjectIds.length <= 1) {
+    return expandedProjectIds[0] ?? null;
+  }
+
+  const overflowProjectIds = expandedProjectIds.filter(
+    (projectId) =>
+      projectListHeightPx({
+        projectId,
+        threads: input.threads,
+        sortMode: input.sortMode,
+        collapsedWorktrees: input.collapsedWorktrees,
+      }) > SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX,
+  );
+
+  return overflowProjectIds.length === 1 ? overflowProjectIds[0]! : null;
+}
+
+export function resolveProjectThreadListMaxHeight(input: {
+  growableProjectId: string | null;
+  projectId: string;
+  itemContentHeightPx: number;
+}): string | undefined {
+  if (input.itemContentHeightPx <= SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX) {
+    return undefined;
+  }
+
+  if (input.growableProjectId === input.projectId) {
+    return `${input.itemContentHeightPx}px`;
+  }
+
+  return `${SIDEBAR_THREAD_LIST_MAX_HEIGHT_PX}px`;
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
@@ -1,0 +1,207 @@
+import type { Thread } from "@/shared/contracts";
+import { groupThreads, type ThreadListEntry, type WorktreeThreadGroup } from "./groupThreads";
+import type { ThreadSortMode } from "./sortMode";
+
+export type SidebarVirtualRow =
+  | {
+      kind: "thread";
+      key: string;
+      thread: Thread;
+      threadIndex: number;
+      group: string;
+      showWorktreeBadge: boolean;
+      showWorktreeFilesButton?: boolean;
+      sortDisabled?: boolean;
+    }
+  | {
+      kind: "worktree-group";
+      key: string;
+      group: WorktreeThreadGroup;
+      entryIndex: number;
+      sortableGroup: string;
+      sortDisabled: boolean;
+    }
+  | {
+      kind: "thread-group";
+      key: string;
+      entry: Extract<ThreadListEntry, { kind: "thread-group" }>;
+    }
+  | { kind: "divider"; key: string }
+  | { kind: "section-label"; key: string; label: string };
+
+function isRecent(iso: string): boolean {
+  return Date.now() - new Date(iso).getTime() < 24 * 60 * 60 * 1000;
+}
+
+function getEntryDate(entry: ThreadListEntry, field: "updatedAt" | "createdAt"): string {
+  if (entry.kind === "thread") return entry.thread[field];
+  return entry.group.threads.reduce(
+    (latest, t) => (t[field] > latest ? t[field] : latest),
+    entry.group.threads[0]![field],
+  );
+}
+
+function entryIsStarred(entry: ThreadListEntry): boolean {
+  if (entry.kind === "thread") return entry.thread.starred;
+  return entry.group.threads.some((t) => t.starred);
+}
+
+export function estimateSidebarRowSize(row: SidebarVirtualRow | undefined): number {
+  if (!row) return 32;
+  if (row.kind === "divider") return 10;
+  if (row.kind === "section-label") return 28;
+  if (row.kind === "worktree-group") return 34;
+  if (row.kind === "thread-group") return 30;
+  return 30;
+}
+
+export function estimateSidebarProjectListHeightPx(rows: SidebarVirtualRow[]): number {
+  return rows.reduce((total, row) => total + estimateSidebarRowSize(row), 0);
+}
+
+function pushEntryRows(
+  rows: SidebarVirtualRow[],
+  entry: ThreadListEntry,
+  entryIndex: number,
+  input: {
+    projectId: string;
+    dndGroup: string;
+    dndDisabled: boolean;
+    collapsedWorktrees: Record<string, boolean>;
+    nextUngroupedIndex: () => number;
+  },
+) {
+  if (entry.kind === "thread") {
+    const idx = input.nextUngroupedIndex();
+    rows.push({
+      kind: "thread",
+      key: `thread:${entry.thread.id}`,
+      thread: entry.thread,
+      threadIndex: idx,
+      group: input.dndGroup,
+      showWorktreeBadge: true,
+      showWorktreeFilesButton: !!entry.thread.worktreePath,
+      sortDisabled: input.dndDisabled,
+    });
+    return;
+  }
+
+  if (entry.kind === "worktree-group") {
+    rows.push({
+      kind: "worktree-group",
+      key: `wt:${entry.group.worktreePath}`,
+      group: entry.group,
+      entryIndex,
+      sortableGroup: input.dndGroup,
+      sortDisabled: input.dndDisabled,
+    });
+    if (!(input.collapsedWorktrees[entry.group.worktreePath] ?? false)) {
+      entry.group.threads.forEach((thread, threadIndex) => {
+        rows.push({
+          kind: "thread",
+          key: `wt:${entry.group.worktreePath}:thread:${thread.id}`,
+          thread,
+          threadIndex,
+          group: `wt:${entry.group.worktreePath}`,
+          showWorktreeBadge: false,
+          showWorktreeFilesButton: false,
+        });
+      });
+    }
+    return;
+  }
+
+  const groupKey = entry.group.groupId;
+  rows.push({
+    kind: "thread-group",
+    key: `group:${groupKey}`,
+    entry,
+  });
+  if (!(input.collapsedWorktrees[`group:${groupKey}`] ?? false)) {
+    entry.group.threads.forEach((thread, threadIndex) => {
+      rows.push({
+        kind: "thread",
+        key: `group:${groupKey}:thread:${thread.id}`,
+        thread,
+        threadIndex,
+        group: `group:${groupKey}`,
+        showWorktreeBadge: !!thread.worktreePath,
+        sortDisabled: input.dndDisabled,
+      });
+    });
+  }
+}
+
+export function buildSidebarProjectRows(input: {
+  projectId: string;
+  projectThreads: Thread[];
+  sortMode: ThreadSortMode;
+  collapsedWorktrees: Record<string, boolean>;
+}): SidebarVirtualRow[] {
+  const rows: SidebarVirtualRow[] = [];
+  const dndGroup = `project-entries:${input.projectId}`;
+
+  if (input.sortMode === "manual") {
+    const orderedThreads = [...input.projectThreads].sort(
+      (a, b) => Number(b.starred) - Number(a.starred),
+    );
+    orderedThreads.forEach((thread, idx) => {
+      rows.push({
+        kind: "thread",
+        key: `thread:${thread.id}`,
+        thread,
+        threadIndex: idx,
+        group: dndGroup,
+        showWorktreeBadge: true,
+        showWorktreeFilesButton: !!thread.worktreePath,
+      });
+    });
+    return rows;
+  }
+
+  const dateField = input.sortMode === "created" ? "createdAt" : "updatedAt";
+  const entries = groupThreads(
+    [...input.projectThreads].sort((a, b) => b[dateField].localeCompare(a[dateField])),
+  );
+  const starredEntries = entries.filter(entryIsStarred);
+  const unstarredEntries = entries.filter((e) => !entryIsStarred(e));
+  const recentEntries = unstarredEntries.filter((e) => isRecent(getEntryDate(e, dateField)));
+  const olderEntries = unstarredEntries.filter((e) => !isRecent(getEntryDate(e, dateField)));
+  const hasBothSections = recentEntries.length > 0 && olderEntries.length > 0;
+  let ungroupedIndex = 0;
+
+  const nextUngroupedIndex = () => ungroupedIndex++;
+  const pushList = (list: ThreadListEntry[], offset = 0) => {
+    list.forEach((entry, i) => {
+      pushEntryRows(rows, entry, offset + i, {
+        projectId: input.projectId,
+        dndGroup,
+        dndDisabled: true,
+        collapsedWorktrees: input.collapsedWorktrees,
+        nextUngroupedIndex,
+      });
+      const isLast = i === list.length - 1;
+      if (isLast) return;
+      if (
+        entry.kind === "worktree-group" &&
+        !(input.collapsedWorktrees[entry.group.worktreePath] ?? false)
+      ) {
+        rows.push({ kind: "divider", key: `wt-divider:${entry.group.worktreePath}` });
+      } else if (
+        entry.kind === "thread-group" &&
+        !(input.collapsedWorktrees[`group:${entry.group.groupId}`] ?? false)
+      ) {
+        rows.push({ kind: "divider", key: `group-divider:${entry.group.groupId}` });
+      }
+    });
+  };
+
+  pushList(starredEntries);
+  pushList(recentEntries, starredEntries.length);
+  if (hasBothSections) {
+    rows.push({ kind: "section-label", key: "older-label", label: "Older" });
+  }
+  pushList(olderEntries, starredEntries.length + recentEntries.length);
+
+  return rows;
+}


### PR DESCRIPTION
- **Feature:** When exactly one expanded project’s thread list exceeds the height cap, let that list grow naturally so long thread lists stay visible without scrolling inside a fixed box
- Keep the existing capped height when multiple expanded projects overflow, or when all lists fit within the cap
- Extract sidebar row building and height estimation into shared modules so layout logic can predict list size before render
- Pass a resolved growable project id from the sidebar through project sections into each thread list
- Add unit tests for growable project selection and per-project max-height resolution