### PR TITLE
Improve terminal status handling and session handoff

### DIFF
--- a/src/supervisor/agents/base.posix-login-shell.test.ts
+++ b/src/supervisor/agents/base.posix-login-shell.test.ts
@@ -23,6 +23,7 @@ import {
   cliSubcommandAuthProbe,
   primeExecutablePathCache,
   primeProjectShellEnv,
+  resolveLaunchSpec,
   resolveExecutablePathAsync,
 } from "./base";
 
@@ -108,6 +109,34 @@ describe.skipIf(process.platform === "win32")("POSIX login shell wrappers", () =
         NVM_DIR: "/Users/demo/.nvm",
         HOMEBREW_PREFIX: "/opt/homebrew",
         EDITOR: "nvim",
+      },
+    });
+  });
+
+  it("shell-wraps launches that opt out of absolute binary direct spawn", async () => {
+    execFileAsyncMock.mockResolvedValue({
+      stdout: [
+        "opencode\t/Users/demo/.opencode/bin/opencode",
+        "__LIGHTCODE_ENV_BEGIN__",
+        "PATH=/opt/homebrew/bin:/usr/bin:/bin",
+      ].join("\n"),
+      stderr: "",
+    });
+
+    await primeExecutablePathCache(["opencode"]);
+
+    expect(
+      resolveLaunchSpec(posixProject, {
+        binary: "opencode",
+        args: ["--version"],
+        preferShell: true,
+      }),
+    ).toEqual({
+      command: "/bin/zsh",
+      args: expectedShellArgs("exec 'opencode' '--version'"),
+      cwd: "/Users/demo/project",
+      env: {
+        PATH: "/opt/homebrew/bin:/usr/bin:/bin",
       },
     });
   });

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -327,7 +327,10 @@ export function buildAgentCommand(
  * concerns — all branching lives here.
  */
 export function resolveLaunchSpec(location: ProjectLocation, argv: AgentArgvSpec): CommandSpec {
-  const resolvedExecPath = resolveAgentBinaryPath(location, argv.binary);
+  const resolvedExecPath =
+    argv.preferShell && location.kind === "posix"
+      ? undefined
+      : resolveAgentBinaryPath(location, argv.binary);
   const spec = buildAgentCommand(location, argv.binary, argv.args, resolvedExecPath, argv.env);
   if (argv.sessionRef) {
     spec.sessionRef = argv.sessionRef;

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -135,6 +135,7 @@ export interface AgentArgvSpec {
   args: string[];
   env?: Record<string, string>;
   sessionRef?: SessionRef;
+  preferShell?: boolean;
 }
 
 export interface DetectProbeCtx {

--- a/src/supervisor/agents/copilot/copilot.test.ts
+++ b/src/supervisor/agents/copilot/copilot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { OscNotification, OscShellEvent } from "@/shared/osc";
 import { buildCopilotArgs } from "./argv";
 import { copilotDetectionSpec } from "./detection";
 import {
@@ -12,6 +13,53 @@ import {
 describe("copilotDetectionSpec", () => {
   it("uses Copilot CLI login for terminal authentication", () => {
     expect(copilotDetectionSpec.loginCommand).toBe("copilot login");
+  });
+});
+
+function oscNotify(body: string, code: 9 | 99 | 777 = 9): OscNotification {
+  return { code, title: "", body, payload: undefined };
+}
+
+describe("createCopilotAdapter OSC status", () => {
+  const adapter = createCopilotAdapter();
+
+  it("maps iTerm2 OSC 9;4 progress to working and idle", () => {
+    expect(adapter.handleOscNotification?.(oscNotify("4;3;0"))).toEqual({
+      status: "working",
+      attention: "working",
+      corroborated: true,
+    });
+    expect(adapter.handleOscNotification?.(oscNotify("4;1;42"))).toEqual({
+      status: "working",
+      attention: "working",
+      corroborated: true,
+    });
+    expect(adapter.handleOscNotification?.(oscNotify("4;0;0"))).toEqual({
+      status: "idle",
+      attention: "none",
+      corroborated: true,
+    });
+  });
+
+  it("ignores non-OSC-9 progress-looking notifications", () => {
+    expect(adapter.handleOscNotification?.(oscNotify("4;3;0", 777))).toBeNull();
+    expect(adapter.handleOscNotification?.(oscNotify("4;0;0", 99))).toBeNull();
+  });
+
+  it("maps shell integration preexec/finished markers as a WSL fallback", () => {
+    const preexec: OscShellEvent = { code: 133, kind: "command-pre-exec" };
+    const finished: OscShellEvent = { code: 133, kind: "command-finished", exitCode: 0 };
+
+    expect(adapter.handleOscShellEvent?.(preexec)).toEqual({
+      status: "working",
+      attention: "working",
+      corroborated: true,
+    });
+    expect(adapter.handleOscShellEvent?.(finished)).toEqual({
+      status: "idle",
+      attention: "none",
+      corroborated: true,
+    });
   });
 });
 

--- a/src/supervisor/agents/gemini/gemini.test.ts
+++ b/src/supervisor/agents/gemini/gemini.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
+import type { OscTitle } from "@/shared/osc";
 import { createGeminiAdapter } from ".";
 import { buildGeminiArgs } from "./argv";
 import { geminiIntentFor } from "./plugin/intentMap";
 import { detectGeminiInvalidSessionRef } from "./session";
-import { detectGeminiTerminalStatus } from "./terminal";
+import { detectGeminiOscTitleStatus } from "./terminal";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-describe("detectGeminiTerminalStatus", () => {
+describe("detectGeminiOscTitleStatus", () => {
   it("detects idle from ◇ Ready title bar indicator", () => {
-    const text = "0;◇  Ready (my-project)";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+    const text = "◇  Ready (my-project)";
+    expect(detectGeminiOscTitleStatus(text)).toEqual({
       status: "idle",
       attention: "none",
       corroborated: true,
@@ -19,8 +20,8 @@ describe("detectGeminiTerminalStatus", () => {
   });
 
   it("detects working from ✦ Working title bar indicator", () => {
-    const text = "0;✦  Working… (my-project)";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+    const text = "✦  Working… (my-project)";
+    expect(detectGeminiOscTitleStatus(text)).toEqual({
       status: "working",
       attention: "working",
       corroborated: true,
@@ -28,160 +29,64 @@ describe("detectGeminiTerminalStatus", () => {
   });
 
   it("detects needs_reply from ✋ Action Required title bar indicator", () => {
-    const text = "0;✋  Action Required (my-project)";
-    const result = detectGeminiTerminalStatus(text);
+    const text = "✋  Action Required (my-project)";
+    const result = detectGeminiOscTitleStatus(text);
     expect(result?.status).toBe("needs_reply");
     expect(result?.attention).toBe("needs_reply");
-  });
-
-  it("detects needs_reply from Enter to select footer", () => {
-    const text = "Enter to select · ↑/↓ to navigate · Esc to cancel";
-    const result = detectGeminiTerminalStatus(text);
-    expect(result?.status).toBe("needs_reply");
-    expect(result?.attention).toBe("needs_reply");
-  });
-
-  it("detects working from esc-to-cancel prompt", () => {
-    const text = "⠋ Thinking about your request... (esc to cancel, 2s)";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
-      status: "working",
-      attention: "working",
-      corroborated: true,
-    });
-  });
-
-  it("ignores stale spinner without esc-to-cancel context", () => {
-    const text = "⠋ Resuming session...\n>   Type your message or @path/to/file";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
-      status: "idle",
-      attention: "none",
-      corroborated: false,
-    });
-  });
-
-  it("detects approval prompt from [y/n] pattern", () => {
-    const text = "Allow gemini to write to file.ts? [y/n]";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
-      status: "needs_approval",
-      attention: "needs_approval",
-      corroborated: true,
-    });
   });
 
   it("returns null when no pattern matches", () => {
-    expect(detectGeminiTerminalStatus("random text with no indicators")).toBeNull();
+    expect(detectGeminiOscTitleStatus("Type your message or @path/to/file")).toBeNull();
+    expect(detectGeminiOscTitleStatus("? for shortcuts")).toBeNull();
+    expect(detectGeminiOscTitleStatus("⠋ Thinking... (esc to cancel, 2s)")).toBeNull();
   });
+});
 
-  it("Ready wins over earlier Working when closer to end", () => {
-    const text = "0;✦  Working… (my-project)\nsome output\n0;◇  Ready (my-project)";
-    expect(detectGeminiTerminalStatus(text)?.status).toBe("idle");
-  });
+describe("createGeminiAdapter handleOscNotification", () => {
+  const adapter = createGeminiAdapter();
 
-  it("Action Required wins over Working when closer to end", () => {
-    const text = "0;✦  Working… (my-project)\nsome output\n0;✋  Action Required (my-project)";
-    expect(detectGeminiTerminalStatus(text)?.status).toBe("needs_reply");
-  });
-
-  it("keeps working when the input prompt is still visible below the spinner", () => {
-    const text = [
-      "0;✦  Working… (my-project)",
-      "⠋ Thinking... Moving Towards the Goal (esc to cancel, 4s)",
-      ">   Type your message or @path/to/file",
-      "? for shortcuts",
-    ].join("\n");
-
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+  it("maps iTerm2 OSC 9;4 progress to working and idle", () => {
+    expect(
+      adapter.handleOscNotification?.({ code: 9, title: "", body: "4;3;0", payload: undefined }),
+    ).toEqual({
       status: "working",
       attention: "working",
       corroborated: true,
     });
-  });
-
-  it("returns to idle when Ready appears after earlier working output", () => {
-    const text = [
-      "⠋ Thinking... Moving Towards the Goal (esc to cancel, 4s)",
-      ">   Type your message or @path/to/file",
-      "0;◇  Ready (my-project)",
-      ">   Type your message or @path/to/file",
-    ].join("\n");
-
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+    expect(
+      adapter.handleOscNotification?.({ code: 9, title: "", body: "4;0;0", payload: undefined }),
+    ).toEqual({
       status: "idle",
       attention: "none",
       corroborated: true,
     });
   });
+});
 
-  it("keeps working when spinner is present but no title bar signal exists", () => {
-    const text = [
-      "⠋ This is taking a bit longer, we're still on it. (esc to cancel, 2m 13s)",
-      ">   Type your message or @path/to/file",
-      "? for shortcuts",
-    ].join("\n");
+describe("createGeminiAdapter handleOscTitle", () => {
+  const adapter = createGeminiAdapter();
+  const oscTitle = (text: string, code: 0 | 1 | 2 = 0): OscTitle => ({ code, text });
 
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+  it("does not parse stripped TUI text for status", () => {
+    expect(adapter.detectTerminalStatus).toBeUndefined();
+  });
+
+  it("maps Gemini title-bar status to Lightcode status", () => {
+    expect(adapter.handleOscTitle?.(oscTitle("✦  Working… (lightcode)"))).toEqual({
       status: "working",
       attention: "working",
       corroborated: true,
     });
-  });
-
-  it("still uses the input prompt as an idle fallback when no stronger signal exists", () => {
-    const text = ">   Type your message or @path/to/file";
-    expect(detectGeminiTerminalStatus(text)).toEqual({
+    expect(adapter.handleOscTitle?.(oscTitle("◇  Ready (lightcode)"))).toEqual({
       status: "idle",
       attention: "none",
-      corroborated: false,
+      corroborated: true,
     });
-  });
-
-  it("ignores stale working output deep in history when only the idle prompt remains in the tail", () => {
-    const text = [
-      "0;✦  Working… (my-project)",
-      "x".repeat(1500),
-      ">   Type your message or @path/to/file",
-    ].join("\n");
-
-    expect(detectGeminiTerminalStatus(text)).toEqual({
-      status: "idle",
-      attention: "none",
-      corroborated: false,
+    expect(adapter.handleOscTitle?.(oscTitle("✋  Action Required (lightcode)"))).toEqual({
+      status: "needs_reply",
+      attention: "needs_reply",
+      corroborated: true,
     });
-  });
-
-  it("detects needs_reply from Action Required with numbered options", () => {
-    const text = [
-      "Which modules would you like to update?",
-      "",
-      "● 1.  All npm modules",
-      "  2.  Specific packages",
-      "  3.  Other",
-      "",
-      "Enter to select · ↑/↓ to navigate · Esc to cancel",
-      "",
-      "0;✋  Action Required (my-project)",
-    ].join("\n");
-
-    const result = detectGeminiTerminalStatus(text);
-    expect(result?.status).toBe("needs_reply");
-    expect(result?.attention).toBe("needs_reply");
-  });
-
-  it("detects needs_reply from plan approval with Action Required", () => {
-    const text = [
-      "Ready to start implementation?",
-      "",
-      "● 1.  Yes, automatically accept edits",
-      "  2.  Yes, manually accept edits",
-      "",
-      "Enter to select",
-      "",
-      "0;✋  Action Required (my-project)",
-    ].join("\n");
-
-    const result = detectGeminiTerminalStatus(text);
-    expect(result?.status).toBe("needs_reply");
-    expect(result?.attention).toBe("needs_reply");
   });
 });
 

--- a/src/supervisor/agents/gemini/index.ts
+++ b/src/supervisor/agents/gemini/index.ts
@@ -8,6 +8,7 @@ import {
   createKnownSessionRef,
   detectAgentInstall,
   detectProbeLocation,
+  iterm2ProgressOscHint,
   type AgentAdapter,
   type AgentEnvContext,
   type CreateStructuredSessionInput,
@@ -26,7 +27,7 @@ import {
   uninstallGeminiPlugin,
 } from "./plugin/install";
 import { detectGeminiInvalidSessionRef } from "./session";
-import { detectGeminiTerminalStatus } from "./terminal";
+import { detectGeminiOscTitleStatus } from "./terminal";
 
 export { detectGeminiInvalidSessionRef } from "./session";
 
@@ -36,6 +37,10 @@ warnIfPluginManifestMissing("gemini", GEMINI_PLUGIN_VERSION);
 
 function geminiHookActiveTerminalFallback(hint: TerminalStatusHint): boolean {
   return hint.status === "needs_reply" || hint.status === "needs_approval";
+}
+
+function geminiOscTitleHint(title: { text: string }): TerminalStatusHint | null {
+  return detectGeminiOscTitleStatus(title.text);
 }
 
 export function createGeminiAdapter(): AgentAdapter {
@@ -153,7 +158,8 @@ export function createGeminiAdapter(): AgentAdapter {
       const restStr = rest.map((s) => (s.kind === "file" ? `@${s.path}` : s.content)).join("");
       return attachmentLines ? `${restStr}\n\n${attachmentLines} ` : restStr;
     },
-    detectTerminalStatus: detectGeminiTerminalStatus,
+    handleOscNotification: iterm2ProgressOscHint,
+    handleOscTitle: geminiOscTitleHint,
     shouldApplyTerminalStatusWhileHookActive: geminiHookActiveTerminalFallback,
     detectInvalidSessionRef: detectGeminiInvalidSessionRef,
 

--- a/src/supervisor/agents/gemini/plugin/install.ts
+++ b/src/supervisor/agents/gemini/plugin/install.ts
@@ -73,9 +73,8 @@ interface GeminiSettings {
  * they all converged on `session.turn_started`, fired up to 2N+ times per
  * turn (matcher: "*"), and the supervisor already deduplicates identical
  * state transitions in `ThreadOutputPipeline.updateState`. Tool-level
- * granularity is recoverable from the terminal title-bar heuristic
- * (`detectGeminiTerminalStatus`) and per-tool extras were only consumed by
- * `hookDebug` for diagnostics.
+ * granularity is recoverable from Gemini's OSC title status, and per-tool
+ * extras were only consumed by `hookDebug` for diagnostics.
  */
 const GEMINI_HOOK_SPECS: ReadonlyArray<{ event: string; matcher?: string }> = [
   { event: "SessionStart" },

--- a/src/supervisor/agents/gemini/terminal.ts
+++ b/src/supervisor/agents/gemini/terminal.ts
@@ -4,100 +4,22 @@ type HintEntry = {
   re: RegExp;
   status: TerminalStatusHint["status"];
   attention: TerminalStatusHint["attention"];
-  signal?: "primary" | "fallbackIdle";
 };
 
-/** Strong signals — checked first, always authoritative. */
-const GEMINI_STRONG: HintEntry[] = [
-  // Title bar: action required — plan approval, tool approval, numbered selection
+// Gemini's OSC window title carries exactly one status marker, so the first
+// matching entry wins — highest priority first.
+const GEMINI_OSC_TITLE_HINTS: HintEntry[] = [
   { re: /✋\s+Action Required/i, status: "needs_reply", attention: "needs_reply" },
-  // Selection prompt footer (secondary, less reliable in stripped buffer)
-  { re: /Enter to select/i, status: "needs_reply", attention: "needs_reply" },
-  // Approval / consent prompt — y/n style tool-call confirmation
-  {
-    re: /\[y\/n\]|\(y\/N\)|Allow\s+.*\?|Do you want to proceed|Continue\?/i,
-    status: "needs_approval",
-    attention: "needs_approval",
-  },
-  // Title bar: working indicator (✦ sparkle + "Working…")
   { re: /✦\s+Working|⚙\s+Working/i, status: "working", attention: "working" },
-  // Active generation — spinner line always contains "(esc to cancel".
-  // This is the definitive working indicator; standalone braille characters
-  // are NOT matched because they persist as stale data in the rolling buffer
-  // after "Resuming session…" and similar loading screens.
-  { re: /\(esc to cancel/i, status: "working", attention: "working" },
-  // Title bar: ready/idle indicator (◇ diamond + "Ready")
   { re: /◇\s+Ready/i, status: "idle", attention: "none" },
 ];
 
-/** Fallback idle — used only when no strong signal exists. */
-const GEMINI_FALLBACK_IDLE: HintEntry[] = [
-  // TUI input prompt — "Type your message" or "* Type your message"
-  { re: /Type your message/i, status: "idle", attention: "none", signal: "fallbackIdle" },
-  // TUI shortcuts hint — "? for shortcuts"
-  { re: /\?\s+for shortcuts/i, status: "idle", attention: "none", signal: "fallbackIdle" },
-];
-
-/**
- * Scans the visible terminal buffer for the Gemini CLI's status
- * indicators and returns the match closest to the end of the buffer
- * (the most recent state).
- */
-function findBestMatch(
-  text: string,
-  entries: readonly HintEntry[],
-): { index: number; entry: HintEntry } | null {
-  let best: { index: number; entry: HintEntry } | null = null;
-
-  for (const entry of entries) {
-    const globalRe = new RegExp(
-      entry.re.source,
-      entry.re.flags.includes("g") ? entry.re.flags : entry.re.flags + "g",
-    );
-    let last: RegExpExecArray | null = null;
-    let m: RegExpExecArray | null;
-    while ((m = globalRe.exec(text)) !== null) {
-      last = m;
-    }
-    if (last && (best === null || last.index > best.index)) {
-      best = { index: last.index, entry };
+export function detectGeminiOscTitleStatus(text: string): TerminalStatusHint | null {
+  const title = text.trim();
+  for (const hint of GEMINI_OSC_TITLE_HINTS) {
+    if (hint.re.test(title)) {
+      return { status: hint.status, attention: hint.attention, corroborated: true };
     }
   }
-
-  return best;
-}
-
-export function detectGeminiTerminalStatus(text: string): TerminalStatusHint | null {
-  const recent = text.slice(-1200);
-
-  // Two-tier priority:
-  //   1. Strong signals — title-bar indicators, "(esc to cancel" working
-  //      prompt, approval prompts, "◇ Ready".  Always authoritative.
-  //   2. Fallback idle — "Type your message", "? for shortcuts".
-  //      Used only when no strong signal exists.
-
-  const strongBest = findBestMatch(recent, GEMINI_STRONG);
-  if (strongBest) {
-    return {
-      status: strongBest.entry.status,
-      attention: strongBest.entry.attention,
-      corroborated: true,
-    };
-  }
-
-  const fallbackBest = findBestMatch(recent, GEMINI_FALLBACK_IDLE);
-  if (fallbackBest) {
-    // Fallback idle: check if both "Type your message" and "? for shortcuts"
-    // are present for corroboration, otherwise mark as uncorroborated.
-    const bothPresent =
-      GEMINI_FALLBACK_IDLE.length >= 2 &&
-      GEMINI_FALLBACK_IDLE.every((entry) => entry.re.test(recent));
-    return {
-      status: fallbackBest.entry.status,
-      attention: fallbackBest.entry.attention,
-      corroborated: bothPresent,
-    };
-  }
-
   return null;
 }

--- a/src/supervisor/agents/opencode/index.ts
+++ b/src/supervisor/agents/opencode/index.ts
@@ -100,9 +100,10 @@ export function createOpenCodeAdapter(): AgentAdapter {
     // ── Launch / resume ──────────────────────────────────────────────────
     //
     // Session ID allocation: see `createStructuredSession` below. On a fresh
-    // launch the runtime spins up `opencode acp`, calls `session/new`, captures
-    // the resulting `ses_xxx` id, sets `launchOptions.resumeThreadId`, and then
-    // disposes the ACP connection (because `liveInputMode === "terminal"`).
+    // launch the runtime spins up `opencode serve`, calls `session.create`,
+    // captures the resulting `ses_xxx` id, sets `launchOptions.resumeThreadId`,
+    // and then disposes the SDK connection (because `liveInputMode ===
+    // "terminal"`).
     // The TUI process below picks up the pre-allocated id via `--session <id>`,
     // so the supervisor knows the providerSessionId synchronously instead of
     // polling `opencode session list` after spawn.
@@ -117,6 +118,7 @@ export function createOpenCodeAdapter(): AgentAdapter {
       return {
         binary: "opencode",
         args,
+        preferShell: true,
         ...(sessionId ? { sessionRef: createKnownSessionRef(sessionId) } : {}),
       };
     },
@@ -129,6 +131,7 @@ export function createOpenCodeAdapter(): AgentAdapter {
       return {
         binary: "opencode",
         args: buildOpenCodeArgs(config, prompt, sessionRef.providerSessionId),
+        preferShell: true,
       };
     },
     createInitialSessionRef() {
@@ -177,7 +180,7 @@ export function createOpenCodeAdapter(): AgentAdapter {
     // OpenCode's TUI silently ignores `--prompt` when `--session <id>` is
     // also present (verified empirically against opencode 1.14.30: the prompt
     // text never lands in the session). Since we always pre-allocate the
-    // session id via ACP for new threads, `--session` is *always* present —
+    // session id via SDK for new threads, `--session` is *always* present —
     // so the launch-time prompt path is dead. Defer the initial prompt to the
     // PTY: the runtime queues it as `pendingTerminalPrompt` and types it via
     // `buildDirectInput` once the TUI is ready. Same pattern Codex uses for

--- a/src/supervisor/agents/opencode/opencode.test.ts
+++ b/src/supervisor/agents/opencode/opencode.test.ts
@@ -395,9 +395,9 @@ describe("createOpenCodeAdapter", () => {
     ).toBeUndefined();
   });
 
-  it("skips ACP session setup when resuming an existing session", async () => {
+  it("skips SDK session setup when resuming an existing session", async () => {
     // On resume the providerSessionId is already known — no need to ask
-    // `opencode acp` to allocate a new one. Returning undefined keeps the
+    // `opencode serve` to allocate a new one. Returning undefined keeps the
     // existing flow (just `opencode --session <id>`).
     const adapter = createOpenCodeAdapter();
     await expect(
@@ -414,7 +414,7 @@ describe("createOpenCodeAdapter", () => {
   });
 
   it("buildLaunchArgv returns no --session and no sessionRef when launchOptions is empty", () => {
-    // Defensive path: if ACP allocation never ran (failed, skipped, structured
+    // Defensive path: if SDK allocation never ran (failed, skipped, structured
     // session disabled), the TUI is launched without `--session` and OpenCode
     // creates a fresh session itself — same as before Shape A.
     const adapter = createOpenCodeAdapter();
@@ -427,6 +427,7 @@ describe("createOpenCodeAdapter", () => {
     );
     expect(argv.args).not.toContain("--session");
     expect(argv.sessionRef).toBeUndefined();
+    expect(argv.preferShell).toBe(true);
   });
 
   it("isReadyForInitialPrompt fires on the keybind footer", () => {
@@ -438,7 +439,7 @@ describe("createOpenCodeAdapter", () => {
   });
 
   it("buildLaunchArgv promotes launchOptions.resumeThreadId to --session and sessionRef", () => {
-    // This is the post-ACP path: the structured session captured a freshly
+    // This is the post-SDK path: the structured session captured a freshly
     // allocated session id and stashed it in launchOptions before disposing.
     const adapter = createOpenCodeAdapter();
     const argv = adapter.buildLaunchArgv(
@@ -446,16 +447,37 @@ describe("createOpenCodeAdapter", () => {
       { model: "opencode/big-pickle" },
       "hello",
       undefined,
-      { resumeThreadId: "ses_acp_allocated" },
+      { resumeThreadId: "ses_sdk_allocated" },
     );
     expect(argv.args).toEqual([
       "--session",
-      "ses_acp_allocated",
+      "ses_sdk_allocated",
       "--model",
       "opencode/big-pickle",
       "--prompt",
       "hello",
     ]);
-    expect(argv.sessionRef?.providerSessionId).toBe("ses_acp_allocated");
+    expect(argv.sessionRef?.providerSessionId).toBe("ses_sdk_allocated");
+    expect(argv.preferShell).toBe(true);
+  });
+
+  it("buildResumeArgv opts into shell resolution for the terminal TUI", () => {
+    const adapter = createOpenCodeAdapter();
+    const argv = adapter.buildResumeArgv(
+      { kind: "windows", path: "C:\\repo" },
+      { model: "opencode/big-pickle" },
+      "continue",
+      { providerSessionId: "ses_existing", discoveredAt: new Date().toISOString() },
+    );
+
+    expect(argv.args).toEqual([
+      "--session",
+      "ses_existing",
+      "--model",
+      "opencode/big-pickle",
+      "--prompt",
+      "continue",
+    ]);
+    expect(argv.preferShell).toBe(true);
   });
 });

--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -88,6 +88,39 @@ describe("OpencodeSdkSession", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("stores the created session id in launch options for terminal TUI handoff", async () => {
+    const dispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    mocks.acquireOpenCodeServer.mockResolvedValue({
+      client: {
+        global: { event: vi.fn<() => Promise<{ stream: AsyncGenerator<Event> }>>() },
+        command: { list: vi.fn<() => Promise<{ data: [] }>>().mockResolvedValue({ data: [] }) },
+        session: {
+          create: vi
+            .fn<() => Promise<{ data: { id: string } }>>()
+            .mockResolvedValue({ data: { id: "ses_created" } }),
+        },
+      },
+      baseUrl: "http://127.0.0.1:0",
+      handle: {},
+      dispose,
+    });
+
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "terminal",
+    });
+
+    await session.activate();
+    await expect(session.openThread(config)).resolves.toBe("ses_created");
+
+    expect(session.launchOptions.resumeThreadId).toBe("ses_created");
+
+    await session.dispose();
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("restarts the OpenCode server once when session.create loses its connection", async () => {
     const firstDispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const secondDispose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -374,6 +374,11 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     return Promise.resolve(new OpencodeSdkSession(input));
   }
 
+  private rememberSessionId(id: string): void {
+    this.sessionId = id;
+    this.launchOptions = { ...this.launchOptions, resumeThreadId: id };
+  }
+
   setListener(listener: StructuredSessionListener): void {
     this.listener = listener;
     if (this.bufferedRuntimeEvents.length > 0 && listener.onRuntimeEvent) {
@@ -453,7 +458,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       const existingData = existing.data;
       const id = existingData?.id;
       if (!id) throw new Error("opencode session.get returned no id");
-      this.sessionId = id;
+      this.rememberSessionId(id);
       this.sessionHasPermissionOverride = existingData.permission !== undefined;
       this.appliedPermissionSyncKey = undefined;
       if (this.mapperState) setOpenCodeMainSessionId(this.mapperState, id);
@@ -489,7 +494,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     }
     const id = created.data?.id;
     if (!id) throw new Error("opencode session.create returned no id");
-    this.sessionId = id;
+    this.rememberSessionId(id);
     this.sessionHasPermissionOverride = permission !== undefined;
     this.appliedPermissionSyncKey = this.permissionSyncKey(config);
     if (this.mapperState) setOpenCodeMainSessionId(this.mapperState, id);

--- a/src/supervisor/runtime/threadSession/terminalEnv.test.ts
+++ b/src/supervisor/runtime/threadSession/terminalEnv.test.ts
@@ -70,12 +70,12 @@ describe("resolveTerminalColorEnv", () => {
   );
 });
 
-describe("getClaudeL2TerminalEnv", () => {
+describe("getIterm2StatusL2TerminalEnv", () => {
   it("spoofs iTerm for Claude when CLI hooks are not active", async () => {
-    const { getClaudeL2TerminalEnv } = await loadTerminalEnv();
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
 
     expect(
-      getClaudeL2TerminalEnv({
+      getIterm2StatusL2TerminalEnv({
         agentKind: "claude",
         projectLocation: { kind: "windows", path: "C:\\repo" },
         disableCliHookPlugin: false,
@@ -88,10 +88,10 @@ describe("getClaudeL2TerminalEnv", () => {
   });
 
   it("does not spoof iTerm for Claude while hooks are active", async () => {
-    const { getClaudeL2TerminalEnv } = await loadTerminalEnv();
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
 
     expect(
-      getClaudeL2TerminalEnv({
+      getIterm2StatusL2TerminalEnv({
         agentKind: "claude",
         projectLocation: { kind: "windows", path: "C:\\repo" },
         disableCliHookPlugin: false,
@@ -101,10 +101,10 @@ describe("getClaudeL2TerminalEnv", () => {
   });
 
   it("spoofs iTerm for Claude when hooks are injected but disabled", async () => {
-    const { getClaudeL2TerminalEnv } = await loadTerminalEnv();
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
 
     expect(
-      getClaudeL2TerminalEnv({
+      getIterm2StatusL2TerminalEnv({
         agentKind: "claude",
         projectLocation: { kind: "windows", path: "C:\\repo" },
         disableCliHookPlugin: true,
@@ -116,11 +116,43 @@ describe("getClaudeL2TerminalEnv", () => {
     });
   });
 
-  it("does not spoof iTerm for other agents", async () => {
-    const { getClaudeL2TerminalEnv } = await loadTerminalEnv();
+  it("spoofs iTerm for Gemini when CLI hooks are not active", async () => {
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
 
     expect(
-      getClaudeL2TerminalEnv({
+      getIterm2StatusL2TerminalEnv({
+        agentKind: "gemini",
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        disableCliHookPlugin: false,
+        cliHookEnvInjected: false,
+      }),
+    ).toEqual({
+      TERM_PROGRAM: "iTerm.app",
+      TERM_PROGRAM_VERSION: "3.6.6",
+    });
+  });
+
+  it("spoofs iTerm for Copilot even while partial hooks are active", async () => {
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
+
+    expect(
+      getIterm2StatusL2TerminalEnv({
+        agentKind: "copilot",
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        disableCliHookPlugin: false,
+        cliHookEnvInjected: true,
+      }),
+    ).toEqual({
+      TERM_PROGRAM: "iTerm.app",
+      TERM_PROGRAM_VERSION: "3.6.6",
+    });
+  });
+
+  it("does not spoof iTerm for other agents", async () => {
+    const { getIterm2StatusL2TerminalEnv } = await loadTerminalEnv();
+
+    expect(
+      getIterm2StatusL2TerminalEnv({
         agentKind: "codex",
         projectLocation: { kind: "windows", path: "C:\\repo" },
         disableCliHookPlugin: false,

--- a/src/supervisor/runtime/threadSession/terminalEnv.ts
+++ b/src/supervisor/runtime/threadSession/terminalEnv.ts
@@ -47,20 +47,28 @@ export function resolveTerminalColorEnv(location: ProjectLocation): TerminalColo
   return { TERM: FALLBACK_TERM, COLORTERM: "truecolor" };
 }
 
-export function getClaudeL2TerminalEnv(input: {
+const ITERM2_STATUS_ENV = {
+  TERM_PROGRAM: "iTerm.app",
+  TERM_PROGRAM_VERSION: "3.6.6",
+};
+
+export function getIterm2StatusL2TerminalEnv(input: {
   agentKind: AgentKind;
   projectLocation: ProjectLocation;
   disableCliHookPlugin: boolean;
   cliHookEnvInjected: boolean;
 }): Record<string, string> {
-  if (input.agentKind !== "claude") {
+  if (input.agentKind === "copilot") {
+    return ITERM2_STATUS_ENV;
+  }
+
+  if (input.agentKind !== "claude" && input.agentKind !== "gemini") {
     return {};
   }
+
   if (!input.disableCliHookPlugin && input.cliHookEnvInjected) {
     return {};
   }
-  return {
-    TERM_PROGRAM: "iTerm.app",
-    TERM_PROGRAM_VERSION: "3.6.6",
-  };
+
+  return ITERM2_STATUS_ENV;
 }

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -73,7 +73,7 @@ import {
   USER_INTERRUPT_RECOVERY_GRACE_MS,
 } from "./threadSession/userInterrupt";
 import { writeSubmittedPrompt } from "./threadSession/promptWrite";
-import { getClaudeL2TerminalEnv, resolveTerminalColorEnv } from "./threadSession/terminalEnv";
+import { getIterm2StatusL2TerminalEnv, resolveTerminalColorEnv } from "./threadSession/terminalEnv";
 import {
   hookDebugProjectLabel,
   requireSessionPty,
@@ -1546,7 +1546,7 @@ export class ThreadSessionManager {
     }
     Object.assign(
       agentEnv,
-      getClaudeL2TerminalEnv({
+      getIterm2StatusL2TerminalEnv({
         agentKind: input.agentKind,
         projectLocation: input.projectLocation,
         disableCliHookPlugin: this.readDisableCliHookPlugin(),
@@ -1560,6 +1560,7 @@ export class ThreadSessionManager {
       : undefined;
     let pty;
     if (command) {
+      ensureNodePtySpawnHelperExecutable();
       const ptyEnv = {
         ...sanitizedProcessEnv,
         ...(command.env ?? {}),


### PR DESCRIPTION
- Feature/refactor: switch Gemini status detection to OSC title hints and add Copilot OSC progress coverage, reducing dependence on stale terminal-buffer heuristics.
- Preserve OpenCode terminal handoff by carrying created session IDs through launch options so resumed TUI sessions reuse the same provider session.
- Allow selected POSIX launches to shell-wrap instead of direct-spawning an absolute binary, while keeping the project shell environment intact.
- Broaden terminal-session setup with iTerm2 status env spoofing and explicit PTY launch setup so supported agents report status consistently at launch.