### PR TITLE
Fix context usage reporting and child-scoped updates

### DIFF
--- a/src/renderer/components/thread/threadContextUsage.test.ts
+++ b/src/renderer/components/thread/threadContextUsage.test.ts
@@ -85,10 +85,11 @@ describe("threadContextUsage", () => {
     expect(summary.remainingLabel).toBe("129K");
   });
 
-  it("only treats positive provider token usage as reportable", () => {
+  it("treats zero-token provider context usage as reportable", () => {
     expect(hasReportedContextUsage(undefined)).toBe(false);
+    expect(hasReportedContextUsage({})).toBe(false);
     expect(hasReportedContextUsage({ maxTokens: 200_000 })).toBe(false);
-    expect(hasReportedContextUsage({ usedTokens: 0, maxTokens: 200_000 })).toBe(false);
+    expect(hasReportedContextUsage({ usedTokens: 0, maxTokens: 200_000 })).toBe(true);
     expect(hasReportedContextUsage({ usedTokens: 1, maxTokens: 200_000 })).toBe(true);
   });
 

--- a/src/renderer/components/thread/threadContextUsage.ts
+++ b/src/renderer/components/thread/threadContextUsage.ts
@@ -22,7 +22,8 @@ export interface ThreadContextUsageSummary {
 }
 
 export function hasReportedContextUsage(usage: ThreadContextUsage | undefined): boolean {
-  return (usage?.usedTokens ?? 0) > 0;
+  if (!usage) return false;
+  return usage.usedTokens !== undefined || (usage.breakdown?.length ?? 0) > 0;
 }
 
 export function resolveThreadContextUsageSummary(input: {

--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -140,6 +140,56 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     }
   });
 
+  it("preserves the context limit and replaces stale breakdown on partial updates", () => {
+    apply("t1", {
+      type: "context.updated",
+      threadId: "t1",
+      usage: {
+        usedTokens: 71_000,
+        maxTokens: 200_000,
+        breakdown: [{ id: "input", label: "Input", tokens: 71_000 }],
+      },
+    });
+
+    apply("t1", {
+      type: "context.updated",
+      threadId: "t1",
+      usage: {
+        usedTokens: 9_900,
+        breakdown: [{ id: "current-context", label: "Current context", tokens: 9_900 }],
+      },
+    });
+
+    expect(store.getState().runtimeContextByThread["t1"]).toEqual({
+      usedTokens: 9_900,
+      maxTokens: 200_000,
+      breakdown: [{ id: "current-context", label: "Current context", tokens: 9_900 }],
+    });
+  });
+
+  it("keeps compacted usage when a later refresh reports only the context limit", () => {
+    apply("t1", {
+      type: "context.updated",
+      threadId: "t1",
+      usage: {
+        usedTokens: 15_000,
+        breakdown: [{ id: "current-context", label: "Current context", tokens: 15_000 }],
+      },
+    });
+
+    apply("t1", {
+      type: "context.updated",
+      threadId: "t1",
+      usage: { maxTokens: 1_000_000 },
+    });
+
+    expect(store.getState().runtimeContextByThread["t1"]).toEqual({
+      usedTokens: 15_000,
+      maxTokens: 1_000_000,
+      breakdown: [{ id: "current-context", label: "Current context", tokens: 15_000 }],
+    });
+  });
+
   it("deduplicates overlapping streamed chunks", () => {
     apply("t1", {
       type: "item.started",

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1354,6 +1354,42 @@ describe("sdkCanonicalMapping — sub-agents", () => {
       },
     ]);
   });
+
+  it("drops child-scoped context updates so the composer tracks parent context only", () => {
+    const state = createClaudeMapperState("thread-1");
+    const events = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "compact_boundary",
+        parent_tool_use_id: "toolu_parent",
+        compact_metadata: { trigger: "auto", pre_tokens: 20_000, post_tokens: 6_000 },
+        session_id: "claude-session",
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    expect(events.some((event) => event.type === "context.updated")).toBe(false);
+    expect(events).toMatchObject([
+      {
+        type: "item.started",
+        itemType: "tool_call",
+        parentItemId: "toolu_parent",
+        payload: {
+          name: "ContextCompaction",
+          status: "success",
+          args: { trigger: "auto", pre_tokens: 20_000, post_tokens: 6_000 },
+        },
+      },
+      {
+        type: "item.completed",
+        payload: {
+          name: "ContextCompaction",
+          status: "success",
+          args: { trigger: "auto", pre_tokens: 20_000, post_tokens: 6_000 },
+        },
+      },
+    ]);
+  });
 });
 
 describe("sdkCanonicalMapping — task progress", () => {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1389,11 +1389,6 @@ describe("sdkCanonicalMapping — task progress", () => {
 
     expect(events).toMatchObject([
       {
-        type: "context.updated",
-        threadId: "thread-1",
-        usage: { usedTokens: 4200 },
-      },
-      {
         type: "item.updated",
         threadId: "thread-1",
         itemId: "toolu_T1",
@@ -1411,9 +1406,10 @@ describe("sdkCanonicalMapping — task progress", () => {
         },
       },
     ]);
+    expect(events.some((event) => event.type === "context.updated")).toBe(false);
   });
 
-  it("still emits task_progress usage for unknown tool_use_id", () => {
+  it("does not treat task_progress usage as parent context-window usage", () => {
     const state = createClaudeMapperState("thread-1");
     const events = mapClaudeSdkMessage(
       {
@@ -1427,16 +1423,10 @@ describe("sdkCanonicalMapping — task progress", () => {
       } as unknown as SDKMessage,
       state,
     );
-    expect(events).toEqual([
-      {
-        type: "context.updated",
-        threadId: "thread-1",
-        usage: { usedTokens: 1 },
-      },
-    ]);
+    expect(events).toEqual([]);
   });
 
-  it("emits task_notification usage even without a parent tool row", () => {
+  it("does not emit task_notification usage as parent context-window usage", () => {
     const state = createClaudeMapperState("thread-1");
     const events = mapClaudeSdkMessage(
       {
@@ -1450,13 +1440,7 @@ describe("sdkCanonicalMapping — task progress", () => {
       } as unknown as SDKMessage,
       state,
     );
-    expect(events).toEqual([
-      {
-        type: "context.updated",
-        threadId: "thread-1",
-        usage: { usedTokens: 98_765 },
-      },
-    ]);
+    expect(events).toEqual([]);
   });
 });
 
@@ -1492,6 +1476,29 @@ describe("sdkCanonicalMapping — context usage", () => {
           { id: "messages-1", label: "Messages", tokens: 45_000 },
         ],
       },
+    });
+  });
+
+  it("does not emit placeholder zero-token context usage from a sparse SDK response", () => {
+    const event = mapClaudeContextUsageResponse("thread-1", {
+      categories: [],
+      totalTokens: 0,
+      maxTokens: 1_000_000,
+      rawMaxTokens: 1_000_000,
+      percentage: 0,
+      gridRows: [],
+      model: "claude-opus-4-7[1m]",
+      memoryFiles: [],
+      mcpTools: [],
+      isAutoCompactEnabled: true,
+      agents: [],
+      apiUsage: null,
+    } satisfies SDKControlGetContextUsageResponse);
+
+    expect(event).toEqual({
+      type: "context.updated",
+      threadId: "thread-1",
+      usage: { maxTokens: 1_000_000 },
     });
   });
 
@@ -1560,6 +1567,14 @@ describe("sdkCanonicalMapping — compaction", () => {
           args: { trigger: "manual", pre_tokens: 290000, post_tokens: 9900 },
         },
       },
+      {
+        type: "context.updated",
+        threadId: "thread-1",
+        usage: {
+          usedTokens: 9900,
+          breakdown: [{ id: "current-context", label: "Current context", tokens: 9900 }],
+        },
+      },
     ]);
   });
 
@@ -1590,6 +1605,13 @@ describe("sdkCanonicalMapping — compaction", () => {
           name: "ContextCompaction",
           status: "success",
           args: { trigger: "auto", pre_tokens: 100000, post_tokens: 12000 },
+        },
+      },
+      {
+        type: "context.updated",
+        usage: {
+          usedTokens: 12000,
+          breakdown: [{ id: "current-context", label: "Current context", tokens: 12000 }],
         },
       },
     ]);

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -906,8 +906,6 @@ function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): Runt
     obj.usage && typeof obj.usage === "object"
       ? (obj.usage as { total_tokens?: number; tool_uses?: number; duration_ms?: number })
       : undefined;
