### PR TITLE
Fix Windows agent launch for npm-installed .cmd shims

### DIFF
--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -152,6 +152,40 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     expect(resolveExecutablePath("claude")).toBe(exePath);
   });
 
+  it("keeps the .cmd path for npm node-shim wrappers (e.g. codex.cmd → node codex.js)", () => {
+    // Regression: a previous version of resolveWindowsCmdExeTarget greedily
+    // matched `"%dp0%\node.exe"` in npm's standard Node-script shim and
+    // returned node.exe directly. That stripped the .js entry script, so
+    // buildAgentCommand spawned `node.exe --model ... --enable ...` and Node
+    // rejected the agent's flags with "bad option: --model". The .cmd must
+    // remain so resolveWindowsNodeCmdShim can extract the .js entry later.
+    const root = mkdtempSync(join(tmpdir(), "lightcode-codex-shim-"));
+    tempDirs.push(root);
+    const cmdPath = join(root, "codex.cmd");
+    const nodeExePath = join(root, "node.exe");
+    const jsPath = join(root, "node_modules", "@openai", "codex", "bin", "codex.js");
+    mkdirSync(join(root, "node_modules", "@openai", "codex", "bin"), { recursive: true });
+    writeFileSync(nodeExePath, "");
+    writeFileSync(jsPath, "");
+    writeFileSync(
+      cmdPath,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*',
+        "",
+      ].join("\r\n"),
+    );
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(root, "codex"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("codex")).toBe(cmdPath);
+  });
+
   it("applies the same fallback to async resolution", async () => {
     execFileAsyncMock.mockRejectedValueOnce(new Error("not found")).mockResolvedValueOnce({
       stdout: "C:\\Users\\demo\\scoop\\shims\\opencode.exe\r\n",

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -229,6 +229,13 @@ function resolveWindowsCmdExeTarget(path: string | undefined): string | undefine
   if (!path || !/\.cmd$/i.test(path)) return undefined;
   try {
     const body = readFileSync(path, "utf8");
+    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.js" %*`.
+    // Leave those alone so the downstream resolveWindowsNodeCmdShim (in base/index.ts)
+    // can extract the .js entry and invoke node with it directly. Substituting to
+    // node.exe here would strip the script arg and pass agent flags straight to
+    // node, which rejects them ("bad option: --model", etc.) and exits — breaking
+    // every npm-installed agent (codex, commandcode, gemini, …) on Windows.
+    if (/["']?%dp0%\\[^"']+?\.js["']?\s+%\*/i.test(body)) return undefined;
     const match = /"%dp0%\\([^"]+?\.exe)"/i.exec(body);
     if (!match?.[1]) return undefined;
     const target = join(dirname(path), match[1]);


### PR DESCRIPTION
**Bugfix**

- On Windows, resolving npm-installed agents (e.g. Codex, Gemini) no longer replaces `.cmd` shims with `node.exe` alone, which had dropped the entry script and caused Node to reject agent flags (`bad option: --model`).
- npm’s standard Node-script shim pattern (`"%dp0%\node.exe" "%dp0%\…\entry.js"`) is left intact so later shim parsing can invoke `node` with the correct `.js` entry.
- Adds a Windows regression test for the Codex-style `.cmd` wrapper to guard against the greedy `.exe` substitution returning.