### PR TITLE
Show inline git diff when opening modified files from git review

### DIFF
--- a/src/renderer/state/fileEditorStore.ts
+++ b/src/renderer/state/fileEditorStore.ts
@@ -85,6 +85,11 @@ export interface FileEditorBuffer {
   hasBom: boolean;
   isDirty: boolean;
   isLoading: boolean;
+  gitDiff?: FileEditorGitDiffContext;
+}
+
+export interface FileEditorGitDiffContext {
+  diff: string;
 }
 
 export interface FileEditorPendingReveal {
@@ -110,7 +115,11 @@ interface FileEditorStoreState {
     path: string,
     mode?: FileEditorOverlayMode | null,
     preview?: boolean,
-    options?: { lineNumber?: number; markdownPreview?: boolean },
+    options?: {
+      lineNumber?: number;
+      markdownPreview?: boolean;
+      gitDiff?: FileEditorGitDiffContext;
+    },
   ) => Promise<ReadProjectFileResult>;
   consumeReveal: (token: number) => void;
   pinTab: (path: string) => void;
@@ -201,6 +210,14 @@ function buildBuffer(result: ReadProjectFileResult): FileEditorBuffer {
     isDirty: false,
     isLoading: false,
   };
+}
+
+function withGitDiff(
+  buffer: FileEditorBuffer,
+  gitDiff: FileEditorGitDiffContext | undefined,
+): FileEditorBuffer {
+  const { gitDiff: _gitDiff, ...rest } = buffer;
+  return gitDiff ? { ...rest, gitDiff } : rest;
 }
 
 /**
@@ -344,6 +361,10 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
           activePath: openPath,
           markdownPreviewPath,
           ...(reveal ? { pendingReveal: reveal } : {}),
+          buffers: {
+            ...changes.buffers,
+            [openPath]: withGitDiff(existing, options?.gitDiff),
+          },
         };
       });
       const cachedResult = {
@@ -370,17 +391,20 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
         ...(reveal ? { pendingReveal: reveal } : {}),
         buffers: {
           ...changes.buffers,
-          [openPath]: {
-            path: openPath,
-            status: "ready",
-            modifiedAtMs: 0,
-            content: "",
-            savedContent: "",
-            lineEnding: "lf",
-            hasBom: false,
-            isDirty: false,
-            isLoading: true,
-          },
+          [openPath]: withGitDiff(
+            {
+              path: openPath,
+              status: "ready",
+              modifiedAtMs: 0,
+              content: "",
+              savedContent: "",
+              lineEnding: "lf",
+              hasBom: false,
+              isDirty: false,
+              isLoading: true,
+            },
+            options?.gitDiff,
+          ),
         },
       };
     });
@@ -400,7 +424,7 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
       set((state) => ({
         buffers: {
           ...state.buffers,
-          [openPath]: buildBuffer(result),
+          [openPath]: withGitDiff(buildBuffer(result), options?.gitDiff),
         },
       }));
       captureProductEvent("file.opened", {
@@ -660,7 +684,7 @@ export const useFileEditorStore = create<FileEditorStoreState>((set, get) => ({
           continue;
         }
 
-        nextBuffers[path] = buildBuffer(result);
+        nextBuffers[path] = withGitDiff(buildBuffer(result), current.gitDiff);
         changed = true;
       }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1401,6 +1401,51 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   background-color: var(--content-background) !important;
 }
 
+.lc-git-add-line {
+  background-color: rgba(64, 200, 174, 0.12);
+}
+
+.lc-git-add-rail {
+  background-color: rgb(64, 200, 174);
+  width: 3px !important;
+  margin-left: 2px;
+}
+
+.lc-git-delete-rail {
+  background-color: rgb(239, 68, 68);
+  width: 3px !important;
+  margin-left: 2px;
+}
+
+.lc-git-delete-zone {
+  height: 100%;
+  overflow: hidden;
+  background-color: rgba(239, 68, 68, 0.18);
+  color: #fca5a5;
+  font-family: var(--monaco-monospace-font, "Cascadia Code", Consolas, monospace);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.lc-git-delete-zone-line {
+  display: flex;
+  min-width: max-content;
+  white-space: pre;
+}
+
+.lc-git-delete-zone-marker {
+  width: 1.5ch;
+  flex: 0 0 auto;
+  color: #ef4444;
+}
+
+.lc-git-delete-zone-margin {
+  height: 100%;
+  background-color: rgb(239, 68, 68);
+  width: 3px !important;
+  margin-left: 2px;
+}
+
 .lightcode-terminal-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) var(--lightcode-terminal-scrollbar-width);

--- a/src/renderer/utils/gitHelpers.ts
+++ b/src/renderer/utils/gitHelpers.ts
@@ -8,6 +8,15 @@ import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import type { FileEditorRootContext } from "@/renderer/state/fileEditorStore";
 
+interface GitDiffEditorRequest {
+  staged: boolean;
+  status: string;
+}
+
+type OpenFileInEditorOptions =
+  | number
+  | { lineNumber?: number; markdownPreview?: boolean; gitDiff?: GitDiffEditorRequest };
+
 export const GIT_FETCH_PRIORITY_INTERVAL_MS = 180_000;
 export const GIT_FETCH_BACKGROUND_INTERVAL_MS = 720_000;
 export const STALE_THREAD_SWEEP_INTERVAL_MS = 5 * 60_000;
@@ -70,12 +79,16 @@ export function compareFilesByDirThenName(a: { path: string }, b: { path: string
   return aName.localeCompare(bName, undefined, { sensitivity: "base" });
 }
 
+export function shouldOpenGitDiffEditor(status: string): boolean {
+  return status === "M";
+}
+
 export async function openFileInEditor(
   project: Project,
   worktreePath: string | undefined,
   worktreeBranch: string | undefined,
   path: string,
-  options?: number | { lineNumber?: number; markdownPreview?: boolean },
+  options?: OpenFileInEditorOptions,
 ): Promise<void> {
   const fileEditor = useFileEditorStore.getState();
   const targetContext = buildFileEditorContext(project, worktreePath, worktreeBranch);
@@ -86,13 +99,29 @@ export async function openFileInEditor(
   if (!isSameContext) {
     fileEditor.setRootContext(targetContext);
   }
+  const openOptions = typeof options === "number" ? { lineNumber: options } : options;
+  let gitDiff: { diff: string } | undefined;
+  if (openOptions?.gitDiff && shouldOpenGitDiffEditor(openOptions.gitDiff.status)) {
+    try {
+      const result = await readBridge().getGitDiff({
+        projectLocation: targetContext.projectLocation,
+        filePath: path,
+        staged: openOptions.gitDiff.staged,
+      });
+      gitDiff = { diff: result.diff };
+    } catch (error) {
+      captureRendererException(error, { featureArea: "git" });
+    }
+  }
+  const editorOptions = {
+    ...(openOptions?.lineNumber !== undefined ? { lineNumber: openOptions.lineNumber } : {}),
+    ...(openOptions?.markdownPreview !== undefined
+      ? { markdownPreview: openOptions.markdownPreview }
+      : {}),
+    ...(gitDiff ? { gitDiff } : {}),
+  };
   try {
-    await fileEditor.openFile(
-      path,
-      "modal",
-      false,
-      typeof options === "number" ? { lineNumber: options } : options,
-    );
+    await fileEditor.openFile(path, "modal", false, editorOptions);
   } catch (error) {
     captureRendererException(error, { featureArea: "file-editor" });
     toast.danger(error instanceof Error ? error.message : String(error));

--- a/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/FileEditorPane.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/FileEditorPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { toast } from "@heroui/react";
 import { MarkdownPreview } from "../MarkdownPreview";
-import { Editor, type BeforeMount, type OnMount, type Monaco } from "@monaco-editor/react";
+import { Editor, type BeforeMount, type Monaco, type OnMount } from "@monaco-editor/react";
 import type { editor as MonacoEditor } from "monaco-editor";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
@@ -20,8 +20,31 @@ import { SortableTab } from "./parts/SortableTab";
 import { EditorToolbar } from "./parts/EditorToolbar";
 import { useLspSync } from "./parts/useLspSync";
 import { useMergeConflictContribution } from "./parts/mergeConflict/useMergeConflictContribution";
+import { useGitDiffContribution } from "./parts/gitDiff/useGitDiffContribution";
 
 export { getLanguageFromPath } from "./parts/langMap";
+
+const EDITOR_OPTIONS: MonacoEditor.IStandaloneEditorConstructionOptions = {
+  fontSize: 13,
+  lineHeight: 20,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  wordWrap: "on",
+  automaticLayout: true,
+  padding: { top: 4, bottom: 4 },
+  renderLineHighlightOnlyWhenFocus: true,
+  overviewRulerLanes: 0,
+  hideCursorInOverviewRuler: true,
+  overviewRulerBorder: false,
+  scrollbar: {
+    verticalScrollbarSize: 10,
+    horizontalScrollbarSize: 10,
+    verticalSliderSize: 8,
+    horizontalSliderSize: 8,
+  },
+  contextmenu: true,
+  tabSize: 2,
+};
 
 export function FileEditorPane(props: {
   showTabs: boolean;
@@ -224,13 +247,23 @@ function EditorBody(props: {
   const { activePath, projectLocation, bufferStatus, monacoTheme, showPreview, isMarkdown } = props;
   const content = useActiveBufferContent();
   const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
-  const [editorInstance, setEditorInstance] = useState<MonacoEditor.IStandaloneCodeEditor | null>(
-    null,
-  );
-  const [monacoInstance, setMonacoInstance] = useState<Monaco | null>(null);
+  const [editorState, setEditorState] = useState<{
+    path: string;
+    editor: MonacoEditor.IStandaloneCodeEditor;
+    monaco: Monaco;
+  } | null>(null);
+  const editorInstance = editorState?.path === activePath ? editorState.editor : null;
+  const monacoInstance = editorState?.path === activePath ? editorState.monaco : null;
   const pendingReveal = useFileEditorStore((state) => state.pendingReveal);
+  const gitDiff = useFileEditorStore((state) => {
+    const path = state.activePath;
+    if (!path) return null;
+    const buffer = state.buffers[path];
+    return buffer?.status === "ready" ? (buffer.gitDiff ?? null) : null;
+  });
 
   useMergeConflictContribution({ editor: editorInstance, monaco: monacoInstance });
+  useGitDiffContribution({ editor: editorInstance, gitDiff, bufferStatus });
 
   useEffect(() => {
     if (!pendingReveal || !editorInstance) return;
@@ -247,17 +280,22 @@ function EditorBody(props: {
     defineAppThemes(monaco);
   };
 
-  const handleEditorMount: OnMount = (editor, monaco) => {
-    editorRef.current = editor;
-    props.onMonacoReady(monaco);
-    setEditorInstance(editor);
-    setMonacoInstance(monaco);
+  function registerSaveCommand(editor: MonacoEditor.IStandaloneCodeEditor, monaco: Monaco) {
     // eslint-disable-next-line no-bitwise -- Monaco uses bitmask key combos
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
       const path = useFileEditorStore.getState().activePath;
       if (path) props.onSave(path);
     });
+  }
+
+  const handleEditorMount: OnMount = (editor, monaco) => {
+    editorRef.current = editor;
+    props.onMonacoReady(monaco);
+    setEditorState({ path: activePath, editor, monaco });
+    registerSaveCommand(editor, monaco);
   };
+
+  const modelPath = projectLocation ? createLspFileUri(projectLocation, activePath) : activePath;
 
   return (
     <div className="min-h-0 flex-1 overflow-hidden">
@@ -265,7 +303,7 @@ function EditorBody(props: {
         <MarkdownPreview content={content ?? ""} />
       ) : bufferStatus === "ready" ? (
         <Editor
-          path={projectLocation ? createLspFileUri(projectLocation, activePath) : activePath}
+          path={modelPath}
           language={getLanguageFromPath(activePath)}
           theme={monacoTheme}
           value={content ?? ""}
@@ -274,27 +312,7 @@ function EditorBody(props: {
           }}
           beforeMount={handleBeforeMount}
           onMount={handleEditorMount}
-          options={{
-            fontSize: 13,
-            lineHeight: 20,
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-            wordWrap: "on",
-            automaticLayout: true,
-            padding: { top: 4, bottom: 4 },
-            renderLineHighlightOnlyWhenFocus: true,
-            overviewRulerLanes: 0,
-            hideCursorInOverviewRuler: true,
-            overviewRulerBorder: false,
-            scrollbar: {
-              verticalScrollbarSize: 10,
-              horizontalScrollbarSize: 10,
-              verticalSliderSize: 8,
-              horizontalSliderSize: 8,
-            },
-            contextmenu: true,
-            tabSize: 2,
-          }}
+          options={EDITOR_OPTIONS}
           loading={
             <div className="flex h-full items-center justify-center text-sm text-muted">
               Loading editor…

--- a/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/gitDiff/useGitDiffContribution.ts
+++ b/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/gitDiff/useGitDiffContribution.ts
@@ -1,0 +1,301 @@
+import { useEffect } from "react";
+import type { editor as MonacoEditor } from "monaco-editor";
+import { type DiffOp, diffLineOps } from "@/shared/lineUnifiedDiff";
+import type { FileEditorGitDiffContext } from "@/renderer/state/fileEditorStore";
+
+/**
+ * Renders git-diff gutter rails plus deleted-line view zones in the Monaco editor and keeps
+ * them live as the user types. Mirrors `useMergeConflictContribution`: the heavy diff logic
+ * lives here rather than in the view, and content-change recomputes are coalesced per frame.
+ */
+export function useGitDiffContribution(args: {
+  editor: MonacoEditor.IStandaloneCodeEditor | null;
+  gitDiff: FileEditorGitDiffContext | null;
+  bufferStatus: string;
+}) {
+  const { editor, gitDiff, bufferStatus } = args;
+
+  useEffect(() => {
+    if (!gitDiff || !editor || bufferStatus !== "ready") return;
+    const fallbackDecorations = buildGitDiffDecorations(gitDiff.diff);
+    const baseline = buildGitDiffBaseline(gitDiff.diff, editor.getValue());
+    const decorations = editor.createDecorationsCollection();
+    const zoneIds: string[] = [];
+
+    const render = () => {
+      const diffDecorations = baseline
+        ? buildLiveGitDiffDecorations(baseline, editor.getValue(), fallbackDecorations)
+        : fallbackDecorations;
+      decorations.set(diffDecorations.decorations);
+      replaceGitDiffZones(editor, zoneIds, diffDecorations.deletedZones);
+    };
+
+    let frame: number | null = null;
+    const schedule = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        render();
+      });
+    };
+
+    render();
+    const contentListener = editor.onDidChangeModelContent(schedule);
+
+    return () => {
+      contentListener.dispose();
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      replaceGitDiffZones(editor, zoneIds, []);
+      decorations.clear();
+    };
+  }, [gitDiff, editor, bufferStatus]);
+}
+
+interface GitDiffEditorDecorations {
+  decorations: MonacoEditor.IModelDeltaDecoration[];
+  deletedZones: Array<{ afterLineNumber: number; lines: string[] }>;
+}
+
+/** LCS DP allocates `(n+1)*(m+1)` cells; beyond this we fall back to the static diff parse. */
+const MAX_GIT_DIFF_DECORATION_CELLS = 4_000_000;
+const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+function buildGitDiffBaseline(diff: string, currentText: string): string | null {
+  const currentLines = splitDiffTextLines(currentText);
+  const baselineLines: string[] = [];
+  let currentIndex = 0;
+  let foundHunk = false;
+
+  for (const hunk of parseGitDiffHunks(diff)) {
+    foundHunk = true;
+    const hunkCurrentIndex = Math.max(0, hunk.newStart - 1);
+    if (hunkCurrentIndex < currentIndex || hunkCurrentIndex > currentLines.length) return null;
+
+    baselineLines.push(...currentLines.slice(currentIndex, hunkCurrentIndex));
+    currentIndex = hunkCurrentIndex;
+
+    for (const rawLine of hunk.lines) {
+      if (rawLine.startsWith(" ")) {
+        const expectedLine = rawLine.slice(1);
+        if (currentLines[currentIndex] !== expectedLine) return null;
+        baselineLines.push(expectedLine);
+        currentIndex += 1;
+        continue;
+      }
+      if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
+        if (currentLines[currentIndex] !== rawLine.slice(1)) return null;
+        currentIndex += 1;
+        continue;
+      }
+      if (rawLine.startsWith("-") && !rawLine.startsWith("---")) {
+        baselineLines.push(rawLine.slice(1));
+      }
+    }
+  }
+
+  if (!foundHunk || currentIndex > currentLines.length) return null;
+  baselineLines.push(...currentLines.slice(currentIndex));
+  return baselineLines.join("\n");
+}
+
+function buildLiveGitDiffDecorations(
+  baseline: string,
+  currentText: string,
+  fallbackDecorations: GitDiffEditorDecorations,
+): GitDiffEditorDecorations {
+  const ops = diffBaselineOps(baseline, currentText);
+  if (!ops) return fallbackDecorations;
+  return buildGitDiffDecorationsFromOps(ops);
+}
+
+/**
+ * Diff the reconstructed baseline against the live editor text, returning `null` (so callers fall
+ * back to the static diff) when the file is too large for the LCS DP. Delegates to the shared
+ * `diffLineOps`; baseline is already `\n`-joined, so only the current text needs CRLF normalizing.
+ */
+function diffBaselineOps(baseline: string, currentText: string): DiffOp[] | null {
+  const normalizedCurrent = currentText.replace(/\r\n/g, "\n");
+  const oldLineCount = splitDiffTextLines(baseline).length;
+  const newLineCount = splitDiffTextLines(normalizedCurrent).length;
+  if ((oldLineCount + 1) * (newLineCount + 1) > MAX_GIT_DIFF_DECORATION_CELLS) return null;
+  return diffLineOps(baseline, normalizedCurrent);
+}
+
+function parseGitDiffHunks(diff: string): Array<{ newStart: number; lines: string[] }> {
+  const hunks: Array<{ newStart: number; lines: string[] }> = [];
+  let currentHunk: { newStart: number; lines: string[] } | null = null;
+
+  for (const rawLine of diff.split(/\r?\n/)) {
+    const hunk = HUNK_HEADER.exec(rawLine);
+    if (hunk) {
+      currentHunk = { newStart: Number(hunk[1] ?? "1"), lines: [] };
+      hunks.push(currentHunk);
+      continue;
+    }
+    if (!currentHunk) continue;
+    currentHunk.lines.push(rawLine);
+  }
+
+  return hunks;
+}
+
+/** Accumulates added/deleted line decorations and groups runs of deleted lines into view zones. */
+function createDecorationCollector() {
+  const decorations: MonacoEditor.IModelDeltaDecoration[] = [];
+  const deletedZones: GitDiffEditorDecorations["deletedZones"] = [];
+  let deletedLines: string[] = [];
+  let deletedAfterLineNumber = 0;
+
+  const flushDeleted = () => {
+    if (deletedLines.length === 0) return;
+    deletedZones.push({ afterLineNumber: deletedAfterLineNumber, lines: deletedLines });
+    deletedLines = [];
+  };
+
+  return {
+    unchanged() {
+      flushDeleted();
+    },
+    added(newLine: number) {
+      flushDeleted();
+      decorations.push(createAddedLineDecoration(newLine));
+    },
+    deleted(newLine: number, text: string) {
+      if (deletedLines.length === 0) deletedAfterLineNumber = Math.max(0, newLine - 1);
+      deletedLines.push(text);
+      decorations.push(createDeletedLineDecoration(Math.max(1, newLine)));
+    },
+    finish(): GitDiffEditorDecorations {
+      flushDeleted();
+      return { decorations, deletedZones };
+    },
+  };
+}
+
+function buildGitDiffDecorationsFromOps(ops: DiffOp[]): GitDiffEditorDecorations {
+  const collector = createDecorationCollector();
+  let newLine = 1;
+  for (const op of ops) {
+    if (op.kind === "equal") {
+      collector.unchanged();
+      newLine += 1;
+    } else if (op.kind === "insert") {
+      collector.added(newLine);
+      newLine += 1;
+    } else {
+      collector.deleted(newLine, op.text);
+    }
+  }
+  return collector.finish();
+}
+
+function buildGitDiffDecorations(diff: string): GitDiffEditorDecorations {
+  const collector = createDecorationCollector();
+  let newLine: number | null = null;
+
+  for (const rawLine of diff.split(/\r?\n/)) {
+    const hunk = HUNK_HEADER.exec(rawLine);
+    if (hunk) {
+      collector.unchanged();
+      newLine = Number(hunk[1] ?? "1");
+      continue;
+    }
+    if (newLine === null) continue;
+    if (rawLine.startsWith(" ")) {
+      collector.unchanged();
+      newLine += 1;
+      continue;
+    }
+    if (rawLine.startsWith("+") && !rawLine.startsWith("+++")) {
+      collector.added(newLine);
+      newLine += 1;
+      continue;
+    }
+    if (rawLine.startsWith("-") && !rawLine.startsWith("---")) {
+      collector.deleted(newLine, rawLine.slice(1));
+    }
+  }
+  return collector.finish();
+}
+
+function createAddedLineDecoration(lineNumber: number): MonacoEditor.IModelDeltaDecoration {
+  return {
+    range: { startLineNumber: lineNumber, startColumn: 1, endLineNumber: lineNumber, endColumn: 1 },
+    options: {
+      isWholeLine: true,
+      className: "lc-git-add-line",
+      linesDecorationsClassName: "lc-git-add-rail",
+      stickiness: 1,
+    },
+  };
+}
+
+function createDeletedLineDecoration(lineNumber: number): MonacoEditor.IModelDeltaDecoration {
+  return {
+    range: {
+      startLineNumber: lineNumber,
+      startColumn: 1,
+      endLineNumber: lineNumber,
+      endColumn: 1,
+    },
+    options: {
+      isWholeLine: true,
+      linesDecorationsClassName: "lc-git-delete-rail",
+      stickiness: 1,
+    },
+  };
+}
+
+function replaceGitDiffZones(
+  editor: MonacoEditor.IStandaloneCodeEditor,
+  zoneIds: string[],
+  deletedZones: GitDiffEditorDecorations["deletedZones"],
+) {
+  try {
+    editor.changeViewZones((accessor) => {
+      for (const id of zoneIds) accessor.removeZone(id);
+      zoneIds.length = 0;
+      for (const zone of deletedZones) {
+        zoneIds.push(
+          accessor.addZone({
+            afterLineNumber: zone.afterLineNumber,
+            heightInLines: zone.lines.length,
+            domNode: createDeletedLinesNode(zone.lines),
+            marginDomNode: createDeletedLinesMarginNode(),
+            suppressMouseDown: true,
+          }),
+        );
+      }
+    });
+  } catch {}
+}
+
+function splitDiffTextLines(text: string): string[] {
+  if (text.length === 0) return [];
+  const normalized = text.replace(/\r\n/g, "\n");
+  const withoutTrailingNewline = normalized.endsWith("\n") ? normalized.slice(0, -1) : normalized;
+  return withoutTrailingNewline.split("\n");
+}
+
+function createDeletedLinesNode(lines: string[]): HTMLElement {
+  const node = document.createElement("div");
+  node.className = "lc-git-delete-zone";
+  for (const line of lines) {
+    const row = document.createElement("div");
+    row.className = "lc-git-delete-zone-line";
+    const marker = document.createElement("span");
+    marker.className = "lc-git-delete-zone-marker";
+    marker.textContent = "-";
+    const content = document.createElement("span");
+    content.textContent = line.length > 0 ? line : " ";
+    row.append(marker, content);
+    node.append(row);
+  }
+  return node;
+}
+
+function createDeletedLinesMarginNode(): HTMLElement {
+  const node = document.createElement("div");
+  node.className = "lc-git-delete-zone-margin";
+  return node;
+}

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
@@ -80,7 +80,10 @@ export function FileRow(props: {
   }
 
   function handleOpenInEditor() {
-    void openFileInEditor(project, worktreePath, worktreeBranch, path);
+    if (!file) return;
+    void openFileInEditor(project, worktreePath, worktreeBranch, path, {
+      gitDiff: { staged: file.staged, status: file.status },
+    });
   }
 
   return (

--- a/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
@@ -196,7 +196,9 @@ export function StackedFileCard(props: {
   }
 
   function handleOpenInEditor() {
-    void openFileInEditor(project, worktreePath, worktreeBranch, file.path);
+    void openFileInEditor(project, worktreePath, worktreeBranch, file.path, {
+      gitDiff: { staged: file.staged, status: file.status },
+    });
   }
 
   const isNewFile = file.deletions === 0 && file.status !== "M" && file.status !== "D";

--- a/src/shared/lineUnifiedDiff.ts
+++ b/src/shared/lineUnifiedDiff.ts
@@ -3,7 +3,7 @@ export interface LineChangeStats {
   removed: number;
 }
 
-type DiffOp =
+export type DiffOp =
   | { kind: "equal"; text: string }
   | { kind: "delete"; text: string }
   | { kind: "insert"; text: string };
@@ -59,7 +59,7 @@ export function buildLineUnifiedDiff(path: string, oldText: string, newText: str
   ].join("\n");
 }
 
-function diffLineOps(oldText: string, newText: string): DiffOp[] {
+export function diffLineOps(oldText: string, newText: string): DiffOp[] {
   if (oldText === newText) {
     return splitLines(oldText).map((text) => ({ kind: "equal", text }));
   }


### PR DESCRIPTION
- Open modified files from Git Review with an inline diff in the file editor so you can edit with added/removed context visible in place
- Fetch staged/unstaged diff via the editor open path and attach it to file editor buffers for the active tab
- Render gutter highlights and deleted-line zones in Monaco, with live updates as you type (shared line diff utilities)
- Wire Git Review sidebar and stacked diff “open in editor” actions to request diff context for modified (`M`) files only