### PR TITLE
Allow opening and reading files outside active project root

### DIFF
--- a/src/renderer/state/fileEditorStore.test.ts
+++ b/src/renderer/state/fileEditorStore.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { useFileEditorStore } from "./fileEditorStore";
+import {
+  useFileEditorStore,
+  type FileEditorRootContext,
+  resolvePathForFileOpen,
+} from "./fileEditorStore";
 
 function makeBuffer(path: string) {
   return {
@@ -270,5 +274,56 @@ describe("fileEditorStore preview tabs", () => {
     expect(useFileEditorStore.getState().previewTab).toBeNull();
     expect(useFileEditorStore.getState().markdownPreviewPath).toBeNull();
     expect(useFileEditorStore.getState().tabs).toEqual(["other.ts"]);
+  });
+});
+
+describe("resolvePathForFileOpen (worktree-relative traversal regression)", () => {
+  const posixWorktreeLocation = {
+    kind: "posix" as const,
+    path: "/Users/me/code/main-repo/.git/worktrees/feature-x",
+  };
+
+  const posixMainRepoLocation = {
+    kind: "posix" as const,
+    path: "/Users/me/code/main-repo",
+  };
+
+  const worktreeContext: FileEditorRootContext = {
+    projectId: "proj-1",
+    projectName: "main-repo",
+    projectLocation: posixWorktreeLocation,
+    rootLabel: "feature-x",
+    worktreePath: "/Users/me/code/main-repo/.git/worktrees/feature-x",
+  };
+
+  const mainRepoContext: FileEditorRootContext = {
+    projectId: "proj-1",
+    projectName: "main-repo",
+    projectLocation: posixMainRepoLocation,
+    rootLabel: "main-repo",
+  };
+
+  it("resolves a worktree-rooted relative path with .. against the worktree (not the main repo)", () => {
+    const result = resolvePathForFileOpen(worktreeContext, "../sibling/file.txt");
+    expect(result).toBe("/Users/me/code/main-repo/.git/worktrees/feature-x/../sibling/file.txt");
+  });
+
+  it("resolves an escaping relative under main repo context against the main root", () => {
+    const result = resolvePathForFileOpen(mainRepoContext, "../outside.txt");
+    expect(result).toBe("/Users/me/code/main-repo/../outside.txt");
+  });
+
+  it("leaves normal project-relative paths unchanged", () => {
+    expect(resolvePathForFileOpen(worktreeContext, "src/app.ts")).toBe("src/app.ts");
+    expect(resolvePathForFileOpen(mainRepoContext, "README.md")).toBe("README.md");
+  });
+
+  it("leaves already-absolute paths unchanged", () => {
+    expect(resolvePathForFileOpen(worktreeContext, "/etc/hosts")).toBe("/etc/hosts");
+    expect(resolvePathForFileOpen(mainRepoContext, "/tmp/x.txt")).toBe("/tmp/x.txt");
+  });
+
+  it("returns raw path when no rootContext", () => {
+    expect(resolvePathForFileOpen(null, "../foo")).toBe("../foo");
   });
 });

--- a/src/renderer/state/fileEditorStore.ts
+++ b/src/renderer/state/fileEditorStore.ts
@@ -10,15 +10,39 @@ import { captureProductEvent } from "../analytics/posthog";
 import { captureRendererException } from "../diagnostics/sentry";
 import { hasUnresolvedConflicts } from "@/renderer/utils/mergeConflicts";
 import { useGitStore } from "./gitStore";
