### PR TITLE
Emit structured updates for OpenCode pending requests

### DIFF
--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -378,6 +378,7 @@ describe("OpencodeSdkSession", () => {
 
   it("records single-question option replies as question answer events", async () => {
     const runtimeEvents: RuntimeEvent[] = [];
+    const updates: StructuredSessionUpdate[] = [];
     const questionReply = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     let releaseQuestionEvent!: () => void;
     const waitForSession = new Promise<void>((resolve) => {
@@ -435,7 +436,7 @@ describe("OpencodeSdkSession", () => {
     session.setListener({
       onClose: () => {},
       onError: () => {},
-      onUpdate: () => {},
+      onUpdate: (update) => updates.push(update),
       onRuntimeEvent: (event) => runtimeEvents.push(event),
     });
 
@@ -446,6 +447,9 @@ describe("OpencodeSdkSession", () => {
     await vi.waitFor(() => {
       expect(runtimeEvents.some((event) => event.type === "request.opened")).toBe(true);
     });
+    expect(updates).toContainEqual(
+      expect.objectContaining({ status: "needs_reply", attention: "needs_reply" }),
+    );
 
     await session.resolveServerRequest("opencode-q-req1", { optionId: "q0.1" });
 
@@ -469,6 +473,7 @@ describe("OpencodeSdkSession", () => {
         ],
       },
     });
+    expect(updates.at(-1)).toMatchObject({ status: "working", attention: "working" });
   });
 
   it("omits a session permission override in supervised mode", async () => {

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -581,6 +581,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       } catch {
         // Server-side may have already received another reply or aborted.
       }
+      this.emitUpdateAfterRequestResolution();
       return;
     }
 
@@ -612,6 +613,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
           }),
         );
       }
+      this.emitUpdateAfterRequestResolution();
     }
   }
 
@@ -830,6 +832,35 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     }
   }
 
+  private sessionRefUpdate(): { sessionRef: SessionRef } | Record<string, never> {
+    return this.sessionId ? { sessionRef: createKnownSessionRef(this.sessionId) } : {};
+  }
+
+  private pendingRequestStatus(): { status: ThreadStatus; attention: ThreadAttention } | undefined {
+    let hasQuestion = false;
+    for (const pending of this.pendingRequests.values()) {
+      if (pending.kind === "permission") {
+        return { status: "needs_approval", attention: "needs_approval" };
+      }
+      hasQuestion = true;
+    }
+    return hasQuestion ? { status: "needs_reply", attention: "needs_reply" } : undefined;
+  }
+
+  private emitPendingRequestUpdate(): void {
+    const pending = this.pendingRequestStatus();
+    if (!pending) return;
+    this.listener?.onUpdate({ ...pending, ...this.sessionRefUpdate() });
+  }
+
+  private emitUpdateAfterRequestResolution(): void {
+    const pending = this.pendingRequestStatus();
+    this.listener?.onUpdate({
+      ...(pending ?? { status: "working", attention: "working" }),
+      ...this.sessionRefUpdate(),
+    });
+  }
+
   private startEventStream(): void {
     const acquired = this.requireAcquired();
     const ctrl = new AbortController();
@@ -907,17 +938,16 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     if (event.type === "session.status") {
       const upd = mapStatusUpdate(event.properties);
       this.listener?.onUpdate({
-        ...upd,
-        ...(this.sessionId ? { sessionRef: createKnownSessionRef(this.sessionId) } : {}),
+        ...(this.pendingRequestStatus() ?? upd),
+        ...this.sessionRefUpdate(),
       });
       return;
     }
 
     if (event.type === "session.idle") {
       this.listener?.onUpdate({
-        status: "idle",
-        attention: "none",
-        ...(this.sessionId ? { sessionRef: createKnownSessionRef(this.sessionId) } : {}),
+        ...(this.pendingRequestStatus() ?? { status: "idle", attention: "none" }),
+        ...this.sessionRefUpdate(),
       });
       return;
     }
@@ -929,6 +959,12 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         requestID: event.properties.id,
         sessionID: event.properties.sessionID,
       });
+      this.emitPendingRequestUpdate();
+    }
+
+    if (event.type === "permission.replied") {
+      const requestId = `opencode-perm-${event.properties.requestID}` as ThreadServerRequestId;
+      if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
     }
 
     if (event.type === "question.asked") {
@@ -941,6 +977,12 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         optionValues: questionMetadata.optionValues,
         sourceQuestions: questionMetadata.sourceQuestions,
       });
+      this.emitPendingRequestUpdate();
+    }
+
+    if (event.type === "question.replied" || event.type === "question.rejected") {
+      const requestId = `opencode-q-${event.properties.requestID}` as ThreadServerRequestId;
+      if (this.pendingRequests.delete(requestId)) this.emitUpdateAfterRequestResolution();
     }
 
     if (event.type === "session.error") {


### PR DESCRIPTION
- **Bugfix:** OpenCode structured sessions did not emit session updates when questions or permissions were pending, so the UI could miss `needs_reply` / `needs_approval` state.
- Pending request status now takes precedence over server `session.status` and `session.idle` events so thread attention stays accurate while a reply or approval is outstanding.
- Resolving a request emits an immediate structured update, returning to `working` when no pending requests remain.
- Tests cover the question-reply flow and assert the expected `needs_reply` → `working` update sequence.