### PR TITLE
Add Command Code usage tracking and browser login

### DIFF
--- a/packages/agents-usage/src/collectors/commandcode.test.ts
+++ b/packages/agents-usage/src/collectors/commandcode.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { createFakeHost, FAKE_NOW_MS } from "../testHost";
+import {
+  collectCommandCode,
+  COMMANDCODE_AUTH_SESSION_ENDPOINT,
+  COMMANDCODE_BILLING_CREDITS_ENDPOINT,
+  COMMANDCODE_BILLING_SUBSCRIPTIONS_ENDPOINT,
+  COMMANDCODE_USAGE_SUMMARY_ENDPOINT,
+  formatCommandCodePlanLabel,
+  isCommandCodeSessionLive,
+  parseCommandCodeUsage,
+} from "./commandcode";
+
+const CREDITS_BODY = JSON.stringify({
+  credits: {
+    belowThreshold: false,
+    creditThreshold: 0,
+    monthlyCredits: 9.9924,
+    purchasedCredits: 0,
+    premiumMonthlyCredits: 0,
+    opensourceMonthlyCredits: 9.9924,
+  },
+});
+
+const SUMMARY_BODY = JSON.stringify({
+  totalCount: 25,
+  totalCost: 0.0076,
+  averageCost: 0.000304,
+  successRate: 100,
+  completedCount: 25,
+  failedCount: 0,
+  totalTokensIn: "172284",
+  totalTokensOut: "1787",
+  totalTokens: "174071",
+  totalCredits: 0.0076,
+  totalFreeCredits: 0,
+  totalMonthlyCredits: 0.0076,
+  totalPurchasedCredits: 0,
+});
+
+const SUBSCRIPTIONS_BODY = JSON.stringify({
+  success: true,
+  data: {
+    status: "active",
+    planId: "individual-go",
+    currentPeriodStart: "2026-06-01T03:37:07.000Z",
+    currentPeriodEnd: "2026-07-01T03:37:07.000Z",
+    cancelAtPeriodEnd: false,
+  },
+});
+
+describe("formatCommandCodePlanLabel", () => {
+  it("maps known planIds to display names", () => {
+    expect(formatCommandCodePlanLabel("individual-go")).toBe("Go");
+    expect(formatCommandCodePlanLabel("individual-pro")).toBe("Pro");
+    expect(formatCommandCodePlanLabel("individual-max")).toBe("Max");
+  });
+
+  it("falls back to the raw value for unknown planIds", () => {
+    expect(formatCommandCodePlanLabel("weird-plan")).toBe("weird-plan");
+  });
+
+  it("returns undefined for missing/blank input", () => {
+    expect(formatCommandCodePlanLabel(undefined)).toBeUndefined();
+    expect(formatCommandCodePlanLabel("  ")).toBeUndefined();
+  });
+});
+
+describe("parseCommandCodeUsage", () => {
+  it("maps the studio responses into a single monthly usd bar", () => {
+    const snap = parseCommandCodeUsage(
+      JSON.parse(CREDITS_BODY),
+      JSON.parse(SUMMARY_BODY),
+      JSON.parse(SUBSCRIPTIONS_BODY),
+      FAKE_NOW_MS,
+    );
+
+    expect(snap.providerId).toBe("commandcode");
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("Go");
+
+    const w = snap.windows[0]!;
+    expect(w.id).toBe("monthly");
+    expect(w.unit).toBe("usd");
+    expect(w.currency).toBe("USD");
+    expect(w.used).toBeCloseTo(0.0076);
+    expect(w.limit).toBeCloseTo(10.0);
+    expect(w.usedPercent).toBeCloseTo(0.076);
+    expect(w.resetsAt).toBe(Date.parse("2026-07-01T03:37:07.000Z"));
+
+    // The bar already conveys the full picture, so the snapshot intentionally
+    // carries no `cost`/`credits`/`tokens` fields — surfacing them in the
+    // panel's meta block would duplicate the bar.
+    expect(snap.credits).toBeUndefined();
+    expect(snap.cost).toBeUndefined();
+    expect(snap.tokens).toBeUndefined();
+  });
+
+  it("emits only the window when the plan is missing", () => {
+    const snap = parseCommandCodeUsage(
+      { credits: { monthlyCredits: 5 } },
+      { totalCost: 2.5 },
+      {},
+      FAKE_NOW_MS,
+    );
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBeUndefined();
+    expect(snap.windows[0]!.used).toBe(2.5);
+    expect(snap.windows[0]!.limit).toBe(7.5);
+    expect(snap.credits).toBeUndefined();
+    expect(snap.cost).toBeUndefined();
+  });
+
+  it("tolerates completely missing bodies without throwing", () => {
+    const snap = parseCommandCodeUsage(undefined, undefined, undefined, FAKE_NOW_MS);
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.usedPercent).toBe(0);
+    expect(snap.windows[0]!.used).toBeUndefined();
+    expect(snap.windows[0]!.limit).toBeUndefined();
+    expect(snap.credits).toBeUndefined();
+    expect(snap.cost).toBeUndefined();
+    expect(snap.tokens).toBeUndefined();
+  });
+});
+
+describe("isCommandCodeSessionLive", () => {
+  it("returns true when /auth/get-session returns a non-null JSON object", async () => {
+    const host = createFakeHost({
+      routes: {
+        [COMMANDCODE_AUTH_SESSION_ENDPOINT]: {
+          body: JSON.stringify({ user: { id: "u1" }, plan: "go" }),
+        },
+      },
+    });
+    await expect(isCommandCodeSessionLive(host.http, "cc_session=abc")).resolves.toBe(true);
+  });
+
+  it("returns false on a 200 + null body (signed out)", async () => {
+    const host = createFakeHost({
+      routes: { [COMMANDCODE_AUTH_SESSION_ENDPOINT]: { body: "null" } },
+    });
+    await expect(isCommandCodeSessionLive(host.http, "cc_session=abc")).resolves.toBe(false);
+  });
+
+  it("returns false on a 401", async () => {
+    const host = createFakeHost({
+      routes: { [COMMANDCODE_AUTH_SESSION_ENDPOINT]: { status: 401, body: "" } },
+    });
+    await expect(isCommandCodeSessionLive(host.http, "cc_session=abc")).resolves.toBe(false);
+  });
+
+  it("returns false on an empty cookie", async () => {
+    const host = createFakeHost();
+    await expect(isCommandCodeSessionLive(host.http, "")).resolves.toBe(false);
+  });
+});
+
+describe("collectCommandCode", () => {
+  it("returns auth-missing when no cookie has been stored", async () => {
+    const host = createFakeHost();
+    const snap = await collectCommandCode(host);
+    expect(snap.status).toBe("auth-missing");
+    expect(snap.windows).toEqual([]);
+  });
+
+  it("collects usage from the studio endpoints when a live cookie is present", async () => {
+    const host = createFakeHost({
+      secrets: { commandcode: { cookie: "cc_session=abc" } },
+      routes: {
+        [COMMANDCODE_AUTH_SESSION_ENDPOINT]: {
+          body: JSON.stringify({ user: { id: "u1" } }),
+        },
+        [COMMANDCODE_BILLING_CREDITS_ENDPOINT]: { body: CREDITS_BODY },
+        [COMMANDCODE_USAGE_SUMMARY_ENDPOINT]: { body: SUMMARY_BODY },
+        [COMMANDCODE_BILLING_SUBSCRIPTIONS_ENDPOINT]: { body: SUBSCRIPTIONS_BODY },
+      },
+    });
+    const snap = await collectCommandCode(host);
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("Go");
+    expect(snap.windows[0]!.unit).toBe("usd");
+    expect(snap.windows[0]!.used).toBeCloseTo(0.0076);
+    expect(snap.windows[0]!.limit).toBeCloseTo(10.0);
+    expect(snap.credits).toBeUndefined();
+  });
+
+  it("returns auth-missing when the session probe fails (expired cookie)", async () => {
+    const host = createFakeHost({
+      secrets: { commandcode: { cookie: "cc_session=expired" } },
+      routes: { [COMMANDCODE_AUTH_SESSION_ENDPOINT]: { status: 401, body: "" } },
+    });
+    const snap = await collectCommandCode(host);
+    expect(snap.status).toBe("auth-missing");
+  });
+});

