### PR TITLE
Keep worktree dev terminals open until last thread is done

### DIFF
--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -349,6 +349,57 @@ describe("threadActions", () => {
     expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: "shell:worktree" });
     expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: "shell:worktree-split" });
   });
+
+  it("keeps worktree dev terminals open when marking one of multiple worktree threads done", () => {
+    const worktreePath = "/repo/.worktrees/feature";
+    const project = useAppStore.getState().addProject({
+      kind: "posix",
+      path: "/repo",
+    });
+    const firstThread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "hello",
+      worktreePath,
+    });
+    const secondThread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "hello",
+      worktreePath,
+    });
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: project.id,
+      activeWorktreePath: worktreePath,
+      tabs: [
+        {
+          id: "shell:worktree",
+          projectId: project.id,
+          worktreePath,
+          title: "feature",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      activeTabId: "shell:worktree",
+      tabActivity: { "shell:worktree": true },
+    });
+
+    toggleMarkThreadDone(firstThread.id);
+
+    const termState = useDevTerminalStore.getState();
+    expect(termState.isOpen).toBe(true);
+    expect(termState.activeProjectId).toBe(project.id);
+    expect(termState.activeWorktreePath).toBe(worktreePath);
+    expect(termState.tabs.map((tab) => tab.id)).toEqual(["shell:worktree"]);
+    expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: firstThread.id });
+    expect(bridge.closeThread).not.toHaveBeenCalledWith({ threadId: "shell:worktree" });
+    expect(
+      useAppStore.getState().threads.find((thread) => thread.id === secondThread.id)?.done,
+    ).toBe(false);
+  });
 });
 
 function makeThread(input: Partial<Thread> = {}): Thread {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -219,7 +219,12 @@ export function toggleMarkThreadDone(threadId: string): void {
   } else {
     void unloadStoredThread(threadId, { keepSidePanels: true }).catch(() => undefined);
     const worktreePath = thread.worktreePath;
-    if (worktreePath) {
+    const isLastOpenWorktreeThread =
+      worktreePath !== undefined &&
+      store.threads.every(
+        (t) => t.id === threadId || t.worktreePath !== worktreePath || t.done || t.archived,
+      );
+    if (worktreePath && isLastOpenWorktreeThread) {
       const termStore = useDevTerminalStore.getState();
       const removedTabIds = termStore.removeTabsForWorktree(worktreePath);
       void closeThreads(removedTabIds);

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -1,4 +1,4 @@
-import { GitFork, Play, Plus, Trash2 } from "lucide-react";
+import { CircleCheck, GitFork, Play, Plus, Trash2 } from "lucide-react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import type { Project } from "@/shared/contracts";
 import { ContextMenu } from "@/renderer/components/common";
@@ -21,7 +21,7 @@ import {
 import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
 import { openWorktreeTerminal, runProjectAction } from "@/renderer/actions/terminalActions";
 import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
-import { openNewThreadInWorktree } from "@/renderer/actions/threadActions";
+import { openNewThreadInWorktree, toggleMarkThreadDone } from "@/renderer/actions/threadActions";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useIsWorktreeCollapsed, useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
@@ -49,6 +49,7 @@ export function SidebarWorktreeGroup(props: {
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
   const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
   const groupThreadIds = group.threads.map((t) => t.id);
+  const activeThreads = group.threads.filter((t) => !t.done);
   const isDone = group.threads.every((t) => t.done);
 
   const { ref } = useSortable({
@@ -84,6 +85,12 @@ export function SidebarWorktreeGroup(props: {
             icon: <GitFork className="size-3.5" />,
             items: worktreeGitItems,
           },
+          {
+            id: "mark-all-done",
+            label: "Mark All Done",
+            icon: <CircleCheck className="size-3.5" />,
+            isDisabled: activeThreads.length === 0,
+          },
           ...(project.scripts?.actions?.length
             ? [
                 {
@@ -118,6 +125,11 @@ export function SidebarWorktreeGroup(props: {
           if (key === "git-review") openGitReview(project.id, group.worktreePath);
           if (key === "delete-worktree")
             deleteWorktreeGroup(project.id, group.worktreePath, groupThreadIds);
+          if (key === "mark-all-done") {
+            for (const thread of group.threads) {
+              if (!thread.done) toggleMarkThreadDone(thread.id);
+            }
+          }
           if (key === "git-sync") gitSync(project.id, group.worktreePath);
           if (key === "git-push") gitPush(project.id, group.worktreePath);
           if (key === "git-pull") gitPull(project.id, group.worktreePath);


### PR DESCRIPTION
- **Bugfix:** When marking a worktree thread done, dev terminal tabs for that worktree stay open if other active threads still use the same worktree, instead of tearing down on the first completion.
- **Sidebar:** Add a worktree group context menu action to mark all threads in the group done in one step.
- **Tests:** Cover multi-thread worktrees so completing one thread does not close shared dev terminals or unrelated threads.