### PR TITLE
Ignore linked worktree directory churn in project watcher

### DIFF
--- a/src/supervisor/projectWatcher.test.ts
+++ b/src/supervisor/projectWatcher.test.ts
@@ -13,6 +13,7 @@ function makeLocation(linuxPath: string): WslLocation {
 
 describe("ProjectWatcher WSL worktrees", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -124,6 +125,45 @@ describe("ProjectWatcher WSL worktrees", () => {
       }),
     );
     expect(unsubscribe).not.toHaveBeenCalled();
+    await watcher.dispose();
+  });
+
+  it("ignores linked-worktree directory churn from git status", async () => {
+    vi.useFakeTimers();
+    const unsubscribe = vi.fn<() => Promise<void>>(async () => undefined);
+    const watch = vi.fn<WslBridgeClient["watch"]>(async () => ({
+      subscriptionId: "sub",
+      unsubscribe,
+    }));
+    const client = {
+      readFile: vi.fn<WslBridgeClient["readFile"]>(async () => {
+        throw new Error("missing");
+      }),
+      stat: vi.fn<WslBridgeClient["stat"]>(async (_location: WslLocation, paths: string[]) => ({
+        stats: paths.map((path) => ({
+          path,
+          exists: true,
+          isDirectory: path.endsWith("/.git"),
+          isFile: !path.endsWith("/.git"),
+        })),
+      })),
+      watch,
+    } as unknown as WslBridgeClient;
+    const onGitChanged = vi.fn<(projectId: string) => void>();
+    const watcher = new ProjectWatcher({
+      onGitChanged,
+      onTreeChanged: vi.fn<(projectId: string) => void>(),
+    });
+    watcher.setWslClient(client);
+
+    watcher.watch("project-1", makeLocation("/home/demo/work/repo"));
+
+    await vi.waitFor(() => expect(watch).toHaveBeenCalledTimes(1));
+    const onEvent = watch.mock.calls[0]![2];
+    onEvent({ subscriptionId: "sub", scope: "git", paths: ["worktrees/feature"] });
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onGitChanged).not.toHaveBeenCalled();
     await watcher.dispose();
   });
 });

--- a/src/supervisor/projectWatcher.ts
+++ b/src/supervisor/projectWatcher.ts
@@ -68,6 +68,7 @@ function isKnownGitNoisePath(value: string): boolean {
     value === "FETCH_HEAD" ||
     value === "index" ||
     value === "index.lock" ||
+    /^worktrees\/[^/]+$/.test(value) ||
     /^worktrees\/[^/]+\/index$/.test(value) ||
     /^worktrees\/[^/]+\/index\.lock$/.test(value) ||
     /^\.watchman-cookie-/.test(value) ||


### PR DESCRIPTION
- **Bugfix:** Stop `ProjectWatcher` from treating linked-worktree directory events under `.git/worktrees/<name>` as meaningful repo git changes.
- Extend known git noise filtering so top-level `worktrees/<name>` paths are ignored alongside existing worktree index noise.
- Prevents spurious `onGitChanged` callbacks and unnecessary UI or supervisor refresh when worktrees churn on disk.
- Add WSL worktree watch test asserting `worktrees/feature` events do not invoke `onGitChanged`.