-  const contextUsage = contextUsageFromTaskUsage(state.threadId, usage);
-  if (contextUsage) events.push(contextUsage);
 
   const toolUseId = typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined;
   if (!toolUseId) return events;
@@ -941,13 +939,22 @@ function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): Runt
   return events;
 }
 
-function contextUsageFromTaskUsage(
+function contextUsageFromCompactionMetadata(
   threadId: string,
-  usage: { total_tokens?: number; tool_uses?: number; duration_ms?: number } | undefined,
+  metadata: unknown,
 ): RuntimeEvent | undefined {
-  const usedTokens = readNonNegativeInteger(usage?.total_tokens);
-  if (usedTokens === undefined || usedTokens <= 0) return undefined;
-  return createContextUsageEvent(threadId, { usedTokens });
+  if (!metadata || typeof metadata !== "object") return undefined;
+  const obj = metadata as Record<string, unknown>;
+  const usedTokens =
+    readNonNegativeInteger(obj.post_tokens) ?? readNonNegativeInteger(obj.postTokens);
+  if (usedTokens === undefined) return undefined;
+  return createContextUsageEvent(threadId, {
+    usedTokens,
+    breakdown:
+      usedTokens > 0
+        ? [{ id: "current-context", label: "Current context", tokens: usedTokens }]
+        : [],
+  });
 }
 
 function mapPermissionDenied(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
@@ -1260,7 +1267,6 @@ export function mapClaudeContextUsageResponse(
   threadId: string,
   response: SDKControlGetContextUsageResponse,
 ): RuntimeEvent | undefined {
-  const usedTokens = readNonNegativeInteger(response.totalTokens);
   const maxTokens =
     readPositiveInteger(response.maxTokens) ?? readPositiveInteger(response.rawMaxTokens);
   const breakdown = response.categories
@@ -1279,6 +1285,11 @@ export function mapClaudeContextUsageResponse(
       };
     })
     .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined);
