### PR TITLE
Fix Antigravity session discovery and isolate one-shot spawns

### DIFF
--- a/src/shared/ansi.test.ts
+++ b/src/shared/ansi.test.ts
@@ -9,6 +9,10 @@ describe("stripAnsi", () => {
   it("removes CSI sequences", () => {
     expect(stripAnsi("\u001b[2Jhello")).toBe("hello");
   });
+
+  it("removes OSC sequences", () => {
+    expect(stripAnsi("title\r\n\u001b]0;powershell.exe\u0007")).toBe("title\r\n");
+  });
 });
 
 describe("stripAnsiPreservingLayout", () => {

--- a/src/shared/ansi.ts
+++ b/src/shared/ansi.ts
@@ -1,6 +1,10 @@
+// OSC (`]…` terminated by BEL/ST) must be the first alternative: the
+// single-char C1 class `[@-Z\\-_]` spans 0x5C-0x5F and so includes `]` (0x5D),
+// which would otherwise consume just `]` and leave the OSC body (e.g. a
+// `]0;title` window-title sequence) un-stripped.
 const ANSI_PATTERN =
   // eslint-disable-next-line no-control-regex
-  /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\))/g;
+  /\u001B(?:\][^\u0007]*(?:\u0007|\u001B\\)|[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 
 /** Cap CUF→spaces so hostile or buggy PTY output cannot force huge allocations. */
 const MAX_CUF_SPACES = 8192;

--- a/src/supervisor/agents/antigravity/antigravity.test.ts
+++ b/src/supervisor/agents/antigravity/antigravity.test.ts
@@ -43,6 +43,12 @@ describe("createAntigravityAdapter", () => {
 
     expect(adapter.kind).toBe("antigravity");
     expect(adapter.binary).toBe("agy");
+    expect(adapter.update).toEqual({
+      builtIn: { binary: "agy", args: ["update"] },
+      latestVersionUrls: [
+        "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json",
+      ],
+    });
     expect(adapter.capabilities.models).toEqual([
       {
         id: ANTIGRAVITY_MANAGED_MODEL_ID,
@@ -80,6 +86,11 @@ describe("createAntigravityAdapter", () => {
       command: "agy",
       args: ["-p", "summarize"],
       stdin: "",
+      // Isolate the cwd so the one-shot's last_conversations.json[cwd] write
+      // can't be mistaken for the real interactive session (see index.ts).
+      isolateCwd: true,
+      // agy print mode emits its answer only when attached to a terminal.
+      pty: true,
     });
   });
 });

--- a/src/supervisor/agents/antigravity/detection.ts
+++ b/src/supervisor/agents/antigravity/detection.ts
@@ -48,5 +48,10 @@ export const antigravityDetectionSpec: DetectionSpec = {
   binary: "agy",
   capabilities: defaultAntigravityCapabilities,
   authProbes: [configDirAuthProbe],
-  update: { builtIn: { binary: "agy", args: ["update"] } },
+  update: {
+    builtIn: { binary: "agy", args: ["update"] },
+    latestVersionUrls: [
+      "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json",
+    ],
+  },
 };

--- a/src/supervisor/agents/antigravity/index.ts
+++ b/src/supervisor/agents/antigravity/index.ts
@@ -17,7 +17,7 @@ import {
   locationCwd,
   readAntigravityConversationIds,
   readAntigravityLastConversationForCwd,
-  readNewestAntigravityConversationId,
+  readNewestAntigravityConversationForCwd,
   resolveAntigravityWatchPaths,
 } from "./session";
 import { detectAntigravityTerminalStatus } from "./terminal";
@@ -33,6 +33,7 @@ export function createAntigravityAdapter(): AgentAdapter {
     kind: "antigravity",
     label: "Antigravity",
     binary: "agy",
+    ...(antigravityDetectionSpec.update ? { update: antigravityDetectionSpec.update } : {}),
     get capabilities() {
       return capabilities;
     },
@@ -49,10 +50,10 @@ export function createAntigravityAdapter(): AgentAdapter {
     },
 
     buildLaunchArgv(location, config, prompt) {
-      // `agy` has no flag to pre-assign a conversation id; the id is only
-      // visible after the session writes its first `.pb` file. Snapshot the
-      // existing ids + the workspace's cached "last" id so `discoverSessionRef`
-      // can identify the brand-new one once it appears.
+      // `agy` has no flag to pre-assign a conversation id; the conversation db
+      // only appears once the session starts. Snapshot the existing ids + the
+      // workspace's cached "last" id so `discoverSessionRef` can pick out the
+      // brand-new conversation created for this launch.
       preSpawnConversationIds = readAntigravityConversationIds(location);
       preSpawnLastConversationForCwd = readAntigravityLastConversationForCwd(
         location,
@@ -74,6 +75,20 @@ export function createAntigravityAdapter(): AgentAdapter {
 
     async discoverSessionRef(location: ProjectLocation) {
       const cwd = locationCwd(location);
+      // Primary: the conversation db created for THIS workspace. It exists as
+      // soon as the interactive session starts, and the workspace match rules
+      // out concurrent one-shot calls (title/commit/PR), which run in an
+      // isolated cwd. Required to be correct on the first hit — the runtime
+      // locks the first discovered ref and stops watching.
+      const matched = readNewestAntigravityConversationForCwd(
+        location,
+        preSpawnConversationIds,
+        cwd,
+      );
+      if (matched) return createKnownSessionRef(matched);
+      // Fallback: the workspace → last-conversation cache. `agy` only writes
+      // this on exit, so it covers re-discovery of an already-closed session
+      // (e.g. after an app restart) rather than the live case above.
       const latest = readAntigravityLastConversationForCwd(location, cwd);
       if (
         latest &&
@@ -82,8 +97,7 @@ export function createAntigravityAdapter(): AgentAdapter {
       ) {
         return createKnownSessionRef(latest);
       }
-      const newest = readNewestAntigravityConversationId(location, preSpawnConversationIds);
-      return newest ? createKnownSessionRef(newest) : undefined;
+      return undefined;
     },
 
     watchSessionRef(location, onChanged) {
@@ -118,7 +132,14 @@ export function createAntigravityAdapter(): AgentAdapter {
 
     buildOneShotCommand(_model, _effort, prompt) {
       if (!prompt) return undefined;
-      return { command: "agy", args: ["-p", prompt], stdin: "" };
+      // `agy -p` persists a throwaway conversation AND rewrites
+      // last_conversations.json[cwd] with its id. Running it in the project cwd
+      // would race the real `--prompt-interactive` session for that cache key
+      // and make `discoverSessionRef` latch onto the one-shot conversation
+      // (title gen, commit-msg, PR summary). `agy` has no flag to pre-assign a
+      // conversation id, so isolate the cwd instead — the prompt is fully
+      // self-contained, so the working directory is irrelevant to the output.
+      return { command: "agy", args: ["-p", prompt], stdin: "", isolateCwd: true, pty: true };
     },
   };
 }

--- a/src/supervisor/agents/antigravity/session.test.ts
+++ b/src/supervisor/agents/antigravity/session.test.ts
@@ -12,6 +12,23 @@ function makeTempHome(): string {
   return dir;
 }
 
+// Mimic an `agy` conversation SQLite db: the workspace is stored as a
+// length-delimited protobuf field-1 string `0x0A <len> file://<cwd>`. An
+// optional `decoy` is an unframed `file://` in conversation text placed before
+// the workspace, to prove the framed field is preferred. Returns the path.
+function writeConversationDb(dir: string, id: string, cwd: string, decoy?: string): string {
+  const path = join(dir, `${id}.db`);
+  const uri = Buffer.from(
+    `file://${cwd.startsWith("/") ? cwd : `/${cwd.replace(/\\/g, "/")}`}`,
+    "latin1",
+  );
+  const parts = [Buffer.from("SQLite format 3 ", "latin1")];
+  if (decoy) parts.push(Buffer.from(`(see ${decoy} for details) `, "latin1"));
+  parts.push(Buffer.from([0x0a, uri.length]), uri, Buffer.from([0x1a, 0x00]));
+  writeFileSync(path, Buffer.concat(parts));
+  return path;
+}
+
 async function loadSessionModule(home: string) {
   vi.resetModules();
   vi.doMock("node:os", async (importActual) => {
@@ -60,7 +77,7 @@ describe("Antigravity session files", () => {
     expect(resolveAntigravityWatchPaths(location)).toEqual([configDir, join(home, ".gemini")]);
   });
 
-  it("reads the cwd mapping and newest new conversation id", async () => {
+  it("reads the cwd mapping and snapshots conversation ids", async () => {
     const home = makeTempHome();
     const configDir = join(home, ".gemini", "antigravity-cli");
     const conversationsDir = join(configDir, "conversations");
@@ -71,25 +88,15 @@ describe("Antigravity session files", () => {
       JSON.stringify({ [location.path]: "conversation-new" }),
       "utf8",
     );
-    const oldPath = join(conversationsDir, "conversation-old.pb");
-    const newPath = join(conversationsDir, "conversation-new.pb");
-    writeFileSync(oldPath, "");
-    writeFileSync(newPath, "");
-    utimesSync(oldPath, new Date("2026-05-20T00:00:00.000Z"), new Date("2026-05-20T00:00:00.000Z"));
-    utimesSync(newPath, new Date("2026-05-20T00:00:01.000Z"), new Date("2026-05-20T00:00:01.000Z"));
+    writeFileSync(join(conversationsDir, "conversation-old.pb"), "");
+    writeFileSync(join(conversationsDir, "conversation-new.pb"), "");
 
-    const {
-      readAntigravityConversationIds,
-      readAntigravityLastConversationForCwd,
-      readNewestAntigravityConversationId,
-    } = await loadSessionModule(home);
+    const { readAntigravityConversationIds, readAntigravityLastConversationForCwd } =
+      await loadSessionModule(home);
 
     expect(readAntigravityLastConversationForCwd(location, location.path)).toBe("conversation-new");
     expect(readAntigravityConversationIds(location)).toEqual(
       new Set(["conversation-old", "conversation-new"]),
-    );
-    expect(readNewestAntigravityConversationId(location, new Set(["conversation-old"]))).toBe(
-      "conversation-new",
     );
   });
 
@@ -120,5 +127,61 @@ describe("Antigravity session files", () => {
     await expect(adapter.discoverSessionRef?.(location)).resolves.toMatchObject({
       providerSessionId: "conversation-new",
     });
+  });
+
+  it("snapshots both .pb and .db ids and ignores -wal/-shm sidecars", async () => {
+    const home = makeTempHome();
+    const conversationsDir = join(home, ".gemini", "antigravity-cli", "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+    writeFileSync(join(conversationsDir, "legacy.pb"), "");
+    writeConversationDb(conversationsDir, "modern", location.path);
+    writeFileSync(join(conversationsDir, "modern.db-wal"), "");
+    writeFileSync(join(conversationsDir, "modern.db-shm"), "");
+
+    const { readAntigravityConversationIds } = await loadSessionModule(home);
+
+    expect(readAntigravityConversationIds(location)).toEqual(new Set(["legacy", "modern"]));
+  });
+
+  it("discovers the new conversation whose stored workspace matches the launch cwd", async () => {
+    const home = makeTempHome();
+    const conversationsDir = join(home, ".gemini", "antigravity-cli", "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+
+    const { createAntigravityAdapter } = await loadAdapterModule(home);
+    const adapter = createAntigravityAdapter();
+    adapter.buildLaunchArgv(location, { model: "auto" }, "hello");
+
+    // Real interactive session for this workspace (with a decoy file:// in its
+    // content), plus a concurrent one-shot (title gen) that ran in an isolated
+    // cwd. The one-shot is made NEWER so a naive newest-by-mtime would wrongly
+    // pick it; the workspace match must still select the real session.
+    const real = writeConversationDb(
+      conversationsDir,
+      "real-session",
+      location.path,
+      "file:///C:/some/output.log",
+    );
+    const oneShot = writeConversationDb(conversationsDir, "title-gen", "C:\\Users\\me\\Temp");
+    utimesSync(real, new Date("2026-05-20T00:00:00Z"), new Date("2026-05-20T00:00:00Z"));
+    utimesSync(oneShot, new Date("2026-05-20T00:00:05Z"), new Date("2026-05-20T00:00:05Z"));
+
+    await expect(adapter.discoverSessionRef?.(location)).resolves.toMatchObject({
+      providerSessionId: "real-session",
+    });
+  });
+
+  it("does not rediscover a conversation that existed before launch", async () => {
+    const home = makeTempHome();
+    const conversationsDir = join(home, ".gemini", "antigravity-cli", "conversations");
+    mkdirSync(conversationsDir, { recursive: true });
+    // Pre-existing conversation for this workspace is captured in the snapshot.
+    writeConversationDb(conversationsDir, "old-session", location.path);
+
+    const { createAntigravityAdapter } = await loadAdapterModule(home);
+    const adapter = createAntigravityAdapter();
+    adapter.buildLaunchArgv(location, { model: "auto" }, "hello");
+
+    await expect(adapter.discoverSessionRef?.(location)).resolves.toBeUndefined();
   });
 });

--- a/src/supervisor/agents/antigravity/session.ts
+++ b/src/supervisor/agents/antigravity/session.ts
@@ -30,8 +30,14 @@ export function antigravityConfigDirExists(location: ProjectLocation): boolean {
 
 interface AntigravityConversationFile {
   id: string;
+  path: string;
   mtimeMs: number;
 }
+
+// `agy` migrated its conversation store from protobuf `.pb` files to SQLite
+// `.db` files; both forms may coexist. The `.db-wal`/`.db-shm` sidecars of an
+// open database must be excluded — only the base file names a conversation.
+const CONVERSATION_FILE_RE = /\.(pb|db)$/;
 
 function readAntigravityConversationFiles(
   location: ProjectLocation,
@@ -40,11 +46,12 @@ function readAntigravityConversationFiles(
   if (!dir || !existsSync(dir)) return [];
   try {
     return readdirSync(dir)
-      .filter((file) => file.endsWith(".pb"))
+      .filter((file) => CONVERSATION_FILE_RE.test(file))
       .map((file) => {
         const path = join(dir, file);
         return {
-          id: file.replace(/\.pb$/, ""),
+          id: file.replace(CONVERSATION_FILE_RE, ""),
+          path,
           mtimeMs: statSync(path).mtimeMs,
         };
       });
@@ -57,13 +64,106 @@ export function readAntigravityConversationIds(location: ProjectLocation): Set<s
   return new Set(readAntigravityConversationFiles(location).map((file) => file.id));
 }
 
-export function readNewestAntigravityConversationId(
+/**
+ * Extract the workspace directory a conversation was created in. `agy` stores
+ * it as a `file://<cwd>` URI inside the SQLite db (trajectory_metadata_blob),
+ * written when the conversation is created. Reading the raw bytes of the db
+ * and its `-wal` sidecar (fresh writes may not be checkpointed yet) and
+ * scanning for that URI avoids a SQLite dependency and any lock contention
+ * with the live session.
+ *
+ * The URI is a length-delimited protobuf string, so the byte immediately
+ * before `file://` is its length — matching that distinguishes the real
+ * workspace field from a `file://` that merely appears in conversation text
+ * (which is not framed that way). A path cannot contain protobuf tag bytes
+ * (< 0x20), so each candidate URI is the printable-ASCII run from `file://`.
+ */
+function readAntigravityConversationWorkspace(dbPath: string): string | undefined {
+  const prefixLen = "file://".length;
+  for (const candidate of [dbPath, `${dbPath}-wal`]) {
+    let buf: Buffer;
+    try {
+      buf = readFileSync(candidate);
+    } catch {
+      continue;
+    }
+    let fallback: string | undefined;
+    for (
+      let start = buf.indexOf("file://");
+      start >= 0;
+      start = buf.indexOf("file://", start + 1)
+    ) {
+      let end = start;
+      while (end < buf.length && buf[end]! >= 0x20 && buf[end]! <= 0x7e) end += 1;
+      const value = buf.toString("latin1", start + prefixLen, end);
+      if (isFramedProtobufString(buf, start, end - start)) return value;
+      fallback ??= value;
+    }
+    if (fallback !== undefined) return fallback;
+  }
+  return undefined;
+}
+
+/**
+ * Whether the bytes at `start` begin a protobuf field-1 (tag 0x0A) string of
+ * exactly `length` bytes — i.e. `0x0A <varint length> <string>`. Used to pin
+ * the workspace URI field and reject a `file://` that merely appears inside
+ * conversation text. Handles the 1- and 2-byte varint lengths that cover any
+ * realistic path (< 16 KiB).
+ */
+function isFramedProtobufString(buf: Buffer, start: number, length: number): boolean {
+  if (length < 0x80) {
+    return start >= 2 && buf[start - 1] === length && buf[start - 2] === 0x0a;
+  }
+  if (length < 0x4000) {
+    return (
+      start >= 3 &&
+      buf[start - 2] === ((length & 0x7f) | 0x80) &&
+      buf[start - 1] === length >> 7 &&
+      buf[start - 3] === 0x0a
+    );
+  }
+  return false;
+}
+
+function normalizeWorkspacePath(value: string): string {
+  // file URIs use forward slashes and prefix a Windows drive with a slash
+  // (file:///C:/x → /C:/x). Drop that and unify separators so a db-stored
+  // workspace compares equal to the launch cwd on every platform.
+  return value
+    .replace(/^\/(?=[A-Za-z]:)/, "")
+    .replace(/\\/g, "/")
+    .replace(/\/+$/, "");
+}
+
+function workspaceMatchesCwd(workspace: string, cwd: string): boolean {
+  const left = normalizeWorkspacePath(workspace);
+  const right = normalizeWorkspacePath(cwd);
+  // Windows drive paths are case-insensitive; posix/WSL paths are not.
+  return /^[A-Za-z]:/.test(right) ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+/**
+ * The newest conversation created since `previousIds` whose stored workspace
+ * matches `cwd`. This is the live-session-safe discovery signal: the db (and
+ * its workspace URI) exist as soon as the interactive session starts, while
+ * one-shot calls (title/commit/PR) run in an isolated cwd and are excluded by
+ * the workspace match. `last_conversations.json` cannot be used here — `agy`
+ * only writes it on exit, so it is empty while the session is alive.
+ */
+export function readNewestAntigravityConversationForCwd(
   location: ProjectLocation,
   previousIds: ReadonlySet<string>,
+  cwd: string,
 ): string | undefined {
-  return readAntigravityConversationFiles(location)
+  const fresh = readAntigravityConversationFiles(location)
     .filter((file) => !previousIds.has(file.id))
-    .sort((left, right) => right.mtimeMs - left.mtimeMs)[0]?.id;
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+  for (const file of fresh) {
+    const workspace = readAntigravityConversationWorkspace(file.path);
+    if (workspace && workspaceMatchesCwd(workspace, cwd)) return file.id;
+  }
+  return undefined;
 }
 
 // `agy` writes its workspace → most-recent conversation mapping here after

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -280,7 +280,9 @@ export interface AgentOneShotRunner {
     model: string,
     effort?: string,
     prompt?: string,
-  ): { command: string; args: string[]; stdin?: string } | undefined;
+  ):
+    | { command: string; args: string[]; stdin?: string; isolateCwd?: boolean; pty?: boolean }
+    | undefined;
   runOneShot?(input: RunOneShotInput): Promise<string>;
   buildContextExtractionCommand?(
     sessionRef: SessionRef,

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -37,6 +37,12 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
       "https://storage.googleapis.com/grok-build-public-artifacts/cli/stable",
     ],
   },
+  antigravity: {
+    builtIn: { binary: "agy", args: ["update"] },
+    latestVersionUrls: [
+      "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json",
+    ],
+  },
 };
 
 function makeStatus(overrides: Partial<AgentStatus>): AgentStatus {
@@ -262,6 +268,21 @@ describe("getLatestVersionForAdapter", () => {
     expect(result).toEqual({ version: "0.2.3", source: "version-url" });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://x.ai/cli/stable");
+  });
+
+  it("extracts a manifest version from provider version URLs", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ version: "1.0.4" }),
+    } as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await getLatestVersionForAdapter(makeAdapter("antigravity"));
+    expect(result).toEqual({ version: "1.0.4", source: "version-url" });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json",
+    );
   });
 
   it("falls back to the next provider version URL", async () => {

--- a/src/supervisor/agents/updateAgent.ts
+++ b/src/supervisor/agents/updateAgent.ts
@@ -214,6 +214,22 @@ async function fetchHomebrewCaskLatestVersion(cask: string): Promise<string | un
 }
 
 async function fetchLatestVersionFromUrls(urls: readonly string[]): Promise<string | undefined> {
+  const parseVersion = (body: string): string | undefined => {
+    const trimmed = body.trim();
+    try {
+      const data = JSON.parse(trimmed) as { version?: unknown; tag_name?: unknown; name?: unknown };
+      const value =
+        typeof data.version === "string"
+          ? data.version
+          : typeof data.tag_name === "string"
+            ? data.tag_name
+            : data.name;
+      return typeof value === "string" && value.length > 0 ? value.replace(/^v/, "") : undefined;
+    } catch {
+      return trimmed;
+    }
+  };
+
   for (const url of urls) {
     let timer: NodeJS.Timeout | undefined;
     try {
@@ -227,7 +243,7 @@ async function fetchLatestVersionFromUrls(urls: readonly string[]): Promise<stri
         console.warn(`[updateAgent] version URL probe failed for ${url}: HTTP ${response.status}`);
         continue;
       }
-      const version = (await response.text()).trim();
+      const version = parseVersion(await response.text());
       if (version) return version;
       console.warn(`[updateAgent] version URL probe for ${url} returned no version`);
     } catch (error) {

--- a/src/supervisor/oneShotPromptRunner.ts
+++ b/src/supervisor/oneShotPromptRunner.ts
@@ -1,6 +1,6 @@
 import type { ProjectLocation } from "@/shared/contracts";
 import type { AgentAdapter, CommandSpec } from "./agents/base";
-import { buildOneShotSpec, spawnAgent } from "./oneShotSpawn";
+import { prepareOneShot } from "./oneShotSpawn";
 
 // Spawn returns these errno codes when the OS rejects the argv length:
 // - ENAMETOOLONG: macOS / Windows (via libuv mapping)
@@ -140,7 +140,7 @@ export async function runOneShotPromptWithFallback(
     if (!cmd) {
       throw new Error(`${options.adapter.label} does not support one-shot generation`);
     }
-    const spawnSpec = buildOneShotSpec(options.location, cmd.command, cmd.args);
+    const { spec: spawnSpec, spawn } = prepareOneShot(options.location, cmd);
 
     if (hasNextAttempt && isArgvLikelyTooLong(spawnSpec)) {
       console.warn(
@@ -154,7 +154,7 @@ export async function runOneShotPromptWithFallback(
     );
 
     try {
-      return await spawnAgent(spawnSpec, cmd.stdin ?? prompt, options.timeoutMs, options.signal);
+      return await spawn(spawnSpec, cmd.stdin ?? prompt, options.timeoutMs, options.signal);
     } catch (err) {
       lastError = err;
       if (hasNextAttempt && isArgvTooLongError(err)) {

--- a/src/supervisor/oneShotSpawn.test.ts
+++ b/src/supervisor/oneShotSpawn.test.ts
@@ -1,0 +1,56 @@
+import { tmpdir } from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+
+const buildAgentCommandMock = vi.hoisted(() =>
+  vi.fn<(location: ProjectLocation, command: string, args: string[]) => unknown>(),
+);
+
+vi.mock("./agents/base", () => ({ buildAgentCommand: buildAgentCommandMock }));
+
+import { buildOneShotSpec } from "./oneShotSpawn";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildAgentCommandMock.mockImplementation((location) => ({ command: "agy", args: [], location }));
+});
+
+function capturedLocation(): ProjectLocation {
+  return buildAgentCommandMock.mock.calls[0]?.[0] as ProjectLocation;
+}
+
+describe("buildOneShotSpec isolateCwd", () => {
+  const windowsProject: ProjectLocation = { kind: "windows", path: "C:\\Users\\demo\\project" };
+  const wslProject: ProjectLocation = {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/home/demo/project",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+  };
+
+  it("uses the project cwd by default", () => {
+    buildOneShotSpec(windowsProject, "agy", ["-p", "hi"]);
+    expect(capturedLocation()).toEqual(windowsProject);
+  });
+
+  it("redirects a native one-shot to the OS temp dir when isolated", () => {
+    buildOneShotSpec(windowsProject, "agy", ["-p", "hi"], { isolateCwd: true });
+    expect(capturedLocation()).toEqual({ kind: "windows", path: tmpdir() });
+  });
+
+  it("redirects a WSL one-shot to /tmp inside the distro when isolated", () => {
+    buildOneShotSpec(wslProject, "agy", ["-p", "hi"], { isolateCwd: true });
+    // Distro + uncPath are preserved; only the working directory is neutralized.
+    expect(capturedLocation()).toEqual({
+      kind: "wsl",
+      distro: "Ubuntu",
+      linuxPath: "/tmp",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+    });
+  });
+
+  it("does not neutralize the cwd when isolateCwd is false", () => {
+    buildOneShotSpec(wslProject, "agy", ["-p", "hi"], { isolateCwd: false });
+    expect(capturedLocation()).toEqual(wslProject);
+  });
+});

--- a/src/supervisor/oneShotSpawn.ts
+++ b/src/supervisor/oneShotSpawn.ts
@@ -1,13 +1,58 @@
 import { spawn as spawnChild } from "node:child_process";
+import { tmpdir } from "node:os";
+import { spawn as spawnPty } from "node-pty";
+import { stripAnsi } from "@/shared/ansi";
 import type { ProjectLocation } from "@/shared/contracts";
 import { buildAgentCommand, type CommandSpec } from "./agents/base";
+import { ensureNodePtySpawnHelperExecutable } from "./nodePty";
+
+export interface OneShotSpecOptions {
+  /**
+   * Run the one-shot in a throwaway scratch cwd instead of the project cwd.
+   * Some CLIs (e.g. `agy`) key their "last conversation per workspace" cache
+   * on the working directory, so a one-shot launched in the project cwd would
+   * overwrite that entry and get mistaken for the real interactive session by
+   * `discoverSessionRef`. One-shots embed all input in the prompt, so the cwd
+   * is irrelevant to the result.
+   */
+  isolateCwd?: boolean | undefined;
+}
+
+/**
+ * Swap a location's working directory for a platform-appropriate scratch dir,
+ * keeping every other field (distro, kind) intact. WSL must stay a Linux path
+ * inside the distro; native uses the OS temp dir.
+ */
+function isolatedCwdLocation(location: ProjectLocation): ProjectLocation {
+  if (location.kind === "wsl") {
+    return { ...location, linuxPath: "/tmp" };
+  }
+  return { ...location, path: tmpdir() };
+}
 
 export function buildOneShotSpec(
   location: ProjectLocation,
   command: string,
   args: string[],
+  options?: OneShotSpecOptions,
 ): CommandSpec {
-  return buildAgentCommand(location, command, args);
+  const effectiveLocation = options?.isolateCwd ? isolatedCwdLocation(location) : location;
+  return buildAgentCommand(effectiveLocation, command, args);
+}
+
+/**
+ * Resolve the spawn spec and spawn implementation for a `buildOneShotCommand`
+ * result in one place, so every one-shot caller honors the two command flags
+ * identically: `isolateCwd` neutralizes the working directory (see
+ * `OneShotSpecOptions`) and `pty` selects the terminal-backed spawner for CLIs
+ * that only emit their answer when attached to a tty (e.g. `agy -p`).
+ */
+export function prepareOneShot(
+  location: ProjectLocation,
+  cmd: { command: string; args: string[]; isolateCwd?: boolean; pty?: boolean },
+): { spec: CommandSpec; spawn: typeof spawnAgent } {
+  const spec = buildOneShotSpec(location, cmd.command, cmd.args, { isolateCwd: cmd.isolateCwd });
+  return { spec, spawn: cmd.pty ? spawnAgentPty : spawnAgent };
 }
 
 export function spawnAgent(
@@ -63,5 +108,78 @@ export function spawnAgent(
     });
 
     child.stdin.end(input);
+  });
+}
+
+function mergedPtyEnv(env: Record<string, string> | undefined): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries({ ...process.env, ...env })) {
+    if (typeof value === "string") merged[key] = value;
+  }
+  return merged;
+}
+
+export function spawnAgentPty(
+  spec: CommandSpec,
+  input: string,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Aborted"));
+      return;
+    }
+
+    ensureNodePtySpawnHelperExecutable();
+
+    let pty;
+    try {
+      pty = spawnPty(spec.command, spec.args, {
+        cols: 120,
+        rows: 30,
+        ...(spec.cwd ? { cwd: spec.cwd } : {}),
+        env: mergedPtyEnv(spec.env),
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    let output = "";
+    let timedOut = false;
+
+    const onAbort = () => {
+      pty.kill();
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      pty.kill();
+    }, timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+
+    const dataDisposable = pty.onData((data) => {
+      output += data;
+    });
+    const exitDisposable = pty.onExit(({ exitCode }) => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      dataDisposable.dispose();
+      exitDisposable.dispose();
+
+      const text = stripAnsi(output).trim();
+      if (signal?.aborted) {
+        reject(new Error("Aborted"));
+      } else if (timedOut) {
+        reject(new Error("Agent timed out"));
+      } else if (exitCode === 0 && text) {
+        resolve(text);
+      } else {
+        reject(new Error(text || `Agent exited with code ${exitCode}`));
+      }
+    });
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (input) pty.write(input);
   });
 }

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -1,6 +1,6 @@
 import type { ProjectLocation } from "@/shared/contracts";
 import type { AgentAdapter } from "./agents/base";
-import { buildOneShotSpec, spawnAgent } from "./oneShotSpawn";
+import { prepareOneShot } from "./oneShotSpawn";
 
 const PROMPT =
   "Generate a concise title for a coding conversation based on the user's first message below.\n" +
@@ -106,8 +106,8 @@ async function runViaCli(
   if (!cmd) {
     throw new Error(`${adapter.label} does not support one-shot generation`);
   }
-  const spawnSpec = buildOneShotSpec(location, cmd.command, cmd.args);
-  return spawnAgent(spawnSpec, cmd.stdin ?? prompt, TITLE_GEN_TIMEOUT_MS);
+  const { spec, spawn } = prepareOneShot(location, cmd);
+  return spawn(spec, cmd.stdin ?? prompt, TITLE_GEN_TIMEOUT_MS);
 }
 
 function timeoutSignal(timeoutMs: number): AbortSignal | undefined {


### PR DESCRIPTION
**Type:** Bugfix

- Scope Antigravity session discovery to the project cwd so one-shots and other workspaces no longer hijack the active interactive session (including `.db` stores and cwd-aware conversation matching).
- Run Antigravity one-shots (title generation, summarize) in an isolated temp cwd and via PTY so `last_conversations` cache writes and print-mode output do not corrupt or break real sessions.
- Strip OSC ANSI sequences correctly so PTY one-shot output parses cleanly for titles and summaries.
- Register Antigravity’s auto-update manifest URL and parse JSON manifest responses when checking for the latest CLI version.