### PR TITLE
Fix Git badge PR icon alignment when diff stats are shown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/icons/
 .tmp/
 tmp/
 .agent/
+mcps/
 lightcode-diff.patch
 review.diff
 .spec-workflow/

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -96,4 +96,34 @@ describe("GitBadge", () => {
 
     expect(screen.queryByRole("button", { name: "Git status for feature/pr" })).toBeNull();
   });
+
+  it("renders diff stats before the PR icon so the icon stays aligned with the timestamp", () => {
+    useGitStore.setState({
+      worktreeStatuses: {
+        "/wt/feature": makeStatus({ totalInsertions: 12, totalDeletions: 3 }),
+      },
+      prData: {
+        "/wt/feature": {
+          number: 1,
+          state: "open",
+          title: "PR",
+          url: "https://github.com/o/r/pull/1",
+          baseBranch: "main",
+          isDraft: false,
+          updatedAt: "2026-06-02T00:00:00.000Z",
+        },
+      },
+    });
+
+    render(<GitBadge projectId="project-1" projectName="feature/pr" worktreePath="/wt/feature" />);
+
+    const badge = screen.getByRole("button", { name: "Git status for feature/pr" });
+    const insertion = screen.getByText("+12");
+    const prIcon = badge.querySelector(".lucide-git-pull-request");
+
+    expect(prIcon).not.toBeNull();
+    expect(
+      insertion.compareDocumentPosition(prIcon!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -96,22 +96,22 @@ export function GitBadge(props: {
       onKeyDown={(e) => handleKeyActivate(e, () => props.onPress?.(), { stopPropagation: true })}
     >
       <span className="flex items-center gap-1 text-[10px] font-medium">
-        {showPrIcon && <GitPullRequest className={`size-3 ${prIconColor}`} />}
-        {showWorktreeFork && (
-          <Tooltip delay={150}>
-            <Tooltip.Trigger tabIndex={-1} role="none">
-              <span className="flex items-center">
-                <GitFork className="size-3" />
-              </span>
-            </Tooltip.Trigger>
-            <Tooltip.Content placement="right">Worktree: {props.projectName}</Tooltip.Content>
-          </Tooltip>
-        )}
         {hasChanges && (
           <span className="flex items-center gap-0.5">
             {totalInsertions > 0 && <span className="text-success">+{totalInsertions}</span>}
             {totalDeletions > 0 && <span className="text-danger">-{totalDeletions}</span>}
           </span>
+        )}
+        {showPrIcon && <GitPullRequest className={`size-3 shrink-0 ${prIconColor}`} />}
+        {showWorktreeFork && (
+          <Tooltip delay={150}>
+            <Tooltip.Trigger tabIndex={-1} role="none">
+              <span className="flex shrink-0 items-center">
+                <GitFork className="size-3" />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content placement="right">Worktree: {props.projectName}</Tooltip.Content>
+          </Tooltip>
         )}
       </span>
     </div>


### PR DESCRIPTION
**Type:** Bugfix

- Reorder sidebar Git badge content so insertion/deletion counts render before the PR icon, keeping the icon aligned with the timestamp when both are visible.
- Add `shrink-0` on the PR and worktree fork icons so flex layout does not compress them when diff stats are present.
- Add a regression test that asserts diff stats precede the PR icon in the DOM when both are shown.
- Ignore `mcps/` in `.gitignore` so local MCP config is not committed.