### PR TITLE
fix(worktree): exit setup shell on success and avoid double PTY

### DIFF
--- a/src/renderer/utils/shellUtils.test.ts
+++ b/src/renderer/utils/shellUtils.test.ts
@@ -20,7 +20,11 @@ vi.mock("@/renderer/bridge", () => ({
   readBridge: () => bridge,
 }));
 
-import { appendExitOnSuccess, writeScriptToShellThenExitOnSuccess } from "./shellUtils";
+import {
+  appendExitOnSuccess,
+  buildScriptWithExitOnSuccess,
+  writeScriptToShellThenExitOnSuccess,
+} from "./shellUtils";
 
 function emit(event: SupervisorEvent) {
   for (const handler of [...supervisorHandlers]) handler(event);
@@ -41,6 +45,24 @@ describe("appendExitOnSuccess", () => {
 
   it("uses a conditional statement for native Windows (PowerShell `exit` is a keyword)", () => {
     expect(appendExitOnSuccess("npm ci", "windows")).toBe("npm ci; if ($?) { exit }");
+  });
+});
+
+describe("buildScriptWithExitOnSuccess", () => {
+  it("uses `&&` for multi-line posix scripts", () => {
+    expect(buildScriptWithExitOnSuccess("npm install\nnpm run setup", "posix")).toBe(
+      "npm install && npm run setup && exit",
+    );
+  });
+
+  it("uses PowerShell-compatible success guards for multi-line Windows scripts", () => {
+    expect(buildScriptWithExitOnSuccess("npm install\nnpm run setup", "windows")).toBe(
+      "npm install; if ($?) { npm run setup; if ($?) { exit } }",
+    );
+  });
+
+  it("returns an empty command for blank scripts", () => {
+    expect(buildScriptWithExitOnSuccess("# nope\n\n", "windows")).toBe("");
   });
 });
 
@@ -72,6 +94,19 @@ describe("writeScriptToShellThenExitOnSuccess", () => {
     emit({ type: "thread-output", threadId: "shell:1", data: "PS> ", outputLength: 4 });
 
     expect(lastWrite()).toBe("npm ci; if ($?) { exit }\r");
+  });
+
+  it("writes a PowerShell-compatible guarded chain for native Windows shells", () => {
+    writeScriptToShellThenExitOnSuccess(
+      "shell:1",
+      "npm install\nnpm run setup",
+      "windows",
+      () => {},
+    );
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "PS> ", outputLength: 4 });
+
+    expect(lastWrite()).toBe("npm install; if ($?) { npm run setup; if ($?) { exit } }\r");
   });
 
   it("strips comments and blank lines before joining", () => {

--- a/src/renderer/utils/shellUtils.test.ts
+++ b/src/renderer/utils/shellUtils.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupervisorEvent } from "@/shared/ipc";
+
+const bridge = vi.hoisted(() => ({
+  onSupervisorEvent: vi.fn<(handler: (event: SupervisorEvent) => void) => () => void>(),
+  writeTerminal: vi.fn<(payload: { threadId: string; data: string }) => Promise<void>>(),
+}));
+
+const supervisorHandlers = vi.hoisted(() => [] as Array<(event: SupervisorEvent) => void>);
+
+vi.mock("@heroui/react", () => ({
+  toast: {
+    danger: vi.fn<(message: string) => void>(),
+    success: vi.fn<(message: string) => void>(),
+    warning: vi.fn<(message: string) => void>(),
+  },
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+import { appendExitOnSuccess, writeScriptToShellThenExitOnSuccess } from "./shellUtils";
+
+function emit(event: SupervisorEvent) {
+  for (const handler of [...supervisorHandlers]) handler(event);
+}
+
+function lastWrite(): string {
+  return bridge.writeTerminal.mock.calls.at(-1)?.[0].data ?? "";
+}
+
+describe("appendExitOnSuccess", () => {
+  it("uses `&& exit` for posix shells (exit is a command)", () => {
+    expect(appendExitOnSuccess("npm ci", "posix")).toBe("npm ci && exit");
+  });
+
+  it("uses `&& exit` for wsl (runs bash even on a Windows host)", () => {
+    expect(appendExitOnSuccess("npm ci", "wsl")).toBe("npm ci && exit");
+  });
+
+  it("uses a conditional statement for native Windows (PowerShell `exit` is a keyword)", () => {
+    expect(appendExitOnSuccess("npm ci", "windows")).toBe("npm ci; if ($?) { exit }");
+  });
+});
+
+describe("writeScriptToShellThenExitOnSuccess", () => {
+  beforeEach(() => {
+    supervisorHandlers.length = 0;
+    bridge.writeTerminal.mockReset().mockResolvedValue(undefined);
+    bridge.onSupervisorEvent.mockReset().mockImplementation((handler) => {
+      supervisorHandlers.push(handler);
+      return () => {
+        const index = supervisorHandlers.indexOf(handler);
+        if (index >= 0) supervisorHandlers.splice(index, 1);
+      };
+    });
+  });
+
+  it("writes the normalized chain with a posix exit tail on first output", () => {
+    writeScriptToShellThenExitOnSuccess("shell:1", "npm install\nnpm run setup", "posix", () => {});
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+
+    expect(bridge.writeTerminal).toHaveBeenCalledTimes(1);
+    expect(lastWrite()).toBe("npm install && npm run setup && exit\r");
+  });
+
+  it("writes a PowerShell conditional exit tail for native Windows shells", () => {
+    writeScriptToShellThenExitOnSuccess("shell:1", "npm ci", "windows", () => {});
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "PS> ", outputLength: 4 });
+
+    expect(lastWrite()).toBe("npm ci; if ($?) { exit }\r");
+  });
+
+  it("strips comments and blank lines before joining", () => {
+    writeScriptToShellThenExitOnSuccess("shell:1", "# bootstrap\n\nnpm ci\n", "posix", () => {});
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "ready", outputLength: 5 });
+
+    expect(lastWrite()).toBe("npm ci && exit\r");
+  });
+
+  it("only writes once per PTY, ignoring subsequent output", () => {
+    writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", () => {});
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+    emit({ type: "thread-output", threadId: "shell:1", data: "more", outputLength: 6 });
+
+    expect(bridge.writeTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-sends the command after a thread-reset (PTY respawn)", () => {
+    writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", () => {});
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+    expect(bridge.writeTerminal).toHaveBeenCalledTimes(1);
+
+    // A viewport-sized respawn replaces the PTY; the command must land again.
+    emit({ type: "thread-reset", threadId: "shell:1" });
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+
+    expect(bridge.writeTerminal).toHaveBeenCalledTimes(2);
+    expect(lastWrite()).toBe("echo hi && exit\r");
+  });
+
+  it("invokes onExit with the exit code and stops listening", () => {
+    const onExit = vi.fn<(exitCode: number | null) => void>();
+    writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", onExit);
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+    emit({ type: "thread-exited", threadId: "shell:1", exitCode: 0 });
+
+    expect(onExit).toHaveBeenCalledWith(0);
+    expect(supervisorHandlers).toHaveLength(0);
+  });
+
+  it("ignores events for other shells", () => {
+    const onExit = vi.fn<(exitCode: number | null) => void>();
+    writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", onExit);
+
+    emit({ type: "thread-output", threadId: "shell:2", data: "$ ", outputLength: 2 });
+    emit({ type: "thread-exited", threadId: "shell:2", exitCode: 0 });
+
+    expect(bridge.writeTerminal).not.toHaveBeenCalled();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("detach() unsubscribes so no command is written afterward", () => {
+    const detach = writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", () => {});
+
+    detach();
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+
+    expect(bridge.writeTerminal).not.toHaveBeenCalled();
+    expect(supervisorHandlers).toHaveLength(0);
+  });
+
+  it("is a no-op for blank / comments-only scripts", () => {
+    const onExit = vi.fn<(exitCode: number | null) => void>();
+    const detach = writeScriptToShellThenExitOnSuccess(
+      "shell:1",
+      "# only a comment\n\n",
+      "posix",
+      onExit,
+    );
+
+    expect(bridge.onSupervisorEvent).not.toHaveBeenCalled();
+    expect(() => detach()).not.toThrow();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/utils/shellUtils.ts
+++ b/src/renderer/utils/shellUtils.ts
@@ -17,11 +17,28 @@ export function startShellWithToast(payload: StartShellPayload, label: string): 
 }
 
 export function normalizeShellScript(script: string): string {
+  return normalizeShellScriptLines(script).join(" && ");
+}
+
+function normalizeShellScriptLines(script: string): string[] {
   return script
     .split(/\r?\n/)
     .map((l) => l.trim())
-    .filter((l) => l !== "" && !l.startsWith("#"))
-    .join(" && ");
+    .filter((l) => l !== "" && !l.startsWith("#"));
+}
+
+function buildPowerShellExitOnSuccess(lines: string[]): string {
+  return lines.reduceRight((tail, line) => `${line}; if ($?) { ${tail} }`, "exit");
+}
+
+export function buildScriptWithExitOnSuccess(
+  script: string,
+  locationKind: ProjectLocation["kind"],
+): string {
+  const lines = normalizeShellScriptLines(script);
+  if (lines.length === 0) return "";
+  if (locationKind === "windows") return buildPowerShellExitOnSuccess(lines);
+  return `${lines.join(" && ")} && exit`;
 }
 
 export function writeScriptToShell(shellId: string, script: string) {
@@ -85,7 +102,7 @@ export function writeScriptToShellThenExitOnSuccess(
   const command = normalizeShellScript(script);
   // Nothing meaningful to run — leave the (caller-guarded) shell untouched.
   if (!command) return () => undefined;
-  const data = `${appendExitOnSuccess(command, locationKind)}\r`;
+  const data = `${buildScriptWithExitOnSuccess(script, locationKind)}\r`;
 
   let armed = true;
   let detached = false;

--- a/src/renderer/utils/shellUtils.ts
+++ b/src/renderer/utils/shellUtils.ts
@@ -42,6 +42,87 @@ export function writeScriptToShell(shellId: string, script: string) {
   });
 }
 
+/**
+ * Appends a shell-correct "exit only if every command succeeded" tail to a
+ * normalized command chain.
+ *
+ * Native Windows runs PowerShell (pwsh 7 or Windows PowerShell 5.1), where
+ * `exit` is a language keyword that cannot be the right-hand operand of `&&`
+ * (`<chain> && exit` errors with "exit not recognized" and does NOT exit). A
+ * conditional statement (`; if ($?) { exit }`) exits on success and stays
+ * interactive on failure. The cmd.exe fallback is unreachable here because
+ * `powershell.exe` ships with every Windows. WSL and posix shells (and cmd)
+ * treat `exit` as a command, so `&& exit` runs it only on success.
+ */
+export function appendExitOnSuccess(
+  command: string,
+  locationKind: ProjectLocation["kind"],
+): string {
+  return locationKind === "windows" ? `${command}; if ($?) { exit }` : `${command} && exit`;
+}
+
+/**
+ * Runs a script in an already-started shell, then lets the shell exit on its
+ * own once every command succeeds (see {@link appendExitOnSuccess}); on failure
+ * the chain stops short of the exit and the shell stays interactive for
+ * inspection. The command is re-sent on every `thread-reset` so it lands in the
+ * surviving PTY when the shell respawns (e.g. a panel-driven, viewport-sized
+ * respawn).
+ *
+ * `onExit` fires once the shell's PTY exits — success, or a manual `exit` — and
+ * the listener detaches itself first. Returns a detach fn so callers can stop
+ * listening if the shell is torn down before it finishes (a manual close kills
+ * the PTY with `ignoreExit`, suppressing `thread-exited`), avoiding a dangling
+ * subscription. Unlike {@link runShellScriptToCompletion} this keeps the shell
+ * visible and never times out, so long installs are not cut short.
+ */
+export function writeScriptToShellThenExitOnSuccess(
+  shellId: string,
+  script: string,
+  locationKind: ProjectLocation["kind"],
+  onExit: (exitCode: number | null) => void,
+): () => void {
+  const command = normalizeShellScript(script);
+  // Nothing meaningful to run — leave the (caller-guarded) shell untouched.
+  if (!command) return () => undefined;
+  const data = `${appendExitOnSuccess(command, locationKind)}\r`;
+
+  let armed = true;
+  let detached = false;
+  let unsubscribe: () => void = () => undefined;
+  const detach = () => {
+    if (detached) return;
+    detached = true;
+    unsubscribe();
+  };
+  unsubscribe = readBridge().onSupervisorEvent((event) => {
+    if (!("threadId" in event) || event.threadId !== shellId) return;
+    if (event.type === "thread-reset") {
+      // A fresh PTY spawned; re-send on its first output so the command runs
+      // in the survivor rather than a PTY that is about to be replaced.
+      armed = true;
+      return;
+    }
+    if (event.type === "thread-output" && armed) {
+      armed = false;
+      void readBridge()
+        .writeTerminal({ threadId: shellId, data })
+        .catch((error) => {
+          console.warn(
+            `[shellUtils] Unable to write command to shell ${shellId}:`,
+            error instanceof Error ? error.message : error,
+          );
+        });
+      return;
+    }
+    if (event.type === "thread-exited") {
+      detach();
+      onExit(event.exitCode);
+    }
+  });
+  return detach;
+}
+
 export async function runShellScriptToCompletion(
   shellId: string,
   projectLocation: ProjectLocation,

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -29,11 +29,16 @@ import {
   useProjectIds,
   useProjectWithoutDraftConfig,
 } from "@/renderer/state/useThread";
-import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTerminalStore";
+import { closeAllPanels } from "@/renderer/actions/panelActions";
 import { SplitPaneContainer, type Rect } from "@/renderer/components/layout/SplitPaneContainer";
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
 import { ThreadDraftView } from "@/renderer/components/thread/ThreadDraftView";
-import { startShellWithToast, writeScriptToShell } from "@/renderer/utils/shellUtils";
+import {
+  normalizeShellScript,
+  startShellWithToast,
+  writeScriptToShellThenExitOnSuccess,
+} from "@/renderer/utils/shellUtils";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
 import { HomeView } from "@/renderer/views/HomeView";
 import { buildProjectDraftConfig } from "./draftConfig";
@@ -398,22 +403,75 @@ async function primeWorktreeGitState(project: Project, worktreePath: string): Pr
 }
 
 function runWorktreeSetupScript(project: Project, worktreePath: string, setupScript: string): void {
+  // Blank / comments-only scripts have nothing to run — skip the terminal
+  // entirely rather than leaving an idle "setup" shell behind.
+  if (!normalizeShellScript(setupScript)) return;
+
   const wtLocation = buildWorktreeLocation(project.location, worktreePath);
   const store = useDevTerminalStore.getState();
   const tab = store.addTab(project.id, "setup", worktreePath);
-  if (useSharedSettings.getState().autoShowTerminalPanel) {
+  const autoShow = useSharedSettings.getState().autoShowTerminalPanel;
+  const panelAlreadyOpen = store.isOpen;
+  if (autoShow) {
     store.openWorktreePanel(project.id, worktreePath);
   }
   store.setActiveTab(tab.id);
-  startShellWithToast(
-    {
-      shellId: tab.id,
-      projectLocation: wtLocation,
-      worktreePath,
-    },
-    "setup shell",
+
+  // When the terminal panel is (or becomes) visible, every tab mounts its own
+  // XTermSurface, which spawns the PTY itself at the measured viewport size.
+  // Spawning eagerly too would create a second PTY for the same shell id and
+  // race it, re-running the setup chain. Only spawn eagerly when the panel
+  // stays closed (no surface ever mounts), where this is the sole spawn.
+  if (!autoShow && !panelAlreadyOpen) {
+    startShellWithToast(
+      {
+        shellId: tab.id,
+        projectLocation: wtLocation,
+        worktreePath,
+      },
+      "setup shell",
+    );
+  }
+
+  // Auto-close the setup terminal once every command succeeds (the script
+  // self-exits) so worktrees don't accumulate stale shells. A failed setup
+  // stops short of the exit and leaves the shell open for inspection.
+  const detach = writeScriptToShellThenExitOnSuccess(tab.id, setupScript, wtLocation.kind, () =>
+    removeWorktreeSetupTab(tab),
   );
-  writeScriptToShell(tab.id, setupScript);
+  // If the tab is closed before setup finishes (manual close, worktree
+  // deletion), `closeThread` suppresses `thread-exited`, so detach the exit
+  // listener here instead of leaking it for the rest of the session.
+  const unsubscribeTabs = useDevTerminalStore.subscribe((state, prev) => {
+    if (state.tabs === prev.tabs) return;
+    if (state.tabs.some((t) => t.id === tab.id)) return;
+    detach();
+    unsubscribeTabs();
+  });
+}
+
+/**
+ * Removes a finished setup terminal tab. The PTY has already exited (success or
+ * a manual `exit`), so the supervisor session is gone — removing the tab is
+ * sufficient and `closeThread` would be a no-op. If the setup tab was the only
+ * one in the worktree context the panel is showing, close the panel too so the
+ * auto-opened panel doesn't linger on an empty "Open a terminal" state (mirrors
+ * manual close in DevTerminalPanel).
+ */
+function removeWorktreeSetupTab(tab: DevTerminalTab): void {
+  const store = useDevTerminalStore.getState();
+  const showingThisContext =
+    store.isOpen &&
+    store.activeProjectId === tab.projectId &&
+    (store.activeWorktreePath ?? undefined) === tab.worktreePath;
+  store.removeTab(tab.id);
+  if (!showingThisContext) return;
+  const remaining = useDevTerminalStore
+    .getState()
+    .tabs.filter((t) => t.projectId === tab.projectId && t.worktreePath === tab.worktreePath);
+  if (remaining.length > 0) return;
+  if (useSharedSettings.getState().terminalPosition !== "bottom") closeAllPanels();
+  useDevTerminalStore.getState().closePanel();
 }
 
 /**


### PR DESCRIPTION
- Add PowerShell-safe exit tail and script writer with thread-reset replay
- Skip empty setup scripts; spawn PTY only when terminal panel stays hidden
- Auto-remove setup tab and close panel when setup completes successfully
- Add shellUtils tests for exit tails and writeScriptToShellThenExitOnSuccess