### PR TITLE
Probe Claude fast-mode availability per account

### DIFF
--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -26,6 +26,7 @@ import type { MentionInputHandle } from "../composer";
 import { flattenSegments } from "../composer/serializeMentions";
 import { PresentationModeTabs } from "./PresentationModeTabs";
 import { capabilitiesForPresentation, filterHiddenModels } from "./threadComposerOptions";
+import { supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
@@ -119,7 +120,7 @@ function resolveDefaultConfig(
   const model = resolveModelValue(capabilities, preferred?.model);
   const effort = resolveEffortValue(capabilities, model, preferred?.effort);
   const contextSize = resolveContextSizeValue(capabilities, model, preferred?.contextSize);
-  const fast = capabilities.fastModels?.includes(model) ? preferred?.fast === true : false;
+  const fast = supportsUsableFastMode(capabilities, model) ? preferred?.fast === true : false;
   const thinking = capabilities.thinkingModels?.includes(model)
     ? preferred?.thinking === true
     : false;

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -44,6 +44,12 @@ export type ComposerControl =
       isSelected: boolean;
       onChange?: (isSelected: boolean) => void;
       isDisabled?: boolean;
+      /**
+       * When set, the toggle is rendered dimmed and non-interactive with this
+       * message as its tooltip (e.g. a Fast toggle the account can't use). Kept
+       * hoverable rather than natively `disabled` so the tooltip still shows.
+       */
+      disabledReason?: string;
       iconOnly?: boolean;
       fillIconOnSelect?: boolean;
       isCurrentState?: boolean;
@@ -387,20 +393,26 @@ export function ThreadComposer(props: {
 
     if (control.kind === "toggle") {
       const hideLabel = control.iconOnly || shouldHideLabel;
+      // A `disabledReason` toggle stays hoverable (not natively `disabled`) so
+      // its explanatory tooltip still fires; it's dimmed and click is a no-op.
+      const gated = Boolean(control.disabledReason);
       const toggle = (
         <ToggleButton
           key={`toggle-${index}`}
           aria-label={control.label}
+          aria-disabled={gated}
           className={`lightcode-composer-toggle ${
             control.fillIconOnSelect ? "lightcode-composer-toggle--fill-icon-selected " : ""
           }${control.isCurrentState ? "lightcode-composer-toggle--current " : ""}${
             control.iconOnly ? "min-w-9 px-2" : "min-w-0 px-2.5"
-          }${control.className ? ` ${control.className}` : ""}`}
-          isDisabled={control.isDisabled ?? false}
-          isSelected={control.isSelected}
+          }${gated ? " opacity-50 cursor-not-allowed" : ""}${
+            control.className ? ` ${control.className}` : ""
+          }`}
+          isDisabled={gated ? false : (control.isDisabled ?? false)}
+          isSelected={gated ? false : control.isSelected}
           size="sm"
           variant="ghost"
-          onChange={control.onChange ?? (() => undefined)}
+          onChange={gated ? () => undefined : (control.onChange ?? (() => undefined))}
         >
           {resolveIcon(control)}
           {!control.iconOnly && (
@@ -411,11 +423,12 @@ export function ThreadComposer(props: {
         </ToggleButton>
       );
 
-      if (hideLabel) {
+      const tooltipText = gated ? control.disabledReason : hideLabel ? control.label : undefined;
+      if (tooltipText) {
         return (
-          <Tooltip key={`toggle-tooltip-${index}`}>
-            {toggle}
-            <Tooltip.Content placement="top">{control.label}</Tooltip.Content>
+          <Tooltip key={`toggle-tooltip-${index}`} delay={0}>
+            <Tooltip.Trigger>{toggle}</Tooltip.Trigger>
+            <Tooltip.Content placement="top">{tooltipText}</Tooltip.Content>
           </Tooltip>
         );
       }

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -33,6 +33,7 @@ import { ActiveSubAgentTile } from "./ChatPane/parts/items/ActiveSubAgentTile";
 import { selectActiveSubAgentParentItemIds } from "./ChatPane/chatPaneSelectors";
 import { ThreadCommandPanel } from "./ThreadCommandPanel";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
+import { supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { ThreadContextDock } from "./ThreadContextDock";
 import { ThreadContextIndicator } from "./ThreadContextIndicator";
 import { ThreadErrorDock } from "./ThreadErrorDock";
@@ -258,7 +259,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
           agentStatus?.capabilities.efforts ??
           []
         ).length ?? 0) > 0,
-      supportsFast: agentStatus?.capabilities.fastModels?.includes(thread.config.model) ?? false,
+      supportsFast: agentStatus
+        ? supportsUsableFastMode(agentStatus.capabilities, thread.config.model)
+        : false,
     },
   );
   const filteredCommands = filterSlashCommands(availableCommands, slashQuery);
@@ -446,7 +449,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       return;
     }
     if (localAction?.kind === "toggle-fast") {
-      if (agentStatus?.capabilities.fastModels?.includes(thread.config.model)) {
+      if (agentStatus && supportsUsableFastMode(agentStatus.capabilities, thread.config.model)) {
         props.onConfigChange({ ...thread.config, fast: thread.config.fast !== true });
       }
       mentionRef.current?.clear();

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -39,6 +39,7 @@ import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
 import { ThreadAuthRequiredDock } from "./ThreadAuthRequiredDock";
 import { ThreadDockHeader, ThreadDockSection } from "./ThreadDockUI";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
+import { supportsUsableFastMode } from "./threadDraftViewHelpers";
 import {
   filterSlashCommands,
   handleSlashCommandPanelKeyDown,
@@ -254,8 +255,7 @@ export function ThreadDraftComposerArea(props: {
           props.selectedAgent.capabilities.efforts ??
           []
         ).length ?? 0) > 0,
-      supportsFast:
-        props.selectedAgent.capabilities.fastModels?.includes(props.config.model) ?? false,
+      supportsFast: supportsUsableFastMode(props.selectedAgent.capabilities, props.config.model),
     },
   );
   const filteredCommands = filterSlashCommands(availableCommands, slashQuery);
@@ -326,7 +326,7 @@ export function ThreadDraftComposerArea(props: {
       return;
     }
     if (localAction?.kind === "toggle-fast") {
-      if (props.selectedAgent.capabilities.fastModels?.includes(props.config.model)) {
+      if (supportsUsableFastMode(props.selectedAgent.capabilities, props.config.model)) {
         props.onConfigChange({ fast: props.config.fast !== true });
       }
       mentionRef.current?.clear();

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AgentCapability } from "@/shared/contracts";
-import { patchConfigForModelChange } from "./buildModelPickerControls";
+import { buildModelPickerControls, patchConfigForModelChange } from "./buildModelPickerControls";
 
 const capabilities = {
   models: [
@@ -61,5 +61,43 @@ describe("patchConfigForModelChange", () => {
       contextSize: "128k",
       fast: false,
     });
+  });
+
+  it("forces fast off when the account can't use fast mode", () => {
+    const gated = { ...capabilities, fastDisabledReason: "disabled" } as AgentCapability;
+    expect(patchConfigForModelChange(gated, "a", { fast: true })).toMatchObject({
+      model: "a",
+      fast: false,
+    });
+  });
+});
+
+describe("buildModelPickerControls fast toggle", () => {
+  const baseInput = {
+    providers: [],
+    selectedAgentKind: "claude",
+    model: "a",
+    fast: false,
+    onProviderModelChange: () => undefined,
+    onConfigPatch: () => undefined,
+  };
+
+  it("marks the Fast toggle disabled with a reason when the account is gated", () => {
+    const controls = buildModelPickerControls({
+      ...baseInput,
+      capabilities: { ...capabilities, fastDisabledReason: "no fast for you" } as AgentCapability,
+    });
+    const fastToggle = controls.find((c) => c.kind === "toggle" && c.label === "Fast");
+    expect(
+      fastToggle && "disabledReason" in fastToggle ? fastToggle.disabledReason : undefined,
+    ).toBe("no fast for you");
+  });
+
+  it("leaves the Fast toggle enabled when fast mode is available", () => {
+    const controls = buildModelPickerControls({ ...baseInput, capabilities });
+    const fastToggle = controls.find((c) => c.kind === "toggle" && c.label === "Fast");
+    expect(
+      fastToggle && "disabledReason" in fastToggle ? fastToggle.disabledReason : undefined,
+    ).toBe(undefined);
   });
 });

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -9,7 +9,7 @@ import type { ProviderModelMenuProvider } from "@/renderer/components/common";
 import { getComposerControls } from "@/renderer/components/providers";
 import { EffortIcon } from "@/renderer/components/providers/EffortIcon";
 import type { ComposerControl } from "./ThreadComposer";
-import { formatEffortLabel } from "./threadDraftViewHelpers";
+import { formatEffortLabel, supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { capabilitiesForPresentation, filterHiddenModels } from "./threadComposerOptions";
 
 export type ModelPickerConfigPatch = {
@@ -91,7 +91,7 @@ export function patchConfigForModelChange(
     model,
     ...(!effortValid && nextEfforts.length > 0 ? { effort: nextEfforts[0] } : {}),
     ...(nextContextDefault ? { contextSize: nextContextDefault } : {}),
-    ...(capabilities.fastModels?.includes(model) ? {} : { fast: false }),
+    ...(supportsUsableFastMode(capabilities, model) ? {} : { fast: false }),
     ...(capabilities.thinkingModels?.includes(model) ? {} : { thinking: false }),
   };
 }
@@ -186,6 +186,7 @@ export function buildModelPickerControls(input: BuildModelPickerControlsInput): 
   }
 
   if (supportsFast) {
+    const fastDisabledReason = filteredCaps.fastDisabledReason;
     controls.push({
       kind: "toggle",
       label: "Fast",
@@ -195,6 +196,7 @@ export function buildModelPickerControls(input: BuildModelPickerControlsInput): 
       tier: 3,
       isSelected: fast === true,
       ...(isDisabled !== undefined ? { isDisabled } : {}),
+      ...(fastDisabledReason ? { disabledReason: fastDisabledReason } : {}),
       onChange: (selected) => onConfigPatch({ fast: selected }),
     });
   }

--- a/src/renderer/components/thread/threadDraftViewHelpers.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentCapability,
   AgentStatus,
   ProjectDraftConfig,
   ProviderDraftConfig,
@@ -64,8 +65,19 @@ export function resolveContextSizeValue(
 }
 
 export function resolveFastValue(agent: AgentStatus, model: string, preferred?: boolean): boolean {
-  if (!agent.capabilities.fastModels?.includes(model)) return false;
+  if (!supportsUsableFastMode(agent.capabilities, model)) return false;
   return preferred === true;
+}
+
+/**
+ * The model supports fast mode AND the account can actually use it. Returns
+ * false when fast mode is gated (e.g. org-disabled, `fastDisabledReason` set) so
+ * the `/fast` command and provider hand-off don't enable an unusable mode. The
+ * Fast *toggle* still renders (disabled) — that path keys off `fastModels` +
+ * `fastDisabledReason` directly so it can show the explanatory tooltip.
+ */
+export function supportsUsableFastMode(capabilities: AgentCapability, model: string): boolean {
+  return (capabilities.fastModels?.includes(model) ?? false) && !capabilities.fastDisabledReason;
 }
 
 export function resolveThinkingValue(

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -136,6 +136,7 @@ const agentPresentationCapabilityOverrideSchema = z
     modelContextSizes: z.record(z.string(), z.array(z.string().min(1))).optional(),
     defaultContextSize: z.string().optional(),
     fastModels: z.array(z.string().min(1)).optional(),
+    fastDisabledReason: z.string().optional(),
     thinkingModels: z.array(z.string().min(1)).optional(),
     modes: z.array(threadModeSchema),
     approvalPolicies: z.array(labeledOptionSchema),
@@ -171,6 +172,13 @@ export const agentCapabilitySchema = z.object({
   defaultContextSize: z.string().optional(),
   /** Model ids that support a fast/turbo execution mode. */
   fastModels: z.array(z.string().min(1)).optional(),
+  /**
+   * Set when a `fastModels` model technically supports fast mode but it is
+   * unavailable for the authenticated account (e.g. disabled by the org). The
+   * composer keeps the Fast toggle visible but renders it disabled with this
+   * message as its tooltip.
+   */
+  fastDisabledReason: z.string().optional(),
   /** Model ids that support a thinking/reasoning toggle separate from effort level. */
   thinkingModels: z.array(z.string().min(1)).optional(),
   modes: z.array(threadModeSchema).default([]),

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -6,6 +6,12 @@ import { probeClaudeCapabilities } from "./probe";
 /** Default `--permission-mode` when `ThreadConfig.approvalPolicy` is omitted. */
 export const CLAUDE_DEFAULT_APPROVAL_POLICY = "auto" as const;
 
+/**
+ * Shown on the disabled Fast toggle when the capabilities probe finds fast mode
+ * is unavailable for the account. Mirrors Claude Code's own `/fast` wording.
+ */
+export const CLAUDE_FAST_MODE_DISABLED_MESSAGE = "Fast mode has been disabled by your organization";
+
 const CLAUDE_BUILT_IN_SLASH_COMMANDS: AgentCapability["slashCommands"] = [
   {
     id: "goal",

--- a/src/supervisor/agents/claude/fastModeCache.ts
+++ b/src/supervisor/agents/claude/fastModeCache.ts
@@ -1,0 +1,30 @@
+import { promises as fs } from "node:fs";
+import { join } from "node:path";
+import { resolveLightcodePaths } from "@/shared/lightcodePaths";
+import { FAST_MODE_CACHE_FILENAME } from "./fastModeCacheCore";
+
+/**
+ * Host-side fast-mode availability cache path. The native probe and the WSL
+ * probe worker both read/write this one file via the shared core (the worker is
+ * handed the path as a `/mnt/c/...` mount), so a probe runs the billed turn at
+ * most once per account across native + WSL, and an explicit
+ * `refreshAgentStatuses` clears it to re-check.
+ *
+ * Honors the injected data dir (matching the rest of the supervisor) so dev runs
+ * (`~/.lightcode-dev`) and prod don't read/write each other's cache.
+ */
+export function resolveFastModeCachePath(): string {
+  return join(
+    resolveLightcodePaths(process.env.LIGHTCODE_DATA_DIR).cacheDir,
+    FAST_MODE_CACHE_FILENAME,
+  );
+}
+
+/** Cleared on explicit refresh so an org enabling/disabling fast is picked up. */
+export async function clearFastModeCache(): Promise<void> {
+  try {
+    await fs.rm(resolveFastModeCachePath(), { force: true });
+  } catch {
+    // Best-effort.
+  }
+}

--- a/src/supervisor/agents/claude/fastModeCacheCore.ts
+++ b/src/supervisor/agents/claude/fastModeCacheCore.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Path-based fast-mode availability cache (no path resolution of its own) so it
+ * can be shared by the native probe (host paths via `fastModeCache.ts`) and the
+ * WSL probe worker (a Windows path handed in as a `/mnt/c/...` mount). Keyed by
+ * a hash of the account email so raw addresses never hit disk, and so native +
+ * WSL entries for different accounts coexist in the one file.
+ */
+
+export const FAST_MODE_CACHE_FILENAME = "claude-fast-mode.json";
+const CACHE_VERSION = 1;
+
+interface FastModeCacheFile {
+  version: number;
+  accounts: Record<string, { available: boolean }>;
+}
+
+export function fastModeAccountKey(accountEmail: string): string {
+  return createHash("sha256").update(accountEmail.trim().toLowerCase()).digest("hex").slice(0, 16);
+}
+
+async function readCacheFile(cachePath: string): Promise<FastModeCacheFile> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(cachePath, "utf8")) as FastModeCacheFile;
+    if (parsed.version === CACHE_VERSION && parsed.accounts) return parsed;
+  } catch {
+    // Missing/corrupt cache falls through to an empty one.
+  }
+  return { version: CACHE_VERSION, accounts: {} };
+}
+
+/** `undefined` = no cached answer for this account (caller should probe). */
+export async function readFastAvailabilityAt(
+  cachePath: string,
+  accountEmail: string,
+): Promise<boolean | undefined> {
+  const cache = await readCacheFile(cachePath);
+  return cache.accounts[fastModeAccountKey(accountEmail)]?.available;
+}
+
+export async function writeFastAvailabilityAt(
+  cachePath: string,
+  accountEmail: string,
+  available: boolean,
+): Promise<void> {
+  try {
+    const cache = await readCacheFile(cachePath);
+    cache.accounts[fastModeAccountKey(accountEmail)] = { available };
+    await fs.mkdir(dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, JSON.stringify(cache), "utf8");
+  } catch {
+    // Best-effort cache; a write failure just means we re-probe next time.
+  }
+}

--- a/src/supervisor/agents/claude/fastModeProbe.ts
+++ b/src/supervisor/agents/claude/fastModeProbe.ts
@@ -1,0 +1,59 @@
+import type { Query, SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { AsyncPromptQueue } from "./promptQueue";
+import { readFastAvailabilityAt, writeFastAvailabilityAt } from "./fastModeCacheCore";
+
+/**
+ * Decide whether fast mode is available for the authenticated account, shared by
+ * the native probe and the WSL probe worker.
+ *
+ * The gate is per account/org and has no static signal — the SDK init still
+ * advertises `supportsFastMode` on the model regardless. The only reliable read
+ * is the runtime `fast_mode_state` after requesting fast on, which needs a live
+ * turn, so the answer is cached per account at `cachePath` and the turn runs at
+ * most once until an explicit refresh clears the cache.
+ *
+ * Returns `true`/`false` for available/unavailable, or `undefined` when unknown
+ * (no account, timeout, or a CLI that predates the flag) — callers must treat
+ * `undefined` as ungated (fail-open: never gate on uncertainty).
+ */
+export async function resolveFastAvailability(
+  runtime: Query,
+  queue: AsyncPromptQueue,
+  accountEmail: string | undefined,
+  cachePath: string,
+): Promise<boolean | undefined> {
+  if (!accountEmail) return undefined;
+
+  const cached = await readFastAvailabilityAt(cachePath, accountEmail);
+  if (cached !== undefined) return cached;
+
+  try {
+    // Fast mode only applies to Opus, and that's the only family the Fast toggle
+    // is offered for. Pin the probe turn to Opus so an account whose default is
+    // Sonnet (no fast support) doesn't read as "fast disabled".
+    await runtime.setModel("opus");
+  } catch {
+    // Older transports may reject live model changes — fall back to the default.
+  }
+  try {
+    await runtime.applyFlagSettings({ fastMode: true });
+  } catch {
+    return undefined; // CLI predates the flag — leave fast ungated.
+  }
+  queue.push({
+    type: "user",
+    session_id: "",
+    parent_tool_use_id: null,
+    message: { role: "user", content: "Respond with the single word: ok" },
+  } as SDKUserMessage);
+
+  for await (const message of runtime) {
+    if (message.type !== "result") continue;
+    const available = (message as { fast_mode_state?: string }).fast_mode_state === "on";
+    await writeFastAvailabilityAt(cachePath, accountEmail, available);
+    return available;
+  }
+
+  // Aborted/timed out before a result: don't cache a spurious "disabled".
+  return undefined;
+}

--- a/src/supervisor/agents/claude/mergedSettings.test.ts
+++ b/src/supervisor/agents/claude/mergedSettings.test.ts
@@ -3,13 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ProjectLocation } from "@/shared/contracts";
-import { prepareClaudeUltracodeSettingsFile } from "./ultracodeSettings";
+import { prepareClaudeMergedSettingsFile } from "./mergedSettings";
 
-describe("prepareClaudeUltracodeSettingsFile (native)", () => {
+describe("prepareClaudeMergedSettingsFile (native)", () => {
   let workDir: string;
 
   beforeAll(() => {
-    workDir = mkdtempSync(join(tmpdir(), "lightcode-ultracode-test-"));
+    workDir = mkdtempSync(join(tmpdir(), "lightcode-merged-settings-test-"));
   });
 
   afterAll(() => {
@@ -18,7 +18,7 @@ describe("prepareClaudeUltracodeSettingsFile (native)", () => {
 
   const posixLocation: ProjectLocation = { kind: "posix", path: "/tmp/proj" };
 
-  it("merges ultracode:true into the plugin settings file content", async () => {
+  it("merges the given flags into the plugin settings file content", async () => {
     const pluginSettings = join(workDir, "settings.json");
     const original = {
       hooks: { UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo hi" }] }] },
@@ -26,31 +26,39 @@ describe("prepareClaudeUltracodeSettingsFile (native)", () => {
     };
     await fs.writeFile(pluginSettings, JSON.stringify(original), "utf8");
 
-    const outPath = await prepareClaudeUltracodeSettingsFile(pluginSettings, posixLocation);
-    expect(outPath).toBe(join(workDir, "settings-ultracode.json"));
+    const outPath = await prepareClaudeMergedSettingsFile(pluginSettings, posixLocation, {
+      ultracode: true,
+      fastMode: true,
+    });
+    expect(outPath).toBe(join(workDir, "settings-lightcode.json"));
     const written = JSON.parse(await fs.readFile(outPath!, "utf8"));
     expect(written.ultracode).toBe(true);
+    expect(written.fastMode).toBe(true);
     expect(written.hooks).toEqual(original.hooks);
     expect(written.preferredNotifChannel).toBe("iterm2");
   });
 
   it("returns undefined when the source file is missing", async () => {
     const missing = join(workDir, "does-not-exist.json");
-    const outPath = await prepareClaudeUltracodeSettingsFile(missing, posixLocation);
+    const outPath = await prepareClaudeMergedSettingsFile(missing, posixLocation, {
+      ultracode: true,
+    });
     expect(outPath).toBeUndefined();
   });
 
-  it("treats unparseable source as empty and still writes a file with ultracode:true", async () => {
+  it("treats unparseable source as empty and still writes the merged flags", async () => {
     const pluginSettings = join(workDir, "broken.json");
     await fs.writeFile(pluginSettings, "not json {", "utf8");
-    const outPath = await prepareClaudeUltracodeSettingsFile(pluginSettings, posixLocation);
-    expect(outPath).toBe(join(workDir, "settings-ultracode.json"));
+    const outPath = await prepareClaudeMergedSettingsFile(pluginSettings, posixLocation, {
+      ultracode: true,
+    });
+    expect(outPath).toBe(join(workDir, "settings-lightcode.json"));
     const written = JSON.parse(await fs.readFile(outPath!, "utf8"));
     expect(written).toEqual({ ultracode: true });
   });
 
   it("returns undefined when the path is empty", async () => {
-    const outPath = await prepareClaudeUltracodeSettingsFile("", posixLocation);
+    const outPath = await prepareClaudeMergedSettingsFile("", posixLocation, { ultracode: true });
     expect(outPath).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/claude/mergedSettings.ts
+++ b/src/supervisor/agents/claude/mergedSettings.ts
@@ -3,23 +3,27 @@ import { dirname, join, posix as posixPath } from "node:path";
 import type { ProjectLocation } from "@/shared/contracts";
 import { toWslUncPath } from "@/shared/wsl";
 
+const MERGED_SETTINGS_FILENAME = "settings-lightcode.json";
+
 /**
- * Generate a sibling `settings-ultracode.json` next to the hook plugin's
- * `settings.json`, with `"ultracode": true` merged into the top level.
+ * Generate a sibling `settings-lightcode.json` next to the hook plugin's
+ * `settings.json`, with the given session flags (e.g. `{ ultracode: true }` or
+ * `{ fastMode: true }`) merged into the top level.
  *
  * Why we can't just append a second `--settings` flag: Claude's CLI takes the
  * first `--settings` value and silently drops the rest, so passing the inline
- * `{"ultracode":true}` alongside the plugin's path either disables hooks or
- * disables ultracode depending on order. The CLI is happy with a single file
- * that carries both — that's what this helper produces.
+ * flags alongside the plugin's path either disables hooks or disables the flags
+ * depending on order. The CLI is happy with a single file that carries both —
+ * that's what this helper produces.
  *
  * Returns the path the CLI should be told to read (native path on Windows /
  * posix, Linux-side path on WSL), or `undefined` if the source can't be read
  * (we fall back to the plugin's regular settings file in that case).
  */
-export async function prepareClaudeUltracodeSettingsFile(
+export async function prepareClaudeMergedSettingsFile(
   pluginSettingsPath: string,
   projectLocation: ProjectLocation,
+  flags: Record<string, unknown>,
 ): Promise<string | undefined> {
   if (!pluginSettingsPath) return undefined;
 
@@ -27,12 +31,12 @@ export async function prepareClaudeUltracodeSettingsFile(
     const distro = projectLocation.distro;
     const linuxSource = pluginSettingsPath;
     const linuxDir = posixPath.dirname(linuxSource);
-    const linuxOut = `${linuxDir}/settings-ultracode.json`;
+    const linuxOut = `${linuxDir}/${MERGED_SETTINGS_FILENAME}`;
     const uncSource = toWslUncPath(distro, linuxSource);
     const uncOut = toWslUncPath(distro, linuxOut);
     try {
       const content = await fs.readFile(uncSource, "utf8");
-      const merged = mergeUltracode(content);
+      const merged = mergeFlags(content, flags);
       await fs.writeFile(uncOut, merged, "utf8");
       return linuxOut;
     } catch {
@@ -42,8 +46,8 @@ export async function prepareClaudeUltracodeSettingsFile(
 
   try {
     const content = await fs.readFile(pluginSettingsPath, "utf8");
-    const merged = mergeUltracode(content);
-    const outPath = join(dirname(pluginSettingsPath), "settings-ultracode.json");
+    const merged = mergeFlags(content, flags);
+    const outPath = join(dirname(pluginSettingsPath), MERGED_SETTINGS_FILENAME);
     await fs.writeFile(outPath, merged, "utf8");
     return outPath;
   } catch {
@@ -51,7 +55,7 @@ export async function prepareClaudeUltracodeSettingsFile(
   }
 }
 
-function mergeUltracode(content: string): string {
+function mergeFlags(content: string, flags: Record<string, unknown>): string {
   let parsed: Record<string, unknown>;
   try {
     const raw = JSON.parse(content);
@@ -59,5 +63,5 @@ function mergeUltracode(content: string): string {
   } catch {
     parsed = {};
   }
-  return JSON.stringify({ ...parsed, ultracode: true });
+  return JSON.stringify({ ...parsed, ...flags });
 }

--- a/src/supervisor/agents/claude/probe.ts
+++ b/src/supervisor/agents/claude/probe.ts
@@ -1,12 +1,16 @@
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentAuthMethod, AgentCapability } from "@/shared/contracts";
-import type { SDKUserMessage, SlashCommand } from "@anthropic-ai/claude-agent-sdk";
+import type { SlashCommand } from "@anthropic-ai/claude-agent-sdk";
 import {
   readWslLoginShellCommandOutputAsync,
   type CapabilitiesProbeResult,
   type DetectProbeCtx,
 } from "../base";
+import { CLAUDE_FAST_MODE_DISABLED_MESSAGE } from "./detection";
+import { resolveFastModeCachePath } from "./fastModeCache";
+import { resolveFastAvailability } from "./fastModeProbe";
+import { AsyncPromptQueue } from "./promptQueue";
 
 const CLAUDE_TERMINAL_AUTH_METHOD: AgentAuthMethod = {
   type: "terminal",
@@ -81,23 +85,6 @@ export function mapClaudeSlashCommands(
   }));
 }
 
-function abortEndedUserStream(signal: AbortSignal): AsyncIterable<SDKUserMessage> {
-  return {
-    [Symbol.asyncIterator]: (): AsyncIterator<SDKUserMessage> => ({
-      next: () =>
-        new Promise<IteratorResult<SDKUserMessage>>((resolve) => {
-          if (signal.aborted) {
-            resolve({ done: true, value: undefined });
-            return;
-          }
-          signal.addEventListener("abort", () => resolve({ done: true, value: undefined }), {
-            once: true,
-          });
-        }),
-    }),
-  };
-}
-
 function probeDir(): string {
   return typeof __dirname !== "undefined" ? __dirname : dirname(fileURLToPath(import.meta.url));
 }
@@ -137,9 +124,10 @@ async function probeClaudeSdkPartialNative(
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
     const abort = new AbortController();
     const timer = setTimeout(() => abort.abort(), timeoutMs);
+    const queue = new AsyncPromptQueue();
     try {
       const q = query({
-        prompt: abortEndedUserStream(abort.signal),
+        prompt: queue,
         options: {
           abortController: abort,
           pathToClaudeCodeExecutable: executablePath,
@@ -152,13 +140,26 @@ async function probeClaudeSdkPartialNative(
       });
       const init = await q.initializationResult();
       const slashCommands = mapClaudeSlashCommands(init.commands);
+      const fastAvailable = await resolveFastAvailability(
+        q,
+        queue,
+        init.account?.email,
+        resolveFastModeCachePath(),
+      );
+      const fastDisabledReason =
+        fastAvailable === false ? CLAUDE_FAST_MODE_DISABLED_MESSAGE : undefined;
       try {
+        queue.close();
         q.close();
       } catch {
         // ignore
       }
       abort.abort();
-      return slashCommands.length > 0 ? { slashCommands } : undefined;
+      if (slashCommands.length === 0 && !fastDisabledReason) return undefined;
+      return {
+        ...(slashCommands.length > 0 ? { slashCommands } : {}),
+        ...(fastDisabledReason ? { fastDisabledReason } : {}),
+      };
     } finally {
       clearTimeout(timer);
     }
@@ -180,12 +181,18 @@ async function probeClaudeSdkPartialWsl(
   const workerHostPath = getSdkWorkerPath();
   const workerWslPath =
     process.platform === "win32" ? win32PathToWslMount(workerHostPath) : workerHostPath;
+  // The worker runs in-distro, so hand it the fast-mode cache as a `/mnt/c/...`
+  // mount; it reads/writes the same file the native path uses (keyed by account
+  // hash), so the billed turn runs at most once per account.
+  const cacheHostPath = resolveFastModeCachePath();
+  const cacheWslPath =
+    process.platform === "win32" ? win32PathToWslMount(cacheHostPath) : cacheHostPath;
 
   const result = await readWslLoginShellCommandOutputAsync(
     ctx.location.distro,
     "/tmp",
     "node",
-    [workerWslPath, ctx.executablePath, String(timeoutMs)],
+    [workerWslPath, ctx.executablePath, String(timeoutMs), cacheWslPath],
     { timeout: timeoutMs + 3000 },
   );
 
@@ -200,16 +207,20 @@ async function probeClaudeSdkPartialWsl(
   try {
     const parsed = JSON.parse(result.stdout) as {
       slashCommands?: AgentCapability["slashCommands"];
+      fastAvailable?: boolean;
       error?: string;
     };
     if (parsed.error) {
       console.log("[claude-probe] wsl worker error field:", parsed.error);
       return undefined;
     }
-    if (parsed.slashCommands?.length) {
-      return { slashCommands: parsed.slashCommands };
-    }
-    return undefined;
+    const fastDisabledReason =
+      parsed.fastAvailable === false ? CLAUDE_FAST_MODE_DISABLED_MESSAGE : undefined;
+    if (!parsed.slashCommands?.length && !fastDisabledReason) return undefined;
+    return {
+      ...(parsed.slashCommands?.length ? { slashCommands: parsed.slashCommands } : {}),
+      ...(fastDisabledReason ? { fastDisabledReason } : {}),
+    };
   } catch {
     console.log("[claude-probe] wsl worker: invalid json stdout");
     return undefined;
@@ -221,7 +232,9 @@ export async function probeClaudeCapabilities(
 ): Promise<CapabilitiesProbeResult | undefined> {
   if (!ctx.executablePath) return undefined;
 
-  const timeoutMs = process.platform === "win32" ? 12_000 : 10_000;
+  // Both paths may run a one-off fast-mode availability turn on a cache miss, so
+  // allow extra headroom over a plain init probe.
+  const timeoutMs = process.platform === "win32" ? 25_000 : 20_000;
   const sdkPartial =
     ctx.location.kind === "wsl"
       ? await probeClaudeSdkPartialWsl(ctx, timeoutMs)

--- a/src/supervisor/agents/claude/promptQueue.ts
+++ b/src/supervisor/agents/claude/promptQueue.ts
@@ -1,0 +1,44 @@
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+
+/**
+ * Push-driven async queue feeding the Claude Agent SDK's streaming-input mode:
+ * callers `push()` user turns as they arrive and `close()` when the stream
+ * ends. Shared by the live session runtime and the capabilities probe (which
+ * pushes a single throwaway turn to read fast-mode availability).
+ */
+export class AsyncPromptQueue implements AsyncIterable<SDKUserMessage> {
+  private items: SDKUserMessage[] = [];
+  private waiters: Array<(result: IteratorResult<SDKUserMessage>) => void> = [];
+  private closed = false;
+
+  push(message: SDKUserMessage): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: message });
+      return;
+    }
+    this.items.push(message);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ done: true, value: undefined });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
+    return {
+      next: () => {
+        const value = this.items.shift();
+        if (value) return Promise.resolve({ done: false, value });
+        if (this.closed) return Promise.resolve({ done: true, value: undefined });
+        return new Promise<IteratorResult<SDKUserMessage>>((resolve) => {
+          this.waiters.push(resolve);
+        });
+      },
+    };
+  }
+}

--- a/src/supervisor/agents/claude/sdkProbeWorker.ts
+++ b/src/supervisor/agents/claude/sdkProbeWorker.ts
@@ -1,27 +1,16 @@
 /**
  * Runs inside WSL (login-shell `node` invocation) to execute the Claude Agent SDK
  * with a Linux `claude` path. Prints one JSON object on stdout:
- * `{ "slashCommands": AgentSlashCommand[] }`.
+ * `{ "slashCommands": AgentSlashCommand[], "fastAvailable"?: boolean }`.
+ *
+ * Args: <claudePath> <timeoutMs> [<fastModeCachePath>]. When the cache path is
+ * given (a `/mnt/c/...` mount of the host cache), fast-mode availability is
+ * probed once per account and shared with the native path.
  */
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import type { SDKUserMessage, SlashCommand } from "@anthropic-ai/claude-agent-sdk";
-
-function abortEndedUserStream(signal: AbortSignal): AsyncIterable<SDKUserMessage> {
-  return {
-    [Symbol.asyncIterator]: (): AsyncIterator<SDKUserMessage> => ({
-      next: () =>
-        new Promise<IteratorResult<SDKUserMessage>>((resolve) => {
-          if (signal.aborted) {
-            resolve({ done: true, value: undefined });
-            return;
-          }
-          signal.addEventListener("abort", () => resolve({ done: true, value: undefined }), {
-            once: true,
-          });
-        }),
-    }),
-  };
-}
+import type { SlashCommand } from "@anthropic-ai/claude-agent-sdk";
+import { AsyncPromptQueue } from "./promptQueue";
+import { resolveFastAvailability } from "./fastModeProbe";
 
 function mapCommands(commands: SlashCommand[]) {
   return commands.map((c) => ({
@@ -35,6 +24,7 @@ function mapCommands(commands: SlashCommand[]) {
 async function main() {
   const claudePath = process.argv[2];
   const timeoutMs = Math.min(Math.max(Number(process.argv[3]) || 12_000, 3000), 60_000);
+  const cachePath = process.argv[4]?.trim() || undefined;
 
   if (!claudePath?.trim()) {
     console.error(JSON.stringify({ error: "missing_claude_path" }));
@@ -44,10 +34,11 @@ async function main() {
 
   const abort = new AbortController();
   const timer = setTimeout(() => abort.abort(), timeoutMs);
+  const queue = new AsyncPromptQueue();
 
   try {
     const q = query({
-      prompt: abortEndedUserStream(abort.signal),
+      prompt: queue,
       options: {
         abortController: abort,
         pathToClaudeCodeExecutable: claudePath,
@@ -60,9 +51,18 @@ async function main() {
     });
 
     const init = await q.initializationResult();
-    const payload = { slashCommands: mapCommands(init.commands) };
+    const slashCommands = mapCommands(init.commands);
+    const fastAvailable = cachePath
+      ? await resolveFastAvailability(q, queue, init.account?.email, cachePath)
+      : undefined;
+
+    const payload = {
+      slashCommands,
+      ...(fastAvailable !== undefined ? { fastAvailable } : {}),
+    };
     console.log(JSON.stringify(payload));
     try {
+      queue.close();
       q.close();
     } catch {
       // ignore

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -69,6 +69,7 @@ import {
   type ClaudeQuestion,
 } from "./sdkCanonicalMapping";
 import { mapClaudeSlashCommands } from "./probe";
+import { AsyncPromptQueue } from "./promptQueue";
 
 const CLAUDE_EXIT_PLAN_MODE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "ExitPlanMode",
@@ -95,43 +96,6 @@ type PendingRequest = PendingPermission | PendingQuestion;
 type CompletedClaudeTurn = {
   resumeSessionAt: string | undefined;
 };
-
-class AsyncPromptQueue implements AsyncIterable<SDKUserMessage> {
-  private items: SDKUserMessage[] = [];
-  private waiters: Array<(result: IteratorResult<SDKUserMessage>) => void> = [];
-  private closed = false;
-
-  push(message: SDKUserMessage): void {
-    if (this.closed) return;
-    const waiter = this.waiters.shift();
-    if (waiter) {
-      waiter({ done: false, value: message });
-      return;
-    }
-    this.items.push(message);
-  }
-
-  close(): void {
-    if (this.closed) return;
-    this.closed = true;
-    for (const waiter of this.waiters.splice(0)) {
-      waiter({ done: true, value: undefined });
-    }
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<SDKUserMessage> {
-    return {
-      next: () => {
-        const value = this.items.shift();
-        if (value) return Promise.resolve({ done: false, value });
-        if (this.closed) return Promise.resolve({ done: true, value: undefined });
-        return new Promise<IteratorResult<SDKUserMessage>>((resolve) => {
-          this.waiters.push(resolve);
-        });
-      },
-    };
-  }
-}
 
 function projectCwd(location: ProjectLocation): string {
   switch (location.kind) {
@@ -431,6 +395,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
   private appliedModel: string | undefined;
   private appliedPermissionMode: PermissionMode | undefined;
   private appliedUltracode = false;
+  private appliedFast = false;
   private currentStatus: ThreadStatus = "idle";
   private currentAttention: ThreadAttention = "none";
   private currentSlashCommands: AgentSlashCommand[] | undefined;
@@ -583,6 +548,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     }
 
     await this.syncUltracodeFlag(query);
+    await this.syncFastMode(query);
 
     const message = await buildSdkUserMessage(prompt, segments);
     this.promptQueue.push(message);
@@ -606,6 +572,23 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.appliedUltracode = wantUltracode;
     } catch {
       // Older CLIs ignore the unknown flag; effort still degrades to xhigh.
+    }
+  }
+
+  /**
+   * Fast mode is a session flag (`fastMode`), not a model-level setting. Apply
+   * it through the flag-settings layer when the user enabled the Fast toggle.
+   * When the account can't use fast mode the toggle is gated off upstream, so
+   * `config.fast` is never true here in that case.
+   */
+  private async syncFastMode(runtime: Query): Promise<void> {
+    const wantFast = this.currentConfig.fast === true;
+    if (wantFast === this.appliedFast) return;
+    try {
+      await runtime.applyFlagSettings({ fastMode: wantFast ? true : null });
+      this.appliedFast = wantFast;
+    } catch {
+      // Older CLIs ignore the flag; fast mode simply stays off.
     }
   }
 
@@ -645,6 +628,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.appliedModel = undefined;
     this.appliedPermissionMode = undefined;
     this.appliedUltracode = false;
+    this.appliedFast = false;
     this.startQuery(this.sessionId, resumeSessionAt);
     await this.requireQuery();
 
@@ -937,6 +921,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.appliedPermissionMode = permissionMode;
       void this.refreshSlashCommands(this.queryRuntime);
       void this.syncUltracodeFlag(this.queryRuntime);
+      void this.syncFastMode(this.queryRuntime);
       return this.queryRuntime;
     })();
 

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -6,6 +6,7 @@ import type { AgentStatus } from "@/shared/contracts";
 import { resolveLightcodePaths } from "@/shared/lightcodePaths";
 import type { AgentAdapter } from "../agents/base";
 import { detectWslAgentStatuses, SupervisorRuntime } from "../runtime";
+import { STATUS_CACHE_VERSION } from "./agentStatusService";
 
 const tempDirs: string[] = [];
 const runtimesToDispose: SupervisorRuntime[] = [];
@@ -48,7 +49,7 @@ describe("agent status cache", () => {
     writeFileSync(
       statusCachePath,
       JSON.stringify({
-        version: 2,
+        version: STATUS_CACHE_VERSION,
         windows: [
           {
             kind: "claude",
@@ -177,7 +178,7 @@ describe("agent status cache", () => {
     writeFileSync(
       statusCachePath,
       JSON.stringify({
-        version: 2,
+        version: STATUS_CACHE_VERSION,
         windows: [
           {
             kind: "codex",

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -34,7 +34,7 @@ const execFileAsync = promisify(execFile);
  * on the project location (e.g. `grok login --device-auth` on WSL). v3 adds
  * `AgentCapability.fastDisabledReason` (Claude fast-mode org gating).
  */
-const STATUS_CACHE_VERSION = 3;
+export const STATUS_CACHE_VERSION = 3;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -23,6 +23,7 @@ import {
   type AgentEnvContext,
   getWslCommand,
 } from "../agents/base";
+import { clearFastModeCache } from "../agents/claude/fastModeCache";
 
 const execFileAsync = promisify(execFile);
 
@@ -30,9 +31,10 @@ const execFileAsync = promisify(execFile);
  * Bump whenever a cached `AgentStatus` field's shape or derivation changes so
  * that previously-saved caches are invalidated and a fresh detection runs. v2
  * coincides with `DetectionSpec.loginCommand` becoming a function that depends
- * on the project location (e.g. `grok login --device-auth` on WSL).
+ * on the project location (e.g. `grok login --device-auth` on WSL). v3 adds
+ * `AgentCapability.fastDisabledReason` (Claude fast-mode org gating).
  */
-const STATUS_CACHE_VERSION = 2;
+const STATUS_CACHE_VERSION = 3;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 
 function migrateSettingDef(definition: Record<string, unknown>): Record<string, unknown> {
@@ -252,6 +254,9 @@ export class AgentStatusService {
     // install/update just ran), so bypass the binary-path TTL cache and re-read
     // PATH (including the registry-backed Windows user/machine PATH) fresh.
     invalidateExecutablePathCache();
+    // Also re-check Claude's per-account fast-mode availability (an org may have
+    // since enabled/disabled it); the next capabilities probe repopulates it.
+    void clearFastModeCache();
     if (payload.scope) {
       return this.runScopedDetection(wslDistros, payload.scope);
     }

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -51,7 +51,7 @@ import {
   primeProjectShellEnv,
   resolveLaunchSpec,
 } from "../agents/base";
-import { prepareClaudeUltracodeSettingsFile } from "../agents/claude/ultracodeSettings";
+import { prepareClaudeMergedSettingsFile } from "../agents/claude/mergedSettings";
 import { captureSupervisorException } from "../diagnostics/sentry";
 import { ensureNodePtySpawnHelperExecutable } from "../nodePty";
 import type { WindowsShellPreference } from "../shellPreference";
@@ -955,24 +955,28 @@ export class ThreadSessionManager {
    * `--enable <hooks-feature>` as trailing user input instead of a real flag.
    */
   /**
-   * Swap the hook plugin's `--settings <path>` for an ultracode-merged
-   * sibling file when the user picked `effort: "ultracode"`. Claude's CLI
-   * keeps only the first `--settings` it sees and silently drops the rest,
-   * so the inline `{"ultracode":true}` and the plugin's hooks file can't
-   * coexist as separate flags — they have to be one file.
+   * Swap the hook plugin's `--settings <path>` for a sibling file with the
+   * session flags merged in (ultracode and/or fast mode). Claude's CLI keeps
+   * only the first `--settings` it sees and silently drops the rest, so the
+   * inline flags and the plugin's hooks file can't coexist as separate flags —
+   * they have to be one file.
    */
-  private async applyClaudeUltracodeSettingsRewrite(
+  private async applyClaudeMergedSettingsRewrite(
     adapter: AgentAdapter,
     args: string[],
     config: ThreadConfig,
     projectLocation: ProjectLocation,
   ): Promise<string[]> {
-    if (adapter.kind !== "claude" || config.effort !== "ultracode") return args;
+    if (adapter.kind !== "claude") return args;
+    const flags: Record<string, unknown> = {};
+    if (config.effort === "ultracode") flags.ultracode = true;
+    if (config.fast === true) flags.fastMode = true;
+    if (Object.keys(flags).length === 0) return args;
     const idx = args.findIndex((arg, i) => arg === "--settings" && i + 1 < args.length);
     if (idx < 0) return args;
     const originalPath = args[idx + 1];
     if (!originalPath) return args;
-    const rewritten = await prepareClaudeUltracodeSettingsFile(originalPath, projectLocation);
+    const rewritten = await prepareClaudeMergedSettingsFile(originalPath, projectLocation, flags);
     if (!rewritten) return args;
     const out = [...args];
     out[idx + 1] = rewritten;
@@ -1392,7 +1396,7 @@ export class ThreadSessionManager {
         payload.sessionRef,
       );
     }
-    argv.args = await this.applyClaudeUltracodeSettingsRewrite(
+    argv.args = await this.applyClaudeMergedSettingsRewrite(
       adapter,
       argv.args,
       payload.config,
@@ -1996,7 +2000,7 @@ export class ThreadSessionManager {
         session.sessionRef,
       );
     }
-    argv.args = await this.applyClaudeUltracodeSettingsRewrite(
+    argv.args = await this.applyClaudeMergedSettingsRewrite(
       session.adapter,
       argv.args,
       config,
@@ -2095,7 +2099,7 @@ export class ThreadSessionManager {
           session.launchPrompt,
         );
       }
-      argv.args = await this.applyClaudeUltracodeSettingsRewrite(
+      argv.args = await this.applyClaudeMergedSettingsRewrite(
         session.adapter,
         argv.args,
         session.config,


### PR DESCRIPTION
- **Feature:** Probe whether Claude fast mode is actually available for the signed-in account (org-gated) during capabilities detection, with per-account disk caching so the check runs at most once until refresh
- Extend agent capabilities with `fastDisabledReason` and bump status cache to v3 so the UI reflects org-disabled fast mode instead of relying on static model lists
- Keep the Fast toggle visible but non-interactive with an explanatory tooltip when unavailable; gate model changes, `/fast`, and provider hand-off on real eligibility
- Generalize Claude merged settings (from ultracode-only) to pass session flags such as `fastMode`, and share probe/session plumbing via `AsyncPromptQueue` across native and WSL paths