### PR TITLE
Fix Claude credential lookup via macOS keychain

### DIFF
--- a/src/supervisor/runtime/claudeCredentials.ts
+++ b/src/supervisor/runtime/claudeCredentials.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { OAuthToken } from "@lightcode/agents-usage";
+import { readClaudeCredentialsFromMacKeychain } from "./macClaudeKeychain";
 import { readClaudeCredentialsFromWindowsVault } from "./windowsClaudeVault";
 import { readClaudeCredsFromWsl } from "./wslCredentials";
 
@@ -62,6 +63,15 @@ export async function resolveClaudeToken(): Promise<OAuthToken | undefined> {
       if (token) return token;
     } catch {
       // try the next candidate dir
+    }
+  }
+  // Current native Claude Code builds on macOS store the same JSON payload in
+  // the login keychain instead of writing `~/.claude/.credentials.json`.
+  if (process.platform === "darwin") {
+    const blob = await readClaudeCredentialsFromMacKeychain();
+    if (blob) {
+      const token = parseClaudeCredentials(blob);
+      if (token) return token;
     }
   }
   // On native Windows, Claude Code may store the OAuth token in the Windows

--- a/src/supervisor/runtime/macClaudeKeychain.ts
+++ b/src/supervisor/runtime/macClaudeKeychain.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { homedir, userInfo } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const KEYCHAIN_TIMEOUT_MS = 5_000;
+const CREDENTIAL_SUFFIX = "-credentials";
+const ACCOUNT_RE = /^[a-zA-Z0-9._-]+$/;
+
+interface KeychainEnv {
+  CLAUDE_CONFIG_DIR?: string | undefined;
+  CLAUDE_SECURESTORAGE_CONFIG_DIR?: string | undefined;
+  CLAUDE_CODE_CUSTOM_OAUTH_URL?: string | undefined;
+}
+
+export function claudeKeychainAccount(
+  env: { USER?: string | undefined } = process.env,
+  fallbackUsername = userInfo().username,
+): string {
+  const account = env.USER || fallbackUsername || "claude-code-user";
+  return ACCOUNT_RE.test(account) ? account : "claude-code-user";
+}
+
+function defaultClaudeConfigDir(): string {
+  return join(homedir(), ".claude");
+}
+
+function secureStorageConfigDir(env: KeychainEnv): string {
+  const secureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  if (secureDir !== undefined) return (secureDir || defaultClaudeConfigDir()).normalize("NFC");
+  return (env.CLAUDE_CONFIG_DIR || defaultClaudeConfigDir()).normalize("NFC");
+}
+
+function keychainConfigHashSuffix(env: KeychainEnv): string {
+  const secureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+  const useDefaultKey = secureDir !== undefined ? secureDir.length === 0 : !env.CLAUDE_CONFIG_DIR;
+  if (useDefaultKey) return "";
+  return `-${createHash("sha256").update(secureStorageConfigDir(env)).digest("hex").slice(0, 8)}`;
+}
+
+function oauthSuffixes(env: KeychainEnv): string[] {
+  const suffixes = [""];
+  if (env.CLAUDE_CODE_CUSTOM_OAUTH_URL) suffixes.push("-custom-oauth");
+  // Developer/local Claude builds use this suffix. Trying it after the prod
+  // name is harmless and keeps usage working for non-production installs.
+  suffixes.push("-local-oauth");
+  return [...new Set(suffixes)];
+}
+
+export function claudeKeychainServiceNames(env: KeychainEnv = process.env): string[] {
+  const hashSuffix = keychainConfigHashSuffix(env);
+  return oauthSuffixes(env).map(
+    (oauthSuffix) => `Claude Code${oauthSuffix}${CREDENTIAL_SUFFIX}${hashSuffix}`,
+  );
+}
+
+export async function readClaudeCredentialsFromMacKeychain(): Promise<string | undefined> {
+  if (process.platform !== "darwin") return undefined;
+  const account = claudeKeychainAccount();
+  for (const service of claudeKeychainServiceNames()) {
+    try {
+      const { stdout } = await execFileAsync(
+        "security",
+        ["find-generic-password", "-a", account, "-w", "-s", service],
+        { timeout: KEYCHAIN_TIMEOUT_MS, encoding: "utf8" },
+      );
+      const trimmed = stdout.trim();
+      if (trimmed) return trimmed;
+    } catch {
+      // Try the next candidate. Missing/locked keychains degrade to auth-missing.
+    }
+  }
+  return undefined;
+}

--- a/src/supervisor/runtime/usageCredentials.test.ts
+++ b/src/supervisor/runtime/usageCredentials.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseClaudeCredentials } from "./claudeCredentials";
+import { claudeKeychainAccount, claudeKeychainServiceNames } from "./macClaudeKeychain";
 import { parseCodexAuth } from "./codexCredentials";
 import { copilotCredentialTargetFromConfig } from "./copilotCredentials";
 import { cursorUserIdFromJwt } from "./cursorCredentials";
@@ -57,6 +58,37 @@ describe("parseClaudeCredentials", () => {
     expect(parseClaudeCredentials("{}")).toBeUndefined();
     expect(parseClaudeCredentials(JSON.stringify({ claudeAiOauth: {} }))).toBeUndefined();
     expect(parseClaudeCredentials("not json")).toBeUndefined();
+  });
+});
+
+describe("macOS Claude keychain helpers", () => {
+  it("matches Claude Code's default OAuth credential service", () => {
+    expect(
+      claudeKeychainServiceNames({
+        CLAUDE_CONFIG_DIR: undefined,
+        CLAUDE_SECURESTORAGE_CONFIG_DIR: undefined,
+        CLAUDE_CODE_CUSTOM_OAUTH_URL: undefined,
+      }),
+    ).toEqual(["Claude Code-credentials", "Claude Code-local-oauth-credentials"]);
+  });
+
+  it("hashes non-default config dirs into the service name", () => {
+    expect(
+      claudeKeychainServiceNames({
+        CLAUDE_CONFIG_DIR: "/tmp/lightcode-claude",
+        CLAUDE_SECURESTORAGE_CONFIG_DIR: undefined,
+        CLAUDE_CODE_CUSTOM_OAUTH_URL: "https://claude.example.test",
+      }),
+    ).toEqual([
+      "Claude Code-credentials-54bcf3fb",
+      "Claude Code-custom-oauth-credentials-54bcf3fb",
+      "Claude Code-local-oauth-credentials-54bcf3fb",
+    ]);
+  });
+
+  it("falls back to Claude's safe account name when the username is not keychain-safe", () => {
+    expect(claudeKeychainAccount({ USER: "bad user" }, "fallback")).toBe("claude-code-user");
+    expect(claudeKeychainAccount({ USER: "" }, "fallback_user")).toBe("fallback_user");
   });
 });
 


### PR DESCRIPTION
- Bugfix: restore Claude auth on macOS when newer Claude Code builds store credentials in the login keychain instead of `~/.claude/.credentials.json`.
- Add a dedicated keychain lookup path that matches Claude Code's service/account naming, including config-dir hashing and OAuth variants, so existing installs remain compatible.
- Expand coverage for the default, custom-config, and unsafe-username cases to lock in the fallback behavior.