--- a/packages/agents-usage/src/collectors/commandcode.ts
+++ b/packages/agents-usage/src/collectors/commandcode.ts
@@ -1,0 +1,259 @@
+import { toEpochMs } from "../formatters";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse } from "../host";
+import type { UsageSnapshot, UsageWindow } from "../types";
+
+/**
+ * Command Code (api.commandcode.ai). The CLI ships a long-lived API key in
+ * `~/.commandcode/auth.json`, but the public Provider API at `/provider/v1/*`
+ * has no usage or billing endpoints — and the key is rejected (401) by the
+ * studio's `/internal/*` routes. Usage therefore flows through the same
+ * in-app browser login as Grok/OpenCode: the user signs in at commandcode.ai,
+ * we capture the session cookie, and forward it to the studio's undocumented
+ * internal billing/usage routes. Endpoints are private and may rotate without
+ * notice; responses are normalized into the shared `UsageSnapshot` shape.
+ *
+ *   GET /auth/get-session            → session probe (null body = signed out)
+ *   GET /internal/billing/credits    → { credits: { monthlyCredits, purchasedCredits, ... } }
+ *   GET /internal/usage/summary      → { totalCost, totalTokensIn, totalTokensOut, ... }
+ *   GET /internal/billing/subscriptions → { success, data: { planId, currentPeriodEnd, ... } }
+ *
+ * Command Code is pay-as-you-go within a monthly credit cap (no rate-limit
+ * windows), so the snapshot surfaces a single `monthly` `usd` window whose
+ * `used` is consumed this cycle and whose `limit` is the original monthly
+ * allocation (`monthlyCredits + totalCost`). The bar is the single source of
+ * truth — the snapshot intentionally does NOT carry `cost`/`credits`/`tokens`,
+ * which the panel's meta block would otherwise re-render as duplicates.
+ */
+
+const COMMANDCODE_BASE = "https://api.commandcode.ai";
+export const COMMANDCODE_AUTH_SESSION_ENDPOINT = `${COMMANDCODE_BASE}/auth/get-session`;
+export const COMMANDCODE_BILLING_CREDITS_ENDPOINT = `${COMMANDCODE_BASE}/internal/billing/credits`;
+export const COMMANDCODE_USAGE_SUMMARY_ENDPOINT = `${COMMANDCODE_BASE}/internal/usage/summary`;
+export const COMMANDCODE_BILLING_SUBSCRIPTIONS_ENDPOINT = `${COMMANDCODE_BASE}/internal/billing/subscriptions`;
+
+export const COMMANDCODE_PROVIDER_ID = "commandcode" as const;
+
+interface CommandCodeCreditsBody {
+  credits?: {
+    monthlyCredits?: number;
+  };
+}
+
+interface CommandCodeUsageSummaryBody {
+  totalCost?: number;
+}
+
+interface CommandCodeSubscriptionsBody {
+  success?: boolean;
+  data?: {
+    planId?: string;
+    currentPeriodStart?: string;
+    currentPeriodEnd?: string;
+    status?: string;
+    cancelAtPeriodEnd?: boolean;
+  };
+}
+
+const COMMANDCODE_PLAN_LABELS: Record<string, string> = {
+  "individual-go": "Go",
+  "individual-pro": "Pro",
+  "individual-max": "Max",
+  "individual-ultra": "Ultra",
+  "team-pro": "Team Pro",
+  "team-business": "Team Business",
+  "team-enterprise": "Team Enterprise",
+  enterprise: "Enterprise",
+  "open-source": "Open Source",
+  free: "Free",
+};
+
+/** Map a `planId` from /internal/billing/subscriptions to a display name. */
+export function formatCommandCodePlanLabel(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return COMMANDCODE_PLAN_LABELS[trimmed] ?? trimmed;
+}
+
+function numeric(value: number | string | undefined): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/**
+ * Pure: map parsed studio responses to a `UsageSnapshot`. The bar already shows
+ * used/limit/reset in $ for a `usd` window, so the snapshot intentionally
+ * carries NO `cost`, `credits`, or `tokens` field — the panel's meta block
+ * would otherwise duplicate the bar (e.g. `~$0.01 · ... · est.` plus
+ * `Credits: $9.99` under a bar that already says `$0.01 / $10.00`). The
+ * remaining balance is implicit in `limit - used`; the period is implicit in
+ * `resetsAt`.
+ */
+export function parseCommandCodeUsage(
+  creditsBody: unknown,
+  summaryBody: unknown,
+  subscriptionsBody: unknown,
+  nowMs: number,
+): UsageSnapshot {
+  const credits = ((creditsBody ?? {}) as CommandCodeCreditsBody).credits ?? {};
+  const summary = (summaryBody ?? {}) as CommandCodeUsageSummaryBody;
+  const subscription = ((subscriptionsBody ?? {}) as CommandCodeSubscriptionsBody).data ?? {};
+
+  const remainingMonthly = numeric(credits.monthlyCredits) ?? 0;
+  const hasConsumed = summary.totalCost !== undefined;
+  const consumed = numeric(summary.totalCost) ?? 0;
+  const monthlyAllocation = remainingMonthly + consumed;
+
+  const usedPercent =
+    monthlyAllocation > 0 ? Math.min(100, Math.max(0, (consumed / monthlyAllocation) * 100)) : 0;
+  const resetsAt = toEpochMs(subscription.currentPeriodEnd);
+
+  const monthlyWindow: UsageWindow = {
+    id: "monthly",
+    label: "Monthly credits",
+    usedPercent,
+    unit: "usd",
+    currency: "USD",
+    ...(hasConsumed ? { used: Number(consumed.toFixed(4)) } : {}),
+    ...(monthlyAllocation > 0 ? { limit: Number(monthlyAllocation.toFixed(4)) } : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+  };
+
+  const plan = formatCommandCodePlanLabel(subscription.planId);
+  const snapshot: UsageSnapshot = {
+    providerId: COMMANDCODE_PROVIDER_ID,
+    status: "ok",
+    windows: [monthlyWindow],
+    fetchedAt: nowMs,
+  };
+  if (plan) snapshot.plan = plan;
+  return snapshot;
+}
+
+function commandCodeRequest(
+  http: HttpClient,
+  method: "GET" | "POST",
+  url: string,
+  cookie: string,
+  timeoutMs: number,
+): Promise<HttpResponse> {
+  return http.request({
+    method,
+    url,
+    headers: {
+      Cookie: cookie,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Origin: "https://commandcode.ai",
+      Referer: "https://commandcode.ai/",
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
+    },
+    timeoutMs,
+  });
+}
+
+/**
+ * True iff the captured `Cookie` header authenticates as a live commandcode.ai
+ * session. `GET /auth/get-session` returns 200 + a JSON object when signed in
+ * and 200 + literal `null` (or an empty body) when signed out — so a non-null
+ * parsed body is the simplest "is live" signal.
+ */
+export async function isCommandCodeSessionLive(
+  http: HttpClient,
+  cookieHeader: string,
+): Promise<boolean> {
+  if (!cookieHeader) return false;
+  const res = await commandCodeRequest(
+    http,
+    "GET",
+    COMMANDCODE_AUTH_SESSION_ENDPOINT,
+    cookieHeader,
+    5_000,
+  );
+  if (res.status < 200 || res.status >= 300) return false;
+  const body = res.body.trim();
+  if (!body || body === "null") return false;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return parsed !== null && typeof parsed === "object";
+  } catch {
+    return false;
+  }
+}
+
+async function fetchJson(http: HttpClient, url: string, cookie: string): Promise<unknown> {
+  const res = await commandCodeRequest(http, "GET", url, cookie, 15_000);
+  if (res.status === 401 || res.status === 403) {
+    return { __authMissing: true, status: res.status };
+  }
+  if (res.status < 200 || res.status >= 300) {
+    return { __error: `HTTP ${res.status}` };
+  }
+  try {
+    return JSON.parse(res.body);
+  } catch {
+    return { __error: "invalid JSON response" };
+  }
+}
+
+/**
+ * Collect Command Code usage via the captured browser session cookie. Returns
+ * an `auth-missing` snapshot when no cookie has been stored, distinguishing it
+ * from a transient error so the UI can prompt for sign-in.
+ */
+export async function collectCommandCode(
+  host: HostPort,
+  _opts?: CollectOptions,
+): Promise<UsageSnapshot> {
+  const now = host.now();
+  const cookie = await host.credentials.getSecret(COMMANDCODE_PROVIDER_ID, "cookie");
+  if (!cookie) {
+    return {
+      providerId: COMMANDCODE_PROVIDER_ID,
+      status: "auth-missing",
+      windows: [],
+      fetchedAt: now,
+    };
+  }
+
+  let live = false;
+  try {
+    live = await isCommandCodeSessionLive(host.http, cookie);
+  } catch {
+    live = false;
+  }
+  if (!live) {
+    return {
+      providerId: COMMANDCODE_PROVIDER_ID,
+      status: "auth-missing",
+      windows: [],
+      fetchedAt: now,
+    };
+  }
+
+  const [credits, summary, subscriptions] = await Promise.all([
+    fetchJson(host.http, COMMANDCODE_BILLING_CREDITS_ENDPOINT, cookie),
+    fetchJson(host.http, COMMANDCODE_USAGE_SUMMARY_ENDPOINT, cookie),
+    fetchJson(host.http, COMMANDCODE_BILLING_SUBSCRIPTIONS_ENDPOINT, cookie),
+  ]);
+
+  if (
+    (credits as { __authMissing?: boolean })?.__authMissing ||
+    (summary as { __authMissing?: boolean })?.__authMissing ||
+    (subscriptions as { __authMissing?: boolean })?.__authMissing
+  ) {
+    return {
+      providerId: COMMANDCODE_PROVIDER_ID,
+      status: "auth-missing",
+      windows: [],
+      fetchedAt: now,
+    };
+  }
+
+  return parseCommandCodeUsage(credits, summary, subscriptions, now);
+}

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -43,6 +43,17 @@ export {
 export { collectCopilot, parseCopilotUsage, COPILOT_USER_ENDPOINT } from "./collectors/copilot";
 export { collectCursor, parseCursorUsage, CURSOR_USAGE_ENDPOINT } from "./collectors/cursor";
 export {
+  collectCommandCode,
+  formatCommandCodePlanLabel,
+  isCommandCodeSessionLive,
+  parseCommandCodeUsage,
+  COMMANDCODE_AUTH_SESSION_ENDPOINT,
+  COMMANDCODE_BILLING_CREDITS_ENDPOINT,
+  COMMANDCODE_BILLING_SUBSCRIPTIONS_ENDPOINT,
+  COMMANDCODE_PROVIDER_ID,
+  COMMANDCODE_USAGE_SUMMARY_ENDPOINT,
+} from "./collectors/commandcode";
+export {
   collectGrok,
   isGrokSessionLive,
   parseGrokUsage,

--- a/packages/agents-usage/src/registry.test.ts
+++ b/packages/agents-usage/src/registry.test.ts
@@ -10,14 +10,14 @@ describe("createUsageCollectorRegistry", () => {
         .descriptors()
         .map((d) => d.id)
         .sort(),
-    ).toEqual(["claude", "codex", "copilot", "cursor", "gemini", "grok"]);
+    ).toEqual(["claude", "codex", "commandcode", "copilot", "cursor", "gemini", "grok"]);
     expect(reg.has("claude")).toBe(true);
     expect(reg.has("nope")).toBe(false);
   });
 
   it("collectAll returns one snapshot per provider, auth-missing without tokens", async () => {
     const snaps = await createUsageCollectorRegistry().collectAll(undefined, createFakeHost());
-    expect(snaps).toHaveLength(6);
+    expect(snaps).toHaveLength(7);
     expect(snaps.every((s) => s.status === "auth-missing")).toBe(true);
   });
 

