### PR TITLE
Fix ACP agent icons on thread lists and navigation surfaces

### DIFF
--- a/src/renderer/components/providers/ThreadProviderIcon.tsx
+++ b/src/renderer/components/providers/ThreadProviderIcon.tsx
@@ -1,0 +1,48 @@
+import type { Thread } from "@/shared/contracts";
+import {
+  isDetectingAgentsForLocation,
+  useAgentStatusesStore,
+} from "@/renderer/state/agentStatusesStore";
+import { useProject } from "@/renderer/state/useThread";
+import { useProjectAgentStatuses } from "@/renderer/hooks/uiSelectors";
+import { ProviderIcon } from "./ProviderIcon";
+import { getStatusTone, type StatusTone } from "./statusTone";
+
+/**
+ * Renders a thread's agent icon, resolving ACP-registry icons the same way on
+ * every surface. Built-in providers (Claude, Codex, …) ship a `kind`-keyed icon
+ * in {@link ProviderIcon}'s registry, but ACP-registry agents (e.g. GLM) carry
+ * their icon as a URL on the resolved `AgentStatus`. Passing only `kind` to
+ * `ProviderIcon` makes those agents fall back to the generic letter badge — the
+ * bug seen in the collapsed sidebar, archived list and search results.
+ *
+ * This component is the single source of truth for thread icons: it looks the
+ * agent up in the agent-statuses store, scoped to the thread's project
+ * environment (native vs WSL), and forwards the resolved `icon`/`label`. While
+ * detection is still in flight it forwards `pending` so list rows reserve the
+ * slot instead of flashing the fallback. Reuse it instead of calling
+ * `ProviderIcon` with a bare `kind` from a thread.
+ */
+export function ThreadProviderIcon(props: {
+  thread: Thread;
+  tone?: StatusTone | undefined;
+  className?: string | undefined;
+}) {
+  const { thread } = props;
+  const location = useProject(thread.projectId)?.location;
+  const agents = useProjectAgentStatuses(location);
+  const agent = agents.find((a) => a.kind === thread.agentKind);
+  const pending = useAgentStatusesStore((s) =>
+    location ? isDetectingAgentsForLocation(s, location) : false,
+  );
+  return (
+    <ProviderIcon
+      kind={thread.agentKind}
+      tone={props.tone ?? getStatusTone(thread)}
+      pending={pending}
+      fallbackLabel={agent?.label}
+      {...(agent?.icon ? { icon: agent.icon } : {})}
+      {...(props.className ? { className: props.className } : {})}
+    />
+  );
+}

--- a/src/renderer/components/providers/index.ts
+++ b/src/renderer/components/providers/index.ts
@@ -2,6 +2,7 @@
 export * from "./statusTone";
 export * from "./StatusIcon";
 export * from "./ProviderIcon";
