### PR TITLE
Surface subagent progress metadata and token usage

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -598,6 +598,26 @@ describe("ChatPane", () => {
     expect(document.body).not.toHaveTextContent("WindowsApps");
   });
 
+  it("shows provider-reported subagent model and tokens without falling back to the parent model", async () => {
+    const thread = { ...makeThread(), config: { model: "gpt-parent-main" } };
+    seedSubAgentTool(thread.id, {
+      itemId: "task-1",
+      model: "opus",
+      tokens: 336_000,
+      lastToolName: "Bash",
+      stepCount: 21,
+    });
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    expect(await screen.findByText("Opus")).toBeInTheDocument();
+    expect(screen.getByText("336k tok")).toBeInTheDocument();
+    expect(screen.getByText("Bash")).toBeInTheDocument();
+    expect(screen.getByText("21 steps")).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("gpt-parent-main");
+  });
+
   it("collapses long user messages behind a show more button", async () => {
     const thread = makeThread();
     seedUserMessage(
@@ -1224,6 +1244,36 @@ function startCommandItem(threadId: string, itemId: string, command: string) {
     itemId,
     itemType: "command_execution",
     payload: { command },
+  });
+}
+
+function seedSubAgentTool(
+  threadId: string,
+  args: {
+    itemId: string;
+    model: string;
+    tokens: number;
+    lastToolName: string;
+    stepCount: number;
+  },
+) {
+  useAppStore.getState().applyRuntimeEvent(threadId, {
+    type: "item.started",
+    threadId,
+    itemId: args.itemId,
+    itemType: "tool_call",
+    payload: {
+      name: "Task",
+      status: "running",
+      args: { description: "Audit project", model: args.model },
+      isSubAgent: true,
+      progress: {
+        model: args.model,
+        tokens: args.tokens,
+        lastToolName: args.lastToolName,
+        stepCount: args.stepCount,
+      },
+    },
   });
 }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
@@ -15,6 +15,7 @@ import { deriveToolDisplay, isWorkflowTool } from "./toolDisplay";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { ThreadDockHeader, ThreadDockList, ThreadDockSection } from "../../../ThreadDockUI";
 import { parseWorkflowInfo } from "./workflowDisplay";
+import { SubAgentProgressMeta, hasSubAgentProgressMeta } from "./subAgentProgressMeta";
 
 interface ActiveSubAgentTileProps {
   threadId: string;
@@ -141,6 +142,7 @@ function ActiveSubAgentRow({
   const isDone = !isRunning;
   const progress = payload?.progress;
   const stepCount = progress?.stepCount ?? childCount;
+  const liveLabel = progress?.lastToolName ?? progress?.description;
 
   const innerClass = `flex items-center gap-2 rounded px-2 py-1 leading-5 ${
     isDone ? "opacity-60" : ""
@@ -172,16 +174,21 @@ function ActiveSubAgentRow({
         ) : workflowIsLive ? (
           <span className="shrink-0 text-foreground-muted opacity-80">starting…</span>
         ) : isRunning ? (
-          <span className="shrink-0 tabular-nums text-foreground-muted opacity-80">
-            {progress?.lastToolName || progress?.description ? (
-              <span className="mr-1.5 max-w-[20ch] truncate inline-block align-bottom">
-                {progress?.lastToolName ?? progress?.description}
-              </span>
-            ) : null}
-            <span>
-              {stepCount} step{stepCount === 1 ? "" : "s"}
-            </span>
-          </span>
+          <SubAgentProgressMeta
+            progress={progress}
+            liveLabel={liveLabel}
+            stepCount={stepCount}
+            includeStepCount
+            className="max-w-[45%] shrink-0 text-foreground-muted opacity-80"
+            liveMaxClassName="max-w-[20ch]"
+            loaderClassName="text-foreground-muted"
+          />
+        ) : hasSubAgentProgressMeta(progress) ? (
+          <SubAgentProgressMeta
+            progress={progress}
+            className="max-w-[45%] shrink-0 text-foreground-muted opacity-80"
+            loaderClassName="text-foreground-muted"
+          />
         ) : null}
       </button>
       <button

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
@@ -13,6 +13,7 @@ import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { getChildItemIdsStoreSelector } from "../../chatPaneSelectors";
 import { extractAcpResultPart } from "./acpToolPayload";
 import { ItemMarkdown } from "./ItemMarkdown";
+import { SubAgentProgressMeta, hasSubAgentProgressMeta } from "./subAgentProgressMeta";
 import { deriveToolDisplay, isWorkflowTool } from "./toolDisplay";
 import { parseWorkflowInfo } from "./workflowDisplay";
 import { WorkflowResultGroup } from "./WorkflowResultGroup";
@@ -198,18 +199,18 @@ function resolveStatus(
   }
 
   if (isRunning) {
-    const stepLabel = `${stepCount} step${stepCount === 1 ? "" : "s"}`;
     return {
       rightLabel: (
-        <span className="inline-flex min-w-0 items-center gap-1.5 text-[color:var(--muted)]">
-          {liveLabel ? (
-            <span className="max-w-[28ch] truncate" title={progress?.description ?? liveLabel}>
-              {liveLabel}
-            </span>
-          ) : null}
-          <span>{stepLabel}</span>
-          <PixelLoader size="xxs" className="text-[color:var(--muted)]" />
-        </span>
+        <SubAgentProgressMeta
+          progress={progress}
+          liveLabel={liveLabel}
+          stepCount={stepCount}
+          includeStepCount
+          showLoader
+          className="text-[color:var(--muted)]"
+          liveMaxClassName="max-w-[28ch]"
+          loaderClassName="text-[color:var(--muted)]"
+        />
       ),
       rightLabelClassName: "!text-[color:var(--muted)]",
     };
@@ -230,6 +231,18 @@ function resolveStatus(
         icon
       ),
       rightLabelClassName: "text-danger",
+    };
+  }
+  if (hasSubAgentProgressMeta(progress)) {
+    return {
+      rightLabel: (
+        <SubAgentProgressMeta
+          progress={progress}
+          className="text-[color:var(--muted)]"
+          loaderClassName="text-[color:var(--muted)]"
+        />
+      ),
+      rightLabelClassName: "!text-[color:var(--muted)]",
     };
   }
   return {

--- a/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSubAgentProgressParts,
+  formatSubAgentModelLabel,
+  hasSubAgentProgressMeta,
+} from "./subAgentProgressMeta";
+
+describe("subAgentProgressMeta", () => {
+  it("builds model, token, live, and step labels from provider-reported progress", () => {
+    expect(
+      buildSubAgentProgressParts({
+        progress: { model: "opus", tokens: 336_000 },
+        liveLabel: "Bash",
+        stepCount: 21,
+        includeStepCount: true,
+      }),
+    ).toEqual([
+      { kind: "model", label: "Opus" },
+      { kind: "tokens", label: "336k tok" },
+      { kind: "live", label: "Bash" },
+      { kind: "steps", label: "21 steps" },
+    ]);
+  });
+
+  it("does not claim model metadata when the provider did not report a subagent model", () => {
+    expect(hasSubAgentProgressMeta({ tokens: 42 })).toBe(true);
+    expect(hasSubAgentProgressMeta({ stepCount: 3 })).toBe(false);
+    expect(formatSubAgentModelLabel(undefined)).toBeUndefined();
+  });
+
+  it("formats common provider model ids compactly", () => {
+    expect(formatSubAgentModelLabel("gpt-5.4-mini")).toBe("GPT-5.4 Mini");
+    expect(formatSubAgentModelLabel("gemini-2.5-pro")).toBe("Gemini 2.5 Pro");
+    expect(formatSubAgentModelLabel("claude-opus-4-8")).toBe("Opus 4.8");
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.tsx
@@ -1,0 +1,139 @@
+import { Fragment } from "react";
+import type { ToolCallProgress } from "@/shared/contracts";
+import { PixelLoader } from "@/renderer/components/common/PixelLoader";
+import {
+  formatBracketParamHints,
+  stripBracketParams,
+} from "@/renderer/components/common/ProviderModelMenu/parts/modelShortcutLabel";
+
+export type SubAgentProgressPartKind = "model" | "tokens" | "live" | "steps";
+
+export interface SubAgentProgressPart {
+  kind: SubAgentProgressPartKind;
+  label: string;
+}
+
+export function hasSubAgentProgressMeta(progress: ToolCallProgress | undefined): boolean {
+  return buildSubAgentProgressParts({ progress }).length > 0;
+}
+
+export function buildSubAgentProgressParts(args: {
+  progress: ToolCallProgress | undefined;
+  liveLabel?: string | undefined;
+  stepCount?: number | undefined;
+  includeStepCount?: boolean;
+}): SubAgentProgressPart[] {
+  const { progress, liveLabel, stepCount, includeStepCount = false } = args;
+  const parts: SubAgentProgressPart[] = [];
+  const modelLabel = formatSubAgentModelLabel(progress?.model);
+  if (modelLabel) parts.push({ kind: "model", label: modelLabel });
+  const tokenLabel = formatSubAgentTokenLabel(progress?.tokens);
+  if (tokenLabel) parts.push({ kind: "tokens", label: tokenLabel });
+  const normalizedLiveLabel = liveLabel?.trim();
+  if (normalizedLiveLabel) parts.push({ kind: "live", label: normalizedLiveLabel });
+  if (includeStepCount && stepCount !== undefined) {
+    parts.push({ kind: "steps", label: formatSubAgentStepLabel(stepCount) });
+  }
+  return parts;
+}
+
+export function SubAgentProgressMeta({
+  progress,
+  liveLabel,
+  stepCount,
+  includeStepCount = false,
+  showLoader = false,
+  className = "",
+  liveMaxClassName = "max-w-[24ch]",
+  loaderClassName = "text-[color:var(--muted)]",
+}: {
+  progress: ToolCallProgress | undefined;
+  liveLabel?: string | undefined;
+  stepCount?: number | undefined;
+  includeStepCount?: boolean;
+  showLoader?: boolean;
+  className?: string;
+  liveMaxClassName?: string;
+  loaderClassName?: string;
+}) {
+  const parts = buildSubAgentProgressParts({ progress, liveLabel, stepCount, includeStepCount });
+  if (parts.length === 0 && !showLoader) return null;
+  return (
+    <span className={`inline-flex min-w-0 items-center gap-1.5 tabular-nums ${className}`}>
+      {parts.map((part, index) => (
+        <Fragment key={`${part.kind}-${index}`}>
+          {index > 0 ? <span className="shrink-0 opacity-60">·</span> : null}
+          <span
+            className={part.kind === "live" ? `${liveMaxClassName} min-w-0 truncate` : "shrink-0"}
+            title={part.kind === "live" ? part.label : undefined}
+          >
+            {part.label}
+          </span>
+        </Fragment>
+      ))}
+      {showLoader ? <PixelLoader size="xxs" className={loaderClassName} /> : null}
+    </span>
+  );
+}
+
+export function formatSubAgentModelLabel(model: string | undefined): string | undefined {
+  const raw = model?.trim();
+  if (!raw) return undefined;
+  const base = stripBracketParams(raw).trim();
+  if (!base) return undefined;
+  const label = formatKnownModelId(base) ?? formatGenericModelLabel(base);
+  const hints = raw.includes("[") ? formatBracketParamHints(raw) : undefined;
+  return hints ? `${label} · ${hints}` : label;
+}
+
+function formatSubAgentTokenLabel(tokens: number | undefined): string | undefined {
+  if (tokens === undefined || tokens <= 0) return undefined;
+  return `${formatCompactNumber(tokens)} tok`;
+}
+
+function formatSubAgentStepLabel(stepCount: number): string {
+  return `${stepCount} step${stepCount === 1 ? "" : "s"}`;
+}
+
+function formatCompactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}m`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  return String(n);
+}
+
+function formatKnownModelId(modelId: string): string | undefined {
+  const claudeShort = /^(opus|sonnet|haiku)$/i.exec(modelId);
+  if (claudeShort) return capitalizeSegment(claudeShort[1]!);
+
+  const claudeRelease = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)$/i.exec(modelId);
+  if (claudeRelease) {
+    return `${capitalizeSegment(claudeRelease[1]!)} ${claudeRelease[2]}.${claudeRelease[3]}`;
+  }
+
+  const gpt = /^gpt-(\d+(?:\.\d+)?)(?:-(mini|nano|codex|spark|max))?$/i.exec(modelId);
+  if (gpt) {
+    const suffix = gpt[2] ? ` ${capitalizeSegment(gpt[2])}` : "";
+    return `GPT-${gpt[1]}${suffix}`;
+  }
+
+  return undefined;
+}
+
+function formatGenericModelLabel(modelId: string): string {
+  return modelId
+    .split(/[-_/\s]+/g)
+    .filter(Boolean)
+    .map(formatModelSegment)
+    .join(" ");
+}
+
+function formatModelSegment(segment: string): string {
+  if (/^gpt$/i.test(segment)) return "GPT";
+  if (/^llm$/i.test(segment)) return "LLM";
+  if (/^ai$/i.test(segment)) return "AI";
+  return capitalizeSegment(segment);
+}
+
+function capitalizeSegment(segment: string): string {
+  return segment.length <= 1 ? segment : segment[0]!.toUpperCase() + segment.slice(1);
+}

--- a/src/shared/contracts/runtimeEvent.test.ts
+++ b/src/shared/contracts/runtimeEvent.test.ts
@@ -279,7 +279,7 @@ describe("item payload schemas", () => {
       args: { command: "ls" },
       result: "ok",
       status: "success",
-      progress: { description: "running", tokens: 100, stepCount: 2 },
+      progress: { description: "running", model: "opus", tokens: 100, stepCount: 2 },
       isSubAgent: true,
     };
     expect(toolCallPayloadSchema.parse(roundTrip(payload))).toEqual(payload);

--- a/src/shared/contracts/runtimeEvent.ts
+++ b/src/shared/contracts/runtimeEvent.ts
@@ -142,6 +142,8 @@ export type FileChangePayload = z.infer<typeof fileChangePayloadSchema>;
 export const toolCallProgressSchema = z.object({
   description: z.string().optional(),
   lastToolName: z.string().optional(),
+  /** Provider-reported model used by this sub-agent, when the provider exposes the actual sub-agent model. */
+  model: z.string().min(1).optional(),
   summary: z.string().optional(),
   tokens: z.number().int().nonnegative().optional(),
   toolUses: z.number().int().nonnegative().optional(),

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -792,6 +792,7 @@ describe("mapAcpSessionUpdate", () => {
         rawInput: {
           description: "Explore worktree watcher",
           subagent_type: "worker",
+          model: "gemini-2.5-pro",
           prompt: "Trace watcher flow",
         },
       } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
@@ -822,6 +823,7 @@ describe("mapAcpSessionUpdate", () => {
           isSubAgent: true,
           progress: {
             description: "Reading README.md",
+            model: "gemini-2.5-pro",
             summary: "Reading README.md",
           },
         },

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -453,12 +453,14 @@ export function mapAcpSessionUpdate(
             },
           })
         : payload;
-      item.payload = mergeToolPayload(item.payload, nextPayload);
+      const mergedPayload = mergeToolPayload(item.payload, nextPayload);
+      const emittedPayload = mergeProgressForEmission(nextPayload, mergedPayload);
+      item.payload = mergedPayload;
       events.push({
         type: isTerminal ? "item.completed" : "item.updated",
         threadId,
         itemId: item.itemId,
-        payload: nextPayload,
+        payload: emittedPayload,
       });
       if (subAgentProgress?.text) {
         events.push(...buildSubAgentProgressEvents(state, item, subAgentProgress.text, isTerminal));
@@ -590,6 +592,7 @@ function buildAcpToolCallPayload(
   const locations = extractToolLocations(toolCall.locations);
   const name = title ?? kind ?? "tool";
   const contentResult = extractToolCallContentText(toolCall.content, resolveTerminalOutput);
+  const subAgentModel = isSubAgent ? readStringField(toolCall.rawInput, "model") : undefined;
   const base: Record<string, unknown> = {
     name,
     args: toolCall.rawInput,
@@ -599,6 +602,7 @@ function buildAcpToolCallPayload(
     ...(kind ? { kind } : {}),
     ...(locations.length > 0 ? { locations } : {}),
     ...(isSubAgent ? { isSubAgent: true } : {}),
+    ...(subAgentModel ? { progress: { model: subAgentModel } } : {}),
   };
   if (itemType === "command_execution") {
     const cmd = readStringField(toolCall.rawInput, "command");
@@ -1001,6 +1005,18 @@ function mergeToolPayload(
     };
   }
   return merged;
+}
+
+function mergeProgressForEmission(
+  next: Record<string, unknown>,
+  merged: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!next.progress || typeof next.progress !== "object" || Array.isArray(next.progress)) {
+    return next;
+  }
+  const progress = merged.progress;
+  if (!progress || typeof progress !== "object" || Array.isArray(progress)) return next;
+  return { ...next, progress };
 }
 
 /** Find the first `ToolCallContent` entry of type `"terminal"` and return its id. */

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -212,7 +212,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
       });
 
       expect(state.activeGoalItemId).toBe("goal-turn-goal");
-      expect(state.activeGoalTokensUsed).toBe(34_000);
+      expect(state.activeGoalCompletedTurnTokensUsed).toBe(34_000);
 
       vi.setSystemTime(new Date("2026-05-12T10:03:00Z"));
       const successResult = mapClaudeSdkMessage(
@@ -266,7 +266,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
 
       expect(state.activeGoalItemId).toBe("goal-turn-goal");
       expect(state.activeGoalObjective).toBe("fix the bug");
-      expect(state.activeGoalTokensUsed).toBe(10_000);
+      expect(state.activeGoalCompletedTurnTokensUsed).toBe(10_000);
     } finally {
       vi.useRealTimers();
     }
@@ -298,7 +298,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
       expect(state.activeGoalItemId).toBe("goal-turn-goal-2");
       expect(state.activeGoalObjective).toBe("new objective");
       expect(state.activeGoalStartedAtMs).toBe(Date.now());
-      expect(state.activeGoalTokensUsed).toBeUndefined();
+      expect(state.activeGoalCompletedTurnTokensUsed).toBeUndefined();
     } finally {
       vi.useRealTimers();
     }
@@ -341,7 +341,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
     expect(state.activeGoalItemId).toBeUndefined();
   });
 
-  it("does not lower goal token usage when a final result reports fewer tokens than polling", () => {
+  it("does not lower goal token usage when a final result reports fewer tokens than live spend", () => {
     const state = createClaudeMapperState("thread-1");
     vi.useFakeTimers();
     try {
@@ -649,6 +649,49 @@ describe("sdkCanonicalMapping — tool use", () => {
         args: { file_path: "src/foo.ts", offset: 0 },
       }),
     });
+  });
+
+  it("surfaces Task model override from streamed input JSON", () => {
+    const state = createClaudeMapperState("thread-1");
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "toolu_task", name: "Task", input: {} },
+      }),
+      state,
+    );
+
+    const events = mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json:
+            '{"description":"Audit","subagent_type":"general-purpose","model":"sonnet"}',
+        },
+      }),
+      state,
+    );
+
+    expect(events).toMatchObject([
+      {
+        type: "item.updated",
+        threadId: "thread-1",
+        itemId: "toolu_task",
+        payload: {
+          name: "Task",
+          args: {
+            description: "Audit",
+            subagent_type: "general-purpose",
+            model: "sonnet",
+          },
+          status: "running",
+          progress: { model: "sonnet" },
+        },
+      },
+    ]);
   });
 
   it("maps Claude Workflow tool calls as subagent-like tool_call items", () => {
@@ -1367,7 +1410,7 @@ describe("sdkCanonicalMapping — task progress", () => {
           type: "tool_use",
           id: "toolu_T1",
           name: "Task",
-          input: { description: "research" },
+          input: { description: "research", model: "opus" },
         },
       }),
       state,
@@ -1403,6 +1446,7 @@ describe("sdkCanonicalMapping — task progress", () => {
           progress: {
             description: "Searching for callers",
             lastToolName: "Grep",
+            model: "opus",
             tokens: 4200,
             toolUses: 3,
             durationMs: 1500,
@@ -1457,6 +1501,101 @@ describe("sdkCanonicalMapping — task progress", () => {
         usage: { usedTokens: 98_765 },
       },
     ]);
+  });
+
+  it("adds deduped task usage to active goal token totals", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal count subagent tokens", undefined);
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:20Z"));
+      const firstProgress = mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "task_progress",
+          session_id: "claude-session",
+          task_id: "task-1",
+          tool_use_id: "toolu_T1",
+          description: "Searching",
+          usage: { total_tokens: 4_200, tool_uses: 3, duration_ms: 1_500 },
+        } as unknown as SDKMessage,
+        state,
+      );
+      expect(firstProgress).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({
+            status: "active",
+            tokensUsed: 4_200,
+          }),
+        }),
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:00:30Z"));
+      const secondProgress = mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "task_progress",
+          session_id: "claude-session",
+          task_id: "task-1",
+          tool_use_id: "toolu_T1",
+          description: "Reading",
+          usage: { total_tokens: 5_000, tool_uses: 4, duration_ms: 2_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+      expect(secondProgress).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({ tokensUsed: 5_000 }),
+        }),
+      );
+
+      const lowerDuplicate = mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "task_notification",
+          session_id: "claude-session",
+          task_id: "task-1",
+          status: "completed",
+          summary: "Done",
+          usage: { total_tokens: 4_900, tool_uses: 4, duration_ms: 2_100 },
+        } as unknown as SDKMessage,
+        state,
+      );
+      expect(
+        lowerDuplicate.some(
+          (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+        ),
+      ).toBe(false);
+
+      vi.setSystemTime(new Date("2026-05-12T10:01:00Z"));
+      const resultEvents = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        } as unknown as SDKMessage,
+        state,
+      );
+      expect(resultEvents).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({
+            status: "complete",
+            tokensUsed: 5_015,
+          }),
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -2151,7 +2290,7 @@ describe("sdkCanonicalMapping — requests", () => {
 });
 
 describe("sdkCanonicalMapping — emitActiveGoalTokenUpdate", () => {
-  it("emits a goal item.updated with context usage tokens when a goal is active", () => {
+  it("emits a goal item.updated with spend tokens when a goal is active", () => {
     const state = createClaudeMapperState("thread-1");
     vi.useFakeTimers();
     try {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -111,14 +111,9 @@ export function startClaudeTurn(
       state.activeGoalItemId = goalItemId;
       state.activeGoalObjective = goalPayload.objective;
       state.activeGoalStartedAtMs = Date.now();
-      delete state.activeGoalTokensUsed;
-      delete state.activeGoalResultTokensUsed;
+      resetActiveGoalTokenAccounting(state);
     } else {
-      delete state.activeGoalItemId;
-      delete state.activeGoalObjective;
-      delete state.activeGoalStartedAtMs;
-      delete state.activeGoalTokensUsed;
-      delete state.activeGoalResultTokensUsed;
+      clearActiveGoal(state);
     }
   } else if (isClearPrompt(prompt) && state.activeGoalItemId) {
     const payload = goalPayloadFromProviderState(
@@ -126,11 +121,7 @@ export function startClaudeTurn(
       "cleared",
     );
     events.push(...updateGoalItemEvents(state.threadId, state.activeGoalItemId, payload));
-    delete state.activeGoalItemId;
-    delete state.activeGoalObjective;
-    delete state.activeGoalStartedAtMs;
-    delete state.activeGoalTokensUsed;
-    delete state.activeGoalResultTokensUsed;
+    clearActiveGoal(state);
   }
   if (isManualCompactPrompt(prompt)) {
     const compactItemId = `compact-${turnId}`;
@@ -466,6 +457,7 @@ function startToolItem(
   if (state.toolItemsById.has(tool.itemId)) return;
   if (index !== undefined) state.toolItemsByIndex.set(index, tool);
   state.toolItemsById.set(tool.itemId, tool);
+  syncSubAgentModelProgress(tool);
   if (tool.planAggregatorRole) {
     // Suppress the underlying tool row — the aggregator's plan item is the
     // visible surface for TodoWrite / Task* calls. Forward any input that's
@@ -483,6 +475,13 @@ function startToolItem(
     itemType: tool.itemType,
     payload: toolPayload(tool, "running"),
   });
+}
+
+function syncSubAgentModelProgress(tool: ToolItemState): void {
+  if (tool.toolName !== "Task") return;
+  const model = readStringField(tool.input, "model");
+  if (!model) return;
+  tool.progress = { ...tool.progress, model };
 }
 
 function classifyRequestType(toolName: string): CanonicalRequestType {
@@ -896,6 +895,7 @@ function extractText(value: unknown): string {
 function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
   const obj = message as {
+    task_id?: unknown;
     tool_use_id?: unknown;
     description?: unknown;
     last_tool_name?: unknown;
@@ -908,11 +908,14 @@ function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): Runt
       : undefined;
   const contextUsage = contextUsageFromTaskUsage(state.threadId, usage);
   if (contextUsage) events.push(contextUsage);
+  const goalUsage = emitActiveGoalTaskUsageUpdate(state, obj, usage);
+  if (goalUsage) events.push(goalUsage);
 
   const toolUseId = typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined;
   if (!toolUseId) return events;
   const tool = state.toolItemsById.get(toolUseId);
   if (!tool) return events;
+  syncSubAgentModelProgress(tool);
 
   const next: ToolCallProgress = {
     ...tool.progress,
@@ -948,6 +951,34 @@ function contextUsageFromTaskUsage(
   const usedTokens = readNonNegativeInteger(usage?.total_tokens);
   if (usedTokens === undefined || usedTokens <= 0) return undefined;
   return createContextUsageEvent(threadId, { usedTokens });
+}
+
+function emitActiveGoalTaskUsageUpdate(
+  state: ClaudeMapperState,
+  message: { task_id?: unknown; tool_use_id?: unknown },
+  usage: { total_tokens?: number; tool_uses?: number; duration_ms?: number } | undefined,
+): RuntimeEvent | undefined {
+  if (!hasActiveGoal(state)) return undefined;
+  const totalTokens = readNonNegativeInteger(usage?.total_tokens);
+  if (totalTokens === undefined || totalTokens <= 0) return undefined;
+
+  const key = activeGoalTaskUsageKey(message);
+  if (!key) return undefined;
+
+  const taskTokens = (state.activeGoalTaskTokensByKey ??= new Map<string, number>());
+  const previous = taskTokens.get(key) ?? 0;
+  if (totalTokens <= previous) return undefined;
+  taskTokens.set(key, totalTokens);
+  return emitActiveGoalAggregateTokenUpdate(state);
+}
+
+function activeGoalTaskUsageKey(message: {
+  task_id?: unknown;
+  tool_use_id?: unknown;
+}): string | undefined {
+  const taskId = typeof message.task_id === "string" ? message.task_id : undefined;
+  const toolUseId = typeof message.tool_use_id === "string" ? message.tool_use_id : undefined;
+  return taskId ?? toolUseId;
 }
 
 function mapPermissionDenied(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
@@ -1123,6 +1154,33 @@ export function extractResultErrorMessage(message: SDKMessage): string | undefin
   return undefined;
 }
 
+type ActiveGoalState = ClaudeMapperState & {
+  activeGoalItemId: string;
+  activeGoalObjective: string;
+  activeGoalStartedAtMs: number;
+};
+
+function hasActiveGoal(state: ClaudeMapperState): state is ActiveGoalState {
+  return (
+    state.activeGoalItemId !== undefined &&
+    state.activeGoalObjective !== undefined &&
+    state.activeGoalStartedAtMs !== undefined
+  );
+}
+
+function resetActiveGoalTokenAccounting(state: ClaudeMapperState): void {
+  delete state.activeGoalCompletedTurnTokensUsed;
+  delete state.activeGoalLiveApiTokensUsed;
+  delete state.activeGoalTaskTokensByKey;
+}
+
+function clearActiveGoal(state: ClaudeMapperState): void {
+  delete state.activeGoalItemId;
+  delete state.activeGoalObjective;
+  delete state.activeGoalStartedAtMs;
+  resetActiveGoalTokenAccounting(state);
+}
+
 function completeActiveGoalEvents(
   state: ClaudeMapperState,
   message: Extract<SDKMessage, { type: "result" }>,
@@ -1136,11 +1194,10 @@ function completeActiveGoalEvents(
   const nowMs = Date.now();
   const usage = readClaudeResultUsage(message);
   if (usage !== undefined) {
-    const resultTokensUsed = (state.activeGoalResultTokensUsed ?? 0) + usage;
-    state.activeGoalResultTokensUsed = resultTokensUsed;
-    state.activeGoalTokensUsed = Math.max(state.activeGoalTokensUsed ?? 0, resultTokensUsed);
+    state.activeGoalCompletedTurnTokensUsed =
+      (state.activeGoalCompletedTurnTokensUsed ?? 0) + usage;
   }
-  const totalTokensUsed = state.activeGoalTokensUsed;
+  const totalTokensUsed = activeGoalAggregateTokens(state);
   const elapsedSeconds = Math.max(0, Math.round((nowMs - startedAtMs) / 1000));
 
   if (turnState === "interrupted") {
@@ -1164,11 +1221,7 @@ function completeActiveGoalEvents(
     ];
   }
 
-  delete state.activeGoalItemId;
-  delete state.activeGoalObjective;
-  delete state.activeGoalStartedAtMs;
-  delete state.activeGoalTokensUsed;
-  delete state.activeGoalResultTokensUsed;
+  clearActiveGoal(state);
 
   const payload = goalPayloadFromProviderState(
     {
@@ -1187,21 +1240,21 @@ export function emitActiveGoalTokenUpdate(
   state: ClaudeMapperState,
   tokensUsed: number,
 ): RuntimeEvent | undefined {
-  if (
-    !state.activeGoalItemId ||
-    !state.activeGoalObjective ||
-    state.activeGoalStartedAtMs === undefined
-  ) {
-    return undefined;
-  }
+  if (!hasActiveGoal(state)) return undefined;
+  state.activeGoalLiveApiTokensUsed = Math.max(state.activeGoalLiveApiTokensUsed ?? 0, tokensUsed);
+  return emitActiveGoalAggregateTokenUpdate(state);
+}
+
+function emitActiveGoalAggregateTokenUpdate(state: ClaudeMapperState): RuntimeEvent | undefined {
+  if (!hasActiveGoal(state)) return undefined;
+  const aggregateTokens = activeGoalAggregateTokens(state);
+  if (aggregateTokens === undefined) return undefined;
   const elapsedSeconds = Math.max(0, Math.round((Date.now() - state.activeGoalStartedAtMs) / 1000));
-  const bestKnownTokensUsed = Math.max(state.activeGoalTokensUsed ?? 0, tokensUsed);
-  state.activeGoalTokensUsed = bestKnownTokensUsed;
   const payload = goalPayloadFromProviderState(
     {
       objective: state.activeGoalObjective,
       status: "active",
-      tokensUsed: bestKnownTokensUsed,
+      tokensUsed: aggregateTokens,
       timeUsedSeconds: elapsedSeconds,
       updatedAt: Date.now() / 1000,
     },
@@ -1215,18 +1268,46 @@ export function emitActiveGoalTokenUpdate(
   };
 }
 
+function activeGoalAggregateTokens(state: ClaudeMapperState): number | undefined {
+  const baseTokens = Math.max(
+    state.activeGoalCompletedTurnTokensUsed ?? 0,
+    state.activeGoalLiveApiTokensUsed ?? 0,
+  );
+  const taskTokens = sumActiveGoalTaskTokens(state);
+  const totalTokens = baseTokens + taskTokens;
+  return totalTokens > 0 ? totalTokens : undefined;
+}
+
+function sumActiveGoalTaskTokens(state: ClaudeMapperState): number {
+  let total = 0;
+  for (const tokens of state.activeGoalTaskTokensByKey?.values() ?? []) total += tokens;
+  return total;
+}
+
 function readClaudeResultUsage(
   message: Extract<SDKMessage, { type: "result" }>,
 ): number | undefined {
   const usage = (message as { usage?: unknown }).usage;
+  return readClaudeUsageSpendTokens(usage, { fallbackToTotalTokens: true });
+}
+
+export function readClaudeApiUsageSpendTokens(usage: unknown): number | undefined {
+  return readClaudeUsageSpendTokens(usage, { fallbackToTotalTokens: false });
+}
+
+function readClaudeUsageSpendTokens(
+  usage: unknown,
+  options: { fallbackToTotalTokens: boolean },
+): number | undefined {
   if (!usage || typeof usage !== "object") return undefined;
   const record = usage as Record<string, unknown>;
-  const total = readNonNegativeInteger(record.total_tokens);
-  if (total !== undefined) return total;
   const input = readNonNegativeInteger(record.input_tokens) ?? 0;
   const output = readNonNegativeInteger(record.output_tokens) ?? 0;
-  const sum = input + output;
-  return sum > 0 ? sum : undefined;
+  const cacheCreation = readNonNegativeInteger(record.cache_creation_input_tokens) ?? 0;
+  const cacheRead = readNonNegativeInteger(record.cache_read_input_tokens) ?? 0;
+  const sum = input + output + cacheCreation + cacheRead;
+  if (sum > 0) return sum;
+  return options.fallbackToTotalTokens ? readNonNegativeInteger(record.total_tokens) : undefined;
 }
 
 function mapResultState(message: Extract<SDKMessage, { type: "result" }>): TurnState {
@@ -1418,6 +1499,7 @@ function mapClaudeSdkMessageInner(
         if (!fingerprint || fingerprint === tool.lastInputFingerprint) return events;
         tool.input = nextInput;
         tool.lastInputFingerprint = fingerprint;
+        syncSubAgentModelProgress(tool);
         if (tool.planAggregatorRole) {
           events.push(...applyPlanAggregatorInput(state, tool));
           return events;

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -41,8 +41,9 @@ export interface ClaudeMapperState {
   activeGoalItemId?: string;
   activeGoalObjective?: string;
   activeGoalStartedAtMs?: number;
-  activeGoalTokensUsed?: number;
-  activeGoalResultTokensUsed?: number;
+  activeGoalCompletedTurnTokensUsed?: number;
+  activeGoalLiveApiTokensUsed?: number;
+  activeGoalTaskTokensByKey?: Map<string, number>;
   planAggregator?: PlanAggregatorState;
 }
 

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -714,6 +714,81 @@ describe("ClaudeSdkSession", () => {
     await session.dispose();
   });
 
+  it("updates active goal tokens from live SDK api usage including cache", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = createFakeQuery();
+      fake.getContextUsage.mockResolvedValue({
+        categories: [{ name: "Messages", tokens: 238_000, color: "#3366ff" }],
+        totalTokens: 238_000,
+        maxTokens: 1_000_000,
+        rawMaxTokens: 1_000_000,
+        percentage: 23.8,
+        gridRows: [],
+        model: "claude-opus-4-7[1m]",
+        memoryFiles: [],
+        mcpTools: [],
+        isAutoCompactEnabled: true,
+        agents: [],
+        apiUsage: {
+          input_tokens: 1_500,
+          output_tokens: 500,
+          cache_creation_input_tokens: 99_000,
+          cache_read_input_tokens: 136_000,
+        },
+      });
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const runtimeEvents: RuntimeEvent[] = [];
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-goal-spend",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: (event) => runtimeEvents.push(event),
+        onUpdate: () => {},
+        onError: () => {},
+        onClose: () => {},
+      });
+
+      await session.openThread(config);
+      await session.startTurn("/goal fix live token count", config);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(runtimeEvents).toContainEqual({
+        type: "context.updated",
+        threadId: "thread-claude-goal-spend",
+        usage: {
+          usedTokens: 238_000,
+          maxTokens: 1_000_000,
+          breakdown: [{ id: "messages-0", label: "Messages", tokens: 238_000 }],
+        },
+      });
+      expect(runtimeEvents).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          threadId: "thread-claude-goal-spend",
+          payload: expect.objectContaining({
+            objective: "fix live token count",
+            status: "active",
+            tokensUsed: 237_000,
+          }),
+        }),
+      );
+      expect(runtimeEvents).not.toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          payload: expect.objectContaining({ tokensUsed: 238_000 }),
+        }),
+      );
+
+      await session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("treats a steered/interrupted turn as idle rather than a failed turn", async () => {
     const fake = createFakeQuery();
     mockSdk.query.mockReturnValue(fake.runtime);
@@ -806,7 +881,7 @@ describe("ClaudeSdkSession", () => {
     expect(goalUpdates.at(-1)).toMatchObject({
       payload: {
         status: "active",
-        tokensUsed: 42_000,
+        tokensUsed: 12_000,
       },
     });
     expect(runtimeEvents).not.toContainEqual(

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -45,7 +45,6 @@ import {
   type ThreadHistory,
 } from "../base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
-import { readNonNegativeInteger } from "../contextUsage";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { chosenOptionIds } from "../questionAnswers";
 import { applyClaudeContextSuffix } from "./argv";
@@ -64,6 +63,7 @@ import {
   mapClaudeSdkMessage,
   nonDiagnosticErrors,
   parseClaudeQuestions,
+  readClaudeApiUsageSpendTokens,
   startClaudeTurn,
   type ClaudeMapperState,
   type ClaudeQuestion,
@@ -1121,15 +1121,16 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       const event = mapClaudeContextUsageResponse(this.input.threadId, usage);
       if (event) this.emitRuntimeEvents([event]);
       if (this.mapperState.activeGoalItemId) {
-        const usedTokens = readNonNegativeInteger(usage.totalTokens);
-        if (usedTokens !== undefined && usedTokens > 0) {
-          const goalUpdate = emitActiveGoalTokenUpdate(this.mapperState, usedTokens);
-          if (goalUpdate) this.emitRuntimeEvents([goalUpdate]);
-        }
+        const spendTokens = readClaudeApiUsageSpendTokens(usage.apiUsage);
+        const goalUpdate =
+          spendTokens !== undefined
+            ? emitActiveGoalTokenUpdate(this.mapperState, spendTokens)
+            : undefined;
+        if (goalUpdate) this.emitRuntimeEvents([goalUpdate]);
       }
     } catch {
       // Older transports can reject this control call. In that case, keep the
-      // existing context state instead of emitting billing-token totals as usage.
+      // existing context and goal-spend state until a result message arrives.
     }
   }
 


### PR DESCRIPTION
Tickets: none

- Feature + refactor: expose provider-reported subagent model, token usage, last tool, and step counts in the chat UI instead of falling back to the parent model.
- Thread progress payloads and shared runtime contracts now carry subagent model metadata end to end, so ACP and Claude mappings can preserve and emit it consistently.
- Claude goal accounting now tracks live API spend tokens, including cache usage, and resets goal state with clearer token-tracking fields between turns.
- Updated tests cover the new progress metadata formatting, runtime contract shape, provider mappings, and Claude token accounting behavior.