--- a/packages/agents-usage/src/registry.ts
+++ b/packages/agents-usage/src/registry.ts
@@ -1,5 +1,6 @@
 import { collectClaude } from "./collectors/claude";
 import { collectCodex } from "./collectors/codex";
+import { collectCommandCode } from "./collectors/commandcode";
 import { collectCopilot } from "./collectors/copilot";
 import { collectCursor } from "./collectors/cursor";
 import { collectGemini } from "./collectors/gemini";
@@ -84,6 +85,17 @@ const GEMINI_COLLECTOR: UsageCollector = {
   collect: collectGemini,
 };
 
+const COMMANDCODE_COLLECTOR: UsageCollector = {
+  descriptor: {
+    id: "commandcode",
+    label: "Command Code",
+    mechanism: "cookie",
+    needsLogin: true,
+    windowIds: ["monthly"],
+  },
+  collect: collectCommandCode,
+};
+
 // Antigravity is collected supervisor-side from its local language server
 // (LS-only), not here; see src/supervisor/runtime/antigravityUsageScanner.ts.
 
@@ -94,6 +106,7 @@ const BUILT_IN: UsageCollector[] = [
   CURSOR_COLLECTOR,
   GROK_COLLECTOR,
   GEMINI_COLLECTOR,
+  COMMANDCODE_COLLECTOR,
 ];
 
 /** Descriptors for the built-in HTTP collectors, in registration order. */

