### PR TITLE
Centralize settings scrolling at overlay level

### DIFF
--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -146,6 +146,10 @@ vi.mock("./parts/SearchSettings", () => ({
   SearchSettings: () => <div>Search</div>,
 }));
 
+vi.mock("./parts/UsageSettings", () => ({
+  UsageSettings: () => <div>Usage</div>,
+}));
+
 vi.mock("./parts/ArchivedThreadsSettings", () => ({
   ArchivedThreadsSettings: () => <div>Archived</div>,
 }));
@@ -276,6 +280,21 @@ describe("SettingsOverlay", () => {
       fireEvent.click(screen.getByRole("button", { name: section }));
       expect(within(screen.getByRole("main")).getByText(section)).toBeInTheDocument();
     }
+  });
+
+  it("owns normal settings scrolling at the overlay level", () => {
+    const { container } = render(<SettingsOverlay onClose={() => undefined} />);
+    const firstScroller = container.querySelector<HTMLElement>("[data-settings-scroll-area]");
+    expect(firstScroller).not.toBeNull();
+    firstScroller!.scrollTop = 240;
+
+    fireEvent.click(screen.getByRole("button", { name: "Usage" }));
+
+    const nextScroller = container.querySelector<HTMLElement>("[data-settings-scroll-area]");
+    expect(nextScroller).not.toBeNull();
+    expect(nextScroller).not.toBe(firstScroller);
+    expect(nextScroller!.scrollTop).toBe(0);
+    expect(within(screen.getByRole("main")).getByText("Usage")).toBeInTheDocument();
   });
 
   it("marks agents that need attention in the sidebar", () => {

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -89,6 +89,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
   );
   const isAgentsSectionActive = activeSection === "agents" || activeSection.startsWith("agents:");
   const wslDistros = wslProjectDistrosKey ? wslProjectDistrosKey.split("\0") : [];
+  const section = renderSection(activeSection, setActiveSection);
 
   const refreshAgents = () => {
     if (isRefreshingAgents) {
@@ -140,14 +141,24 @@ export function SettingsOverlay(props: { onClose: () => void }) {
         />
       }
       content={
-        <div className="relative h-full min-h-0">
-          {renderSection(activeSection, setActiveSection)}
-          {isAgentsSectionActive && isRefreshingAgents ? (
-            <div className="absolute inset-0 z-20 bg-background/90 backdrop-blur-sm">
-              <AgentDiscoveryScreen wslDistros={wslDistros} onCancel={cancelRefreshAgents} />
-            </div>
-          ) : null}
-        </div>
+        activeSection === "acpRegistry" ? (
+          <div key={activeSection} className="relative h-full min-h-0">
+            {section}
+          </div>
+        ) : (
+          <div
+            key={activeSection}
+            data-settings-scroll-area="true"
+            className="relative h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4 [overflow-anchor:none] [scrollbar-gutter:stable]"
+          >
+            {section}
+            {isAgentsSectionActive && isRefreshingAgents ? (
+              <div className="absolute inset-0 z-20 bg-background/90 backdrop-blur-sm">
+                <AgentDiscoveryScreen wslDistros={wslDistros} onCancel={cancelRefreshAgents} />
+              </div>
+            ) : null}
+          </div>
+        )
       }
     />
   );

--- a/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
@@ -4,6 +4,7 @@ import { Button, Select } from "@/renderer/components/common";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { friendlyError } from "@/shared/messages";
 import type { AudioTranscriptionModel } from "@/shared/settings";
+import { SettingsPage } from "./SettingsForm";
 
 const SYSTEM_MICROPHONE_ID = "system-default";
 
@@ -94,105 +95,93 @@ export function AudioSettings() {
   }, []);
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <h1 className="mb-6 text-lg font-semibold text-foreground">Audio</h1>
-
-        <div className="space-y-5">
-          <SettingRow
-            title="Show voice input button"
-            description="Show the microphone button in the composer."
-          >
-            <Switch
-              isSelected={showVoiceInputButton}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setAudioSetting("showVoiceInputButton", selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </SettingRow>
-          <SettingRow
-            title="Microphone"
-            description="Device used by the composer voice input button."
-          >
-            <Select
-              aria-label="Microphone"
-              className="w-[280px] shrink-0"
-              options={microphoneOptions}
-              value={microphoneDeviceId || SYSTEM_MICROPHONE_ID}
-              onChange={(value) => {
-                startTransition(() => {
-                  setAudioSetting(
-                    "microphoneDeviceId",
-                    value === SYSTEM_MICROPHONE_ID ? "" : value,
-                  );
-                });
-              }}
-            />
-          </SettingRow>
-          <SettingRow
-            title="Test microphone"
-            description="Check the live input level from the selected device."
-          >
-            <MicrophoneTestBar microphoneDeviceId={microphoneDeviceId} />
-          </SettingRow>
-          <SettingRow
-            title="Voice input language"
-            description="Language the speech model should expect when transcribing composer dictation."
-          >
-            <Select
-              aria-label="Voice input language"
-              className="w-[280px] shrink-0"
-              options={languageOptions}
-              value={transcriptionLanguage}
-              onChange={(value) => {
-                startTransition(() => {
-                  setAudioSetting("transcriptionLanguage", value);
-                });
-              }}
-            />
-          </SettingRow>
-          <SettingRow
-            title="Voice input model"
-            description="Fastest uses Whisper tiny; Better uses Whisper base."
-          >
-            <Select
-              aria-label="Voice input model"
-              className="w-[280px] shrink-0"
-              options={modelOptions}
-              value={transcriptionModel}
-              onChange={(value) => {
-                startTransition(() => {
-                  setAudioSetting("transcriptionModel", value as AudioTranscriptionModel);
-                });
-              }}
-            />
-          </SettingRow>
-          <SettingRow
-            title="Use WebGPU acceleration"
-            description="Run local transcription on the GPU when available."
-          >
-            <Switch
-              isSelected={useWebGpu}
-              onChange={(selected) => {
-                startTransition(() => {
-                  setAudioSetting("useWebGpu", selected);
-                });
-              }}
-            >
-              <Switch.Control>
-                <Switch.Thumb />
-              </Switch.Control>
-            </Switch>
-          </SettingRow>
-        </div>
-      </div>
-    </div>
+    <SettingsPage title="Audio" bodyClassName="space-y-5">
+      <SettingRow
+        title="Show voice input button"
+        description="Show the microphone button in the composer."
+      >
+        <Switch
+          isSelected={showVoiceInputButton}
+          onChange={(selected) => {
+            startTransition(() => {
+              setAudioSetting("showVoiceInputButton", selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+      <SettingRow title="Microphone" description="Device used by the composer voice input button.">
+        <Select
+          aria-label="Microphone"
+          className="w-[280px] shrink-0"
+          options={microphoneOptions}
+          value={microphoneDeviceId || SYSTEM_MICROPHONE_ID}
+          onChange={(value) => {
+            startTransition(() => {
+              setAudioSetting("microphoneDeviceId", value === SYSTEM_MICROPHONE_ID ? "" : value);
+            });
+          }}
+        />
+      </SettingRow>
+      <SettingRow
+        title="Test microphone"
+        description="Check the live input level from the selected device."
+      >
+        <MicrophoneTestBar microphoneDeviceId={microphoneDeviceId} />
+      </SettingRow>
+      <SettingRow
+        title="Voice input language"
+        description="Language the speech model should expect when transcribing composer dictation."
+      >
+        <Select
+          aria-label="Voice input language"
+          className="w-[280px] shrink-0"
+          options={languageOptions}
+          value={transcriptionLanguage}
+          onChange={(value) => {
+            startTransition(() => {
+              setAudioSetting("transcriptionLanguage", value);
+            });
+          }}
+        />
+      </SettingRow>
+      <SettingRow
+        title="Voice input model"
+        description="Fastest uses Whisper tiny; Better uses Whisper base."
+      >
+        <Select
+          aria-label="Voice input model"
+          className="w-[280px] shrink-0"
+          options={modelOptions}
+          value={transcriptionModel}
+          onChange={(value) => {
+            startTransition(() => {
+              setAudioSetting("transcriptionModel", value as AudioTranscriptionModel);
+            });
+          }}
+        />
+      </SettingRow>
+      <SettingRow
+        title="Use WebGPU acceleration"
+        description="Run local transcription on the GPU when available."
+      >
+        <Switch
+          isSelected={useWebGpu}
+          onChange={(selected) => {
+            startTransition(() => {
+              setAudioSetting("useWebGpu", selected);
+            });
+          }}
+        >
+          <Switch.Control>
+            <Switch.Thumb />
+          </Switch.Control>
+        </Switch>
+      </SettingRow>
+    </SettingsPage>
   );
 }
 

--- a/src/renderer/views/SettingsOverlay/parts/SettingsForm.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsForm.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SettingsPage } from "./SettingsForm";
+
+describe("SettingsPage", () => {
+  it("does not create its own scroll container", () => {
+    const { container } = render(
+      <SettingsPage title="General">
+        <div>Body</div>
+      </SettingsPage>,
+    );
+
+    const scrollers = container.querySelectorAll("[data-settings-scroll-area]");
+
+    expect(scrollers).toHaveLength(0);
+  });
+});

--- a/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsForm.tsx
@@ -17,15 +17,13 @@ export function SettingsPage(props: {
 }) {
   const { title, description, actions, bodyClassName = "space-y-4", children } = props;
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4 [scrollbar-gutter:stable]">
-      <div className="mx-auto min-h-full max-w-[720px]">
-        <div className={`flex items-center justify-between gap-4 ${description ? "mb-2" : "mb-6"}`}>
-          <h1 className="text-lg font-semibold text-foreground">{title}</h1>
-          {actions ? <div className="shrink-0">{actions}</div> : null}
-        </div>
-        {description ? <p className="mb-6 text-xs text-muted">{description}</p> : null}
-        <div className={bodyClassName}>{children}</div>
+    <div className="mx-auto min-h-full max-w-[720px]">
+      <div className={`flex items-center justify-between gap-4 ${description ? "mb-2" : "mb-6"}`}>
+        <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
       </div>
+      {description ? <p className="mb-6 text-xs text-muted">{description}</p> : null}
+      <div className={bodyClassName}>{children}</div>
     </div>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -1383,275 +1383,269 @@ export function SingleAgentSettings(props: { agentKind: string }) {
   };
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
-      <div className="mx-auto max-w-[720px]">
-        <div className="mb-6">
-          <div className="flex items-center justify-between gap-4 mb-4">
-            <div className="flex items-center gap-3">
-              <ProviderIcon
-                kind={agent.kind}
-                icon={agent.icon}
-                fallbackLabel={agent.label}
-                className="size-8"
-              />
-              <div className="flex flex-col">
-                <h1 className="text-lg font-semibold text-foreground leading-tight">
-                  {agent.label}
-                </h1>
-                <p className="text-[11px] text-muted">
-                  {isDisabled ? "Agent is currently disabled" : "Agent is active and ready"}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              {updateAvailable && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 min-h-7 gap-1 px-2 text-[11px]"
-                  isPending={updatePending}
-                  onPress={performUpdate}
-                >
-                  <ArrowUpCircle className="size-3" />
-                  Update to v{latestRegistryVersion}
-                </Button>
-              )}
-              <Switch
-                isSelected={!isDisabled}
-                isDisabled={binaryUpdatePendingEnvKey !== undefined}
-                size="sm"
-                aria-label="Enabled"
-                onChange={(selected) => {
-                  startTransition(() => {
-                    setAgentDisabled(agent.kind, !selected);
-                  });
-                  if (selected) {
-                    void readBridge()
-                      .refreshAgentStatuses(wslDistros, { agentKinds: [agent.kind] })
-                      .catch(() => undefined);
-                  }
-                }}
-              >
-                <Switch.Control>
-                  <Switch.Thumb />
-                </Switch.Control>
-              </Switch>
+    <div className="mx-auto max-w-[720px]">
+      <div className="mb-6">
+        <div className="flex items-center justify-between gap-4 mb-4">
+          <div className="flex items-center gap-3">
+            <ProviderIcon
+              kind={agent.kind}
+              icon={agent.icon}
+              fallbackLabel={agent.label}
+              className="size-8"
+            />
+            <div className="flex flex-col">
+              <h1 className="text-lg font-semibold text-foreground leading-tight">{agent.label}</h1>
+              <p className="text-[11px] text-muted">
+                {isDisabled ? "Agent is currently disabled" : "Agent is active and ready"}
+              </p>
             </div>
           </div>
-
-          <div className="space-y-0.5 border-t border-border/10 pt-3">
-            {installedHere.map(renderInstalledEnvironmentRow)}
-            {installableHere.map(renderInstallableEnvironmentRow)}
-            {installedWsl.map(renderInstalledEnvironmentRow)}
-            {installableWsl.map(renderInstallableEnvironmentRow)}
+          <div className="flex items-center gap-3">
+            {updateAvailable && (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                isPending={updatePending}
+                onPress={performUpdate}
+              >
+                <ArrowUpCircle className="size-3" />
+                Update to v{latestRegistryVersion}
+              </Button>
+            )}
+            <Switch
+              isSelected={!isDisabled}
+              isDisabled={binaryUpdatePendingEnvKey !== undefined}
+              size="sm"
+              aria-label="Enabled"
+              onChange={(selected) => {
+                startTransition(() => {
+                  setAgentDisabled(agent.kind, !selected);
+                });
+                if (selected) {
+                  void readBridge()
+                    .refreshAgentStatuses(wslDistros, { agentKinds: [agent.kind] })
+                    .catch(() => undefined);
+                }
+              }}
+            >
+              <Switch.Control>
+                <Switch.Thumb />
+              </Switch.Control>
+            </Switch>
           </div>
         </div>
 
-        <div className="space-y-4">
-          {hasAuthSettings && (
-            <div className="space-y-2">
-              {envVarAuthMethod && acpInstanceId ? (
-                <div className="flex items-start justify-between gap-4 rounded-xl border border-border bg-surface-secondary px-3 py-2 text-foreground">
-                  <div className="flex min-w-0 items-start gap-2">
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium">{envVarAuthMethod.name}</p>
-                      <p className="text-xs text-muted">
-                        Saved credentials are shared across all environments.
-                      </p>
-                      <div className="mt-3 flex flex-col gap-2">
-                        {envVarAuthMethod.vars.map((variable) => {
-                          const hasAuthValue = Object.prototype.hasOwnProperty.call(
-                            authValues,
-                            variable.name,
-                          );
-                          const allEnvVarSaved =
-                            missingAuthStatuses.length === 0 && installedStatuses.length > 0;
-                          return (
-                            <Input
-                              key={variable.name}
-                              aria-label={variable.label ?? variable.name}
-                              className="w-full"
-                              placeholder={variable.label ?? variable.name}
-                              type={
-                                variable.secret === false || (!hasAuthValue && allEnvVarSaved)
-                                  ? "text"
-                                  : "password"
-                              }
-                              value={
-                                hasAuthValue
-                                  ? (authValues[variable.name] ?? "")
-                                  : allEnvVarSaved
-                                    ? SAVED_SECRET_MASK
-                                    : ""
-                              }
-                              onFocus={() => {
-                                if (allEnvVarSaved && !hasAuthValue) {
-                                  setAuthValues((current) => ({
-                                    ...current,
-                                    [variable.name]: "",
-                                  }));
-                                }
-                              }}
-                              onBlur={(event) => {
-                                if (!allEnvVarSaved) return;
-                                if (
-                                  event.relatedTarget instanceof HTMLElement &&
-                                  event.relatedTarget.closest("[data-acp-auth-save]")
-                                ) {
-                                  return;
-                                }
-                                setAuthValues((current) => {
-                                  if (
-                                    !Object.prototype.hasOwnProperty.call(current, variable.name)
-                                  ) {
-                                    return current;
-                                  }
-                                  const next = { ...current };
-                                  delete next[variable.name];
-                                  return next;
-                                });
-                              }}
-                              onChange={(event) =>
+        <div className="space-y-0.5 border-t border-border/10 pt-3">
+          {installedHere.map(renderInstalledEnvironmentRow)}
+          {installableHere.map(renderInstallableEnvironmentRow)}
+          {installedWsl.map(renderInstalledEnvironmentRow)}
+          {installableWsl.map(renderInstallableEnvironmentRow)}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {hasAuthSettings && (
+          <div className="space-y-2">
+            {envVarAuthMethod && acpInstanceId ? (
+              <div className="flex items-start justify-between gap-4 rounded-xl border border-border bg-surface-secondary px-3 py-2 text-foreground">
+                <div className="flex min-w-0 items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium">{envVarAuthMethod.name}</p>
+                    <p className="text-xs text-muted">
+                      Saved credentials are shared across all environments.
+                    </p>
+                    <div className="mt-3 flex flex-col gap-2">
+                      {envVarAuthMethod.vars.map((variable) => {
+                        const hasAuthValue = Object.prototype.hasOwnProperty.call(
+                          authValues,
+                          variable.name,
+                        );
+                        const allEnvVarSaved =
+                          missingAuthStatuses.length === 0 && installedStatuses.length > 0;
+                        return (
+                          <Input
+                            key={variable.name}
+                            aria-label={variable.label ?? variable.name}
+                            className="w-full"
+                            placeholder={variable.label ?? variable.name}
+                            type={
+                              variable.secret === false || (!hasAuthValue && allEnvVarSaved)
+                                ? "text"
+                                : "password"
+                            }
+                            value={
+                              hasAuthValue
+                                ? (authValues[variable.name] ?? "")
+                                : allEnvVarSaved
+                                  ? SAVED_SECRET_MASK
+                                  : ""
+                            }
+                            onFocus={() => {
+                              if (allEnvVarSaved && !hasAuthValue) {
                                 setAuthValues((current) => ({
                                   ...current,
-                                  [variable.name]: event.target.value,
-                                }))
+                                  [variable.name]: "",
+                                }));
                               }
-                            />
-                          );
-                        })}
-                      </div>
+                            }}
+                            onBlur={(event) => {
+                              if (!allEnvVarSaved) return;
+                              if (
+                                event.relatedTarget instanceof HTMLElement &&
+                                event.relatedTarget.closest("[data-acp-auth-save]")
+                              ) {
+                                return;
+                              }
+                              setAuthValues((current) => {
+                                if (!Object.prototype.hasOwnProperty.call(current, variable.name)) {
+                                  return current;
+                                }
+                                const next = { ...current };
+                                delete next[variable.name];
+                                return next;
+                              });
+                            }}
+                            onChange={(event) =>
+                              setAuthValues((current) => ({
+                                ...current,
+                                [variable.name]: event.target.value,
+                              }))
+                            }
+                          />
+                        );
+                      })}
                     </div>
                   </div>
-                  <div className="flex shrink-0 flex-row items-center gap-2">
+                </div>
+                <div className="flex shrink-0 flex-row items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="tertiary"
+                    isIconOnly
+                    aria-label="Save"
+                    isDisabled={!canSaveEnvAuth}
+                    isPending={authPending}
+                    data-acp-auth-save=""
+                    onPress={saveEnvAuth}
+                  >
+                    <Save className="size-4" />
+                  </Button>
+                  {!usePerEnvAuthRows && (
                     <Button
                       size="sm"
                       variant="tertiary"
                       isIconOnly
-                      aria-label="Save"
-                      isDisabled={!canSaveEnvAuth}
+                      aria-label="Logout"
                       isPending={authPending}
-                      data-acp-auth-save=""
-                      onPress={saveEnvAuth}
+                      onPress={clearEnvVarCredentials}
                     >
-                      <Save className="size-4" />
+                      <LogOut className="size-4 text-danger" />
                     </Button>
-                    {!usePerEnvAuthRows && (
-                      <Button
-                        size="sm"
-                        variant="tertiary"
-                        isIconOnly
-                        aria-label="Logout"
-                        isPending={authPending}
-                        onPress={clearEnvVarCredentials}
-                      >
-                        <LogOut className="size-4 text-danger" />
-                      </Button>
-                    )}
+                  )}
+                </div>
+              </div>
+            ) : null}
+
+            {!usePerEnvAuthRows &&
+            !showEnvVarOnly &&
+            (agentAuth || loginStatus || logoutStatuses.length > 0) ? (
+              <div className="flex items-start justify-between gap-4 py-1">
+                <div className="flex min-w-0 items-start gap-2">
+                  <div className="min-w-0 flex-1">
+                    <p className={`text-sm font-medium ${authMissing ? "text-warning" : ""}`}>
+                      {authMissing ? (
+                        <AlertTriangle className="mr-1.5 inline size-4 -translate-y-px text-warning" />
+                      ) : null}
+                      {authMissing ? "Login required" : "Authentication"}
+                    </p>
+                    <p className="text-xs text-muted truncate">
+                      {authPendingMessage ??
+                        (authMissing
+                          ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
+                              envVarAuthMethod
+                                ? agentAuth
+                                  ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials.`
+                                  : `Save ${envVarAuthMethod.name} credentials.`
+                                : agentAuth
+                                  ? `Complete ${agentAuth.method.name} sign-in.`
+                                  : loginCommand
+                                    ? `Run ${loginCommand} to sign in.`
+                                    : "Sign in with the agent CLI."
+                            }`
+                          : "Credentials are configured.")}
+                    </p>
                   </div>
                 </div>
-              ) : null}
-
-              {!usePerEnvAuthRows &&
-              !showEnvVarOnly &&
-              (agentAuth || loginStatus || logoutStatuses.length > 0) ? (
-                <div className="flex items-start justify-between gap-4 py-1">
-                  <div className="flex min-w-0 items-start gap-2">
-                    <div className="min-w-0 flex-1">
-                      <p className={`text-sm font-medium ${authMissing ? "text-warning" : ""}`}>
-                        {authMissing ? (
-                          <AlertTriangle className="mr-1.5 inline size-4 -translate-y-px text-warning" />
-                        ) : null}
-                        {authMissing ? "Login required" : "Authentication"}
-                      </p>
-                      <p className="text-xs text-muted truncate">
-                        {authPendingMessage ??
-                          (authMissing
-                            ? `${missingAuthLabel ? `${missingAuthLabel} needs authentication. ` : ""}${
-                                envVarAuthMethod
-                                  ? agentAuth
-                                    ? `Complete ${agentAuth.method.name} sign-in or save ${envVarAuthMethod.name} credentials.`
-                                    : `Save ${envVarAuthMethod.name} credentials.`
-                                  : agentAuth
-                                    ? `Complete ${agentAuth.method.name} sign-in.`
-                                    : loginCommand
-                                      ? `Run ${loginCommand} to sign in.`
-                                      : "Sign in with the agent CLI."
-                              }`
-                            : "Credentials are configured.")}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 flex-col items-end gap-2">
-                    {agentAuth && supportsAcpAgentAuth ? (
-                      (agentAuthEntries.length > 0 ? agentAuthEntries : [agentAuth]).map(
-                        (entry, index) => (
-                          <Button
-                            key={`${entry.status.kind}-${entry.status.envKind ?? "native"}-${entry.status.envDistro ?? index}`}
-                            size="sm"
-                            variant="tertiary"
-                            className="h-7 min-h-7 gap-1 px-2 text-[11px]"
-                            isPending={authPending}
-                            onPress={() => authenticateAgent(entry)}
-                          >
-                            <LogIn className="size-3" />
-                            {authMissing ? "Login" : "Re-login"}
-                          </Button>
-                        ),
-                      )
-                    ) : loginStatus && loginCommand ? (
-                      <Button
-                        size="sm"
-                        variant="tertiary"
-                        className="h-7 min-h-7 gap-1 px-2 text-[11px]"
-                        onPress={() => runTerminalLogin(loginStatus, terminalLoginMethod)}
-                      >
-                        <LogIn className="size-3" />
-                        {authMissing ? "Login" : "Re-login"}
-                      </Button>
-                    ) : null}
-                    {logoutStatuses.map((status, index) => (
-                      <Button
-                        key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
-                        size="sm"
-                        variant="tertiary"
-                        className="h-7 min-h-7 gap-1 px-2 text-[11px]"
-                        isPending={authPending}
-                        onPress={() => logoutAgent(status)}
-                      >
-                        <LogOut className="size-3 text-danger" />
-                        Logout
-                      </Button>
-                    ))}
-                  </div>
+                <div className="flex shrink-0 flex-col items-end gap-2">
+                  {agentAuth && supportsAcpAgentAuth ? (
+                    (agentAuthEntries.length > 0 ? agentAuthEntries : [agentAuth]).map(
+                      (entry, index) => (
+                        <Button
+                          key={`${entry.status.kind}-${entry.status.envKind ?? "native"}-${entry.status.envDistro ?? index}`}
+                          size="sm"
+                          variant="tertiary"
+                          className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                          isPending={authPending}
+                          onPress={() => authenticateAgent(entry)}
+                        >
+                          <LogIn className="size-3" />
+                          {authMissing ? "Login" : "Re-login"}
+                        </Button>
+                      ),
+                    )
+                  ) : loginStatus && loginCommand ? (
+                    <Button
+                      size="sm"
+                      variant="tertiary"
+                      className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                      onPress={() => runTerminalLogin(loginStatus, terminalLoginMethod)}
+                    >
+                      <LogIn className="size-3" />
+                      {authMissing ? "Login" : "Re-login"}
+                    </Button>
+                  ) : null}
+                  {logoutStatuses.map((status, index) => (
+                    <Button
+                      key={`${status.kind}-${status.envKind ?? "native"}-${status.envDistro ?? index}-logout`}
+                      size="sm"
+                      variant="tertiary"
+                      className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+                      isPending={authPending}
+                      onPress={() => logoutAgent(status)}
+                    >
+                      <LogOut className="size-3 text-danger" />
+                      Logout
+                    </Button>
+                  ))}
                 </div>
-              ) : null}
-            </div>
-          )}
-        </div>
-
-        <div className={`transition-opacity ${isDisabled ? "pointer-events-none opacity-40" : ""}`}>
-          {defs.length > 0 && (
-            <div className="mt-6">
-              {defs.map((def) => (
-                <AgentSettingRow key={def.key} agentKind={agent.kind} def={def} />
-              ))}
-            </div>
-          )}
-
-          {hasSelectableModels && (
-            <div className="mt-6">
-              <ModelVisibilityDropdown agentKind={agent.kind} provider={menuProvider} />
-            </div>
-          )}
-        </div>
-
-        <HookPluginSettings
-          agentKind={agent.kind}
-          agentLabel={agent.label}
-          statuses={installedStatuses}
-        />
+              </div>
+            ) : null}
+          </div>
+        )}
       </div>
+
+      <div className={`transition-opacity ${isDisabled ? "pointer-events-none opacity-40" : ""}`}>
+        {defs.length > 0 && (
+          <div className="mt-6">
+            {defs.map((def) => (
+              <AgentSettingRow key={def.key} agentKind={agent.kind} def={def} />
+            ))}
+          </div>
+        )}
+
+        {hasSelectableModels && (
+          <div className="mt-6">
+            <ModelVisibilityDropdown agentKind={agent.kind} provider={menuProvider} />
+          </div>
+        )}
+      </div>
+
+      <HookPluginSettings
+        agentKind={agent.kind}
+        agentLabel={agent.label}
+        statuses={installedStatuses}
+      />
     </div>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -131,7 +131,13 @@ export function UsageSettings() {
       title="Usage"
       description="Track per-provider session, weekly, and monthly usage. Windows are reported by each provider; estimated cost is reconstructed from local logs."
       actions={
-        <Button size="sm" variant="secondary" isDisabled={isRefreshing} onPress={refreshNow}>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-foreground"
+          isDisabled={isRefreshing}
+          onPress={refreshNow}
+        >
           <RefreshCw className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
           Refresh
         </Button>


### PR DESCRIPTION
- **Refactor:** Move the scroll container from individual settings pages into `SettingsOverlay`, keyed by section so scroll position resets when you switch tabs.
- Drop per-page `overflow-y-auto` wrappers from `SettingsPage`, Audio, and Single Agent settings to avoid nested scroll areas and inconsistent behavior.
- Leave the ACP registry section on its own layout where it does not use the shared scroll wrapper.
- Align Usage settings refresh control with ghost button styling used elsewhere in settings.
- Add overlay and `SettingsPage` tests to guard scroll ownership and section-switch reset behavior.