### PR TITLE
Dedupe Codex errors and defer generic systemError fallback

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -62,6 +62,15 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
+// A `thread/status/changed → systemError` notification carries no message, so
+// we surface a generic fallback. But Codex often follows it with a specific
+// error (a `turn/completed(failed)` or `thread/error` notification carrying the
+// real reason, e.g. a usage-limit / "remote compact task" failure). Defer the
+// generic fallback briefly so a specific error can preempt it — otherwise the
+// user sees the generic notice *plus* the real error. The delay only postpones
+// an error message; the error status icon updates synchronously.
+const CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS = 250;
+
 function spawnAppServer(command: CommandSpec): ChildProcess {
   return spawn(command.command, command.args, {
     cwd: command.cwd ?? process.cwd(),
@@ -120,6 +129,17 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   // `thread/status/changed` (which Codex emits as `idle` after an aborted
   // turn) must not overwrite the error state. Cleared on the next user turn.
   private errorSticky = false;
+  // Error messages already surfaced for the current turn. Codex can report one
+  // underlying failure (e.g. a usage limit) through several channels — the
+  // turn/start rejection, a `turn/completed(failed)` notification, and a
+  // `thread/error` notification — each carrying the same text. Deduping here
+  // keeps the user from seeing the same error two or three times. Cleared on
+  // the next user turn.
+  private readonly seenErrorMessages = new Set<string>();
+  // Pending deferred generic system-error fallback (see
+  // CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS). Cancelled if a specific error
+  // arrives first, on the next user turn, or on dispose.
+  private pendingSystemErrorFallback: ReturnType<typeof setTimeout> | undefined;
   private mapperState: CodexMapperState | undefined;
   /**
    * Runtime events emitted before the listener was wired. Replayed on
@@ -169,12 +189,41 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
   private emitRuntimeEvents(events: RuntimeEvent[]): void {
     if (events.length === 0) return;
+    const forwarded: RuntimeEvent[] = [];
+    for (const event of events) {
+      if (event.type === "error") {
+        // Collapse duplicate error notifications within a single turn so one
+        // underlying failure does not surface multiple identical toasts.
+        if (this.seenErrorMessages.has(event.message)) continue;
+        this.seenErrorMessages.add(event.message);
+        // A concrete error preempts the deferred generic system-error fallback.
+        this.clearPendingSystemErrorFallback();
+      }
+      forwarded.push(event);
+    }
+    if (forwarded.length === 0) return;
     if (!this.listener?.onRuntimeEvent) {
-      this.bufferedRuntimeEvents.push(...events);
+      this.bufferedRuntimeEvents.push(...forwarded);
       return;
     }
-    for (const event of events) {
+    for (const event of forwarded) {
       this.listener.onRuntimeEvent(event);
+    }
+  }
+
+  private scheduleSystemErrorFallback(message: string): void {
+    this.clearPendingSystemErrorFallback();
+    this.pendingSystemErrorFallback = setTimeout(() => {
+      this.pendingSystemErrorFallback = undefined;
+      if (this.isDisposed) return;
+      this.emitRuntimeEvents([{ type: "error", threadId: this.threadId, message }]);
+    }, CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS);
+  }
+
+  private clearPendingSystemErrorFallback(): void {
+    if (this.pendingSystemErrorFallback !== undefined) {
+      clearTimeout(this.pendingSystemErrorFallback);
+      this.pendingSystemErrorFallback = undefined;
     }
   }
 
@@ -437,8 +486,11 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     segments?: PromptSegment[],
     options?: StartTurnOptions,
   ): Promise<void> {
-    // New user turn clears any sticky error from a previous failed turn.
+    // New user turn clears any sticky error from a previous failed turn, along
+    // with the per-turn error dedupe state and any pending fallback timer.
     this.errorSticky = false;
+    this.seenErrorMessages.clear();
+    this.clearPendingSystemErrorFallback();
     const threadId = await this.waitForRemoteThreadId();
 
     const turnId = `turn-${randomUUID()}`;
@@ -583,6 +635,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     }
     this.isDisposed = true;
 
+    this.clearPendingSystemErrorFallback();
     this.transport.dispose();
 
     this.rejectPendingRequests(new Error("Codex app-server session disposed."));
@@ -700,6 +753,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           // notification or a turn/start rejection (which set `errorSticky`),
           // surface a fallback runtime error event so `ThreadErrorDock`
           // renders something instead of leaving the user with an empty dock.
+          // The fallback is *deferred* (not emitted synchronously) so a
+          // specific error Codex sends moments later — e.g. a usage-limit
+          // "remote compact task" failure — can preempt the generic notice.
           // Set `errorSticky` *after* `emitDerivedUpdate` so the derived
           // `onUpdate` call still fires — `emitDerivedUpdate` short-circuits
           // when `errorSticky` is already true.
@@ -707,16 +763,11 @@ export class CodexStructuredSession implements StructuredSessionHandle {
             nextStatus.type === "systemError" &&
             this.currentThreadStatus.type !== "systemError" &&
             !this.errorSticky;
-          if (shouldFallbackEmit) {
-            const fallbackMessage = extractCodexStatusErrorMessage(params.status);
-            this.emitRuntimeEvents([
-              { type: "error", threadId: this.threadId, message: fallbackMessage },
-            ]);
-          }
           this.currentThreadStatus = nextStatus;
           this.emitDerivedUpdate();
           if (shouldFallbackEmit) {
             this.errorSticky = true;
+            this.scheduleSystemErrorFallback(extractCodexStatusErrorMessage(params.status));
           }
           return;
         }

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -218,6 +218,7 @@ describe("CodexStructuredSession", () => {
     session["bufferedRuntimeEvents"] = [];
     session["isDisposed"] = false;
     session["currentThreadStatus"] = { type: "idle" };
+    session["seenErrorMessages"] = new Set<string>();
     session["request"] = async (
       method: string,
       params: Record<string, unknown>,
@@ -561,6 +562,107 @@ describe("CodexStructuredSession", () => {
       },
     ]);
     expect((structuredSession["inboundRequests"] as Map<string, unknown>).size).toBe(0);
+  });
+
+  function makeNotificationSession(): {
+    onMessage: (message: unknown) => void;
+    runtimeEvents: RuntimeEvent[];
+  } {
+    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const runtimeEvents: RuntimeEvent[] = [];
+    let onMessage: ((message: unknown) => void) | undefined;
+    session["threadId"] = "local-thread";
+    session["remoteThreadId"] = "provider-thread";
+    session["isDisposed"] = false;
+    session["currentThreadStatus"] = { type: "idle" };
+    session["seenErrorMessages"] = new Set<string>();
+    session["bufferedRuntimeEvents"] = [];
+    session["pendingRequests"] = new Map();
+    session["inboundRequests"] = new Map();
+    session["rejectPendingRequests"] = () => {};
+    session["request"] = async () => ({});
+    session["listener"] = {
+      onRuntimeEvent: (event: RuntimeEvent) => runtimeEvents.push(event),
+      onUpdate: () => {},
+    };
+    session["transport"] = {
+      setListener: (next: { onMessage: (message: unknown) => void }) => {
+        onMessage = next.onMessage;
+      },
+      write: () => {},
+    };
+    (session["attachTransportHandlers"] as () => void).call(session);
+    if (!onMessage) throw new Error("transport listener was not attached");
+    return { onMessage, runtimeEvents };
+  }
+
+  it("collapses a single usage-limit failure into one error event", () => {
+    vi.useFakeTimers();
+    try {
+      const { onMessage, runtimeEvents } = makeNotificationSession();
+      const usageLimit =
+        "Error running remote compact task You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits.";
+
+      // Observed ordering: the bare systemError status change lands first, then
+      // Codex reports the real reason via turn/completed(failed) and a
+      // duplicate thread/error notification. The specific message must preempt
+      // the generic system-error fallback, and the duplicate must be dropped.
+      onMessage({
+        jsonrpc: "2.0",
+        method: "thread/status/changed",
+        params: { threadId: "provider-thread", status: { type: "systemError" } },
+      });
+      onMessage({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "provider-thread",
+          turn: { id: "turn-1", status: "failed", error: { message: usageLimit } },
+        },
+      });
+      onMessage({
+        jsonrpc: "2.0",
+        method: "thread/error",
+        params: { message: usageLimit },
+      });
+
+      vi.advanceTimersByTime(1000);
+
+      expect(runtimeEvents.filter((event) => event.type === "error")).toEqual([
+        { type: "error", threadId: "local-thread", message: usageLimit },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still surfaces the generic system-error fallback when no specific error follows", () => {
+    vi.useFakeTimers();
+    try {
+      const { onMessage, runtimeEvents } = makeNotificationSession();
+
+      onMessage({
+        jsonrpc: "2.0",
+        method: "thread/status/changed",
+        params: { threadId: "provider-thread", status: { type: "systemError" } },
+      });
+
+      // The fallback is deferred — nothing is emitted synchronously.
+      expect(runtimeEvents.filter((event) => event.type === "error")).toEqual([]);
+
+      vi.advanceTimersByTime(1000);
+
+      expect(runtimeEvents.filter((event) => event.type === "error")).toEqual([
+        {
+          type: "error",
+          threadId: "local-thread",
+          message:
+            "Codex reported a system error. The session may be out of usage or otherwise unable to continue.",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
**Type:** Bugfix

- Stop showing the same Codex failure multiple times per turn by deduplicating identical error messages across turn rejection, `turn/completed(failed)`, and `thread/error` notifications.
- Defer the generic `systemError` fallback message briefly so a specific error from a later notification can replace it instead of stacking generic and real errors.
- Keep the error status icon in sync immediately; only the fallback message is delayed.
- Add tests for the observed usage-limit failure sequence (`systemError` status, then failed turn, then duplicate `thread/error`).