### PR TITLE
Fix macOS WebAuthn access group wiring

### DIFF
--- a/scripts/build-desktop-artifact.mjs
+++ b/scripts/build-desktop-artifact.mjs
@@ -198,6 +198,37 @@ function copyPackagedDist(stageRoot) {
   }
 }
 
+function prepareMacEntitlements(stageRoot, channel) {
+  const accessGroup = channelTable.webAuthnKeychainAccessGroupFor(
+    process.env.APPLE_TEAM_ID,
+    channel,
+  );
+  if (!accessGroup) {
+    console.log("[stage] APPLE_TEAM_ID not set; using base mac entitlements");
+    return "build/entitlements.mac.plist";
+  }
+
+  const sourcePath = join(stageRoot, "build", "entitlements.mac.plist");
+  const generatedPath = join(stageRoot, "build", "entitlements.mac.generated.plist");
+  const plist = readFileSync(sourcePath, "utf8");
+  if (plist.includes("keychain-access-groups")) {
+    return "build/entitlements.mac.plist";
+  }
+
+  const keychainEntitlement = [
+    "    <key>keychain-access-groups</key>",
+    "    <array>",
+    `        <string>${accessGroup}</string>`,
+    "    </array>",
+  ].join("\n");
+  if (!plist.includes("</dict>")) {
+    throw new Error("mac entitlements plist is missing </dict>");
+  }
+  writeFileSync(generatedPath, plist.replace("</dict>", `${keychainEntitlement}\n</dict>`));
+  console.log(`[stage] enabled mac WebAuthn keychain access group ${accessGroup}`);
+  return "build/entitlements.mac.generated.plist";
+}
+
 // The Claude Agent SDK lists `@anthropic-ai/claude-agent-sdk-<plat>-<arch>` as
 // optionalDependencies — each platform pack contains a ~200 MB precompiled
 // SEA binary of the `claude` CLI. The asar exclusion in the staged
@@ -313,7 +344,12 @@ async function main() {
     writeFileSync(join(stageRoot, "package.json"), `${JSON.stringify(stagePkg, null, 2)}\n`);
 
     // 5. Stage electron-builder config.
-    writeFileSync(join(stageRoot, "electron-builder.yml"), buildElectronBuilderConfig());
+    const channel = channelTable.normalizeChannel(process.env.LIGHTCODE_CHANNEL);
+    const macEntitlements = prepareMacEntitlements(stageRoot, channel);
+    writeFileSync(
+      join(stageRoot, "electron-builder.yml"),
+      buildElectronBuilderConfig({ macEntitlements }),
+    );
 
     // 6. Install prod + stage devdeps with a flat layout.
     //    node-linker=hoisted makes pnpm produce an npm-style flat node_modules,
@@ -421,7 +457,7 @@ async function main() {
   }
 }
 
