### PR TITLE
Recover hung GUI stop and stale structured sessions

### DIFF
--- a/src/supervisor/runtime/sessionTypes.ts
+++ b/src/supervisor/runtime/sessionTypes.ts
@@ -53,7 +53,7 @@ export interface SessionRuntime {
   terminalSize: TerminalSize;
   launchPrompt: string;
   outputLength: number;
-  structuredSession?: StructuredSessionHandle;
+  structuredSession?: StructuredSessionHandle | undefined;
   /** Mode the thread was launched in. Preserved for restart / recovery flows. */
   presentationMode?: ThreadPresentationMode;
   ignoreExit?: boolean;
@@ -75,6 +75,16 @@ export interface SessionRuntime {
    */
   pendingSteer?: PendingSteerSlot | undefined;
   structuredTurnInterruptRequested?: boolean | undefined;
+  /**
+   * Force-stop watchdog for a structured (GUI) turn. Armed when the user
+   * requests a stop and reset on any inbound sign of life (status update or
+   * runtime event) while the interrupt is still pending. If it fires, the
+   * session is treated as stale/disconnected: the structured session is
+   * disposed and the thread is forced into a stopped `error` state so the UI
+   * does not hang on "waiting for agent to stop" forever.
+   * Cleared on stop-acknowledged, PTY exit, teardown, and `clearSessionTimers`.
+   */
+  structuredInterruptWatchdog?: ReturnType<typeof setTimeout> | undefined;
   /**
    * GUI Codex launches optimistically enter `working` before the app-server
    * listener is attached. Codex then replays the newly opened thread's idle

--- a/src/supervisor/runtime/threadOutputPipeline.ts
+++ b/src/supervisor/runtime/threadOutputPipeline.ts
@@ -120,6 +120,10 @@ export class ThreadOutputPipeline {
       clearTimeout(session.userInterruptRecoveryTimer);
       session.userInterruptRecoveryTimer = undefined;
     }
+    if (session.structuredInterruptWatchdog) {
+      clearTimeout(session.structuredInterruptWatchdog);
+      session.structuredInterruptWatchdog = undefined;
+    }
   }
 
   getLatestTerminalStatusHint(session: SessionRuntime): TerminalStatusHint | null {

--- a/src/supervisor/runtime/threadSession/userInterrupt.ts
+++ b/src/supervisor/runtime/threadSession/userInterrupt.ts
@@ -9,6 +9,24 @@ import type { SessionRuntime } from "../sessionTypes";
 export const USER_INTERRUPT_RECOVERY_GRACE_MS = 1200;
 
 /**
+ * Force-stop window for a structured (GUI) turn after the user requests a stop.
+ *
+ * A structured thread only leaves `working` once the agent emits a status
+ * update acknowledging the cancel. If the session is stale or disconnected
+ * (process alive but unresponsive, or the connection dropped without an exit
+ * event) that update never arrives and the thread spins on "working" forever.
+ *
+ * When a stop is requested we arm a watchdog and reset it on any inbound sign
+ * of life (status update or runtime event). If the agent goes fully silent for
+ * this long with the interrupt still pending, we treat the session as stale,
+ * dispose it, and force the thread into a stopped `error` state.
+ *
+ * Healthy agents (Claude SDK / ACP) acknowledge interrupts in well under a
+ * second, so 10s is a safe margin that still recovers a stuck thread quickly.
+ */
+export const STRUCTURED_INTERRUPT_STALE_KILL_MS = 10_000;
+
+/**
  * True iff the user keystroke payload represents an interrupt intent the
  * user expects to unblock the agent. Matches:
  *   - `\x03`   (Ctrl+C)     — always an interrupt

--- a/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
@@ -1,0 +1,274 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentKind } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc";
+import type { AgentAdapter, StructuredSessionHandle } from "../agents/base";
+import type { SessionRuntime } from "./sessionTypes";
+
+vi.mock("../agents/base", async (importActual) => {
+  const actual = await importActual<typeof import("../agents/base")>();
+  return {
+    ...actual,
+    primeProjectShellEnv: vi.fn<(cwd: string) => Promise<Record<string, string> | undefined>>(() =>
+      Promise.resolve(undefined),
+    ),
+  };
+});
+
+import { ThreadSessionManager } from "./threadSessionManager";
+import { STRUCTURED_INTERRUPT_STALE_KILL_MS } from "./threadSession/userInterrupt";
+
+vi.mock("node-pty", () => ({
+  spawn: vi.fn<() => unknown>(() => ({
+    pid: 123,
+    kill: vi.fn<() => void>(),
+    onData: vi.fn<() => void>(),
+    onExit: vi.fn<() => void>(),
+    write: vi.fn<() => void>(),
+  })),
+}));
+
+/**
+ * Covers the structured force-stop watchdog (`ThreadSessionManager`): a GUI
+ * thread only leaves `working` once the agent acks the cancel, so a stale or
+ * disconnected session would otherwise spin on "waiting for agent to stop"
+ * forever. The watchdog disposes the dead session and forces `error` after the
+ * grace window, and bails if the turn already ended (the cancel was honored).
+ */
+
+const AGENT_KIND: AgentKind = "grok";
+const THREAD_ID = "thread-stale";
+
+const managersToDispose: ThreadSessionManager[] = [];
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const manager of managersToDispose.splice(0)) {
+    await manager.dispose();
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createStructuredSession(
+  overrides: Partial<StructuredSessionHandle> = {},
+): StructuredSessionHandle {
+  return {
+    launchOptions: {},
+    // Best-effort, resolves immediately — mirrors ACP `connection.cancel`, which
+    // returns even when the agent is dead and will never emit a status update.
+    interruptTurn: vi.fn<NonNullable<StructuredSessionHandle["interruptTurn"]>>(
+      async () => undefined,
+    ),
+    setListener: vi.fn<StructuredSessionHandle["setListener"]>(),
+    dispose: vi.fn<StructuredSessionHandle["dispose"]>(async () => undefined),
+    ...overrides,
+  };
+}
+
+function createAdapter(structuredSession: StructuredSessionHandle): AgentAdapter & {
+  createStructuredSession: NonNullable<AgentAdapter["createStructuredSession"]>;
+} {
+  return {
+    kind: AGENT_KIND,
+    label: AGENT_KIND,
+    binary: AGENT_KIND,
+    capabilities: {
+      models: [],
+      efforts: [],
+      modelEfforts: {},
+      modes: [],
+      approvalPolicies: [],
+      sandboxModes: [],
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: "server",
+      presentationMode: "gui",
+      presentationModes: ["gui"],
+      settingDefs: [],
+    },
+    detectInstall: vi.fn<AgentAdapter["detectInstall"]>(),
+    buildLaunchArgv: vi.fn<AgentAdapter["buildLaunchArgv"]>(() => ({
+      binary: AGENT_KIND,
+      args: [],
+    })),
+    buildResumeArgv: vi.fn<AgentAdapter["buildResumeArgv"]>(() => ({
+      binary: AGENT_KIND,
+      args: [],
+    })),
+    createInitialSessionRef: vi.fn<AgentAdapter["createInitialSessionRef"]>(() => undefined),
+    createStructuredSession: vi.fn<NonNullable<AgentAdapter["createStructuredSession"]>>(
+      async () => structuredSession,
+    ),
+  } as unknown as AgentAdapter & {
+    createStructuredSession: NonNullable<AgentAdapter["createStructuredSession"]>;
+  };
+}
+
+function createManager(adapter: AgentAdapter): {
+  manager: ThreadSessionManager;
+  events: SupervisorEvent[];
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "lightcode-stale-interrupt-"));
+  tempDirs.push(tempDir);
+  const events: SupervisorEvent[] = [];
+  const manager = new ThreadSessionManager({
+    emit: (event: SupervisorEvent) => {
+      events.push(event);
+    },
+    isDev: false,
+    logsDir: join(tempDir, "logs"),
+    settingsPath: join(tempDir, "settings.json"),
+    readDisableCliHookPlugin: () => false,
+    adapters: new Map([[AGENT_KIND, adapter]]),
+    windowsShell: { shell: "powershell.exe", kind: "powershell", args: ["-NoLogo"] },
+  });
+  managersToDispose.push(manager);
+  return { manager, events };
+}
+
+function createWorkingSession(
+  adapter: AgentAdapter,
+  structuredSession: StructuredSessionHandle,
+): SessionRuntime {
+  return {
+    instanceId: "instance-stale",
+    threadId: THREAD_ID,
+    agentKind: AGENT_KIND,
+    adapter,
+    projectLocation: { kind: "windows", path: "C:\\repo" },
+    config: { model: `${AGENT_KIND}/model` },
+    terminalSize: { cols: 80, rows: 24 },
+    launchPrompt: "",
+    sessionRef: { providerSessionId: "ses_existing" },
+    status: "working",
+    attention: "working",
+    canResumeWithConfig: true,
+    outputLength: 0,
+    prevChunk: "",
+    lastStrippedPtyChunk: "",
+    ptyOscCarry: "",
+    presentationMode: "gui",
+    structuredSession,
+  } as SessionRuntime;
+}
+
+describe("ThreadSessionManager structured stale-interrupt watchdog", () => {
+  it("force-stops a stale session after the grace window: disposes it and forces error", async () => {
+    const structuredSession = createStructuredSession();
+    const adapter = createAdapter(structuredSession);
+    const { manager, events } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.interruptThread({ threadId: THREAD_ID });
+    expect(structuredSession.interruptTurn).toHaveBeenCalledTimes(1);
+    expect(session.structuredTurnInterruptRequested).toBe(true);
+    expect(session.structuredInterruptWatchdog).toBeDefined();
+
+    // No status update arrives (stale/disconnected) — almost expire, still stuck.
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_STALE_KILL_MS - 1);
+    expect(session.status).toBe("working");
+    expect(structuredSession.dispose).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(structuredSession.dispose).toHaveBeenCalledTimes(1);
+    expect(session.structuredSession).toBeUndefined();
+    expect(session.status).toBe("error");
+    expect(session.structuredTurnInterruptRequested).toBe(false);
+    expect(session.structuredInterruptWatchdog).toBeUndefined();
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: "thread-state", threadId: THREAD_ID, status: "error" }),
+    );
+  });
+
+  it("does not force-stop once the turn has left `working` (cancel honored)", async () => {
+    const structuredSession = createStructuredSession();
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.interruptThread({ threadId: THREAD_ID });
+    // Agent acknowledged the cancel: the turn ended before the watchdog fired.
+    session.status = "idle";
+
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_STALE_KILL_MS + 1);
+    expect(structuredSession.dispose).not.toHaveBeenCalled();
+    expect(session.structuredSession).toBe(structuredSession);
+    expect(session.status).toBe("idle");
+  });
+
+  it("ignores a stale session whose interrupt is no longer pending", async () => {
+    const structuredSession = createStructuredSession();
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.interruptThread({ threadId: THREAD_ID });
+    session.structuredTurnInterruptRequested = false;
+
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_STALE_KILL_MS + 1);
+    expect(structuredSession.dispose).not.toHaveBeenCalled();
+    expect(session.status).toBe("working");
+  });
+
+  it("restarts a force-stopped GUI session on the next submit", async () => {
+    const structuredSession = createStructuredSession();
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.interruptThread({ threadId: THREAD_ID });
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_STALE_KILL_MS);
+
+    const startTurn = vi.fn<NonNullable<StructuredSessionHandle["startTurn"]>>(
+      async () => undefined,
+    );
+    const replacementSession = createStructuredSession({ startTurn });
+    vi.mocked(adapter.createStructuredSession).mockResolvedValue(replacementSession);
+
+    await manager.sendThreadInput({
+      threadId: THREAD_ID,
+      prompt: "after force stop",
+      config: { model: `${AGENT_KIND}/model` },
+    });
+
+    expect(startTurn).toHaveBeenCalledTimes(1);
+    expect(startTurn).toHaveBeenCalledWith(
+      "after force stop",
+      { model: `${AGENT_KIND}/model` },
+      undefined,
+      expect.objectContaining({ userMessageItemId: expect.any(String) }),
+    );
+    expect(manager.sessions.get(THREAD_ID)?.structuredSession).toBe(replacementSession);
+  });
+
+  it("clears the watchdog when the manager is disposed", async () => {
+    const structuredSession = createStructuredSession();
+    const adapter = createAdapter(structuredSession);
+    const { manager, events } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.interruptThread({ threadId: THREAD_ID });
+    expect(session.structuredInterruptWatchdog).toBeDefined();
+
+    await manager.dispose();
+    expect(session.structuredInterruptWatchdog).toBeUndefined();
+
+    events.length = 0;
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_STALE_KILL_MS);
+    expect(events).toEqual([]);
+  });
+});

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -68,6 +68,7 @@ import { rewriteSegmentsForWsl } from "./threadAttachments";
 import {
   isInterruptibleBusyStatus,
   isUserInterruptKeystroke,
+  STRUCTURED_INTERRUPT_STALE_KILL_MS,
   USER_INTERRUPT_RECOVERY_GRACE_MS,
 } from "./threadSession/userInterrupt";
 import { writeSubmittedPrompt } from "./threadSession/promptWrite";
