### PR TITLE
Add summary git status and watch visible worktrees

### DIFF
--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -3,6 +3,8 @@ import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "./state/appStore";
 import { useGitStore } from "./state/gitStore";
+import { usePanelStore } from "./state/panelStore";
+import { useSidebarUiStore } from "./state/sidebarUiStore";
 import { gitMergeAndRemove } from "@/renderer/actions/gitActions";
 import { openThread, unloadThread } from "@/renderer/actions/threadActions";
 
@@ -337,6 +339,18 @@ describe("App", () => {
       ghAvailable: {},
       prData: {},
       worktreeSourceInfo: {},
+    });
+    usePanelStore.setState({
+      gitReviewContext: null,
+      gitReviewAsPanel: false,
+      filesPanelContext: null,
+      rightPanelTab: "git",
+      threadSortMode: "updated",
+    });
+    useSidebarUiStore.setState({
+      collapsedProjects: {},
+      collapsedWorktrees: {},
+      threadListLimits: {},
     });
   });
 
@@ -969,6 +983,107 @@ describe("App", () => {
           "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-x",
           "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-y",
         ],
+      });
+    });
+  });
+
+  it("reactively updates watched worktrees when a hidden worktree panel opens and closes", async () => {
+    useAppStore.persist.hasHydrated = vi.fn<() => boolean>().mockReturnValue(true);
+    useAppStore.persist.onHydrate = vi.fn<() => () => void>(() => () => undefined);
+    useAppStore.persist.onFinishHydration = vi.fn<() => () => void>(() => () => undefined);
+
+    const visiblePath = "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-y";
+    const hiddenPath = "C:\\Users\\demo\\.lightcode\\worktrees\\repo-12345678\\feature-z";
+
+    useSidebarUiStore.setState({ threadListLimits: { "project-1": 1 } });
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [
+        {
+          id: "project-1",
+          name: "Repo",
+          location: {
+            kind: "windows",
+            path: "C:\\repo",
+          },
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      threads: [
+        {
+          id: "thread-visible",
+          projectId: "project-1",
+          title: "Visible worktree",
+          agentKind: "codex",
+          config: { model: "gpt-5.4" },
+          status: "idle",
+          attention: "none",
+          canResumeWithConfig: false,
+          worktreePath: visiblePath,
+          worktreeBranch: "feature/y",
+          archived: false,
+          done: false,
+          starred: false,
+          createdAt: "2026-03-22T00:00:00.000Z",
+          updatedAt: "2026-03-22T00:00:00.000Z",
+        },
+        {
+          id: "thread-hidden",
+          projectId: "project-1",
+          title: "Hidden worktree",
+          agentKind: "codex",
+          config: { model: "gpt-5.4" },
+          status: "finished",
+          attention: "none",
+          canResumeWithConfig: false,
+          worktreePath: hiddenPath,
+          worktreeBranch: "feature/z",
+          archived: false,
+          done: false,
+          starred: false,
+          createdAt: "2026-03-21T00:00:00.000Z",
+          updatedAt: "2026-03-21T00:00:00.000Z",
+        },
+      ],
+      view: { kind: "home" },
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(bridge.gitWatchWorktrees).toHaveBeenCalledWith({
+        projectId: "project-1",
+        worktreePaths: [visiblePath],
+      });
+    });
+    bridge.gitWatchWorktrees.mockClear();
+
+    act(() => {
+      usePanelStore.setState({
+        gitReviewContext: { projectId: "project-1", worktreePath: hiddenPath },
+        gitReviewAsPanel: true,
+        rightPanelTab: "git",
+      });
+    });
+
+    await waitFor(() => {
+      expect(bridge.gitWatchWorktrees).toHaveBeenCalledWith({
+        projectId: "project-1",
+        worktreePaths: [visiblePath, hiddenPath],
+      });
+    });
+    bridge.gitWatchWorktrees.mockClear();
+
+    act(() => {
+      usePanelStore.setState({
+        gitReviewContext: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(bridge.gitWatchWorktrees).toHaveBeenCalledWith({
+        projectId: "project-1",
+        worktreePaths: [visiblePath],
       });
     });
   });

--- a/src/renderer/hooks/useGitRefresh.ts
+++ b/src/renderer/hooks/useGitRefresh.ts
@@ -4,13 +4,17 @@ import { parseDraftProjectId } from "@/shared/paneId";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { buildActiveProjectsKey } from "@/renderer/state/projectKeys";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import {
   cleanupGitRefreshProjects,
   refreshGitProject,
   stopPendingPrRefresh,
   syncPendingPrRefreshProjects,
+  syncWatchedWorktreeProjects,
 } from "@/renderer/state/gitRefresh";
 import {
   GIT_FETCH_PRIORITY_INTERVAL_MS,
@@ -18,6 +22,24 @@ import {
 } from "@/renderer/utils/gitHelpers";
 
 const WSL_STATUS_POLL_INTERVAL_MS = 3_000;
+
+/**
+ * Subscribe to a store and invoke `onChange` whenever any of the selected
+ * fields changes identity. Collapses the otherwise-identical "compare a fixed
+ * field tuple, then re-sync" guards so the worktree-watch subscriptions below
+ * stay in one shape instead of four hand-written `===` chains.
+ */
+function subscribeToFieldChanges<S>(
+  subscribe: (listener: (state: S, prev: S) => void) => () => void,
+  selectFields: (state: S) => readonly unknown[],
+  onChange: () => void,
+): () => void {
+  return subscribe((state, prev) => {
+    const next = selectFields(state);
+    const previous = selectFields(prev);
+    if (next.some((value, index) => value !== previous[index])) onChange();
+  });
+}
 
 export function useGitRefresh(storeHydrated: boolean) {
   // Subscribe only to the active-project identity/location key so draft config
@@ -86,6 +108,12 @@ export function useGitRefresh(storeHydrated: boolean) {
         .catch(() => undefined);
     }
 
+    function syncActiveWorktrees() {
+      if (!isActive) return;
+      syncWatchedWorktreeProjects(activeProjects);
+      syncPendingPrRefreshProjects(activeProjects);
+    }
+
     const unsubWatcher = readBridge().onSupervisorEvent((event) => {
       // Both events are git-affecting: `.git` metadata clearly, and worktree
       // edits change `git status` output (a tracked file becomes modified,
@@ -104,10 +132,10 @@ export function useGitRefresh(storeHydrated: boolean) {
       }
     });
 
+    syncActiveWorktrees();
     for (const project of activeProjects) {
       void refreshGitProject(project, "initial", "full", { isActive: isActiveCheck });
     }
-    syncPendingPrRefreshProjects(activeProjects);
     const unsubPendingPrRefresh = useGitStore.subscribe((state, prev) => {
       if (
         state.statuses !== prev.statuses ||
@@ -117,11 +145,31 @@ export function useGitRefresh(storeHydrated: boolean) {
         syncPendingPrRefreshProjects(activeProjects);
       }
     });
-    const unsubPendingPrThreadRefresh = useAppStore.subscribe(
-      (state) => state.threads,
-      () => {
-        syncPendingPrRefreshProjects(activeProjects);
-      },
+    const unsubActiveWorktreeApp = subscribeToFieldChanges(
+      useAppStore.subscribe,
+      (state) => [state.threads, state.view, state.projects],
+      syncActiveWorktrees,
+    );
+    const unsubActiveWorktreePanel = subscribeToFieldChanges(
+      usePanelStore.subscribe,
+      (state) => [
+        state.gitReviewContext,
+        state.gitReviewAsPanel,
+        state.filesPanelContext,
+        state.rightPanelTab,
+        state.threadSortMode,
+      ],
+      syncActiveWorktrees,
+    );
+    const unsubActiveWorktreeSidebar = subscribeToFieldChanges(
+      useSidebarUiStore.subscribe,
+      (state) => [state.collapsedProjects, state.collapsedWorktrees, state.threadListLimits],
+      syncActiveWorktrees,
+    );
+    const unsubActiveWorktreeTerminal = subscribeToFieldChanges(
+      useDevTerminalStore.subscribe,
+      (state) => [state.isOpen, state.activeProjectId, state.activeWorktreePath],
+      syncActiveWorktrees,
     );
 
     async function fetchRemotes() {
@@ -203,7 +251,10 @@ export function useGitRefresh(storeHydrated: boolean) {
       for (const timer of watcherDebounceTimers.values()) clearTimeout(timer);
       watcherDebounceTimers.clear();
       unsubPendingPrRefresh();
-      unsubPendingPrThreadRefresh();
+      unsubActiveWorktreeApp();
+      unsubActiveWorktreePanel();
+      unsubActiveWorktreeSidebar();
+      unsubActiveWorktreeTerminal();
       stopPendingPrRefresh();
       unsubWatcher();
       for (const project of activeProjects) {

--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -10,6 +10,8 @@ import type {
 import { useAppStore } from "./appStore";
 import { useGitStore } from "./gitStore";
 import { buildBranchPrKey } from "./gitSelectors";
+import { usePanelStore } from "./panelStore";
+import { useSidebarUiStore } from "./sidebarUiStore";
 import {
   cleanupGitRefreshProjects,
   PR_PENDING_REFRESH_INTERVAL_MS,
@@ -107,6 +109,16 @@ const worktreeThread: Thread = {
   updatedAt: "2026-04-04T00:00:00.000Z",
 };
 
+const hiddenWorktreeThread: Thread = {
+  ...worktreeThread,
+  id: "t-hidden",
+  title: "Hidden worktree thread",
+  worktreePath: "/repo-hidden",
+  worktreeBranch: "feature/hidden",
+  createdAt: "2026-04-03T00:00:00.000Z",
+  updatedAt: "2026-04-03T00:00:00.000Z",
+};
+
 describe("pending PR refresh", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -132,7 +144,19 @@ describe("pending PR refresh", () => {
       prFiles: {},
       prDiffs: {},
     });
-    useAppStore.setState({ projects: [project], threads: [] });
+    usePanelStore.setState({
+      gitReviewContext: null,
+      gitReviewAsPanel: false,
+      filesPanelContext: null,
+      rightPanelTab: "git",
+      threadSortMode: "updated",
+    });
+    useSidebarUiStore.setState({
+      collapsedProjects: {},
+      collapsedWorktrees: {},
+      threadListLimits: {},
+    });
+    useAppStore.setState({ projects: [project], threads: [], view: { kind: "home" } });
   });
 
   afterEach(() => {
@@ -228,6 +252,23 @@ describe("pending PR refresh", () => {
     await vi.advanceTimersByTimeAsync(PR_PENDING_REFRESH_INTERVAL_MS);
 
     expect(ghGetPrForBranchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not poll pending PR checks for worktree threads hidden behind See more", async () => {
+    useSidebarUiStore.setState({ threadListLimits: { p1: 1 } });
+    useAppStore.setState({ threads: [worktreeThread, hiddenWorktreeThread] });
+    useGitStore.getState().setPrData("/repo-wt", basePr);
+    useGitStore.getState().setPrData("/repo-hidden", { ...basePr, number: 43 });
+    ghGetPrForBranchMock.mockResolvedValue({ ...basePr, checksStatus: "PENDING" });
+    ghGetPrDetailsMock.mockResolvedValue({ details: baseDetails });
+
+    syncPendingPrRefreshProjects([{ id: "p1", location }]);
+
+    expect(ghGetPrForBranchMock).toHaveBeenCalledTimes(1);
+    expect(ghGetPrForBranchMock).toHaveBeenCalledWith({
+      projectLocation: location,
+      branch: "feature/wt",
+    });
   });
 
   it("does not poll orphaned pending PR details", async () => {
@@ -333,7 +374,19 @@ describe("watcher git status refresh", () => {
       prFiles: {},
       prDiffs: {},
     });
-    useAppStore.setState({ projects: [project], threads: [] });
+    usePanelStore.setState({
+      gitReviewContext: null,
+      gitReviewAsPanel: false,
+      filesPanelContext: null,
+      rightPanelTab: "git",
+      threadSortMode: "updated",
+    });
+    useSidebarUiStore.setState({
+      collapsedProjects: {},
+      collapsedWorktrees: {},
+      threadListLimits: {},
+    });
+    useAppStore.setState({ projects: [project], threads: [], view: { kind: "home" } });
   });
 
   afterEach(() => {
@@ -380,14 +433,22 @@ describe("watcher git status refresh", () => {
         commit: "abc123",
         isMain: true,
       },
+      {
+        path: "/repo-old",
+        branch: "feature/old",
+        commit: "abc123",
+        isMain: false,
+      },
     ]);
-    useAppStore.setState({ threads: [worktreeThread] });
+    useSidebarUiStore.setState({ threadListLimits: { p1: 1 } });
+    useAppStore.setState({ threads: [worktreeThread, hiddenWorktreeThread] });
 
     await refreshGitProject(project, "watcher", "status");
 
     expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
       projectLocation: location,
       worktreePaths: ["/repo-wt"],
+      detail: "full",
     });
     expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
   });
@@ -429,7 +490,10 @@ describe("watcher git status refresh", () => {
       .mockResolvedValue({
         status,
         branches: { current: "main", branches: [] },
-        worktrees: [{ path: "/repo", branch: "main", commit: "abc123", isMain: true }],
+        worktrees: [
+          { path: "/repo", branch: "main", commit: "abc123", isMain: true },
+          { path: "/repo-old", branch: "feature/old", commit: "abc123", isMain: false },
+        ],
         ghAvailable: false,
       });
     Object.defineProperty(window, "lightcode", {
@@ -441,7 +505,8 @@ describe("watcher git status refresh", () => {
         gitWorktreeStatusBatch,
       },
     });
-    useAppStore.setState({ threads: [worktreeThread] });
+    useSidebarUiStore.setState({ threadListLimits: { p1: 1 } });
+    useAppStore.setState({ threads: [worktreeThread, hiddenWorktreeThread] });
 
     await refreshGitProject(project, "initial", "full");
 
@@ -452,7 +517,82 @@ describe("watcher git status refresh", () => {
     expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
       projectLocation: location,
       worktreePaths: ["/repo-wt"],
+      detail: "full",
     });
     expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
+  });
+
+  it("keeps hidden worktree threads watched while they are open in a thread pane", async () => {
+    const gitWatchWorktrees = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockResolvedValue({ statuses: {} });
+    const gitProjectSnapshot = vi
+      .fn<() => Promise<{ status: GitStatusResult; worktrees: []; ghAvailable: boolean }>>()
+      .mockResolvedValue({ status, worktrees: [], ghAvailable: false });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        gitProjectSnapshot,
+        gitWatchWorktrees,
+        gitWorktreeStatusBatch,
+      },
+    });
+    useSidebarUiStore.setState({ threadListLimits: { p1: 1 } });
+    useAppStore.setState({
+      threads: [worktreeThread, hiddenWorktreeThread],
+      view: { kind: "thread", panes: ["t-hidden"] as [string, ...string[]] },
+    });
+
+    await refreshGitProject(project, "initial", "full");
+
+    expect(gitWatchWorktrees).toHaveBeenCalledWith({
+      projectId: "p1",
+      worktreePaths: ["/repo-hidden", "/repo-wt"],
+    });
+  });
+
+  it("keeps hidden worktree threads watched while their git panel is active", async () => {
+    const gitWatchWorktrees = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockResolvedValue({ statuses: {} });
+    const gitProjectSnapshot = vi
+      .fn<() => Promise<{ status: GitStatusResult; worktrees: []; ghAvailable: boolean }>>()
+      .mockResolvedValue({ status, worktrees: [], ghAvailable: false });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        gitProjectSnapshot,
+        gitWatchWorktrees,
+        gitWorktreeStatusBatch,
+      },
+    });
+    useSidebarUiStore.setState({ threadListLimits: { p1: 1 } });
+    usePanelStore.setState({
+      gitReviewContext: { projectId: "p1", worktreePath: "/repo-hidden" },
+      gitReviewAsPanel: true,
+      rightPanelTab: "git",
+    });
+    useAppStore.setState({ threads: [worktreeThread, hiddenWorktreeThread] });
+
+    await refreshGitProject(project, "initial", "full");
+
+    expect(gitWatchWorktrees).toHaveBeenCalledWith({
+      projectId: "p1",
+      worktreePaths: ["/repo-hidden", "/repo-wt"],
+    });
   });
 });

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -1,9 +1,17 @@
-import type { PrData, ProjectLocation } from "@/shared/contracts";
+import type { GitStatusDetail, PrData, ProjectLocation } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { aggregatePrChecksStatus, combineChecksStatus } from "@/renderer/utils/prStatus";
+import {
+  buildSidebarProjectRows,
+  SIDEBAR_THREAD_LIST_PAGE_SIZE,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows";
 
 export type GitRefreshReason = "initial" | "watcher" | "fetch" | "manual" | "poll";
 export type GitRefreshMode = "status" | "full";
@@ -25,6 +33,10 @@ export const PR_POST_PUSH_STATUS_WAIT_MS = 15_000;
 export const PR_POST_PUSH_STATUS_POLL_MS = 5_000;
 
 const alwaysActive = () => true;
+
+function getWorktreeStatusDetail(reason: GitRefreshReason): GitStatusDetail {
+  return reason === "fetch" || reason === "poll" ? "summary" : "full";
+}
 
 type ActiveGitProject = { id: string; location: ProjectLocation };
 
@@ -63,6 +75,113 @@ const postPushPrRefreshEntries = new Map<string, PostPushPrRefreshEntry>();
 
 function isRefreshCurrent(projectId: string, token: symbol, isActive: () => boolean): boolean {
   return isActive() && activeRefreshTokens.get(projectId) === token;
+}
+
+function addPanelContextWorktreePath(
+  paths: Set<string>,
+  projectId: string,
+  enabled: boolean,
+  context: { projectId: string; worktreePath?: string } | null,
+): void {
+  if (enabled && context?.projectId === projectId && context.worktreePath) {
+    paths.add(context.worktreePath);
+  }
+}
+
+export function getProjectActiveWorktreePaths(projectId: string): string[] {
+  const appState = useAppStore.getState();
+  const panelState = usePanelStore.getState();
+  const sidebarState = useSidebarUiStore.getState();
+  const paths = new Set<string>();
+  const project = appState.projects.find((p) => p.id === projectId);
+  const projectThreads = appState.threads.filter((t) => t.projectId === projectId && !t.archived);
+
+  if (project && !project.disabled && !(sidebarState.collapsedProjects[projectId] ?? false)) {
+    const rows = buildSidebarProjectRows({
+      projectId,
+      projectThreads,
+      sortMode: panelState.threadSortMode,
+      collapsedWorktrees: sidebarState.collapsedWorktrees,
+      visibleLimit: sidebarState.threadListLimits[projectId] ?? SIDEBAR_THREAD_LIST_PAGE_SIZE,
+    });
+    for (const row of rows) {
+      if (row.kind === "worktree-group") paths.add(row.group.worktreePath);
+      if (row.kind === "thread" && row.thread.worktreePath) paths.add(row.thread.worktreePath);
+    }
+  }
+
+  if (appState.view.kind === "thread") {
+    const paneIds = new Set(appState.view.panes);
+    for (const thread of appState.threads) {
+      if (thread.projectId === projectId && paneIds.has(thread.id) && thread.worktreePath) {
+        paths.add(thread.worktreePath);
+      }
+    }
+  }
+
+  addPanelContextWorktreePath(
+    paths,
+    projectId,
+    panelState.rightPanelTab === "git" && panelState.gitReviewAsPanel,
+    panelState.gitReviewContext,
+  );
+  addPanelContextWorktreePath(
+    paths,
+    projectId,
+    panelState.rightPanelTab === "files",
+    panelState.filesPanelContext,
+  );
+
+  const terminalState = useDevTerminalStore.getState();
+  const terminalIsVisible =
+    terminalState.isOpen &&
+    (useSharedSettings.getState().terminalPosition === "bottom" ||
+      panelState.rightPanelTab === "terminal");
+  if (
+    terminalIsVisible &&
+    terminalState.activeProjectId === projectId &&
+    terminalState.activeWorktreePath
+  ) {
+    paths.add(terminalState.activeWorktreePath);
+  }
+
+  return Array.from(paths).sort();
+}
+
+function getProjectActiveWorktreePathSet(projectId: string): Set<string> {
+  return new Set(getProjectActiveWorktreePaths(projectId));
+}
+
+export function syncWatchedWorktreeProject(projectId: string): string[] {
+  const worktreePaths = getProjectActiveWorktreePaths(projectId);
+  const wtPaths = worktreePaths.join("\0");
+  if (wtPaths !== watchedWorktreePaths.get(projectId)) {
+    watchedWorktreePaths.set(projectId, wtPaths);
+    readBridge()
+      .gitWatchWorktrees({
+        projectId,
+        worktreePaths,
+      })
+      .catch(() => undefined);
+  }
+  return worktreePaths;
+}
+
+export function syncWatchedWorktreeProjects(activeProjects: readonly ActiveGitProject[]): void {
+  for (const project of activeProjects) {
+    syncWatchedWorktreeProject(project.id);
+  }
+}
+
+function getActiveWorktreeBranchThreads(projectId: string) {
+  const activePaths = getProjectActiveWorktreePathSet(projectId);
+  if (activePaths.size === 0) return [];
+  return useAppStore.getState().threads.filter((thread) => {
+    if (thread.projectId !== projectId || !thread.worktreePath || !thread.worktreeBranch) {
+      return false;
+    }
+    return activePaths.has(thread.worktreePath);
+  });
 }
 
 async function withRefreshTimeout<T>(
@@ -115,10 +234,12 @@ function buildPendingPrRefreshTargets(
     if (status?.branch) {
       visitBranchPr(project, buildBranchPrKey(project.id), status.branch);
     }
+    const activeWorktreePaths = getProjectActiveWorktreePathSet(project.id);
     for (const thread of appState.threads) {
       if (thread.projectId !== project.id || !thread.worktreePath || !thread.worktreeBranch) {
         continue;
       }
+      if (!activeWorktreePaths.has(thread.worktreePath)) continue;
       visitBranchPr(project, thread.worktreePath, thread.worktreeBranch);
     }
   }
@@ -172,10 +293,12 @@ function isPostPushPrRefreshTargetActive(target: PostPushPrRefreshTarget): boole
   if (target.prKey === buildBranchPrKey(target.projectId)) {
     return gitState.statuses[target.projectId]?.branch === target.branch;
   }
+  const activeWorktreePaths = getProjectActiveWorktreePathSet(target.projectId);
   return appState.threads.some(
     (thread) =>
       thread.projectId === target.projectId &&
       thread.worktreePath === target.prKey &&
+      activeWorktreePaths.has(thread.worktreePath) &&
       thread.worktreeBranch === target.branch,
   );
 }
@@ -291,6 +414,7 @@ export function cleanupGitRefreshProjects(activeProjectIds: ReadonlySet<string>)
 
 async function refreshProjectStatusOnly(
   project: { id: string; location: ProjectLocation },
+  reason: GitRefreshReason,
   isActive: () => boolean,
 ): Promise<void> {
   const statusResult = await readBridge()
@@ -301,22 +425,13 @@ async function refreshProjectStatusOnly(
     useGitStore.getState().setStatus(project.id, statusResult);
   }
 
-  const cachedWorktreePaths =
-    useGitStore
-      .getState()
-      .worktrees[project.id]?.filter((wt) => !wt.isMain)
-      .map((wt) => wt.path) ?? [];
-  const threadWorktreePaths = useAppStore
-    .getState()
-    .threads.flatMap((thread) =>
-      thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
-    );
-  const childWorktreePaths = [...new Set([...cachedWorktreePaths, ...threadWorktreePaths])];
-  if (childWorktreePaths.length === 0) return;
+  const threadWorktreePaths = getProjectActiveWorktreePaths(project.id);
+  if (threadWorktreePaths.length === 0) return;
   const batch = await readBridge()
     .gitWorktreeStatusBatch({
       projectLocation: project.location,
-      worktreePaths: childWorktreePaths,
+      worktreePaths: threadWorktreePaths,
+      detail: getWorktreeStatusDetail(reason),
     })
     .catch(() => undefined);
   if (!isActive() || !batch) return;
@@ -366,7 +481,7 @@ export async function refreshGitProject(
         }
 
         if (mode === "status") {
-          await refreshProjectStatusOnly(project, () =>
+          await refreshProjectStatusOnly(project, reason, () =>
             isRefreshCurrent(project.id, refreshToken, isActive),
           );
           return;
@@ -414,40 +529,31 @@ export async function refreshGitProject(
           if (!worktrees) return;
           if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
           const childWorktrees = worktrees.filter((wt) => !wt.isMain);
-          const childWorktreePaths = childWorktrees.map((wt) => wt.path);
-          const threadWorktreePaths = useAppStore
-            .getState()
-            .threads.flatMap((thread) =>
-              thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
-            );
-          const watchWorktreePaths = [...new Set([...childWorktreePaths, ...threadWorktreePaths])];
+          const watchWorktreePaths = syncWatchedWorktreeProject(project.id);
+          const watchedWorktreePathSet = new Set(watchWorktreePaths);
+          const activeChildWorktrees = childWorktrees.filter((wt) =>
+            watchedWorktreePathSet.has(wt.path),
+          );
 
-          const wtPaths = [...watchWorktreePaths].sort().join("\0");
-          if (wtPaths !== watchedWorktreePaths.get(project.id)) {
-            watchedWorktreePaths.set(project.id, wtPaths);
-            readBridge()
-              .gitWatchWorktrees({
-                projectId: project.id,
-                worktreePaths: watchWorktreePaths,
-              })
-              .catch(() => undefined);
-          }
-
-          const statusesPromise = readBridge()
-            .gitWorktreeStatusBatch({
-              projectLocation: project.location,
-              worktreePaths: watchWorktreePaths,
-            })
-            .then((batch) => {
-              if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
-              if (Object.keys(batch.statuses).length > 0) {
-                useGitStore.getState().setWorktreeStatuses(batch.statuses);
-              }
-            })
-            .catch(() => undefined);
+          const statusesPromise =
+            watchWorktreePaths.length === 0
+              ? Promise.resolve()
+              : readBridge()
+                  .gitWorktreeStatusBatch({
+                    projectLocation: project.location,
+                    worktreePaths: watchWorktreePaths,
+                    detail: getWorktreeStatusDetail(reason),
+                  })
+                  .then((batch) => {
+                    if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
+                    if (Object.keys(batch.statuses).length > 0) {
+                      useGitStore.getState().setWorktreeStatuses(batch.statuses);
+                    }
+                  })
+                  .catch(() => undefined);
 
           const sourceInfoPromise = Promise.all(
-            childWorktrees
+            activeChildWorktrees
               .filter((wt) => wt.branch)
               .map(async (wt) => {
                 try {
@@ -483,10 +589,7 @@ export async function refreshGitProject(
         // `status.branch`. They run concurrently with everything above.
         const prUpdates: Record<string, PrData | null> = {};
         const prNumberUpdates = new Map<string, number | undefined>();
-        const currentThreads = useAppStore.getState().threads;
-        const wtThreads = currentThreads.filter(
-          (t) => t.projectId === project.id && t.worktreeBranch && t.worktreePath,
-        );
+        const wtThreads = getActiveWorktreeBranchThreads(project.id);
 
         const wtPrPromises = wtThreads.map(async (t) => {
           const ghAvailable = await ghAvailablePromise;

--- a/src/renderer/state/gitStore.test.ts
+++ b/src/renderer/state/gitStore.test.ts
@@ -165,6 +165,49 @@ describe("gitStore batch updates", () => {
     expect(secondStatuses["/wt/b"]?.ahead).toBe(1);
   });
 
+  it("preserves matching full diff stats when a summary worktree status lands", () => {
+    useGitStore.getState().setWorktreeStatus("/wt/a", {
+      ...baseStatus,
+      unstaged: [
+        {
+          path: "src/changed.ts",
+          status: "M",
+          staged: false,
+          insertions: 8,
+          deletions: 2,
+        },
+      ],
+      totalInsertions: 8,
+      totalDeletions: 2,
+    });
+
+    useGitStore.getState().setWorktreeStatuses({
+      "/wt/a": {
+        detail: "summary",
+        ...baseStatus,
+        remoteInfo: null,
+        unstaged: [
+          {
+            path: "src/changed.ts",
+            status: "M",
+            staged: false,
+            insertions: 0,
+            deletions: 0,
+          },
+        ],
+        totalInsertions: 0,
+        totalDeletions: 0,
+      },
+    });
+
+    const status = useGitStore.getState().worktreeStatuses["/wt/a"]!;
+    expect(status.detail).toBe("summary");
+    expect(status.remoteInfo).toBe(baseStatus.remoteInfo);
+    expect(status.unstaged[0]).toMatchObject({ insertions: 8, deletions: 2 });
+    expect(status.totalInsertions).toBe(8);
+    expect(status.totalDeletions).toBe(2);
+  });
+
   it("dedupes by path when staging an MM file (one entry, latest stats win)", () => {
     const stagedM = {
       path: "src/foo.ts",

--- a/src/renderer/state/gitStore.ts
+++ b/src/renderer/state/gitStore.ts
@@ -118,6 +118,7 @@ function areGitStatusesEqual(a: GitStatusResult | undefined, b: GitStatusResult)
   const leftRemote = a.remoteInfo;
   const rightRemote = b.remoteInfo;
   return (
+    a.detail === b.detail &&
     a.isRepo === b.isRepo &&
     a.branch === b.branch &&
     a.tracking === b.tracking &&
@@ -138,6 +139,49 @@ function areGitStatusesEqual(a: GitStatusResult | undefined, b: GitStatusResult)
     areStatusFilesEqual(a.staged, b.staged) &&
     areStatusFilesEqual(a.unstaged, b.unstaged)
   );
+}
+
+function mergeSummaryFiles(
+  previous: readonly FileChange[],
+  incoming: readonly FileChange[],
+): FileChange[] {
+  if (incoming.length === 0) return [];
+  const previousByKey = new Map(
+    previous.map((file) => [
+      `${file.staged}\0${file.path}\0${file.oldPath ?? ""}\0${file.status}`,
+      file,
+    ]),
+  );
+  return incoming.map((file) => {
+    const previousFile = previousByKey.get(
+      `${file.staged}\0${file.path}\0${file.oldPath ?? ""}\0${file.status}`,
+    );
+    return previousFile
+      ? { ...file, insertions: previousFile.insertions, deletions: previousFile.deletions }
+      : file;
+  });
+}
+
+function mergeSummaryStatus(
+  previous: GitStatusResult | undefined,
+  incoming: GitStatusResult,
+): GitStatusResult {
+  if (incoming.detail !== "summary" || !previous) return incoming;
+  const staged = mergeSummaryFiles(previous.staged, incoming.staged);
+  const unstaged = mergeSummaryFiles(previous.unstaged, incoming.unstaged);
+  return {
+    ...incoming,
+    hasRemote: incoming.hasRemote || previous.hasRemote,
+    remoteInfo: incoming.remoteInfo ?? previous.remoteInfo,
+    staged,
+    unstaged,
+    totalInsertions:
+      staged.reduce((sum, file) => sum + file.insertions, 0) +
+      unstaged.reduce((sum, file) => sum + file.insertions, 0),
+    totalDeletions:
+      staged.reduce((sum, file) => sum + file.deletions, 0) +
+      unstaged.reduce((sum, file) => sum + file.deletions, 0),
+  };
 }
 
 function areBranchListsEqual(a: GitBranchListResult | undefined, b: GitBranchListResult) {
@@ -373,9 +417,10 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
     }),
 
   setWorktreeStatus: (worktreePath, status) => {
-    if (areGitStatusesEqual(get().worktreeStatuses[worktreePath], status)) return;
+    const nextStatus = mergeSummaryStatus(get().worktreeStatuses[worktreePath], status);
+    if (areGitStatusesEqual(get().worktreeStatuses[worktreePath], nextStatus)) return;
     set((state) => ({
-      worktreeStatuses: { ...state.worktreeStatuses, [worktreePath]: status },
+      worktreeStatuses: { ...state.worktreeStatuses, [worktreePath]: nextStatus },
     }));
   },
 
@@ -384,14 +429,15 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
       let nextWorktreeStatuses = state.worktreeStatuses;
       let changed = false;
       for (const [worktreePath, status] of Object.entries(statuses)) {
-        if (areGitStatusesEqual(nextWorktreeStatuses[worktreePath], status)) {
+        const nextStatus = mergeSummaryStatus(nextWorktreeStatuses[worktreePath], status);
+        if (areGitStatusesEqual(nextWorktreeStatuses[worktreePath], nextStatus)) {
           continue;
         }
         if (!changed) {
           nextWorktreeStatuses = { ...state.worktreeStatuses };
           changed = true;
         }
-        nextWorktreeStatuses[worktreePath] = status;
+        nextWorktreeStatuses[worktreePath] = nextStatus;
       }
       return changed ? { worktreeStatuses: nextWorktreeStatuses } : state;
     }),

--- a/src/renderer/views/GitReviewOverlay/GitReviewOverlay.tsx
+++ b/src/renderer/views/GitReviewOverlay/GitReviewOverlay.tsx
@@ -68,7 +68,7 @@ export function GitReviewOverlay(props: {
   // Eagerly fetch status on mount when it's not yet in the store
   // (e.g. worktree was just created and the poll cycle hasn't run yet)
   useEffect(() => {
-    if (gitStatus) return;
+    if (gitStatus && gitStatus.detail !== "summary") return;
     void fetchStatus();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- one-shot on mount
 

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
@@ -83,7 +83,7 @@ export function GitReviewPanel(props: {
   }
 
   useEffect(() => {
-    if (gitStatus) return;
+    if (gitStatus && gitStatus.detail !== "summary") return;
     void fetchStatus();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- one-shot on mount
 

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -21,7 +21,7 @@ import {
   useAgentStatusesStore,
 } from "@/renderer/state/agentStatusesStore";
 import { useAppStore } from "@/renderer/state/appStore";
-import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import { getProjectActiveWorktreePaths, refreshGitProject } from "@/renderer/state/gitRefresh";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
@@ -378,18 +378,8 @@ export function AppContent() {
 }
 
 async function primeWorktreeGitState(project: Project, worktreePath: string): Promise<void> {
-  const cachedWorktreePaths =
-    useGitStore
-      .getState()
-      .worktrees[project.id]?.filter((worktree) => !worktree.isMain)
-      .map((worktree) => worktree.path) ?? [];
-  const threadWorktreePaths = useAppStore
-    .getState()
-    .threads.flatMap((thread) =>
-      thread.projectId === project.id && thread.worktreePath ? [thread.worktreePath] : [],
-    );
   const worktreePaths = [
-    ...new Set([...cachedWorktreePaths, ...threadWorktreePaths, worktreePath]),
+    ...new Set([...getProjectActiveWorktreePaths(project.id), worktreePath]),
   ].sort();
   const watchWorktrees = readBridge()
     .gitWatchWorktrees({ projectId: project.id, worktreePaths })

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -19,7 +19,11 @@ export interface GitFileChange {
   deletions: number;
 }
 
+export const gitStatusDetailSchema = z.enum(["summary", "full"]);
+export type GitStatusDetail = z.infer<typeof gitStatusDetailSchema>;
+
 export interface GitStatusResult {
+  detail?: GitStatusDetail;
   isRepo: boolean;
   branch: string;
   tracking: string;
@@ -121,6 +125,7 @@ export type RestoreFileCheckpointPayload = z.infer<typeof restoreFileCheckpointP
 export const gitWorktreeStatusBatchPayloadSchema = z.object({
   projectLocation: projectLocationSchema,
   worktreePaths: z.array(z.string().min(1)),
+  detail: gitStatusDetailSchema.optional(),
 });
 export type GitWorktreeStatusBatchPayload = z.infer<typeof gitWorktreeStatusBatchPayloadSchema>;
 

--- a/src/supervisor/git.ts
+++ b/src/supervisor/git.ts
@@ -8,6 +8,7 @@ import type {
   GitGetWorktreeSourceBranchResult,
   GitMergeToSourceResult,
   GitPullFromSourceResult,
+  GitStatusDetail,
   GitStatusResult,
   GitSwitchBranchResult,
   GitWorktreeListResult,
@@ -38,6 +39,8 @@ import {
   parseWorktreeListOutput,
 } from "./git/worktreeService";
 import type { WslBridgeClient } from "./wsl/bridge/client";
+
+const GIT_WORKTREE_STATUS_CONCURRENCY = 4;
 
 export {
   computeDefaultWorktreePath,
@@ -148,25 +151,40 @@ export class GitService {
   async getWorktreeStatusBatch(
     location: ProjectLocation,
     worktreePaths: string[],
+    detail: GitStatusDetail = "full",
   ): Promise<Record<string, GitStatusResult>> {
     if (worktreePaths.length === 0) return {};
 
     if (location.kind === "wsl") {
+      if (detail === "summary") {
+        return this.statusService.getWorktreeStatusSummaryBatchWsl(location, worktreePaths);
+      }
       return this.statusService.getWorktreeStatusBatchWsl(location, worktreePaths);
     }
 
-    const entries = await Promise.all(
-      worktreePaths.map(async (path) => {
+    const statuses: Record<string, GitStatusResult> = {};
+    let nextIndex = 0;
+    const runWorker = async () => {
+      while (nextIndex < worktreePaths.length) {
+        const path = worktreePaths[nextIndex++]!;
         try {
           const wtLocation = buildWorktreeLocation(location, path);
-          const status = await this.statusService.getStatus(wtLocation);
-          return [path, status] as const;
+          statuses[path] =
+            detail === "summary"
+              ? await this.statusService.getStatusSummary(wtLocation)
+              : await this.statusService.getStatus(wtLocation);
         } catch {
-          return undefined;
+          // Worktrees whose status fetch fails are silently dropped.
         }
-      }),
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(GIT_WORKTREE_STATUS_CONCURRENCY, worktreePaths.length) },
+        runWorker,
+      ),
     );
-    return Object.fromEntries(entries.filter((e) => e !== undefined));
+    return statuses;
   }
 
   async getDiff(

--- a/src/supervisor/git/statusService.ts
+++ b/src/supervisor/git/statusService.ts
@@ -275,6 +275,53 @@ export function buildGitStatusResultFromOutputs(args: {
   };
 }
 
+function buildGitStatusSummaryFromOutput(statusOutput: string): GitStatusResult {
+  const parsed = parseStatusPorcelainV2(statusOutput);
+  return {
+    detail: "summary",
+    isRepo: true,
+    branch: parsed.branch,
+    tracking: parsed.tracking,
+    hasRemote: parsed.tracking.length > 0,
+    remoteInfo: null,
+    ahead: parsed.ahead,
+    behind: parsed.behind,
+    staged: parsed.staged,
+    unstaged: parsed.unstaged,
+    totalInsertions: 0,
+    totalDeletions: 0,
+    ...(parsed.mergeInProgress
+      ? {
+          mergeInProgress: true,
+          conflictFiles: parsed.conflictFiles.map((path) => ({
+            path,
+            status: "U",
+            staged: false,
+            insertions: 0,
+            deletions: 0,
+          })),
+        }
+      : {}),
+  };
+}
+
+function nonRepoSummaryStatus(): GitStatusResult {
+  return {
+    detail: "summary",
+    isRepo: false,
+    branch: "",
+    tracking: "",
+    hasRemote: false,
+    remoteInfo: null,
+    ahead: 0,
+    behind: 0,
+    staged: [],
+    unstaged: [],
+    totalInsertions: 0,
+    totalDeletions: 0,
+  };
+}
+
 export class GitStatusService {
   private readonly untrackedStatsCache = new Map<string, UntrackedStatsCacheEntry>();
 
@@ -373,6 +420,33 @@ export class GitStatusService {
         ? { mergeInProgress: true, conflictFiles: conflictFileChanges }
         : {}),
     };
+  }
+
+  async getStatusSummary(location: ProjectLocation): Promise<GitStatusResult> {
+    if (location.kind === "wsl") {
+      const results =
+        (await execGitBatchWslBridge(
+          location,
+          [{ cwd: location.linuxPath, args: ["status", "--porcelain=v2", "-b"] }],
+          GIT_STATUS_TIMEOUT,
+        )) ??
+        (await parallelWslCommandsAsync(
+          location.distro,
+          [{ cwd: location.linuxPath, cmd: "git status --porcelain=v2 -b" }],
+          { timeoutMs: GIT_STATUS_TIMEOUT },
+        ));
+      const result = results[0];
+      return result?.ok ? buildGitStatusSummaryFromOutput(result.stdout) : nonRepoSummaryStatus();
+    }
+
+    try {
+      const statusOutput = await execGit(location, ["status", "--porcelain=v2", "-b"], {
+        timeout: GIT_STATUS_TIMEOUT,
+      });
+      return buildGitStatusSummaryFromOutput(statusOutput);
+    } catch {
+      return nonRepoSummaryStatus();
+    }
   }
 
   /**
@@ -517,6 +591,38 @@ export class GitStatusService {
         }
       }),
     );
+    return out;
+  }
+
+  async getWorktreeStatusSummaryBatchWsl(
+    location: ProjectLocation & { kind: "wsl" },
+    worktreePaths: string[],
+  ): Promise<Record<string, GitStatusResult>> {
+    if (worktreePaths.length === 0) return {};
+
+    const bridgeCommands = worktreePaths.map((cwd) => ({
+      cwd,
+      args: ["status", "--porcelain=v2", "-b"],
+    }));
+    const commands = worktreePaths.map((cwd) => ({
+      cwd,
+      cmd: "git status --porcelain=v2 -b",
+    }));
+    const bridgeResults = await execGitBatchWslBridge(location, bridgeCommands, GIT_STATUS_TIMEOUT);
+    const results =
+      bridgeResults ??
+      (await parallelWslCommandsAsync(location.distro, commands, {
+        timeoutMs: GIT_STATUS_TIMEOUT,
+      }));
+
+    const out: Record<string, GitStatusResult> = {};
+    for (let i = 0; i < worktreePaths.length; i += 1) {
+      const result = results[i];
+      if (!result) continue;
+      out[worktreePaths[i]!] = result.ok
+        ? buildGitStatusSummaryFromOutput(result.stdout)
+        : nonRepoSummaryStatus();
+    }
     return out;
   }
 

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -1120,6 +1120,7 @@ export class SupervisorRuntime {
     const statuses = await this.gitService.getWorktreeStatusBatch(
       payload.projectLocation,
       payload.worktreePaths,
+      payload.detail ?? "full",
     );
     return { statuses };
   }


### PR DESCRIPTION
- Introduce a `summary` vs `full` git status detail level so background poll/fetch cycles can skip expensive per-file diff stats while still reporting branch, ahead/behind, and change lists
- Watch and refresh only worktrees that are visible in the sidebar (respecting collapsed projects/worktrees, thread list limits, open panels, and dev terminals), and react when that visibility changes
- Merge incoming summary updates with cached full status so existing line counts and remote info stay accurate until a full refresh runs
- Upgrade summary-only cache entries to full status when Git Review opens, and centralize active worktree path resolution for git priming
- Add supervisor summary status paths (including WSL batch), bounded concurrency for native batch status, and tests covering watch sync, summary merge, and review behavior