### PR TITLE
Raise default agent command timeout to 30 seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ review.diff
 .spec-workflow/
 **/worktrees/
 .cursor/
+mcps/
 .antigravitycli/
 .recovery/
 resources/wsl-helpers/watcher.node

--- a/src/supervisor/agents/base.posix-login-shell.test.ts
+++ b/src/supervisor/agents/base.posix-login-shell.test.ts
@@ -203,7 +203,7 @@ describe.skipIf(process.platform === "win32")("POSIX login shell wrappers", () =
       ["auth", "status"],
       expect.objectContaining({
         cwd: "/Users/demo/project",
-        timeout: 10_000,
+        timeout: 30_000,
         windowsHide: true,
       }),
     );

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -503,12 +503,15 @@ export async function readAgentCommandOutput(
   }
   const spec = buildAgentCommand(location, executablePath, args);
   const effectiveCwd = options?.posixCwd ?? spec.cwd;
+  const runOptions = {
+    ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+    ...(spec.env ? { env: spec.env } : {}),
+    ...(options?.timeoutMs ? { timeout: options.timeoutMs } : {}),
+  };
   return readCommandOutputAsync(
     spec.command,
     spec.args,
-    effectiveCwd || spec.env
-      ? { ...(effectiveCwd ? { cwd: effectiveCwd } : {}), ...(spec.env ? { env: spec.env } : {}) }
-      : undefined,
+    Object.keys(runOptions).length > 0 ? runOptions : undefined,
   );
 }
 

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -12,6 +12,9 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+/** Default exec timeout for agent CLI probes and commands without an explicit `timeout`. */
+export const DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS = 30_000;
+
 let cachedWindowsSearchPath: string | undefined | null = null;
 
 function getWindowsEnvValue(name: string): string | undefined {
@@ -775,12 +778,12 @@ export async function resolveExecutablePathAsync(command: string): Promise<strin
 export async function readCommandOutputAsync(
   command: string,
   args: string[],
-  options?: { cwd?: string; env?: Record<string, string> },
+  options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   try {
     const { stdout, stderr } = await execFileAsync(command, args, {
       windowsHide: true,
-      timeout: 10_000,
+      timeout: options?.timeout ?? DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS,
       ...(options?.cwd ? { cwd: options.cwd } : {}),
       ...(options?.env ? { env: { ...process.env, ...options.env } } : {}),
     });
@@ -941,7 +944,7 @@ export async function readWslCommandOutputAsync(
       ],
       {
         windowsHide: true,
-        timeout: 10_000,
+        timeout: DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS,
       },
     );
     return { ok: true, stdout: (stdout ?? "").trim(), stderr: (stderr ?? "").trim() };
@@ -972,7 +975,7 @@ export async function readWslLoginShellCommandOutputAsync(
       ["-d", distro, "--cd", linuxCwd, "--", shellPath, "-l", "-i", "-c", script],
       {
         windowsHide: true,
-        timeout: options?.timeout ?? 10_000,
+        timeout: options?.timeout ?? DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS,
         ...(options?.maxBuffer ? { maxBuffer: options.maxBuffer } : {}),
       },
     );
@@ -999,7 +1002,7 @@ export async function execInWsl(
     ["-d", distro, "--cd", linuxCwd, "--", command, ...args],
     {
       windowsHide: true,
-      timeout: options?.timeout ?? 10_000,
+      timeout: options?.timeout ?? DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS,
       ...(options?.maxBuffer ? { maxBuffer: options.maxBuffer } : {}),
       ...(options?.env ? { env: options.env } : {}),
     },

--- a/src/supervisor/agents/base/readAgentCommandOutput.test.ts
+++ b/src/supervisor/agents/base/readAgentCommandOutput.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+
+const readCommandOutputAsyncMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      command: string,
+      args: string[],
+      options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
+    ) => Promise<{ ok: boolean; stdout: string; stderr: string }>
+  >(),
+);
+
+vi.mock("./processRuntime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./processRuntime")>();
+  return {
+    ...actual,
+    readCommandOutputAsync: readCommandOutputAsyncMock,
+  };
+});
+
+import { readAgentCommandOutput } from "./index";
+
+const WINDOWS_LOCATION: ProjectLocation = {
+  kind: "windows",
+  path: "C:\\repo",
+};
+
+describe("readAgentCommandOutput", () => {
+  beforeEach(() => {
+    readCommandOutputAsyncMock.mockReset();
+    readCommandOutputAsyncMock.mockResolvedValue({ ok: true, stdout: "", stderr: "" });
+  });
+
+  it("forwards timeoutMs to native readCommandOutputAsync", async () => {
+    await readAgentCommandOutput(WINDOWS_LOCATION, "cursor-agent", ["update"], {
+      timeoutMs: 300_000,
+    });
+
+    expect(readCommandOutputAsyncMock).toHaveBeenCalledOnce();
+    expect(readCommandOutputAsyncMock.mock.calls[0]?.[2]?.timeout).toBe(300_000);
+  });
+
+  it("does not set a timeout when timeoutMs is omitted", async () => {
+    await readAgentCommandOutput(WINDOWS_LOCATION, "cursor-agent", ["--version"]);
+
+    expect(readCommandOutputAsyncMock).toHaveBeenCalledOnce();
+    expect(readCommandOutputAsyncMock.mock.calls[0]?.[2]?.timeout).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Type:** Bugfix

- Increase the supervisor’s default exec timeout for agent CLI probes and WSL command paths from 10s to 30s so slow or cold-start commands are less likely to fail spuriously
- Forward `timeoutMs` from `readAgentCommandOutput` into native `readCommandOutputAsync` so callers can override the default when needed
- Centralize the default in `DEFAULT_COMMAND_OUTPUT_TIMEOUT_MS` and align POSIX login-shell test expectations
- Add unit tests for optional vs explicit timeout forwarding on `readAgentCommandOutput`
- Ignore `mcps/` in `.gitignore`