### PR TITLE
Fix provider model menu label line height

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -353,11 +353,11 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
             : "flex min-w-0 flex-col items-start justify-center gap-0.5"
         }
       >
-        <span className="max-w-full truncate leading-none">
+        <span className="max-w-full truncate leading-tight">
           {currentLabelParts.name || "Select model"}
         </span>
         {currentSubProvider ? (
-          <span className="max-w-full truncate text-[10px] font-medium leading-none text-muted/70">
+          <span className="max-w-full truncate text-[10px] font-medium leading-tight text-muted/70">
             {currentSubProvider.label}
           </span>
         ) : null}


### PR DESCRIPTION
- **Type:** Bugfix
- Replace `leading-none` with `leading-tight` on the model name and sub-provider labels in `ProviderModelMenu` so truncated text has enough vertical space and reads clearly in the trigger.
- Keeps the existing two-line layout (model name + optional sub-provider) without changing truncation or typography scale.