### PR TITLE
Avoid worktree removal when threads share a worktree path

### DIFF
--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -3,7 +3,13 @@ import { waitFor } from "@testing-library/react";
 import type { Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
-import { openThread, reopenStoredThread, toggleMarkThreadDone } from "./threadActions";
+import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
+import {
+  deleteThread,
+  openThread,
+  reopenStoredThread,
+  toggleMarkThreadDone,
+} from "./threadActions";
 
 const { bridge } = vi.hoisted(() => ({
   bridge: {
@@ -14,9 +20,16 @@ const { hasHydratedThreadRuntimeItems, hydrateThreadRuntimeItems } = vi.hoisted(
   hasHydratedThreadRuntimeItems: vi.fn<(threadId: string) => boolean>().mockReturnValue(false),
   hydrateThreadRuntimeItems: vi.fn<(threadId: string) => Promise<void>>().mockResolvedValue(),
 }));
+const { performWorktreeRemoval } = vi.hoisted(() => ({
+  performWorktreeRemoval: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
 
 vi.mock("@/renderer/bridge", () => ({
   readBridge: () => bridge,
+}));
+
+vi.mock("@/renderer/actions/worktreeActions", () => ({
+  performWorktreeRemoval,
 }));
 
 vi.mock("@/renderer/state/chatRuntimePersister", () => ({
@@ -30,6 +43,7 @@ describe("threadActions", () => {
     localStorage.clear();
     hasHydratedThreadRuntimeItems.mockReturnValue(false);
     hydrateThreadRuntimeItems.mockResolvedValue(undefined);
+    performWorktreeRemoval.mockResolvedValue(undefined);
     useAppStore.setState((state) => ({
       ...state,
       projects: [],
@@ -49,6 +63,7 @@ describe("threadActions", () => {
       focusRequestId: 0,
       tabActivity: {},
     });
+    useWorktreeDeleteStore.setState({ dialog: null });
   });
 
   it("hydrates a persisted GUI thread before opening the pane", async () => {
@@ -198,6 +213,85 @@ describe("threadActions", () => {
     await Promise.resolve();
 
     expect(useAppStore.getState().threads[0]?.status).toBe("inactive");
+  });
+
+  it("deletes a shared-worktree thread without prompting to remove the worktree", () => {
+    const worktreePath = "/repo/.worktrees/feature";
+    const firstThread = makeThread({
+      id: "thread-a",
+      worktreePath,
+      worktreeBranch: "lightcode/feature",
+    });
+    const secondThread = makeThread({
+      id: "thread-b",
+      worktreePath,
+      worktreeBranch: "lightcode/feature",
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [firstThread, secondThread] }));
+
+    deleteThread(firstThread.id, worktreePath, firstThread.projectId);
+
+    expect(useAppStore.getState().threads.map((thread) => thread.id)).toEqual(["thread-b"]);
+    expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: firstThread.id });
+    expect(useWorktreeDeleteStore.getState().dialog).toBeNull();
+  });
+
+  it("prompts to remove the worktree when deleting the sole thread using it", () => {
+    const worktreePath = "/repo/.worktrees/feature";
+    const thread = makeThread({
+      worktreePath,
+      worktreeBranch: "lightcode/feature",
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    deleteThread(thread.id, worktreePath, thread.projectId);
+
+    expect(useAppStore.getState().threads).toHaveLength(1);
+    expect(bridge.closeThread).not.toHaveBeenCalled();
+    expect(useWorktreeDeleteStore.getState().dialog).toEqual({
+      kind: "single-thread",
+      threadId: thread.id,
+      projectId: thread.projectId,
+      worktreePath,
+      worktreeBranch: "lightcode/feature",
+    });
+  });
+
+  it("waits for the thread to close before removing the worktree", async () => {
+    let resolveClose: () => void = () => undefined;
+    const closePromise = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+    bridge.closeThread.mockReturnValueOnce(closePromise);
+    localStorage.setItem("lightcode-delete-worktree-pref", "thread-and-worktree");
+    const worktreePath = "/repo/.worktrees/feature";
+    const project = useAppStore.getState().addProject({
+      kind: "posix",
+      path: "/repo",
+    });
+    const thread = makeThread({
+      projectId: project.id,
+      worktreePath,
+      worktreeBranch: "lightcode/feature",
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    deleteThread(thread.id, worktreePath, project.id);
+
+    expect(useAppStore.getState().threads).toHaveLength(0);
+    expect(bridge.closeThread).toHaveBeenCalledTimes(1);
+    expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: thread.id });
+    expect(performWorktreeRemoval).not.toHaveBeenCalled();
+
+    resolveClose();
+
+    await waitFor(() => {
+      expect(performWorktreeRemoval).toHaveBeenCalledWith(
+        project,
+        worktreePath,
+        "lightcode/feature",
+      );
+    });
   });
 
   it("closes worktree dev terminals when marking a worktree thread done", () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -246,46 +246,49 @@ export function renameThread(threadId: string, title: string): void {
   useAppStore.getState().renameThread(threadId, title);
 }
 
-export function deleteThread(threadId: string, worktreePath?: string, projectId?: string): void {
-  const deleteThreadStoreAction = useAppStore.getState().deleteThread;
+function deleteThreadOnly(threadId: string): void {
+  useAppStore.getState().deleteThread(threadId);
+  void readBridge()
+    .closeThread({ threadId })
+    .catch(() => undefined);
+}
 
+export function deleteThread(threadId: string, worktreePath?: string, projectId?: string): void {
   if (!worktreePath) {
-    deleteThreadStoreAction(threadId);
-    void readBridge()
-      .closeThread({ threadId })
-      .catch(() => undefined);
+    deleteThreadOnly(threadId);
+    return;
+  }
+
+  const allThreads = useAppStore.getState().threads;
+  const siblings = allThreads.filter((t) => t.worktreePath === worktreePath && t.id !== threadId);
+
+  // Other threads still use this worktree — delete the thread without offering worktree removal.
+  if (siblings.length > 0) {
+    deleteThreadOnly(threadId);
     return;
   }
 
   const pref = readWorktreeDeletePref();
   if (pref === "thread-only") {
-    deleteThreadStoreAction(threadId);
-    void readBridge()
-      .closeThread({ threadId })
-      .catch(() => undefined);
+    deleteThreadOnly(threadId);
     return;
   }
 
   if (pref === "thread-and-worktree") {
-    const allThreads = useAppStore.getState().threads;
     const thread = allThreads.find((t) => t.id === threadId);
-    const siblings = allThreads.filter((t) => t.worktreePath === worktreePath && t.id !== threadId);
-    deleteThreadStoreAction(threadId);
-    for (const t of siblings) {
-      deleteThreadStoreAction(t.id);
-    }
+    useAppStore.getState().deleteThread(threadId);
 
     const project = useAppStore.getState().projects.find((p) => p.id === projectId);
     if (project) {
       void (async () => {
-        await closeThreads([threadId, ...siblings.map((t) => t.id)]);
+        await closeThreads([threadId]);
         await performWorktreeRemoval(project, worktreePath, thread?.worktreeBranch);
       })();
     }
     return;
   }
 
-  const thread = useAppStore.getState().threads.find((t) => t.id === threadId);
+  const thread = allThreads.find((t) => t.id === threadId);
   useWorktreeDeleteStore.getState().setDialog({
     kind: "single-thread",
     threadId,


### PR DESCRIPTION
**Type:** Bugfix

- Deleting a thread that shares a worktree with others no longer offers worktree removal or deletes sibling threads still using that path.
- With the “delete thread and worktree” preference, only the selected thread is removed and the worktree is dropped when it is the last thread on that path.
- Sole-thread deletes still show the worktree removal dialog when no preference is saved.
- Tests cover shared-worktree deletion, sole-thread prompting, and worktree removal after the thread closes.