### PR TITLE
Split settings overlay into focused settings pages

### DIFF
--- a/src/renderer/components/providers/commitGen.test.ts
+++ b/src/renderer/components/providers/commitGen.test.ts
@@ -127,7 +127,7 @@ describe("getCommitGenCandidates", () => {
 describe("provider default hints", () => {
   it("builds commit-generation hint text from provider registrations", () => {
     expect(getCommitGenDefaultsHint()).toBe(
-      "Defaults: Claude -> Sonnet high, Codex -> GPT-5.4 Mini xhigh, Copilot -> auto, Cursor -> Composer 2 Fast, Gemini -> 3 Flash",
+      "Defaults: Claude -> Sonnet high, Codex -> GPT-5.4 Mini xhigh, Copilot -> auto, Cursor -> Composer 2.5, Gemini -> 3 Flash",
     );
   });
 });

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentStatus, Project } from "@/shared/contracts";
@@ -110,6 +110,22 @@ vi.mock("./parts/GeneralSettings", () => ({
   GeneralSettings: () => <div>General</div>,
 }));
 
+vi.mock("./parts/AppearanceSettings", () => ({
+  AppearanceSettings: () => <div>Appearance</div>,
+}));
+
+vi.mock("./parts/TerminalSettings", () => ({
+  TerminalSettings: () => <div>Terminal</div>,
+}));
+
+vi.mock("./parts/ThreadSettings", () => ({
+  ThreadSettings: () => <div>Threads</div>,
+}));
+
+vi.mock("./parts/GitSettings", () => ({
+  GitSettings: () => <div>Git</div>,
+}));
+
 vi.mock("./parts/NotificationSettings", () => ({
   NotificationSettings: () => <div>Notifications</div>,
 }));
@@ -120,6 +136,10 @@ vi.mock("./parts/AISettings", () => ({
 
 vi.mock("./parts/AcpRegistrySettings", () => ({
   AcpRegistrySettings: () => <div>Agent Registry Settings</div>,
+}));
+
+vi.mock("./parts/AgentsGeneralSettings", () => ({
+  AgentsGeneralSettings: () => <div>Agents General Settings</div>,
 }));
 
 vi.mock("./parts/SearchSettings", () => ({
@@ -194,7 +214,9 @@ describe("SettingsOverlay", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Agents" }));
 
-    expect(screen.getByRole("button", { name: "Gemini" })).toBeInTheDocument();
+    const geminiButton = screen.getByRole("button", { name: "Gemini" });
+    expect(geminiButton).toBeInTheDocument();
+    fireEvent.click(geminiButton);
     expect(screen.getByText("Agent gemini")).toBeInTheDocument();
   });
 
@@ -224,6 +246,36 @@ describe("SettingsOverlay", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Agent Registry" }));
     expect(screen.getByText("Agent Registry Settings")).toBeInTheDocument();
+  });
+
+  it("opens Agents on General and toggles closed on a second click", () => {
+    statusesState.agentStatuses = [
+      makeStatus("claude", {
+        label: "Claude Code",
+        envKind: "posix",
+      }),
+    ];
+
+    render(<SettingsOverlay onClose={() => undefined} />);
+
+    const agentsButton = screen.getByRole("button", { name: "Agents" });
+    fireEvent.click(agentsButton);
+    expect(
+      within(screen.getByRole("main")).getByText("Agents General Settings"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(agentsButton);
+    expect(within(screen.getByRole("main")).getByText("General")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Agent Registry" })).not.toBeInTheDocument();
+  });
+
+  it("routes split general sections from the sidebar", () => {
+    render(<SettingsOverlay onClose={() => undefined} />);
+
+    for (const section of ["Appearance", "Terminal", "Threads", "Git"]) {
+      fireEvent.click(screen.getByRole("button", { name: section }));
+      expect(within(screen.getByRole("main")).getByText(section)).toBeInTheDocument();
+    }
   });
 
   it("marks agents that need attention in the sidebar", () => {

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -6,14 +6,18 @@ import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
 import { PageLayout } from "@/renderer/components/layout/PageLayout";
 import { getSettingsInstalledAgents } from "@/shared/agentStatus";
+import { AppearanceSettings } from "./parts/AppearanceSettings";
 import { BrowserSettings } from "./parts/BrowserSettings";
 import { AudioSettings } from "./parts/AudioSettings";
 import { GeneralSettings } from "./parts/GeneralSettings";
+import { GitSettings } from "./parts/GitSettings";
 import { NotificationSettings } from "./parts/NotificationSettings";
 import { AISettings } from "./parts/AISettings";
 import { AcpRegistrySettings } from "./parts/AcpRegistrySettings";
 import { AgentsGeneralSettings } from "./parts/AgentsGeneralSettings";
 import { SearchSettings } from "./parts/SearchSettings";
+import { TerminalSettings } from "./parts/TerminalSettings";
+import { ThreadSettings } from "./parts/ThreadSettings";
 import { ArchivedThreadsSettings } from "./parts/ArchivedThreadsSettings";
 import { AboutSettings } from "./parts/AboutSettings";
 import { DevSettings } from "./parts/DevSettings";
@@ -24,6 +28,10 @@ import type { SettingsSection } from "./parts/types";
 const SECTION_VIEWS: Partial<Record<SettingsSection, () => ReactNode>> = {
   general: () => <GeneralSettings />,
   audio: () => <AudioSettings />,
+  appearance: () => <AppearanceSettings />,
+  terminal: () => <TerminalSettings />,
+  threads: () => <ThreadSettings />,
+  git: () => <GitSettings />,
   notifications: () => <NotificationSettings />,
   ai: () => <AISettings />,
   search: () => <SearchSettings />,

--- a/src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AISettings.tsx
@@ -23,6 +23,7 @@ import {
   sortByAutoPreference,
 } from "@/renderer/components/providers";
 import { TuxIcon } from "@/renderer/components/common";
+import { SettingsPage } from "./SettingsForm";
 
 type EnvKind = "windows" | "wsl";
 type Mode = "auto" | "custom" | "disabled";
@@ -280,84 +281,81 @@ export function AISettings() {
   );
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-lg font-semibold text-foreground">AI</h1>
-          {hasWsl ? (
-            <ToggleButtonGroup
-              aria-label="Environment"
-              className="h-7 [&_button]:h-7 [&_button]:min-h-0 [&_button]:min-w-0 [&_button]:px-2"
-              selectionMode="single"
-              disallowEmptySelection
-              size="sm"
-              selectedKeys={[envKind]}
-              onSelectionChange={(keys) => {
-                const next = [...keys][0] as EnvKind | undefined;
-                if (next) setEnvKind(next);
-              }}
-            >
-              <ToggleButton isIconOnly id="windows" aria-label="Windows">
-                <Monitor className="size-3.5" />
-              </ToggleButton>
-              <ToggleButton isIconOnly id="wsl" aria-label="WSL">
-                <ToggleButtonGroup.Separator />
-                <TuxIcon className="size-7" />
-              </ToggleButton>
-            </ToggleButtonGroup>
-          ) : null}
-        </div>
+    <SettingsPage
+      title="AI"
+      bodyClassName="space-y-8"
+      actions={
+        hasWsl ? (
+          <ToggleButtonGroup
+            aria-label="Environment"
+            className="h-7 [&_button]:h-7 [&_button]:min-h-0 [&_button]:min-w-0 [&_button]:px-2"
+            selectionMode="single"
+            disallowEmptySelection
+            size="sm"
+            selectedKeys={[envKind]}
+            onSelectionChange={(keys) => {
+              const next = [...keys][0] as EnvKind | undefined;
+              if (next) setEnvKind(next);
+            }}
+          >
+            <ToggleButton isIconOnly id="windows" aria-label="Windows">
+              <Monitor className="size-3.5" />
+            </ToggleButton>
+            <ToggleButton isIconOnly id="wsl" aria-label="WSL">
+              <ToggleButtonGroup.Separator />
+              <TuxIcon className="size-7" />
+            </ToggleButton>
+          </ToggleButtonGroup>
+        ) : null
+      }
+    >
+      <GenConfigSection
+        heading="Title Generation"
+        allowDisabled
+        description="Generates short titles for new threads."
+        defaultsHint={getTitleGenDefaultsHint()}
+        agentStatuses={activeStatuses}
+        provider={titleGenProvider}
+        model={titleGenModel}
+        effort={titleGenEffort}
+        resolve={resolveTitleGenConfig}
+        getCandidates={getTitleGenCandidates}
+        onConfigChange={setTitleGenConfig}
+      />
 
-        <div className="space-y-8">
-          <GenConfigSection
-            heading="Title Generation"
-            allowDisabled
-            description="Generates short titles for new threads."
-            defaultsHint={getTitleGenDefaultsHint()}
-            agentStatuses={activeStatuses}
-            provider={titleGenProvider}
-            model={titleGenModel}
-            effort={titleGenEffort}
-            resolve={resolveTitleGenConfig}
-            getCandidates={getTitleGenCandidates}
-            onConfigChange={setTitleGenConfig}
-          />
+      <GenConfigSection
+        heading="Commit Message Generation"
+        description="Generates commit messages from staged changes."
+        defaultsHint={getCommitGenDefaultsHint()}
+        agentStatuses={activeStatuses}
+        provider={commitGenProvider}
+        model={commitGenModel}
+        effort={commitGenEffort}
+        resolve={resolveCommitGenConfig}
+        getCandidates={getCommitGenCandidates}
+        onConfigChange={setCommitGenConfig}
+      />
 
-          <GenConfigSection
-            heading="Commit Message Generation"
-            description="Generates commit messages from staged changes."
-            defaultsHint={getCommitGenDefaultsHint()}
-            agentStatuses={activeStatuses}
-            provider={commitGenProvider}
-            model={commitGenModel}
-            effort={commitGenEffort}
-            resolve={resolveCommitGenConfig}
-            getCandidates={getCommitGenCandidates}
-            onConfigChange={setCommitGenConfig}
+      <GenConfigSection
+        heading="Conflict Resolver"
+        description="Resolves merge conflicts during rebase or merge."
+        defaultsHint={getConflictResolverDefaultsHint()}
+        agentStatuses={activeStatuses}
+        provider={conflictResolverProvider}
+        model={conflictResolverModel}
+        effort={conflictResolverEffort}
+        resolve={resolveConflictResolverConfig}
+        getCandidates={getConflictResolverCandidates}
+        onConfigChange={setConflictResolverConfig}
+        presentationMode={conflictResolverPresentationMode}
+        extraControls={
+          <PresentationModeToggle
+            ariaLabel="Open conflict resolver in"
+            value={conflictResolverPresentationMode}
+            onChange={setConflictResolverPresentationMode}
           />
-
-          <GenConfigSection
-            heading="Conflict Resolver"
-            description="Resolves merge conflicts during rebase or merge."
-            defaultsHint={getConflictResolverDefaultsHint()}
-            agentStatuses={activeStatuses}
-            provider={conflictResolverProvider}
-            model={conflictResolverModel}
-            effort={conflictResolverEffort}
-            resolve={resolveConflictResolverConfig}
-            getCandidates={getConflictResolverCandidates}
-            onConfigChange={setConflictResolverConfig}
-            presentationMode={conflictResolverPresentationMode}
-            extraControls={
-              <PresentationModeToggle
-                ariaLabel="Open conflict resolver in"
-                value={conflictResolverPresentationMode}
-                onChange={setConflictResolverPresentationMode}
-              />
-            }
-          />
-        </div>
-      </div>
-    </div>
+        }
+      />
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
@@ -5,6 +5,7 @@ import { PixelLoader } from "@/renderer/components/common";
 import { useUpdateStore } from "@/renderer/state/updateStore";
 import { productNameFor } from "@/shared/channel";
 import { formatBytes } from "@/shared/formatBytes";
+import { SettingsPage } from "./SettingsForm";
 import appIconStableUrl from "../../../../../build/icon.png";
 import appIconNightlyUrl from "../../../../../build/icon-nightly.png";
 
@@ -92,63 +93,59 @@ export function AboutSettings() {
   const appIconUrl = bridge.channel === "nightly" ? appIconNightlyUrl : appIconStableUrl;
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">About</h1>
-
-        <div className="mb-8 flex items-center gap-4">
-          <img src={appIconUrl} alt={productName} className="size-12 shrink-0 rounded-lg" />
-          <div>
-            <p className="text-lg font-semibold text-foreground">{productName}</p>
-            <p className="text-xs text-muted">
-              AI agent orchestrator — manage coding agents via Terminal and Native ACP.
-            </p>
-          </div>
+    <SettingsPage title="About" bodyClassName="">
+      <div className="mb-8 flex items-center gap-4">
+        <img src={appIconUrl} alt={productName} className="size-12 shrink-0 rounded-lg" />
+        <div>
+          <p className="text-lg font-semibold text-foreground">{productName}</p>
+          <p className="text-xs text-muted">
+            AI agent orchestrator — manage coding agents via Terminal and Native ACP.
+          </p>
         </div>
-
-        <div className="space-y-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Version</p>
-              <p className="text-xs text-muted">{bridge.appVersion}</p>
-            </div>
-            <div className="shrink-0">
-              <UpdateButton />
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-sm font-medium text-foreground">Channel</p>
-            <p className="text-sm text-muted capitalize">{bridge.channel}</p>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-sm font-medium text-foreground">Electron</p>
-            <p className="text-sm text-muted">{bridge.electronVersion}</p>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-sm font-medium text-foreground">License</p>
-            <p className="text-sm text-muted">Apache-2.0</p>
-          </div>
-        </div>
-
-        <div className="mt-8 space-y-3 border-t border-white/6 pt-6">
-          <AboutLink href={WEBSITE_URL}>Website</AboutLink>
-          <br />
-          <AboutLink href={GITHUB_REPO}>GitHub Repository</AboutLink>
-          <br />
-          <AboutLink href={`${GITHUB_REPO}/releases`}>Changelog</AboutLink>
-          <br />
-          <AboutLink href={`${GITHUB_REPO}/issues`}>Report an Issue</AboutLink>
-          <br />
-          <AboutLink href={`${GITHUB_REPO}/blob/master/LICENSE`}>License</AboutLink>
-        </div>
-
-        <p className="mt-8 text-xs text-muted">
-          &copy; {new Date().getFullYear()} Serhii Vecherenko. All rights reserved.
-        </p>
       </div>
-    </div>
+
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">Version</p>
+            <p className="text-xs text-muted">{bridge.appVersion}</p>
+          </div>
+          <div className="shrink-0">
+            <UpdateButton />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm font-medium text-foreground">Channel</p>
+          <p className="text-sm text-muted capitalize">{bridge.channel}</p>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm font-medium text-foreground">Electron</p>
+          <p className="text-sm text-muted">{bridge.electronVersion}</p>
+        </div>
+
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm font-medium text-foreground">License</p>
+          <p className="text-sm text-muted">Apache-2.0</p>
+        </div>
+      </div>
+
+      <div className="mt-8 space-y-3 border-t border-white/6 pt-6">
+        <AboutLink href={WEBSITE_URL}>Website</AboutLink>
+        <br />
+        <AboutLink href={GITHUB_REPO}>GitHub Repository</AboutLink>
+        <br />
+        <AboutLink href={`${GITHUB_REPO}/releases`}>Changelog</AboutLink>
+        <br />
+        <AboutLink href={`${GITHUB_REPO}/issues`}>Report an Issue</AboutLink>
+        <br />
+        <AboutLink href={`${GITHUB_REPO}/blob/master/LICENSE`}>License</AboutLink>
+      </div>
+
+      <p className="mt-8 text-xs text-muted">
+        &copy; {new Date().getFullYear()} Serhii Vecherenko. All rights reserved.
+      </p>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/AgentsGeneralSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AgentsGeneralSettings.tsx
@@ -1,17 +1,12 @@
 import { ModelOrderSection } from "./ModelOrderSection";
 import { ModelVisibilitySection } from "./ModelVisibilitySection";
+import { SettingsPage } from "./SettingsForm";
 
 export function AgentsGeneralSettings() {
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Agents · General</h1>
-
-        <div className="space-y-4">
-          <ModelVisibilitySection />
-          <ModelOrderSection />
-        </div>
-      </div>
-    </div>
+    <SettingsPage title="Agents · General">
+      <ModelVisibilitySection />
+      <ModelOrderSection />
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -1,0 +1,53 @@
+import { startTransition } from "react";
+import type { ThemeMode } from "@/shared/contracts";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { Select } from "@/renderer/components/common";
+import { SettingRow, SettingsPage } from "./SettingsForm";
+import { fontSizeOptions, themeOptions } from "./settingsOptions";
+
+export function AppearanceSettings() {
+  const themeMode = useSharedSettings((state) => state.themeMode);
+  const setThemeMode = useSharedSettings((state) => state.setThemeMode);
+  const guiChatFontSize = useSharedSettings((state) => state.guiChatFontSize);
+  const setGuiChatFontSize = useSharedSettings((state) => state.setGuiChatFontSize);
+
+  return (
+    <SettingsPage title="Appearance">
+      <SettingRow title="Theme" description="Choose how Lightcode looks.">
+        <Select
+          aria-label="Theme"
+          className="w-[160px] shrink-0"
+          options={themeOptions}
+          value={themeMode}
+          onChange={(value) => {
+            startTransition(() => {
+              setThemeMode(value as ThemeMode);
+            });
+          }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        title="GUI chat font size"
+        description={
+          <>
+            Agent chat (ACP / markdown). Command rows use this size minus 1&nbsp;px; tool and plan
+            lines minus 2&nbsp;px.
+          </>
+        }
+      >
+        <Select
+          aria-label="GUI chat font size"
+          className="w-[160px] shrink-0"
+          options={fontSizeOptions}
+          value={String(guiChatFontSize)}
+          onChange={(value) => {
+            startTransition(() => {
+              setGuiChatFontSize(Number.parseInt(value, 10) || 13);
+            });
+          }}
+        />
+      </SettingRow>
+    </SettingsPage>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
@@ -2,6 +2,7 @@ import { Button, Surface, Tooltip } from "@heroui/react";
 import { ArchiveRestore, Trash2 } from "lucide-react";
 import { useAppStore } from "@/renderer/state/appStore";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
+import { SettingsPage } from "./SettingsForm";
 
 export function ArchivedThreadsSettings() {
   const threads = useAppStore((s) => s.threads);
@@ -11,59 +12,55 @@ export function ArchivedThreadsSettings() {
   const archivedThreads = threads.filter((t) => t.archived);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Archived Threads</h1>
-
-        {archivedThreads.length === 0 ? (
-          <p className="text-sm text-muted">No archived threads.</p>
-        ) : (
-          <Surface variant="secondary" className="divide-y divide-white/6 rounded-xl">
-            {archivedThreads.map((thread) => {
-              const project = projects.find((p) => p.id === thread.projectId);
-              return (
-                <div key={thread.id} className="flex items-center gap-3 px-4 py-3">
-                  <ProviderIcon kind={thread.agentKind} className="size-4 shrink-0 text-muted" />
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <p className="truncate text-sm font-medium text-foreground">{thread.title}</p>
-                    {project && <p className="truncate text-xs text-muted">{project.name}</p>}
-                  </div>
-                  <div className="flex shrink-0 gap-1">
-                    <Tooltip delay={150}>
-                      <Tooltip.Trigger>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          isIconOnly
-                          aria-label="Restore thread"
-                          onPress={() => unarchiveThread(thread.id)}
-                        >
-                          <ArchiveRestore className="size-4" />
-                        </Button>
-                      </Tooltip.Trigger>
-                      <Tooltip.Content>Restore thread</Tooltip.Content>
-                    </Tooltip>
-                    <Tooltip delay={150}>
-                      <Tooltip.Trigger>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          isIconOnly
-                          aria-label="Delete thread"
-                          onPress={() => deleteThread(thread.id)}
-                        >
-                          <Trash2 className="size-4 text-danger" />
-                        </Button>
-                      </Tooltip.Trigger>
-                      <Tooltip.Content>Delete permanently</Tooltip.Content>
-                    </Tooltip>
-                  </div>
+    <SettingsPage title="Archived Threads" bodyClassName="">
+      {archivedThreads.length === 0 ? (
+        <p className="text-sm text-muted">No archived threads.</p>
+      ) : (
+        <Surface variant="secondary" className="divide-y divide-white/6 rounded-xl">
+          {archivedThreads.map((thread) => {
+            const project = projects.find((p) => p.id === thread.projectId);
+            return (
+              <div key={thread.id} className="flex items-center gap-3 px-4 py-3">
+                <ProviderIcon kind={thread.agentKind} className="size-4 shrink-0 text-muted" />
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <p className="truncate text-sm font-medium text-foreground">{thread.title}</p>
+                  {project && <p className="truncate text-xs text-muted">{project.name}</p>}
                 </div>
-              );
-            })}
-          </Surface>
-        )}
-      </div>
-    </div>
+                <div className="flex shrink-0 gap-1">
+                  <Tooltip delay={150}>
+                    <Tooltip.Trigger>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        isIconOnly
+                        aria-label="Restore thread"
+                        onPress={() => unarchiveThread(thread.id)}
+                      >
+                        <ArchiveRestore className="size-4" />
+                      </Button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content>Restore thread</Tooltip.Content>
+                  </Tooltip>
+                  <Tooltip delay={150}>
+                    <Tooltip.Trigger>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        isIconOnly
+                        aria-label="Delete thread"
+                        onPress={() => deleteThread(thread.id)}
+                      >
+                        <Trash2 className="size-4 text-danger" />
+                      </Button>
+                    </Tooltip.Trigger>
+                    <Tooltip.Content>Delete permanently</Tooltip.Content>
+                  </Tooltip>
+                </div>
+              </div>
+            );
+          })}
+        </Surface>
+      )}
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
@@ -3,6 +3,7 @@ import { Switch } from "@heroui/react";
 import { Select } from "@/renderer/components/common";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import type { BrowserLinkOpenTarget, BrowserLinkPresentationMode } from "@/shared/settings";
+import { SettingRow, SettingsPage } from "./SettingsForm";
 
 const linkOpenTargetOptions = [
   { id: "internal", label: "App Browser" },
@@ -22,106 +23,84 @@ export function BrowserSettings() {
   const setBrowserSetting = useSharedSettings((s) => s.setBrowserSetting);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Browser</h1>
-
-        <div className="space-y-4">
-          <SettingRow
-            title="Open links in"
-            description="Choose whether links from Lightcode and browser popups stay in Lightcode or open externally."
-          >
-            <Select
-              aria-label="Open links in"
-              className="w-[180px] shrink-0"
-              options={linkOpenTargetOptions}
-              value={linkOpenTarget}
-              onChange={(value) => {
-                startTransition(() => {
-                  setBrowserSetting("linkOpenTarget", value as BrowserLinkOpenTarget);
-                });
-              }}
-            />
-          </SettingRow>
-          <SettingRow
-            title="Show opened links in"
-            description="When links open in a Lightcode browser tab, choose where the browser is revealed."
-          >
-            <Select
-              aria-label="Show opened links in"
-              className="w-[180px] shrink-0"
-              options={linkPresentationModeOptions}
-              value={linkPresentationMode}
-              onChange={(value) => {
-                startTransition(() => {
-                  setBrowserSetting("linkPresentationMode", value as BrowserLinkPresentationMode);
-                });
-              }}
-            />
-          </SettingRow>
-          <SettingRow
-            title="Allow eval"
-            description={
-              <>
-                Lets agents call <code>eval</code> to run arbitrary JavaScript inside the embedded
-                page. Off by default — turn on only when you trust the loaded sites and the agent.
-              </>
-            }
-          >
-            <Switch
-              isSelected={allowEval}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setBrowserSetting("allowEval", selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </SettingRow>
-          <SettingRow
-            title="Allow agents to read/write cookies and storage"
-            description={
-              <>
-                Enables <code>cookies</code> and <code>storage</code>. Cookies can contain session
-                tokens and storage often holds auth state — only enable when you trust both the
-                agent and the sites it visits.
-              </>
-            }
-          >
-            <Switch
-              isSelected={allowDataAccess}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setBrowserSetting("allowDataAccess", selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </SettingRow>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function SettingRow(props: {
-  title: string;
-  description: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-foreground">{props.title}</p>
-        <p className="text-xs text-muted">{props.description}</p>
-      </div>
-      {props.children}
-    </div>
+    <SettingsPage title="Browser">
+      <SettingRow
+        title="Open links in"
+        description="Choose whether links from Lightcode and browser popups stay in Lightcode or open externally."
+      >
+        <Select
+          aria-label="Open links in"
+          className="w-[180px] shrink-0"
+          options={linkOpenTargetOptions}
+          value={linkOpenTarget}
+          onChange={(value) => {
+            startTransition(() => {
+              setBrowserSetting("linkOpenTarget", value as BrowserLinkOpenTarget);
+            });
+          }}
+        />
+      </SettingRow>
+      <SettingRow
+        title="Show opened links in"
+        description="When links open in a Lightcode browser tab, choose where the browser is revealed."
+      >
+        <Select
+          aria-label="Show opened links in"
+          className="w-[180px] shrink-0"
+          options={linkPresentationModeOptions}
+          value={linkPresentationMode}
+          onChange={(value) => {
+            startTransition(() => {
+              setBrowserSetting("linkPresentationMode", value as BrowserLinkPresentationMode);
+            });
+          }}
+        />
+      </SettingRow>
+      <SettingRow
+        title="Allow eval"
+        description={
+          <>
+            Lets agents call <code>eval</code> to run arbitrary JavaScript inside the embedded page.
+            Off by default — turn on only when you trust the loaded sites and the agent.
+          </>
+        }
+      >
+        <Switch
+          isSelected={allowEval}
+          onChange={(selected) => {
+            startTransition(() => {
+              setBrowserSetting("allowEval", selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+      <SettingRow
+        title="Allow agents to read/write cookies and storage"
+        description={
+          <>
+            Enables <code>cookies</code> and <code>storage</code>. Cookies can contain session
+            tokens and storage often holds auth state — only enable when you trust both the agent
+            and the sites it visits.
+          </>
+        }
+      >
+        <Switch
+          isSelected={allowDataAccess}
+          onChange={(selected) => {
+            startTransition(() => {
+              setBrowserSetting("allowDataAccess", selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
@@ -1,44 +1,34 @@
 import { startTransition } from "react";
 import { Switch } from "@heroui/react";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { SettingRow, SettingsPage } from "./SettingsForm";
 
 export function DevSettings() {
   const disableCliHookPlugin = useSharedSettings((state) => state.disableCliHookPlugin);
   const setDisableCliHookPlugin = useSharedSettings((state) => state.setDisableCliHookPlugin);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-2 text-lg font-semibold text-foreground">Dev</h1>
-        <p className="mb-6 text-xs text-muted">
-          Development-only overrides. Only visible in the LIGHTCODE DEV build.
-        </p>
-
-        <div className="space-y-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Disable CLI hook plugin (L1)</p>
-              <p className="text-xs text-muted">
-                Drops incoming hook envelopes on the supervisor so agents fall back to L2 (OSC 9;4
-                progress) without touching install or iTerm2 notifications. Takes effect on the next
-                hook event — no restart needed.
-              </p>
-            </div>
-            <Switch
-              isSelected={disableCliHookPlugin}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setDisableCliHookPlugin(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-        </div>
-      </div>
-    </div>
+    <SettingsPage
+      title="Dev"
+      description="Development-only overrides. Only visible in the LIGHTCODE DEV build."
+    >
+      <SettingRow
+        title="Disable CLI hook plugin (L1)"
+        description="Drops incoming hook envelopes on the supervisor so agents fall back to L2 (OSC 9;4 progress) without touching install or iTerm2 notifications. Takes effect on the next hook event — no restart needed."
+      >
+        <Switch
+          isSelected={disableCliHookPlugin}
+          onChange={(selected) => {
+            startTransition(() => {
+              setDisableCliHookPlugin(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
@@ -1,465 +1,115 @@
 import { startTransition } from "react";
-import { NumberField, Switch } from "@heroui/react";
-import type {
-  GitReviewMode,
-  NewThreadMode,
-  TerminalPosition,
-  ThemeMode,
-  ThreadRemoveAction,
-} from "@/shared/contracts";
+import { Switch } from "@heroui/react";
+import type { NewThreadMode } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { Select } from "@/renderer/components/common";
-
-const themeOptions = [
-  { id: "system", label: "System" },
-  { id: "light", label: "Light" },
-  { id: "dark", label: "Dark" },
-] as const;
-
-const terminalPositionOptions = [
-  { id: "right", label: "Right" },
-  { id: "bottom", label: "Bottom" },
-] as const;
-
-const threadRemoveActionOptions = [
-  { id: "archive", label: "Archive" },
-  { id: "delete", label: "Delete" },
-] as const;
-
-const newThreadModeOptions = [
-  { id: "page", label: "Page" },
-  { id: "panel", label: "Panel" },
-] as const;
-
-const gitReviewModeOptions = [
-  { id: "panel", label: "Panel" },
-  { id: "page", label: "Page" },
-] as const;
-
-const scrollSpeedOptions = Array.from({ length: 10 }, (_, i) => ({
-  id: String(i + 1),
-  label: `${i + 1}x`,
-})) as readonly { id: string; label: string }[];
-
-const fontSizeOptions = Array.from({ length: 13 }, (_, i) => ({
-  id: String(i + 8),
-  label: `${i + 8}px`,
-})) as readonly { id: string; label: string }[];
+import { SettingRow, SettingsPage } from "./SettingsForm";
+import { newThreadModeOptions } from "./settingsOptions";
 
 export function GeneralSettings() {
-  const themeMode = useSharedSettings((state) => state.themeMode);
-  const setThemeMode = useSharedSettings((state) => state.setThemeMode);
-  const terminalPosition = useSharedSettings((state) => state.terminalPosition);
-  const setTerminalPosition = useSharedSettings((state) => state.setTerminalPosition);
-  const collapseTerminalComposer = useSharedSettings((state) => state.collapseTerminalComposer);
-  const setCollapseTerminalComposer = useSharedSettings(
-    (state) => state.setCollapseTerminalComposer,
-  );
-  const autoShowTerminalPanel = useSharedSettings((state) => state.autoShowTerminalPanel);
-  const setAutoShowTerminalPanel = useSharedSettings((state) => state.setAutoShowTerminalPanel);
-  const staleThreadUnloadMinutes = useSharedSettings((state) => state.staleThreadUnloadMinutes);
-  const setStaleThreadUnloadMinutes = useSharedSettings(
-    (state) => state.setStaleThreadUnloadMinutes,
-  );
-  const autoArchiveDoneAfterDays = useSharedSettings((state) => state.autoArchiveDoneAfterDays);
-  const setAutoArchiveDoneAfterDays = useSharedSettings(
-    (state) => state.setAutoArchiveDoneAfterDays,
-  );
-  const scrollSpeed = useSharedSettings((state) => state.scrollSpeed);
-  const setScrollSpeed = useSharedSettings((state) => state.setScrollSpeed);
-  const agentTerminalFontSize = useSharedSettings((state) => state.agentTerminalFontSize);
-  const setAgentTerminalFontSize = useSharedSettings((state) => state.setAgentTerminalFontSize);
-  const guiChatFontSize = useSharedSettings((state) => state.guiChatFontSize);
-  const setGuiChatFontSize = useSharedSettings((state) => state.setGuiChatFontSize);
-  const terminalPanelFontSize = useSharedSettings((state) => state.terminalPanelFontSize);
-  const setTerminalPanelFontSize = useSharedSettings((state) => state.setTerminalPanelFontSize);
   const preventSleepWhileWorking = useSharedSettings((state) => state.preventSleepWhileWorking);
   const setPreventSleepWhileWorking = useSharedSettings(
     (state) => state.setPreventSleepWhileWorking,
   );
   const closeToTray = useSharedSettings((state) => state.closeToTray);
   const setCloseToTray = useSharedSettings((state) => state.setCloseToTray);
-  const threadRemoveAction = useSharedSettings((state) => state.threadRemoveAction);
-  const setThreadRemoveAction = useSharedSettings((state) => state.setThreadRemoveAction);
   const newThreadMode = useSharedSettings((state) => state.newThreadMode);
   const setNewThreadMode = useSharedSettings((state) => state.setNewThreadMode);
   const homeScopeEnabled = useSharedSettings((state) => state.homeScopeEnabled);
   const setHomeScopeEnabled = useSharedSettings((state) => state.setHomeScopeEnabled);
-  const gitReviewMode = useSharedSettings((state) => state.gitReviewMode);
-  const setGitReviewMode = useSharedSettings((state) => state.setGitReviewMode);
   const editorLspEnabled = useSharedSettings((state) => state.editorLspEnabled);
   const setEditorLspEnabled = useSharedSettings((state) => state.setEditorLspEnabled);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">General</h1>
+    <SettingsPage title="General">
+      <SettingRow
+        title="Default new thread"
+        description="Open new threads as a full page or a side-by-side panel."
+      >
+        <Select
+          aria-label="Default new thread"
+          className="w-[160px] shrink-0"
+          options={newThreadModeOptions}
+          value={newThreadMode}
+          onChange={(value) => {
+            startTransition(() => {
+              setNewThreadMode(value as NewThreadMode);
+            });
+          }}
+        />
+      </SettingRow>
 
-        <div className="space-y-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Theme</p>
-              <p className="text-xs text-muted">Choose how Lightcode looks.</p>
-            </div>
-            <Select
-              aria-label="Theme"
-              className="w-[160px] shrink-0"
-              options={themeOptions}
-              value={themeMode}
-              onChange={(value) => {
-                startTransition(() => {
-                  setThemeMode(value as ThemeMode);
-                });
-              }}
-            />
-          </div>
+      <SettingRow
+        title="Home scope"
+        description="Show a projectless Home scope for OS-level agent sessions."
+      >
+        <Switch
+          isSelected={homeScopeEnabled}
+          onChange={(selected) => {
+            startTransition(() => {
+              setHomeScopeEnabled(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
 
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Terminal position</p>
-              <p className="text-xs text-muted">Where the terminal panel appears.</p>
-            </div>
-            <Select
-              aria-label="Terminal position"
-              className="w-[160px] shrink-0"
-              options={terminalPositionOptions}
-              value={terminalPosition}
-              onChange={(value) => {
-                startTransition(() => {
-                  setTerminalPosition(value as TerminalPosition);
-                });
-              }}
-            />
-          </div>
+      <SettingRow
+        title="Prevent sleep while working"
+        description="Keep the system awake while any thread is actively working."
+      >
+        <Switch
+          isSelected={preventSleepWhileWorking}
+          onChange={(selected) => {
+            startTransition(() => {
+              setPreventSleepWhileWorking(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
 
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Auto-show terminal panel</p>
-              <p className="text-xs text-muted">
-                Automatically show the terminal panel when running commands or creating worktrees.
-              </p>
-            </div>
-            <Switch
-              isSelected={autoShowTerminalPanel}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setAutoShowTerminalPanel(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
+      <SettingRow
+        title="Close to tray"
+        description="When you close the window, keep Lightcode running in the system tray. Disable to quit on close."
+      >
+        <Switch
+          isSelected={closeToTray}
+          onChange={(selected) => {
+            startTransition(() => {
+              setCloseToTray(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
 
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Collapse terminal composer</p>
-              <p className="text-xs text-muted">
-                Hide the composer by default in terminal-native threads.
-              </p>
-            </div>
-            <Switch
-              isSelected={collapseTerminalComposer}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setCollapseTerminalComposer(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Unload idle threads after</p>
-              <p className="text-xs text-muted">
-                Hidden resumable threads are swept every 5 minutes and unloaded after this idle age.
-              </p>
-            </div>
-            <NumberField
-              aria-label="Unload idle threads after (minutes)"
-              className="w-[160px] shrink-0"
-              minValue={0}
-              step={10}
-              value={staleThreadUnloadMinutes}
-              onChange={(value) => {
-                if (value === undefined || Number.isNaN(value)) return;
-                startTransition(() => {
-                  setStaleThreadUnloadMinutes(Math.max(0, Math.floor(value)));
-                });
-              }}
-            >
-              <NumberField.Group>
-                <NumberField.DecrementButton />
-                <NumberField.Input />
-                <NumberField.IncrementButton />
-              </NumberField.Group>
-            </NumberField>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Auto-archive done threads after</p>
-              <p className="text-xs text-muted">
-                Threads marked done that haven&apos;t been touched for this many days are archived
-                automatically on app launch. Set to 0 to disable.
-              </p>
-            </div>
-            <NumberField
-              aria-label="Auto-archive done threads after (days)"
-              className="w-[160px] shrink-0"
-              minValue={0}
-              maxValue={3650}
-              step={1}
-              value={autoArchiveDoneAfterDays}
-              onChange={(value) => {
-                if (Number.isNaN(value)) return;
-                startTransition(() => {
-                  setAutoArchiveDoneAfterDays(Math.max(0, Math.floor(value)));
-                });
-              }}
-            >
-              <NumberField.Group>
-                <NumberField.DecrementButton />
-                <NumberField.Input />
-                <NumberField.IncrementButton />
-              </NumberField.Group>
-            </NumberField>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Agent terminal font size</p>
-              <p className="text-xs text-muted">
-                Base font size for agent terminals. Auto-shrinks in narrow or short panes.
-              </p>
-            </div>
-            <Select
-              aria-label="Agent terminal font size"
-              className="w-[160px] shrink-0"
-              options={fontSizeOptions}
-              value={String(agentTerminalFontSize)}
-              onChange={(value) => {
-                startTransition(() => {
-                  setAgentTerminalFontSize(Number.parseInt(value, 10) || 12);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">GUI chat font size</p>
-              <p className="text-xs text-muted">
-                Agent chat (ACP / markdown). Command rows use this size minus 1&nbsp;px; tool and
-                plan lines minus 2&nbsp;px.
-              </p>
-            </div>
-            <Select
-              aria-label="GUI chat font size"
-              className="w-[160px] shrink-0"
-              options={fontSizeOptions}
-              value={String(guiChatFontSize)}
-              onChange={(value) => {
-                startTransition(() => {
-                  setGuiChatFontSize(Number.parseInt(value, 10) || 13);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Terminal panel font size</p>
-              <p className="text-xs text-muted">
-                Base font size for the terminal panel. Auto-shrinks in narrow or short panes.
-              </p>
-            </div>
-            <Select
-              aria-label="Terminal panel font size"
-              className="w-[160px] shrink-0"
-              options={fontSizeOptions}
-              value={String(terminalPanelFontSize)}
-              onChange={(value) => {
-                startTransition(() => {
-                  setTerminalPanelFontSize(Number.parseInt(value, 10) || 11);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Terminal scroll speed</p>
-              <p className="text-xs text-muted">
-                Scroll speed multiplier for the terminal scrollback buffer.
-              </p>
-            </div>
-            <Select
-              aria-label="Terminal scroll speed"
-              className="w-[160px] shrink-0"
-              options={scrollSpeedOptions}
-              value={String(scrollSpeed)}
-              onChange={(value) => {
-                startTransition(() => {
-                  setScrollSpeed(Number.parseInt(value, 10) || 2);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Prevent sleep while working</p>
-              <p className="text-xs text-muted">
-                Keep the system awake while any thread is actively working.
-              </p>
-            </div>
-            <Switch
-              isSelected={preventSleepWhileWorking}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setPreventSleepWhileWorking(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Close to tray</p>
-              <p className="text-xs text-muted">
-                When you close the window, keep Lightcode running in the system tray. Disable to
-                quit on close.
-              </p>
-            </div>
-            <Switch
-              isSelected={closeToTray}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setCloseToTray(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Default thread removal</p>
-              <p className="text-xs text-muted">
-                Action for the quick-remove button on sidebar threads.
-              </p>
-            </div>
-            <Select
-              aria-label="Default thread removal"
-              className="w-[160px] shrink-0"
-              options={threadRemoveActionOptions}
-              value={threadRemoveAction}
-              onChange={(value) => {
-                startTransition(() => {
-                  setThreadRemoveAction(value as ThreadRemoveAction);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Default new thread</p>
-              <p className="text-xs text-muted">
-                Open new threads as a full page or a side-by-side panel.
-              </p>
-            </div>
-            <Select
-              aria-label="Default new thread"
-              className="w-[160px] shrink-0"
-              options={newThreadModeOptions}
-              value={newThreadMode}
-              onChange={(value) => {
-                startTransition(() => {
-                  setNewThreadMode(value as NewThreadMode);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Home scope</p>
-              <p className="text-xs text-muted">
-                Show a projectless Home scope for OS-level agent sessions.
-              </p>
-            </div>
-            <Switch
-              isSelected={homeScopeEnabled}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setHomeScopeEnabled(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Git review mode</p>
-              <p className="text-xs text-muted">
-                Open git review as a right-side panel or a full page.
-              </p>
-            </div>
-            <Select
-              aria-label="Git review mode"
-              className="w-[160px] shrink-0"
-              options={gitReviewModeOptions}
-              value={gitReviewMode}
-              onChange={(value) => {
-                startTransition(() => {
-                  setGitReviewMode(value as GitReviewMode);
-                });
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Editor LSP</p>
-              <p className="text-xs text-muted">
-                Enable language server support for type checking, completions, and diagnostics.
-                Requires a language server installed (e.g. typescript-language-server).
-              </p>
-            </div>
-            <Switch
-              isSelected={editorLspEnabled}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setEditorLspEnabled(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-        </div>
-      </div>
-    </div>
+      <SettingRow
+        title="Editor LSP"
+        description="Enable language server support for type checking, completions, and diagnostics. Requires a language server installed."
+      >
+        <Switch
+          isSelected={editorLspEnabled}
+          onChange={(selected) => {
+            startTransition(() => {
+              setEditorLspEnabled(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
@@ -1,0 +1,32 @@
+import { startTransition } from "react";
+import type { GitReviewMode } from "@/shared/contracts";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { Select } from "@/renderer/components/common";
+import { SettingRow, SettingsPage } from "./SettingsForm";
+import { gitReviewModeOptions } from "./settingsOptions";
+
+export function GitSettings() {
+  const gitReviewMode = useSharedSettings((state) => state.gitReviewMode);
+  const setGitReviewMode = useSharedSettings((state) => state.setGitReviewMode);
+
+  return (
+    <SettingsPage title="Git">
+      <SettingRow
+        title="Git review mode"
+        description="Open git review as a right-side panel or a full page."
+      >
+        <Select
+          aria-label="Git review mode"
+          className="w-[160px] shrink-0"
+          options={gitReviewModeOptions}
+          value={gitReviewMode}
+          onChange={(value) => {
+            startTransition(() => {
+              setGitReviewMode(value as GitReviewMode);
+            });
+          }}
+        />
+      </SettingRow>
+    </SettingsPage>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
@@ -3,6 +3,7 @@ import { Switch } from "@heroui/react";
 import type { NotificationFilter } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { Select } from "@/renderer/components/common";
+import { SettingRow, SettingsPage } from "./SettingsForm";
 
 const filterOptions = [
   { id: "unfocused", label: "Only when unfocused" },
@@ -22,43 +23,76 @@ export function NotificationSettings() {
   const setNotifyL2Cli = useSharedSettings((s) => s.setNotifyL2Cli);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Notifications</h1>
+    <SettingsPage title="Notifications">
+      <SettingRow
+        title="Enable notifications"
+        description="Show notifications when thread status changes."
+      >
+        <Switch
+          isSelected={notificationsEnabled}
+          onChange={(selected) => {
+            startTransition(() => {
+              setNotificationsEnabled(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
 
-        <div className="space-y-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">Enable notifications</p>
-              <p className="text-xs text-muted">Show notifications when thread status changes.</p>
-            </div>
-            <Switch
-              isSelected={notificationsEnabled}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setNotificationsEnabled(selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </div>
-
-          <div
-            className={`space-y-4 transition-opacity ${notificationsEnabled ? "" : "pointer-events-none opacity-40"}`}
+      <div
+        className={`space-y-4 transition-opacity ${notificationsEnabled ? "" : "pointer-events-none opacity-40"}`}
+      >
+        <SettingRow
+          title="Play notification sound"
+          description="Play a sound when a notification is shown."
+        >
+          <Switch
+            isSelected={notificationSound}
+            onChange={(selected) => {
+              startTransition(() => {
+                setNotificationSound(selected);
+              });
+            }}
           >
+            <Switch.Control>
+              <Switch.Thumb />
+            </Switch.Control>
+          </Switch>
+        </SettingRow>
+
+        <SettingRow
+          title="Show notifications"
+          description="When to display in-app toasts for visible threads."
+        >
+          <Select
+            aria-label="Show notifications"
+            className="w-[180px] shrink-0"
+            options={filterOptions}
+            value={notificationFilter}
+            onChange={(value) => {
+              startTransition(() => {
+                setNotificationFilter(value as NotificationFilter);
+              });
+            }}
+          />
+        </SettingRow>
+
+        <div className="pt-2">
+          <p className="mb-3 text-sm font-medium text-foreground">Notify me about</p>
+          <div className="space-y-3">
             <div className="flex items-center justify-between gap-4">
               <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">Play notification sound</p>
-                <p className="text-xs text-muted">Play a sound when a notification is shown.</p>
+                <p className="text-sm text-foreground">Done</p>
+                <p className="text-xs text-muted">Thread finished or waiting for your input.</p>
               </div>
               <Switch
-                isSelected={notificationSound}
+                isSelected={notificationStatuses.done}
                 onChange={(selected) => {
                   startTransition(() => {
-                    setNotificationSound(selected);
+                    setNotificationStatuses({ done: selected });
                   });
                 }}
               >
@@ -70,99 +104,33 @@ export function NotificationSettings() {
 
             <div className="flex items-center justify-between gap-4">
               <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">Show notifications</p>
-                <p className="text-xs text-muted">
-                  When to display in-app toasts for visible threads.
-                </p>
-              </div>
-              <Select
-                aria-label="Show notifications"
-                className="w-[180px] shrink-0"
-                options={filterOptions}
-                value={notificationFilter}
-                onChange={(value) => {
-                  startTransition(() => {
-                    setNotificationFilter(value as NotificationFilter);
-                  });
-                }}
-              />
-            </div>
-
-            <div className="pt-2">
-              <p className="mb-3 text-sm font-medium text-foreground">Notify me about</p>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between gap-4">
-                  <div className="min-w-0">
-                    <p className="text-sm text-foreground">Done</p>
-                    <p className="text-xs text-muted">Thread finished or waiting for your input.</p>
-                  </div>
-                  <Switch
-                    isSelected={notificationStatuses.done}
-                    onChange={(selected) => {
-                      startTransition(() => {
-                        setNotificationStatuses({ done: selected });
-                      });
-                    }}
-                  >
-                    <Switch.Control>
-                      <Switch.Thumb />
-                    </Switch.Control>
-                  </Switch>
-                </div>
-
-                <div className="flex items-center justify-between gap-4">
-                  <div className="min-w-0">
-                    <p className="text-sm text-foreground">Needs Attention</p>
-                    <p className="text-xs text-muted">Approval or reply required from you.</p>
-                  </div>
-                  <Switch
-                    isSelected={notificationStatuses.needsAttention}
-                    onChange={(selected) => {
-                      startTransition(() => {
-                        setNotificationStatuses({ needsAttention: selected });
-                      });
-                    }}
-                  >
-                    <Switch.Control>
-                      <Switch.Thumb />
-                    </Switch.Control>
-                  </Switch>
-                </div>
-
-                <div className="flex items-center justify-between gap-4">
-                  <div className="min-w-0">
-                    <p className="text-sm text-foreground">Error</p>
-                    <p className="text-xs text-muted">Agent encountered an error.</p>
-                  </div>
-                  <Switch
-                    isSelected={notificationStatuses.error}
-                    onChange={(selected) => {
-                      startTransition(() => {
-                        setNotificationStatuses({ error: selected });
-                      });
-                    }}
-                  >
-                    <Switch.Control>
-                      <Switch.Thumb />
-                    </Switch.Control>
-                  </Switch>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between gap-4 pt-2">
-              <div className="min-w-0">
-                <p className="text-sm font-medium text-foreground">Notify for L2 CLI threads</p>
-                <p className="text-xs text-muted">
-                  When off, suppress notifications from terminal threads whose status comes from the
-                  OSC fallback (no CLI hook plugin).
-                </p>
+                <p className="text-sm text-foreground">Needs Attention</p>
+                <p className="text-xs text-muted">Approval or reply required from you.</p>
               </div>
               <Switch
-                isSelected={notifyL2Cli}
+                isSelected={notificationStatuses.needsAttention}
                 onChange={(selected) => {
                   startTransition(() => {
-                    setNotifyL2Cli(selected);
+                    setNotificationStatuses({ needsAttention: selected });
+                  });
+                }}
+              >
+                <Switch.Control>
+                  <Switch.Thumb />
+                </Switch.Control>
+              </Switch>
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm text-foreground">Error</p>
+                <p className="text-xs text-muted">Agent encountered an error.</p>
+              </div>
+              <Switch
+                isSelected={notificationStatuses.error}
+                onChange={(selected) => {
+                  startTransition(() => {
+                    setNotificationStatuses({ error: selected });
                   });
                 }}
               >
@@ -173,7 +141,26 @@ export function NotificationSettings() {
             </div>
           </div>
         </div>
+
+        <SettingRow
+          className="pt-2"
+          title="Notify for L2 CLI threads"
+          description="When off, suppress notifications from terminal threads whose status comes from the OSC fallback (no CLI hook plugin)."
+        >
+          <Switch
+            isSelected={notifyL2Cli}
+            onChange={(selected) => {
+              startTransition(() => {
+                setNotifyL2Cli(selected);
+              });
+            }}
+          >
+            <Switch.Control>
+              <Switch.Thumb />
+            </Switch.Control>
+          </Switch>
+        </SettingRow>
       </div>
-    </div>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
@@ -1,6 +1,7 @@
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { DEFAULT_SEARCH_EXCLUDE } from "@/shared/searchExclude";
 import { SearchExcludeBody } from "./SearchExcludeBody";
+import { SettingsPage } from "./SettingsForm";
 
 export function SearchSettings() {
   const useIgnoreFiles = useSharedSettings((s) => s.searchUseIgnoreFiles);
@@ -9,27 +10,22 @@ export function SearchSettings() {
   const setExclude = useSharedSettings((s) => s.setSearchExclude);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-2 text-lg font-semibold text-foreground">Search</h1>
-        <p className="mb-6 text-xs text-muted">
-          Control which files appear in the @file mention search. Per-project overrides live in each
-          project's settings.
-        </p>
-
-        <SearchExcludeBody
-          useIgnoreFiles={useIgnoreFiles}
-          useIgnoreFilesNote={
-            <>
-              When enabled, search respects <code>.gitignore</code> entries.
-            </>
-          }
-          onUseIgnoreFilesChange={setUseIgnoreFiles}
-          baseline={DEFAULT_SEARCH_EXCLUDE}
-          value={exclude}
-          onValueChange={setExclude}
-        />
-      </div>
-    </div>
+    <SettingsPage
+      title="Search"
+      description="Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
+    >
+      <SearchExcludeBody
+        useIgnoreFiles={useIgnoreFiles}
+        useIgnoreFilesNote={
+          <>
+            When enabled, search respects <code>.gitignore</code> entries.
+          </>
+        }
+        onUseIgnoreFilesChange={setUseIgnoreFiles}
+        baseline={DEFAULT_SEARCH_EXCLUDE}
+        value={exclude}
+        onValueChange={setExclude}
+      />
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+export function SettingsPage(props: {
+  title: string;
+  /** Optional subtitle rendered under the title. */
+  description?: ReactNode;
+  /** Optional controls rendered to the right of the title (e.g. an env toggle). */
+  actions?: ReactNode;
+  /**
+   * Class for the body wrapper. Defaults to `space-y-4` (the standard row gap).
+   * Pass `""` to opt out when the body has bespoke spacing (e.g. About, Archived).
+   * Always use the destructuring default — switching to a truthy fallback would
+   * silently override the explicit `""` opt-out.
+   */
+  bodyClassName?: string;
+  children: ReactNode;
+}) {
+  const { title, description, actions, bodyClassName = "space-y-4", children } = props;
+  return (
+    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
+      <div className="mx-auto max-w-[720px]">
+        <div className={`flex items-center justify-between gap-4 ${description ? "mb-2" : "mb-6"}`}>
+          <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+          {actions ? <div className="shrink-0">{actions}</div> : null}
+        </div>
+        {description ? <p className="mb-6 text-xs text-muted">{description}</p> : null}
+        <div className={bodyClassName}>{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function SettingRow(props: {
+  title: string;
+  description: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`flex items-center justify-between gap-4 ${props.className ?? ""}`}>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground">{props.title}</p>
+        <p className="text-xs text-muted">{props.description}</p>
+      </div>
+      {props.children}
+    </div>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -6,15 +6,19 @@ import {
   Bot,
   Boxes,
   FlaskConical,
+  GitFork,
   Globe,
   Info,
   Mic,
+  MessageSquare,
   PanelLeft,
   PanelLeftClose,
+  Palette,
   RefreshCw,
   Search,
   Settings2,
   Sparkles,
+  TerminalSquare,
 } from "lucide-react";
 import type { AgentStatus } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -58,9 +62,12 @@ export function SettingsSidebar(props: {
     activeSection.startsWith("agents:");
   const devMode = isDevApp();
 
-  const selectFirstAgent = () => {
-    const first = installedAgents[0];
-    onSectionChange(first ? `agents:${first.kind}` : "agents");
+  const openAgents = () => {
+    if (isAgentsActive) {
+      onSectionChange("general");
+      return;
+    }
+    onSectionChange(installedAgents.length > 0 ? "agentsGeneral" : "agents");
   };
 
   return (
@@ -81,6 +88,34 @@ export function SettingsSidebar(props: {
               label="Audio"
               isActive={activeSection === "audio"}
               onPress={() => onSectionChange("audio")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<Palette className="size-4" />}
+              label="Appearance"
+              isActive={activeSection === "appearance"}
+              onPress={() => onSectionChange("appearance")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<TerminalSquare className="size-4" />}
+              label="Terminal"
+              isActive={activeSection === "terminal"}
+              onPress={() => onSectionChange("terminal")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<MessageSquare className="size-4" />}
+              label="Threads"
+              isActive={activeSection === "threads"}
+              onPress={() => onSectionChange("threads")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<GitFork className="size-4" />}
+              label="Git"
+              isActive={activeSection === "git"}
+              onPress={() => onSectionChange("git")}
             />
             <SidebarButton
               iconOnly
@@ -108,7 +143,7 @@ export function SettingsSidebar(props: {
               icon={<Bot className="size-4" />}
               label="Agents"
               isActive={isAgentsActive}
-              onPress={selectFirstAgent}
+              onPress={openAgents}
             />
             {isAgentsActive && (
               <SidebarButton
@@ -231,6 +266,30 @@ export function SettingsSidebar(props: {
               onPress={() => onSectionChange("audio")}
             />
             <SidebarButton
+              icon={<Palette className="size-4" />}
+              label="Appearance"
+              isActive={activeSection === "appearance"}
+              onPress={() => onSectionChange("appearance")}
+            />
+            <SidebarButton
+              icon={<TerminalSquare className="size-4" />}
+              label="Terminal"
+              isActive={activeSection === "terminal"}
+              onPress={() => onSectionChange("terminal")}
+            />
+            <SidebarButton
+              icon={<MessageSquare className="size-4" />}
+              label="Threads"
+              isActive={activeSection === "threads"}
+              onPress={() => onSectionChange("threads")}
+            />
+            <SidebarButton
+              icon={<GitFork className="size-4" />}
+              label="Git"
+              isActive={activeSection === "git"}
+              onPress={() => onSectionChange("git")}
+            />
+            <SidebarButton
               icon={<Bell className="size-4" />}
               label="Notifications"
               isActive={activeSection === "notifications"}
@@ -252,7 +311,7 @@ export function SettingsSidebar(props: {
               icon={<Bot className="size-4" />}
               label="Agents"
               isActive={activeSection === "agents"}
-              onPress={selectFirstAgent}
+              onPress={openAgents}
               suffix={
                 <button
                   type="button"

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/renderer/utils/acpRegistryAuth";
 import { Input, PixelLoader, Select } from "@/renderer/components/common";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
+import { SettingsPage } from "./SettingsForm";
 import {
   buildProviderModelItems,
   statusToMenuProvider,
@@ -740,12 +741,9 @@ export function SingleAgentSettings(props: { agentKind: string }) {
 
   if (!agent) {
     return (
-      <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-        <div className="mx-auto max-w-[720px]">
-          <h1 className="mb-6 text-lg font-semibold text-foreground">Agent not found</h1>
-          <p className="text-sm text-muted">This agent is not installed.</p>
-        </div>
-      </div>
+      <SettingsPage title="Agent not found" bodyClassName="">
+        <p className="text-sm text-muted">This agent is not installed.</p>
+      </SettingsPage>
     );
   }
 
@@ -1386,11 +1384,8 @@ export function SingleAgentSettings(props: { agentKind: string }) {
 
 export function AgentSettingsEmpty() {
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Agents</h1>
-        <p className="text-sm text-muted">No agents installed.</p>
-      </div>
-    </div>
+    <SettingsPage title="Agents" bodyClassName="">
+      <p className="text-sm text-muted">No agents installed.</p>
+    </SettingsPage>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
@@ -1,0 +1,129 @@
+import { startTransition } from "react";
+import { Switch } from "@heroui/react";
+import type { TerminalPosition } from "@/shared/contracts";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { Select } from "@/renderer/components/common";
+import { SettingRow, SettingsPage } from "./SettingsForm";
+import { fontSizeOptions, scrollSpeedOptions, terminalPositionOptions } from "./settingsOptions";
+
+export function TerminalSettings() {
+  const terminalPosition = useSharedSettings((state) => state.terminalPosition);
+  const setTerminalPosition = useSharedSettings((state) => state.setTerminalPosition);
+  const collapseTerminalComposer = useSharedSettings((state) => state.collapseTerminalComposer);
+  const setCollapseTerminalComposer = useSharedSettings(
+    (state) => state.setCollapseTerminalComposer,
+  );
+  const autoShowTerminalPanel = useSharedSettings((state) => state.autoShowTerminalPanel);
+  const setAutoShowTerminalPanel = useSharedSettings((state) => state.setAutoShowTerminalPanel);
+  const scrollSpeed = useSharedSettings((state) => state.scrollSpeed);
+  const setScrollSpeed = useSharedSettings((state) => state.setScrollSpeed);
+  const agentTerminalFontSize = useSharedSettings((state) => state.agentTerminalFontSize);
+  const setAgentTerminalFontSize = useSharedSettings((state) => state.setAgentTerminalFontSize);
+  const terminalPanelFontSize = useSharedSettings((state) => state.terminalPanelFontSize);
+  const setTerminalPanelFontSize = useSharedSettings((state) => state.setTerminalPanelFontSize);
+
+  return (
+    <SettingsPage title="Terminal">
+      <SettingRow title="Terminal position" description="Where the terminal panel appears.">
+        <Select
+          aria-label="Terminal position"
+          className="w-[160px] shrink-0"
+          options={terminalPositionOptions}
+          value={terminalPosition}
+          onChange={(value) => {
+            startTransition(() => {
+              setTerminalPosition(value as TerminalPosition);
+            });
+          }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        title="Auto-show terminal panel"
+        description="Automatically show the terminal panel when running commands or creating worktrees."
+      >
+        <Switch
+          isSelected={autoShowTerminalPanel}
+          onChange={(selected) => {
+            startTransition(() => {
+              setAutoShowTerminalPanel(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+
+      <SettingRow
+        title="Collapse terminal composer"
+        description="Hide the composer by default in terminal-native threads."
+      >
+        <Switch
+          isSelected={collapseTerminalComposer}
+          onChange={(selected) => {
+            startTransition(() => {
+              setCollapseTerminalComposer(selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+
+      <SettingRow
+        title="Agent terminal font size"
+        description="Base font size for agent terminals. Auto-shrinks in narrow or short panes."
+      >
+        <Select
+          aria-label="Agent terminal font size"
+          className="w-[160px] shrink-0"
+          options={fontSizeOptions}
+          value={String(agentTerminalFontSize)}
+          onChange={(value) => {
+            startTransition(() => {
+              setAgentTerminalFontSize(Number.parseInt(value, 10) || 12);
+            });
+          }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        title="Terminal panel font size"
+        description="Base font size for the terminal panel. Auto-shrinks in narrow or short panes."
+      >
+        <Select
+          aria-label="Terminal panel font size"
+          className="w-[160px] shrink-0"
+          options={fontSizeOptions}
+          value={String(terminalPanelFontSize)}
+          onChange={(value) => {
+            startTransition(() => {
+              setTerminalPanelFontSize(Number.parseInt(value, 10) || 11);
+            });
+          }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        title="Terminal scroll speed"
+        description="Scroll speed multiplier for the terminal scrollback buffer."
+      >
+        <Select
+          aria-label="Terminal scroll speed"
+          className="w-[160px] shrink-0"
+          options={scrollSpeedOptions}
+          value={String(scrollSpeed)}
+          onChange={(value) => {
+            startTransition(() => {
+              setScrollSpeed(Number.parseInt(value, 10) || 2);
+            });
+          }}
+        />
+      </SettingRow>
+    </SettingsPage>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
@@ -1,0 +1,92 @@
+import { startTransition } from "react";
+import { NumberField } from "@heroui/react";
+import type { ThreadRemoveAction } from "@/shared/contracts";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { Select } from "@/renderer/components/common";
+import { SettingRow, SettingsPage } from "./SettingsForm";
+import { threadRemoveActionOptions } from "./settingsOptions";
+
+export function ThreadSettings() {
+  const staleThreadUnloadMinutes = useSharedSettings((state) => state.staleThreadUnloadMinutes);
+  const setStaleThreadUnloadMinutes = useSharedSettings(
+    (state) => state.setStaleThreadUnloadMinutes,
+  );
+  const autoArchiveDoneAfterDays = useSharedSettings((state) => state.autoArchiveDoneAfterDays);
+  const setAutoArchiveDoneAfterDays = useSharedSettings(
+    (state) => state.setAutoArchiveDoneAfterDays,
+  );
+  const threadRemoveAction = useSharedSettings((state) => state.threadRemoveAction);
+  const setThreadRemoveAction = useSharedSettings((state) => state.setThreadRemoveAction);
+
+  return (
+    <SettingsPage title="Threads">
+      <SettingRow
+        title="Unload idle threads after"
+        description="Hidden resumable threads are swept every 5 minutes and unloaded after this idle age."
+      >
+        <NumberField
+          aria-label="Unload idle threads after (minutes)"
+          className="w-[160px] shrink-0"
+          minValue={0}
+          step={10}
+          value={staleThreadUnloadMinutes}
+          onChange={(value) => {
+            if (value === undefined || Number.isNaN(value)) return;
+            startTransition(() => {
+              setStaleThreadUnloadMinutes(Math.max(0, Math.floor(value)));
+            });
+          }}
+        >
+          <NumberField.Group>
+            <NumberField.DecrementButton />
+            <NumberField.Input />
+            <NumberField.IncrementButton />
+          </NumberField.Group>
+        </NumberField>
+      </SettingRow>
+
+      <SettingRow
+        title="Auto-archive done threads after"
+        description="Threads marked done that have not been touched for this many days are archived automatically on app launch. Set to 0 to disable."
+      >
+        <NumberField
+          aria-label="Auto-archive done threads after (days)"
+          className="w-[160px] shrink-0"
+          minValue={0}
+          maxValue={3650}
+          step={1}
+          value={autoArchiveDoneAfterDays}
+          onChange={(value) => {
+            if (Number.isNaN(value)) return;
+            startTransition(() => {
+              setAutoArchiveDoneAfterDays(Math.max(0, Math.floor(value)));
+            });
+          }}
+        >
+          <NumberField.Group>
+            <NumberField.DecrementButton />
+            <NumberField.Input />
+            <NumberField.IncrementButton />
+          </NumberField.Group>
+        </NumberField>
+      </SettingRow>
+
+      <SettingRow
+        title="Default thread removal"
+        description="Action for the quick-remove button on sidebar threads."
+      >
+        <Select
+          aria-label="Default thread removal"
+          className="w-[160px] shrink-0"
+          options={threadRemoveActionOptions}
+          value={threadRemoveAction}
+          onChange={(value) => {
+            startTransition(() => {
+              setThreadRemoveAction(value as ThreadRemoveAction);
+            });
+          }}
+        />
+      </SettingRow>
+    </SettingsPage>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsOptions.ts
@@ -1,0 +1,35 @@
+export const themeOptions = [
+  { id: "system", label: "System" },
+  { id: "light", label: "Light" },
+  { id: "dark", label: "Dark" },
+] as const;
+
+export const terminalPositionOptions = [
+  { id: "right", label: "Right" },
+  { id: "bottom", label: "Bottom" },
+] as const;
+
+export const threadRemoveActionOptions = [
+  { id: "archive", label: "Archive" },
+  { id: "delete", label: "Delete" },
+] as const;
+
+export const newThreadModeOptions = [
+  { id: "page", label: "Page" },
+  { id: "panel", label: "Panel" },
+] as const;
+
+export const gitReviewModeOptions = [
+  { id: "panel", label: "Panel" },
+  { id: "page", label: "Page" },
+] as const;
+
+export const scrollSpeedOptions = Array.from({ length: 10 }, (_, i) => ({
+  id: String(i + 1),
+  label: `${i + 1}x`,
+})) as readonly { id: string; label: string }[];
+
+export const fontSizeOptions = Array.from({ length: 13 }, (_, i) => ({
+  id: String(i + 8),
+  label: `${i + 8}px`,
+})) as readonly { id: string; label: string }[];

--- a/src/renderer/views/SettingsOverlay/parts/types.ts
+++ b/src/renderer/views/SettingsOverlay/parts/types.ts
@@ -1,6 +1,10 @@
 export type SettingsSection =
   | "general"
   | "audio"
+  | "appearance"
+  | "terminal"
+  | "threads"
+  | "git"
   | "notifications"
   | "ai"
   | "acpRegistry"


### PR DESCRIPTION
- **Refactor:** Break the monolithic General settings page into dedicated Appearance, Terminal, Threads, and Git pages so related preferences are easier to find and maintain.
- Add shared `SettingsPage` / `SettingRow` layout primitives and centralized option lists to keep page structure and copy consistent across the overlay.
- Extend the settings sidebar, section routing, and types with the new destinations and icons.
- Migrate existing panels (AI, Browser, Notifications, Search, Dev, About, agents, archived threads, and per-agent settings) onto the shared layout without changing underlying settings behavior.
- Update overlay tests to cover the expanded navigation and new page mocks.