### PR TITLE
Prevent path truncation in lightcode-local URLs

### DIFF
--- a/src/shared/promptContent.test.ts
+++ b/src/shared/promptContent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildPromptContentBlocks } from "./promptContent";
+import { buildPromptContentBlocks, toLocalFileUrl } from "./promptContent";
 
 describe("buildPromptContentBlocks", () => {
   it("keeps text-only prompts as a text block", () => {
@@ -34,11 +34,57 @@ describe("buildPromptContentBlocks", () => {
       {
         kind: "image",
         mimeType: "image/png",
-        dataUrl: "lightcode-local:///C:/tmp/shot.png",
+        dataUrl: "lightcode-local://local/C:/tmp/shot.png",
         path: "C:\\tmp\\shot.png",
         name: "shot.png",
         source: "attachment",
       },
     ]);
+  });
+});
+
+describe("toLocalFileUrl", () => {
+  it("builds a constant-host URL for a POSIX absolute path", () => {
+    expect(toLocalFileUrl("/Users/me/img.png")).toBe("lightcode-local://local/Users/me/img.png");
+  });
+
+  it("builds a constant-host URL for a Windows drive path", () => {
+    expect(toLocalFileUrl("C:\\Users\\me\\img.png")).toBe(
+      "lightcode-local://local/C:/Users/me/img.png",
+    );
+  });
+
+  // Regression guard for the `standard: true` scheme privilege (commit bd0faf73).
+  // Standard/special schemes parse with WHATWG "special authority ignore
+  // slashes": leading slashes collapse and the first path segment is consumed
+  // as the (lowercased) host. The old `lightcode-local:///<path>` form
+  // therefore lost its first path segment — `/Users` on macOS, the drive
+  // letter on Windows — so the protocol handler resolved the wrong file and
+  // pasted images failed to render. The constant `local` host absorbs that
+  // parsing so the real path survives intact in `pathname`. This helper mirrors
+  // the resolution in src/main/attachments/localFiles.ts.
+  function resolveLikeProtocolHandler(url: string, platform: "darwin" | "win32"): string {
+    // lightcode-local is non-special in Node; swap to a special scheme to
+    // reproduce Chromium's standard-scheme canonicalization (host extraction).
+    const asSpecial = url.replace(/^lightcode-local:/, "https:");
+    const raw = decodeURIComponent(new URL(asSpecial).pathname);
+    return platform === "win32" && /^\/[A-Za-z]:/.test(raw) ? raw.slice(1) : raw;
+  }
+
+  it("round-trips a POSIX path through standard-scheme parsing", () => {
+    expect(resolveLikeProtocolHandler(toLocalFileUrl("/Users/me/img.png"), "darwin")).toBe(
+      "/Users/me/img.png",
+    );
+  });
+
+  it("round-trips a path containing spaces", () => {
+    const path = "/Users/me/Application Support/img.png";
+    expect(resolveLikeProtocolHandler(toLocalFileUrl(path), "darwin")).toBe(path);
+  });
+
+  it("round-trips a Windows drive path through standard-scheme parsing", () => {
+    expect(resolveLikeProtocolHandler(toLocalFileUrl("C:\\Users\\me\\img.png"), "win32")).toBe(
+      "C:/Users/me/img.png",
+    );
   });
 });

--- a/src/shared/promptContent.ts
+++ b/src/shared/promptContent.ts
@@ -43,7 +43,16 @@ export function isImagePath(path: string, mimeType?: string): boolean {
 
 export function toLocalFileUrl(absolutePath: string): string {
   const normalized = absolutePath.replaceAll("\\", "/");
-  return `lightcode-local:///${normalized}`;
+  // The `lightcode-local` scheme is registered as `standard: true` (so cached
+  // ACP registry icons can load as CSS mask-image sources). Standard/special
+  // schemes parse with WHATWG "special authority ignore slashes": leading
+  // slashes collapse and the first path segment becomes the host. Anchoring the
+  // path to a constant `local` host keeps the real path intact in the URL's
+  // `pathname` — without it, `/Users/…` (macOS) or the drive letter (Windows)
+  // would be eaten as the host and the protocol handler would resolve the wrong
+  // file. See src/main/attachments/localFiles.ts.
+  const path = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  return `lightcode-local://local${path}`;
 }
 
 export function buildPromptContentBlocks(


### PR DESCRIPTION
- Fixes a bug where pasted images and local files fail to render due to path truncation in `lightcode-local` URLs
- Prevents the first segment of absolute POSIX and Windows paths from being consumed as the URL host by anchoring paths to a constant `local` host
- Adds comprehensive unit tests to verify path serialization and round-trip parsing across macOS and Windows paths