### PR TITLE
Add selectable theme presets and adaptive interaction tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,42 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lightcode</title>
+    <script>
+      // Pre-paint theme bootstrap: apply the saved appearance + background before
+      // the first frame so the initial paint matches the active theme instead of
+      // flashing the hardcoded base palette. The renderer re-applies the full
+      // token set on mount (see renderer/theme/applyAppTheme.ts).
+      (function () {
+        try {
+          var root = document.documentElement;
+          var boot = JSON.parse(localStorage.getItem("lightcode-boot") || "null");
+          var appearance =
+            boot && (boot.appearance === "light" || boot.appearance === "dark")
+              ? boot.appearance
+              : null;
+          if (!appearance) {
+            var settings = JSON.parse(localStorage.getItem("lightcode-shared-settings") || "null");
+            var mode = settings && settings.themeMode;
+            var prefersDark =
+              !window.matchMedia || window.matchMedia("(prefers-color-scheme: dark)").matches;
+            appearance =
+              mode === "light"
+                ? "light"
+                : mode === "dark"
+                  ? "dark"
+                  : prefersDark
+                    ? "dark"
+                    : "light";
+          }
+          root.classList.remove("light", "dark");
+          root.classList.add(appearance);
+          root.dataset.theme = appearance;
+          if (boot && boot.bg) root.style.backgroundColor = boot.bg;
+        } catch (e) {
+          // Ignore; the renderer applies real settings shortly after mount.
+        }
+      })();
+    </script>
   </head>
   <body class="bg-background text-foreground">
     <div id="root"></div>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,7 +1,8 @@
 import { watch } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { app, BrowserWindow, Menu } from "electron";
+import { app, BrowserWindow, Menu, nativeTheme } from "electron";
+import { resolveThemeMode } from "@/shared/themeMode";
 import { closeDatabase, dbGetThreads, initDatabase } from "./db";
 import { cleanupOrphanedAttachments, prepareLightcodeDataRoot } from "./lightcodeData";
 import { createLocalIpcHandlers } from "./ipc/localHandlers";
