### PR TITLE
Keep Claude goals active across steered turns and track usage

### DIFF
--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildClaudeQuestionAnswerEvents,
   createClaudeMapperState,
+  emitActiveGoalTokenUpdate,
   mapClaudeContextUsageResponse,
   mapClaudePermissionRequest,
   mapClaudeQuestionRequest,
@@ -167,6 +168,212 @@ describe("sdkCanonicalMapping — prompt content", () => {
     );
 
     expect(resultEvents.some((event) => event.type === "item.updated")).toBe(false);
+  });
+
+  it("keeps the goal active on an interrupted (steered) turn and accumulates tokens", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(
+        state,
+        "turn-goal",
+        "/goal ship unified GUI goal support",
+        undefined,
+        "user-goal",
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:01:00Z"));
+      const interruptedResult = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["[ede_diagnostic] turn interrupted before assistant content"],
+          session_id: "claude-session",
+          usage: { input_tokens: 30_000, output_tokens: 4_000, total_tokens: 34_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      const goalUpdate = interruptedResult.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(goalUpdate).toMatchObject({
+        type: "item.updated",
+        itemId: "goal-turn-goal",
+        payload: {
+          action: "updated",
+          objective: "ship unified GUI goal support",
+          status: "active",
+          tokensUsed: 34_000,
+          timeUsedSeconds: 60,
+        },
+      });
+
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+      expect(state.activeGoalTokensUsed).toBe(34_000);
+
+      vi.setSystemTime(new Date("2026-05-12T10:03:00Z"));
+      const successResult = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { input_tokens: 50_000, output_tokens: 8_000, total_tokens: 58_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      const completedUpdate = successResult.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(completedUpdate).toMatchObject({
+        payload: {
+          status: "complete",
+          tokensUsed: 92_000,
+          timeUsedSeconds: 180,
+        },
+      });
+      expect(state.activeGoalItemId).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves active goal state across steered turns when new prompt is not /goal", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal fix the bug", undefined, "user-goal");
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:30Z"));
+      mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["[ede_diagnostic] turn interrupted"],
+          session_id: "claude-session",
+          usage: { total_tokens: 10_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:35Z"));
+      startClaudeTurn(state, "turn-steer", "actually focus on the auth module", undefined);
+
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+      expect(state.activeGoalObjective).toBe("fix the bug");
+      expect(state.activeGoalTokensUsed).toBe(10_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("replaces active goal when a new /goal command is issued after an interrupt", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal-1", "/goal old objective", undefined);
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:30Z"));
+      mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "error_during_execution",
+          is_error: true,
+          errors: ["[ede_diagnostic] turn interrupted"],
+          session_id: "claude-session",
+          usage: { total_tokens: 5_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:35Z"));
+      startClaudeTurn(state, "turn-goal-2", "/goal new objective", undefined);
+
+      expect(state.activeGoalItemId).toBe("goal-turn-goal-2");
+      expect(state.activeGoalObjective).toBe("new objective");
+      expect(state.activeGoalStartedAtMs).toBe(Date.now());
+      expect(state.activeGoalTokensUsed).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears an active goal when /clear starts a new conversation", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-goal", "/goal fix the bug", undefined);
+
+    const clearEvents = startClaudeTurn(state, "turn-clear", "/clear", undefined);
+
+    expect(clearEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.updated",
+        itemId: "goal-turn-goal",
+        payload: expect.objectContaining({
+          action: "cleared",
+          objective: "fix the bug",
+        }),
+      }),
+    );
+    expect(state.activeGoalItemId).toBeUndefined();
+    expect(state.activeGoalObjective).toBeUndefined();
+  });
+
+  it("accepts documented clear aliases for /goal", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-goal", "/goal fix the bug", undefined);
+
+    const stopEvents = startClaudeTurn(state, "turn-stop", "/goal stop", undefined);
+
+    expect(stopEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemId: "goal-turn-stop",
+        itemType: "goal",
+        payload: expect.objectContaining({ action: "cleared" }),
+      }),
+    );
+    expect(state.activeGoalItemId).toBeUndefined();
+  });
+
+  it("does not lower goal token usage when a final result reports fewer tokens than polling", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal ship it", undefined);
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:45Z"));
+      emitActiveGoalTokenUpdate(state, 42_000);
+
+      vi.setSystemTime(new Date("2026-05-12T10:01:00Z"));
+      const resultEvents = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { total_tokens: 4_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      const goalUpdate = resultEvents.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(goalUpdate).toMatchObject({
+        payload: {
+          status: "complete",
+          tokensUsed: 42_000,
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -1937,5 +2144,38 @@ describe("sdkCanonicalMapping — requests", () => {
       answers: {},
     });
     expect(events).toEqual([]);
+  });
+});
+
+describe("sdkCanonicalMapping — emitActiveGoalTokenUpdate", () => {
+  it("emits a goal item.updated with context usage tokens when a goal is active", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal ship it", undefined);
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:45Z"));
+      const event = emitActiveGoalTokenUpdate(state, 42_000);
+
+      expect(event).toMatchObject({
+        type: "item.updated",
+        threadId: "thread-1",
+        itemId: "goal-turn-goal",
+        payload: {
+          objective: "ship it",
+          status: "active",
+          tokensUsed: 42_000,
+          timeUsedSeconds: 45,
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns undefined when no goal is active", () => {
+    const state = createClaudeMapperState("thread-1");
+    expect(emitActiveGoalTokenUpdate(state, 1_000)).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -111,11 +111,26 @@ export function startClaudeTurn(
       state.activeGoalItemId = goalItemId;
       state.activeGoalObjective = goalPayload.objective;
       state.activeGoalStartedAtMs = Date.now();
+      delete state.activeGoalTokensUsed;
+      delete state.activeGoalResultTokensUsed;
     } else {
       delete state.activeGoalItemId;
       delete state.activeGoalObjective;
       delete state.activeGoalStartedAtMs;
+      delete state.activeGoalTokensUsed;
+      delete state.activeGoalResultTokensUsed;
     }
+  } else if (isClearPrompt(prompt) && state.activeGoalItemId) {
+    const payload = goalPayloadFromProviderState(
+      state.activeGoalObjective ? { objective: state.activeGoalObjective } : {},
+      "cleared",
+    );
+    events.push(...updateGoalItemEvents(state.threadId, state.activeGoalItemId, payload));
+    delete state.activeGoalItemId;
+    delete state.activeGoalObjective;
+    delete state.activeGoalStartedAtMs;
+    delete state.activeGoalTokensUsed;
+    delete state.activeGoalResultTokensUsed;
   }
   if (isManualCompactPrompt(prompt)) {
     const compactItemId = `compact-${turnId}`;
@@ -137,6 +152,10 @@ export function startClaudeTurn(
 
 function isManualCompactPrompt(prompt: string): boolean {
   return /^\/compact(?:\s|$)/.test(prompt.trimStart());
+}
+
+function isClearPrompt(prompt: string): boolean {
+  return /^\/clear(?:\s|$)/.test(prompt.trimStart());
 }
 
 function ensureTextItem(
@@ -1107,29 +1126,93 @@ export function extractResultErrorMessage(message: SDKMessage): string | undefin
 function completeActiveGoalEvents(
   state: ClaudeMapperState,
   message: Extract<SDKMessage, { type: "result" }>,
+  turnState: TurnState,
 ): RuntimeEvent[] {
   const goalItemId = state.activeGoalItemId;
   const objective = state.activeGoalObjective;
   const startedAtMs = state.activeGoalStartedAtMs;
   if (!goalItemId || !objective || startedAtMs === undefined) return [];
 
+  const nowMs = Date.now();
+  const usage = readClaudeResultUsage(message);
+  if (usage !== undefined) {
+    const resultTokensUsed = (state.activeGoalResultTokensUsed ?? 0) + usage;
+    state.activeGoalResultTokensUsed = resultTokensUsed;
+    state.activeGoalTokensUsed = Math.max(state.activeGoalTokensUsed ?? 0, resultTokensUsed);
+  }
+  const totalTokensUsed = state.activeGoalTokensUsed;
+  const elapsedSeconds = Math.max(0, Math.round((nowMs - startedAtMs) / 1000));
+
+  if (turnState === "interrupted") {
+    const payload = goalPayloadFromProviderState(
+      {
+        objective,
+        status: "active",
+        ...(totalTokensUsed !== undefined ? { tokensUsed: totalTokensUsed } : {}),
+        timeUsedSeconds: elapsedSeconds,
+        updatedAt: nowMs / 1000,
+      },
+      "updated",
+    );
+    return [
+      {
+        type: "item.updated",
+        threadId: state.threadId,
+        itemId: goalItemId,
+        payload,
+      },
+    ];
+  }
+
   delete state.activeGoalItemId;
   delete state.activeGoalObjective;
   delete state.activeGoalStartedAtMs;
+  delete state.activeGoalTokensUsed;
+  delete state.activeGoalResultTokensUsed;
 
-  const nowMs = Date.now();
-  const usage = readClaudeResultUsage(message);
   const payload = goalPayloadFromProviderState(
     {
       objective,
       status: "complete",
-      ...(usage !== undefined ? { tokensUsed: usage } : {}),
-      timeUsedSeconds: Math.max(0, Math.round((nowMs - startedAtMs) / 1000)),
+      ...(totalTokensUsed !== undefined ? { tokensUsed: totalTokensUsed } : {}),
+      timeUsedSeconds: elapsedSeconds,
       updatedAt: nowMs / 1000,
     },
     "updated",
   );
   return updateGoalItemEvents(state.threadId, goalItemId, payload);
+}
+
+export function emitActiveGoalTokenUpdate(
+  state: ClaudeMapperState,
+  tokensUsed: number,
+): RuntimeEvent | undefined {
+  if (
+    !state.activeGoalItemId ||
+    !state.activeGoalObjective ||
+    state.activeGoalStartedAtMs === undefined
+  ) {
+    return undefined;
+  }
+  const elapsedSeconds = Math.max(0, Math.round((Date.now() - state.activeGoalStartedAtMs) / 1000));
+  const bestKnownTokensUsed = Math.max(state.activeGoalTokensUsed ?? 0, tokensUsed);
+  state.activeGoalTokensUsed = bestKnownTokensUsed;
+  const payload = goalPayloadFromProviderState(
+    {
+      objective: state.activeGoalObjective,
+      status: "active",
+      tokensUsed: bestKnownTokensUsed,
+      timeUsedSeconds: elapsedSeconds,
+      updatedAt: Date.now() / 1000,
+    },
+    "updated",
+  );
+  return {
+    type: "item.updated",
+    threadId: state.threadId,
+    itemId: state.activeGoalItemId,
+    payload,
+  };
 }
 
 function readClaudeResultUsage(
@@ -1160,8 +1243,16 @@ function mapResultState(message: Extract<SDKMessage, { type: "result" }>): TurnS
   return "failed";
 }
 
-export function mapClaudeSdkMessage(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
-  const events = mapClaudeSdkMessageInner(message, state);
+interface ClaudeSdkMessageMappingOptions {
+  resultState?: TurnState;
+}
+
+export function mapClaudeSdkMessage(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+  options?: ClaudeSdkMessageMappingOptions,
+): RuntimeEvent[] {
+  const events = mapClaudeSdkMessageInner(message, state, options);
   return tagParent(events, readParentToolUseId(message), state);
 }
 
@@ -1201,7 +1292,11 @@ function readPositiveInteger(value: unknown): number | undefined {
   return parsed !== undefined && parsed > 0 ? parsed : undefined;
 }
 
-function mapClaudeSdkMessageInner(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
+function mapClaudeSdkMessageInner(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+  options?: ClaudeSdkMessageMappingOptions,
+): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
   if (message.type === "stream_event") {
     const event = message.event as unknown as Record<string, unknown>;
@@ -1466,13 +1561,13 @@ function mapClaudeSdkMessageInner(message: SDKMessage, state: ClaudeMapperState)
   }
 
   if (message.type === "result") {
-    const stateValue = mapResultState(message);
+    const stateValue = options?.resultState ?? mapResultState(message);
     events.push(...closeClaudeOpenItems(state));
     if (stateValue === "failed") {
       const msg = extractResultErrorMessage(message) ?? "Claude turn failed.";
       events.push({ type: "error", threadId: state.threadId, message: msg });
     }
-    events.push(...completeActiveGoalEvents(state, message));
+    events.push(...completeActiveGoalEvents(state, message, stateValue));
     if (state.currentTurnId) {
       events.push({
         type: "turn.completed",

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -41,6 +41,8 @@ export interface ClaudeMapperState {
   activeGoalItemId?: string;
   activeGoalObjective?: string;
   activeGoalStartedAtMs?: number;
+  activeGoalTokensUsed?: number;
+  activeGoalResultTokensUsed?: number;
   planAggregator?: PlanAggregatorState;
 }
 

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -761,4 +761,68 @@ describe("ClaudeSdkSession", () => {
 
     await session.dispose();
   });
+
+  it("keeps a goal active when interruptTurn is authoritative for the result", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const runtimeEvents: RuntimeEvent[] = [];
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-goal-steer",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    const openedSessionId = await session.openThread(config);
+    await flushAsyncWork();
+
+    await session.startTurn("/goal fix the bug", config);
+    await session.interruptTurn();
+    const goalItemId = runtimeEvents.find(
+      (event): event is Extract<RuntimeEvent, { type: "item.started" }> =>
+        event.type === "item.started" && event.itemType === "goal",
+    )?.itemId;
+    expect(goalItemId).toBeDefined();
+
+    fake.emitMessage({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["execution stopped by user"],
+      usage: { total_tokens: 12_000 },
+      session_id: openedSessionId,
+    } as unknown as SDKMessage);
+    await flushAsyncWork();
+
+    const goalUpdates = runtimeEvents.filter(
+      (event) => event.type === "item.updated" && event.itemId === goalItemId,
+    );
+    expect(goalUpdates.at(-1)).toMatchObject({
+      payload: {
+        status: "active",
+        tokensUsed: 42_000,
+      },
+    });
+    expect(runtimeEvents).not.toContainEqual(
+      expect.objectContaining({
+        type: "item.updated",
+        itemId: goalItemId,
+        payload: expect.objectContaining({ status: "complete" }),
+      }),
+    );
+    expect(runtimeEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn.completed",
+        state: "interrupted",
+      }),
+    );
+
+    await session.dispose();
+  });
 });

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -23,6 +23,7 @@ import type {
   ThreadConfig,
   ThreadServerRequestId,
   ThreadStatus,
+  TurnState,
 } from "@/shared/contracts";
 import { areAgentSlashCommandsEqual } from "@/shared/contracts";
 import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
@@ -44,6 +45,7 @@ import {
   type ThreadHistory,
 } from "../base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
+import { readNonNegativeInteger } from "../contextUsage";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { chosenOptionIds } from "../questionAnswers";
 import { applyClaudeContextSuffix } from "./argv";
@@ -53,6 +55,7 @@ import {
   buildClaudeQuestionAnswerEvents,
   closeClaudeOpenItems,
   createClaudeMapperState,
+  emitActiveGoalTokenUpdate,
   extractResultErrorMessage,
   isApiErrorResult,
   mapClaudePermissionRequest,
@@ -448,6 +451,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
   // in the errors array — otherwise the supervisor's drain-on-idle hook would
   // miss the steer and the staged prompt would never flush.
   private interruptInFlight = false;
+  private goalTrackingTimer: ReturnType<typeof setInterval> | undefined;
 
   private constructor(input: CreateStructuredSessionInput) {
     this.input = input;
@@ -556,6 +560,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       startClaudeTurn(this.mapperState, turnId, prompt, segments, options?.userMessageItemId),
     );
     this.emitUpdate({ status: "working", attention: "working" });
+    this.startGoalTracking();
 
     const query = await this.requireQuery();
     const model = applyClaudeContextSuffix(config.model, config.contextSize);
@@ -745,9 +750,29 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.emitUpdate({ status: "working", attention: "working" });
   }
 
+  private startGoalTracking(): void {
+    this.stopGoalTracking();
+    if (!this.mapperState.activeGoalItemId) return;
+    this.goalTrackingTimer = setInterval(() => {
+      if (this.disposed || !this.mapperState.activeGoalItemId) {
+        this.stopGoalTracking();
+        return;
+      }
+      void this.refreshContextUsage();
+    }, 15_000);
+  }
+
+  private stopGoalTracking(): void {
+    if (this.goalTrackingTimer !== undefined) {
+      clearInterval(this.goalTrackingTimer);
+      this.goalTrackingTimer = undefined;
+    }
+  }
+
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    this.stopGoalTracking();
     for (const [requestId, pending] of this.pendingRequests) {
       if (pending.kind === "permission") {
         pending.resolve({ behavior: "deny", message: "Session closed." });
@@ -1038,12 +1063,21 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.currentTurnAssistantUuid = message.uuid;
     }
 
-    const events = mapClaudeSdkMessage(message, this.mapperState);
+    let wasInterrupted = false;
+    let resultState: TurnState | undefined;
+    if (message.type === "result") {
+      wasInterrupted =
+        this.interruptInFlight || (message.subtype !== "success" && isInterruptedResult(message));
+      if (wasInterrupted) resultState = "interrupted";
+    }
+    const events = mapClaudeSdkMessage(
+      message,
+      this.mapperState,
+      resultState ? { resultState } : undefined,
+    );
     this.emitRuntimeEvents(events);
     if (message.type === "result") {
       void this.refreshContextUsage();
-      const wasInterrupted =
-        this.interruptInFlight || (message.subtype !== "success" && isInterruptedResult(message));
       this.interruptInFlight = false;
       const remaining = nonDiagnosticErrors(message);
       // claude.exe surfaces upstream API failures (e.g. 401 auth, 429 rate
@@ -1069,6 +1103,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       }
       this.currentTurnAssistantUuid = undefined;
       this.currentTurnInFlight = false;
+      if (!wasInterrupted) this.stopGoalTracking();
       this.emitUpdate({
         status: failed ? "error" : "idle",
         attention: failed ? "error" : "none",
@@ -1100,6 +1135,13 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       if (this.disposed) return;
       const event = mapClaudeContextUsageResponse(this.input.threadId, usage);
       if (event) this.emitRuntimeEvents([event]);
+      if (this.mapperState.activeGoalItemId) {
+        const usedTokens = readNonNegativeInteger(usage.totalTokens);
+        if (usedTokens !== undefined && usedTokens > 0) {
+          const goalUpdate = emitActiveGoalTokenUpdate(this.mapperState, usedTokens);
+          if (goalUpdate) this.emitRuntimeEvents([goalUpdate]);
+        }
+      }
     } catch {
       // Older transports can reject this control call. In that case, keep the
       // existing context state instead of emitting billing-token totals as usage.

--- a/src/supervisor/agents/goalRuntime.ts
+++ b/src/supervisor/agents/goalRuntime.ts
@@ -18,7 +18,7 @@ export function parseGoalSlashCommand(prompt: string): GoalItemPayload | undefin
 
   const rawArgs = match[1]?.trim() ?? "";
   if (rawArgs.length === 0) return { action: "viewed" };
-  if (/^(clear|reset|off|none)$/iu.test(rawArgs)) return { action: "cleared" };
+  if (/^(clear|stop|off|reset|none|cancel)$/iu.test(rawArgs)) return { action: "cleared" };
   return {
     action: "set",
     objective: rawArgs,


### PR DESCRIPTION
- **Bugfix:** Goals no longer complete prematurely when a turn is interrupted or steered; they stay active until a successful finish or an explicit clear.
- Accumulate token usage across interrupted and successful Claude result messages so goal progress reflects the full multi-turn effort.
- Refresh context usage on a timer while a goal is active so the UI shows up-to-date token counts during long runs.
- Treat `/clear` and expanded goal-clear phrases (`stop`, `cancel`, etc.) as proper goal teardown, resetting mapper tracking state.
- Add mapping and session tests for steered/interrupted goal flows and authoritative interrupt handling.