### PR TITLE
Add min-h-full to settings page content wrapper

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
@@ -18,7 +18,7 @@ export function SettingsPage(props: {
   const { title, description, actions, bodyClassName = "space-y-4", children } = props;
   return (
     <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
+      <div className="mx-auto min-h-full max-w-[720px]">
         <div className={`flex items-center justify-between gap-4 ${description ? "mb-2" : "mb-6"}`}>
           <h1 className="text-lg font-semibold text-foreground">{title}</h1>
           {actions ? <div className="shrink-0">{actions}</div> : null}


### PR DESCRIPTION
**Type:** Bugfix

- Ensure the settings page content column fills the scrollable viewport height
- Apply `min-h-full` on the centered `max-w-[720px]` wrapper in `SettingsForm`
- Addresses short settings sections that did not stretch to the full overlay height