### PR TITLE
Include userInputForm on single-question tool input requests

### DIFF
--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1861,7 +1861,7 @@ describe("sdkCanonicalMapping — requests", () => {
     });
   });
 
-  it("parses AskUserQuestion input and exposes single-question options", () => {
+  it("parses AskUserQuestion input and exposes single-question options with a structured form", () => {
     const questions = parseClaudeQuestions({
       questions: [
         {
@@ -1880,6 +1880,9 @@ describe("sdkCanonicalMapping — requests", () => {
       requestType: "tool_user_input",
       payload: {
         summary: "Choose one",
+        details: {
+          userInputForm: { questions },
+        },
         multiSelect: true,
         options: [{ optionId: "A", label: "A", description: "Alpha" }],
       },

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -640,7 +640,7 @@ export function mapClaudeQuestionRequest(input: {
       summary: firstQuestion?.question ?? "Claude needs more information",
       details: {
         questions: input.questions,
-        ...(!isSingleQuestion ? { userInputForm: { questions: input.questions } } : {}),
+        userInputForm: { questions: input.questions },
       },
       ...(isSingleQuestion && firstQuestion?.options ? { options: firstQuestion.options } : {}),
       ...(isSingleQuestion && firstQuestion?.multiSelect !== undefined

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.test.ts
@@ -297,6 +297,22 @@ describe("sdkCanonicalMapping — permission/question events", () => {
     expect(ev.requestId).toBe("opencode-q-q_1");
     expect(ev.requestType).toBe("tool_user_input");
     expect(ev.payload.multiSelect).toBe(true);
+    expect(ev.payload.details).toEqual({
+      userInputForm: {
+        questions: [
+          {
+            id: "q0",
+            question: "Pick frameworks",
+            header: "Frameworks",
+            options: [
+              { optionId: "q0.0", label: "React", description: "UI lib" },
+              { optionId: "q0.1", label: "Vue", description: "Reactive" },
+            ],
+            multiSelect: true,
+          },
+        ],
+      },
+    });
     expect(ev.payload.options).toHaveLength(2);
     expect(ev.payload.options?.[0]?.label).toBe("React");
   });

--- a/src/supervisor/agents/opencode/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/opencode/sdkCanonicalMapping.ts
@@ -821,13 +821,14 @@ function questionRequestPayload(req: QuestionRequest): {
       ...(q.multiple ? { multiSelect: true } : {}),
     });
   }
+  const first = formQuestions[0];
   if (formQuestions.length > 1) {
     return { summary, details: { userInputForm: { questions: formQuestions } } };
   }
-  const first = formQuestions[0];
   return first
     ? {
         summary,
+        details: { userInputForm: { questions: formQuestions } },
         options: first.options,
         ...(first.multiSelect ? { multiSelect: true } : {}),
       }


### PR DESCRIPTION
- **Bugfix:** Single-question tool user input requests now include `details.userInputForm`, not only top-level `options` and `multiSelect`.
- Ensures the renderer can show a structured question form for one-question prompts, matching multi-question behavior.
- Applies the same payload shape in Claude and OpenCode SDK canonical mapping for cross-provider parity.
- Extends Claude and OpenCode mapping tests to assert `userInputForm` on single-question requests.