### PR TITLE
Improve neutral control contrast and theme-aware git/PR tokens

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -581,6 +581,33 @@
   cursor: default;
 }
 
+/* Tertiary: a quiet neutral that still reads as interactive. Borderless, like
+   HeroUI's stock tertiary — the separation from the surface comes from the fill
+   (a step toward --foreground, in the same family as --surface-tertiary /
+   --default), stepped slightly past --default so it stays visible. */
+.button--tertiary {
+  --button-bg: color-mix(in oklab, var(--surface) 82%, var(--foreground));
+  --button-bg-hover: color-mix(in oklab, var(--surface) 78%, var(--foreground));
+  --button-bg-pressed: var(--button-bg-hover);
+}
+
+.light .button--tertiary,
+[data-theme="light"] .button--tertiary {
+  --button-bg: color-mix(in oklab, var(--surface) 80%, var(--foreground));
+  --button-bg-hover: color-mix(in oklab, var(--surface) 74%, var(--foreground));
+}
+
+/* Commit-message field. HeroUI's secondary textarea fills with --default, which
+   sits ~1.1:1 on the near-white git panel in light themes — the field reads as
+   part of the background. Step the fill further toward --foreground so it reads
+   as a distinct field (~1.6:1): recessed gray in light, raised lighter in dark.
+   Scoped to this field only (variant="secondary" + .lc-commit-message). */
+.lc-commit-message.textarea--secondary {
+  --textarea-bg: color-mix(in oklab, var(--surface) 78%, var(--foreground));
+  --textarea-bg-hover: color-mix(in oklab, var(--surface) 74%, var(--foreground));
+  --textarea-bg-focus: var(--textarea-bg);
+}
+
 /* HeroUI sets `.tooltip__trigger { display: inline-block }`, which inherits
    line-height from the surrounding text and adds descender space below
    block-level children (e.g. svg). That makes triggers wrapping an icon render
@@ -723,6 +750,16 @@
   border-color: var(--primary);
 }
 
+/* HeroUI switch off-state track: HeroUI fills it with --default, which sits
+   ~1:1 on the page in light themes — an off toggle reads as empty background.
+   Step the track toward --foreground so it reads as a control and the white
+   thumb stays distinct (~1.8:1 in light, ~2.8:1 in dark). The checked track
+   (--switch-control-bg-checked = accent) and the hover/pressed derivations are
+   untouched — they still flow from this base. */
+.switch {
+  --switch-control-bg: color-mix(in oklab, var(--surface) 70%, var(--foreground));
+}
+
 @layer base {
   :root {
     /* Intentional overrides from HeroUI defaults */
@@ -730,11 +767,22 @@
     --field-radius: calc(var(--radius) * 2);
     --link: var(--accent);
     --focus: var(--foreground);
+
+    /* Soft-accent text: HeroUI uses raw --accent for the label that sits on a
+       soft/neutral fill (secondary button labels, selected toggle labels,
+       badges, chips). Full --accent drops to ~2.4:1 on those fills in
+       lower-contrast palettes (Solarized, Monokai). Deepen it toward
+       --foreground so it stays accent-hued but clears the UI-text floor on
+       every preset; both inputs are themed, so it adapts per theme/mode.
+       Enforced by themePresets.test ("keeps interactive colors readable"). */
+    --color-accent-soft-foreground: color-mix(in oklab, var(--accent) 65%, var(--foreground));
     --surface-shadow: 0 20px 60px rgba(0, 0, 0, 0.08);
     --overlay-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
 
     /* App-specific variables (not HeroUI) */
     --working-tone: var(--success);
+    --pr-merged: oklch(0.7 0.17 292);
+    --git-branch-tone: var(--muted);
     --sidebar-background: var(--surface);
     --content-background: var(--background);
     --window-header-background: var(--sidebar-background);
@@ -765,9 +813,21 @@
     --overlay: oklch(0.99 0.002 286);
     --muted: oklch(0.52 0.01 286);
     --scrollbar: oklch(0.78 0.01 286);
-    --default: oklch(0.93 0.004 286);
+    /* Neutral fill behind secondary/tertiary buttons, selects, chips, badges,
+       toggle/checkbox/radio controls. Stepped darker than HeroUI's stock
+       near-white default (~0.94) so these controls separate from the panel in
+       light themes (~1.35:1 vs page) instead of vanishing into it. */
+    --default: oklch(0.86 0.004 286);
     --accent: oklch(0.62 0.11 245);
     --accent-foreground: var(--snow);
+    --success: oklch(0.45 0.16 150);
+    --success-foreground: var(--snow);
+    --warning: oklch(0.5 0.14 78);
+    --warning-foreground: var(--snow);
+    --danger: oklch(0.48 0.2 25);
+    --danger-foreground: var(--snow);
+    --pr-merged: oklch(0.5 0.18 292);
+    --git-branch-tone: oklch(0.5 0.13 265);
     --field-background: oklch(0.975 0.002 286);
     --field-placeholder: oklch(0.55 0.01 286);
     --field-border: oklch(0.84 0.006 286 / 0.7);
@@ -797,6 +857,8 @@
     --default: oklch(0.28 0.004 286);
     --accent: oklch(0.77 0.08 244);
     --accent-foreground: oklch(0.18 0.004 286);
+    --danger: oklch(0.64 0.2 24.63);
+    --danger-foreground: var(--snow);
     --field-background: oklch(0.23 0.004 286);
     --field-placeholder: oklch(0.54 0.01 286);
     --field-border: oklch(0.34 0.006 286 / 0.85);

--- a/src/renderer/theme/themePresets.test.ts
+++ b/src/renderer/theme/themePresets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyAppTheme } from "./applyAppTheme";
-import { contrastRatio } from "./colorMath";
+import { contrastRatio, mixHex, toHex } from "./colorMath";
 import { APP_THEME_PRESETS, DEFAULT_THEME_ID, getThemePreset } from "./themePresets";
 import { MANAGED_THEME_VARS } from "./themeTokens";
 
@@ -12,6 +12,47 @@ const PANEL_FLOOR = 4.0;
 // Muted must also stay visibly dimmer than the active foreground (hierarchy);
 // foregrounds in low-contrast palettes are brightened/darkened to hold this.
 const MUTED_FG_GAP_FLOOR = 1.9;
+const UI_BOUNDARY_FLOOR = 3.0;
+const UI_FILL_FLOOR = 1.25;
+
+const semanticTokens = {
+  light: {
+    success: "oklch(0.45 0.16 150)",
+    warning: "oklch(0.5 0.14 78)",
+    danger: "oklch(0.48 0.2 25)",
+    prMerged: "oklch(0.5 0.18 292)",
+    gitBranch: "oklch(0.5 0.13 265)",
+  },
+  dark: {
+    success: "oklch(0.7329 0.1935 150.81)",
+    warning: "oklch(0.8203 0.1388 76.34)",
+    danger: "oklch(0.64 0.2 24.63)",
+    prMerged: "oklch(0.7 0.17 292)",
+  },
+} as const;
+
+function oklchToHex(input: string): string {
+  const match = input.match(/oklch\(([\d.]+)%?\s+([\d.]+)\s+([\d.]+)/);
+  if (!match) throw new Error(`Unsupported color: ${input}`);
+  const l = Number(match[1]) / (input.includes("%") ? 100 : 1);
+  const c = Number(match[2]);
+  const h = (Number(match[3]) * Math.PI) / 180;
+  const a = c * Math.cos(h);
+  const b = c * Math.sin(h);
+  const l_ = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m_ = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s_ = (l - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  return toHex([
+    linearToSrgb(4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_) * 255,
+    linearToSrgb(-1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_) * 255,
+    linearToSrgb(-0.0041960863 * l_ - 0.7034186147 * m_ + 1.707614701 * s_) * 255,
+  ]);
+}
+
+function linearToSrgb(value: number): number {
+  const v = Math.min(1, Math.max(0, value));
+  return v <= 0.0031308 ? 12.92 * v : 1.055 * v ** (1 / 2.4) - 0.055;
+}
 
 describe("theme presets", () => {
   it("includes the base default theme first", () => {
@@ -79,6 +120,76 @@ describe("theme presets", () => {
         const gap = contrastRatio(v["--foreground"]!, v["--muted"]!);
         if (gap < MUTED_FG_GAP_FLOOR) {
           failures.push(`${preset.id}/${mode} gap ${gap.toFixed(2)} < ${MUTED_FG_GAP_FLOOR}`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it("keeps interactive colors readable across every theme", () => {
+    // Semantic status colors are fixed oklch literals (not derived per preset),
+    // so convert them to hex once per mode rather than inside the preset loop.
+    const semanticHex = {
+      light: {
+        success: oklchToHex(semanticTokens.light.success),
+        warning: oklchToHex(semanticTokens.light.warning),
+        danger: oklchToHex(semanticTokens.light.danger),
+        prMerged: oklchToHex(semanticTokens.light.prMerged),
+        gitBranch: oklchToHex(semanticTokens.light.gitBranch),
+      },
+      dark: {
+        success: oklchToHex(semanticTokens.dark.success),
+        warning: oklchToHex(semanticTokens.dark.warning),
+        danger: oklchToHex(semanticTokens.dark.danger),
+        prMerged: oklchToHex(semanticTokens.dark.prMerged),
+      },
+    } as const;
+
+    const failures: string[] = [];
+    for (const preset of APP_THEME_PRESETS) {
+      for (const mode of ["light", "dark"] as const) {
+        const v = preset[mode];
+        const surface = v["--surface"]!;
+        const content = v["--content-background"]!;
+        const fg = v["--foreground"]!;
+        const accent = v["--accent"]!;
+        const sem = semanticHex[mode];
+        // git-branch is a fixed tone in light; in dark it's the themed --muted.
+        const gitBranch = mode === "light" ? semanticHex.light.gitBranch : v["--muted"]!;
+
+        // Tertiary fill steps toward fg (mirrors styles.css .button--tertiary),
+        // measured against --surface: tertiary buttons only render on panel
+        // surfaces (sidebars, dialogs, popovers), never the bare page — some
+        // themes pair a pure-white surface with a gray page where a
+        // surface-keyed fill couldn't clear the page without going muddy.
+        const buttonBg = mixHex(fg, surface, mode === "light" ? 0.2 : 0.18);
+        const buttonHover = mixHex(fg, surface, mode === "light" ? 0.26 : 0.22);
+        // Soft-accent label (--color-accent-soft-foreground): styles.css deepens
+        // HeroUI's raw --accent toward fg so it stays accent-hued but legible.
+        // It drives secondary-button labels (on the --default fill) and selected
+        // toggle/badge/chip labels (on a 15% --accent-soft tint) — clear both.
+        const softLabel = mixHex(accent, fg, 0.65);
+        const accentSoftFill = mixHex(accent, surface, 0.15);
+        const defaultFill = mixHex(fg, surface, mode === "light" ? 0.18 : 0.14);
+
+        const checks: [string, string, string, number][] = [
+          ["success/content", sem.success, content, UI_BOUNDARY_FLOOR],
+          ["warning/content", sem.warning, content, UI_BOUNDARY_FLOOR],
+          ["danger/content", sem.danger, content, UI_BOUNDARY_FLOOR],
+          ["pr-merged/content", sem.prMerged, content, UI_BOUNDARY_FLOOR],
+          ["git-branch/content", gitBranch, content, UI_BOUNDARY_FLOOR],
+          ["tertiary bg/surface", buttonBg, surface, UI_FILL_FLOOR],
+          ["tertiary hover/surface", buttonHover, surface, UI_FILL_FLOOR],
+          ["tertiary text/bg", fg, buttonBg, BG_FLOOR],
+          ["tertiary text/hover", fg, buttonHover, BG_FLOOR],
+          ["soft-accent label/accent-soft", softLabel, accentSoftFill, UI_BOUNDARY_FLOOR],
+          ["soft-accent label/default", softLabel, defaultFill, UI_BOUNDARY_FLOOR],
+        ];
+        for (const [pair, a, b, floor] of checks) {
+          const ratio = contrastRatio(a, b);
+          if (ratio < floor) {
+            failures.push(`${preset.id}/${mode} ${pair} ${ratio.toFixed(2)} < ${floor}`);
+          }
         }
       }
     }

--- a/src/renderer/theme/themePresets.ts
+++ b/src/renderer/theme/themePresets.ts
@@ -371,8 +371,8 @@ export const THEME_SPECS: AppThemeSpec[] = [
 export const APP_THEME_PRESETS: AppThemePreset[] = THEME_SPECS.map((spec) => ({
   id: spec.id,
   label: spec.label,
-  light: buildVariant(spec.light),
-  dark: buildVariant(spec.dark),
+  light: buildVariant(spec.light, "light"),
+  dark: buildVariant(spec.dark, "dark"),
 }));
 
 const PRESETS_BY_ID = new Map(APP_THEME_PRESETS.map((entry) => [entry.id, entry]));

--- a/src/renderer/theme/themeTokens.ts
+++ b/src/renderer/theme/themeTokens.ts
@@ -97,7 +97,7 @@ const mix = (a: string, aPct: number, b: string): string =>
 const fade = (color: string, pct: number): string =>
   `color-mix(in oklab, ${color} ${pct}%, transparent)`;
 
-export function buildVariant(spec: ThemeSpec): ThemeVariantVars {
+export function buildVariant(spec: ThemeSpec, mode: "light" | "dark"): ThemeVariantVars {
   const { bg, surface, fg, accent, accentFg, border } = spec;
   const sidebar = spec.sidebar ?? surface;
   const content = spec.content ?? bg;
@@ -129,7 +129,12 @@ export function buildVariant(spec: ThemeSpec): ThemeVariantVars {
     "--overlay": mix(surface, 93, fg),
     "--muted": muted.hex,
     "--scrollbar": fade(muted.hex, 60),
-    "--default": mix(surface, 86, fg),
+    // Neutral fill for secondary/tertiary buttons, selects, chips, toggle and
+    // checkbox/radio controls. Stepped toward fg so the controls separate from
+    // the panel — more in light (where surfaces cluster near white and would
+    // otherwise swallow the fill, ~1.35:1 vs page) than in dark, where
+    // over-stepping would lighten the fill into the (light) accent label.
+    "--default": mix(surface, mode === "light" ? 82 : 86, fg),
     "--accent": accent,
     "--accent-foreground": accentFg,
     "--field-background": mix(surface, 95, fg),

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -66,7 +66,7 @@ export function getPrStatusTone(
 }
 
 export const PR_TONE_BG_CLASS: Record<PrStatusTone, string> = {
-  merged: "bg-purple-400",
+  merged: "bg-[var(--pr-merged)]",
   draft: "bg-gray-400",
   danger: "bg-danger",
   warning: "bg-warning",
@@ -74,7 +74,7 @@ export const PR_TONE_BG_CLASS: Record<PrStatusTone, string> = {
 };
 
 export const PR_TONE_TEXT_CLASS: Record<PrStatusTone, string> = {
-  merged: "text-purple-400",
+  merged: "text-[color:var(--pr-merged)]",
   draft: "text-gray-400",
   danger: "text-danger",
   warning: "text-warning",

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
@@ -68,7 +68,7 @@ export function CommitSyncPanel(props: {
               placeholder="Commit message (Ctrl+Enter)"
               rows={1}
               value={commitMessage}
-              className={canGenerateMessage ? "pr-8" : ""}
+              className={`lc-commit-message ${canGenerateMessage ? "pr-8" : ""}`}
               variant="secondary"
               disabled={isCommitting}
               onChange={(e) => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -50,7 +50,7 @@ describe("GitBadge", () => {
     });
   });
 
-  it("shows a muted PR icon when a pushed worktree can create a PR", () => {
+  it("shows a branch-tone PR icon when a pushed worktree can create a PR", () => {
     useGitStore.setState({
       worktreeStatuses: { "/wt/feature": makeStatus() },
       ghAvailable: { "project-1": true },
@@ -62,7 +62,7 @@ describe("GitBadge", () => {
     const icon = badge.querySelector("svg");
 
     expect(icon).not.toBeNull();
-    expect(icon).toHaveClass("text-muted/60");
+    expect(icon).toHaveClass("text-[color:var(--git-branch-tone)]");
     expect(icon).toHaveClass("lucide-git-pull-request");
   });
 

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -78,7 +78,7 @@ export function GitBadge(props: {
   const showWorktreeFork = (props.fallbackToWorktreeIcon ?? false) && isWorktree && !showPrIcon;
   if (!isRepo || (!hasChanges && !showPrIcon && !showWorktreeFork)) return null;
   const prIconColor = canCreatePr
-    ? "text-muted/60"
+    ? "text-[color:var(--git-branch-tone)]"
     : PR_TONE_TEXT_CLASS[getPrStatusTone(prState, checksStatus)];
   return (
     <div
@@ -107,7 +107,7 @@ export function GitBadge(props: {
           <Tooltip delay={150}>
             <Tooltip.Trigger tabIndex={-1} role="none">
               <span className="flex shrink-0 items-center">
-                <GitFork className="size-3" />
+                <GitFork className="size-3 text-[color:var(--git-branch-tone)]" />
               </span>
             </Tooltip.Trigger>
             <Tooltip.Content placement="right">Worktree: {props.projectName}</Tooltip.Content>

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
@@ -111,7 +111,7 @@ function AgentIcon(props: {
       kind={props.installedKind ?? `acp-registry:${props.agent.id}`}
       icon={props.agent.icon}
       fallbackLabel={props.agent.name}
-      className={`size-8 shrink-0 rounded-lg ${props.isInstalled ? "!text-white !opacity-100" : ""}`}
+      className={`size-8 shrink-0 rounded-lg ${props.isInstalled ? "!text-foreground !opacity-100" : ""}`}
     />
   );
 }
@@ -561,7 +561,7 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
           <ProviderIcon
             kind={agent.id}
             fallbackLabel={agent.label}
-            className={`size-8 shrink-0 rounded-lg ${isInstalled ? "!text-white !opacity-100" : ""}`}
+            className={`size-8 shrink-0 rounded-lg ${isInstalled ? "!text-foreground !opacity-100" : ""}`}
           />
 
           <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -583,7 +583,7 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                   <div className="flex flex-col items-end gap-1">
                     {nativeStatus ? (
                       <span className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs text-muted">
-                        <CheckCircle2 className="size-3.5 text-white" />
+                        <CheckCircle2 className="size-3.5 text-success" />
                         Detected <span className="text-muted/70">(local)</span>
                       </span>
                     ) : null}
@@ -592,7 +592,7 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                         key={`${agent.id}-${status.envDistro ?? "wsl"}`}
                         className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs text-muted"
                       >
-                        <CheckCircle2 className="size-3.5 text-white" />
+                        <CheckCircle2 className="size-3.5 text-success" />
                         Detected{" "}
                         <span className="text-muted/70">
                           {status.envDistro ? `WSL (${status.envDistro})` : "WSL"}
@@ -760,7 +760,7 @@ export function AcpRegistrySettings(props: { onOpenAgentSettings?: (kind: string
                         key={`${status.kind}-${status.envKind ?? "local"}-${status.envDistro ?? "default"}`}
                         className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs text-muted"
                       >
-                        <CheckCircle2 className="size-3.5 text-white" />
+                        <CheckCircle2 className="size-3.5 text-success" />
                         Detected{" "}
                         <span className="text-muted/70">({detectionScopeLabel(status)})</span>
                       </span>

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -458,7 +458,7 @@ function AgentInstallEnvironmentRow(props: {
         <Button
           size="sm"
           variant="tertiary"
-          className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
+          className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted hover:text-foreground"
           aria-label={`Install${envSuffix}`}
           isPending={props.installPending}
           onPress={() => props.onInstall(props.status)}
@@ -629,7 +629,7 @@ function AgentEnvironmentRow(props: {
                       key={method.id}
                       size="sm"
                       variant="tertiary"
-                      className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
+                      className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted hover:text-foreground"
                       aria-label={`${loginLabel} ${method.name}${envSuffix}`}
                       onPress={() => props.onLogin(method)}
                     >
@@ -641,7 +641,7 @@ function AgentEnvironmentRow(props: {
                 <Button
                   size="sm"
                   variant="tertiary"
-                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
+                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted hover:text-foreground"
                   aria-label={`${loginLabel}${envSuffix}`}
                   onPress={() => props.onLogin(singleMethod)}
                 >
@@ -652,7 +652,7 @@ function AgentEnvironmentRow(props: {
                 <Button
                   size="sm"
                   variant="tertiary"
-                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted-foreground hover:text-foreground"
+                  className="h-6 min-h-6 px-2 py-0 text-[10px] text-muted hover:text-foreground"
                   aria-label={`Logout${envSuffix}`}
                   onPress={props.onLogout}
                 >


### PR DESCRIPTION
**Type:** Bugfix

- Strengthen light-theme neutral fills (`--default`, tertiary buttons, switches, commit message field) so secondary controls read clearly against near-white panels without washing out dark-theme accent labels.
- Add theme-managed semantic tokens for merged PRs and git branch/worktree affordances, replacing hardcoded purple/gray utility classes in badges and PR status styling.
- Tune settings surfaces (ACP registry, single-agent install/login rows) so installed icons, success indicators, and tertiary actions use theme foreground/success tokens instead of low-contrast white-on-accent treatments.
- Extend theme preset tests with UI boundary/fill contrast floors and semantic token coverage to guard regressions across presets.