+export * from "./ThreadProviderIcon";
 export * from "./commitGen";
 export * from "./conflictResolver";
 export * from "./titleGen";

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -1,12 +1,10 @@
 import { ArrowRight, FolderOpen, House, Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
-import { getProjectAgentStatuses } from "@/shared/agentStatus";
 import { isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
-import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { openThread } from "@/renderer/actions/threadActions";
-import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
+import { ThreadProviderIcon } from "@/renderer/components/providers";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
 
 export function HomeView() {
@@ -26,12 +24,6 @@ export function HomeView() {
         .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
         .slice(0, 8),
     ),
-  );
-  const { agentStatuses, wslAgentStatuses } = useAgentStatusesStore(
-    useShallow((state) => ({
-      agentStatuses: state.agentStatuses,
-      wslAgentStatuses: state.wslAgentStatuses,
-    })),
   );
   const openDraft = useAppStore((state) => state.openDraft);
 
@@ -85,12 +77,6 @@ export function HomeView() {
                       const project = isHomeProjectId(thread.projectId)
                         ? homeProject
                         : projects.find((p) => p.id === thread.projectId);
-                      const availableAgents = project
-                        ? getProjectAgentStatuses(project.location, agentStatuses, wslAgentStatuses)
-                        : [...agentStatuses, ...wslAgentStatuses];
-                      const threadAgent = availableAgents.find(
-                        (agent) => agent.installed && agent.kind === thread.agentKind,
-                      );
                       return (
                         <button
                           key={thread.id}
@@ -98,13 +84,7 @@ export function HomeView() {
                           onClick={() => openThread(thread.id)}
                           type="button"
                         >
-                          <ProviderIcon
-                            kind={thread.agentKind}
-                            {...(threadAgent?.icon ? { icon: threadAgent.icon } : {})}
-                            fallbackLabel={threadAgent?.label}
-                            tone={getStatusTone(thread)}
-                            className="size-4 shrink-0"
-                          />
+                          <ThreadProviderIcon thread={thread} className="size-4 shrink-0" />
                           <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
                             {thread.title}
                           </p>

--- a/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
@@ -270,7 +270,13 @@ export function ContinueInProviderDialog(props: {
                         id: a.kind,
                         label: a.label,
                         icon: (
-                          <ProviderIcon kind={a.kind} tone="active" className="size-3.5 shrink-0" />
+                          <ProviderIcon
+                            kind={a.kind}
+                            {...(a.icon ? { icon: a.icon } : {})}
+                            fallbackLabel={a.label}
+                            tone="active"
+                            className="size-3.5 shrink-0"
+                          />
                         ),
                       }))}
                       onChange={handleProviderChange}
@@ -278,6 +284,8 @@ export function ContinueInProviderDialog(props: {
                         selectedAgent ? (
                           <ProviderIcon
                             kind={selectedAgent.kind}
+                            {...(selectedAgent.icon ? { icon: selectedAgent.icon } : {})}
+                            fallbackLabel={selectedAgent.label}
                             tone="active"
                             className="size-3.5 shrink-0"
                           />

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -17,7 +17,7 @@ import type { Thread } from "@/shared/contracts";
 import { formatBytes } from "@/shared/formatBytes";
 import { isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { SidebarButton } from "@/renderer/components/common";
-import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
+import { ThreadProviderIcon } from "@/renderer/components/providers";
 import {
   sidebarBodyScrollClass,
   sidebarColumnLayoutClass,
@@ -143,13 +143,7 @@ function HomeTerminalButton(props: { projectId: string; projectName: string }) {
 }
 
 function ThreadIcon(props: { thread: Thread }) {
-  return (
-    <ProviderIcon
-      kind={props.thread.agentKind}
-      tone={getStatusTone(props.thread)}
-      className="size-3.5"
-    />
-  );
+  return <ThreadProviderIcon thread={props.thread} className="size-3.5" />;
 }
 
 function CollapsedThreadRail() {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/renderer/components/common", () => ({
 
 vi.mock("@/renderer/components/providers", () => ({
   ProviderIcon: () => null,
+  ThreadProviderIcon: () => null,
   getStatusTone: () => "default",
 }));
 

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -14,14 +14,10 @@ import {
 import type { Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
-import {
-  isDetectingAgentsForLocation,
-  useAgentStatusesStore,
-} from "@/renderer/state/agentStatusesStore";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useIsDraggingThread, type DragSourceData } from "@/renderer/dnd";
 import { ContextMenu, SidebarButton } from "@/renderer/components/common";
-import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
+import { ThreadProviderIcon, getStatusTone } from "@/renderer/components/providers";
 import { readBridge } from "@/renderer/bridge";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions";
@@ -78,10 +74,6 @@ export function SortableThreadItem(props: {
   const isCurrentThread = useIsCurrentThread(thread.id);
   const currentThreadCount = useCurrentThreadIdsCount();
   const projectAgents = useProjectAgentStatuses(project.location);
-  const threadAgent = projectAgents.find((agent) => agent.kind === thread.agentKind);
-  const isDetectingAgents = useAgentStatusesStore((s) =>
-    isDetectingAgentsForLocation(s, project.location),
-  );
   const worktreeGitItems = useWorktreeGitItems(
     thread.projectId,
     thread.worktreePath ?? "",
@@ -302,16 +294,7 @@ export function SortableThreadItem(props: {
         <SidebarButton
           size="xs"
           statusTone={statusTone}
-          icon={
-            <ProviderIcon
-              kind={thread.agentKind}
-              {...(threadAgent?.icon ? { icon: threadAgent.icon } : {})}
-              fallbackLabel={threadAgent?.label}
-              tone={statusTone}
-              pending={isDetectingAgents}
-              className="size-3.5 shrink-0"
-            />
-          }
+          icon={<ThreadProviderIcon thread={thread} className="size-3.5 shrink-0" />}
           label={
             editingThreadId === thread.id ? (
               <InlineRenameInput

--- a/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ArchivedThreadsSettings.tsx
@@ -1,7 +1,7 @@
 import { Button, Surface, Tooltip } from "@heroui/react";
 import { ArchiveRestore, Trash2 } from "lucide-react";
 import { useAppStore } from "@/renderer/state/appStore";
-import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
+import { ThreadProviderIcon } from "@/renderer/components/providers/ThreadProviderIcon";
 import { SettingsPage } from "./SettingsForm";
 
 export function ArchivedThreadsSettings() {
@@ -21,7 +21,11 @@ export function ArchivedThreadsSettings() {
             const project = projects.find((p) => p.id === thread.projectId);
             return (
               <div key={thread.id} className="flex items-center gap-3 px-4 py-3">
-                <ProviderIcon kind={thread.agentKind} className="size-4 shrink-0 text-muted" />
+                <ThreadProviderIcon
+                  thread={thread}
+                  tone="inactive"
+                  className="size-4 shrink-0 text-muted"
+                />
                 <div className="flex min-w-0 flex-1 flex-col">
                   <p className="truncate text-sm font-medium text-foreground">{thread.title}</p>
                   {project && <p className="truncate text-xs text-muted">{project.name}</p>}

--- a/src/renderer/views/ThreadSearchOverlay/parts/ThreadSearchResultRow.tsx
+++ b/src/renderer/views/ThreadSearchOverlay/parts/ThreadSearchResultRow.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import type { Project, Thread } from "@/shared/contracts";
-import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
+import { ThreadProviderIcon } from "@/renderer/components/providers";
 import { useDraggable } from "@dnd-kit/react";
 import type { DragSourceData } from "@/renderer/dnd";
 import { handleKeyActivate } from "@/renderer/utils/a11y";
@@ -14,7 +14,6 @@ export function ThreadSearchResultRow(props: {
 }) {
   const { thread, project, isSelected, onActivate, onHover } = props;
   const rowRef = useRef<HTMLDivElement>(null);
-  const tone = getStatusTone(thread);
 
   useDraggable({
     id: `thread-search:${thread.id}`,
@@ -43,7 +42,7 @@ export function ThreadSearchResultRow(props: {
       onMouseMove={onHover}
       onKeyDown={(e) => handleKeyActivate(e, onActivate)}
     >
-      <ProviderIcon kind={thread.agentKind} tone={tone} className="size-3.5 shrink-0" />
+      <ThreadProviderIcon thread={thread} className="size-3.5 shrink-0" />
       <span className={`min-w-0 flex-1 truncate ${thread.done ? "opacity-50 line-through" : ""}`}>
         {thread.title}
       </span>


### PR DESCRIPTION
- **Bugfix:** ACP-registry agents (e.g. GLM) were showing generic letter badges in thread lists because surfaces passed only `agentKind` to `ProviderIcon`, which only maps built-in providers by kind.
- Add `ThreadProviderIcon` as the shared thread icon component: it resolves icon URL and label from the project-scoped agent status store (native vs WSL) and forwards a pending state while detection runs.
- Adopt `ThreadProviderIcon` in the sidebar (expanded and collapsed rail), sortable thread items, home recent threads, archived threads settings, and thread search results so icons stay consistent everywhere.
- Update Continue in Provider dialog picker rows to pass resolved ACP icons and labels, not kind alone.
- Extend sidebar unit test mocks for the new component.