### PR TITLE
Enable Grok Build native Windows install and npm updates

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -302,6 +302,40 @@ describe("AcpRegistrySettings", () => {
     ).toContain("https://antigravity.google/cli/install.sh");
   });
 
+  it("offers Grok Build as a native Windows install", async () => {
+    bridge.platform = "win32";
+    const windowsProject = makeProject({
+      id: "windows-project",
+      name: "Windows Project",
+      location: { kind: "windows", path: "C:\\repo" },
+    });
+    appState.projects = [windowsProject];
+
+    render(<AcpRegistrySettings />);
+
+    await screen.findByRole("heading", { name: "Agent Registry" });
+    const grokCard = screen
+      .getByText(/First-class Grok Build CLI integration/u)
+      .closest(".rounded-lg");
+    expect(grokCard).toBeTruthy();
+    expect(within(grokCard as HTMLElement).queryByText(/Windows is not supported/u)).toBeNull();
+
+    fireEvent.click(within(grokCard as HTMLElement).getByRole("button", { name: "Install" }));
+
+    await waitFor(() => {
+      expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: "Grok Build",
+        }),
+      );
+    });
+    const installInput = runAgentInstallCommandMock.mock.calls[0]?.[0] as
+      | { command: (project: Project) => string }
+      | undefined;
+    const command = withProcessPlatform("win32", () => installInput?.command(windowsProject));
+    expect(command).toContain("irm https://x.ai/cli/install.ps1 | iex");
+  });
+
   it("keeps brew install commands mac-only", () => {
     const wslProject = makeProject({
       id: "wsl-project",
@@ -341,6 +375,9 @@ describe("AcpRegistrySettings", () => {
     expect(entries.get("antigravity")?.installCommand(wslProject)).toContain(
       "curl -fsSL https://antigravity.google/cli/install.sh | bash",
     );
+    expect(entries.get("grok")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://x.ai/cli/install.sh | bash",
+    );
 
     withProcessPlatform("darwin", () => {
       expect(entries.get("codex")?.installCommand(macProject)).toContain(
@@ -352,6 +389,18 @@ describe("AcpRegistrySettings", () => {
       expect(entries.get("opencode")?.installCommand(macProject)).toContain(
         "brew install anomalyco/tap/opencode",
       );
+    });
+
+    withProcessPlatform("win32", () => {
+      expect(
+        entries.get("grok")?.installCommand(
+          makeProject({
+            id: "windows-project",
+            name: "Windows Project",
+            location: { kind: "windows", path: "C:\\repo" },
+          }),
+        ),
+      ).toContain("irm https://x.ai/cli/install.ps1 | iex");
     });
   });
 

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -77,6 +77,7 @@ vi.mock("@/renderer/state/sharedSettingsStore", () => ({
 
 vi.mock("@/renderer/bridge", () => ({
   isWindows: () => bridge.platform === "win32",
+  isMac: () => bridge.platform === "darwin",
   readBridge: () => bridge,
 }));
 
@@ -131,13 +132,13 @@ function makeProject(input: { id: string; name: string; location: Project["locat
   };
 }
 
-function withProcessPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
-  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
-  Object.defineProperty(process, "platform", { value: platform });
+function withHostPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const previous = bridge.platform;
+  bridge.platform = platform;
   try {
     return run();
   } finally {
-    if (descriptor) Object.defineProperty(process, "platform", descriptor);
+    bridge.platform = previous;
   }
 }
 
@@ -164,6 +165,15 @@ const registry: AcpRegistryListResult = {
       version: "1.0.0",
       description: "Cursor through ACP",
       distribution: { npx: { package: "cursor-acp" } },
+    },
+    {
+      id: "grok-build",
+      name: "Grok Build",
+      version: "0.2.11",
+      description: "xAI's coding agent and CLI",
+      distribution: {
+        binary: { windows: { archive: "https://example.com/grok.zip", cmd: "grok" } },
+      },
     },
   ],
 };
@@ -237,6 +247,7 @@ describe("AcpRegistrySettings", () => {
 
     await screen.findByRole("heading", { name: "Agent Registry" });
     expect(screen.queryByText("Codex ACP")).not.toBeInTheDocument();
+    expect(screen.queryByText("xAI's coding agent and CLI")).not.toBeInTheDocument();
     expect(screen.getAllByText("GLM Agent").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Show advanced ACP" })).toBeNull();
 
@@ -332,7 +343,7 @@ describe("AcpRegistrySettings", () => {
     const installInput = runAgentInstallCommandMock.mock.calls[0]?.[0] as
       | { command: (project: Project) => string }
       | undefined;
-    const command = withProcessPlatform("win32", () => installInput?.command(windowsProject));
+    const command = installInput?.command(windowsProject);
     expect(command).toContain("irm https://x.ai/cli/install.ps1 | iex");
   });
 
@@ -379,7 +390,7 @@ describe("AcpRegistrySettings", () => {
       "curl -fsSL https://x.ai/cli/install.sh | bash",
     );
 
-    withProcessPlatform("darwin", () => {
+    withHostPlatform("darwin", () => {
       expect(entries.get("codex")?.installCommand(macProject)).toContain(
         "brew install --cask codex",
       );
@@ -391,7 +402,7 @@ describe("AcpRegistrySettings", () => {
       );
     });
 
-    withProcessPlatform("win32", () => {
+    withHostPlatform("win32", () => {
       expect(
         entries.get("grok")?.installCommand(
           makeProject({

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.test.tsx
@@ -193,8 +193,19 @@ const runAgentLoginCommandMock = vi.hoisted(() =>
     }) => boolean
   >(),
 );
+const runAgentInstallCommandMock = vi.hoisted(() =>
+  vi.fn<
+    (input: {
+      label: string;
+      command: (project: Project) => string;
+      onCommandComplete?: (exitCode: number) => void;
+      project?: Project;
+    }) => boolean
+  >(),
+);
 
 vi.mock("@/renderer/actions/agentLoginActions", () => ({
+  runAgentInstallCommand: runAgentInstallCommandMock,
   runAgentLoginCommand: runAgentLoginCommandMock,
 }));
 
@@ -307,6 +318,7 @@ describe("SingleAgentSettings", () => {
     updateAgentBinaryMock.mockReset().mockResolvedValue({ ok: true });
     toastMock.danger.mockReset();
     toastMock.success.mockReset();
+    runAgentInstallCommandMock.mockReset().mockReturnValue(true);
     runAgentLoginCommandMock.mockReset().mockReturnValue(true);
   });
 
@@ -684,6 +696,106 @@ describe("SingleAgentSettings", () => {
       onCommandComplete: expect.any(Function),
     });
     expect(authenticateAcpAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a native Windows install row when Grok is only installed in WSL", async () => {
+    const windowsProject = makeProject({
+      id: "windows-project",
+      name: "Windows Project",
+      location: { kind: "windows", path: "C:\\project" },
+    });
+    appState.projects = [
+      windowsProject,
+      makeProject({
+        id: "wsl-project",
+        name: "WSL Project",
+        location: {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/home/demo/project",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+        },
+      }),
+    ];
+    statusesState.agentStatuses = [
+      makeStatus("grok", {
+        label: "Grok Build",
+        installed: false,
+        authState: "missing",
+        envKind: "windows",
+      }),
+    ];
+    statusesState.wslAgentStatuses = [
+      makeStatus("grok", {
+        label: "Grok Build",
+        version: "0.2.11",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="grok" />);
+
+    const windowsRow = envRow("Windows");
+    expect(within(windowsRow).getByText("Not installed")).toBeInTheDocument();
+    fireEvent.click(within(windowsRow).getByRole("button", { name: "Install Windows" }));
+
+    expect(runAgentInstallCommandMock).toHaveBeenCalledWith({
+      label: "Grok Build",
+      command: expect.any(Function),
+      onCommandComplete: expect.any(Function),
+      project: windowsProject,
+    });
+  });
+
+  it("shows a WSL install row when Grok is only installed on Windows", async () => {
+    const wslProject = makeProject({
+      id: "wsl-project",
+      name: "WSL Project",
+      location: {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/demo/project",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+      },
+    });
+    appState.projects = [
+      makeProject({
+        id: "windows-project",
+        name: "Windows Project",
+        location: { kind: "windows", path: "C:\\project" },
+      }),
+      wslProject,
+    ];
+    statusesState.agentStatuses = [
+      makeStatus("grok", {
+        label: "Grok Build",
+        version: "0.2.14",
+        envKind: "windows",
+      }),
+    ];
+    statusesState.wslAgentStatuses = [
+      makeStatus("grok", {
+        label: "Grok Build",
+        installed: false,
+        authState: "missing",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+      }),
+    ];
+
+    render(<SingleAgentSettings agentKind="grok" />);
+
+    const wslRow = envRow("WSL (Ubuntu)");
+    expect(within(wslRow).getByText("Not installed")).toBeInTheDocument();
+    fireEvent.click(within(wslRow).getByRole("button", { name: "Install WSL (Ubuntu)" }));
+
+    expect(runAgentInstallCommandMock).toHaveBeenCalledWith({
+      label: "Grok Build",
+      command: expect.any(Function),
+      onCommandComplete: expect.any(Function),
+      project: wslProject,
+    });
   });
 
   it("keeps ACP auth preferred for non-Grok agents that also expose loginCommand", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -27,7 +27,7 @@ import type {
   AgentTerminalAuthMethod,
 } from "@/shared/contracts";
 import { hookEnvForAgentStatus, hookEnvKey, hookEnvLabel } from "@/shared/agentHookPluginEnv";
-import { runAgentLoginCommand } from "@/renderer/actions/agentLoginActions";
+import { runAgentInstallCommand, runAgentLoginCommand } from "@/renderer/actions/agentLoginActions";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
@@ -56,6 +56,7 @@ import {
   type ProviderModelItem,
   type ProviderModelMenuProvider,
 } from "@/renderer/components/common/ProviderModelMenu";
+import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
 
 const SAVED_SECRET_MASK = "***********";
 
@@ -434,6 +435,46 @@ function supportsAcpLogoutStatus(status: AgentStatus, acpInstanceId: string | un
 
 function shouldPreferTerminalLogin(status: AgentStatus): boolean {
   return status.kind === "grok" && Boolean(status.loginCommand);
+}
+
+function AgentInstallEnvironmentRow(props: {
+  agentLabel: string;
+  status: AgentStatus;
+  installPending: boolean;
+  onInstall: (status: AgentStatus) => void;
+}) {
+  const env = envLabel(props.status);
+  const envSuffix = env ? ` ${env}` : "";
+
+  return (
+    <div className="flex flex-col py-1.5 px-2 -mx-2 hover:bg-surface-secondary/40 rounded-lg transition-colors group/env">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+          <span className="shrink-0 text-foreground/90">{env || "Default"}</span>
+          <span className="shrink-0 tabular-nums text-muted/60 font-normal text-xs">
+            Not installed
+          </span>
+        </div>
+        <Button
+          size="sm"
+          variant="tertiary"
+          className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
+          aria-label={`Install${envSuffix}`}
+          isPending={props.installPending}
+          onPress={() => props.onInstall(props.status)}
+        >
+          {props.installPending ? <PixelLoader size="xs" /> : <Download className="size-3" />}
+          {props.installPending ? "Installing" : "Install"}
+        </Button>
+      </div>
+      <div className="flex min-w-0 h-4 items-center">
+        <span className="min-w-0 truncate text-[11px] font-normal text-muted/60">
+          Install {props.agentLabel}
+          {env ? ` for ${env}` : ""}.
+        </span>
+      </div>
+    </div>
+  );
 }
 
 function AgentEnvironmentRow(props: {
@@ -819,6 +860,7 @@ export function SingleAgentSettings(props: { agentKind: string }) {
     agentKind: string;
     version: string | undefined;
   }>();
+  const [installPendingEnvKey, setInstallPendingEnvKey] = useState<string | undefined>();
   const [updatePending, setUpdatePending] = useState(false);
   const [binaryUpdatePendingEnvKey, setBinaryUpdatePendingEnvKey] = useState<string | undefined>();
   // After a successful update we hide the stale version and show a loader on
@@ -834,6 +876,21 @@ export function SingleAgentSettings(props: { agentKind: string }) {
   const installedHere = agentStatuses.filter((a) => a.kind === props.agentKind && a.installed);
   const installedWsl = wslAgentStatuses.filter((a) => a.kind === props.agentKind && a.installed);
   const installedStatuses = [...installedHere, ...installedWsl];
+  const nativeRegistryEntry = NATIVE_AGENT_REGISTRY_ENTRIES.find(
+    (entry) => entry.id === props.agentKind,
+  );
+  const installableHere = nativeRegistryEntry
+    ? agentStatuses.filter(
+        (a) =>
+          a.kind === props.agentKind &&
+          !a.installed &&
+          a.envKind !== "wsl" &&
+          !(a.envKind === "windows" && nativeRegistryEntry.supportsWindows === false),
+      )
+    : [];
+  const installableWsl = nativeRegistryEntry
+    ? wslAgentStatuses.filter((a) => a.kind === props.agentKind && !a.installed)
+    : [];
   const agent = installedHere[0] ?? installedWsl[0];
   const isDisabled = useSharedSettings((s) => s.disabledAgents.includes(props.agentKind));
   const setAgentDisabled = useSharedSettings((s) => s.setAgentDisabled);
@@ -1235,6 +1292,96 @@ export function SingleAgentSettings(props: { agentKind: string }) {
       .finally(() => setBinaryUpdatePendingEnvKey(undefined));
   };
 
+  const installAgentInEnvironment = (status: AgentStatus) => {
+    if (!nativeRegistryEntry) return;
+    const envKey = statusEnvKey(status);
+    const project = findProjectForAgentStatus(status, projects);
+    setInstallPendingEnvKey(envKey);
+    const opened = runAgentInstallCommand({
+      label: agent.label,
+      command: nativeRegistryEntry.installCommand,
+      ...(project ? { project } : {}),
+      onCommandComplete: (exitCode) => {
+        const clearPending = () =>
+          setInstallPendingEnvKey((current) => (current === envKey ? undefined : current));
+        if (exitCode !== 0) {
+          clearPending();
+          return;
+        }
+        void readBridge()
+          .refreshAgentStatuses(wslDistros, {
+            agentKinds: [props.agentKind],
+            envs: [scopeEnvForStatus(status)],
+          })
+          .finally(clearPending);
+      },
+    });
+    if (!opened) setInstallPendingEnvKey(undefined);
+  };
+
+  const renderInstalledEnvironmentRow = (status: AgentStatus) => {
+    const envKey = statusEnvKey(status);
+    const agentMethods =
+      status.authMethods?.filter(isAgentAuthMethod) ??
+      (sharedAgentAuthMethod ? [sharedAgentAuthMethod] : []);
+    const terminalMethod = status.loginCommand
+      ? (findTerminalAuthMethodForStatus(status) ??
+        sharedTerminalAuthMethod ?? {
+          id: "terminal-login",
+          name: "Login",
+          type: "terminal" as const,
+        })
+      : undefined;
+    const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> = usePerEnvAuthRows
+      ? shouldPreferTerminalLogin(status) && terminalMethod
+        ? [terminalMethod]
+        : agentMethods.length > 0
+          ? agentMethods
+          : terminalMethod
+            ? [terminalMethod]
+            : []
+      : [];
+    return (
+      <AgentEnvironmentRow
+        key={`${status.kind}-${envKey}`}
+        acpInstanceId={acpInstanceId}
+        agentLabel={agent.label}
+        authMethods={methods}
+        authPending={authPendingEnvKey === envKey}
+        binaryUpdatePending={binaryUpdatePendingEnvKey === envKey}
+        canLogout={supportsAcpLogoutStatus(status, acpInstanceId)}
+        includeAuthFallback={includeAuthFallbackMetadata}
+        isRedetecting={redetectingEnvKey === envKey}
+        latestNpmVersion={latestNpmVersion}
+        newestInstalledVersion={newestInstalledVersion}
+        pendingMessage={authPendingEnvKey === envKey ? authPendingMessage : undefined}
+        status={status}
+        onLogin={(method) => {
+          if (isAgentAuthMethod(method)) {
+            authenticateAgent({ status, method });
+            return;
+          }
+          runTerminalLogin(status, method);
+        }}
+        onLogout={() => logoutAgent(status)}
+        onUpdate={() => performBinaryUpdate(status)}
+      />
+    );
+  };
+
+  const renderInstallableEnvironmentRow = (status: AgentStatus) => {
+    const envKey = statusEnvKey(status);
+    return (
+      <AgentInstallEnvironmentRow
+        key={`${status.kind}-${envKey}-install`}
+        agentLabel={agent.label}
+        installPending={installPendingEnvKey === envKey}
+        status={status}
+        onInstall={installAgentInEnvironment}
+      />
+    );
+  };
+
   return (
     <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
       <div className="mx-auto max-w-[720px]">
@@ -1293,56 +1440,10 @@ export function SingleAgentSettings(props: { agentKind: string }) {
           </div>
 
           <div className="space-y-0.5 border-t border-border/10 pt-3">
-            {installedStatuses.map((status) => {
-              const envKey = statusEnvKey(status);
-              const agentMethods =
-                status.authMethods?.filter(isAgentAuthMethod) ??
-                (sharedAgentAuthMethod ? [sharedAgentAuthMethod] : []);
-              const terminalMethod = status.loginCommand
-                ? (findTerminalAuthMethodForStatus(status) ??
-                  sharedTerminalAuthMethod ?? {
-                    id: "terminal-login",
-                    name: "Login",
-                    type: "terminal" as const,
-                  })
-                : undefined;
-              const methods: Array<AgentOwnedAuthMethod | AgentTerminalAuthMethod> =
-                usePerEnvAuthRows
-                  ? shouldPreferTerminalLogin(status) && terminalMethod
-                    ? [terminalMethod]
-                    : agentMethods.length > 0
-                      ? agentMethods
-                      : terminalMethod
-                        ? [terminalMethod]
-                        : []
-                  : [];
-              return (
-                <AgentEnvironmentRow
-                  key={`${status.kind}-${envKey}`}
-                  acpInstanceId={acpInstanceId}
-                  agentLabel={agent.label}
-                  authMethods={methods}
-                  authPending={authPendingEnvKey === envKey}
-                  binaryUpdatePending={binaryUpdatePendingEnvKey === envKey}
-                  canLogout={supportsAcpLogoutStatus(status, acpInstanceId)}
-                  includeAuthFallback={includeAuthFallbackMetadata}
-                  isRedetecting={redetectingEnvKey === envKey}
-                  latestNpmVersion={latestNpmVersion}
-                  newestInstalledVersion={newestInstalledVersion}
-                  pendingMessage={authPendingEnvKey === envKey ? authPendingMessage : undefined}
-                  status={status}
-                  onLogin={(method) => {
-                    if (isAgentAuthMethod(method)) {
-                      authenticateAgent({ status, method });
-                      return;
-                    }
-                    runTerminalLogin(status, method);
-                  }}
-                  onLogout={() => logoutAgent(status)}
-                  onUpdate={() => performBinaryUpdate(status)}
-                />
-              );
-            })}
+            {installedHere.map(renderInstalledEnvironmentRow)}
+            {installableHere.map(renderInstallableEnvironmentRow)}
+            {installedWsl.map(renderInstalledEnvironmentRow)}
+            {installableWsl.map(renderInstallableEnvironmentRow)}
           </div>
         </div>
 

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -109,13 +109,18 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
     id: "grok",
     label: "Grok Build",
     description: "First-class Grok Build CLI integration using Lightcode's native runtime.",
-    docsUrl: "https://x.ai/cli",
-    // Grok Build only ships a macOS/Linux installer; native Windows is unsupported.
-    // On Windows the install button is hidden and WSL targets are offered instead.
-    supportsWindows: false,
-    installCommand: () =>
-      "if command -v curl >/dev/null 2>&1; then curl -fsSL https://x.ai/cli/install.sh | bash; " +
-      "else printf 'curl is required to install Grok Build. Install curl, then refresh detected agents.\\n'; fi",
+    docsUrl: "https://docs.x.ai/build/overview",
+    installCommand: (project) =>
+      nativeInstallCommand(project, {
+        mac:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://x.ai/cli/install.sh | bash; " +
+          "else printf 'curl is required to install Grok Build. Install curl, then refresh detected agents.\\n'; fi",
+        posix:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://x.ai/cli/install.sh | bash; " +
+          "else printf 'curl is required to install Grok Build. Install curl, then refresh detected agents.\\n'; fi",
+        windows:
+          "if (Get-Command irm -ErrorAction SilentlyContinue) { irm https://x.ai/cli/install.ps1 | iex } else { Write-Host 'No supported installer found. Install PowerShell Invoke-RestMethod first, then refresh detected agents.' }",
+      }),
   },
   {
     id: "antigravity",

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -1,4 +1,5 @@
 import type { AgentKind, Project } from "@/shared/contracts";
+import { isMac, isWindows } from "@/renderer/bridge";
 
 export interface NativeAgentRegistryEntry {
   id: AgentKind;
@@ -28,7 +29,7 @@ function isWslProject(project: Project): boolean {
 }
 
 function posixOrWindows(project: Project, posix: string, windows: string): string {
-  return isWslProject(project) || process.platform !== "win32" ? posix : windows;
+  return isWslProject(project) || !isWindows() ? posix : windows;
 }
 
 function nativeInstallCommand(
@@ -36,8 +37,8 @@ function nativeInstallCommand(
   commands: { mac: string; posix: string; windows: string },
 ): string {
   if (isWslProject(project)) return commands.posix;
-  if (process.platform === "win32") return commands.windows;
-  return process.platform === "darwin" ? commands.mac : commands.posix;
+  if (isWindows()) return commands.windows;
+  return isMac() ? commands.mac : commands.posix;
 }
 
 export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
@@ -137,7 +138,12 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
   },
 ];
 
-export const KNOWN_NATIVE_FAMILY_ACP_AGENT_IDS = new Set(["claude-acp", "codex-acp", "opencode"]);
+export const KNOWN_NATIVE_FAMILY_ACP_AGENT_IDS = new Set([
+  "claude-acp",
+  "codex-acp",
+  "grok-build",
+  "opencode",
+]);
 
 export const APP_SUPPORTED_ACP_AGENT_IDS = new Set([
   "cursor",
@@ -153,5 +159,6 @@ export const REGISTRY_AGENT_FAMILY_KIND: Record<string, AgentKind> = {
   gemini: "gemini",
   "github-copilot": "copilot",
   "github-copilot-cli": "copilot",
+  "grok-build": "grok",
   opencode: "opencode",
 };

--- a/src/supervisor/agents/base.detect-version.test.ts
+++ b/src/supervisor/agents/base.detect-version.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentCapability } from "@/shared/contracts";
+
+const execFileAsyncMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<{ stdout: string; stderr?: string }>>(),
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  const { promisify } = require("node:util") as typeof import("node:util");
+  return {
+    ...actual,
+    execFile: Object.assign(vi.fn(), {
+      [promisify.custom]: execFileAsyncMock,
+    }),
+  };
+});
+
+import { clearExecutablePathCache, detectAgentInstall, type DetectionSpec } from "./base";
+
+const capabilities: AgentCapability = {
+  models: [],
+  efforts: [],
+  modelEfforts: {},
+  modes: [],
+  approvalPolicies: [],
+  sandboxModes: [],
+  supportsResume: true,
+  supportsDirectInput: true,
+  liveInputMode: "terminal",
+  presentationMode: "terminal",
+  settingDefs: [],
+};
+
+const spec: DetectionSpec = {
+  kind: "grok",
+  label: "Grok Build",
+  binary: "grok",
+  capabilities,
+};
+
+describe("detectAgentInstall version probe", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    // Use a posix probe location so the version command is built without the
+    // PowerShell base64 wrapping, keeping the spawn args readable to assert on.
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    clearExecutablePathCache();
+    execFileAsyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("reads the version from the resolved binary path, not the bare name on PATH", async () => {
+    // 1) binary resolution (`command -v grok`) returns an absolute path the
+    //    supervisor's stale PATH would not contain; 2) the version probe runs.
+    execFileAsyncMock.mockImplementation(async (_cmd: unknown, args: unknown) => {
+      const joined = (Array.isArray(args) ? args : []).join(" ");
+      if (joined.includes("command -v")) return { stdout: "/opt/tools/grok\n", stderr: "" };
+      return { stdout: "grok version 1.2.3\n", stderr: "" };
+    });
+
+    const status = await detectAgentInstall(undefined, spec);
+
+    expect(status.installed).toBe(true);
+    expect(status.version).toBe("1.2.3");
+    // The probe must invoke the resolved absolute path directly — the previous
+    // bug re-ran the bare `grok` through PATH, which misses a CLI installed
+    // after launch.
+    expect(execFileAsyncMock).toHaveBeenCalledWith(
+      "/opt/tools/grok",
+      ["--version"],
+      expect.anything(),
+    );
+  });
+});

--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -19,6 +19,8 @@ vi.mock("node:child_process", async () => {
 
 import {
   clearExecutablePathCache,
+  getRefreshedWindowsPath,
+  invalidateExecutablePathCache,
   resolveExecutablePath,
   resolveExecutablePathAsync,
 } from "./base";
@@ -158,5 +160,53 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     await expect(resolveExecutablePathAsync("gemini")).resolves.toBe(
       "C:\\Users\\demo\\AppData\\Roaming\\npm\\gemini.cmd",
     );
+  });
+
+  it("getRefreshedWindowsPath merges registry PATH beyond the live process Path", () => {
+    spawnSyncMock
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: USER_REG_QUERY, stderr: "" })
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: MACHINE_REG_QUERY, stderr: "" });
+
+    const refreshed = getRefreshedWindowsPath();
+    expect(refreshed).toContain("C:\\Windows\\System32");
+    expect(refreshed).toContain("C:\\Users\\demo\\.local\\bin");
+    expect(refreshed).toContain("C:\\Program Files\\Git\\cmd");
+  });
+
+  it("getRefreshedWindowsPath returns undefined when the registry adds nothing new", () => {
+    // A live process always has a PATH; assert against it (the case-insensitive
+    // delete in beforeEach drops it, so set it explicitly here).
+    process.env.Path = "C:\\Windows\\System32";
+    const onlySystem32 = [
+      "HKEY_CURRENT_USER\\Environment",
+      "    Path    REG_EXPAND_SZ    C:\\Windows\\System32",
+    ].join("\r\n");
+    spawnSyncMock
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: onlySystem32, stderr: "" })
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: onlySystem32, stderr: "" });
+
+    expect(getRefreshedWindowsPath()).toBeUndefined();
+  });
+
+  it("re-reads the registry PATH after invalidateExecutablePathCache (post-install)", () => {
+    process.env.Path = "C:\\Windows\\System32";
+    // Before install: the registry PATH matches the process PATH, so a spawned
+    // shell would only see System32 — the just-installed CLI is absent.
+    const beforeInstall = [
+      "HKEY_CURRENT_USER\\Environment",
+      "    Path    REG_EXPAND_SZ    C:\\Windows\\System32",
+    ].join("\r\n");
+    spawnSyncMock
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: beforeInstall, stderr: "" })
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: beforeInstall, stderr: "" });
+    expect(getRefreshedWindowsPath()).toBeUndefined();
+
+    // The installer added a new dir to the user registry PATH; the post-install
+    // refresh invalidates the cache, so the next read picks it up immediately.
+    invalidateExecutablePathCache();
+    spawnSyncMock
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: USER_REG_QUERY, stderr: "" })
+      .mockReturnValueOnce({ error: undefined, status: 0, stdout: MACHINE_REG_QUERY, stderr: "" });
+    expect(getRefreshedWindowsPath()).toContain("C:\\Users\\demo\\.local\\bin");
   });
 });

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -447,7 +447,6 @@ function extractSemverFromVersionOutput(raw: string | undefined): string | undef
 
 async function readDetectedVersion(
   location: ProjectLocation,
-  binary: string,
   executablePath: string | undefined,
   versionArgs: string[],
 ): Promise<string | undefined> {
@@ -461,7 +460,13 @@ async function readDetectedVersion(
     );
     return result.ok ? extractSemverFromVersionOutput(result.stdout) : undefined;
   }
-  const spec = buildAgentCommand(location, binary, versionArgs);
+  // Run the resolved binary directly rather than re-resolving the bare name
+  // through PATH. The supervisor's PATH is a launch-time snapshot, so a freshly
+  // installed native CLI (e.g. just-installed `grok` on Windows) is found by
+  // detection — which uses the registry-backed fallback — but its `--version`
+  // would miss and the version would render blank. Matches the WSL branch above
+  // and readAgentCommandOutput.
+  const spec = buildAgentCommand(location, executablePath, versionArgs);
   const result = await readCommandOutputAsync(
     spec.command,
     spec.args,
@@ -590,7 +595,7 @@ export async function detectAgentInstall(
   const executablePath = await resolveDetectedBinary(ctx, spec.binary);
 
   const versionArgs = spec.versionArgs ?? ["--version"];
-  const version = await readDetectedVersion(location, spec.binary, executablePath, versionArgs);
+  const version = await readDetectedVersion(location, executablePath, versionArgs);
 
   let capabilities = spec.capabilities;
   let statusProbeResult: StatusProbeResult | undefined;

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -90,7 +90,17 @@ function buildWindowsFallbackPath(): string | undefined {
   return cachedWindowsSearchPath ?? undefined;
 }
 
-function buildWindowsPathOverride(): NodeJS.ProcessEnv | undefined {
+/**
+ * The fresh merged Windows search PATH (current process `Path` + registry user +
+ * machine PATH), or `undefined` when it already matches the live process PATH or
+ * we're not on Windows. Read this at spawn time so a PTY launched after an
+ * installer updated the registry PATH picks up the new entries without an app
+ * restart. Honors {@link invalidateExecutablePathCache} (called on explicit
+ * refresh), so a post-install refresh re-reads the registry before the value is
+ * served here.
+ */
+export function getRefreshedWindowsPath(): string | undefined {
+  if (process.platform !== "win32") return undefined;
   const fallbackPath = buildWindowsFallbackPath();
   if (!fallbackPath) return undefined;
   if (
@@ -99,6 +109,12 @@ function buildWindowsPathOverride(): NodeJS.ProcessEnv | undefined {
   ) {
     return undefined;
   }
+  return fallbackPath;
+}
+
+function buildWindowsPathOverride(): NodeJS.ProcessEnv | undefined {
+  const fallbackPath = getRefreshedWindowsPath();
+  if (!fallbackPath) return undefined;
   return {
     ...process.env,
     Path: fallbackPath,
@@ -402,9 +418,22 @@ function wslProjectShellEnvKey(distro: string, cwd: string): string {
   return `${distro}\u0000${cwd}`;
 }
 
-export function clearExecutablePathCache(): void {
+/**
+ * Drops only the resolved-binary-path caches: the per-command `where.exe` /
+ * `command -v` results and the merged Windows search PATH (which includes the
+ * registry-backed user/machine PATH). Call this before an explicit, user-driven
+ * re-detection (e.g. after installing an agent) so a binary added to PATH by an
+ * installer is found immediately rather than after the 60s TTL or an app
+ * restart. Leaves the login-shell env primes intact — those are unrelated to
+ * "is this binary installed" and are expensive to rebuild.
+ */
+export function invalidateExecutablePathCache(): void {
   execPathCache.clear();
   cachedWindowsSearchPath = null;
+}
+
+export function clearExecutablePathCache(): void {
+  invalidateExecutablePathCache();
   primedPosixEnv = undefined;
   projectShellEnvCache.clear();
   projectShellEnvResolved.clear();

--- a/src/supervisor/agents/grok/detection.ts
+++ b/src/supervisor/agents/grok/detection.ts
@@ -164,6 +164,7 @@ export const grokDetectionSpec: DetectionSpec = {
   capabilities: grokDefaultCapabilities,
   update: {
     builtIn: { binary: "grok", args: ["update"] },
+    npm: "@xai-official/grok",
     latestVersionUrls: [
       "https://x.ai/cli/stable",
       "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -31,6 +31,7 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
   },
   grok: {
     builtIn: { binary: "grok", args: ["update"] },
+    npm: "@xai-official/grok",
     latestVersionUrls: [
       "https://x.ai/cli/stable",
       "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",
@@ -150,6 +151,19 @@ describe("resolveUpdateCommand", () => {
     expect(resolveUpdateCommand(adapter, status, NATIVE_WIN, { skipBuiltIn: true })).toEqual({
       binary: "npm",
       args: ["install", "-g", "@openai/codex@latest"],
+      strategy: "npm-global",
+    });
+  });
+
+  it("falls back to the official Grok npm package when skipping the built-in updater", () => {
+    const adapter = makeAdapter("grok");
+    const status = makeStatus({
+      kind: "grok",
+      executablePath: "C:\\Users\\me\\.grok\\bin\\grok.exe",
+    });
+    expect(resolveUpdateCommand(adapter, status, NATIVE_WIN, { skipBuiltIn: true })).toEqual({
+      binary: "npm",
+      args: ["install", "-g", "@xai-official/grok@latest"],
       strategy: "npm-global",
     });
   });

--- a/src/supervisor/runtime/agentStatusService.test.ts
+++ b/src/supervisor/runtime/agentStatusService.test.ts
@@ -11,9 +11,11 @@ vi.mock("../agents/base", async (importActual) => {
   return {
     ...actual,
     primeExecutablePathCache: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    invalidateExecutablePathCache: vi.fn<() => void>(),
   };
 });
 
+import { invalidateExecutablePathCache } from "../agents/base";
 import { AgentStatusService } from "./agentStatusService";
 
 const tempDirs: string[] = [];
@@ -162,6 +164,24 @@ describe("AgentStatusService", () => {
     await service.refreshAgentStatuses({ wslDistros: [] });
 
     expect(detectInstall).toHaveBeenCalledTimes(2);
+  });
+
+  it("busts the binary-path cache on explicit refresh but not on passive reads", async () => {
+    const detectInstall = vi.fn<AgentAdapter["detectInstall"]>().mockResolvedValue(makeStatus());
+    const { service } = makeService(detectInstall);
+    vi.mocked(invalidateExecutablePathCache).mockClear();
+
+    // Passive read must keep serving from the TTL cache — no invalidation.
+    await service.getAgentStatuses({ wslDistros: [] });
+    expect(invalidateExecutablePathCache).not.toHaveBeenCalled();
+
+    // Explicit full refresh re-reads PATH (e.g. after an install adds a binary).
+    await service.refreshAgentStatuses({ wslDistros: [] });
+    expect(invalidateExecutablePathCache).toHaveBeenCalledTimes(1);
+
+    // Scoped refresh (the post-install path) must invalidate too.
+    await service.refreshAgentStatuses({ wslDistros: [], scope: { agentKinds: ["codex"] } });
+    expect(invalidateExecutablePathCache).toHaveBeenCalledTimes(2);
   });
 
   it("does not auto-probe after an explicit refresh already ran", async () => {

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -17,6 +17,7 @@ import type { SupervisorEvent } from "@/shared/ipc";
 import { normalizeSharedSettings } from "@/shared/settings";
 import { normalizeWslListOutput } from "@/shared/wsl";
 import {
+  invalidateExecutablePathCache,
   primeExecutablePathCache,
   type AgentAdapter,
   type AgentEnvContext,
@@ -247,6 +248,10 @@ export class AgentStatusService {
 
   async refreshAgentStatuses(payload: GetAgentStatusesPayload): Promise<AgentStatusesResponse> {
     const wslDistros = [...new Set(payload.wslDistros)];
+    // An explicit refresh is the signal that something changed on disk (an
+    // install/update just ran), so bypass the binary-path TTL cache and re-read
+    // PATH (including the registry-backed Windows user/machine PATH) fresh.
+    invalidateExecutablePathCache();
     if (payload.scope) {
       return this.runScopedDetection(wslDistros, payload.scope);
     }

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -45,6 +45,7 @@ import {
   type StructuredSessionHandle,
   createKnownSessionRef,
   defaultFormatPromptSegments,
+  getRefreshedWindowsPath,
   getWslCommand,
   injectWslEnv,
   primeProjectShellEnv,
@@ -735,6 +736,19 @@ export class ThreadSessionManager {
       const missingNames = Object.keys(terminalEnv).filter((name) => !wslEnvNames.has(name));
       if (missingNames.length > 0) {
         shellEnv.WSLENV = [...(existingWslEnv ? [existingWslEnv] : []), ...missingNames].join(":");
+      }
+    } else {
+      // A new native shell (terminal tab or the login/install overlay) should
+      // see the same PATH a freshly-opened PowerShell would, not the
+      // supervisor's launch-time snapshot. Re-read the registry-backed PATH at
+      // spawn time so a CLI installed after launch (e.g. just-installed `grok`)
+      // is on PATH without an app restart. Only `Path`/`PATH` are touched to
+      // avoid reintroducing the undefined-value holes a raw process.env spread
+      // would carry.
+      const refreshedPath = getRefreshedWindowsPath();
+      if (refreshedPath) {
+        shellEnv.Path = refreshedPath;
+        shellEnv.PATH = refreshedPath;
       }
     }
 


### PR DESCRIPTION
**Type:** Feature

- Expose Grok Build in the agent registry on native Windows projects with the official PowerShell installer instead of blocking install as unsupported
- Route macOS, Linux/WSL, and Windows installs through the shared native install command helper and point docs at the x.ai build overview
- Register `@xai-official/grok` as the npm update target so Grok can be refreshed globally when the built-in updater is skipped (e.g. on Windows)
- Add settings and supervisor tests covering Windows install UI/commands and npm-global update resolution for Grok