### PR TITLE
Remount git review panel when worktree context changes

### DIFF
--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -89,6 +89,7 @@ export function AppOverlays() {
             }
           >
             <GitReviewOverlay
+              key={`${gitReviewContext.projectId}:${gitReviewContext.worktreePath ?? ""}`}
               project={gitReviewProject}
               {...(gitReviewContext.worktreePath
                 ? {

--- a/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { Project } from "@/shared/contracts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "@/renderer/state/appStore";
+import { GitReviewPanelContent } from "./GitReviewPanelContent";
+
+vi.mock("@/renderer/components/common", () => ({
+  PixelLoader: () => <span>loading</span>,
+}));
+
+vi.mock("@/renderer/views/GitReviewOverlay/parts/GitReviewPanel", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    GitReviewPanel: (props: { statusKey?: string }) => {
+      const [value, setValue] = React.useState("");
+      return (
+        <div>
+          <div data-testid="status-key">{props.statusKey ?? "main"}</div>
+          <input
+            aria-label="Commit message"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        </div>
+      );
+    },
+  };
+});
+
+describe("GitReviewPanelContent", () => {
+  const project: Project = {
+    id: "project-1",
+    name: "Lightcode",
+    createdAt: new Date().toISOString(),
+    location: { kind: "windows", path: "C:\\repo" },
+  };
+
+  beforeEach(() => {
+    useAppStore.setState({ projects: [project], threads: [] });
+  });
+
+  it("remounts git review state when switching worktrees", async () => {
+    const { rerender } = render(
+      <GitReviewPanelContent
+        gitPanelContext={{ projectId: project.id, worktreePath: "C:\\repo-a" }}
+        onClose={() => undefined}
+        onExpandToOverlay={() => undefined}
+      />,
+    );
+
+    const input = await screen.findByLabelText("Commit message");
+    fireEvent.change(input, { target: { value: "commit from first worktree" } });
+    expect(input).toHaveValue("commit from first worktree");
+
+    rerender(
+      <GitReviewPanelContent
+        gitPanelContext={{ projectId: project.id, worktreePath: "C:\\repo-b" }}
+        onClose={() => undefined}
+        onExpandToOverlay={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByTestId("status-key")).toHaveTextContent("C:\\repo-b");
+    expect(screen.getByLabelText("Commit message")).toHaveValue("");
+  });
+});

--- a/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.tsx
@@ -28,6 +28,8 @@ export function GitReviewPanelContent(props: {
     return undefined;
   }
 
+  const gitReviewKey = `${gitPanelContext.projectId}:${gitPanelContext.worktreePath ?? ""}`;
+
   return (
     <Suspense
       fallback={
@@ -37,6 +39,7 @@ export function GitReviewPanelContent(props: {
       }
     >
       <GitReviewPanel
+        key={gitReviewKey}
         project={project}
         {...(gitPanelContext.worktreePath
           ? {


### PR DESCRIPTION
**Type:** Bugfix

- Remount the git review panel when project or worktree context changes so commit messages and in-panel state do not leak across worktrees
- Apply the same remount key to the right-panel git review surface and the expanded git review overlay
- Add a regression test that switching worktrees clears draft commit text and updates the active worktree status key