### PR TITLE
Reopen GUI turn after premature idle

### DIFF
--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -915,6 +915,70 @@ describe("appStore runtime config sync", () => {
     });
   });
 
+  it("reopens a GUI turn when structured runtime activity arrives after a premature idle", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "claude",
+      config: { model: "m" },
+      prompt: "a",
+      presentationMode: "gui",
+    });
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "assistant-1",
+      itemType: "assistant_message",
+    });
+
+    vi.setSystemTime(new Date("2026-05-01T12:00:50.000Z"));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+    });
+    expect(useAppStore.getState().threads[0]).toMatchObject({
+      status: "idle",
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:00:50.000Z",
+    });
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]).toHaveLength(1);
+
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "reasoning-1",
+      itemType: "reasoning",
+    });
+
+    expect(useAppStore.getState().threads[0]).toMatchObject({
+      status: "working",
+      attention: "working",
+      activeTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: undefined,
+    });
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]).toBeUndefined();
+
+    vi.setSystemTime(new Date("2026-05-01T12:01:15.000Z"));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+    });
+
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]?.[0]).toMatchObject({
+      startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+      endedAt: new Date("2026-05-01T12:01:15.000Z").getTime(),
+      anchorItemId: "reasoning-1",
+    });
+  });
+
   it("does not add sub-second completed turns", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -392,7 +392,9 @@ type RuntimeEventState = Pick<
   | "runtimeRequestsByThread"
   | "runtimeContextByThread"
   | "runtimeStructuralVersionByThread"
->;
+  | "runtimeCompletedTurnsByThread"
+> &
+  Pick<AppStoreState, "threads">;
 
 function applyRuntimeEventsToState(
   state: AppStoreState,
@@ -405,6 +407,8 @@ function applyRuntimeEventsToState(
     runtimeRequestsByThread: state.runtimeRequestsByThread,
     runtimeContextByThread: state.runtimeContextByThread,
     runtimeStructuralVersionByThread: state.runtimeStructuralVersionByThread,
+    runtimeCompletedTurnsByThread: state.runtimeCompletedTurnsByThread ?? {},
+    threads: state.threads ?? [],
   };
   let changed = false;
   let bumpStructural = false;
@@ -413,6 +417,10 @@ function applyRuntimeEventsToState(
     const patch = applyRuntimeEventToRuntimeState(nextState, threadId, event);
     if (Object.keys(patch).length === 0) continue;
     nextState = { ...nextState, ...patch };
+    const reopenPatch = reopenGuiTurnForLiveRuntimeActivity(nextState, threadId, event);
+    if (Object.keys(reopenPatch).length > 0) {
+      nextState = { ...nextState, ...reopenPatch };
+    }
     changed = true;
     if (eventAffectsStructuralVersion(event)) bumpStructural = true;
   }
@@ -431,6 +439,89 @@ function applyRuntimeEventsToState(
   return {
     ...nextState,
   };
+}
+
+function reopenGuiTurnForLiveRuntimeActivity(
+  state: RuntimeEventState,
+  threadId: string,
+  event: RuntimeEvent,
+): Partial<RuntimeEventState> {
+  if (!isLiveAssistantActivity(state, threadId, event)) return {};
+  let changed = false;
+  let nextCompletedTurns = state.runtimeCompletedTurnsByThread;
+  const nowIso = new Date().toISOString();
+  const threads = state.threads.map((thread) => {
+    if (
+      thread.id !== threadId ||
+      thread.presentationMode !== "gui" ||
+      (thread.status !== "idle" && thread.status !== "finished")
+    ) {
+      return thread;
+    }
+
+    changed = true;
+    const activeTurnStartedAt = thread.lastTurnStartedAt ?? thread.updatedAt ?? nowIso;
+    const startedAt = parseTurnMs(thread.lastTurnStartedAt);
+    const endedAt = parseTurnMs(thread.lastTurnEndedAt);
+    if (startedAt !== null && endedAt !== null) {
+      nextCompletedTurns = removeCompletedTurnWindow(
+        nextCompletedTurns,
+        threadId,
+        startedAt,
+        endedAt,
+      );
+    }
+    return {
+      ...thread,
+      status: "working" as const,
+      attention: "working" as const,
+      activeTurnStartedAt,
+      lastTurnEndedAt: undefined,
+    };
+  });
+  if (!changed) return {};
+  return {
+    threads,
+    ...(nextCompletedTurns !== state.runtimeCompletedTurnsByThread
+      ? { runtimeCompletedTurnsByThread: nextCompletedTurns }
+      : {}),
+  };
+}
+
+function isLiveAssistantActivity(
+  state: RuntimeEventState,
+  threadId: string,
+  event: RuntimeEvent,
+): boolean {
+  if (event.type === "item.started") {
+    return event.itemType !== "user_message" && event.itemType !== "error";
+  }
+  if (event.type !== "item.updated" && event.type !== "content.delta") return false;
+  const item = state.runtimeItemsByIdByThread[threadId]?.[event.itemId];
+  return item !== undefined && item.state !== "completed" && item.type !== "user_message";
+}
+
+function parseTurnMs(iso: string | undefined): number | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function removeCompletedTurnWindow(
+  turnsByThread: RuntimeEventSlice["runtimeCompletedTurnsByThread"],
+  threadId: string,
+  startedAt: number,
+  endedAt: number,
+): RuntimeEventSlice["runtimeCompletedTurnsByThread"] {
+  const turns = turnsByThread[threadId];
+  if (!turns?.length) return turnsByThread;
+  const filtered = turns.filter((turn) => turn.startedAt !== startedAt || turn.endedAt !== endedAt);
+  if (filtered.length === turns.length) return turnsByThread;
+  if (filtered.length > 0) {
+    return { ...turnsByThread, [threadId]: filtered };
+  }
+  const { [threadId]: _removed, ...rest } = turnsByThread;
+  return rest;
 }
 
 /**


### PR DESCRIPTION
**Type:** Bugfix

- Fix GUI threads that were marked idle while structured runtime activity (e.g. reasoning) was still in flight, so the UI no longer shows a finished turn too early.
- When live assistant activity arrives after that premature idle, restore working status, attention, and active turn timing instead of leaving the thread idle.
- Drop completed-turn records that were written for the falsely closed window so turn history and anchors stay accurate.
- Add an app store regression test for idle → late activity → idle to lock in turn reopening and completed-turn cleanup.