--- a/src/main/usageLogin/UsageLoginManager.ts
+++ b/src/main/usageLogin/UsageLoginManager.ts
@@ -3,6 +3,7 @@ import type { BrowserPanelManager } from "../browser";
 import type { LightcodePaths } from "@/shared/lightcodePaths";
 import type { UsageLoginStateResponse } from "@/shared/contracts";
 import { clearUsageSecret, hasUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
+import { isCommandCodeLoginCookieLive } from "./commandCodeLoginProbe";
 import { isGrokLoginCookieLive } from "./grokLoginProbe";
 import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
 
@@ -48,12 +49,24 @@ interface GitHubDeviceLoginConfig {
 type ProviderLoginConfig = CookieLoginConfig | GitHubDeviceLoginConfig;
 
 const PROVIDER_LABELS: Record<string, string> = {
+  commandcode: "Command Code",
   copilot: "GitHub Copilot",
   grok: "Grok",
   opencode: "OpenCode",
 };
 
 const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
+  commandcode: {
+    kind: "cookie",
+    loginUrl: "https://commandcode.ai/signin",
+    cookieUrl: "https://commandcode.ai/",
+    // commandcode.ai is a better-auth app; cookies that share a name with
+    // session/auth/token signal a candidate login.
+    authCookiePattern: /session|auth|token/i,
+    // Confirm the cookie actually authenticates before prompting — better-auth
+    // can set a placeholder cookie before sign-in completes.
+    validateSession: isCommandCodeLoginCookieLive,
+  },
   copilot: {
     kind: "github-device",
     host: "github.com",

--- a/src/main/usageLogin/commandCodeLoginProbe.ts
+++ b/src/main/usageLogin/commandCodeLoginProbe.ts
@@ -1,0 +1,40 @@
+import { type HttpClient, isCommandCodeSessionLive } from "@lightcode/agents-usage";
+
+/**
+ * Verifies a captured commandcode.ai `Cookie` header is a *real* signed-in
+ * session, not a stale or mid-`/authorize` cookie that merely shares a session
+ * cookie name. Used to gate the browser-login "Found a signed-in session"
+ * prompt. Runs the same `/auth/get-session` probe as the usage collector via
+ * the shared `@lightcode/agents-usage` helper, backed here by global fetch
+ * (the supervisor scanner injects its own HTTP client).
+ */
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+const fetchHttpClient: HttpClient = {
+  async request(req) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), req.timeoutMs ?? PROBE_TIMEOUT_MS);
+    try {
+      const res = await fetch(req.url, {
+        method: req.method ?? "GET",
+        ...(req.headers ? { headers: req.headers } : {}),
+        ...(req.body !== undefined ? { body: req.body } : {}),
+        signal: controller.signal,
+      });
+      const body = await res.text();
+      const headers: Record<string, string> = {};
+      res.headers.forEach((value, key) => {
+        headers[key.toLowerCase()] = value;
+      });
+      return { status: res.status, headers, body };
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+};
+
+/** Resolves true iff the cookie authenticates as a live commandcode.ai session. */
+export function isCommandCodeLoginCookieLive(cookieHeader: string): Promise<boolean> {
+  return isCommandCodeSessionLive(fetchHttpClient, cookieHeader);
+}

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -37,6 +37,7 @@ const RENDERER_META: Record<string, Omit<UsageProvider, "id" | "label">> = {
   },
   // Copilot uses GitHub's OAuth device flow, the others a captured web-session
   // cookie — both surface as the in-app browser login.
+  commandcode: { supportsBrowserLogin: true },
   copilot: { supportsBrowserLogin: true },
   cursor: { sharedWindowReset: true, rings: { outer: ["cursor-auto"], inner: ["cursor-api"] } },
   grok: { supportsBrowserLogin: true },

--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -152,19 +152,19 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     expect(resolveExecutablePath("claude")).toBe(exePath);
   });
 
