### PR TITLE
Fix Claude session usage, Grok cookie validation, and Win shims

### DIFF
--- a/packages/agents-usage/src/collectors/claude.test.ts
+++ b/packages/agents-usage/src/collectors/claude.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./claude";
 
 const FIXTURE = {
-  five_hour: { utilization: 0.57, resets_at: "2026-05-29T12:00:00Z" },
+  five_hour: { utilization: 1, resets_at: "2026-05-29T12:00:00Z" },
   seven_day: { utilization: 0.22, resets_at: "2026-06-01T00:00:00Z" },
   seven_day_opus: { utilization: 0.1, resets_at: "2026-06-01T00:00:00Z" },
   extra_usage: {
@@ -30,11 +30,11 @@ describe("formatClaudePlan", () => {
 });
 
 describe("parseClaudeUsage", () => {
-  it("maps windows and normalizes 0-1 utilization to 0-100", () => {
+  it("maps windows and normalizes mixed Claude utilization units", () => {
     const snap = parseClaudeUsage(FIXTURE, FAKE_NOW_MS, { plan: "Claude Pro Subscription" });
     expect(snap.status).toBe("ok");
     const session = snap.windows.find((w) => w.id === "session-5h");
-    expect(session?.usedPercent).toBe(57);
+    expect(session?.usedPercent).toBe(1);
     expect(session?.resetsAt).toBe(Date.parse("2026-05-29T12:00:00Z"));
     expect(snap.windows.find((w) => w.id === "weekly")?.usedPercent).toBe(22);
     expect(snap.windows.find((w) => w.id === "weekly-opus")?.usedPercent).toBe(10);
@@ -54,6 +54,11 @@ describe("parseClaudeUsage", () => {
   it("omits windows the API does not report", () => {
     const snap = parseClaudeUsage({ five_hour: { utilization: 0.1 } }, FAKE_NOW_MS);
     expect(snap.windows.map((w) => w.id)).toEqual(["session-5h"]);
+  });
+
+  it("treats session utilization as a direct percentage", () => {
+    const snap = parseClaudeUsage({ five_hour: { utilization: 1 } }, FAKE_NOW_MS);
+    expect(snap.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(1);
   });
 });
 

--- a/packages/agents-usage/src/collectors/claude.ts
+++ b/packages/agents-usage/src/collectors/claude.ts
@@ -52,8 +52,9 @@ function windowFrom(
   id: UsageWindowId,
   label: string,
   raw: ClaudeWindowRaw | undefined,
+  normalize: (value: number | undefined) => number | undefined = normalizePercent,
 ): UsageWindow | undefined {
-  const usedPercent = normalizePercent(raw?.utilization);
+  const usedPercent = normalize(raw?.utilization);
   if (usedPercent === undefined) return undefined;
   const resetsAt = toEpochMs(raw?.resets_at);
   return {
@@ -65,6 +66,11 @@ function windowFrom(
   };
 }
 
+function normalizeClaudeSessionPercent(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return undefined;
+  return Math.min(100, Math.max(0, Math.round(value * 10) / 10));
+}
+
 /** Pure: map a parsed `/api/oauth/usage` body to a snapshot. */
 export function parseClaudeUsage(
   body: unknown,
@@ -74,7 +80,7 @@ export function parseClaudeUsage(
   const data = (body ?? {}) as ClaudeUsageResponse;
   const windows: UsageWindow[] = [];
   for (const w of [
-    windowFrom("session-5h", "Session (5h)", data.five_hour),
+    windowFrom("session-5h", "Session (5h)", data.five_hour, normalizeClaudeSessionPercent),
     windowFrom("weekly", "Weekly", data.seven_day),
     windowFrom("weekly-opus", "Weekly (Opus)", data.seven_day_opus),
     windowFrom("weekly-sonnet", "Weekly (Sonnet)", data.seven_day_sonnet),

--- a/packages/agents-usage/src/collectors/grok.test.ts
+++ b/packages/agents-usage/src/collectors/grok.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { createFakeHost } from "../testHost";
-import { collectGrok, parseGrokUsage } from "./grok";
+import { collectGrok, isGrokSessionLive, parseGrokUsage } from "./grok";
 import { GROK_GRPC_ENDPOINT } from "./grokGrpc";
 
 const NOW = 1_717_000_000_000;
+const LIVE_GRPC_MESSAGE_B64 =
+  "CkoKBAignAESAwjFJhoAIgYIgNrPzwYqBgiAl/PQBjINCgUI6g8QBBIAGgAiADINCgUI6g8QAxIAGgAiADINCgUI6g8QAhIAGgAiAA==";
+
+function frameToBase64(messageB64: string): string {
+  const message = Buffer.from(messageB64, "base64");
+  const header = Buffer.alloc(5);
+  header.writeUInt32BE(message.length, 1);
+  return Buffer.concat([header, message]).toString("base64");
+}
+
+const LIVE_GRPC_BODY = frameToBase64(LIVE_GRPC_MESSAGE_B64);
 
 describe("parseGrokUsage", () => {
   it("maps the /billing config block to a monthly credits window", () => {
@@ -41,6 +52,13 @@ describe("parseGrokUsage", () => {
 });
 
 describe("collectGrok cookie session", () => {
+  it("checks whether a browser cookie authenticates to grok.com", async () => {
+    const host = createFakeHost({
+      routes: { [GROK_GRPC_ENDPOINT]: { body: LIVE_GRPC_BODY } },
+    });
+    await expect(isGrokSessionLive(host.http, "sso=abc")).resolves.toBe(true);
+  });
+
   it("keeps the stored session on a transient failure (no token to fall back to)", async () => {
     // A stored grok.com cookie whose check 5xx's, with no CLI token. This must
     // not read as signed out: report a preserved `error`, not auth-missing, so a

--- a/packages/agents-usage/src/collectors/grok.ts
+++ b/packages/agents-usage/src/collectors/grok.ts
@@ -1,5 +1,5 @@
 import { toEpochMs } from "../formatters";
-import type { CollectOptions, HostPort, HttpResponse } from "../host";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse } from "../host";
 import type { UsageSnapshot, UsageWindow } from "../types";
 import {
   GROK_GRPC_EMPTY_FRAME_B64,
@@ -100,18 +100,8 @@ function grokWindowLabel(periodStartMs: number | undefined, resetsAt: number | u
   return "Credits";
 }
 
-/**
- * Collect via the grok.com browser session cookie (codexbar's path): POST the
- * gRPC-web `GetGrokBuildBillingConfig` and parse the protobuf for used/limit
- * credits + reset. Returns undefined to let the caller fall back to the CLI
- * token path on any failure.
- */
-async function collectGrokViaCookie(
-  host: HostPort,
-  cookie: string,
-  nowMs: number,
-): Promise<UsageSnapshot | undefined> {
-  const res = await host.http.request({
+function grokGrpcRequest(http: HttpClient, cookie: string): Promise<HttpResponse> {
+  return http.request({
     method: "POST",
     url: GROK_GRPC_ENDPOINT,
     headers: {
@@ -123,6 +113,26 @@ async function collectGrokViaCookie(
     body: GROK_GRPC_EMPTY_FRAME_B64,
     timeoutMs: 15_000,
   });
+}
+
+export async function isGrokSessionLive(http: HttpClient, cookie: string): Promise<boolean> {
+  const res = await grokGrpcRequest(http, cookie);
+  if (res.status < 200 || res.status >= 300) return false;
+  return unframeGrpcWebText(res.body) !== undefined;
+}
+
+/**
+ * Collect via the grok.com browser session cookie (codexbar's path): POST the
+ * gRPC-web `GetGrokBuildBillingConfig` and parse the protobuf for used/limit
+ * credits + reset. Returns undefined to let the caller fall back to the CLI
+ * token path on any failure.
+ */
+async function collectGrokViaCookie(
+  host: HostPort,
+  cookie: string,
+  nowMs: number,
+): Promise<UsageSnapshot | undefined> {
+  const res = await grokGrpcRequest(host.http, cookie);
   if (res.status === 401 || res.status === 403) {
     return { providerId: "grok", status: "auth-missing", windows: [], fetchedAt: nowMs };
   }

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -44,6 +44,7 @@ export { collectCopilot, parseCopilotUsage, COPILOT_USER_ENDPOINT } from "./coll
 export { collectCursor, parseCursorUsage, CURSOR_USAGE_ENDPOINT } from "./collectors/cursor";
 export {
   collectGrok,
+  isGrokSessionLive,
   parseGrokUsage,
   GROK_BILLING_ENDPOINT,
   GROK_SETTINGS_ENDPOINT,

--- a/src/main/usageLogin/UsageLoginManager.test.ts
+++ b/src/main/usageLogin/UsageLoginManager.test.ts
@@ -9,8 +9,12 @@ vi.mock("electron", () => ({ clipboard: { writeText: vi.fn<(text: string) => voi
 vi.mock("./openCodeLoginProbe", () => ({
   isOpenCodeLoginCookieLive: vi.fn<(cookieHeader: string) => Promise<boolean>>(),
 }));
+vi.mock("./grokLoginProbe", () => ({
+  isGrokLoginCookieLive: vi.fn<(cookieHeader: string) => Promise<boolean>>(),
+}));
 
 const { UsageLoginManager } = await import("./UsageLoginManager");
+const { isGrokLoginCookieLive } = await import("./grokLoginProbe");
 
 const DEVICE_CODE_URL = "/login/device/code";
 const TOKEN_URL = "/login/oauth/access_token";
@@ -22,6 +26,10 @@ function makePanel() {
     showUsageLoginDeviceCode: vi.fn<(deviceCode: unknown) => void>(),
     clearUsageLoginDeviceCode: vi.fn<(providerId: string) => void>(),
     cancelLoginCapture: vi.fn<() => void>(),
+    captureLoginCookies: vi.fn<() => Promise<{ ok: boolean; cookie?: string }>>(async () => ({
+      ok: true,
+      cookie: "sso=abc",
+    })),
   };
 }
 
@@ -73,6 +81,24 @@ afterEach(() => {
 function newManager(panel: ReturnType<typeof makePanel>) {
   return new UsageLoginManager({ cacheDir } as never, () => panel as never);
 }
+
+describe("UsageLoginManager cookie flow", () => {
+  it("validates Grok cookies before saving them", async () => {
+    const panel = makePanel();
+    const manager = newManager(panel);
+
+    await expect(manager.startLogin("grok")).resolves.toEqual({ ok: true });
+
+    expect(panel.captureLoginCookies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loginUrl: "https://grok.com/",
+        cookieUrl: "https://grok.com/",
+        validateSession: isGrokLoginCookieLive,
+      }),
+    );
+    expect(hasUsageSecret(cacheDir, "grok")).toBe(true);
+  });
+});
 
 describe("UsageLoginManager GitHub device flow", () => {
   it("polls past authorization_pending, stores the token, and cleans up", async () => {

--- a/src/main/usageLogin/UsageLoginManager.ts
+++ b/src/main/usageLogin/UsageLoginManager.ts
@@ -3,6 +3,7 @@ import type { BrowserPanelManager } from "../browser";
 import type { LightcodePaths } from "@/shared/lightcodePaths";
 import type { UsageLoginStateResponse } from "@/shared/contracts";
 import { clearUsageSecret, hasUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
+import { isGrokLoginCookieLive } from "./grokLoginProbe";
 import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
 
 /**
@@ -65,6 +66,7 @@ const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
     cookieUrl: "https://grok.com/",
     // grok.com sets SSO/session cookies on successful auth.
     authCookiePattern: /sso|session|auth/i,
+    validateSession: isGrokLoginCookieLive,
   },
   opencode: {
     kind: "cookie",

--- a/src/main/usageLogin/grokLoginProbe.ts
+++ b/src/main/usageLogin/grokLoginProbe.ts
@@ -1,0 +1,30 @@
+import { type HttpClient, isGrokSessionLive } from "@lightcode/agents-usage";
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+const fetchHttpClient: HttpClient = {
+  async request(req) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), req.timeoutMs ?? PROBE_TIMEOUT_MS);
+    try {
+      const res = await fetch(req.url, {
+        method: req.method ?? "GET",
+        ...(req.headers ? { headers: req.headers } : {}),
+        ...(req.body !== undefined ? { body: req.body } : {}),
+        signal: controller.signal,
+      });
+      const body = await res.text();
+      const headers: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        headers[key.toLowerCase()] = value;
+      });
+      return { status: res.status, headers, body };
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+};
+
+export function isGrokLoginCookieLive(cookieHeader: string): Promise<boolean> {
+  return isGrokSessionLive(fetchHttpClient, cookieHeader);
+}

--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => unknown>());
@@ -41,12 +44,14 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
   const originalPATH = process.env.PATH;
   const originalSystemRoot = process.env.SystemRoot;
   const originalUserProfile = process.env.USERPROFILE;
+  let tempDirs: string[] = [];
 
   beforeEach(() => {
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
     clearExecutablePathCache();
     spawnSyncMock.mockReset();
     execFileAsyncMock.mockReset();
+    tempDirs = [];
     process.env.SystemRoot = "C:\\Windows";
     process.env.USERPROFILE = "C:\\Users\\demo";
     process.env.Path = "C:\\Windows\\System32";
@@ -76,6 +81,9 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
       process.env.USERPROFILE = originalUserProfile;
     }
     vi.restoreAllMocks();
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("falls back to the registry-backed Windows Path when ambient lookup misses", () => {
@@ -119,6 +127,29 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     expect(resolveExecutablePath("gemini")).toBe(
       "C:\\Users\\demo\\AppData\\Roaming\\npm\\gemini.cmd",
     );
+  });
+
+  it("resolves npm .cmd shims to their package exe target when present", () => {
+    const root = mkdtempSync(join(tmpdir(), "lightcode-claude-shim-"));
+    tempDirs.push(root);
+    const cmdPath = join(root, "claude.cmd");
+    const exePath = join(root, "node_modules", "@anthropic-ai", "claude-code", "bin", "claude.exe");
+    mkdirSync(join(root, "node_modules", "@anthropic-ai", "claude-code", "bin"), {
+      recursive: true,
+    });
+    writeFileSync(
+      cmdPath,
+      '"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\n',
+    );
+    writeFileSync(exePath, "");
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(root, "claude"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("claude")).toBe(exePath);
   });
 
   it("applies the same fallback to async resolution", async () => {

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -1,5 +1,7 @@
 import { execFile, spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import {
   buildPosixExportPrefix,
@@ -218,7 +220,22 @@ function parseWindowsExecutablePath(stdout: string): string | undefined {
     .split(/\r?\n/g)
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  return lines.findLast((line) => /\.(?:bat|cmd|com|exe|ps1)$/i.test(line)) ?? lines.at(-1);
+  const resolved =
+    lines.findLast((line) => /\.(?:bat|cmd|com|exe|ps1)$/i.test(line)) ?? lines.at(-1);
+  return resolveWindowsCmdExeTarget(resolved) ?? resolved;
+}
+
+function resolveWindowsCmdExeTarget(path: string | undefined): string | undefined {
+  if (!path || !/\.cmd$/i.test(path)) return undefined;
+  try {
+    const body = readFileSync(path, "utf8");
+    const match = /"%dp0%\\([^"]+?\.exe)"/i.exec(body);
+    if (!match?.[1]) return undefined;
+    const target = join(dirname(path), match[1]);
+    return existsSync(target) ? target : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 const wslHomeCache = new Map<string, string>();

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -83,7 +83,7 @@ describe("UsageService", () => {
 
     const claude = result.snapshots.find((s) => s.providerId === "claude");
     expect(claude?.status).toBe("ok");
-    expect(claude?.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(40);
+    expect(claude?.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(0.4);
     // No token → auth-missing, no endpoint hit.
     expect(result.snapshots.find((s) => s.providerId === "codex")?.status).toBe("auth-missing");
 


### PR DESCRIPTION
- Correct Claude 5-hour session utilization so session limits display correctly when the API reports a direct percentage instead of a 0–1 fraction
- Validate Grok browser cookies against the live billing gRPC endpoint before saving login secrets, so invalid or expired sessions are not stored
- Resolve Windows npm `.cmd` shims to their target `.exe` when locating agent executables, improving reliable process launch on Windows