@@ -341,6 +342,15 @@ export class ThreadSessionManager {
         : payload.config;
 
     session.config = effectiveConfig;
+    if (
+      usesStructuredFlow &&
+      !session.structuredSession &&
+      session.status === "error" &&
+      session.sessionRef
+    ) {
+      await this.restartThread(session, prompt, effectiveConfig);
+      return;
+    }
     // Route through the structured session when either the adapter is
     // server-controlled OR this thread was launched in chat mode (the
     // structured session owns input/output instead of the PTY).
@@ -576,12 +586,77 @@ export class ThreadSessionManager {
       return;
     }
     session.structuredTurnInterruptRequested = true;
+    this.armStructuredInterruptWatchdog(session);
     try {
       await session.structuredSession.interruptTurn();
     } catch (error) {
       session.structuredTurnInterruptRequested = false;
+      this.clearStructuredInterruptWatchdog(session);
       throw error;
     }
+  }
+
+  private clearStructuredInterruptWatchdog(session: SessionRuntime): void {
+    if (session.structuredInterruptWatchdog) {
+      clearTimeout(session.structuredInterruptWatchdog);
+      session.structuredInterruptWatchdog = undefined;
+    }
+  }
+
+  /**
+   * Arm (or reset) the force-stop watchdog for a structured turn. Reset on any
+   * inbound sign of life so a healthy-but-slow cancel is never force-killed; it
+   * only fires after the agent has gone fully silent for the grace window with
+   * the interrupt still pending — i.e. the session is stale/disconnected.
+   */
+  private armStructuredInterruptWatchdog(session: SessionRuntime): void {
+    this.clearStructuredInterruptWatchdog(session);
+    const instanceId = session.instanceId;
+    session.structuredInterruptWatchdog = setTimeout(() => {
+      session.structuredInterruptWatchdog = undefined;
+      this.forceStopStaleStructuredTurn(session.threadId, instanceId);
+    }, STRUCTURED_INTERRUPT_STALE_KILL_MS);
+  }
+
+  /**
+   * Re-arm the watchdog if a stop is still pending — called on inbound activity
+   * (status updates / runtime events) so the silence clock restarts whenever
+   * the session proves it is still alive.
+   */
+  private touchStructuredInterruptWatchdog(session: SessionRuntime): void {
+    if (!session.structuredTurnInterruptRequested) return;
+    if (session.status !== "working") return;
+    this.armStructuredInterruptWatchdog(session);
+  }
+
+  /**
+   * The agent never acknowledged a stop request and has gone silent: the
+   * structured session is stale/disconnected. Dispose it best-effort and force
+   * the thread into a stopped `error` state so the UI stops waiting forever.
+   */
+  private forceStopStaleStructuredTurn(threadId: string, instanceId: string): void {
+    const session = this.sessions.get(threadId);
+    if (!session || session.instanceId !== instanceId) {
+      return;
+    }
+    if (this.disposed || session.ignoreExit) {
+      return;
+    }
+    if (session.status !== "working" || !session.structuredTurnInterruptRequested) {
+      return;
+    }
+    this.clearStructuredInterruptWatchdog(session);
+    session.structuredTurnInterruptRequested = false;
+    this.clearPendingSteerSlot(session);
+    const staleSession = session.structuredSession;
+    session.structuredSession = undefined;
+    void Promise.resolve(staleSession?.dispose()).catch((error) => {
+      console.error("[supervisor] failed to dispose stale structured session:", error);
+    });
+    this.failStructuredSession(
+      session,
+      new Error("Agent stopped responding to the stop request and was force-stopped."),
+    );
   }
 
   /**
@@ -824,6 +899,7 @@ export class ThreadSessionManager {
     await Promise.allSettled(
       [...this.sessions.values()].map(async (session) => {
         session.ignoreExit = true;
+        this.outputPipeline.clearSessionTimers(session);
         await session.structuredSession?.dispose();
         this.safePtyKill(session);
       }),
@@ -1620,6 +1696,11 @@ export class ThreadSessionManager {
         );
         if (update.status !== "working") {
           session.structuredTurnInterruptRequested = false;
+          this.clearStructuredInterruptWatchdog(session);
+        } else {
+          // Still working but the agent showed a sign of life — restart the
+          // stale-kill clock so a healthy long-running cancel is not killed.
+          this.touchStructuredInterruptWatchdog(session);
         }
         if (
           session.presentationMode === "gui" &&
@@ -1649,6 +1730,10 @@ export class ThreadSessionManager {
         ) {
           session.suppressInitialStructuredIdle = undefined;
         }
+        // Streaming output is a sign of life — restart the stale-kill clock so a
+        // healthy agent still emitting tool/text deltas after a stop request is
+        // never force-stopped while it works toward honoring the cancel.
+        this.touchStructuredInterruptWatchdog(session);
         this.enqueueRuntimeEvent(session.threadId, event);
       },
     });
@@ -1765,6 +1850,7 @@ export class ThreadSessionManager {
       (session.presentationMode ?? session.adapter.capabilities.presentationMode) === "terminal";
     const useStructuredFlow = isServerControlled || !usesTerminalPresentation;
     session.ignoreExit = true;
+    this.outputPipeline.clearSessionTimers(session);
     // Subagent maps from the prior session would otherwise leak across resume:
     // any unsubscribed buffers, lingering child→parent entries, and overlay
     // subscriptions from the dead session are stale once the structured
@@ -1949,6 +2035,7 @@ export class ThreadSessionManager {
       }
 
       session.ignoreExit = true;
+      this.outputPipeline.clearSessionTimers(session);
       session.stopSessionRefWatcher?.();
       session.stopSessionRefWatcher = undefined;
       await session.structuredSession?.dispose();


### PR DESCRIPTION
**Type:** Bugfix

- Stop GUI threads from hanging on "waiting for agent to stop" when a structured session is stale or disconnected and never acknowledges cancel
- Arm a 10s force-stop watchdog on user stop; reset it on inbound status updates and runtime events so healthy slow cancels are not killed prematurely
- Dispose the dead structured session and move the thread to a stopped error state when the agent stays silent through the grace window
- Auto-restart structured threads when the user submits after a force-stop left the session in error without a live handle
- Add supervisor coverage for stale-interrupt recovery and clear interrupt timers during session teardown, restart, and dispose