-  it("keeps the .cmd path for npm node-shim wrappers (e.g. codex.cmd → node codex.js)", () => {
+  it("keeps the .cmd path for npm node-shim wrappers (e.g. command-code.cmd → node index.mjs)", () => {
     // Regression: a previous version of resolveWindowsCmdExeTarget greedily
     // matched `"%dp0%\node.exe"` in npm's standard Node-script shim and
-    // returned node.exe directly. That stripped the .js entry script, so
+    // returned node.exe directly. That stripped the script entry, so
     // buildAgentCommand spawned `node.exe --model ... --enable ...` and Node
     // rejected the agent's flags with "bad option: --model". The .cmd must
-    // remain so resolveWindowsNodeCmdShim can extract the .js entry later.
-    const root = mkdtempSync(join(tmpdir(), "lightcode-codex-shim-"));
+    // remain so resolveWindowsNodeCmdShim can extract the script entry later.
+    const root = mkdtempSync(join(tmpdir(), "lightcode-command-code-shim-"));
     tempDirs.push(root);
-    const cmdPath = join(root, "codex.cmd");
+    const cmdPath = join(root, "command-code.cmd");
     const nodeExePath = join(root, "node.exe");
-    const jsPath = join(root, "node_modules", "@openai", "codex", "bin", "codex.js");
-    mkdirSync(join(root, "node_modules", "@openai", "codex", "bin"), { recursive: true });
+    const jsPath = join(root, "node_modules", "command-code", "dist", "index.mjs");
+    mkdirSync(join(root, "node_modules", "command-code", "dist"), { recursive: true });
     writeFileSync(nodeExePath, "");
     writeFileSync(jsPath, "");
     writeFileSync(
@@ -172,18 +172,18 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
       [
         "@ECHO off",
         "SETLOCAL",
-        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*',
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe"  "%dp0%\\node_modules\\command-code\\dist\\index.mjs" %*',
         "",
       ].join("\r\n"),
     );
     spawnSyncMock.mockReturnValueOnce({
       error: undefined,
       status: 0,
-      stdout: [join(root, "codex"), cmdPath].join("\r\n"),
+      stdout: [join(root, "command-code"), cmdPath].join("\r\n"),
       stderr: "",
     });
 
-    expect(resolveExecutablePath("codex")).toBe(cmdPath);
+    expect(resolveExecutablePath("command-code")).toBe(cmdPath);
   });
 
   it("applies the same fallback to async resolution", async () => {

--- a/src/supervisor/agents/base.windows-shell.test.ts
+++ b/src/supervisor/agents/base.windows-shell.test.ts
@@ -106,25 +106,25 @@ describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
   it("bypasses npm .cmd shims so multiline args stay in argv", () => {
     const dir = mkdtempSync(join(tmpdir(), "lightcode-cmd-shim-"));
     tempDirs.push(dir);
-    const scriptPath = join(dir, "node_modules", "@openai", "codex", "bin", "codex.js");
+    const scriptPath = join(dir, "node_modules", "command-code", "dist", "index.mjs");
     mkdirSync(join(scriptPath, ".."), { recursive: true });
     writeFileSync(scriptPath, "", "utf8");
     const nodePath = join(dir, "node.exe");
     writeFileSync(nodePath, "", "utf8");
-    const shimPath = join(dir, "codex.cmd");
+    const shimPath = join(dir, "command-code.cmd");
     writeFileSync(
       shimPath,
       [
         "@ECHO off",
         "SETLOCAL",
-        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe"  "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*',
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe"  "%dp0%\\node_modules\\command-code\\dist\\index.mjs" %*',
       ].join("\r\n"),
       "utf8",
     );
 
     const spec = buildAgentCommand(
       { kind: "windows", path: "C:\\repo" },
-      "codex",
+      "command-code",
       ["debug", "prompt-input", "hi\n1\n2"],
       shimPath,
     );

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -206,7 +206,7 @@ function resolveWindowsNodeCmdShim(commandPath: string):
     return undefined;
   }
 
-  const match = /["']?%dp0%\\([^"']+?\.js)["']?\s+%\*/i.exec(content);
+  const match = /["']?%dp0%\\([^"']+?\.[cm]?js)["']?\s+%\*/i.exec(content);
   const relScript = match?.[1];
   if (!relScript) return undefined;
 

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -229,13 +229,13 @@ function resolveWindowsCmdExeTarget(path: string | undefined): string | undefine
   if (!path || !/\.cmd$/i.test(path)) return undefined;
   try {
     const body = readFileSync(path, "utf8");
-    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.js" %*`.
+    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.mjs" %*`.
     // Leave those alone so the downstream resolveWindowsNodeCmdShim (in base/index.ts)
-    // can extract the .js entry and invoke node with it directly. Substituting to
+    // can extract the script entry and invoke node with it directly. Substituting to
     // node.exe here would strip the script arg and pass agent flags straight to
     // node, which rejects them ("bad option: --model", etc.) and exits — breaking
     // every npm-installed agent (codex, commandcode, gemini, …) on Windows.
-    if (/["']?%dp0%\\[^"']+?\.js["']?\s+%\*/i.test(body)) return undefined;
+    if (/["']?%dp0%\\[^"']+?\.[cm]?js["']?\s+%\*/i.test(body)) return undefined;
     const match = /"%dp0%\\([^"]+?\.exe)"/i.exec(body);
     if (!match?.[1]) return undefined;
     const target = join(dirname(path), match[1]);

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -74,6 +74,7 @@ describe("UsageService", () => {
       "antigravity",
       "claude",
       "codex",
+      "commandcode",
       "copilot",
       "cursor",
       "gemini",
@@ -89,7 +90,7 @@ describe("UsageService", () => {
 
     const perProvider = events.filter((e) => e.type === "provider-usage");
     const terminal = events.filter((e) => e.type === "provider-usage-all");
-    expect(perProvider).toHaveLength(8);
+    expect(perProvider).toHaveLength(9);
     expect(terminal).toHaveLength(1);
   });
 


### PR DESCRIPTION
**Type:** Feature (includes Windows agent-launch fix)

- Add a Command Code usage collector that reads monthly credits, spend, and plan via studio session APIs, normalized into the shared usage snapshot shape
- Register Command Code in the usage registry and wire in-app browser sign-in at commandcode.ai, with session probing so only live cookies are accepted
- Expose Command Code in the renderer usage providers list with browser login enabled
- Fix Windows npm `.cmd` shim handling for `.mjs`/`.cjs` entry scripts so Command Code and other npm-installed agents start with the correct script path