+  const rawUsedTokens = readNonNegativeInteger(response.totalTokens);
+  const usedTokens =
+    rawUsedTokens !== undefined && (rawUsedTokens > 0 || breakdown.length > 0)
+      ? rawUsedTokens
+      : undefined;
 
   return createContextUsageEvent(threadId, {
     ...(usedTokens !== undefined ? { usedTokens } : {}),
@@ -1619,6 +1630,8 @@ function mapClaudeSdkMessageInner(
       itemId,
       payload,
     });
+    const contextUsage = contextUsageFromCompactionMetadata(state.threadId, metadata);
+    if (contextUsage) events.push(contextUsage);
     return events;
   }
 

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -1051,33 +1051,34 @@ function tagParent(
   state: ClaudeMapperState,
 ): RuntimeEvent[] {
   if (!parentItemId) return events;
+  const parentScopedEvents = events.filter((event) => event.type !== "context.updated");
   let taggedStarts = 0;
-  for (let i = 0; i < events.length; i += 1) {
-    const event = events[i]!;
+  for (let i = 0; i < parentScopedEvents.length; i += 1) {
+    const event = parentScopedEvents[i]!;
     if (event.type !== "item.started") continue;
     if ("parentItemId" in event && typeof event.parentItemId === "string") continue;
-    events[i] = { ...event, parentItemId };
+    parentScopedEvents[i] = { ...event, parentItemId };
     taggedStarts += 1;
   }
-  if (taggedStarts === 0) return events;
+  if (taggedStarts === 0) return parentScopedEvents;
   // Bump the sub-agent parent's step counter and emit an `item.updated` on the
   // parent so a closed overlay (which gates child events off IPC for perf)
   // still sees the count tick on the pill.
   const parent = state.toolItemsById.get(parentItemId);
-  if (!parent) return events;
+  if (!parent) return parentScopedEvents;
   const prevCount = parent.progress?.stepCount ?? 0;
   const nextProgress: ToolCallProgress = {
     ...(parent.progress ?? {}),
     stepCount: prevCount + taggedStarts,
   };
   parent.progress = nextProgress;
-  events.push({
+  parentScopedEvents.push({
     type: "item.updated",
     threadId: state.threadId,
     itemId: parent.itemId,
     payload: toolPayload(parent, "running"),
   });
-  return events;
+  return parentScopedEvents;
 }
 
 /**


### PR DESCRIPTION
- Treat provider context metadata as reportable even when `usedTokens` is zero, so compacted or partial updates still surface in the renderer.
- Preserve `maxTokens` across partial refreshes and replace stale breakdown data with the latest snapshot.
- Stop Claude child-scoped compaction, task progress, and task notification events from emitting parent context usage, keeping thread-level context state accurate.
- Expand regression coverage for renderer summaries, runtime state merging, and Claude SDK mapping.