### PR TITLE
Use check icon for multi-select question options

### DIFF
--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/QuestionOptionRow.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/QuestionOptionRow.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@heroui/react";
+import { Check } from "lucide-react";
 import type { UserInputOption } from "@/shared/contracts";
 
 export function QuestionOptionRow(props: {
@@ -32,8 +33,14 @@ export function QuestionOptionRow(props: {
       }`}
     >
       {isMultiSelect ? (
-        <span className="mt-0.5 flex size-3 shrink-0 items-center justify-center rounded border border-foreground/30 text-[9px] text-foreground [font-variant-numeric:tabular-nums]">
-          {checked ? "x" : ""}
+        <span
+          className={`mt-0.5 flex size-3.5 shrink-0 items-center justify-center rounded-[3px] border transition-colors ${
+            checked
+              ? "border-accent bg-accent text-accent-foreground"
+              : "border-foreground/30 text-transparent"
+          }`}
+        >
+          <Check className="size-2.5" strokeWidth={3} aria-hidden />
         </span>
       ) : (
         <span className="mt-px w-4 shrink-0 text-[11px] font-medium text-[color:var(--muted)] [font-variant-numeric:tabular-nums]">


### PR DESCRIPTION
- **Bugfix:** Multi-select options in the thread runtime request panel showed an “x” when selected, which read like a dismiss action instead of a checked state.
- Selected options now use a check icon with accent fill so the control matches familiar checkbox behavior.
- Unchecked multi-select options keep a neutral bordered box without a misleading mark.