### PR TITLE
Fix stale PR badges and Codex resume noise

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -1,9 +1,23 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GitStatusResult } from "@/shared/contracts";
+import type { GitStatusResult, PrData, ProjectLocation } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
 import { GitBadge } from "./GitBadge";
+
+const ghGetPrForBranchMock = vi.hoisted(() =>
+  vi.fn<
+    (payload: { projectLocation: ProjectLocation; branch: string }) => Promise<PrData | null>
+  >(),
+);
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({
+    ghGetPrForBranch: ghGetPrForBranchMock,
+  }),
+}));
 
 vi.mock("@dnd-kit/react", () => ({
   useDraggable: () => undefined,
@@ -34,8 +48,22 @@ function makeStatus(overrides: Partial<GitStatusResult> = {}): GitStatusResult {
   };
 }
 
+const basePr: PrData = {
+  number: 1,
+  state: "open",
+  title: "PR",
+  url: "https://github.com/o/r/pull/1",
+  baseBranch: "main",
+  isDraft: false,
+  updatedAt: "2026-06-02T00:00:00.000Z",
+};
+
 describe("GitBadge", () => {
   beforeEach(() => {
+    ghGetPrForBranchMock.mockReset();
+    useAppStore.setState({
+      projects: [],
+    });
     useGitStore.setState({
       statuses: {},
       worktreeStatuses: {},
@@ -103,15 +131,7 @@ describe("GitBadge", () => {
         "/wt/feature": makeStatus({ totalInsertions: 12, totalDeletions: 3 }),
       },
       prData: {
-        "/wt/feature": {
-          number: 1,
-          state: "open",
-          title: "PR",
-          url: "https://github.com/o/r/pull/1",
-          baseBranch: "main",
-          isDraft: false,
-          updatedAt: "2026-06-02T00:00:00.000Z",
-        },
+        "/wt/feature": basePr,
       },
     });
 
@@ -125,5 +145,51 @@ describe("GitBadge", () => {
     expect(
       insertion.compareDocumentPosition(prIcon!) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("does not show a stale project PR while fetching the current branch PR", async () => {
+    let resolvePr: (pr: PrData | null) => void = () => {};
+    ghGetPrForBranchMock.mockReturnValue(
+      new Promise<PrData | null>((resolve) => {
+        resolvePr = resolve;
+      }),
+    );
+    useAppStore.setState({
+      projects: [
+        {
+          id: "project-1",
+          name: "Project",
+          location: { kind: "posix", path: "/repo" },
+          createdAt: "2026-06-02T00:00:00.000Z",
+        },
+      ],
+    });
+    useGitStore.setState({
+      statuses: {
+        "project-1": makeStatus({
+          branch: "feature/current",
+          remoteInfo: { platform: "github", owner: "o", repo: "r", url: "https://github.com/o/r" },
+        }),
+      },
+      ghAvailable: { "project-1": true },
+      prData: {
+        [buildBranchPrKey("project-1")]: { ...basePr, number: 99, title: "Stale PR" },
+      },
+    });
+
+    render(<GitBadge projectId="project-1" projectName="Project" />);
+
+    expect(screen.queryByRole("button", { name: "Git status for Project" })).toBeNull();
+    expect(ghGetPrForBranchMock).toHaveBeenCalledWith({
+      projectLocation: { kind: "posix", path: "/repo" },
+      branch: "feature/current",
+    });
+
+    resolvePr({ ...basePr, number: 2, title: "Current PR" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Git status for Project" })).toBeInTheDocument();
+    });
+    expect(useGitStore.getState().prData[buildBranchPrKey("project-1")]?.number).toBe(2);
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -1,7 +1,9 @@
-import { useId, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { GitFork, GitPullRequest } from "lucide-react";
 import { Tooltip } from "@heroui/react";
 import { useDraggable } from "@dnd-kit/react";
+import { readBridge } from "@/renderer/bridge";
+import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
 import { useShallow } from "zustand/shallow";
@@ -42,34 +44,89 @@ export function GitBadge(props: {
     element: elementRef,
   });
 
-  const { isRepo, totalInsertions, totalDeletions, prState, checksStatus, canCreatePr } =
-    useGitStore(
-      useShallow((s) => {
-        const gitStatus = props.worktreePath
-          ? s.worktreeStatuses[props.worktreePath]
-          : s.statuses[props.projectId];
-        const pr = props.worktreePath
-          ? s.prData[props.worktreePath]
-          : s.prData[buildBranchPrKey(props.projectId)];
-        const details = pr?.number ? s.prDetails[`${props.projectId}#${pr.number}`] : undefined;
-        const detailsStatus = aggregatePrChecksStatus(details?.checks);
-        const isWorktree = props.worktreePath !== undefined;
-        const hasPr = pr !== undefined && pr !== null && pr.state !== "closed";
-        return {
-          isRepo: gitStatus?.isRepo ?? false,
-          totalInsertions: gitStatus?.totalInsertions ?? 0,
-          totalDeletions: gitStatus?.totalDeletions ?? 0,
-          prState: pr?.state,
-          checksStatus: combineChecksStatus(detailsStatus, pr?.checksStatus),
-          canCreatePr:
-            isWorktree &&
-            (s.ghAvailable[props.projectId] ?? false) &&
-            !hasPr &&
-            Boolean(gitStatus?.tracking) &&
-            (gitStatus?.ahead ?? 0) === 0,
-        };
-      }),
-    );
+  const projectLocation = useAppStore((s) =>
+    props.worktreePath ? undefined : s.projects.find((p) => p.id === props.projectId)?.location,
+  );
+  const [verifiedProjectPrBranch, setVerifiedProjectPrBranch] = useState<string | null>(null);
+  const projectPrKey = buildBranchPrKey(props.projectId);
+
+  const {
+    isRepo,
+    branch,
+    remotePlatform,
+    ghAvailable,
+    totalInsertions,
+    totalDeletions,
+    prState,
+    checksStatus,
+    canCreatePr,
+  } = useGitStore(
+    useShallow((s) => {
+      const gitStatus = props.worktreePath
+        ? s.worktreeStatuses[props.worktreePath]
+        : s.statuses[props.projectId];
+      const currentBranch = gitStatus?.branch ?? "";
+      const pr = props.worktreePath
+        ? s.prData[props.worktreePath]
+        : verifiedProjectPrBranch === currentBranch
+          ? s.prData[projectPrKey]
+          : null;
+      const details = pr?.number ? s.prDetails[`${props.projectId}#${pr.number}`] : undefined;
+      const detailsStatus = aggregatePrChecksStatus(details?.checks);
+      const isWorktree = props.worktreePath !== undefined;
+      const hasPr = pr !== undefined && pr !== null && pr.state !== "closed";
+      return {
+        isRepo: gitStatus?.isRepo ?? false,
+        branch: currentBranch,
+        remotePlatform: gitStatus?.remoteInfo?.platform,
+        ghAvailable: s.ghAvailable[props.projectId] ?? false,
+        totalInsertions: gitStatus?.totalInsertions ?? 0,
+        totalDeletions: gitStatus?.totalDeletions ?? 0,
+        prState: pr?.state,
+        checksStatus: combineChecksStatus(detailsStatus, pr?.checksStatus),
+        canCreatePr:
+          isWorktree &&
+          (s.ghAvailable[props.projectId] ?? false) &&
+          !hasPr &&
+          Boolean(gitStatus?.tracking) &&
+          (gitStatus?.ahead ?? 0) === 0,
+      };
+    }),
+  );
+
+  useEffect(() => {
+    if (props.worktreePath) return;
+    setVerifiedProjectPrBranch(null);
+    useGitStore.getState().setPrData(projectPrKey, null);
+    if (!isRepo || !branch || !projectLocation || !ghAvailable) return;
+    if (remotePlatform !== "github" && remotePlatform !== "unknown") return;
+
+    let isActive = true;
+    readBridge()
+      .ghGetPrForBranch({ projectLocation, branch })
+      .then((pr) => {
+        if (!isActive) return;
+        if (useGitStore.getState().statuses[props.projectId]?.branch !== branch) return;
+        useGitStore.getState().setPrData(projectPrKey, pr);
+        setVerifiedProjectPrBranch(branch);
+      })
+      .catch(() => {
+        if (isActive) setVerifiedProjectPrBranch(branch);
+      });
+    return () => {
+      isActive = false;
+    };
+  }, [
+    props.worktreePath,
+    props.projectId,
+    projectPrKey,
+    isRepo,
+    branch,
+    projectLocation,
+    ghAvailable,
+    remotePlatform,
+  ]);
+
   const hasChanges = totalInsertions > 0 || totalDeletions > 0;
   const isWorktree = props.worktreePath !== undefined;
   const hasVisiblePr =

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -70,6 +70,7 @@ function sleep(ms: number): Promise<void> {
 // user sees the generic notice *plus* the real error. The delay only postpones
 // an error message; the error status icon updates synchronously.
 const CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS = 250;
+const CODEX_RESUME_STATUS_REPLAY_SUPPRESSION_MS = 500;
 
 function spawnAppServer(command: CommandSpec): ChildProcess {
   return spawn(command.command, command.args, {
@@ -87,6 +88,38 @@ function spawnAppServer(command: CommandSpec): ChildProcess {
 
 function toSessionRef(threadId: string): SessionRef {
   return createKnownSessionRef(threadId);
+}
+
+function isPlainActiveStatus(status: CodexThreadStatus): boolean {
+  if (status.type !== "active") {
+    return false;
+  }
+  const flags = new Set(status.activeFlags ?? []);
+  return !flags.has("waitingOnApproval") && !flags.has("waitingOnUserInput");
+}
+
+function readNotificationThreadId(
+  params: Record<string, unknown> | undefined,
+  fallbackThreadId: string | undefined,
+): string | undefined {
+  if (params && typeof params.threadId === "string") {
+    return params.threadId;
+  }
+  const thread =
+    params && typeof params.thread === "object" && params.thread !== null
+      ? (params.thread as Record<string, unknown>)
+      : undefined;
+  if (typeof thread?.id === "string") {
+    return thread.id;
+  }
+  const turn =
+    params && typeof params.turn === "object" && params.turn !== null
+      ? (params.turn as Record<string, unknown>)
+      : undefined;
+  if (typeof turn?.threadId === "string") {
+    return turn.threadId;
+  }
+  return fallbackThreadId;
 }
 
 // ── Structured Session ──────────────────────────────────────────
@@ -141,6 +174,12 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   // arrives first, on the next user turn, or on dispose.
   private pendingSystemErrorFallback: ReturnType<typeof setTimeout> | undefined;
   private mapperState: CodexMapperState | undefined;
+  /**
+   * Codex can report a plain `active` status while `thread/resume` is only
+   * attaching to an existing saved thread. Treat that as history-load noise
+   * until `thread/read` confirms the real remote state.
+   */
+  private readonly resumeActiveStatusSuppressionUntil = new Map<string, number>();
   /**
    * Runtime events emitted before the listener was wired. Replayed on
    * `setListener` — same race as `AcpStructuredSession`.
@@ -225,6 +264,57 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       clearTimeout(this.pendingSystemErrorFallback);
       this.pendingSystemErrorFallback = undefined;
     }
+  }
+
+  private beginResumeActiveStatusSuppression(threadId: string): void {
+    this.resumeActiveStatusSuppressionUntil.set(threadId, Number.POSITIVE_INFINITY);
+  }
+
+  private settleResumeActiveStatusSuppression(
+    threadId: string,
+    confirmedStatus?: CodexThreadStatus,
+  ): void {
+    if (!this.resumeActiveStatusSuppressionUntil.has(threadId)) {
+      return;
+    }
+    if (confirmedStatus && isPlainActiveStatus(confirmedStatus)) {
+      this.resumeActiveStatusSuppressionUntil.delete(threadId);
+      return;
+    }
+    const suppressUntil = Date.now() + CODEX_RESUME_STATUS_REPLAY_SUPPRESSION_MS;
+    this.resumeActiveStatusSuppressionUntil.set(threadId, suppressUntil);
+    setTimeout(() => {
+      if (this.resumeActiveStatusSuppressionUntil.get(threadId) === suppressUntil) {
+        this.resumeActiveStatusSuppressionUntil.delete(threadId);
+      }
+    }, CODEX_RESUME_STATUS_REPLAY_SUPPRESSION_MS);
+  }
+
+  private shouldSuppressResumeActiveStatus(threadId: string, status: CodexThreadStatus): boolean {
+    const suppressUntil = this.resumeActiveStatusSuppressionUntil.get(threadId);
+    if (suppressUntil === undefined) {
+      return false;
+    }
+    if (Date.now() > suppressUntil) {
+      this.resumeActiveStatusSuppressionUntil.delete(threadId);
+      return false;
+    }
+    return isPlainActiveStatus(status);
+  }
+
+  private isResumeReplaySuppressed(threadId: string | undefined): boolean {
+    if (!threadId) {
+      return false;
+    }
+    const suppressUntil = this.resumeActiveStatusSuppressionUntil.get(threadId);
+    if (suppressUntil === undefined) {
+      return false;
+    }
+    if (Date.now() > suppressUntil) {
+      this.resumeActiveStatusSuppressionUntil.delete(threadId);
+      return false;
+    }
+    return true;
   }
 
   private async dispatchCodexGoalCommand(
@@ -370,6 +460,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     let threadId: string;
 
     if (sessionRef) {
+      this.beginResumeActiveStatusSuppression(sessionRef.providerSessionId);
       try {
         await this.request("thread/resume", {
           ...threadOverrides,
@@ -380,8 +471,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         if (!isRecoverableResumeError(msg)) {
+          this.resumeActiveStatusSuppressionUntil.delete(sessionRef.providerSessionId);
           throw error;
         }
+        this.resumeActiveStatusSuppressionUntil.delete(sessionRef.providerSessionId);
         console.log("[codex] thread/resume failed (%s), falling back to thread/start", msg);
         const result = await this.request("thread/start", startParams);
         threadId = extractThreadField(result, "id") ?? "";
@@ -403,6 +496,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
     this.remoteThreadId = threadId;
     this.launchOptions = { ...this.launchOptions, resumeThreadId: threadId };
+    if (sessionRef) {
+      void this.syncRemoteThreadState(threadId, toSessionRef(threadId));
+    }
 
     return threadId;
   }
@@ -492,6 +588,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     this.seenErrorMessages.clear();
     this.clearPendingSystemErrorFallback();
     const threadId = await this.waitForRemoteThreadId();
+    this.resumeActiveStatusSuppressionUntil.delete(threadId);
 
     const turnId = `turn-${randomUUID()}`;
     const userItemId = options?.userMessageItemId ?? `user-${turnId}`;
@@ -707,11 +804,15 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         }
 
         const { method, params } = message;
+        const notificationThreadId = readNotificationThreadId(params, this.remoteThreadId);
+        const suppressResumeReplay = this.isResumeReplaySuppressed(notificationThreadId);
 
         // Translate to canonical chat events for chat-mode renderers. Runs
         // alongside the existing status-derivation logic below — terminal mode
         // is unaffected.
-        const runtimeEvents = mapCodexNotification(method, params, this.ensureMapperState());
+        const runtimeEvents = suppressResumeReplay
+          ? []
+          : mapCodexNotification(method, params, this.ensureMapperState());
         if (runtimeEvents.length > 0) this.emitRuntimeEvents(runtimeEvents);
 
         if (method === "thread/started" && params && "thread" in params) {
@@ -729,10 +830,20 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
           this.remoteThreadId = threadId;
           const nextSessionRef = toSessionRef(threadId);
-          this.currentThreadStatus =
+          const nextStatus: CodexThreadStatus =
             "status" in thread && thread.status && typeof thread.status === "object"
               ? (thread.status as CodexThreadStatus)
               : { type: "idle" };
+          if (this.shouldSuppressResumeActiveStatus(threadId, nextStatus)) {
+            this.listener?.onUpdate({
+              status: "idle",
+              attention: "none",
+              sessionRef: nextSessionRef,
+            });
+            void this.syncRemoteThreadState(threadId, nextSessionRef);
+            return;
+          }
+          this.currentThreadStatus = nextStatus;
           this.emitDerivedUpdate(nextSessionRef);
           void this.syncRemoteThreadState(threadId, nextSessionRef);
           return;
@@ -763,6 +874,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
             nextStatus.type === "systemError" &&
             this.currentThreadStatus.type !== "systemError" &&
             !this.errorSticky;
+          if (this.shouldSuppressResumeActiveStatus(String(params.threadId), nextStatus)) {
+            return;
+          }
           this.currentThreadStatus = nextStatus;
           this.emitDerivedUpdate();
           if (shouldFallbackEmit) {
@@ -773,6 +887,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         }
 
         if (method === "turn/started" && params) {
+          if (suppressResumeReplay) {
+            return;
+          }
           const incomingThreadId =
             "threadId" in params ? String(params.threadId) : this.remoteThreadId;
           if (incomingThreadId && !this.isCurrentThreadNotification(incomingThreadId)) {
@@ -790,6 +907,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         }
 
         if ((method === "turn/completed" || method === "turn/aborted") && params) {
+          if (suppressResumeReplay) {
+            return;
+          }
           const incomingThreadId =
             "threadId" in params ? String(params.threadId) : this.remoteThreadId;
           if (!incomingThreadId) return;
@@ -890,6 +1010,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   }
 
   private async syncRemoteThreadState(threadId: string, sessionRef?: SessionRef): Promise<void> {
+    let confirmedStatus: CodexThreadStatus | undefined;
     try {
       const result = await this.request("thread/read", {
         threadId,
@@ -906,11 +1027,14 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       }
 
       if ("status" in thread && thread.status && typeof thread.status === "object") {
-        this.currentThreadStatus = thread.status as CodexThreadStatus;
+        confirmedStatus = thread.status as CodexThreadStatus;
+        this.currentThreadStatus = confirmedStatus;
       }
       this.emitDerivedUpdate(sessionRef);
     } catch {
       // Ignore best-effort sync failures and continue using notifications.
+    } finally {
+      this.settleResumeActiveStatusSuppression(threadId, confirmedStatus);
     }
   }
 

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -19,6 +19,7 @@ import type { RuntimeEvent } from "@/shared/contracts";
 import { codexIntentFor } from "./plugin/intentMap";
 import { mapCodexModels, mapCodexRequirements, mapCodexSlashCommands } from "./probe";
 import { CodexStdioTransport } from "./stdioTransport";
+import type { StructuredSessionUpdate } from "../base";
 
 describe("deriveCodexStructuredState", () => {
   it("maps active approval state to needs_approval", () => {
@@ -219,6 +220,7 @@ describe("CodexStructuredSession", () => {
     session["isDisposed"] = false;
     session["currentThreadStatus"] = { type: "idle" };
     session["seenErrorMessages"] = new Set<string>();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
     session["request"] = async (
       method: string,
       params: Record<string, unknown>,
@@ -576,6 +578,7 @@ describe("CodexStructuredSession", () => {
     session["isDisposed"] = false;
     session["currentThreadStatus"] = { type: "idle" };
     session["seenErrorMessages"] = new Set<string>();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
     session["bufferedRuntimeEvents"] = [];
     session["pendingRequests"] = new Map();
     session["inboundRequests"] = new Map();
@@ -595,6 +598,141 @@ describe("CodexStructuredSession", () => {
     if (!onMessage) throw new Error("transport listener was not attached");
     return { onMessage, runtimeEvents };
   }
+
+  it("does not surface resume-time active status as new work", async () => {
+    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const updates: StructuredSessionUpdate[] = [];
+    const runtimeEvents: RuntimeEvent[] = [];
+    const requests: CodexRequestRecord[] = [];
+    let onMessage: ((message: unknown) => void) | undefined;
+    let resolveThreadRead: (value: unknown) => void = () => {};
+    const threadRead = new Promise<unknown>((resolve) => {
+      resolveThreadRead = resolve;
+    });
+
+    session["threadId"] = "local-thread";
+    session["remoteThreadId"] = undefined;
+    session["launchOptions"] = {};
+    session["activated"] = true;
+    session["isDisposed"] = false;
+    session["currentThreadStatus"] = { type: "idle" };
+    session["seenErrorMessages"] = new Set<string>();
+    session["bufferedRuntimeEvents"] = [];
+    session["pendingRequests"] = new Map();
+    session["inboundRequests"] = new Map();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
+    session["rejectPendingRequests"] = () => {};
+    session["request"] = async (
+      method: string,
+      params: Record<string, unknown>,
+      timeoutMs?: number,
+    ) => {
+      requests.push({
+        method,
+        params,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+      if (method === "thread/resume") {
+        onMessage?.({
+          jsonrpc: "2.0",
+          method: "thread/started",
+          params: {
+            thread: {
+              id: "provider-thread",
+              status: { type: "active", activeFlags: [] },
+            },
+          },
+        });
+        return {};
+      }
+      if (method === "thread/read") {
+        return threadRead;
+      }
+      return {};
+    };
+    session["transport"] = {
+      setListener: (next: { onMessage: (message: unknown) => void }) => {
+        onMessage = next.onMessage;
+      },
+      write: () => {},
+    };
+
+    (session["attachTransportHandlers"] as () => void).call(session);
+    await (session as unknown as CodexStructuredSession).openThread(
+      { model: "gpt-5.4" },
+      {
+        providerSessionId: "provider-thread",
+        discoveredAt: "2026-05-10T12:00:00.000Z",
+      },
+    );
+    (session as unknown as CodexStructuredSession).setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (update) => updates.push(update),
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+
+    expect(updates).toEqual([
+      expect.objectContaining({
+        status: "idle",
+        attention: "none",
+        sessionRef: expect.objectContaining({ providerSessionId: "provider-thread" }),
+      }),
+    ]);
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: {
+        threadId: "provider-thread",
+        turn: { id: "old-turn", threadId: "provider-thread" },
+      },
+    });
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId: "provider-thread",
+        item: {
+          id: "old-assistant",
+          type: "assistant_message",
+          text: "history",
+        },
+      },
+    });
+
+    resolveThreadRead({ thread: { status: { type: "idle" } } });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "thread/started",
+      params: {
+        thread: {
+          id: "provider-thread",
+          status: { type: "active", activeFlags: [] },
+        },
+      },
+    });
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: {
+        threadId: "provider-thread",
+        turn: { id: "late-old-turn", threadId: "provider-thread" },
+      },
+    });
+
+    expect(requests.map((request) => request.method)).toContain("thread/read");
+    expect(runtimeEvents).toEqual([]);
+    expect(updates).not.toContainEqual(
+      expect.objectContaining({
+        status: "working",
+        attention: "working",
+      }),
+    );
+  });
 
   it("collapses a single usage-limit failure into one error event", () => {
     vi.useFakeTimers();

--- a/src/supervisor/wsl/bridge/bridge.test.ts
+++ b/src/supervisor/wsl/bridge/bridge.test.ts
@@ -71,6 +71,26 @@ function closeServer(server: Server): Promise<void> {
   return new Promise((resolve) => server.close(() => resolve()));
 }
 
+function listenLocalServer(server: Server, preferredHost: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    function listen(host: string) {
+      server.once("error", (error: NodeJS.ErrnoException) => {
+        if (host === preferredHost && error.code === "EADDRNOTAVAIL") {
+          listen("127.0.0.1");
+          return;
+        }
+        reject(error);
+      });
+      server.listen(0, host, () => {
+        const address = server.address();
+        if (!address || typeof address === "string") throw new Error("unexpected address");
+        resolve(`http://${host}:${address.port}`);
+      });
+    }
+    listen(preferredHost);
+  });
+}
+
 async function post(url: string, body: unknown): Promise<{ status: number; body: unknown }> {
   const response = await fetch(url, {
     method: "POST",
@@ -116,13 +136,7 @@ describe("bridge.mjs Browser MCP proxy", () => {
         res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
       });
     });
-    upstreamBaseUrl = await new Promise<string>((resolve) => {
-      upstream.listen(0, "127.0.0.2", () => {
-        const address = upstream.address();
-        if (!address || typeof address === "string") throw new Error("unexpected address");
-        resolve(`http://127.0.0.2:${address.port}`);
-      });
-    });
+    upstreamBaseUrl = await listenLocalServer(upstream, "127.0.0.2");
     bridge = await startBridge({
       LIGHTCODE_BROWSER_MCP_URL: upstreamBaseUrl,
       LIGHTCODE_BROWSER_MCP_TOKEN: "upstream-token",

--- a/src/supervisor/wsl/bridge/bridge.test.ts
+++ b/src/supervisor/wsl/bridge/bridge.test.ts
@@ -76,7 +76,7 @@ function listenLocalServer(server: Server, preferredHost: string): Promise<strin
     function listen(host: string) {
       server.once("error", (error: NodeJS.ErrnoException) => {
         if (host === preferredHost && error.code === "EADDRNOTAVAIL") {
-          listen("127.0.0.1");
+          listen("0.0.0.0");
           return;
         }
         reject(error);
@@ -136,7 +136,7 @@ describe("bridge.mjs Browser MCP proxy", () => {
         res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
       });
     });
-    upstreamBaseUrl = await listenLocalServer(upstream, "127.0.0.2");
+    upstreamBaseUrl = await listenLocalServer(upstream, "0.0.0.0");
     bridge = await startBridge({
       LIGHTCODE_BROWSER_MCP_URL: upstreamBaseUrl,
       LIGHTCODE_BROWSER_MCP_TOKEN: "upstream-token",


### PR DESCRIPTION
- Stop the sidebar Git badge from briefly showing stale project PR data while the current branch PR lookup is still in flight.
- Suppress transient Codex resume `active` status updates until the remote thread state is confirmed, so reopening an existing thread does not look like new work.
- Adjust the WSL bridge test to cover the localhost fallback path when the preferred bind host is unavailable.