### PR TITLE
Add drag-and-drop file attachments to thread composer

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { type LightcodeChannel, normalizeChannel } from "@/shared/channel";
 import {
   createInvokeBridge,
@@ -86,6 +86,9 @@ const bridge: LightcodeBridge = {
   posthogHost: resolveArgValue("--lc-posthog-host="),
   posthogKey: resolveArgValue("--lc-posthog-key="),
   sentryEnabled: resolveSentryEnabled(),
+  getDroppedFilePaths(files) {
+    return files.map((file) => webUtils.getPathForFile(file)).filter((path) => path.length > 0);
+  },
   ...createInvokeBridge((channel, ...args) => ipcRenderer.invoke(channel, ...args)),
   onSupervisorEvent(listener) {
     const handler = (_event: Electron.IpcRendererEvent, payload: SupervisorEvent) => {

--- a/src/renderer/components/thread/ThreadComposer.test.tsx
+++ b/src/renderer/components/thread/ThreadComposer.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
 
@@ -56,6 +56,21 @@ function renderComposer(controls = composerControls()) {
       prompt=""
       submitDisabled
       submitLabel="Send message"
+      onPromptChange={vi.fn<(value: string) => void>()}
+      onSubmit={vi.fn<() => void>()}
+    />,
+  );
+}
+
+function renderComposerWithAttach(onAttachFiles: (paths: string[]) => void) {
+  return render(
+    <ThreadComposer
+      controls={composerControls()}
+      placeholder="Send a message..."
+      prompt=""
+      submitDisabled
+      submitLabel="Send message"
+      onAttachFiles={onAttachFiles}
       onPromptChange={vi.fn<(value: string) => void>()}
       onSubmit={vi.fn<() => void>()}
     />,
@@ -160,5 +175,37 @@ describe("ThreadComposer", () => {
     ]);
 
     expect(visibleText("Thinking")).toBeVisible();
+  });
+
+  it("shows an attachment drop target for supported files", () => {
+    const { container } = renderComposerWithAttach(vi.fn());
+    const shell = container.querySelector<HTMLElement>(".lightcode-composer-shell");
+    expect(shell).not.toBeNull();
+
+    fireEvent.dragEnter(shell!, {
+      dataTransfer: { types: ["Files"], files: [], dropEffect: "copy" },
+    });
+
+    expect(screen.getByText("Drop here to attach")).toBeVisible();
+  });
+
+  it("attaches files dragged from the project tree", () => {
+    const onAttachFiles = vi.fn<(paths: string[]) => void>();
+    const { container } = renderComposerWithAttach(onAttachFiles);
+    const shell = container.querySelector<HTMLElement>(".lightcode-composer-shell");
+    expect(shell).not.toBeNull();
+
+    fireEvent.drop(shell!, {
+      dataTransfer: {
+        types: ["application/lightcode-composer-file"],
+        files: [],
+        getData: (type: string) =>
+          type === "application/lightcode-composer-file"
+            ? JSON.stringify({ path: "src/App.tsx", type: "file" })
+            : "",
+      },
+    });
+
+    expect(onAttachFiles).toHaveBeenCalledWith(["src/App.tsx"]);
   });
 });

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ReactNode, useEffect, useLayoutEffect, useRef, useState, type DragEvent } from "react";
 import { ArrowUp, Square } from "lucide-react";
 import { ToggleButton, Tooltip } from "@heroui/react";
 import {
@@ -21,6 +21,7 @@ export type ComposerIconKind = "effort" | "permission";
 
 const COLLAPSE_LEVELS = [0, 1, 2, 3, 4, 5] as const;
 const DEFAULT_LABEL_COLLAPSE_LEVEL = 1;
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
 
 export type ComposerControl =
   | {
@@ -160,6 +161,7 @@ export function ThreadComposer(props: {
   preserveDisabledControlStyle?: boolean;
   onPromptChange: (value: string) => void;
   onSubmit: () => void;
+  onAttachFiles?: (paths: string[]) => void;
   onStop?: (() => void) | undefined;
   controls: ComposerControl[];
   leadingControls?: ReactNode | ((wrapLevel: number) => ReactNode);
@@ -186,6 +188,7 @@ export function ThreadComposer(props: {
     preserveDisabledControlStyle = false,
     onPromptChange,
     onSubmit,
+    onAttachFiles,
     onStop,
     controls,
     leadingControls,
@@ -195,9 +198,11 @@ export function ThreadComposer(props: {
   } = props;
 
   const [wrapLevel, setWrapLevel] = useState(0);
+  const [isAttachmentDropActive, setIsAttachmentDropActive] = useState(false);
   const controlsRef = useRef<HTMLDivElement>(null);
   const probeContainerRef = useRef<HTMLDivElement>(null);
   const editorHostRef = useRef<HTMLDivElement>(null);
+  const attachmentDragDepthRef = useRef(0);
   const probeContentCacheRef = useRef<{ key: string; content: ReactNode } | undefined>(undefined);
   const derivedToolbarLayoutKey = controls
     .map((control) => {
@@ -585,6 +590,57 @@ export function ThreadComposer(props: {
     );
   };
 
+  const hasAttachmentDragData = (dataTransfer: DataTransfer) =>
+    Array.from(dataTransfer.types).some(
+      (type) => type === "Files" || type === COMPOSER_FILE_DRAG_TYPE,
+    );
+
+  const resolveAttachmentDropPaths = (dataTransfer: DataTransfer): string[] => {
+    const payload = dataTransfer.getData(COMPOSER_FILE_DRAG_TYPE);
+    if (payload) {
+      try {
+        const parsed = JSON.parse(payload) as { path?: unknown; type?: unknown };
+        return typeof parsed.path === "string" && parsed.type === "file" ? [parsed.path] : [];
+      } catch {
+        return [];
+      }
+    }
+    return window.lightcode.getDroppedFilePaths(Array.from(dataTransfer.files));
+  };
+
+  const handleAttachmentDragEnter = (event: DragEvent<HTMLDivElement>) => {
+    if (!onAttachFiles || !hasAttachmentDragData(event.dataTransfer)) return;
+    event.preventDefault();
+    attachmentDragDepthRef.current += 1;
+    event.dataTransfer.dropEffect = "copy";
+    setIsAttachmentDropActive(true);
+  };
+
+  const handleAttachmentDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!onAttachFiles || !hasAttachmentDragData(event.dataTransfer)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleAttachmentDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (!onAttachFiles || !hasAttachmentDragData(event.dataTransfer)) return;
+    attachmentDragDepthRef.current = Math.max(0, attachmentDragDepthRef.current - 1);
+    if (attachmentDragDepthRef.current === 0) {
+      setIsAttachmentDropActive(false);
+    }
+  };
+
+  const handleAttachmentDrop = (event: DragEvent<HTMLDivElement>) => {
+    if (!onAttachFiles || !hasAttachmentDragData(event.dataTransfer)) return;
+    event.preventDefault();
+    attachmentDragDepthRef.current = 0;
+    setIsAttachmentDropActive(false);
+    const paths = resolveAttachmentDropPaths(event.dataTransfer);
+    if (paths.length > 0) {
+      onAttachFiles(paths);
+    }
+  };
+
   const toolbar = (
     <div className={toolbarClassName}>
       {leadingControls && (
@@ -608,8 +664,17 @@ export function ThreadComposer(props: {
 
   return (
     <div>
-      <div className={shellClassName}>
+      <div
+        className={shellClassName}
+        onDragEnter={handleAttachmentDragEnter}
+        onDragOver={handleAttachmentDragOver}
+        onDragLeave={handleAttachmentDragLeave}
+        onDrop={handleAttachmentDrop}
+      >
         {variant === "draft" && <div className="lightcode-composer-border-glow" />}
+        {isAttachmentDropActive ? (
+          <div className="lightcode-composer-drop-overlay">Drop here to attach</div>
+        ) : null}
         {fixedContent}
         {attachmentBar}
         <div ref={editorHostRef}>{renderEditor()}</div>

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -928,6 +928,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         };
                   })()}
                   onPromptChange={setPrompt}
+                  onAttachFiles={attachments.addFiles}
                   onSubmit={() => {
                     const segments = mentionRef.current?.serializeSegments();
                     submitPrompt(

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -546,6 +546,7 @@ export function ThreadDraftComposerArea(props: {
         submitPending={isSubmitting}
         submitLabel="Launch thread"
         onPromptChange={setPrompt}
+        onAttachFiles={attachments.addFiles}
         onSubmit={() => {
           const segments = mentionRef.current?.serializeSegments() ?? [];
           submitSegments([...attachments.toSegments(), ...segments], prompt);

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1421,6 +1421,22 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   transition: border-color 0.15s ease;
 }
 
+.lightcode-composer-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: inherit;
+  border: 1px dashed color-mix(in oklab, var(--focus) 72%, transparent);
+  background: color-mix(in oklab, var(--composer-surface) 82%, transparent);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  pointer-events: none;
+}
+
 /* Animated 1px border ring around the draft composer. The mask-composite cutout
    keeps the inside of the shell fully transparent (so the underlying composer
    surface shows through unchanged). The rotation is driven by `transform` on a

--- a/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
@@ -15,6 +15,8 @@ import { InlineNameInput } from "./InlineNameInput";
 import { InlineDraftRow } from "./InlineDraftRow";
 import type { TreeDraftState } from "./useProjectTree";
 
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
+
 export function TreeEntryRow(props: {
   entry: ProjectTreeEntry;
   depth: number;
@@ -125,7 +127,13 @@ export function TreeEntryRow(props: {
               "application/lightcode-project-tree",
               JSON.stringify({ path: entry.path, type: entry.type }),
             );
-            event.dataTransfer.effectAllowed = "move";
+            if (!isDirectory) {
+              event.dataTransfer.setData(
+                COMPOSER_FILE_DRAG_TYPE,
+                JSON.stringify({ path: entry.path, type: entry.type }),
+              );
+            }
+            event.dataTransfer.effectAllowed = isDirectory ? "move" : "copyMove";
           }}
           onDragOver={(event) => {
             if (isDirectory) {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
@@ -16,6 +16,7 @@ import {
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 
 const LARGE_DIFF_THRESHOLD = 500;
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
 
 export function ConflictFileCard(props: {
   file: GitFileChange;
@@ -122,8 +123,16 @@ export function ConflictFileCard(props: {
       <div
         role="button"
         tabIndex={0}
+        draggable
         className={`sticky top-0 z-10 group flex cursor-pointer select-none items-center gap-1.5 bg-[var(--content-background)] py-1 text-xs transition-colors hover:bg-content2 ${rowPadX}`}
         onClick={() => setExpanded((v) => !v)}
+        onDragStart={(event) => {
+          event.dataTransfer.setData(
+            COMPOSER_FILE_DRAG_TYPE,
+            JSON.stringify({ path: file.path, type: "file" }),
+          );
+          event.dataTransfer.effectAllowed = "copy";
+        }}
         onKeyDown={(e) => handleKeyActivate(e, () => setExpanded((v) => !v))}
       >
         {expanded ? (

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
@@ -9,6 +9,8 @@ import { handleKeyActivate } from "@/renderer/utils/a11y";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 import { ConflictFileCard } from "./ConflictFileCard";
 
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
+
 export function ConflictGroup(props: {
   files: GitFileChange[];
   project: Project;
@@ -101,12 +103,20 @@ export function ConflictGroup(props: {
               <button
                 key={file.path}
                 type="button"
+                draggable
                 className={`group flex w-full cursor-default items-center gap-1.5 rounded py-1 text-left text-xs transition-colors ${rowPadX} ${
                   isSelected
                     ? "bg-white/[0.08] text-foreground"
                     : "text-muted hover:bg-white/[0.04] hover:text-foreground"
                 }`}
                 onClick={() => onSelectFile(file.path, false)}
+                onDragStart={(event) => {
+                  event.dataTransfer.setData(
+                    COMPOSER_FILE_DRAG_TYPE,
+                    JSON.stringify({ path: file.path, type: "file" }),
+                  );
+                  event.dataTransfer.effectAllowed = "copy";
+                }}
               >
                 <FileIcon path={file.path} />
                 <PathDisplay

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
@@ -15,6 +15,8 @@ import { handleKeyActivate } from "@/renderer/utils/a11y";
 import { openFileInEditor } from "@/renderer/utils/gitHelpers";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
+
 export function FileRow(props: {
   path: string;
   project: Project;
@@ -85,12 +87,20 @@ export function FileRow(props: {
     <>
       <button
         type="button"
+        draggable
         className={`group flex w-full cursor-default items-center gap-1.5 rounded py-1 text-left text-xs transition-colors ${rowPadX} ${
           isSelected
             ? "bg-white/[0.08] text-foreground"
             : "text-muted hover:bg-white/[0.04] hover:text-foreground"
         }`}
         onClick={onSelect}
+        onDragStart={(event) => {
+          event.dataTransfer.setData(
+            COMPOSER_FILE_DRAG_TYPE,
+            JSON.stringify({ path, type: "file" }),
+          );
+          event.dataTransfer.effectAllowed = "copy";
+        }}
       >
         <FileIcon path={path} />
         <PathDisplay

--- a/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
@@ -30,6 +30,7 @@ import { useGitReviewRowPadX } from "./GitReviewSidebar/gitReviewPadXContext";
 // ── Helpers ──────────────────────────────────────────────────
 
 const LARGE_DIFF_THRESHOLD = 500;
+const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
 
 function FileIcon(props: { path: string }) {
   const name = props.path.split(/[\\/]/).pop() ?? props.path;
@@ -207,8 +208,16 @@ export function StackedFileCard(props: {
         <div
           role="button"
           tabIndex={0}
+          draggable
           className={`sticky top-0 z-10 bg-[var(--content-background)] group flex cursor-pointer select-none items-center gap-1.5 py-1 text-xs transition-colors hover:bg-content2 ${rowPadX}`}
           onClick={() => setExpanded((v) => !v)}
+          onDragStart={(event) => {
+            event.dataTransfer.setData(
+              COMPOSER_FILE_DRAG_TYPE,
+              JSON.stringify({ path: file.path, type: "file" }),
+            );
+            event.dataTransfer.effectAllowed = "copy";
+          }}
           onKeyDown={(e) => handleKeyActivate(e, () => setExpanded((v) => !v))}
         >
           {expanded ? (

--- a/src/shared/ipc/bridge.ts
+++ b/src/shared/ipc/bridge.ts
@@ -31,6 +31,7 @@ export type LightcodeBridge = LightcodeInvokeBridge & {
   posthogHost: string;
   posthogKey: string;
   sentryEnabled: boolean;
+  getDroppedFilePaths(files: File[]): string[];
   onSupervisorEvent(listener: (event: SupervisorEvent) => void): () => void;
   onUpdateStatus(listener: (status: UpdateStatus) => void): () => void;
   onBrowserEvent(listener: (event: BrowserEvent) => void): () => void;


### PR DESCRIPTION
**Type:** Feature

- Let users attach files by dropping them onto the thread composer (active thread and draft), with a clear “drop here to attach” overlay while dragging.
- Resolve OS file drops to real paths through the preload bridge so attachments use the same pipeline as picker-based adds.
- Make project-tree files and git review sidebar rows draggable into the composer via a shared drag payload type.
- Cover drag-enter and attach-from-tree behavior in `ThreadComposer` tests.