+import { resolveAbsolutePath } from "@/renderer/utils/resolveAbsolutePath";
 
 /**
  * Paths in the file editor are either project-relative (e.g. `src/foo.ts`)
- * or absolute when the user opens an out-of-project file from chat
- * (e.g. `/etc/hosts`). Absolute paths skip the project-relative IPC and
- * route through the external-file IPC instead.
+ * or absolute (including paths resolved from worktree-relative ".." traversals)
+ * when the user opens a file outside the active root from chat or commands.
+ * Absolute paths skip the project-relative IPC and route through the
+ * external-file IPC instead (which has no containment restriction).
  */
 function isExternalPath(path: string): boolean {
   return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
+}
+
+function containsPathTraversal(path: string): boolean {
+  const normalized = path.replace(/\\/g, "/");
+  return /(^|\/)\.\.($|\/)/.test(normalized);
+}
+
+/**
+ * For user-initiated file opens, turn a relative path containing ".." traversal
+ * into an absolute path resolved against the active worktree (or project) root.
+ * This lets users open sibling directories or files outside the worktree
+ * (e.g. from agent chat output) without weakening the strict
+ * normalizeRelativePath guard used by the project tree browser and search.
+ */
+export function resolvePathForFileOpen(
+  rootContext: FileEditorRootContext | null,
+  rawPath: string,
+): string {
+  if (!rootContext) return rawPath;
+  if (isExternalPath(rawPath)) return rawPath;
+  if (!containsPathTraversal(rawPath)) return rawPath;
+  return resolveAbsolutePath(rootContext.projectLocation, rawPath);
 }
 
 function externalReadAsProjectResult(result: ReadExternalFileResult): ReadProjectFileResult {
@@ -292,30 +316,38 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
       state.pendingReveal && state.pendingReveal.token === token ? { pendingReveal: null } : {},
     ),
   async openFile(path, mode = "modal", preview = false, options) {
-    const lineNumber = options?.lineNumber;
-    const markdownPreviewPath = options?.markdownPreview ? path : null;
-    const reveal: FileEditorPendingReveal | null =
-      lineNumber !== undefined && Number.isFinite(lineNumber) && lineNumber > 0
-        ? { path, lineNumber, token: ++revealTokenCounter }
-        : null;
     const rootContext = get().rootContext;
     if (!rootContext) {
       throw new Error("No file editor context is active.");
     }
 
-    const existing = get().buffers[path];
+    // User-initiated opens of relative paths containing ".." (e.g. "../sibling/file"
+    // from a worktree) are resolved to absolute against the active worktree root
+    // so they route through the unrestricted external read path. This does not
+    // affect the strict project-tree browser/search which continues to use
+    // normalizeRelativePath on the supervisor.
+    const openPath = resolvePathForFileOpen(rootContext, path);
+
+    const lineNumber = options?.lineNumber;
+    const markdownPreviewPath = options?.markdownPreview ? openPath : null;
+    const reveal: FileEditorPendingReveal | null =
+      lineNumber !== undefined && Number.isFinite(lineNumber) && lineNumber > 0
+        ? { path: openPath, lineNumber, token: ++revealTokenCounter }
+        : null;
+
+    const existing = get().buffers[openPath];
     if (existing && !existing.isLoading) {
       set((state) => {
-        const changes = computeTabOpen(state, path, mode, preview);
+        const changes = computeTabOpen(state, openPath, mode, preview);
         return {
           ...changes,
-          activePath: path,
+          activePath: openPath,
           markdownPreviewPath,
           ...(reveal ? { pendingReveal: reveal } : {}),
         };
       });
       const cachedResult = {
-        path,
+        path: openPath,
         status: existing.status,
         modifiedAtMs: existing.modifiedAtMs,
         ...(existing.status === "ready"
@@ -330,16 +362,16 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
     }
 
     set((state) => {
-      const changes = computeTabOpen(state, path, mode, preview);
+      const changes = computeTabOpen(state, openPath, mode, preview);
       return {
         ...changes,
-        activePath: path,
+        activePath: openPath,
         markdownPreviewPath,
         ...(reveal ? { pendingReveal: reveal } : {}),
         buffers: {
           ...changes.buffers,
-          [path]: {
-            path,
+          [openPath]: {
+            path: openPath,
             status: "ready",
             modifiedAtMs: 0,
             content: "",
@@ -354,41 +386,41 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
     });
 
     try {
-      const result = isExternalPath(path)
+      const result = isExternalPath(openPath)
         ? externalReadAsProjectResult(
             await readBridge().readExternalFile({
               projectLocation: rootContext.projectLocation,
-              absolutePath: path,
+              absolutePath: openPath,
             }),
           )
         : await readBridge().readProjectFile({
             projectLocation: rootContext.projectLocation,
-            path,
+            path: openPath,
           });
       set((state) => ({
         buffers: {
           ...state.buffers,
-          [path]: buildBuffer(result),
+          [openPath]: buildBuffer(result),
         },
       }));
       captureProductEvent("file.opened", {
         overlay_mode: mode ?? "unchanged",
-        source: isExternalPath(path) ? "external" : "project",
+        source: isExternalPath(openPath) ? "external" : "project",
       });
       return result;
     } catch (error) {
       set((state) => {
-        const { [path]: _, ...rest } = state.buffers;
+        const { [openPath]: _, ...rest } = state.buffers;
         return {
           buffers: rest,
-          tabs: state.tabs.filter((tabPath) => tabPath !== path),
+          tabs: state.tabs.filter((tabPath) => tabPath !== openPath),
           activePath:
-            state.activePath === path
-              ? (state.tabs.find((tabPath) => tabPath !== path) ?? null)
+            state.activePath === openPath
+              ? (state.tabs.find((tabPath) => tabPath !== openPath) ?? null)
               : state.activePath,
-          previewTab: state.previewTab === path ? null : state.previewTab,
+          previewTab: state.previewTab === openPath ? null : state.previewTab,
           markdownPreviewPath:
-            state.markdownPreviewPath === path ? null : state.markdownPreviewPath,
+            state.markdownPreviewPath === openPath ? null : state.markdownPreviewPath,
         };
       });
       throw error;

--- a/src/shared/contracts/projectTree.ts
+++ b/src/shared/contracts/projectTree.ts
@@ -88,8 +88,8 @@ export interface ReadAbsoluteFileResult {
 }
 
 /**
- * Read a file inside the project root through the project's location context
- * (native FS for Windows/POSIX projects; the WSL bridge for WSL projects).
+ * Read a file through the project's location context (native FS for
+ * Windows/POSIX projects; the WSL bridge for WSL projects).
  *
  * Used by the chat UI to surface a just-created file's content even when the
  * agent didn't stream it. Path resolution:
@@ -97,8 +97,10 @@ export interface ReadAbsoluteFileResult {
  * - Windows projects: pass an absolute Windows path.
  * - POSIX projects: pass an absolute POSIX path.
  *
- * Relative paths are resolved against the project root for convenience. Absolute
- * paths are rejected unless they remain inside the same project root.
+ * Relative paths are resolved against the project root for convenience.
+ * Absolute paths are read as-is, including paths outside the project root
+ * (e.g. a plan in a git worktree) — the editor must be able to open any file
+ * the user or agent references.
  */
 export const readAbsoluteFilePayloadSchema = z.object({
   projectLocation: projectLocationSchema,

--- a/src/supervisor/projectTree.test.ts
+++ b/src/supervisor/projectTree.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import { tmpdir } from "node:os";
 import { beforeEach, afterEach, describe, expect, it } from "vitest";
 import type { ProjectLocation } from "@/shared/contracts";
 import { ProjectTreeService } from "./projectTree";
+import type { WslBridgeClient } from "./wsl/bridge/client";
 
 describe("ProjectTreeService", () => {
   let tempDir: string;
@@ -77,24 +78,32 @@ describe("ProjectTreeService", () => {
     expect(result.status).toBe("binary");
   });
 
-  it("reads absolute file paths only when they stay inside the project root", async () => {
+  it("reads absolute file paths inside and outside the project root", async () => {
     const insidePath = join(tempDir, "inside.txt");
-    const outsidePath = join(tempDir, "..", "outside.txt");
     writeFileSync(insidePath, "inside\n", "utf8");
+    const externalDir = mkdtempSync(join(tmpdir(), "lightcode-abs-external-"));
+    const outsidePath = join(externalDir, "outside.txt");
+    writeFileSync(outsidePath, "outside\n", "utf8");
 
-    await expect(
-      service.readAbsoluteFile({
-        projectLocation: location,
-        absolutePath: insidePath,
-      }),
-    ).resolves.toMatchObject({ status: "ready", content: "inside\n" });
+    try {
+      await expect(
+        service.readAbsoluteFile({
+          projectLocation: location,
+          absolutePath: insidePath,
+        }),
+      ).resolves.toMatchObject({ status: "ready", content: "inside\n" });
 
-    await expect(
-      service.readAbsoluteFile({
-        projectLocation: location,
-        absolutePath: outsidePath,
-      }),
-    ).rejects.toThrow("Path escapes the project root.");
+      // Files outside the project root are allowed — the editor must be able to
+      // open any absolute path the user or agent references.
+      await expect(
+        service.readAbsoluteFile({
+          projectLocation: location,
+          absolutePath: outsidePath,
+        }),
+      ).resolves.toMatchObject({ status: "ready", content: "outside\n" });
+    } finally {
+      rmSync(externalDir, { recursive: true, force: true });
+    }
   });
 
   it("resolves relative readAbsoluteFile paths against the project root", async () => {
@@ -193,5 +202,175 @@ describe("ProjectTreeService", () => {
       path: "dest/renamed.ts",
     });
     expect(existsSync(join(tempDir, "dest", "renamed.ts"))).toBe(false);
+  });
+});
+
+/**
+ * Faithful stand-in for the WSL bridge: it applies the SAME project-root
+ * containment check as the in-distro `resolveSafePath` (bridge.mjs), so a
+ * request whose target escapes the declared `projectRoot` fails with `ESCAPE`
+ * exactly as the real bridge would. The supervisor never confines external
+ * reads/writes to the project root, so anchoring the bridge's `projectRoot`
+ * to `location.linuxPath` for an out-of-root path is what throws
+ * "path escapes projectRoot" on WSL.
+ */
+class ContainmentBridgeClient {
+  files = new Map<string, { content: Buffer; mtimeMs: number }>();
+  reads: { projectRoot: string; path: string }[] = [];
+  writes: { projectRoot: string; path: string }[] = [];
+
+  private resolveOrEscape(projectRoot: string, target: string): string {
+    const normRoot = posix.normalize(projectRoot);
+    const normTarget = posix.normalize(target);
+    const contained =
+      posix.isAbsolute(projectRoot) &&
+      posix.isAbsolute(target) &&
+      (normTarget === normRoot || normTarget.startsWith(`${normRoot}/`));
+    if (!contained) {
+      throw Object.assign(new Error("path escapes projectRoot"), { code: "ESCAPE" });
+    }
+    return normTarget;
+  }
+
+  async readFile(
+    location: { linuxPath: string },
+    absolutePath: string,
+    options?: { maxBytes?: number },
+  ) {
+    this.reads.push({ projectRoot: location.linuxPath, path: absolutePath });
+    const target = this.resolveOrEscape(location.linuxPath, absolutePath);
+    const file = this.files.get(target);
+    if (!file) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    if (options?.maxBytes && file.content.length > options.maxBytes) {
+      return { tooLarge: true as const, size: file.content.length, mtimeMs: file.mtimeMs };
+    }
+    return {
+      size: file.content.length,
+      mtimeMs: file.mtimeMs,
+      contentBase64: file.content.toString("base64"),
+    };
+  }
+
+  async writeFile(
+    location: { linuxPath: string },
+    absolutePath: string,
+    content: Buffer,
+    options?: { expectedMtimeMs?: number },
+  ) {
+    this.writes.push({ projectRoot: location.linuxPath, path: absolutePath });
+    const target = this.resolveOrEscape(location.linuxPath, absolutePath);
+    const file = this.files.get(target);
+    if (!file) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    if (
+      options?.expectedMtimeMs !== undefined &&
+      Math.abs(file.mtimeMs - options.expectedMtimeMs) > 1
+    ) {
+      throw Object.assign(new Error("file changed on disk"), { code: "EMTIME" });
+    }
+    const mtimeMs = file.mtimeMs + 1000;
+    this.files.set(target, { content, mtimeMs });
+    return { mtimeMs, size: content.length };
+  }
+}
+
+describe("ProjectTreeService WSL external files", () => {
+  function makeWslLocation(linuxPath: string): ProjectLocation {
+    return {
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath,
+      uncPath: `\\\\wsl.localhost\\Ubuntu${linuxPath.replace(/\//g, "\\")}`,
+    };
+  }
+
+  let service: ProjectTreeService;
+  let bridge: ContainmentBridgeClient;
+
+  beforeEach(() => {
+    service = new ProjectTreeService();
+    bridge = new ContainmentBridgeClient();
+    service.setWslClient(bridge as unknown as WslBridgeClient);
+  });
+
+  it("readExternalFile reads a path outside the project root on WSL", async () => {
+    // A plan produced in a git worktree lives under ~/.lightcode/worktrees,
+    // outside the project root.
+    const projectRoot = "/home/user/work/repo";
+    const planPath = "/home/user/.lightcode/worktrees/repo/branch/PLAN.md";
+    bridge.files.set(planPath, { content: Buffer.from("# Plan\n"), mtimeMs: 1000 });
+
+    const result = await service.readExternalFile({
+      projectLocation: makeWslLocation(projectRoot),
+      absolutePath: planPath,
+    });
+
+    expect(result).toMatchObject({ status: "ready", content: "# Plan\n" });
+    // The bridge must be anchored at the file's own directory, not the project
+    // root — otherwise its containment check rejects the path.
+    expect(bridge.reads.at(-1)?.projectRoot).toBe("/home/user/.lightcode/worktrees/repo/branch");
+  });
+
+  it("writeExternalFile saves a path outside the project root on WSL", async () => {
+    const projectRoot = "/home/user/work/repo";
+    const notePath = "/home/user/notes/scratch.md";
+    bridge.files.set(notePath, { content: Buffer.from("before\n"), mtimeMs: 5000 });
+    const location = makeWslLocation(projectRoot);
+
+    const read = await service.readExternalFile({
+      projectLocation: location,
+      absolutePath: notePath,
+    });
+    expect(read.status).toBe("ready");
+
+    const result = await service.writeExternalFile({
+      projectLocation: location,
+      absolutePath: notePath,
+      content: "after\n",
+      baseModifiedAtMs: read.modifiedAtMs,
+    });
+
+    expect(result.modifiedAtMs).toBeGreaterThan(read.modifiedAtMs);
+    expect(bridge.files.get(notePath)?.content.toString("utf8")).toBe("after\n");
+    // Both the pre-read and the write anchor the bridge at the file's directory.
+    for (const call of [...bridge.reads, ...bridge.writes]) {
+      expect(call.projectRoot).toBe("/home/user/notes");
+    }
+  });
+
+  it("readExternalFile returns 'missing' when the WSL bridge reports ENOENT", async () => {
+    const result = await service.readExternalFile({
+      projectLocation: makeWslLocation("/home/user/work/repo"),
+      absolutePath: "/home/user/does-not-exist.md",
+    });
+    expect(result.status).toBe("missing");
+  });
+
+  it("readAbsoluteFile reads a path outside the project root on WSL", async () => {
+    const projectRoot = "/home/user/work/repo";
+    const externalPath = "/home/user/.lightcode/worktrees/repo/branch/PLAN.md";
+    bridge.files.set(externalPath, { content: Buffer.from("# Plan\n"), mtimeMs: 2000 });
+
+    const result = await service.readAbsoluteFile({
+      projectLocation: makeWslLocation(projectRoot),
+      absolutePath: externalPath,
+    });
+
+    expect(result).toMatchObject({ status: "ready", content: "# Plan\n" });
+    expect(bridge.reads.at(-1)?.projectRoot).toBe("/home/user/.lightcode/worktrees/repo/branch");
+  });
+
+  it("readAbsoluteFile resolves relative paths against the project root on WSL", async () => {
+    const projectRoot = "/home/user/work/repo";
+    bridge.files.set(`${projectRoot}/src/index.ts`, {
+      content: Buffer.from("export {};\n"),
+      mtimeMs: 3000,
+    });
+
+    const result = await service.readAbsoluteFile({
+      projectLocation: makeWslLocation(projectRoot),
+      absolutePath: "src/index.ts",
+    });
+
+    expect(result).toMatchObject({ status: "ready", content: "export {};\n" });
   });
 });

--- a/src/supervisor/projectTree.ts
+++ b/src/supervisor/projectTree.ts
@@ -249,10 +249,14 @@ export class ProjectTreeService {
   }
 
   /**
-   * Read a file inside the project's root from the project's location context.
-   * Used by the chat UI to surface a just-created file's content when the
-   * agent didn't stream it. Native FS for Windows/POSIX projects; the WSL
-   * bridge for WSL projects.
+   * Read a file from the project's location context. Used by the chat UI to
+   * surface a just-created file's content when the agent didn't stream it.
+   * Native FS for Windows/POSIX projects; the WSL bridge for WSL projects.
+   *
+   * Relative paths resolve against the project root for convenience. Absolute
+   * paths are read as-is, even outside the project root — the user/agent may
+   * reference any file (e.g. a plan in a `~/.lightcode/worktrees` worktree),
+   * and the editor must be able to open it.
    *
    * Returns `{ status: "missing" }` for ENOENT instead of throwing, since the
    * file may have been deleted between the agent run and the renderer fetch
@@ -261,16 +265,21 @@ export class ProjectTreeService {
   async readAbsoluteFile(payload: ReadAbsoluteFilePayload): Promise<ReadAbsoluteFileResult> {
     let raw: RawFileRead;
     try {
-      raw =
-        payload.projectLocation.kind === "wsl" && this.wslClient
-          ? await this.readAbsoluteFileBufferWsl(
-              payload.projectLocation,
-              this.resolveProjectLinuxReadPath(payload.projectLocation, payload.absolutePath),
-              this.wslClient,
-            )
-          : await this.readAbsoluteFileBufferNative(
-              this.resolveProjectNativeReadPath(payload.projectLocation, payload.absolutePath),
-            );
+      if (payload.projectLocation.kind === "wsl" && this.wslClient) {
+        const linuxPath = this.resolveProjectLinuxReadPath(
+          payload.projectLocation,
+          payload.absolutePath,
+        );
+        raw = await this.readAbsoluteFileBufferWsl(
+          this.externalWslLocation(payload.projectLocation, linuxPath),
+          linuxPath,
+          this.wslClient,
+        );
+      } else {
+        raw = await this.readAbsoluteFileBufferNative(
+          this.resolveProjectNativeReadPath(payload.projectLocation, payload.absolutePath),
+        );
+      }
     } catch (err: unknown) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") return { status: "missing" };
       throw err;
@@ -312,7 +321,7 @@ export class ProjectTreeService {
       raw =
         payload.projectLocation.kind === "wsl" && this.wslClient
           ? await this.readAbsoluteFileBufferWsl(
-              payload.projectLocation,
+              this.externalWslLocation(payload.projectLocation, payload.absolutePath),
               payload.absolutePath,
               this.wslClient,
             )
@@ -392,7 +401,8 @@ export class ProjectTreeService {
     payload: WriteExternalFilePayload,
     wslClient: WslBridgeClient,
   ): Promise<WriteExternalFileResult> {
-    const existing = await wslClient.readFile(location, payload.absolutePath, {
+    const externalLocation = this.externalWslLocation(location, payload.absolutePath);
+    const existing = await wslClient.readFile(externalLocation, payload.absolutePath, {
       maxBytes: MAX_EDITABLE_FILE_SIZE,
     });
     if (existing.tooLarge) {
@@ -406,35 +416,53 @@ export class ProjectTreeService {
       throw new Error("Binary files cannot be saved from the editor.");
     }
     const nextBuffer = buildWriteBuffer(existingBuffer, payload.content);
-    const result = await wslClient.writeFile(location, payload.absolutePath, nextBuffer, {
+    const result = await wslClient.writeFile(externalLocation, payload.absolutePath, nextBuffer, {
       expectedMtimeMs: existing.mtimeMs,
     });
     return { modifiedAtMs: result.mtimeMs };
   }
 
+  /**
+   * External reads/writes are intentionally NOT confined to the project root,
+   * but the WSL bridge still requires every target to sit within a declared
+   * `projectRoot`. Anchor that root at the file's own parent directory so the
+   * bridge's path-safety check passes for exactly this file — siblings and
+   * ancestors stay out of scope. Without this, opening an out-of-root path on
+   * WSL (e.g. a plan in a `~/.lightcode/worktrees` worktree, or `/etc/hosts`)
+   * fails with "path escapes projectRoot". Mirrors the `{ ...location,
+   * linuxPath }` idiom used for out-of-root git operations in `git/exec.ts`.
+   */
+  private externalWslLocation(
+    location: Extract<ProjectLocation, { kind: "wsl" }>,
+    absolutePath: string,
+  ): Extract<ProjectLocation, { kind: "wsl" }> {
+    return { ...location, linuxPath: posix.dirname(absolutePath) };
+  }
+
+  /**
+   * Resolve a path for a native read. Relative paths resolve against the
+   * project root (and may not traverse out via `..`); absolute paths are
+   * returned as-is so files outside the project root can be opened.
+   */
   private resolveProjectNativeReadPath(location: ProjectLocation, path: string): string {
     if (!isAbsolute(path)) {
       return this.resolveEntryPath(location, path);
     }
-    const rootPath = resolve(getProjectFsPath(location));
-    const candidatePath = resolve(path);
-    const relativePath = relative(rootPath, candidatePath);
-    if (relativePath.startsWith("..") || relativePath === ".." || isAbsolute(relativePath)) {
-      throw new Error("Path escapes the project root.");
-    }
-    return candidatePath;
+    return resolve(path);
   }
 
+  /**
+   * Resolve a path for a WSL read. Relative paths resolve against the project
+   * root; absolute paths are returned as-is so files outside the project root
+   * can be opened. The bridge's own path-safety check is satisfied by anchoring
+   * `projectRoot` to the file's directory (see {@link externalWslLocation}).
+   */
   private resolveProjectLinuxReadPath(
     location: Extract<ProjectLocation, { kind: "wsl" }>,
     path: string,
   ): string {
     const root = posix.resolve(location.linuxPath);
-    const linuxPath = path.startsWith("/") ? posix.resolve(path) : posix.resolve(root, path);
-    if (linuxPath !== root && !linuxPath.startsWith(`${root}/`)) {
-      throw new Error("Path escapes the project root.");
-    }
-    return linuxPath;
+    return path.startsWith("/") ? posix.resolve(path) : posix.resolve(root, path);
   }
 
   private async readAbsoluteFileBufferNative(absolutePath: string): Promise<RawFileRead> {


### PR DESCRIPTION
- Support reading and opening files located outside the active project root, such as git worktrees or external files referenced by the user or agent.
- Resolve relative paths containing ".." path traversal into absolute paths mapped against the active worktree context during file opens.
- Remove the strict project-root escape check for absolute paths in the project tree service and bridge, allowing safe reads of external paths.
- Add unit tests verifying path resolution for worktree contexts and file reading behavior both inside and outside the project root.