### PR TITLE
Send Codex serviceTier each turn to reset sticky Fast lane

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -498,10 +498,8 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(config.approvalPolicy ? { approvalPolicy: config.approvalPolicy } : {}),
         ...(sandboxPolicy ? { sandboxPolicy } : {}),
         collaborationMode,
-        // The Fast toggle is authoritative: force the tier every turn. `"fast"`
-        // selects the Fast lane; `null` clears it back to the configured default
-        // (the codex app-server's `serviceTier` accepts `"fast" | "flex" | null`).
-        // Sent on each turn since the override is sticky on the server.
+        // Fast toggle is authoritative and the server tier is sticky, so force it
+        // every turn: "fast" selects the Fast lane, null clears it to the default.
         serviceTier: config.fast === true ? "fast" : null,
       });
       this.activeTurnId = extractTurnField(result, "id");

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -498,7 +498,11 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(config.approvalPolicy ? { approvalPolicy: config.approvalPolicy } : {}),
         ...(sandboxPolicy ? { sandboxPolicy } : {}),
         collaborationMode,
-        ...(config.fast ? { serviceTier: "fast" } : {}),
+        // The Fast toggle is authoritative: force the tier every turn. `"fast"`
+        // selects the Fast lane; `null` clears it back to the configured default
+        // (the codex app-server's `serviceTier` accepts `"fast" | "flex" | null`).
+        // Sent on each turn since the override is sticky on the server.
+        serviceTier: config.fast === true ? "fast" : null,
       });
       this.activeTurnId = extractTurnField(result, "id");
       if (this.pendingTurnInterrupt && this.activeTurnId) {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -349,6 +349,34 @@ describe("CodexStructuredSession", () => {
     });
   });
 
+  it("forces serviceTier on each turn: 'fast' when Fast is on, null when off", async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const structuredSession = makeStructuredSession(requests);
+
+    // Fast on → force serviceTier: "fast".
+    await structuredSession.startTurn("go fast", { model: "gpt-5.4", fast: true });
+    expect(requests[0]).toMatchObject({
+      method: "turn/start",
+      params: { serviceTier: "fast" },
+    });
+
+    // Fast off → force serviceTier: null so the app-server reverts to the
+    // default lane (the sticky override would otherwise stay on Fast).
+    await structuredSession.startTurn("back to normal", { model: "gpt-5.4", fast: false });
+    expect(requests[1]?.method).toBe("turn/start");
+    expect(requests[1]?.params.serviceTier).toBeNull();
+  });
+
+  it("forces serviceTier to null on the first turn when Fast is off", async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const structuredSession = makeStructuredSession(requests);
+
+    await structuredSession.startTurn("hello", { model: "gpt-5.4", fast: false });
+
+    expect(requests[0]?.method).toBe("turn/start");
+    expect(requests[0]?.params.serviceTier).toBeNull();
+  });
+
   it("dispatches /goal <objective> to thread/goal/set without starting a model turn", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -349,32 +349,22 @@ describe("CodexStructuredSession", () => {
     });
   });
 
-  it("forces serviceTier on each turn: 'fast' when Fast is on, null when off", async () => {
+  it("forces serviceTier each turn: null when Fast is off (incl. the first turn), 'fast' when on", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);
 
-    // Fast on → force serviceTier: "fast".
-    await structuredSession.startTurn("go fast", { model: "gpt-5.4", fast: true });
-    expect(requests[0]).toMatchObject({
-      method: "turn/start",
-      params: { serviceTier: "fast" },
-    });
-
-    // Fast off → force serviceTier: null so the app-server reverts to the
-    // default lane (the sticky override would otherwise stay on Fast).
-    await structuredSession.startTurn("back to normal", { model: "gpt-5.4", fast: false });
-    expect(requests[1]?.method).toBe("turn/start");
-    expect(requests[1]?.params.serviceTier).toBeNull();
-  });
-
-  it("forces serviceTier to null on the first turn when Fast is off", async () => {
-    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
-    const structuredSession = makeStructuredSession(requests);
-
-    await structuredSession.startTurn("hello", { model: "gpt-5.4", fast: false });
-
+    // Off on the first turn → force null rather than preserving a config.toml tier.
+    await structuredSession.startTurn("normal", { model: "gpt-5.4", fast: false });
     expect(requests[0]?.method).toBe("turn/start");
     expect(requests[0]?.params.serviceTier).toBeNull();
+
+    // On → force "fast".
+    await structuredSession.startTurn("go fast", { model: "gpt-5.4", fast: true });
+    expect(requests[1]?.params.serviceTier).toBe("fast");
+
+    // Back off → force null again to clear the sticky server-side override.
+    await structuredSession.startTurn("back to normal", { model: "gpt-5.4", fast: false });
+    expect(requests[2]?.params.serviceTier).toBeNull();
   });
 
   it("dispatches /goal <objective> to thread/goal/set without starting a model turn", async () => {


### PR DESCRIPTION
**Type:** Bugfix

- Codex keeps `serviceTier` sticky across turns, so turning Fast off could leave the Fast lane active when we only sent `serviceTier` while enabled.
- Each turn now always sends `serviceTier`: `"fast"` when Fast is on, `null` when off (including the first turn) so the server tier matches the toggle.
- Adds tests that Fast off/on/off sends `null`, `"fast"`, and `null` on successive `turn/start` calls.