### PR TITLE
Fix plain workflow results in the chat message surface

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/WorkflowResultGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/WorkflowResultGroup.test.tsx
@@ -47,12 +47,13 @@ describe("WorkflowResultGroup", () => {
     expect(getTopTriggerText()).toContain("2 results");
   });
 
-  it("renders plain text inline without a group disclosure", () => {
-    render(
+  it("renders plain text in a message surface without a group disclosure", () => {
+    const { container } = render(
       <WorkflowResultGroup resultText="Workflow launched in background. Task ID: wikw7toud" />,
     );
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.getByText(/Workflow launched in background/)).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass("rounded-3xl", "px-3", "py-2");
   });
 
   it("renders nothing for a tool_use_error block — error is surfaced via tooltip on the row icon", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/WorkflowResultGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/WorkflowResultGroup.tsx
@@ -1,7 +1,8 @@
-import { Disclosure } from "@heroui/react";
+import { Disclosure, Surface } from "@heroui/react";
 import { memo, useState } from "react";
 import { GitBranch } from "lucide-react";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { chatMessageSurfaceClass } from "./chatMessageSurface";
 import { ItemMarkdown } from "./ItemMarkdown";
 
 /**
@@ -81,9 +82,11 @@ function WorkflowPlainResult({ text, parsed }: { text: string; parsed: unknown |
     );
   }
   return (
-    <div className="w-full min-w-0 text-[length:var(--lc-chat-font-size-command)] text-foreground">
-      <ItemMarkdown text={text} />
-    </div>
+    <Surface variant="transparent" className={chatMessageSurfaceClass}>
+      <div className="min-w-0 leading-snug text-foreground">
+        <ItemMarkdown text={text} />
+      </div>
+    </Surface>
   );
 }
 


### PR DESCRIPTION
- Plain workflow results now render inside the standard chat message surface so background task output matches the rest of the thread.
- This removes the raw inline-text look for ungrouped workflow output while preserving the no-disclosure behavior.
- Updated tests to lock in the expected bubble styling and plain-text rendering path.