@@ -70,6 +71,22 @@ function isCloseToTrayEnabled(): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Resolves the saved appearance so the native window opens with a matching
+ * background instead of flashing a fixed color before the renderer paints.
+ */
+function resolveAppAppearance(): "light" | "dark" {
+  let mode: "system" | "light" | "dark" = "dark";
+  if (lightcodePaths) {
+    try {
+      mode = readSharedSettingsFile(lightcodePaths.settingsPath).themeMode;
+    } catch {
+      // Fall back to dark.
+    }
+  }
+  return resolveThemeMode(mode, nativeTheme.shouldUseDarkColors);
 }
 
 function primeBrowserAllowFlags(): void {
@@ -255,6 +272,7 @@ if (!hasSingleInstanceLock) {
       posthogKey,
       sentryEnabled,
       windowChromeHeight: WINDOW_CHROME_HEIGHT,
+      appearance: resolveAppAppearance(),
       ...(process.env.VITE_DEV_SERVER_URL ? { devServerUrl: process.env.VITE_DEV_SERVER_URL } : {}),
       onClosed: () => {
         mainWindow = null;
@@ -342,6 +360,7 @@ if (!hasSingleInstanceLock) {
           posthogKey,
           sentryEnabled,
           windowChromeHeight: WINDOW_CHROME_HEIGHT,
+          appearance: resolveAppAppearance(),
           ...(process.env.VITE_DEV_SERVER_URL
             ? { devServerUrl: process.env.VITE_DEV_SERVER_URL }
             : {}),

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -28,6 +28,7 @@ describe("sharedSettingsFile", () => {
     const settingsPath = join(makeTempDir(), "settings.json");
     writeSharedSettingsFile(settingsPath, {
       themeMode: "dark",
+      themePreset: "default",
       terminalPosition: "right",
       commitGenProvider: "auto",
       commitGenModel: "",
@@ -101,6 +102,7 @@ describe("sharedSettingsFile", () => {
 
     expect(readSharedSettingsFile(settingsPath)).toEqual({
       themeMode: "dark",
+      themePreset: "default",
       terminalPosition: "right",
       commitGenProvider: "auto",
       commitGenModel: "",

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -60,6 +60,8 @@ export interface CreateMainWindowOptions {
   posthogKey: string;
   sentryEnabled: boolean;
   windowChromeHeight: number;
+  /** Saved appearance, so the native window opens matching the theme. */
+  appearance: "light" | "dark";
   onClosed(): void;
   onClose?: (event: Electron.Event) => void;
   onRendererProcessGone?: (details: RenderProcessGoneDetails) => void;
@@ -69,6 +71,11 @@ export interface CreateMainWindowOptions {
 export function createMainWindow(options: CreateMainWindowOptions): BrowserWindow {
   const saved = getSavedWindowBounds();
   const supportsTitleBarOverlay = process.platform === "win32" || process.platform === "linux";
+  const isDark = options.appearance === "dark";
+  // Base bg/symbol per appearance, matching styles.css and the runtime
+  // setWindowChrome values, so the first frame doesn't flash a fixed palette.
+  const backgroundColor = isDark ? "#141416" : "#f1f1f4";
+  const symbolColor = isDark ? "#fafafa" : "#1f2937";
   const window = new BrowserWindow({
     title: options.title,
     show: false,
@@ -77,14 +84,14 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
     ...(saved?.x != null && saved?.y != null ? { x: saved.x, y: saved.y } : {}),
     minWidth: 540,
     minHeight: 720,
-    backgroundColor: "#1c1f24",
+    backgroundColor,
     autoHideMenuBar: true,
     ...(supportsTitleBarOverlay
       ? {
           titleBarStyle: "hidden" as const,
           titleBarOverlay: {
             color: "#00000000",
-            symbolColor: "#f8fafc",
+            symbolColor,
             height: options.windowChromeHeight,
           },
         }

--- a/src/renderer/components/common/SidebarButton.tsx
+++ b/src/renderer/components/common/SidebarButton.tsx
@@ -63,8 +63,8 @@ export function SidebarButton(props: {
     isDisabled || isDragging
       ? "cursor-not-allowed text-muted/40"
       : isActive && !isDraggingAnything
-        ? "bg-white/[0.08] text-foreground"
-        : `${inactiveText} ${!isDraggingAnything ? "hover:bg-white/[0.04] hover:text-foreground" : ""}`;
+        ? "bg-[var(--row-active)] text-foreground"
+        : `${inactiveText} ${!isDraggingAnything ? "hover:bg-[var(--row-hover)] hover:text-foreground" : ""}`;
 
   const sizeClass = size === "xs" ? "text-xs" : "text-sm";
   const dragRowDim = isDragging && !iconOnly && !isDisabled ? " opacity-60" : "";

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -22,7 +22,7 @@ export function BrowserChip(props: {
         <Tooltip.Trigger>
           <button
             type="button"
-            className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+            className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
             aria-label={title}
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/renderer/components/layout/sidebarChrome.ts
+++ b/src/renderer/components/layout/sidebarChrome.ts
@@ -105,10 +105,11 @@ export function gitReviewSidebarListScrollClass() {
  * Sticky/variable footers: Return to app, Hide sidebar, etc. Border spans column inset only.
  * @see {sidebarColumnLayoutClass}
  */
-export const sidebarFooterNavClass = "shrink-0 space-y-1 border-t border-white/6 pt-2 pb-2";
+export const sidebarFooterNavClass =
+  "shrink-0 space-y-1 border-t border-[var(--hairline)] pt-2 pb-2";
 
 /**
  * Collapsed icon rail: bottom block (pr keeps icons off the right edge in the narrow column).
  * @see {sidebarColumnLayoutClass}
  */
-export const sidebarIconRailFooterClass = "space-y-1 border-t border-white/6 pt-2 pr-2";
+export const sidebarIconRailFooterClass = "space-y-1 border-t border-[var(--hairline)] pt-2 pr-2";

--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
@@ -6,7 +6,7 @@ import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
-import { chatMessageSurfaceClass } from "./chatMessageSurface";
+import { chatPromptSurfaceClass } from "./chatMessageSurface";
 import { ItemMarkdown } from "./ItemMarkdown";
 
 interface QuestionAnswerProps {
@@ -19,7 +19,7 @@ export function QuestionAnswer({ item, checkpointRevertControl }: QuestionAnswer
   const questions = payload?.questions ?? [];
   if (questions.length === 0) return null;
   return (
-    <Surface variant="tertiary" className={`${chatMessageSurfaceClass} relative`}>
+    <Surface variant="tertiary" className={chatPromptSurfaceClass}>
       <div className="min-w-0 space-y-2 leading-snug">
         {questions.map((entry, index) => (
           <div

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
@@ -193,7 +193,7 @@ function Shell({
         <button
           type="button"
           aria-label="Close subagent"
-          className="shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+          className="shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
           onClick={onClose}
         >
           <X className="size-3.5" />

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { normalizeChatProjectPath } from "../../chatPathUtils";
-import { chatMessageSurfaceClass } from "./chatMessageSurface";
+import { chatPromptSurfaceClass } from "./chatMessageSurface";
 import { InlineFilePathChip } from "./InlineFilePathChip";
 import { ItemMarkdown } from "./ItemMarkdown";
 import { extractSelectorPayloads } from "./SelectorBadge";
@@ -114,7 +114,7 @@ export const UserMessage = memo(function UserMessage({
   }
 
   return (
-    <Surface variant="tertiary" className={`${chatMessageSurfaceClass} relative`}>
+    <Surface variant="tertiary" className={chatPromptSurfaceClass}>
       <div className="min-w-0 space-y-1.5 leading-snug">
         {attachments.length > 0 ? (
           <div className="-mt-1">

--- a/src/renderer/components/thread/ChatPane/parts/items/chatMessageSurface.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/chatMessageSurface.ts
@@ -1,1 +1,8 @@
 export const chatMessageSurfaceClass = "w-full rounded-3xl px-3 py-2";
+
+/**
+ * Surface for user-authored rows (the user message and the question/answer
+ * prompt). A hairline border delineates them from transparent agent rows in
+ * low-elevation themes where the tertiary fill alone is too subtle.
+ */
+export const chatPromptSurfaceClass = `${chatMessageSurfaceClass} relative border border-[var(--hairline)]`;

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -92,7 +92,7 @@ export function ProjectSwitchMenu(props: {
         <Dropdown.Trigger
           aria-label="Switch project"
           isDisabled={isDisabled}
-          className="group mx-auto inline-flex max-w-full items-center gap-1.5 rounded border border-transparent px-2 py-0.5 outline-none transition-colors hover:border-border/60 hover:bg-white/[0.03] focus-visible:border-border focus-visible:bg-white/[0.03] disabled:cursor-default disabled:hover:border-transparent disabled:hover:bg-transparent"
+          className="group mx-auto inline-flex max-w-full items-center gap-1.5 rounded border border-transparent px-2 py-0.5 outline-none transition-colors hover:border-border/60 hover:bg-[var(--row-hover)] focus-visible:border-border focus-visible:bg-[var(--row-hover)] disabled:cursor-default disabled:hover:border-transparent disabled:hover:bg-transparent"
         >
           <span className="min-w-0 truncate pb-[0.08em] leading-snug font-medium tracking-normal text-transparent [background-image:linear-gradient(135deg,var(--muted)_0%,color-mix(in_oklab,var(--accent)_30%,var(--muted))_100%)] [background-size:100%_100%] bg-clip-text font-mono">
             {label}
@@ -111,7 +111,7 @@ export function ProjectSwitchMenu(props: {
       <Dropdown.Trigger
         aria-label="Switch project"
         isDisabled={isDisabled}
-        className="group inline-flex min-w-0 max-w-full items-center gap-1 rounded px-1 py-0.5 text-sm leading-tight text-muted/60 outline-none transition-colors hover:bg-white/[0.04] hover:text-foreground focus-visible:bg-white/[0.04] disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted/60"
+        className="group inline-flex min-w-0 max-w-full items-center gap-1 rounded px-1 py-0.5 text-sm leading-tight text-muted/60 outline-none transition-colors hover:bg-[var(--row-hover)] hover:text-foreground focus-visible:bg-[var(--row-hover)] disabled:cursor-default disabled:hover:bg-transparent disabled:hover:text-muted/60"
       >
         {triggerIcon}
         <span className="min-w-0 truncate">{label}</span>

--- a/src/renderer/components/thread/ThreadDraftChrome.tsx
+++ b/src/renderer/components/thread/ThreadDraftChrome.tsx
@@ -45,7 +45,7 @@ export function ThreadDraftCompactHeader(props: {
             <button
               type="button"
               aria-label="Close pane"
-              className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+              className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               onClick={(e) => {
                 e.stopPropagation();
                 props.onClose?.();

--- a/src/renderer/components/thread/ThreadHeaderStatus.tsx
+++ b/src/renderer/components/thread/ThreadHeaderStatus.tsx
@@ -73,7 +73,7 @@ export function ThreadHeaderStatusTooltipBody(props: { thread: Thread }) {
           <p className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs leading-relaxed">
             <span className="text-muted">Support:</span>
             <span
-              className={`relative top-px size-1.5 shrink-0 rounded-full ring-1 ring-white/10 ${supportSourceDotClass(source)}`}
+              className={`relative top-px size-1.5 shrink-0 rounded-full ring-1 ring-[var(--hairline-strong)] ${supportSourceDotClass(source)}`}
               aria-hidden
             />
             <span className="font-semibold text-foreground">{activeSupportLabel(source)}</span>
@@ -107,7 +107,7 @@ export function ThreadHeaderStatusButton(props: {
       <Tooltip.Trigger>
         <button
           type="button"
-          className="lightcode-overlay-header__controls inline-flex shrink-0 rounded-sm p-0.5 outline-offset-2 hover:bg-white/[0.06]"
+          className="lightcode-overlay-header__controls inline-flex shrink-0 rounded-sm p-0.5 outline-offset-2 hover:bg-[var(--row-hover)]"
           aria-label={`${props.agentLabel ?? props.fallbackAgentKind}: ${threadRuntimeStatusLabel(thread)}. Hover for status details.`}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -414,7 +414,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                       <button
                         type="button"
                         aria-label="Continue in another provider"
-                        className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+                        className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                         onClick={(e) => {
                           e.stopPropagation();
                           setContinueDialogOpen(true);
@@ -435,7 +435,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                           runtimeDebugOpen ? "Hide runtime debug panel" : "Show runtime debug panel"
                         }
                         aria-pressed={runtimeDebugOpen}
-                        className={`lightcode-overlay-header__controls shrink-0 rounded p-1 transition-colors hover:bg-white/[0.06] ${runtimeDebugOpen ? "text-foreground" : "text-muted/60 hover:text-foreground"}`}
+                        className={`lightcode-overlay-header__controls shrink-0 rounded p-1 transition-colors hover:bg-[var(--row-hover)] ${runtimeDebugOpen ? "text-foreground" : "text-muted/60 hover:text-foreground"}`}
                         onClick={(e) => {
                           e.stopPropagation();
                           setRuntimeDebugOpen((o) => !o);
@@ -455,7 +455,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                   <button
                     type="button"
                     aria-label={thread.done ? "Unmark done" : "Mark done"}
-                    className={`lightcode-overlay-header__controls shrink-0 rounded p-1 transition-colors hover:bg-white/[0.06] ${thread.done ? "text-[oklch(0.78_0.1_180)]" : "text-muted/60 hover:text-foreground"}`}
+                    className={`lightcode-overlay-header__controls shrink-0 rounded p-1 transition-colors hover:bg-[var(--row-hover)] ${thread.done ? "text-[oklch(0.78_0.1_180)]" : "text-muted/60 hover:text-foreground"}`}
                     onClick={(e) => {
                       e.stopPropagation();
                       onMarkDone();
@@ -468,7 +468,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                   <button
                     type="button"
                     aria-label="Close pane"
-                    className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+                    className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                     onClick={(e) => {
                       e.stopPropagation();
                       onClose?.();

--- a/src/renderer/components/ui/provider.tsx
+++ b/src/renderer/components/ui/provider.tsx
@@ -9,7 +9,7 @@ import {
 import { Toast, toast as heroToast } from "@heroui/react";
 import { Copy } from "lucide-react";
 import { resolveThemeMode } from "@/shared/themeMode";
-import { applyAppTheme, systemPrefersDark } from "@/renderer/theme/applyAppTheme";
+import { applyAppTheme, persistThemeBoot, systemPrefersDark } from "@/renderer/theme/applyAppTheme";
 import { readBridge } from "@/renderer/bridge";
 import { captureRendererException } from "@/renderer/diagnostics/sentry";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -95,6 +95,7 @@ export function AppProvider(props: { children: ReactNode }) {
     root.classList.add(appearance);
     root.dataset.theme = appearance;
     applyAppTheme(root, appearance, themePreset);
+    persistThemeBoot(appearance, themePreset);
   }, [appearance, themePreset]);
 
   useEffect(() => {

--- a/src/renderer/components/ui/provider.tsx
+++ b/src/renderer/components/ui/provider.tsx
@@ -9,6 +9,7 @@ import {
 import { Toast, toast as heroToast } from "@heroui/react";
 import { Copy } from "lucide-react";
 import { resolveThemeMode } from "@/shared/themeMode";
+import { applyAppTheme, systemPrefersDark } from "@/renderer/theme/applyAppTheme";
 import { readBridge } from "@/renderer/bridge";
 import { captureRendererException } from "@/renderer/diagnostics/sentry";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -22,14 +23,6 @@ const toastTitleClassName = "lc-toast__title";
 
 export function useResolvedAppearance(): "light" | "dark" {
   return useContext(AppearanceContext);
-}
-
-function getSystemPrefersDark(): boolean {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return true;
-  }
-
-  return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
 
 interface ToastActionProps {
@@ -71,7 +64,8 @@ function ToastAction({ actionProps, actionLabel, isCopyAction }: ToastActionProp
 export function AppProvider(props: { children: ReactNode }) {
   const { children } = props;
   const themeMode = useSharedSettings((state) => state.themeMode);
-  const [prefersDark, setPrefersDark] = useState(getSystemPrefersDark);
+  const themePreset = useSharedSettings((state) => state.themePreset);
+  const [prefersDark, setPrefersDark] = useState(systemPrefersDark);
   const syncSystemPreference = useEffectEvent((matches: boolean) => {
     setPrefersDark(matches);
   });
@@ -100,7 +94,8 @@ export function AppProvider(props: { children: ReactNode }) {
     root.classList.remove("light", "dark");
     root.classList.add(appearance);
     root.dataset.theme = appearance;
-  }, [appearance]);
+    applyAppTheme(root, appearance, themePreset);
+  }, [appearance, themePreset]);
 
   useEffect(() => {
     if (typeof window === "undefined" || !("lightcode" in window)) {

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -11,6 +11,7 @@ import {
   type RendererCrashReport,
 } from "./RendererCrashScreen";
 import { isIgnorableRejection, isIgnorableWindowError } from "./rendererGlobalErrors";
+import { bootstrapAppThemeFromCache } from "./theme/applyAppTheme";
 
 if (import.meta.env.DEV) {
   const warn = console.warn.bind(console);
@@ -35,6 +36,10 @@ initializeRendererSentry();
 
 document.documentElement.dataset.platform =
   typeof window !== "undefined" && "lightcode" in window ? readBridge().platform : "unknown";
+
+// Apply the cached appearance + theme before first paint so a non-default theme
+// doesn't flash the base palette on launch.
+bootstrapAppThemeFromCache();
 
 const root = document.getElementById("root");
 

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -23,6 +23,7 @@ const STORAGE_KEY = "lightcode-shared-settings";
 interface SharedSettingsState extends SharedSettings {
   sharedSettingsHydrated: boolean;
   setThemeMode: (mode: ThemeMode) => void;
+  setThemePreset: (id: string) => void;
   setTerminalPosition: (position: TerminalPosition) => void;
   setCommitGenConfig: (provider: string, model: string, effort: string) => void;
   setTitleGenConfig: (provider: string, model: string, effort: string) => void;
@@ -158,6 +159,11 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
   sharedSettingsHydrated: initialLoadDone,
   setThemeMode: (themeMode) => {
     set({ themeMode });
+    persistSettings(selectSharedSettings(get()));
+  },
+  setThemePreset: (themePreset) => {
+    if (get().themePreset === themePreset) return;
+    set({ themePreset });
     persistSettings(selectSharedSettings(get()));
   },
   setTerminalPosition: (terminalPosition) => {
@@ -454,6 +460,7 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
 function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
   return {
     themeMode: state.themeMode,
+    themePreset: state.themePreset,
     terminalPosition: state.terminalPosition,
     commitGenProvider: state.commitGenProvider,
     commitGenModel: state.commitGenModel,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -742,6 +742,16 @@
     --terminal-surface: var(--surface);
     --composer-surface: var(--surface);
     --interactive-cursor: default;
+
+    /* Theme-adaptive interaction overlays. Derived from --foreground so they
+       invert per theme: a light wash on dark themes (matching the old
+       white/[x] look) and a dark wash on light themes — where a white wash was
+       invisible. Replaces hardcoded bg-white/[x] selection/hover and
+       border-white/x hairlines so every surface follows the active theme. */
+    --row-hover: color-mix(in oklab, var(--foreground) 6%, transparent);
+    --row-active: color-mix(in oklab, var(--foreground) 11%, transparent);
+    --hairline: color-mix(in oklab, var(--foreground) 9%, transparent);
+    --hairline-strong: color-mix(in oklab, var(--foreground) 15%, transparent);
   }
 
   .light,
@@ -799,7 +809,7 @@
     --content-background: oklch(0.2 0.004 286);
     --window-header-background: var(--sidebar-background);
     --terminal-surface: oklch(0.155 0.004 286);
-    --composer-surface: oklch(0.225 0.004 286);
+    --composer-surface: oklch(0.25 0.004 286);
   }
 
   * {
@@ -1417,9 +1427,11 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
 
 .lightcode-composer-shell {
   position: relative;
-  border: 1px solid var(--border);
+  /* Foreground-derived hairline (not --border) so the primary input stays
+     clearly outlined in every theme, including low-contrast light palettes. */
+  border: 1px solid var(--hairline-strong);
   border-radius: var(--radius-4xl);
-  background: color-mix(in oklab, var(--composer-surface) 94%, transparent);
+  background: var(--composer-surface);
   transition: border-color 0.15s ease;
 }
 
@@ -1693,7 +1705,7 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   height: 100%;
   width: var(--lc-context-progress);
   border-radius: inherit;
-  background: var(--snow, white);
+  background: var(--foreground);
 }
 
 .lightcode-context-dock__bar-fill--warning {
@@ -1708,7 +1720,7 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   --toggle-button-bg-selected: transparent;
   --toggle-button-bg-selected-hover: var(--toggle-button-bg-hover);
   --toggle-button-bg-selected-pressed: var(--toggle-button-bg-pressed);
-  --toggle-button-fg-selected: var(--snow, white);
+  --toggle-button-fg-selected: var(--foreground);
 
   color: var(--muted);
   height: 2.25rem;
@@ -1716,11 +1728,11 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
 }
 
 .lightcode-composer-toggle[data-selected="true"] {
-  color: var(--snow, white);
+  color: var(--foreground);
 }
 
 .lightcode-composer-toggle--current {
-  color: var(--snow, white);
+  color: var(--foreground);
 }
 
 .lightcode-composer-toggle--fill-icon-selected[data-selected="true"] svg {

--- a/src/renderer/theme/applyAppTheme.ts
+++ b/src/renderer/theme/applyAppTheme.ts
@@ -1,0 +1,68 @@
+/**
+ * Applies a theme preset's variant to the document root as inline CSS custom
+ * properties. Inline properties win over the `.light` / `.dark` rules in
+ * styles.css, so the base ("Lightcode") theme is expressed by *clearing* the
+ * managed properties — letting styles.css stay the source of truth — rather
+ * than by re-setting equivalent values.
+ */
+
+import { resolveThemeMode } from "@/shared/themeMode";
+import type { ThemeMode } from "@/shared/contracts";
+import { DEFAULT_THEME_ID, getThemePreset } from "./themePresets";
+import { MANAGED_THEME_VARS } from "./themeTokens";
+
+type Appearance = "light" | "dark";
+
+export function applyAppTheme(root: HTMLElement, appearance: Appearance, themeId: string): void {
+  if (themeId === DEFAULT_THEME_ID) {
+    for (const key of MANAGED_THEME_VARS) {
+      root.style.removeProperty(key);
+    }
+    return;
+  }
+
+  const preset = getThemePreset(themeId);
+  const vars = appearance === "dark" ? preset.dark : preset.light;
+  for (const key of MANAGED_THEME_VARS) {
+    // An empty value clears the declaration, letting the .light/.dark base win.
+    root.style.setProperty(key, vars[key] ?? "");
+  }
+}
+
+// Mirrors the localStorage key in sharedSettingsStore. Read directly here so the
+// pre-paint bootstrap doesn't have to import (and eagerly hydrate) the store.
+const SHARED_SETTINGS_CACHE_KEY = "lightcode-shared-settings";
+
+/** Whether the OS currently prefers a dark color scheme (defaults to dark). */
+export function systemPrefersDark(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return true;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+/**
+ * Synchronously applies the cached appearance + theme to the document root
+ * before React mounts, so a non-default theme doesn't flash the base palette on
+ * launch. The authoritative settings load (provider effect) re-applies and wins
+ * if the cache was stale. Defensive: never throws into the boot path.
+ */
+export function bootstrapAppThemeFromCache(): void {
+  try {
+    const raw = localStorage.getItem(SHARED_SETTINGS_CACHE_KEY);
+    if (!raw) return;
+    const cached = JSON.parse(raw) as { themeMode?: unknown; themePreset?: unknown };
+    const mode: ThemeMode =
+      cached.themeMode === "light" || cached.themeMode === "system" ? cached.themeMode : "dark";
+    const themeId = typeof cached.themePreset === "string" ? cached.themePreset : DEFAULT_THEME_ID;
+    const appearance = resolveThemeMode(mode, systemPrefersDark());
+
+    const root = document.documentElement;
+    root.classList.remove("light", "dark");
+    root.classList.add(appearance);
+    root.dataset.theme = appearance;
+    applyAppTheme(root, appearance, themeId);
+  } catch {
+    // Ignore malformed cache; the provider effect applies real settings shortly.
+  }
+}

--- a/src/renderer/theme/applyAppTheme.ts
+++ b/src/renderer/theme/applyAppTheme.ts
@@ -33,6 +33,24 @@ export function applyAppTheme(root: HTMLElement, appearance: Appearance, themeId
 // pre-paint bootstrap doesn't have to import (and eagerly hydrate) the store.
 const SHARED_SETTINGS_CACHE_KEY = "lightcode-shared-settings";
 
+// Resolved appearance + background, read by the inline pre-paint script in
+// index.html so the first frame matches the active theme. Keep the key in sync.
+const BOOT_CACHE_KEY = "lightcode-boot";
+
+/**
+ * Persists the resolved appearance + background so the next launch's pre-paint
+ * bootstrap (index.html) can match the active theme before the renderer mounts.
+ */
+export function persistThemeBoot(appearance: Appearance, themeId: string): void {
+  try {
+    const preset = getThemePreset(themeId);
+    const background = (appearance === "dark" ? preset.dark : preset.light)["--background"];
+    localStorage.setItem(BOOT_CACHE_KEY, JSON.stringify({ appearance, bg: background }));
+  } catch {
+    // Non-fatal; the bootstrap falls back to themeMode + system preference.
+  }
+}
+
 /** Whether the OS currently prefers a dark color scheme (defaults to dark). */
 export function systemPrefersDark(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {

--- a/src/renderer/theme/colorMath.ts
+++ b/src/renderer/theme/colorMath.ts
@@ -1,0 +1,99 @@
+/**
+ * Minimal, dependency-free color math for theme derivation.
+ *
+ * Used to compute secondary ("muted") text at build time with a guaranteed
+ * WCAG contrast floor — something CSS `color-mix` cannot enforce, since the
+ * achievable contrast depends on the specific foreground/background pair.
+ * Operates on `#rgb` / `#rrggbb` hex (all theme anchors are hex).
+ */
+
+export type Rgb = [number, number, number];
+
+export function parseHex(hex: string): Rgb {
+  let h = hex.replace("#", "").trim();
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  const n = Number.parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+export function toHex(rgb: Rgb): string {
+  const c = (v: number) =>
+    Math.round(Math.min(255, Math.max(0, v)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${c(rgb[0])}${c(rgb[1])}${c(rgb[2])}`;
+}
+
+function channelLuminance(value: number): number {
+  const s = value / 255;
+  return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+export function relativeLuminance(rgb: Rgb): number {
+  return (
+    0.2126 * channelLuminance(rgb[0]) +
+    0.7152 * channelLuminance(rgb[1]) +
+    0.0722 * channelLuminance(rgb[2])
+  );
+}
+
+/** WCAG 2.1 contrast ratio (1–21) between two hex colors. */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(parseHex(a));
+  const lb = relativeLuminance(parseHex(b));
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Linear sRGB blend; `t` is the weight of `a` (1 → a, 0 → b). */
+export function mixHex(a: string, b: string, t: number): string {
+  const ca = parseHex(a);
+  const cb = parseHex(b);
+  return toHex([
+    ca[0] * t + cb[0] * (1 - t),
+    ca[1] * t + cb[1] * (1 - t),
+    ca[2] * t + cb[2] * (1 - t),
+  ]);
+}
+
+export interface ContrastTarget {
+  /** Background the muted color must remain readable against. */
+  color: string;
+  /** Minimum WCAG contrast ratio against `color`. */
+  floor: number;
+}
+
+export interface MutedDerivation {
+  hex: string;
+  /** Blend weight of fg used (higher = closer to fg). */
+  fraction: number;
+}
+
+/**
+ * Returns the *dimmest* blend of `fg` toward the first background that still
+ * clears every target's contrast floor — keeping muted text as recessive as
+ * the palette allows without dropping below readable. If the floors can't be
+ * met within `maxFraction`, returns the `maxFraction` blend (best effort; the
+ * cap preserves a visible gap from the foreground).
+ */
+export function deriveMutedColor(
+  fg: string,
+  targets: ContrastTarget[],
+  opts: { minFraction: number; maxFraction: number; step?: number },
+): MutedDerivation {
+  const blendTo = targets[0]!.color;
+  const step = opts.step ?? 0.01;
+  for (let t = opts.minFraction; t <= opts.maxFraction + 1e-9; t += step) {
+    const hex = mixHex(fg, blendTo, t);
+    if (targets.every((target) => contrastRatio(hex, target.color) >= target.floor)) {
+      return { hex, fraction: t };
+    }
+  }
+  return { hex: mixHex(fg, blendTo, opts.maxFraction), fraction: opts.maxFraction };
+}

--- a/src/renderer/theme/themePresets.test.ts
+++ b/src/renderer/theme/themePresets.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { applyAppTheme } from "./applyAppTheme";
+import { contrastRatio } from "./colorMath";
+import { APP_THEME_PRESETS, DEFAULT_THEME_ID, getThemePreset } from "./themePresets";
+import { MANAGED_THEME_VARS } from "./themeTokens";
+
+// Floors mirror themeTokens: text stays readable on the content background
+// (strict), while muted on panels (surface/sidebar) gets a relaxed floor so it
+// lands dimmer there and keeps a clear gap from the active foreground.
+const BG_FLOOR = 4.5;
+const PANEL_FLOOR = 4.0;
+// Muted must also stay visibly dimmer than the active foreground (hierarchy);
+// foregrounds in low-contrast palettes are brightened/darkened to hold this.
+const MUTED_FG_GAP_FLOOR = 1.9;
+
+describe("theme presets", () => {
+  it("includes the base default theme first", () => {
+    expect(APP_THEME_PRESETS[0]?.id).toBe(DEFAULT_THEME_ID);
+  });
+
+  it("has unique ids and a label for every preset", () => {
+    const ids = APP_THEME_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const preset of APP_THEME_PRESETS) {
+      expect(preset.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("defines every managed variable in both variants", () => {
+    for (const preset of APP_THEME_PRESETS) {
+      for (const variant of [preset.light, preset.dark]) {
+        const missing = MANAGED_THEME_VARS.filter((key) => !variant[key]);
+        expect(missing).toEqual([]);
+      }
+    }
+  });
+
+  it("falls back to the default preset for unknown ids", () => {
+    expect(getThemePreset("does-not-exist").id).toBe(DEFAULT_THEME_ID);
+  });
+
+  // Guards the core fix: muted secondary text and the foreground must stay
+  // readable in every theme/variant, matching the base Lightcode contrast.
+  it("keeps muted and foreground text above the contrast floor", () => {
+    const failures: string[] = [];
+    for (const preset of APP_THEME_PRESETS) {
+      for (const mode of ["light", "dark"] as const) {
+        const v = preset[mode];
+        const bg = v["--background"]!;
+        const surface = v["--surface"]!;
+        const sidebar = v["--sidebar-background"]!;
+        const muted = v["--muted"]!;
+        const fg = v["--foreground"]!;
+        const checks: [string, string, string, number][] = [
+          ["muted/bg", muted, bg, BG_FLOOR],
+          ["muted/surface", muted, surface, PANEL_FLOOR],
+          ["muted/sidebar", muted, sidebar, PANEL_FLOOR],
+          ["fg/bg", fg, bg, BG_FLOOR],
+          ["fg/surface", fg, surface, BG_FLOOR],
+        ];
+        for (const [pair, a, b, floor] of checks) {
+          const ratio = contrastRatio(a, b);
+          if (ratio < floor) {
+            failures.push(`${preset.id}/${mode} ${pair} ${ratio.toFixed(2)} < ${floor}`);
+          }
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  // Guards the second fix: muted must read as clearly dimmer than the active
+  // foreground, otherwise inactive and selected text look the same.
+  it("keeps muted visibly dimmer than the foreground", () => {
+    const failures: string[] = [];
+    for (const preset of APP_THEME_PRESETS) {
+      for (const mode of ["light", "dark"] as const) {
+        const v = preset[mode];
+        const gap = contrastRatio(v["--foreground"]!, v["--muted"]!);
+        if (gap < MUTED_FG_GAP_FLOOR) {
+          failures.push(`${preset.id}/${mode} gap ${gap.toFixed(2)} < ${MUTED_FG_GAP_FLOOR}`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("applyAppTheme", () => {
+  it("sets the variant's anchor color and follows appearance", () => {
+    const el = document.createElement("div");
+    applyAppTheme(el, "dark", "github");
+    expect(el.style.getPropertyValue("--accent")).toBe("#2f81f7");
+    expect(el.style.getPropertyValue("--background")).toBe("#0d1117");
+
+    applyAppTheme(el, "light", "github");
+    expect(el.style.getPropertyValue("--accent")).toBe("#0969da");
+    expect(el.style.getPropertyValue("--background")).toBe("#ffffff");
+  });
+
+  it("clears managed overrides for the base default theme", () => {
+    const el = document.createElement("div");
+    applyAppTheme(el, "dark", "github");
+    expect(el.style.getPropertyValue("--accent")).not.toBe("");
+
+    applyAppTheme(el, "dark", DEFAULT_THEME_ID);
+    for (const key of MANAGED_THEME_VARS) {
+      expect(el.style.getPropertyValue(key)).toBe("");
+    }
+  });
+});

--- a/src/renderer/theme/themePresets.ts
+++ b/src/renderer/theme/themePresets.ts
@@ -1,0 +1,388 @@
+/**
+ * Catalog of selectable app themes.
+ *
+ * Each preset ships a `light` and `dark` variant; the active variant follows
+ * the user's appearance mode (system / light / dark), so e.g. Catppuccin is
+ * Latte in light and Mocha in dark. Palettes are adapted from the popular
+ * VS Code / Cursor / editor themes of the same name and remapped onto
+ * Lightcode's token set — the app keeps its own layout, radius, and typography.
+ *
+ * `THEME_SPECS` holds the authored anchor colors (the source of truth, also
+ * consumed by the contrast test); `APP_THEME_PRESETS` is the derived token set.
+ * Secondary ("muted") text is derived from fg→bg rather than each theme's
+ * comment color so contrast stays readable everywhere (see `themeTokens`). To
+ * add a theme, append one `THEME_SPECS` entry.
+ */
+
+import { buildVariant, type ThemeSpec, type ThemeVariantVars } from "./themeTokens";
+
+export interface AppThemeSpec {
+  id: string;
+  label: string;
+  light: ThemeSpec;
+  dark: ThemeSpec;
+}
+
+export interface AppThemePreset {
+  id: string;
+  label: string;
+  light: ThemeVariantVars;
+  dark: ThemeVariantVars;
+}
+
+export const DEFAULT_THEME_ID = "default";
+
+export const THEME_SPECS: AppThemeSpec[] = [
+  // Lightcode base. Mirrors the `.light` / `.dark` values in styles.css and is
+  // used only for the gallery preview — at runtime the base theme clears all
+  // overrides so styles.css stays the source of truth (see applyAppTheme).
+  {
+    id: DEFAULT_THEME_ID,
+    label: "Lightcode",
+    // sRGB hex of the styles.css oklch values (anchors must be hex so muted can
+    // be contrast-derived). Preview-only — runtime clears overrides for default.
+    light: {
+      bg: "#f1f1f4",
+      surface: "#fafafb",
+      fg: "#18181b",
+      accent: "#478cc4",
+      accentFg: "#ffffff",
+      border: "#cacace",
+      sidebar: "#ececef",
+      content: "#f6f6f9",
+      terminal: "#f4f4f6",
+    },
+    dark: {
+      bg: "#141416",
+      surface: "#1a1a1c",
+      fg: "#fcfcfc",
+      accent: "#88bae4",
+      accentFg: "#111113",
+      border: "#303033",
+      sidebar: "#1a1a1c",
+      content: "#161618",
+      terminal: "#0c0c0e",
+    },
+  },
+
+  // Catppuccin — Latte / Mocha.
+  {
+    id: "catppuccin",
+    label: "Catppuccin",
+    light: {
+      bg: "#eff1f5",
+      surface: "#ffffff",
+      // Darkened from canonical #4c4f69 so muted text reads as clearly dimmer.
+      fg: "#3d3f54",
+      accent: "#8839ef",
+      accentFg: "#ffffff",
+      border: "#bcc0cc",
+      sidebar: "#e6e9ef",
+      terminal: "#dce0e8",
+    },
+    dark: {
+      bg: "#1e1e2e",
+      surface: "#27273a",
+      // Brightened from canonical #cdd6f4 to widen the muted/active gap.
+      fg: "#d2daf5",
+      accent: "#cba6f7",
+      accentFg: "#1e1e2e",
+      border: "#313244",
+      sidebar: "#181825",
+      terminal: "#181825",
+    },
+  },
+
+  // GitHub — Light / Dark (default).
+  {
+    id: "github",
+    label: "GitHub",
+    light: {
+      bg: "#ffffff",
+      surface: "#f6f8fa",
+      fg: "#1f2328",
+      accent: "#0969da",
+      accentFg: "#ffffff",
+      border: "#d0d7de",
+      sidebar: "#f6f8fa",
+      content: "#ffffff",
+      terminal: "#f6f8fa",
+    },
+    dark: {
+      bg: "#0d1117",
+      surface: "#161b22",
+      fg: "#e6edf3",
+      accent: "#2f81f7",
+      accentFg: "#ffffff",
+      border: "#30363d",
+      sidebar: "#0d1117",
+      terminal: "#010409",
+    },
+  },
+
+  // Atom One — Light / Dark.
+  {
+    id: "one",
+    label: "One",
+    light: {
+      bg: "#fafafa",
+      surface: "#ffffff",
+      fg: "#383a42",
+      accent: "#4078f2",
+      accentFg: "#ffffff",
+      border: "#e5e5e6",
+      sidebar: "#eaeaeb",
+      terminal: "#f0f0f0",
+    },
+    dark: {
+      bg: "#282c34",
+      surface: "#2c313a",
+      // Brightened from canonical #abb2bf to widen the muted/active gap.
+      fg: "#dee0e6",
+      accent: "#61afef",
+      accentFg: "#282c34",
+      border: "#3b4048",
+      sidebar: "#21252b",
+      terminal: "#21252b",
+    },
+  },
+
+  // Dracula — Alucard (light) / Dracula (dark).
+  {
+    id: "dracula",
+    label: "Dracula",
+    light: {
+      bg: "#fffbeb",
+      surface: "#ffffff",
+      fg: "#1f1f1f",
+      accent: "#644ac9",
+      accentFg: "#ffffff",
+      border: "#d4cfc0",
+      sidebar: "#f3eedd",
+      terminal: "#f3eedd",
+    },
+    dark: {
+      bg: "#282a36",
+      surface: "#343746",
+      fg: "#f8f8f2",
+      accent: "#bd93f9",
+      accentFg: "#282a36",
+      border: "#44475a",
+      sidebar: "#21222c",
+      terminal: "#21222c",
+    },
+  },
+
+  // Nord — Snow Storm (light) / Polar Night (dark).
+  {
+    id: "nord",
+    label: "Nord",
+    light: {
+      bg: "#eceff4",
+      surface: "#ffffff",
+      fg: "#2e3440",
+      accent: "#5e81ac",
+      accentFg: "#ffffff",
+      border: "#d8dee9",
+      sidebar: "#e5e9f0",
+      terminal: "#e5e9f0",
+    },
+    dark: {
+      bg: "#2e3440",
+      surface: "#3b4252",
+      // Brightened from canonical #d8dee9 to widen the muted/active gap.
+      fg: "#eff2f6",
+      accent: "#88c0d0",
+      accentFg: "#2e3440",
+      border: "#434c5e",
+      sidebar: "#2b303b",
+      terminal: "#272c36",
+    },
+  },
+
+  // Tokyo Night — Day / Night.
+  {
+    id: "tokyo-night",
+    label: "Tokyo Night",
+    light: {
+      bg: "#e1e2e7",
+      surface: "#ffffff",
+      // Darkened from canonical #343b58 so muted text reads as clearly dimmer.
+      fg: "#303651",
+      accent: "#2e7de9",
+      accentFg: "#ffffff",
+      border: "#c4c8da",
+      sidebar: "#d6d8df",
+      terminal: "#d6d8df",
+    },
+    dark: {
+      bg: "#1a1b26",
+      surface: "#1f2335",
+      // Brightened from canonical #c0caf5 to widen the muted/active gap.
+      fg: "#cdd5f7",
+      accent: "#7aa2f7",
+      accentFg: "#1a1b26",
+      border: "#292e42",
+      sidebar: "#16161e",
+      terminal: "#16161e",
+    },
+  },
+
+  // Gruvbox — Light / Dark (medium).
+  {
+    id: "gruvbox",
+    label: "Gruvbox",
+    light: {
+      bg: "#fbf1c7",
+      surface: "#f9f5d7",
+      fg: "#3c3836",
+      accent: "#d65d0e",
+      accentFg: "#fbf1c7",
+      border: "#d5c4a1",
+      sidebar: "#ebdbb2",
+      terminal: "#ebdbb2",
+    },
+    dark: {
+      bg: "#282828",
+      surface: "#32302f",
+      // Brightened from canonical #ebdbb2 to widen the muted/active gap.
+      fg: "#f0e5c7",
+      accent: "#fe8019",
+      accentFg: "#282828",
+      border: "#504945",
+      sidebar: "#1d2021",
+      terminal: "#1d2021",
+    },
+  },
+
+  // Solarized — Light / Dark. fg pulled well past the canonical (famously
+  // low-contrast) base0/base01 so muted text both clears the readability floor
+  // and stays clearly dimmer than the active foreground.
+  {
+    id: "solarized",
+    label: "Solarized",
+    light: {
+      bg: "#fdf6e3",
+      surface: "#eee8d5",
+      fg: "#2e3c41",
+      accent: "#268bd2",
+      accentFg: "#fdf6e3",
+      border: "#ddd6c1",
+      sidebar: "#eee8d5",
+      terminal: "#eee8d5",
+    },
+    dark: {
+      bg: "#002b36",
+      surface: "#073642",
+      fg: "#e3e8e8",
+      accent: "#268bd2",
+      accentFg: "#002b36",
+      border: "#0a4a5a",
+      sidebar: "#002028",
+      terminal: "#002028",
+    },
+  },
+
+  // Rosé Pine — Dawn / Moon.
+  {
+    id: "rose-pine",
+    label: "Rosé Pine",
+    light: {
+      bg: "#faf4ed",
+      surface: "#fffaf3",
+      // Darkened from canonical #575279 so muted text reads as clearly dimmer.
+      fg: "#423e5c",
+      accent: "#907aa9",
+      accentFg: "#ffffff",
+      border: "#dfdad9",
+      sidebar: "#f2e9e1",
+      terminal: "#f2e9e1",
+    },
+    dark: {
+      bg: "#232136",
+      surface: "#2a273f",
+      fg: "#e0def4",
+      accent: "#c4a7e7",
+      accentFg: "#232136",
+      border: "#44415a",
+      sidebar: "#1f1d2e",
+      terminal: "#1f1d2e",
+    },
+  },
+
+  // Everforest — Light / Dark (medium).
+  {
+    id: "everforest",
+    label: "Everforest",
+    light: {
+      bg: "#fdf6e3",
+      surface: "#f4f0d9",
+      // Darkened past canonical #5c6a72 so muted text clears the readability
+      // floor and stays clearly dimmer than the active foreground.
+      fg: "#374147",
+      // Deepened from the canonical #8da101 olive so accent button/link text is
+      // legible (the light olive sat at ~2.6:1).
+      accent: "#677700",
+      accentFg: "#ffffff",
+      border: "#e0dcc7",
+      sidebar: "#efebd4",
+      terminal: "#efebd4",
+    },
+    dark: {
+      bg: "#2d353b",
+      surface: "#343f44",
+      // Brightened from canonical #d3c6aa to widen the muted/active gap.
+      fg: "#eee8dd",
+      accent: "#a7c080",
+      accentFg: "#2d353b",
+      border: "#475258",
+      sidebar: "#272e33",
+      terminal: "#272e33",
+    },
+  },
+
+  // Monokai — adapted light / classic dark.
+  {
+    id: "monokai",
+    label: "Monokai",
+    light: {
+      bg: "#fbfbf8",
+      surface: "#ffffff",
+      fg: "#2c2b29",
+      accent: "#e0156d",
+      accentFg: "#ffffff",
+      border: "#e4e3da",
+      sidebar: "#f1f1ea",
+      terminal: "#f1f1ea",
+    },
+    dark: {
+      bg: "#272822",
+      surface: "#2f302a",
+      fg: "#f8f8f2",
+      accent: "#f92672",
+      accentFg: "#ffffff",
+      border: "#3e3d32",
+      sidebar: "#1d1e19",
+      terminal: "#1d1e19",
+    },
+  },
+];
+
+export const APP_THEME_PRESETS: AppThemePreset[] = THEME_SPECS.map((spec) => ({
+  id: spec.id,
+  label: spec.label,
+  light: buildVariant(spec.light),
+  dark: buildVariant(spec.dark),
+}));
+
+const PRESETS_BY_ID = new Map(APP_THEME_PRESETS.map((entry) => [entry.id, entry]));
+
+export function getThemePreset(id: string): AppThemePreset {
+  return PRESETS_BY_ID.get(id) ?? PRESETS_BY_ID.get(DEFAULT_THEME_ID)!;
+}
+
+/** `{ id, label }` options for a Select, in catalog order. */
+export const APP_THEME_OPTIONS = APP_THEME_PRESETS.map((entry) => ({
+  id: entry.id,
+  label: entry.label,
+}));

--- a/src/renderer/theme/themeTokens.ts
+++ b/src/renderer/theme/themeTokens.ts
@@ -1,0 +1,147 @@
+/**
+ * Theme token derivation.
+ *
+ * A theme preset is authored as a handful of anchor colors (`ThemeSpec`); the
+ * full set of app CSS custom properties is derived from them here via
+ * `color-mix` so palettes stay internally consistent and cheap to author. The
+ * derived values intentionally mirror the relationships baked into the base
+ * theme in `styles.css` (secondary/tertiary surfaces step toward the
+ * foreground, the scrollbar is a translucent muted, etc.).
+ *
+ * Authoring anchors in plain hex (the canonical color each editor theme ships)
+ * keeps the catalog faithful to the upstream themes; only layout-neutral color
+ * tokens are themed, so radius, spacing, fonts, and semantic status colors
+ * (success/warning/danger) stay on the base values.
+ */
+
+import { deriveMutedColor, mixHex } from "./colorMath";
+
+export type ThemeVariantVars = Record<string, string>;
+
+export interface ThemeSpec {
+  /** Editor/content background (the largest surface). */
+  bg: string;
+  /** Panel/card surface (sidebars, popovers, composer). Slightly off `bg`. */
+  surface: string;
+  /** Primary text color. */
+  fg: string;
+  /** Accent / primary action color. */
+  accent: string;
+  /** Text rendered on top of `accent`. */
+  accentFg: string;
+  /** Hairline border / separator base color. */
+  border: string;
+  /** Optional explicit sidebar background. Defaults to `surface`. */
+  sidebar?: string;
+  /** Optional explicit content-area background. Defaults to `bg`. */
+  content?: string;
+  /** Optional explicit agent-terminal background. Defaults to `bg`. */
+  terminal?: string;
+}
+
+/**
+ * Secondary ("muted") text is derived by blending `fg` toward `bg` rather than
+ * taken from each editor theme's comment color. Editor comment colors are tuned
+ * to recede behind code and fail as readable UI text (e.g. One's `#5c6370` is
+ * ~2.3:1 on its background). The blend is pushed only as far as needed to clear
+ * a WCAG contrast floor, so muted stays recessive while matching the base
+ * Lightcode theme's readability (~4.5–6:1) for every palette, and still
+ * inherits each theme's tint because `fg` / `bg` are themed.
+ *
+ * The strict floor applies to the content background (where settings
+ * descriptions and primary body copy sit); panels (surface) and the sidebar
+ * get a relaxed floor so muted lands dimmer there — keeping a clear visual gap
+ * from the active foreground without over-brightening it.
+ */
+const MUTED_BG_FLOOR = 4.5;
+const MUTED_PANEL_FLOOR = 4.0;
+const MUTED_MIN_FRACTION = 0.3;
+const MUTED_MAX_FRACTION = 0.85;
+/** Placeholder text sits this much dimmer (toward bg) than muted. */
+const PLACEHOLDER_DROP = 0.14;
+
+/**
+ * Every CSS custom property this module sets on the document root. Switching to
+ * the base theme clears exactly these so the `.light` / `.dark` rules in
+ * `styles.css` take over again.
+ */
+export const MANAGED_THEME_VARS = [
+  "--background",
+  "--foreground",
+  "--surface",
+  "--surface-secondary",
+  "--surface-tertiary",
+  "--overlay",
+  "--muted",
+  "--scrollbar",
+  "--default",
+  "--accent",
+  "--accent-foreground",
+  "--field-background",
+  "--field-foreground",
+  "--field-placeholder",
+  "--field-border",
+  "--segment",
+  "--border",
+  "--separator",
+  "--sidebar-background",
+  "--content-background",
+  "--terminal-surface",
+  "--composer-surface",
+] as const;
+
+const mix = (a: string, aPct: number, b: string): string =>
+  `color-mix(in oklab, ${a} ${aPct}%, ${b} ${100 - aPct}%)`;
+
+/** Blend `color` with transparency (a translucent tint of itself). */
+const fade = (color: string, pct: number): string =>
+  `color-mix(in oklab, ${color} ${pct}%, transparent)`;
+
+export function buildVariant(spec: ThemeSpec): ThemeVariantVars {
+  const { bg, surface, fg, accent, accentFg, border } = spec;
+  const sidebar = spec.sidebar ?? surface;
+  const content = spec.content ?? bg;
+  const terminal = spec.terminal ?? bg;
+
+  // Derive readable secondary text from fg→bg with a contrast floor. Placeholder
+  // sits a step dimmer than muted; the scrollbar is a translucent muted.
+  const muted = deriveMutedColor(
+    fg,
+    [
+      { color: bg, floor: MUTED_BG_FLOOR },
+      { color: surface, floor: MUTED_PANEL_FLOOR },
+      { color: sidebar, floor: MUTED_PANEL_FLOOR },
+    ],
+    { minFraction: MUTED_MIN_FRACTION, maxFraction: MUTED_MAX_FRACTION },
+  );
+  const placeholder = mixHex(
+    fg,
+    bg,
+    Math.max(MUTED_MIN_FRACTION, muted.fraction - PLACEHOLDER_DROP),
+  );
+
+  return {
+    "--background": bg,
+    "--foreground": fg,
+    "--surface": surface,
+    "--surface-secondary": mix(surface, 92, fg),
+    "--surface-tertiary": mix(surface, 85, fg),
+    "--overlay": mix(surface, 93, fg),
+    "--muted": muted.hex,
+    "--scrollbar": fade(muted.hex, 60),
+    "--default": mix(surface, 86, fg),
+    "--accent": accent,
+    "--accent-foreground": accentFg,
+    "--field-background": mix(surface, 95, fg),
+    "--field-foreground": fg,
+    "--field-placeholder": placeholder,
+    "--field-border": fade(border, 70),
+    "--segment": surface,
+    "--border": border,
+    "--separator": fade(border, 75),
+    "--sidebar-background": sidebar,
+    "--content-background": content,
+    "--terminal-surface": terminal,
+    "--composer-surface": mix(surface, 90, fg),
+  };
+}

--- a/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/ProjectTreeView.tsx
@@ -129,7 +129,7 @@ export function ProjectTreeView(props: {
                 type="button"
                 aria-label="Clear search"
                 onClick={() => tree.setSearchQuery("")}
-                className="flex size-4 shrink-0 items-center justify-center rounded text-muted hover:bg-white/8 hover:text-foreground"
+                className="flex size-4 shrink-0 items-center justify-center rounded text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
               >
                 <X className="size-3" />
               </button>
@@ -322,11 +322,11 @@ function SearchResultRow(props: { entry: ProjectTreeEntry; onOpen: () => void })
 
   return (
     <button
-      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-left text-sm text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground ${
+      className={`flex w-full items-center gap-1.5 rounded-md px-2 py-0.5 text-left text-sm text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground ${
         isSelected
-          ? "bg-white/[0.08] text-foreground"
+          ? "bg-[var(--row-active)] text-foreground"
           : isOpenInTab
-            ? "bg-white/[0.04] text-foreground"
+            ? "bg-[var(--row-hover)] text-foreground"
             : ""
       }`}
       onClick={props.onOpen}

--- a/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
@@ -93,10 +93,10 @@ export function TreeEntryRow(props: {
           draggable
           className={`group flex items-center gap-1.5 rounded-md px-2 py-0.5 text-sm text-muted transition-colors ${
             isSelected
-              ? "bg-white/[0.08] text-foreground"
+              ? "bg-[var(--row-active)] text-foreground"
               : isOpenInTab
-                ? "bg-white/[0.04] text-foreground hover:bg-white/[0.06]"
-                : "hover:bg-white/[0.04] hover:text-foreground"
+                ? "bg-[var(--row-hover)] text-foreground hover:bg-[var(--row-hover)]"
+                : "hover:bg-[var(--row-hover)] hover:text-foreground"
           } ${isDropTarget ? "ring-1 ring-accent/40" : ""}`}
           style={{ paddingLeft: `${depth * 14 + 8}px` }}
           onClick={() => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitDiffContent/parts/DiffSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitDiffContent/parts/DiffSection.tsx
@@ -96,7 +96,7 @@ export function DiffSection(props: {
       <div className="rounded border border-border">
         <FileHeader entry={entry} collapsed={collapsed} onToggleCollapse={onToggleCollapse} />
         <div className="flex h-16 items-center justify-center text-xs text-muted/40">
-          <div className="h-3 w-24 animate-pulse rounded bg-white/[0.06]" />
+          <div className="h-3 w-24 animate-pulse rounded bg-[var(--row-hover)]" />
         </div>
       </div>
     );
@@ -144,7 +144,7 @@ export function DiffSection(props: {
       ) : (
         !collapsed && (
           <div className="flex h-16 items-center justify-center text-xs text-muted/40">
-            <div className="h-3 w-24 animate-pulse rounded bg-white/[0.06]" />
+            <div className="h-3 w-24 animate-pulse rounded bg-[var(--row-hover)]" />
           </div>
         )
       )}

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
@@ -213,7 +213,7 @@ export function GitReviewPanel(props: {
             )}
             <button
               type="button"
-              className={`rounded p-1 transition-colors hover:bg-white/[0.04] hover:text-foreground ${wrapLines ? "text-foreground" : "text-muted"}`}
+              className={`rounded p-1 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground ${wrapLines ? "text-foreground" : "text-muted"}`}
               title={wrapLines ? "No wrap" : "Wrap lines"}
               onClick={() => setWrapLines((v) => !v)}
             >
@@ -221,7 +221,7 @@ export function GitReviewPanel(props: {
             </button>
             <button
               type="button"
-              className="rounded p-1 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-1 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Refresh"
               onClick={() => void handleRefresh()}
             >
@@ -303,7 +303,7 @@ export function GitReviewPanel(props: {
             )}
             <button
               type="button"
-              className={`rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground ${wrapLines ? "text-foreground" : "text-muted"}`}
+              className={`rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground ${wrapLines ? "text-foreground" : "text-muted"}`}
               title={wrapLines ? "No wrap" : "Wrap lines"}
               onClick={() => setWrapLines((v) => !v)}
             >
@@ -311,7 +311,7 @@ export function GitReviewPanel(props: {
             </button>
             <button
               type="button"
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Refresh"
               onClick={() => void handleRefresh()}
             >
@@ -319,7 +319,7 @@ export function GitReviewPanel(props: {
             </button>
             <button
               type="button"
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Open as page"
               onClick={onExpandToOverlay}
             >
@@ -327,7 +327,7 @@ export function GitReviewPanel(props: {
             </button>
             <button
               type="button"
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Hide"
               onClick={onClose}
             >

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
@@ -147,7 +147,7 @@ export function ConflictFileCard(props: {
             <div
               role="button"
               tabIndex={0}
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Stage"
               onClick={handleStageConflict}
               onKeyDown={(e) =>
@@ -159,7 +159,7 @@ export function ConflictFileCard(props: {
             <div
               role="button"
               tabIndex={0}
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Open in editor"
               onClick={handleOpenInEditor}
               onKeyDown={(e) =>

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
@@ -103,8 +103,8 @@ export function ConflictGroup(props: {
                 type="button"
                 className={`group flex w-full cursor-default items-center gap-1.5 rounded py-1 text-left text-xs transition-colors ${rowPadX} ${
                   isSelected
-                    ? "bg-white/[0.08] text-foreground"
-                    : "text-muted hover:bg-white/[0.04] hover:text-foreground"
+                    ? "bg-[var(--row-active)] text-foreground"
+                    : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
                 }`}
                 onClick={() => onSelectFile(file.path, false)}
               >
@@ -127,7 +127,7 @@ export function ConflictGroup(props: {
                     <div
                       role="button"
                       tabIndex={0}
-                      className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                      className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                       title="Stage"
                       onClick={(e) => {
                         e.stopPropagation();
@@ -144,7 +144,7 @@ export function ConflictGroup(props: {
                     <div
                       role="button"
                       tabIndex={0}
-                      className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                      className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                       title="Open in editor"
                       onClick={(e) => {
                         e.stopPropagation();

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileGroup.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileGroup.tsx
@@ -106,7 +106,7 @@ export function FileGroup(props: {
             {staged ? (
               <button
                 type="button"
-                className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                 title="Unstage all"
                 onClick={() => void handleUnstageAll()}
               >
@@ -116,7 +116,7 @@ export function FileGroup(props: {
               <>
                 <button
                   type="button"
-                  className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                  className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                   title="Stage all"
                   onClick={() => void handleStageAll()}
                 >

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
@@ -87,8 +87,8 @@ export function FileRow(props: {
         type="button"
         className={`group flex w-full cursor-default items-center gap-1.5 rounded py-1 text-left text-xs transition-colors ${rowPadX} ${
           isSelected
-            ? "bg-white/[0.08] text-foreground"
-            : "text-muted hover:bg-white/[0.04] hover:text-foreground"
+            ? "bg-[var(--row-active)] text-foreground"
+            : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
         }`}
         onClick={onSelect}
       >
@@ -114,7 +114,7 @@ export function FileRow(props: {
             <div
               role="button"
               tabIndex={0}
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title="Open in editor"
               onClick={(e) => {
                 e.stopPropagation();
@@ -127,7 +127,7 @@ export function FileRow(props: {
             <div
               role="button"
               tabIndex={0}
-              className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+              className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               title={file.staged ? "Unstage" : "Stage"}
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/GitReviewSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/GitReviewSection.tsx
@@ -3,7 +3,7 @@ import { useGitReviewSectionPadX } from "../gitReviewPadXContext";
 
 /**
  * Bordered, padded block at the bottom of the git review sidebar (commit, conflict actions,
- * PR, merge-to-source, etc.). Consolidates `border-t border-white/6 py-2 ${sectionPadX}` so
+ * PR, merge-to-source, etc.). Consolidates `border-t border-[var(--hairline)] py-2 ${sectionPadX}` so
  * spacing tweaks happen in one place.
  */
 export function GitReviewSection(props: {
@@ -14,6 +14,8 @@ export function GitReviewSection(props: {
   const sectionPadX = useGitReviewSectionPadX();
   const gap = props.gap === 1 ? "space-y-1" : "space-y-2";
   return (
-    <div className={`border-t border-white/6 py-2 ${gap} ${sectionPadX}`}>{props.children}</div>
+    <div className={`border-t border-[var(--hairline)] py-2 ${gap} ${sectionPadX}`}>
+      {props.children}
+    </div>
   );
 }

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -111,7 +111,7 @@ export function PrSection(props: {
               <button
                 type="button"
                 aria-label="Review PR"
-                className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                 onClick={() =>
                   usePanelStore.getState().setPrReviewContext({
                     projectId,

--- a/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
@@ -241,7 +241,7 @@ export function StackedFileCard(props: {
               <div
                 role="button"
                 tabIndex={0}
-                className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                 title="Open in editor"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -256,7 +256,7 @@ export function StackedFileCard(props: {
               <div
                 role="button"
                 tabIndex={0}
-                className="rounded p-0.5 text-muted transition-colors hover:bg-white/[0.04] hover:text-foreground"
+                className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                 title={file.staged ? "Unstage" : "Stage"}
                 onClick={handleStageToggle}
                 onKeyDown={(e) =>

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -46,7 +46,7 @@ export function HomeView() {
                   <div className="flex flex-col gap-1">
                     {homeScopeEnabled && homeProject ? (
                       <button
-                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
                         onClick={() => openDraft(homeProject.id)}
                         type="button"
                       >
@@ -60,7 +60,7 @@ export function HomeView() {
                     {projects.map((project) => (
                       <button
                         key={project.id}
-                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
                         onClick={() => openDraft(project.id)}
                         type="button"
                       >
@@ -94,7 +94,7 @@ export function HomeView() {
                       return (
                         <button
                           key={thread.id}
-                          className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-white/[0.04]"
+                          className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
                           onClick={() => openThread(thread.id)}
                           type="button"
                         >

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -345,13 +345,13 @@ export function AppContent() {
       <div className="flex h-full flex-col">
         {activeGroupId && activeGroupName && (
           <div
-            className={`lightcode-content-over-drag-region ${macosTrafficLightPadClass} flex h-[env(titlebar-area-height,32px)] shrink-0 items-center gap-1 border-b border-white/[0.06] px-2`}
+            className={`lightcode-content-over-drag-region ${macosTrafficLightPadClass} flex h-[env(titlebar-area-height,32px)] shrink-0 items-center gap-1 border-b border-[var(--hairline)] px-2`}
           >
             <span className="truncate text-xs font-medium text-muted">{activeGroupName}</span>
             <button
               type="button"
               aria-label="Close group"
-              className="shrink-0 rounded p-0.5 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+              className="shrink-0 rounded p-0.5 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
               onClick={() => useAppStore.getState().closeGroupView()}
             >
               <X className="size-3.5" />

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -173,7 +173,7 @@ export function BrowserPanel(props: { visible: boolean }) {
         onMenuPreviewChange={setMenuPreviewDataUrl}
       />
       <BrowserTabStrip />
-      <div className="relative flex-1 overflow-hidden bg-[var(--surface-background,#0d1117)]">
+      <div className="relative flex-1 overflow-hidden bg-[var(--content-background)]">
         {tabs.map((tab) => (
           <BrowserTabWebview
             key={tab.tabId}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserEmptyState.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserEmptyState.tsx
@@ -3,11 +3,11 @@ import { Globe } from "lucide-react";
 export function BrowserEmptyState(props: { onCreateTab: () => void }) {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-foreground/60">
-      <Globe className="size-8 text-sky-400/60" />
+      <Globe className="size-8 text-accent/60" />
       <div className="text-sm">No browser tab open</div>
       <button
         type="button"
-        className="rounded bg-sky-500 px-3 py-1.5 text-[12px] font-medium text-white hover:bg-sky-400"
+        className="rounded bg-accent px-3 py-1.5 text-[12px] font-medium text-[color:var(--accent-foreground)] hover:opacity-90"
         onClick={props.onCreateTab}
       >
         Open new tab

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -7,7 +7,7 @@ function TabFavicon(props: { faviconUrl?: string; loading: boolean }) {
   if (props.loading) {
     return (
       <span className="flex size-3.5 shrink-0 items-center justify-center">
-        <span className="size-2 animate-pulse rounded-full bg-sky-400/70" />
+        <span className="size-2 animate-pulse rounded-full bg-accent/70" />
       </span>
     );
   }
@@ -99,7 +99,7 @@ export function BrowserTabStrip() {
             <button
               type="button"
               aria-label="Close tab"
-              className="invisible flex h-4 w-4 items-center justify-center rounded text-foreground/50 hover:bg-[var(--input-background-hover,#252b33)] hover:text-foreground group-hover:visible group-focus-within:visible"
+              className="invisible flex h-4 w-4 items-center justify-center rounded text-foreground/50 hover:bg-[var(--row-hover)] hover:text-foreground group-hover:visible group-focus-within:visible"
               title="Close tab"
               onClick={(e) => {
                 e.stopPropagation();

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -131,7 +131,7 @@ export function BrowserToolbar(props: {
   };
 
   return (
-    <div className="flex items-center gap-1 border-b border-border bg-[var(--content-background)] px-1.5 py-1">
+    <div className="flex items-center gap-1 border-b border-border bg-[var(--surface)] px-1.5 py-1">
       <button
         type="button"
         className={toolbarButtonClass}
@@ -177,7 +177,7 @@ export function BrowserToolbar(props: {
       <form className="flex-1" onSubmit={onSubmit}>
         <input
           type="text"
-          className="h-7 w-full rounded border border-border bg-[var(--input-background,#1c2128)] px-2 text-[12px] outline-none focus:border-sky-400"
+          className="h-7 w-full rounded border border-border bg-[var(--field-background)] px-2 text-[12px] text-foreground outline-none placeholder:text-[color:var(--field-placeholder)] focus:border-[color:var(--accent)]"
           placeholder="Search or enter address"
           value={urlInput}
           onChange={(e) => setUrlInput(e.target.value)}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
@@ -168,7 +168,7 @@ export function DevTerminalPanel(props: { hideHeader?: boolean }) {
     projectTabs.length === 0 ? (
       <div className="flex h-full items-center justify-center">
         <button
-          className="cursor-default rounded-lg border border-dashed border-white/10 px-6 py-4 text-sm text-muted transition-colors hover:border-white/20 hover:text-foreground"
+          className="cursor-default rounded-lg border border-dashed border-[var(--hairline-strong)] px-6 py-4 text-sm text-muted transition-colors hover:border-[var(--hairline-strong)] hover:text-foreground"
           onClick={handleAddTab}
           type="button"
         >

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -98,7 +98,7 @@ function UpdateButtons(props: { iconOnly?: boolean }) {
               {Math.round(downloadPercent)}%{speedLine ? ` · ${speedLine}` : ""}
             </span>
           </div>
-          <div className="h-1 w-full rounded-full bg-white/10">
+          <div className="h-1 w-full rounded-full bg-[var(--row-active)]">
             <div
               className="h-1 rounded-full bg-accent transition-[width] duration-300"
               style={{ width: `${Math.round(downloadPercent)}%` }}
@@ -128,7 +128,7 @@ function HomeTerminalButton(props: { projectId: string; projectName: string }) {
       panel="terminal"
       projectId={props.projectId}
       ariaLabel={`Terminal for ${props.projectName}`}
-      className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+      className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
         isActiveTerminal
           ? "text-accent"
           : hasTerminal
@@ -276,7 +276,7 @@ export function Sidebar() {
           </div>
           <CollapsedThreadRail />
 
-          <div className="flex flex-col gap-1 border-t border-white/6 pt-2 pb-2 pr-2">
+          <div className="flex flex-col gap-1 border-t border-[var(--hairline)] pt-2 pb-2 pr-2">
             <UpdateButtons iconOnly />
             <SidebarButton
               iconOnly

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -86,7 +86,7 @@ export function GitBadge(props: {
       role="button"
       tabIndex={0}
       aria-label={`Git status for ${props.projectName}`}
-      className={`shrink-0 cursor-grab rounded px-1 py-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+      className={`shrink-0 cursor-grab rounded px-1 py-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
         props.isActive ? "bg-accent/15 ring-1 ring-accent/40" : "text-muted/60"
       }`}
       onClick={(e) => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
@@ -152,7 +152,7 @@ export function SidebarProjectHeader(props: {
                 panel="files"
                 projectId={project.id}
                 ariaLabel={`Files for ${project.name}`}
-                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
                   isActiveFilesPanel
                     ? "text-accent"
                     : "text-muted/60 opacity-0 group-hover:opacity-100"
@@ -165,7 +165,7 @@ export function SidebarProjectHeader(props: {
                 panel="terminal"
                 projectId={project.id}
                 ariaLabel={`Terminal for ${project.name}`}
-                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
                   isActiveTerminal
                     ? "text-accent"
                     : hasTerminal

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
@@ -164,7 +164,7 @@ function SidebarVirtualThreadRow(props: {
           {row.label}
         </div>
       ) : (
-        <div aria-hidden className="mx-1.5 my-1 h-px bg-white/6" />
+        <div aria-hidden className="mx-1.5 my-1 h-px bg-[var(--hairline)]" />
       )}
     </div>
   );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
@@ -116,7 +116,7 @@ export function SidebarThreadGroup(props: {
             <Tooltip delay={300}>
               <button
                 type="button"
-                className="shrink-0 rounded p-0.5 text-muted/40 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+                className="shrink-0 rounded p-0.5 text-muted/40 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
                 onClick={() => {
                   useAppStore.getState().openGroupView(entry.group.groupId);
                 }}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
@@ -41,7 +41,7 @@ export function ThreadItemSuffix(props: {
               projectId={thread.projectId}
               worktreePath={thread.worktreePath}
               ariaLabel={`Files for ${thread.worktreeBranch ?? thread.title}`}
-              className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+              className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
                 isFilesActive ? "text-accent" : "text-muted/60 opacity-0 group-hover:opacity-100"
               }`}
               onPress={() => openFilesPanel(thread.projectId, thread.worktreePath)}
@@ -54,7 +54,7 @@ export function ThreadItemSuffix(props: {
             projectId={thread.projectId}
             worktreePath={thread.worktreePath}
             ariaLabel={`Terminal for ${thread.worktreeBranch}`}
-            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
               isTerminalActive
                 ? "text-accent"
                 : isTerminalOpen

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
@@ -101,7 +101,7 @@ export function SyncBadge(props: { projectId: string; worktreePath?: string }) {
           role="button"
           tabIndex={0}
           aria-label={label}
-          className="shrink-0 cursor-default rounded px-1 py-0.5 transition-colors text-muted/60 hover:bg-white/[0.04] hover:text-foreground"
+          className="shrink-0 cursor-default rounded px-1 py-0.5 transition-colors text-muted/60 hover:bg-[var(--row-hover)] hover:text-foreground"
           onClick={(e) => {
             e.stopPropagation();
             void handlePress();

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -69,7 +69,7 @@ export function WorktreeGroupHeader(props: {
             projectId={props.projectId}
             worktreePath={props.worktreePath}
             ariaLabel={`Files for ${props.worktreeBranch}`}
-            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
               props.isActiveFiles
                 ? "text-accent"
                 : "text-muted/60 opacity-0 group-hover:opacity-100"
@@ -83,7 +83,7 @@ export function WorktreeGroupHeader(props: {
             projectId={props.projectId}
             worktreePath={props.worktreePath}
             ariaLabel={`Terminal for ${props.worktreeBranch}`}
-            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-white/[0.04] hover:text-foreground active:cursor-grabbing ${
+            className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
               props.isActiveTerminal
                 ? "text-accent"
                 : props.hasTerminal

--- a/src/renderer/views/PrReviewOverlay/parts/PrFileRow.tsx
+++ b/src/renderer/views/PrReviewOverlay/parts/PrFileRow.tsx
@@ -9,8 +9,8 @@ export function PrFileRow(props: { file: PrFile; isSelected: boolean; onSelect: 
       type="button"
       className={`flex w-full cursor-default items-center gap-1.5 rounded px-2 py-1 text-left text-xs transition-colors ${
         isSelected
-          ? "bg-white/[0.08] text-foreground"
-          : "text-muted hover:bg-white/[0.04] hover:text-foreground"
+          ? "bg-[var(--row-active)] text-foreground"
+          : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
       }`}
       onClick={onSelect}
     >

--- a/src/renderer/views/ProjectSettingsOverlay/parts/ActionIconPicker.tsx
+++ b/src/renderer/views/ProjectSettingsOverlay/parts/ActionIconPicker.tsx
@@ -12,7 +12,7 @@ export function ActionIconPicker(props: { value: string; onChange: (name: string
         isIconOnly
         variant="ghost"
         aria-label="Pick icon"
-        className="size-8 min-w-0 shrink-0 border border-white/10 bg-white/[0.03] text-muted hover:border-white/20 hover:text-foreground"
+        className="size-8 min-w-0 shrink-0 border border-[var(--hairline-strong)] bg-[var(--row-hover)] text-muted hover:border-[var(--hairline-strong)] hover:text-foreground"
       >
         <selected.Icon className="size-4" />
       </Button>
@@ -26,7 +26,7 @@ export function ActionIconPicker(props: { value: string; onChange: (name: string
                 className={`flex size-8 items-center justify-center rounded-md transition-colors ${
                   entry.name === value
                     ? "bg-accent/20 text-accent"
-                    : "text-muted hover:bg-white/10 hover:text-foreground"
+                    : "text-muted hover:bg-[var(--row-active)] hover:text-foreground"
                 }`}
                 aria-label={entry.name}
                 onClick={() => onChange(entry.name)}

--- a/src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
+++ b/src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
@@ -55,7 +55,7 @@ export function ActionsSection(props: { projectId: string }) {
           {actions.map((action) => (
             <div
               key={action.id}
-              className="group rounded-lg border border-white/6 bg-white/[0.02] p-3"
+              className="group rounded-lg border border-[var(--hairline)] bg-[var(--row-hover)] p-3"
             >
               <div className="mb-2.5 flex items-center gap-2">
                 <ActionIconPicker
@@ -103,7 +103,7 @@ export function ActionsSection(props: { projectId: string }) {
             </div>
           ))}
 
-          <div className="rounded-lg border border-dashed border-white/10 p-3">
+          <div className="rounded-lg border border-dashed border-[var(--hairline-strong)] p-3">
             <div className="mb-2.5 flex items-center gap-2">
               <ActionIconPicker value={newIcon} onChange={setNewIcon} />
               <Input

--- a/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
@@ -60,7 +60,7 @@ function UpdateButton() {
           </span>
         </div>
         {byteLine ? <p className="text-xs text-muted">{byteLine}</p> : null}
-        <div className="h-1 w-full rounded-full bg-white/10">
+        <div className="h-1 w-full rounded-full bg-[var(--row-active)]">
           <div
             className="h-1 rounded-full bg-accent transition-[width] duration-300"
             style={{ width: `${Math.round(downloadPercent)}%` }}
@@ -131,7 +131,7 @@ export function AboutSettings() {
         </div>
       </div>
 
-      <div className="mt-8 space-y-3 border-t border-white/6 pt-6">
+      <div className="mt-8 space-y-3 border-t border-[var(--hairline)] pt-6">
         <AboutLink href={WEBSITE_URL}>Website</AboutLink>
         <br />
         <AboutLink href={GITHUB_REPO}>GitHub Repository</AboutLink>

--- a/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
@@ -1,21 +1,32 @@
-import { startTransition } from "react";
+import { startTransition, useState, type CSSProperties } from "react";
+import { ChevronDown } from "lucide-react";
 import type { ThemeMode } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useResolvedAppearance } from "@/renderer/components/ui/provider";
+import { getThemePreset } from "@/renderer/theme/themePresets";
 import { Select } from "@/renderer/components/common";
 import { SettingRow, SettingsPage } from "./SettingsForm";
+import { ThemeGallery, ThemeSwatch } from "./ThemeGallery";
 import { fontSizeOptions, themeOptions } from "./settingsOptions";
 
 export function AppearanceSettings() {
   const themeMode = useSharedSettings((state) => state.themeMode);
   const setThemeMode = useSharedSettings((state) => state.setThemeMode);
+  const themePreset = useSharedSettings((state) => state.themePreset);
+  const appearance = useResolvedAppearance();
+  const [themeOpen, setThemeOpen] = useState(false);
+  const activePreset = getThemePreset(themePreset);
+  const activeVars = (
+    appearance === "dark" ? activePreset.dark : activePreset.light
+  ) as CSSProperties;
   const guiChatFontSize = useSharedSettings((state) => state.guiChatFontSize);
   const setGuiChatFontSize = useSharedSettings((state) => state.setGuiChatFontSize);
 
   return (
     <SettingsPage title="Appearance">
-      <SettingRow title="Theme" description="Choose how Lightcode looks.">
+      <SettingRow title="Mode" description="Match your system, or force light or dark.">
         <Select
-          aria-label="Theme"
+          aria-label="Appearance mode"
           className="w-[160px] shrink-0"
           options={themeOptions}
           value={themeMode}
@@ -26,6 +37,30 @@ export function AppearanceSettings() {
           }}
         />
       </SettingRow>
+
+      <div className="space-y-2.5">
+        <button
+          type="button"
+          aria-expanded={themeOpen}
+          onClick={() => setThemeOpen((open) => !open)}
+          className="-mx-2 flex w-[calc(100%+1rem)] items-center justify-between gap-4 rounded-lg px-2 py-1 text-left transition-colors hover:bg-[var(--row-hover)]"
+        >
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">Theme</p>
+            <p className="text-xs text-muted">
+              Popular editor themes adapted to Lightcode. Each follows the light or dark mode above.
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2.5">
+            <span className="text-sm text-foreground">{activePreset.label}</span>
+            <ThemeSwatch vars={activeVars} />
+            <ChevronDown
+              className={`size-4 text-muted transition-transform ${themeOpen ? "rotate-180" : ""}`}
+            />
+          </div>
+        </button>
+        {themeOpen ? <ThemeGallery /> : null}
+      </div>
 
       <SettingRow
         title="GUI chat font size"

--- a/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
@@ -16,7 +16,7 @@ export function ArchivedThreadsSettings() {
       {archivedThreads.length === 0 ? (
         <p className="text-sm text-muted">No archived threads.</p>
       ) : (
-        <Surface variant="secondary" className="divide-y divide-white/6 rounded-xl">
+        <Surface variant="secondary" className="divide-y divide-[var(--hairline)] rounded-xl">
           {archivedThreads.map((thread) => {
             const project = projects.find((p) => p.id === thread.projectId);
             return (

--- a/src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
@@ -103,13 +103,13 @@ export function SearchExcludeBody(props: SearchExcludeBodyProps) {
 function ExcludeList(props: { rows: Row[]; onRemove: (pattern: string) => void }) {
   if (props.rows.length === 0) {
     return (
-      <div className="rounded border border-white/6 bg-surface/40 px-2.5 py-1 text-xs text-muted">
+      <div className="rounded border border-[var(--hairline)] bg-surface/40 px-2.5 py-1 text-xs text-muted">
         No patterns.
       </div>
     );
   }
   return (
-    <div className="max-h-[280px] divide-y divide-white/6 overflow-y-auto rounded border border-white/6 bg-surface/40">
+    <div className="max-h-[280px] divide-y divide-[var(--hairline)] overflow-y-auto rounded border border-[var(--hairline)] bg-surface/40">
       {props.rows.map((row) => (
         <div key={row.pattern} className="flex h-8 items-center gap-2 px-2.5">
           <code className="flex-1 truncate font-mono text-xs text-foreground">{row.pattern}</code>
@@ -128,7 +128,7 @@ function ExcludeList(props: { rows: Row[]; onRemove: (pattern: string) => void }
               type="button"
               aria-label={`Remove ${row.pattern}`}
               onClick={() => props.onRemove(row.pattern)}
-              className="flex size-5 items-center justify-center rounded text-muted hover:bg-white/8 hover:text-foreground"
+              className="flex size-5 items-center justify-center rounded text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
             >
               <Trash2 className="size-3" />
             </button>

--- a/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
@@ -17,7 +17,7 @@ export function SettingsPage(props: {
 }) {
   const { title, description, actions, bodyClassName = "space-y-4", children } = props;
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
+    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4 [scrollbar-gutter:stable]">
       <div className="mx-auto max-w-[720px]">
         <div className={`flex items-center justify-between gap-4 ${description ? "mb-2" : "mb-6"}`}>
           <h1 className="text-lg font-semibold text-foreground">{title}</h1>

--- a/src/renderer/views/SettingsOverlay/parts/ThemeGallery.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ThemeGallery.tsx
@@ -1,0 +1,111 @@
+import { startTransition, type CSSProperties } from "react";
+import { Check } from "lucide-react";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useResolvedAppearance } from "@/renderer/components/ui/provider";
+import { APP_THEME_PRESETS, type AppThemePreset } from "@/renderer/theme/themePresets";
+
+/**
+ * Compact theme swatch: a sidebar strip + content area with an accent dot,
+ * rendered with the preset's variant vars. Used inline (e.g. the collapsed
+ * Theme row) to show the active theme at a glance.
+ */
+export function ThemeSwatch(props: { vars: CSSProperties; className?: string }) {
+  return (
+    <div
+      className={`flex overflow-hidden rounded-md border border-border/60 ${props.className ?? "h-8 w-14"}`}
+      style={props.vars}
+    >
+      <div
+        className="flex w-1/3 flex-col justify-center gap-1 px-1"
+        style={{ background: "var(--sidebar-background)" }}
+      >
+        <span className="h-1 w-full rounded-full" style={{ background: "var(--muted)" }} />
+        <span className="h-1 w-2/3 rounded-full" style={{ background: "var(--muted)" }} />
+      </div>
+      <div
+        className="flex flex-1 flex-col justify-center gap-1 px-1.5"
+        style={{ background: "var(--content-background)" }}
+      >
+        <span className="h-1 w-3/4 rounded-full" style={{ background: "var(--foreground)" }} />
+        <span className="h-1.5 w-1/2 rounded-sm" style={{ background: "var(--accent)" }} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Selectable grid of app themes. Each card previews the preset using the
+ * variant that matches the current appearance, so the swatch reflects exactly
+ * what the app will look like after selection.
+ */
+export function ThemeGallery() {
+  const themePreset = useSharedSettings((state) => state.themePreset);
+  const setThemePreset = useSharedSettings((state) => state.setThemePreset);
+  const appearance = useResolvedAppearance();
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {APP_THEME_PRESETS.map((preset) => (
+        <ThemeCard
+          key={preset.id}
+          preset={preset}
+          appearance={appearance}
+          selected={preset.id === themePreset}
+          onSelect={() => {
+            startTransition(() => {
+              setThemePreset(preset.id);
+            });
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ThemeCard(props: {
+  preset: AppThemePreset;
+  appearance: "light" | "dark";
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const { preset, appearance, selected, onSelect } = props;
+  const vars = (appearance === "dark" ? preset.dark : preset.light) as CSSProperties;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`group flex flex-col gap-2 rounded-lg border p-2 text-left transition-colors ${
+        selected ? "border-accent ring-1 ring-accent" : "border-border hover:border-muted"
+      }`}
+    >
+      <div className="overflow-hidden rounded-md border border-border/50" style={vars}>
+        <div className="flex h-16" style={{ background: "var(--content-background)" }}>
+          <div
+            className="w-1/3 border-r p-1.5"
+            style={{ background: "var(--sidebar-background)", borderColor: "var(--border)" }}
+          >
+            <div className="h-1.5 w-3/4 rounded-full" style={{ background: "var(--muted)" }} />
+            <div
+              className="mt-1.5 h-1.5 w-1/2 rounded-full"
+              style={{ background: "var(--muted)" }}
+            />
+          </div>
+          <div className="flex-1 p-1.5">
+            <div className="h-1.5 w-2/3 rounded-full" style={{ background: "var(--foreground)" }} />
+            <div
+              className="mt-1.5 h-1.5 w-1/2 rounded-full"
+              style={{ background: "var(--muted)" }}
+            />
+            <div className="mt-2 h-3 w-8 rounded-sm" style={{ background: "var(--accent)" }} />
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-2 px-0.5">
+        <span className="truncate text-xs font-medium text-foreground">{preset.label}</span>
+        {selected ? <Check className="size-3.5 shrink-0 text-accent" /> : null}
+      </div>
+    </button>
+  );
+}

--- a/src/renderer/views/ThreadSearchOverlay/ThreadSearchOverlay.tsx
+++ b/src/renderer/views/ThreadSearchOverlay/ThreadSearchOverlay.tsx
@@ -107,9 +107,9 @@ export function ThreadSearchOverlay(props: { onClose: () => void }) {
       <div
         role="dialog"
         aria-label="Search threads"
-        className="relative flex w-full max-w-[640px] flex-col overflow-hidden rounded-3xl border border-white/10 bg-background shadow-2xl"
+        className="relative flex w-full max-w-[640px] flex-col overflow-hidden rounded-3xl border border-[var(--hairline-strong)] bg-background shadow-2xl"
       >
-        <div className="flex items-center gap-2 border-b border-white/6 px-4 py-3">
+        <div className="flex items-center gap-2 border-b border-[var(--hairline)] px-4 py-3">
           <Search className="size-4 shrink-0 text-muted" />
           <input
             ref={inputRef}

--- a/src/renderer/views/ThreadSearchOverlay/parts/ThreadSearchResultRow.tsx
+++ b/src/renderer/views/ThreadSearchOverlay/parts/ThreadSearchResultRow.tsx
@@ -29,8 +29,8 @@ export function ThreadSearchResultRow(props: {
   });
 
   const stateClass = isSelected
-    ? "bg-white/[0.08] text-foreground"
-    : "text-foreground/85 hover:bg-white/[0.04] hover:text-foreground";
+    ? "bg-[var(--row-active)] text-foreground"
+    : "text-foreground/85 hover:bg-[var(--row-hover)] hover:text-foreground";
 
   return (
     <div

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -85,6 +85,13 @@ const audioSettingsSchema = z.object({
 
 export const sharedSettingsSchema = z.object({
   themeMode: themeModeSchema,
+  /**
+   * Selected app theme preset id (see `renderer/theme/themePresets`). The
+   * matching light/dark variant is chosen by `themeMode`. Free-form string so
+   * the catalog can grow without a schema bump; unknown ids fall back to the
+   * base "default" theme at apply time.
+   */
+  themePreset: z.string(),
   terminalPosition: terminalPositionSchema,
   commitGenProvider: z.string(),
   commitGenModel: z.string(),
@@ -229,6 +236,7 @@ export type SharedSettingsInput = Omit<SharedSettings, "agentHookSupport">;
 
 export const defaultSharedSettings: SharedSettings = {
   themeMode: "dark",
+  themePreset: "default",
   terminalPosition: "bottom",
   commitGenProvider: "auto",
   commitGenModel: "",


### PR DESCRIPTION
**Type:** Feature

- Introduce a theme preset catalog (light/dark variants, anchor-to-token derivation, WCAG-aware muted text) and apply selected presets at the document root on startup and when settings change.
- Persist `themePresetId` in shared settings (schema, store, main-process file tests) and add a Theme Gallery in Appearance settings for choosing presets.
- Add theme-adaptive interaction CSS variables and wire the UI provider/bootstrap path so hover, focus, and selection states stay readable across presets.
- Migrate shared surfaces (sidebar, chat, git/PR review, browser panel, overlays, search, and related chrome) from hardcoded interaction classes to the new tokens for consistent theming app-wide.