-function buildElectronBuilderConfig() {
+function buildElectronBuilderConfig(options = {}) {
   // Generate the staged electron-builder config with a drastically simplified
   // `files:` block — the stage's node_modules contains only the runtime
   // externals we listed, so we can include all of node_modules without dragging
@@ -435,6 +471,7 @@ function buildElectronBuilderConfig() {
   const prefix = channelTable.artifactPrefixFor(channel);
   const iconSuffix = channel === "nightly" ? "-nightly" : "";
   const publishChannelLine = updaterChannel ? `\n  channel: ${updaterChannel}` : "";
+  const macEntitlements = options.macEntitlements ?? "build/entitlements.mac.plist";
   const packagedDistFilesYaml = PACKAGED_DIST_FILES.map((glob) =>
     glob.startsWith("!") ? `  - "${glob}"` : `  - ${glob}`,
   ).join("\n");
@@ -529,8 +566,8 @@ mac:
   gatekeeperAssess: false
   extendInfo:
     NSMicrophoneUsageDescription: Lightcode uses the microphone for local voice input in the composer.
-  entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlements: ${macEntitlements}
+  entitlementsInherit: ${macEntitlements}
   notarize: true
 
 npmRebuild: false

--- a/scripts/electron-builder.shared.cjs
+++ b/scripts/electron-builder.shared.cjs
@@ -38,6 +38,16 @@ function artifactPrefixFor(channel) {
   return channel === "nightly" ? "Lightcode-Nightly" : "Lightcode";
 }
 
+function normalizeAppleTeamId(teamId) {
+  const normalized = (teamId ?? "").trim().replace(/\.+$/, "");
+  return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
+}
+
+function webAuthnKeychainAccessGroupFor(teamId, channel) {
+  const normalizedTeamId = normalizeAppleTeamId(teamId);
+  return normalizedTeamId ? `${normalizedTeamId}.${appIdFor(channel)}.webauthn` : null;
+}
+
 module.exports = {
   CHANNELS,
   PACKAGED_DIST_DIRS,
@@ -48,4 +58,6 @@ module.exports = {
   userDataDirNameFor,
   updaterChannelFor,
   artifactPrefixFor,
+  normalizeAppleTeamId,
+  webAuthnKeychainAccessGroupFor,
 };

--- a/src/main/browser/permissions.test.ts
+++ b/src/main/browser/permissions.test.ts
@@ -17,16 +17,37 @@ type RequestHandler = (
   permission: string,
   callback: (granted: boolean) => void,
 ) => void;
+type WebAuthnAccountHandler = (
+  event: unknown,
+  details: { accounts: Array<{ credentialId: string }> },
+  callback: (credentialId: string | null) => void,
+) => void;
 
-function installAndCaptureRequestHandler(): RequestHandler {
+function createFakeSession() {
   let requestHandler: RequestHandler | null = null;
+  let webAuthnAccountHandler: WebAuthnAccountHandler | null = null;
   const session = {
     setPermissionRequestHandler: vi.fn<(handler: RequestHandler) => void>((handler) => {
       requestHandler = handler;
     }),
     setPermissionCheckHandler: vi.fn<() => boolean>(),
+    on: vi.fn<(event: string, handler: WebAuthnAccountHandler) => void>((event, handler) => {
+      if (event === "select-webauthn-account") {
+        webAuthnAccountHandler = handler;
+      }
+    }),
   };
   installSessionPermissions(session as unknown as Parameters<typeof installSessionPermissions>[0]);
+  return {
+    session,
+    getRequestHandler: () => requestHandler,
+    getWebAuthnAccountHandler: () => webAuthnAccountHandler,
+  };
+}
+
+function installAndCaptureRequestHandler(): RequestHandler {
+  const { getRequestHandler } = createFakeSession();
+  const requestHandler = getRequestHandler();
   if (!requestHandler) {
     throw new Error("installSessionPermissions did not register a request handler");
   }
@@ -187,5 +208,30 @@ describe("installSessionPermissions non-media permissions", () => {
   it("denies permissions outside the allow-list", async () => {
     const handler = installAndCaptureRequestHandler();
     await expect(requestPermission(handler, windowContents, "geolocation")).resolves.toBe(false);
+  });
+});
+
+describe("installSessionPermissions WebAuthn account selection", () => {
+  it("selects the first discoverable credential instead of letting Electron cancel by default", () => {
+    const { getWebAuthnAccountHandler } = createFakeSession();
+    const handler = getWebAuthnAccountHandler();
+    expect(handler).toBeTruthy();
+    const callback = vi.fn<(credentialId: string | null) => void>();
+
+    handler?.(
+      {},
+      { accounts: [{ credentialId: "credential-a" }, { credentialId: "credential-b" }] },
+      callback,
+    );
+
+    expect(callback).toHaveBeenCalledWith("credential-a");
+  });
+
+  it("only registers one WebAuthn account handler per session", () => {
+    const { session } = createFakeSession();
+    installSessionPermissions(
+      session as unknown as Parameters<typeof installSessionPermissions>[0],
+    );
+    expect(session.on).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/main/browser/permissions.ts
+++ b/src/main/browser/permissions.ts
@@ -16,6 +16,8 @@ const BLOCKED_NAVIGATION_PROTOCOLS = new Set<string>([
   "view-source:",
 ]);
 
+const SESSIONS_WITH_WEBAUTHN_ACCOUNT_HANDLER = new WeakSet<Session>();
+
 export function isNavigationUrlAllowed(url: string): boolean {
   try {
     const parsed = new URL(url);
@@ -83,6 +85,7 @@ export async function openMicrophoneSettings(): Promise<void> {
 }
 
 export function installSessionPermissions(session: Session): void {
+  installWebAuthnAccountHandler(session);
   session.setPermissionRequestHandler((webContents, permission, callback) => {
     if (!isPermissionAllowed(webContents, permission)) {
       callback(false);
@@ -97,6 +100,16 @@ export function installSessionPermissions(session: Session): void {
   session.setPermissionCheckHandler((webContents, permission) =>
     isPermissionAllowed(webContents, permission),
   );
+}
+
+function installWebAuthnAccountHandler(session: Session): void {
+  if (SESSIONS_WITH_WEBAUTHN_ACCOUNT_HANDLER.has(session)) {
+    return;
+  }
+  SESSIONS_WITH_WEBAUTHN_ACCOUNT_HANDLER.add(session);
+  session.on("select-webauthn-account", (_event, details, callback) => {
+    callback(details.accounts[0]?.credentialId ?? null);
+  });
 }
 
 export function installNavigationGuards(

--- a/src/main/browser/webauthn.ts
+++ b/src/main/browser/webauthn.ts
@@ -1,0 +1,33 @@
+import { app } from "electron";
+import { type LightcodeChannel, webAuthnKeychainAccessGroupFor } from "@/shared/channel";
+
+declare const __APPLE_TEAM_ID__: string | undefined;
+
+const BUILD_APPLE_TEAM_ID = typeof __APPLE_TEAM_ID__ === "string" ? __APPLE_TEAM_ID__ : "";
+
+export function configureMacWebAuthn(channel: LightcodeChannel): boolean {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+
+  const keychainAccessGroup = webAuthnKeychainAccessGroupFor(BUILD_APPLE_TEAM_ID, channel);
+  if (!keychainAccessGroup) {
+    console.error(
+      "[lightcode][webauthn] APPLE_TEAM_ID was not available at build time; macOS platform passkeys are disabled.",
+    );
+    return false;
+  }
+
+  try {
+    app.configureWebAuthn({
+      touchID: {
+        keychainAccessGroup,
+        promptReason: "sign in to $1",
+      },
+    });
+    return true;
+  } catch (error) {
+    console.error("[lightcode][webauthn] configureWebAuthn failed", error);
+    return false;
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -32,6 +32,7 @@ import { WindowsJobObjectManager } from "./windowsJobObject";
 import { captureMainException, initializeMainSentry } from "./diagnostics/sentry";
 import { configureSecretStorageKey } from "@/shared/secretStorage";
 import { readOrCreateSafeStorageSecretKey } from "./secretStorageKey";
+import { configureMacWebAuthn } from "./browser/webauthn";
 
 const isDev = Boolean(process.env.VITE_DEV_SERVER_URL);
 const channel = resolveLightcodeChannel();
@@ -165,6 +166,7 @@ if (!hasSingleInstanceLock) {
 
   app.whenReady().then(async () => {
     Menu.setApplicationMenu(null);
+    configureMacWebAuthn(channel);
 
     installLocalFileProtocolHandler();
     installPickerProtocolHandler();

--- a/src/shared/channel.config-parity.test.ts
+++ b/src/shared/channel.config-parity.test.ts
@@ -4,9 +4,11 @@ import {
   appIdFor,
   artifactPrefixFor,
   LIGHTCODE_CHANNELS,
+  normalizeAppleTeamId,
   productNameFor,
   updaterChannelFor,
   userDataDirNameFor,
+  webAuthnKeychainAccessGroupFor,
 } from "./channel";
 
 const requireFromHere = createRequire(import.meta.url);
@@ -18,7 +20,14 @@ const cjs = requireFromHere("../../scripts/electron-builder.shared.cjs") as {
   userDataDirNameFor: (channel: string) => string;
   updaterChannelFor: (channel: string) => string | undefined;
   artifactPrefixFor: (channel: string) => string;
+  normalizeAppleTeamId: (teamId: string | undefined | null) => string | null;
+  webAuthnKeychainAccessGroupFor: (
+    teamId: string | undefined | null,
+    channel: string,
+  ) => string | null;
 };
+
+const APPLE_TEAM_ID_SAMPLES = ["ABCDE12345", "ABCDE12345.", "", "team", undefined];
 
 describe("electron-builder.shared.cjs mirrors src/shared/channel.ts", () => {
   it("exposes the same channel list", () => {
@@ -32,8 +41,19 @@ describe("electron-builder.shared.cjs mirrors src/shared/channel.ts", () => {
       expect(cjs.userDataDirNameFor(channel)).toBe(userDataDirNameFor(channel));
       expect(cjs.updaterChannelFor(channel)).toBe(updaterChannelFor(channel));
       expect(cjs.artifactPrefixFor(channel)).toBe(artifactPrefixFor(channel));
+      for (const teamId of APPLE_TEAM_ID_SAMPLES) {
+        expect(cjs.webAuthnKeychainAccessGroupFor(teamId, channel)).toBe(
+          webAuthnKeychainAccessGroupFor(teamId, channel),
+        );
+      }
     });
   }
+
+  it("agrees on Apple team id normalization", () => {
+    for (const teamId of APPLE_TEAM_ID_SAMPLES) {
+      expect(cjs.normalizeAppleTeamId(teamId)).toBe(normalizeAppleTeamId(teamId));
+    }
+  });
 
   it("normalizes any unknown value to stable", () => {
     expect(cjs.normalizeChannel("nightly")).toBe("nightly");

--- a/src/shared/channel.test.ts
+++ b/src/shared/channel.test.ts
@@ -6,6 +6,7 @@ import {
   productNameFor,
   updaterChannelFor,
   userDataDirNameFor,
+  webAuthnKeychainAccessGroupFor,
 } from "./channel";
 
 describe("channel", () => {
@@ -37,6 +38,31 @@ describe("channel", () => {
     expect(artifactPrefixFor("stable")).toBe("Lightcode");
     expect(artifactPrefixFor("nightly")).toBe("Lightcode-Nightly");
     expect(artifactPrefixFor("stable")).not.toBe(artifactPrefixFor("nightly"));
+  });
+});
+
+describe("webAuthnKeychainAccessGroupFor", () => {
+  it("builds the stable channel keychain access group", () => {
+    expect(webAuthnKeychainAccessGroupFor("ABCDE12345", "stable")).toBe(
+      "ABCDE12345.com.lightcode.app.webauthn",
+    );
+  });
+
+  it("builds the nightly channel keychain access group", () => {
+    expect(webAuthnKeychainAccessGroupFor("ABCDE12345", "nightly")).toBe(
+      "ABCDE12345.com.lightcode.app.nightly.webauthn",
+    );
+  });
+
+  it("accepts a trailing dot from Apple team identifier prefixes", () => {
+    expect(webAuthnKeychainAccessGroupFor("ABCDE12345.", "stable")).toBe(
+      "ABCDE12345.com.lightcode.app.webauthn",
+    );
+  });
+
+  it("rejects missing or malformed team ids", () => {
+    expect(webAuthnKeychainAccessGroupFor("", "stable")).toBeNull();
+    expect(webAuthnKeychainAccessGroupFor("team", "stable")).toBeNull();
   });
 });
 

--- a/src/shared/channel.ts
+++ b/src/shared/channel.ts
@@ -31,3 +31,20 @@ export function updaterChannelFor(channel: LightcodeChannel): string | undefined
 export function artifactPrefixFor(channel: LightcodeChannel): string {
   return channel === "nightly" ? "Lightcode-Nightly" : "Lightcode";
 }
+
+export function normalizeAppleTeamId(teamId: string | undefined | null): string | null {
+  const normalized = (teamId ?? "").trim().replace(/\.+$/, "");
+  return /^[A-Z0-9]{10}$/.test(normalized) ? normalized : null;
+}
+
+// The keychain access group must be byte-identical between the entitlements
+// plist embedded at sign time (scripts/build-desktop-artifact.mjs) and the
+// value passed to app.configureWebAuthn at runtime (src/main/browser/webauthn.ts),
+// or macOS platform passkeys silently fail. Keep it single-sourced here.
+export function webAuthnKeychainAccessGroupFor(
+  teamId: string | undefined | null,
+  channel: LightcodeChannel,
+): string | null {
+  const normalizedTeamId = normalizeAppleTeamId(teamId);
+  return normalizedTeamId ? `${normalizedTeamId}.${appIdFor(channel)}.webauthn` : null;
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,6 +14,7 @@ function readEnvValue(key: string): string {
 const channel = process.env.LIGHTCODE_CHANNEL === "nightly" ? "nightly" : "stable";
 
 const buildDefines = {
+  __APPLE_TEAM_ID__: JSON.stringify(readEnvValue("APPLE_TEAM_ID")),
   __BUILD_SENTRY_DSN__: JSON.stringify(readEnvValue("SENTRY_DSN")),
   __BUILD_SENTRY_ENVIRONMENT__: JSON.stringify(readEnvValue("SENTRY_ENVIRONMENT")),
   __LIGHTCODE_CHANNEL__: JSON.stringify(channel),


### PR DESCRIPTION
- Bugfix: keep the macOS WebAuthn keychain access group consistent between signing and runtime so Touch ID and passkey sign-in work reliably on Apple builds.
- Enable WebAuthn in the main process and prefer the first discoverable credential during account selection instead of letting Electron cancel the prompt.
- Thread `APPLE_TEAM_ID` through the desktop build, generate mac entitlements when needed, and keep shared channel helpers aligned for stable and nightly app IDs.
- Expand unit and parity coverage for team ID normalization, access-group generation, and WebAuthn permission behavior.