### PR TITLE
Handle OS-level microphone permission and settings link

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -10,7 +10,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>com.apple.security.cs.debugger</key>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>
 </plist>

--- a/src/main/browser/permissions.test.ts
+++ b/src/main/browser/permissions.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMediaAccessStatus = vi.hoisted(() => vi.fn<(mediaType: string) => string>());
+const askForMediaAccess = vi.hoisted(() => vi.fn<(mediaType: string) => Promise<boolean>>());
+const openExternal = vi.hoisted(() => vi.fn<(url: string) => Promise<void>>());
+
+vi.mock("electron", () => ({
+  systemPreferences: { getMediaAccessStatus, askForMediaAccess },
+  shell: { openExternal },
+}));
+
+import { installSessionPermissions, openMicrophoneSettings } from "./permissions";
+
+type FakeWebContents = { getType(): string };
+type RequestHandler = (
+  webContents: FakeWebContents | null,
+  permission: string,
+  callback: (granted: boolean) => void,
+) => void;
+
+function installAndCaptureRequestHandler(): RequestHandler {
+  let requestHandler: RequestHandler | null = null;
+  const session = {
+    setPermissionRequestHandler: vi.fn<(handler: RequestHandler) => void>((handler) => {
+      requestHandler = handler;
+    }),
+    setPermissionCheckHandler: vi.fn<() => boolean>(),
+  };
+  installSessionPermissions(session as unknown as Parameters<typeof installSessionPermissions>[0]);
+  if (!requestHandler) {
+    throw new Error("installSessionPermissions did not register a request handler");
+  }
+  return requestHandler;
+}
+
+// The handler may answer synchronously (non-media) or asynchronously (media on
+// macOS, after the OS prompt resolves); a promise around the callback covers both.
+function requestPermission(
+  handler: RequestHandler,
+  webContents: FakeWebContents | null,
+  permission: string,
+): Promise<boolean> {
+  return new Promise((resolve) => handler(webContents, permission, resolve));
+}
+
+const windowContents: FakeWebContents = { getType: () => "window" };
+const webviewContents: FakeWebContents = { getType: () => "webview" };
+
+const originalPlatform = process.platform;
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+// Drain microtasks so a stray *second* callback invocation (e.g. a dropped
+// `return` after callback(false) falling through to the media branch) is
+// observed, not just the first.
+const flushMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks) so a mockReturnValue/mockResolvedValue set
+  // in one test cannot leak its implementation into a later test that omits it.
+  vi.resetAllMocks();
+  // The mic path logs diagnostics via console.error on the non-granted branches;
+  // silence them so test output stays pristine.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+});
+
+describe("installSessionPermissions media requests on macOS", () => {
+  beforeEach(() => setPlatform("darwin"));
+
+  it("allows media when OS microphone access is already granted, without re-prompting", async () => {
+    getMediaAccessStatus.mockReturnValue("granted");
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(true);
+    expect(askForMediaAccess).not.toHaveBeenCalled();
+  });
+
+  it("prompts for OS microphone access when undetermined and allows on grant", async () => {
+    getMediaAccessStatus.mockReturnValue("not-determined");
+    askForMediaAccess.mockResolvedValue(true);
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(true);
+    expect(askForMediaAccess).toHaveBeenCalledTimes(1);
+    expect(askForMediaAccess).toHaveBeenCalledWith("microphone");
+  });
+
+  it("denies media when the user declines the OS microphone prompt", async () => {
+    getMediaAccessStatus.mockReturnValue("not-determined");
+    askForMediaAccess.mockResolvedValue(false);
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(false);
+  });
+
+  // "restricted" (MDM/policy block) shares a branch with "denied"; exercise both
+  // so a future split of the two paths can't silently regress.
+  it.each(["denied", "restricted"])(
+    "denies media without prompting when OS access is %s",
+    async (status) => {
+      getMediaAccessStatus.mockReturnValue(status);
+      const handler = installAndCaptureRequestHandler();
+      await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(false);
+      expect(askForMediaAccess).not.toHaveBeenCalled();
+    },
+  );
+
+  it("denies media when the OS prompt throws rather than hanging the request", async () => {
+    getMediaAccessStatus.mockReturnValue("not-determined");
+    askForMediaAccess.mockRejectedValue(new Error("TCC unavailable"));
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(false);
+  });
+
+  it("denies media for non-window web contents without querying the OS", async () => {
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, webviewContents, "media")).resolves.toBe(false);
+    expect(getMediaAccessStatus).not.toHaveBeenCalled();
+    expect(askForMediaAccess).not.toHaveBeenCalled();
+  });
+
+  it("invokes the callback exactly once on the async granted media path", async () => {
+    getMediaAccessStatus.mockReturnValue("granted");
+    const handler = installAndCaptureRequestHandler();
+    const callback = vi.fn<(granted: boolean) => void>();
+    handler(windowContents, "media", callback);
+    await flushMicrotasks();
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it("invokes the callback exactly once when denying a non-window media request", async () => {
+    const handler = installAndCaptureRequestHandler();
+    const callback = vi.fn<(granted: boolean) => void>();
+    handler(webviewContents, "media", callback);
+    await flushMicrotasks();
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("installSessionPermissions media requests off macOS", () => {
+  beforeEach(() => setPlatform("win32"));
+
+  it("allows media for a window without querying the OS", async () => {
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "media")).resolves.toBe(true);
+    expect(getMediaAccessStatus).not.toHaveBeenCalled();
+    expect(askForMediaAccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("openMicrophoneSettings", () => {
+  it("opens the macOS Microphone privacy pane", async () => {
+    setPlatform("darwin");
+    await openMicrophoneSettings();
+    expect(openExternal).toHaveBeenCalledWith(
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+    );
+  });
+
+  it("opens the Windows microphone privacy settings", async () => {
+    setPlatform("win32");
+    await openMicrophoneSettings();
+    expect(openExternal).toHaveBeenCalledWith("ms-settings:privacy-microphone");
+  });
+
+  it("does nothing on platforms without a settings deep link", async () => {
+    setPlatform("linux");
+    await openMicrophoneSettings();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});
+
+describe("installSessionPermissions non-media permissions", () => {
+  beforeEach(() => setPlatform("darwin"));
+
+  it("allows allow-listed permissions without touching the OS prompt", async () => {
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "clipboard-read")).resolves.toBe(true);
+    expect(getMediaAccessStatus).not.toHaveBeenCalled();
+  });
+
+  it("denies permissions outside the allow-list", async () => {
+    const handler = installAndCaptureRequestHandler();
+    await expect(requestPermission(handler, windowContents, "geolocation")).resolves.toBe(false);
+  });
+});

--- a/src/main/browser/permissions.ts
+++ b/src/main/browser/permissions.ts
@@ -1,4 +1,4 @@
-import type { WebContents, Session } from "electron";
+import { shell, systemPreferences, type WebContents, type Session } from "electron";
 
 const ALLOWED_PERMISSIONS = new Set<string>([
   "clipboard-read",
@@ -32,9 +32,67 @@ function isPermissionAllowed(webContents: WebContents | null, permission: string
   return ALLOWED_PERMISSIONS.has(permission);
 }
 
+// Granting Chromium's "media" permission is not enough on macOS: microphone
+// capture is also gated by the OS-level TCC grant, which is a separate layer.
+// Without it getUserMedia resolves but yields a silent (all-zero) audio track
+// and no system prompt appears. Drive the OS prompt from the main process so
+// recording works regardless of how the Electron/Chromium getUserMedia path
+// happens to handle TCC. macOS-only; other platforms have no such gate.
+async function ensureMacMicrophoneAccess(): Promise<boolean> {
+  if (process.platform !== "darwin") {
+    return true;
+  }
+  const status = systemPreferences.getMediaAccessStatus("microphone");
+  if (status === "granted") {
+    return true;
+  }
+  // "denied"/"restricted" won't re-open the system alert — the user must change
+  // it in System Settings (or it's blocked by MDM/policy) — so report the
+  // denial rather than silently hanging.
+  if (status === "denied" || status === "restricted") {
+    console.error(
+      `[lightcode][mic] OS microphone access is "${status}"; not prompting (change in System Settings › Privacy & Security › Microphone)`,
+    );
+    return false;
+  }
+  try {
+    const granted = await systemPreferences.askForMediaAccess("microphone");
+    console.error(`[lightcode][mic] OS prompt result: ${granted ? "granted" : "denied"}`);
+    return granted;
+  } catch (error) {
+    console.error("[lightcode][mic] askForMediaAccess(microphone) failed", error);
+    return false;
+  }
+}
+
+// Deep-link to the OS microphone privacy pane so a user who previously denied
+// access can re-enable it. macOS won't re-prompt once denied, and the
+// Microphone pane has no "add app" affordance, so deep-linking is the only
+// recovery path. No universal scheme exists on Linux.
+const MICROPHONE_SETTINGS_URL: Partial<Record<NodeJS.Platform, string>> = {
+  darwin: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+  win32: "ms-settings:privacy-microphone",
+};
+
+export async function openMicrophoneSettings(): Promise<void> {
+  const url = MICROPHONE_SETTINGS_URL[process.platform];
+  if (!url) {
+    return;
+  }
+  await shell.openExternal(url);
+}
+
 export function installSessionPermissions(session: Session): void {
   session.setPermissionRequestHandler((webContents, permission, callback) => {
-    callback(isPermissionAllowed(webContents, permission));
+    if (!isPermissionAllowed(webContents, permission)) {
+      callback(false);
+      return;
+    }
+    if (permission === "media") {
+      void ensureMacMicrophoneAccess().then(callback);
+      return;
+    }
+    callback(true);
   });
   session.setPermissionCheckHandler((webContents, permission) =>
     isPermissionAllowed(webContents, permission),

--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { clipboard, dialog, nativeImage, shell, type BrowserWindow } from "electron";
 import type { BrowserPanelManager } from "../browser";
+import { openMicrophoneSettings } from "../browser/permissions";
 import {
   dbDeleteProject,
   dbDeleteThread,
@@ -102,6 +103,7 @@ export function createLocalIpcHandlers(
     openExternalNative: async (url) => {
       await shell.openExternal(assertSafeExternalUrl(url));
     },
+    openMicrophoneSettings: () => openMicrophoneSettings(),
     focusWindow: () => {
       const win = options.getMainWindow();
       if (!win) return;

--- a/src/main/macEntitlements.test.ts
+++ b/src/main/macEntitlements.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Guards the macOS signing entitlements that ship in the notarized build. The
+// hardened runtime denies microphone capture (no TCC prompt, silent audio)
+// unless the audio-input entitlement is present, and codesign silently drops
+// entitlements if the plist contains XML comments.
+const entitlementsPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../build/entitlements.mac.plist",
+);
+const plist = readFileSync(entitlementsPath, "utf8");
+
+describe("mac hardened-runtime entitlements", () => {
+  it("grants the microphone (audio-input) entitlement so voice input can record", () => {
+    expect(plist).toContain("com.apple.security.device.audio-input");
+  });
+
+  it("does not ship the debugger entitlement", () => {
+    expect(plist).not.toContain("com.apple.security.cs.debugger");
+  });
+
+  it("contains no XML comments (codesign silently drops entitlements when present)", () => {
+    expect(plist).not.toContain("<!--");
+  });
+});

--- a/src/renderer/components/composer/VoiceInputButton.tsx
+++ b/src/renderer/components/composer/VoiceInputButton.tsx
@@ -3,7 +3,7 @@ import { Mic, Square } from "lucide-react";
 import { toast, Tooltip } from "@heroui/react";
 import { Button, PixelLoader } from "@/renderer/components/common";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { friendlyError } from "@/shared/messages";
+import { formatVoiceError, showVoiceCaptureError } from "./voiceError";
 import {
   prepareVoiceAudio,
   subscribeVoiceTranscriptionProgress,
@@ -36,18 +36,6 @@ function createAudioContext(): AudioContext {
     throw new Error("Voice input requires audio support.");
   }
   return new AudioContextCtor();
-}
-
-function formatVoiceError(error: unknown): string {
-  if (error instanceof DOMException) {
-    if (error.name === "NotAllowedError" || error.name === "SecurityError") {
-      return "Microphone permission was denied.";
-    }
-    if (error.name === "NotFoundError" || error.name === "DevicesNotFoundError") {
-      return "No microphone found.";
-    }
-  }
-  return friendlyError(error);
 }
 
 function formatDownloadProgress(progress: VoiceTranscriptionProgress): string {
@@ -226,7 +214,7 @@ export function VoiceInputButton(props: {
       stream?.getTracks().forEach((track) => track.stop());
       void context?.close();
       setState("idle");
-      toast.danger(formatVoiceError(error));
+      showVoiceCaptureError(error);
     }
   }
 

--- a/src/renderer/components/composer/voiceError.test.ts
+++ b/src/renderer/components/composer/voiceError.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type ToastOptions = {
+  description?: string;
+  actionProps?: { children?: string; onPress?: () => void };
+  timeout?: number;
+};
+const dangerToast = vi.hoisted(() => vi.fn<(title: string, options?: ToastOptions) => void>());
+const isMac = vi.hoisted(() => vi.fn<() => boolean>());
+const isWindows = vi.hoisted(() => vi.fn<() => boolean>());
+const openMicrophoneSettings = vi.hoisted(() => vi.fn<() => Promise<void>>());
+
+vi.mock("@heroui/react", () => ({ toast: { danger: dangerToast } }));
+vi.mock("@/renderer/bridge", () => ({
+  isMac,
+  isWindows,
+  readBridge: () => ({ openMicrophoneSettings }),
+}));
+vi.mock("@/shared/messages", () => ({
+  friendlyError: (error: unknown) =>
+    `friendly:${error instanceof Error ? error.message : String(error)}`,
+}));
+
+import { formatVoiceError, showVoiceCaptureError } from "./voiceError";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  isMac.mockReturnValue(false);
+  isWindows.mockReturnValue(false);
+  openMicrophoneSettings.mockResolvedValue(undefined);
+});
+
+describe("formatVoiceError", () => {
+  it("labels a denied microphone", () => {
+    expect(formatVoiceError(new DOMException("x", "NotAllowedError"))).toBe(
+      "Microphone permission was denied.",
+    );
+  });
+
+  it("labels a missing device", () => {
+    expect(formatVoiceError(new DOMException("x", "NotFoundError"))).toBe("No microphone found.");
+  });
+
+  it("falls back to friendlyError for other errors", () => {
+    expect(formatVoiceError(new Error("boom"))).toBe("friendly:boom");
+  });
+});
+
+describe("showVoiceCaptureError", () => {
+  it("on macOS, shows an actionable toast whose action opens microphone settings", () => {
+    isMac.mockReturnValue(true);
+    showVoiceCaptureError(new DOMException("x", "NotAllowedError"));
+    expect(dangerToast).toHaveBeenCalledTimes(1);
+    const [title, options] = dangerToast.mock.calls[0]!;
+    expect(title).toBe("Microphone access is off.");
+    expect(options?.actionProps?.children).toBe("Open Settings");
+    options?.actionProps?.onPress?.();
+    expect(openMicrophoneSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("on Windows, also shows the actionable toast", () => {
+    isWindows.mockReturnValue(true);
+    showVoiceCaptureError(new DOMException("x", "NotAllowedError"));
+    const [title, options] = dangerToast.mock.calls[0]!;
+    expect(title).toBe("Microphone access is off.");
+    expect(options?.actionProps).toBeDefined();
+  });
+
+  it("on a platform without a settings deep link, falls back to the plain denial message", () => {
+    // isMac and isWindows both false (e.g. Linux)
+    showVoiceCaptureError(new DOMException("x", "NotAllowedError"));
+    expect(dangerToast).toHaveBeenCalledWith("Microphone permission was denied.");
+  });
+
+  it("shows the plain message for non-permission errors even on macOS", () => {
+    isMac.mockReturnValue(true);
+    showVoiceCaptureError(new DOMException("x", "NotFoundError"));
+    expect(dangerToast).toHaveBeenCalledWith("No microphone found.");
+  });
+});

--- a/src/renderer/components/composer/voiceError.ts
+++ b/src/renderer/components/composer/voiceError.ts
@@ -1,0 +1,38 @@
+import { toast } from "@heroui/react";
+import { isMac, isWindows, readBridge } from "@/renderer/bridge";
+import { friendlyError } from "@/shared/messages";
+import { isMicrophoneAccessDeniedError } from "./voicePermission";
+
+export function formatVoiceError(error: unknown): string {
+  if (isMicrophoneAccessDeniedError(error)) {
+    return "Microphone permission was denied.";
+  }
+  if (
+    error instanceof DOMException &&
+    (error.name === "NotFoundError" || error.name === "DevicesNotFoundError")
+  ) {
+    return "No microphone found.";
+  }
+  return friendlyError(error);
+}
+
+// A denied microphone is recoverable, but only by re-enabling it in OS settings
+// (macOS won't re-prompt once denied). Surface an actionable toast that opens
+// the right privacy pane instead of a dead-end error. The deep link only exists
+// on macOS/Windows, so fall back to the plain message elsewhere.
+export function showVoiceCaptureError(error: unknown): void {
+  if (isMicrophoneAccessDeniedError(error) && (isMac() || isWindows())) {
+    toast.danger("Microphone access is off.", {
+      description: "Enable microphone access in your system settings, then try again.",
+      actionProps: {
+        children: "Open Settings",
+        onPress: () => {
+          void readBridge().openMicrophoneSettings();
+        },
+      },
+      timeout: 0,
+    });
+    return;
+  }
+  toast.danger(formatVoiceError(error));
+}

--- a/src/renderer/components/composer/voicePermission.test.ts
+++ b/src/renderer/components/composer/voicePermission.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isMicrophoneAccessDeniedError } from "./voicePermission";
+
+describe("isMicrophoneAccessDeniedError", () => {
+  it("is true for a NotAllowedError DOMException", () => {
+    expect(isMicrophoneAccessDeniedError(new DOMException("denied", "NotAllowedError"))).toBe(true);
+  });
+
+  it("is true for a SecurityError DOMException", () => {
+    expect(isMicrophoneAccessDeniedError(new DOMException("blocked", "SecurityError"))).toBe(true);
+  });
+
+  it("is false for a NotFoundError DOMException (no device, not a denial)", () => {
+    expect(isMicrophoneAccessDeniedError(new DOMException("missing", "NotFoundError"))).toBe(false);
+  });
+
+  it("is false for a generic Error", () => {
+    expect(isMicrophoneAccessDeniedError(new Error("boom"))).toBe(false);
+  });
+
+  it("is false for non-error values", () => {
+    expect(isMicrophoneAccessDeniedError("denied")).toBe(false);
+    expect(isMicrophoneAccessDeniedError(null)).toBe(false);
+  });
+});

--- a/src/renderer/components/composer/voicePermission.ts
+++ b/src/renderer/components/composer/voicePermission.ts
@@ -1,0 +1,10 @@
+// Renderer-side helper for recognizing a microphone-permission denial so the
+// composer can offer an actionable "Open Settings" path instead of a dead-end
+// error. getUserMedia rejects with a NotAllowedError/SecurityError DOMException
+// when the OS (or Chromium) denies microphone access.
+export function isMicrophoneAccessDeniedError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    (error.name === "NotAllowedError" || error.name === "SecurityError")
+  );
+}

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -53,6 +53,7 @@ export const MAIN_LOCAL_PROCEDURE_NAMES = [
   "saveHandoffContext",
   "openExternal",
   "openExternalNative",
+  "openMicrophoneSettings",
   "focusWindow",
   "getHomeScopeLocation",
   "getKeybindings",

--- a/src/shared/ipc/procedures/app.ts
+++ b/src/shared/ipc/procedures/app.ts
@@ -47,6 +47,10 @@ export const appProcedures = {
     openExternalPayloadSchema,
     (url) => openExternalPayloadSchema.parse(url),
   ),
+  openMicrophoneSettings: defineNoArgProcedure<void, "main-local">(
+    "openMicrophoneSettings",
+    "main-local",
+  ),
   focusWindow: defineNoArgProcedure<void, "main-local">("focusWindow", "main-local"),
   getHomeScopeLocation: defineNoArgProcedure<ProjectLocation, "main-local">(
     "getHomeScopeLocation",


### PR DESCRIPTION
**Type:** Feature

* **macOS Entitlements Update:** Adds the audio input capability to entitlements so voice input can record on hardened runtime builds, and adds guards to ensure codesigning/entitlements validity.
* **OS-Level Permission Guarding:** Verifies and requests macOS TCC microphone permission from the main process to prevent silent recording failures when Chrome's permissions are bypassed.
* **IPC Integration:** Exposes a new IPC procedure to allow the renderer to programmatically open OS microphone privacy settings.
* **Actionable Error Feedback:** Replaces generic voice errors with platform-aware, actionable toast notifications that direct users to system settings if access is denied.