### PR TITLE
Fix draft composer anchoring after agent selection

### DIFF
--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -244,6 +244,59 @@ const acpGenericStatus: AgentStatus = {
   },
 };
 
+function classNameIncludes(element: HTMLElement, value: string): boolean {
+  return typeof element.className === "string" && element.className.includes(value);
+}
+
+function installDraftComposerLayoutMetrics(): () => void {
+  const originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientHeight",
+  );
+  const originalOffsetHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+  const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return classNameIncludes(this, "max-w-[1040px]") ? 800 : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get() {
+      if (classNameIncludes(this, "max-w-[720px]")) return 160;
+      return Number.parseInt(this.style.height, 10) || 0;
+    },
+  });
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 720,
+      bottom: 0,
+      left: 0,
+      width: 720,
+      height: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+  };
+
+  return () => {
+    if (originalClientHeight) {
+      Object.defineProperty(HTMLElement.prototype, "clientHeight", originalClientHeight);
+    }
+    if (originalOffsetHeight) {
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", originalOffsetHeight);
+    }
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  };
+}
+
 const singleContextThinkingCursorStatus: AgentStatus = {
   ...cursorStatus,
   capabilities: {
@@ -326,6 +379,30 @@ describe("ThreadDraftView", () => {
       expect(providerModel?.currentModel).toBe("auto");
       expect(props.controls.some((control) => control.value === "never")).toBe(true);
     });
+  });
+
+  it("anchors the full draft composer after agents resolve on the initial mount", async () => {
+    const restoreLayoutMetrics = installDraftComposerLayoutMetrics();
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    try {
+      const { container, rerender } = render(
+        <ThreadDraftView project={project} agentStatuses={[]} onStart={onStart} />,
+      );
+
+      expect(container.querySelector("[data-draft-composer-anchor-spacer]")).toBeNull();
+
+      rerender(
+        <ThreadDraftView project={project} agentStatuses={[geminiStatus]} onStart={onStart} />,
+      );
+
+      await waitFor(() => expect(composerSpy).toHaveBeenCalled());
+
+      const spacer = container.querySelector<HTMLElement>("[data-draft-composer-anchor-spacer]");
+      expect(spacer?.style.height).toBe("320px");
+    } finally {
+      restoreLayoutMetrics();
+    }
   });
 
   it("shows the detecting state while agents are still loading", () => {

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -778,7 +778,9 @@ export function ThreadDraftView(props: {
   const anchorBlockRef = useRef<HTMLDivElement>(null);
   const anchorSpacerRef = useRef<HTMLDivElement>(null);
   useStableComposerAnchor({
-    enabled: !props.compact,
+    // Agent detection can render the draft view before the composer DOM exists.
+    // Only arm the anchor once the selected-agent branch can actually mount it.
+    enabled: !props.compact && !!selectedAgent,
     containerRef: anchorContainerRef,
     blockRef: anchorBlockRef,
     spacerRef: anchorSpacerRef,
@@ -877,7 +879,12 @@ export function ThreadDraftView(props: {
         ) : (
           // Spacer whose height is driven by useStableComposerAnchor to keep the
           // composer centered initially, then anchored as it grows.
-          <div ref={anchorSpacerRef} aria-hidden className="w-full shrink-0" />
+          <div
+            ref={anchorSpacerRef}
+            aria-hidden
+            className="w-full shrink-0"
+            data-draft-composer-anchor-spacer=""
+          />
         )}
 
         {/* Composer block: centered initially, then anchored by the input's top edge. */}


### PR DESCRIPTION
- Prevent the full draft composer from anchoring before the selected agent is available, removing the initial-mount race in the draft view.
- Keep the anchor spacer explicitly targetable so the centered-to-anchored layout stays stable.
- Add a regression test that covers the empty-state render followed by agent resolution and verifies the composer anchors afterward.