### PR TITLE
Skip Command Code onboarding for supervisor-launched sessions

### DIFF
--- a/src/supervisor/agents/commandcode/argv.ts
+++ b/src/supervisor/agents/commandcode/argv.ts
@@ -26,7 +26,7 @@ export function buildCommandCodeArgs(
   prompt: string,
   resume?: boolean,
 ): string[] {
-  const args: string[] = ["--trust"];
+  const args: string[] = ["--trust", "--skip-onboarding"];
 
   if (resume) {
     args.push("--continue");

--- a/src/supervisor/agents/commandcode/commandcode.test.ts
+++ b/src/supervisor/agents/commandcode/commandcode.test.ts
@@ -19,6 +19,7 @@ describe("buildCommandCodeArgs", () => {
     // v0.31.2 bundle: initial = permissionMode || (yolo ? "bypass":"standard").
     expect(buildCommandCodeArgs(config, "hello")).toEqual([
       "--trust",
+      "--skip-onboarding",
       "--model",
       "claude-opus-4-8",
       "--permission-mode",
@@ -31,6 +32,7 @@ describe("buildCommandCodeArgs", () => {
   it("adds --continue when resuming", () => {
     expect(buildCommandCodeArgs(config, "next", true)).toEqual([
       "--trust",
+      "--skip-onboarding",
       "--continue",
       "--model",
       "claude-opus-4-8",
@@ -44,6 +46,7 @@ describe("buildCommandCodeArgs", () => {
   it("omits the prompt positional when empty", () => {
     expect(buildCommandCodeArgs(config, "   ")).toEqual([
       "--trust",
+      "--skip-onboarding",
       "--model",
       "claude-opus-4-8",
       "--permission-mode",
@@ -116,6 +119,7 @@ describe("createCommandCodeAdapter", () => {
     expect(launch.binary).toBe("command-code");
     expect(launch.args).toEqual([
       "--trust",
+      "--skip-onboarding",
       "--model",
       "gpt-5.5",
       "--permission-mode",
@@ -138,6 +142,7 @@ describe("createCommandCodeAdapter", () => {
       binary: "command-code",
       args: [
         "--trust",
+        "--skip-onboarding",
         "--continue",
         "--model",
         "gpt-5.5",
@@ -154,7 +159,7 @@ describe("createCommandCodeAdapter", () => {
     const adapter = createCommandCodeAdapter();
     expect(adapter.buildOneShotCommand?.("gpt-5.4-mini", undefined, "summarize")).toEqual({
       command: "command-code",
-      args: ["--trust", "--model", "gpt-5.4-mini", "-p", "summarize"],
+      args: ["--trust", "--skip-onboarding", "--model", "gpt-5.4-mini", "-p", "summarize"],
       stdin: "",
     });
   });

--- a/src/supervisor/agents/commandcode/index.ts
+++ b/src/supervisor/agents/commandcode/index.ts
@@ -86,7 +86,14 @@ export function createCommandCodeAdapter(): AgentAdapter {
       if (!prompt) return undefined;
       return {
         command: "command-code",
-        args: ["--trust", "--model", model || COMMANDCODE_DEFAULT_MODEL_ID, "-p", prompt],
+        args: [
+          "--trust",
+          "--skip-onboarding",
+          "--model",
+          model || COMMANDCODE_DEFAULT_MODEL_ID,
+          "-p",
+          prompt,
+        ],
         stdin: "",
       };
     },


### PR DESCRIPTION
**Type:** Bugfix

- Pass `--skip-onboarding` on every Command Code launch argv built by the supervisor so new threads do not stall on first-run onboarding UI.
- Apply the flag for normal launches, resume (`--continue`), and one-shot commands so behavior stays consistent across entry points.
- Update Command Code adapter tests to expect `--skip-onboarding` alongside existing `--trust` and model/permission args.