### PR TITLE
Separate model visibility by presentation surface

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -20,6 +20,7 @@ import {
   type ProviderModelMenuProvider,
 } from "./parts/buildItems";
 import { deriveSubProvider } from "./parts/deriveSubProvider";
+import { providerMenuKey } from "./parts/providerIdentity";
 import type { ProviderModelItem } from "./parts/types";
 
 export type { ProviderModelMenuProvider };
@@ -240,7 +241,13 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
   const latestFavoritesRef = useRef(favorites);
   const latestRecentsRef = useRef(recents);
 
-  const currentProvider = providers.find((p) => p.kind === currentAgentKind);
+  const currentProvider =
+    providers.find(
+      (p) =>
+        p.kind === currentAgentKind &&
+        (presentationMode === undefined || p.presentationMode === presentationMode),
+    ) ?? providers.find((p) => p.kind === currentAgentKind);
+  const currentProviderKey = currentProvider ? providerMenuKey(currentProvider) : currentAgentKind;
   const effectiveCurrentModel = normalizeCurrentModelForProvider(currentProvider, currentModel);
   const currentLabel =
     currentProvider?.capabilities.models.find((m) => m.id === effectiveCurrentModel)?.label ??
@@ -309,13 +316,17 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
   const selectedKeys = new Set<string>([
     `fav:${currentAgentKind}:${effectiveCurrentModel}`,
     `recent:${currentAgentKind}:${effectiveCurrentModel}`,
-    `model:${currentAgentKind}:${effectiveCurrentModel}`,
+    `model:${currentProviderKey}:${effectiveCurrentModel}`,
   ]);
 
   function handleSelect(itemId: string) {
     const selected = items.find((item) => item.id === itemId);
     if (selected?.type !== "model") return;
-    if (selected.providerKind === currentAgentKind && selected.modelId === effectiveCurrentModel) {
+    if (
+      selected.providerKind === currentAgentKind &&
+      selected.modelId === effectiveCurrentModel &&
+      selected.providerKey === currentProviderKey
+    ) {
       handleOpenChange(false);
       return;
     }

--- a/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
@@ -285,16 +285,29 @@ function findModelEntry(cache: ProviderModelCache, modelId: string): ModelEntry 
   return undefined;
 }
 
+// A favorites/recents ref carries an optional presentationMode. It matches a
+// visible provider of the same kind when neither side pins a mode, or when both
+// pin the same one. Used both to resolve refs and to look up their icons.
+function findVisibleProvider(
+  byKind: ReadonlyMap<string, VisibleProvider[]>,
+  agentKind: string,
+  presentationMode: ThreadPresentationMode | undefined,
+): VisibleProvider | undefined {
+  const candidates = byKind.get(agentKind);
+  if (!candidates) return undefined;
+  return candidates.find(
+    (entry) =>
+      !presentationMode ||
+      !entry.provider.presentationMode ||
+      entry.provider.presentationMode === presentationMode,
+  );
+}
+
 function resolveModelRef(
   ref: ModelRef,
-  visibleProviders: readonly VisibleProvider[],
+  providersByKind: ReadonlyMap<string, VisibleProvider[]>,
 ): ResolvedModelRef | undefined {
-  const visibleProvider = visibleProviders.find((entry) => {
-    if (entry.provider.kind !== ref.agentKind) return false;
-    if (!ref.presentationMode) return true;
-    if (!entry.provider.presentationMode) return true;
-    return entry.provider.presentationMode === ref.presentationMode;
-  });
+  const visibleProvider = findVisibleProvider(providersByKind, ref.agentKind, ref.presentationMode);
   if (!visibleProvider) return undefined;
   const { provider, cache } = visibleProvider;
   const model =
@@ -345,6 +358,12 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     searchText:
       `${provider.kind}\n${provider.label}\n${providerLabelForPresentation(provider)}`.toLowerCase(),
   }));
+  const visibleProvidersByKind = new Map<string, VisibleProvider[]>();
+  for (const entry of visibleProviderEntries) {
+    const list = visibleProvidersByKind.get(entry.provider.kind);
+    if (list) list.push(entry);
+    else visibleProvidersByKind.set(entry.provider.kind, [entry]);
+  }
   const query = search.trim().toLowerCase();
   const isSearching = query.length > 0;
   const out: ProviderModelItem[] = [];
@@ -387,7 +406,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     });
     const items = dedupedRefs
       .filter((ref) => visibleKinds.has(ref.agentKind))
-      .map((ref) => resolveModelRef(ref, visibleProviderEntries))
+      .map((ref) => resolveModelRef(ref, visibleProvidersByKind))
       .filter((m): m is ResolvedModelRef => m !== undefined)
       .filter((m) => {
         if (!isSearching) return true;
@@ -396,12 +415,10 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     if (items.length === 0) return;
     out.push({ type: "header-plain", id: `header:${sectionId}`, label: headerLabel });
     for (const m of items) {
-      const visibleProvider = visibleProviderEntries.find(
-        (entry) =>
-          entry.provider.kind === m.ref.agentKind &&
-          (!m.ref.presentationMode ||
-            !entry.provider.presentationMode ||
-            entry.provider.presentationMode === m.ref.presentationMode),
+      const visibleProvider = findVisibleProvider(
+        visibleProvidersByKind,
+        m.ref.agentKind,
+        m.ref.presentationMode,
       );
       const providerIcon = visibleProvider?.provider.icon;
       out.push({

--- a/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
@@ -6,13 +6,23 @@ import {
   modelLookupAliases,
   stripBracketParams,
 } from "./modelShortcutLabel";
+import {
+  providerLabelForPresentation,
+  providerMenuKey,
+  providerVisibilityKey,
+} from "./providerIdentity";
 import type { ProviderModelItem } from "./types";
 
 export interface ProviderModelMenuProvider {
+  /** Real adapter kind used for launch/favorites. */
   kind: string;
   label: string;
   icon?: string;
   presentationMode?: ThreadPresentationMode;
+  /** Unique UI identity when one adapter exposes multiple model surfaces. */
+  modelPickerKey?: string;
+  /** Settings key used for hidden-model persistence. */
+  hiddenModelsKey?: string;
   capabilities: AgentCapability;
 }
 
@@ -253,6 +263,8 @@ function getProviderModelCache(capability: AgentCapability): ProviderModelCache 
 
 interface VisibleProvider {
   provider: ProviderModelMenuProvider;
+  key: string;
+  visibilityKey: string;
   cache: ProviderModelCache;
   searchText: string;
 }
@@ -275,9 +287,14 @@ function findModelEntry(cache: ProviderModelCache, modelId: string): ModelEntry 
 
 function resolveModelRef(
   ref: ModelRef,
-  providersByKind: ReadonlyMap<string, VisibleProvider>,
+  visibleProviders: readonly VisibleProvider[],
 ): ResolvedModelRef | undefined {
-  const visibleProvider = providersByKind.get(ref.agentKind);
+  const visibleProvider = visibleProviders.find((entry) => {
+    if (entry.provider.kind !== ref.agentKind) return false;
+    if (!ref.presentationMode) return true;
+    if (!entry.provider.presentationMode) return true;
+    return entry.provider.presentationMode === ref.presentationMode;
+  });
   if (!visibleProvider) return undefined;
   const { provider, cache } = visibleProvider;
   const model =
@@ -322,12 +339,12 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     .sort((a, b) => providerSortKey(a.kind) - providerSortKey(b.kind));
   const visibleProviderEntries: VisibleProvider[] = visibleProviders.map((provider) => ({
     provider,
+    key: providerMenuKey(provider),
+    visibilityKey: providerVisibilityKey(provider),
     cache: getProviderModelCache(provider.capabilities),
-    searchText: `${provider.kind}\n${provider.label}`.toLowerCase(),
+    searchText:
+      `${provider.kind}\n${provider.label}\n${providerLabelForPresentation(provider)}`.toLowerCase(),
   }));
-  const visibleProvidersByKind = new Map(
-    visibleProviderEntries.map((entry) => [entry.provider.kind, entry]),
-  );
   const query = search.trim().toLowerCase();
   const isSearching = query.length > 0;
   const out: ProviderModelItem[] = [];
@@ -370,7 +387,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     });
     const items = dedupedRefs
       .filter((ref) => visibleKinds.has(ref.agentKind))
-      .map((ref) => resolveModelRef(ref, visibleProvidersByKind))
+      .map((ref) => resolveModelRef(ref, visibleProviderEntries))
       .filter((m): m is ResolvedModelRef => m !== undefined)
       .filter((m) => {
         if (!isSearching) return true;
@@ -379,11 +396,20 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     if (items.length === 0) return;
     out.push({ type: "header-plain", id: `header:${sectionId}`, label: headerLabel });
     for (const m of items) {
-      const providerIcon = visibleProvidersByKind.get(m.ref.agentKind)?.provider.icon;
+      const visibleProvider = visibleProviderEntries.find(
+        (entry) =>
+          entry.provider.kind === m.ref.agentKind &&
+          (!m.ref.presentationMode ||
+            !entry.provider.presentationMode ||
+            entry.provider.presentationMode === m.ref.presentationMode),
+      );
+      const providerIcon = visibleProvider?.provider.icon;
       out.push({
         type: "model",
         id: `${sectionId}:${m.ref.agentKind}:${m.ref.modelId}`,
         providerKind: m.ref.agentKind,
+        providerKey: visibleProvider?.key ?? m.ref.agentKind,
+        hiddenModelsKey: visibleProvider?.visibilityKey ?? m.ref.agentKind,
         modelId: m.ref.modelId,
         label: m.label,
         ...(m.ref.presentationMode ? { presentationMode: m.ref.presentationMode } : {}),
@@ -411,7 +437,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     }
   }
 
-  for (const { provider, cache, searchText } of visibleProviderEntries) {
+  for (const { provider, key, visibilityKey, cache, searchText } of visibleProviderEntries) {
     const cap = provider.capabilities;
     const providerHit = isSearching && searchText.includes(query);
     const currentEntry =
@@ -433,10 +459,12 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     if (showProviderHeaders) {
       out.push({
         type: "header-provider",
-        id: `provider:${provider.kind}`,
+        id: `provider:${key}`,
         providerKind: provider.kind,
+        providerKey: key,
+        hiddenModelsKey: visibilityKey,
         ...(provider.icon ? { providerIcon: provider.icon } : {}),
-        label: provider.label,
+        label: providerLabelForPresentation(provider),
       });
     }
 
@@ -445,8 +473,10 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
       for (const m of sortFavoritesFirst(filtered, provider.kind)) {
         out.push({
           type: "model",
-          id: `model:${provider.kind}:${m.id}`,
+          id: `model:${key}:${m.id}`,
           providerKind: provider.kind,
+          providerKey: key,
+          hiddenModelsKey: visibilityKey,
           modelId: m.id,
           label: m.label,
           ...(provider.presentationMode ? { presentationMode: provider.presentationMode } : {}),
@@ -479,8 +509,10 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     for (const m of sortFavoritesFirst(ungrouped, provider.kind)) {
       out.push({
         type: "model",
-        id: `model:${provider.kind}:${m.id}`,
+        id: `model:${key}:${m.id}`,
         providerKind: provider.kind,
+        providerKey: key,
+        hiddenModelsKey: visibilityKey,
         modelId: m.id,
         label: m.label,
         ...(provider.presentationMode ? { presentationMode: provider.presentationMode } : {}),
@@ -498,16 +530,20 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
       if (!models?.length) continue;
       out.push({
         type: "header-sub",
-        id: `sub:${provider.kind}:${sp.id}`,
+        id: `sub:${key}:${sp.id}`,
         providerKind: provider.kind,
+        providerKey: key,
+        hiddenModelsKey: visibilityKey,
         subId: sp.id,
         label: sp.label,
       });
       for (const m of sortFavoritesFirst(models, provider.kind)) {
         out.push({
           type: "model",
-          id: `model:${provider.kind}:${m.id}`,
+          id: `model:${key}:${m.id}`,
           providerKind: provider.kind,
+          providerKey: key,
+          hiddenModelsKey: visibilityKey,
           modelId: m.id,
           label: m.label,
           ...(provider.presentationMode ? { presentationMode: provider.presentationMode } : {}),

--- a/src/renderer/components/common/ProviderModelMenu/parts/modelShortcutLabel.test.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/modelShortcutLabel.test.ts
@@ -100,4 +100,44 @@ describe("buildProviderModelItems shortcut labels", () => {
     );
     expect(favorite?.type === "model" ? favorite.label : undefined).toBe("Composer 2.5 · Fast");
   });
+
+  it("keeps Cursor CLI and Cursor ACP as separate provider sections", () => {
+    const items = buildProviderModelItems({
+      providers: [
+        {
+          ...cursorProvider,
+          label: "Cursor CLI",
+          presentationMode: "terminal",
+          modelPickerKey: "cursor:terminal",
+          hiddenModelsKey: "cursor",
+        },
+        {
+          kind: "cursor",
+          label: "Cursor",
+          presentationMode: "gui",
+          modelPickerKey: "cursor:gui",
+          hiddenModelsKey: "cursor-acp",
+          capabilities: {
+            ...cursorProvider.capabilities,
+            models: [
+              {
+                id: "gpt-5.5[context=272k,reasoning=medium,fast=false]",
+                label: "GPT-5.5 · 272K · Medium",
+              },
+            ],
+          },
+        },
+      ],
+      search: "",
+    });
+
+    const headers = items.filter((item) => item.type === "header-provider");
+    expect(headers.map((header) => header.label)).toEqual(["Cursor CLI", "Cursor"]);
+    expect(headers.map((header) => header.hiddenModelsKey)).toEqual(["cursor", "cursor-acp"]);
+    expect(items.filter((item) => item.type === "model").map((item) => item.id)).toEqual([
+      "model:cursor:terminal:composer-2.5",
+      "model:cursor:terminal:gpt-5.5",
+      "model:cursor:gui:gpt-5.5[context=272k,reasoning=medium,fast=false]",
+    ]);
+  });
 });

--- a/src/renderer/components/common/ProviderModelMenu/parts/providerIdentity.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/providerIdentity.ts
@@ -1,0 +1,37 @@
+import type { ThreadPresentationMode } from "@/shared/contracts";
+
+export const CURSOR_ACP_MODEL_VISIBILITY_KEY = "cursor-acp";
+
+type ProviderIdentityInput = {
+  kind: string;
+  label?: string;
+  presentationMode?: ThreadPresentationMode;
+  modelPickerKey?: string;
+  hiddenModelsKey?: string;
+};
+
+export function providerMenuKey(provider: ProviderIdentityInput): string {
+  if (provider.modelPickerKey) return provider.modelPickerKey;
+  return provider.presentationMode
+    ? `${provider.kind}:${provider.presentationMode}`
+    : provider.kind;
+}
+
+export function providerVisibilityKey(provider: ProviderIdentityInput): string {
+  if (provider.hiddenModelsKey) return provider.hiddenModelsKey;
+  return modelVisibilityKey(provider.kind, provider.presentationMode);
+}
+
+export function modelVisibilityKey(
+  agentKind: string,
+  presentationMode?: ThreadPresentationMode,
+): string {
+  return agentKind === "cursor" && presentationMode === "gui"
+    ? CURSOR_ACP_MODEL_VISIBILITY_KEY
+    : agentKind;
+}
+
+export function providerLabelForPresentation(provider: ProviderIdentityInput): string {
+  if (provider.kind !== "cursor") return provider.label ?? provider.kind;
+  return provider.presentationMode === "terminal" ? "Cursor CLI" : (provider.label ?? "Cursor");
+}

--- a/src/renderer/components/common/ProviderModelMenu/parts/types.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/types.ts
@@ -10,6 +10,8 @@ export interface ProviderModelHeaderProvider {
   type: "header-provider";
   id: string;
   providerKind: string;
+  providerKey: string;
+  hiddenModelsKey: string;
   providerIcon?: string;
   label: string;
 }
@@ -18,6 +20,8 @@ export interface ProviderModelHeaderSubProvider {
   type: "header-sub";
   id: string;
   providerKind: string;
+  providerKey: string;
+  hiddenModelsKey: string;
   subId: string;
   label: string;
 }
@@ -26,6 +30,8 @@ export interface ProviderModelRow {
   type: "model";
   id: string;
   providerKind: string;
+  providerKey: string;
+  hiddenModelsKey: string;
   providerIcon?: string;
   presentationMode?: ThreadPresentationMode;
   modelId: string;

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -13,6 +13,7 @@ import type {
   ThreadPresentationMode,
 } from "@/shared/contracts";
 import { Button, PixelLoader } from "@/renderer/components/common";
+import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { readBridge } from "@/renderer/bridge";
 import type { ComposerControl } from "./ThreadComposer";
 import { ThreadComposer } from "./ThreadComposer";
@@ -352,7 +353,7 @@ export function ContinueInProviderDialog(props: {
   const selectedTargetCapabilities = selectedAgent
     ? filterHiddenModels(
         capabilitiesForPresentation(selectedAgent.capabilities, targetPresentationMode),
-        allHiddenModels[selectedAgent.kind],
+        allHiddenModels[modelVisibilityKey(selectedAgent.kind, targetPresentationMode)],
       )
     : undefined;
   const providerModelProviders = buildProviderModelMenuProviders(otherAgents, {
@@ -392,7 +393,9 @@ export function ContinueInProviderDialog(props: {
   const supportsTargetGuiMode = otherAgents.some((agent) => supportsPresentation(agent, "gui"));
 
   // --- Extraction config (source provider) ---
-  const hiddenModelIds = useSharedSettings((s) => s.hiddenModels[thread.agentKind]);
+  const hiddenModelIds = useSharedSettings(
+    (s) => s.hiddenModels[modelVisibilityKey(thread.agentKind, sourcePresentationMode)],
+  );
   const filteredSourceCaps = sourceAgent
     ? filterHiddenModels(
         capabilitiesForPresentation(sourceAgent.capabilities, sourcePresentationMode),

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -10,6 +10,7 @@ import type {
   ThreadServerRequestId,
 } from "@/shared/contracts";
 import { ProviderModelMenuProvider, BranchSelector, type BranchSelection } from "../common";
+import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { migrateCursorBaseId, parseCursorModelId } from "@/shared/cursorModelId";
 import {
   AttachmentBar,
@@ -320,7 +321,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         ? s.worktreeStatuses[thread.worktreePath]?.branch
         : s.statuses[thread.projectId]?.branch),
   );
-  const hiddenModelIds = useSharedSettings((s) => s.hiddenModels[thread.agentKind]);
+  const hiddenModelIds = useSharedSettings(
+    (s) => s.hiddenModels[modelVisibilityKey(thread.agentKind, presentationMode)],
+  );
   const controls = buildControls(thread, agentStatus, hiddenModelIds, props.onConfigChange);
   const controlsWithOpenSignal = controls.map((control): ComposerControl => {
     if (controlOpenRequest?.target === "model" && control.kind === "provider-model") {

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -13,6 +13,7 @@ import { readBridge } from "@/renderer/bridge";
 import { getConfigNormalizer } from "@/renderer/components/providers/ProviderIcon";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { PixelLoader } from "@/renderer/components/common";
+import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { capabilitiesForPresentation, filterHiddenModels } from "./threadComposerOptions";
@@ -559,7 +560,9 @@ export function ThreadDraftView(props: {
   ]);
 
   const hiddenModelIds = useSharedSettings((s) =>
-    selectedAgent ? s.hiddenModels[selectedAgent.kind] : undefined,
+    selectedAgent
+      ? s.hiddenModels[modelVisibilityKey(selectedAgent.kind, presentationMode)]
+      : undefined,
   );
   const allHiddenModels = useSharedSettings((s) => s.hiddenModels);
   const selectedAgentFilteredCapabilities = useMemo(

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import type { AgentCapability } from "@/shared/contracts";
-import { buildModelPickerControls, patchConfigForModelChange } from "./buildModelPickerControls";
+import type { AgentCapability, AgentStatus } from "@/shared/contracts";
+import {
+  buildModelPickerControls,
+  buildProviderModelMenuProviders,
+  patchConfigForModelChange,
+} from "./buildModelPickerControls";
 
 const capabilities = {
   models: [
@@ -99,5 +103,82 @@ describe("buildModelPickerControls fast toggle", () => {
     expect(
       fastToggle && "disabledReason" in fastToggle ? fastToggle.disabledReason : undefined,
     ).toBe(undefined);
+  });
+});
+
+describe("buildProviderModelMenuProviders", () => {
+  const cursorStatus: AgentStatus = {
+    kind: "cursor",
+    label: "Cursor",
+    installed: true,
+    authState: "authenticated",
+    capabilities: {
+      models: [
+        { id: "composer-2.5", label: "Composer 2.5" },
+        { id: "gpt-5", label: "GPT-5" },
+      ],
+      efforts: [],
+      modelEfforts: {},
+      modes: ["agent"],
+      approvalPolicies: [],
+      sandboxModes: [],
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: "terminal",
+      presentationMode: "terminal",
+      presentationModes: ["terminal", "gui"],
+      settingDefs: [],
+      presentationCapabilities: {
+        gui: {
+          models: [
+            {
+              id: "gpt-5[context=272k,reasoning=medium,fast=false]",
+              label: "GPT-5 · 272K · Medium",
+            },
+            {
+              id: "composer-2.5[context=default,reasoning=medium,fast=false]",
+              label: "Composer 2.5 · Medium",
+            },
+          ],
+          efforts: [],
+          modelEfforts: {
+            "gpt-5[context=272k,reasoning=medium,fast=false]": [],
+            "composer-2.5[context=default,reasoning=medium,fast=false]": [],
+          },
+        },
+      },
+    },
+  };
+
+  it("uses separate Cursor CLI and Cursor ACP hidden-model keys", () => {
+    const terminalProviders = buildProviderModelMenuProviders([cursorStatus], {
+      presentationMode: "terminal",
+      hiddenModelsByAgent: { cursor: ["gpt-5"] },
+    });
+
+    expect(terminalProviders[0]).toMatchObject({
+      kind: "cursor",
+      label: "Cursor CLI",
+      hiddenModelsKey: "cursor",
+    });
+    expect(terminalProviders[0]?.capabilities.models.map((model) => model.id)).toEqual([
+      "composer-2.5",
+    ]);
+
+    const guiProviders = buildProviderModelMenuProviders([cursorStatus], {
+      presentationMode: "gui",
+      hiddenModelsByAgent: {
+        "cursor-acp": ["gpt-5[context=272k,reasoning=medium,fast=false]"],
+      },
+    });
+
+    expect(guiProviders[0]).toMatchObject({
+      kind: "cursor",
+      label: "Cursor",
+      hiddenModelsKey: "cursor-acp",
+    });
+    expect(guiProviders[0]?.capabilities.models.map((model) => model.id)).toEqual([
+      "composer-2.5[context=default,reasoning=medium,fast=false]",
+    ]);
   });
 });

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -6,6 +6,12 @@ import type {
   ThreadPresentationMode,
 } from "@/shared/contracts";
 import type { ProviderModelMenuProvider } from "@/renderer/components/common";
+import {
+  modelVisibilityKey,
+  providerLabelForPresentation,
+  providerMenuKey,
+  providerVisibilityKey,
+} from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { getComposerControls } from "@/renderer/components/providers";
 import { EffortIcon } from "@/renderer/components/providers/EffortIcon";
 import type { ComposerControl } from "./ThreadComposer";
@@ -59,15 +65,25 @@ export function buildProviderModelMenuProviders(
     .map((agent) => {
       const agentPresentationMode =
         resolvePresentationMode?.(agent) ?? presentationMode ?? agent.capabilities.presentationMode;
-      const capabilities = filterHiddenModels(
-        capabilitiesForPresentation(agent.capabilities, agentPresentationMode),
-        hiddenModelsByAgent?.[agent.kind],
-      );
-      return {
+      const menuProvider: ProviderModelMenuProvider = {
         kind: agent.kind,
         label: agent.label,
+        presentationMode: agentPresentationMode,
         ...(agent.icon ? { icon: agent.icon } : {}),
-        ...(resolvePresentationMode ? { presentationMode: agentPresentationMode } : {}),
+        modelPickerKey: providerMenuKey({
+          kind: agent.kind,
+          presentationMode: agentPresentationMode,
+        }),
+        hiddenModelsKey: modelVisibilityKey(agent.kind, agentPresentationMode),
+        capabilities: capabilitiesForPresentation(agent.capabilities, agentPresentationMode),
+      };
+      const capabilities = filterHiddenModels(
+        menuProvider.capabilities,
+        hiddenModelsByAgent?.[providerVisibilityKey(menuProvider)],
+      );
+      return {
+        ...menuProvider,
+        label: providerLabelForPresentation(menuProvider),
         capabilities,
       };
     });

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -6,6 +6,7 @@ import type {
   ThreadPresentationMode,
 } from "@/shared/contracts";
 import type { ProviderModelMenuProvider } from "@/renderer/components/common";
+import { statusToMenuProvider } from "@/renderer/components/common/ProviderModelMenu";
 import {
   modelVisibilityKey,
   providerLabelForPresentation,
@@ -48,6 +49,26 @@ export type BuildModelPickerControlsInput = {
   onConfigPatch: (patch: ModelPickerConfigPatch) => void;
 };
 
+/**
+ * Build the menu provider for a single agent surface, applying the
+ * presentation-specific identity (key, visibility key, label) and capabilities.
+ */
+function makeMenuProvider(
+  agent: AgentStatus,
+  presentationMode: ThreadPresentationMode,
+): ProviderModelMenuProvider {
+  const provider: ProviderModelMenuProvider = {
+    kind: agent.kind,
+    label: agent.label,
+    presentationMode,
+    ...(agent.icon ? { icon: agent.icon } : {}),
+    modelPickerKey: providerMenuKey({ kind: agent.kind, presentationMode }),
+    hiddenModelsKey: modelVisibilityKey(agent.kind, presentationMode),
+    capabilities: capabilitiesForPresentation(agent.capabilities, presentationMode),
+  };
+  return { ...provider, label: providerLabelForPresentation(provider) };
+}
+
 export function buildProviderModelMenuProviders(
   agents: readonly AgentStatus[],
   options?: {
@@ -65,28 +86,31 @@ export function buildProviderModelMenuProviders(
     .map((agent) => {
       const agentPresentationMode =
         resolvePresentationMode?.(agent) ?? presentationMode ?? agent.capabilities.presentationMode;
-      const menuProvider: ProviderModelMenuProvider = {
-        kind: agent.kind,
-        label: agent.label,
-        presentationMode: agentPresentationMode,
-        ...(agent.icon ? { icon: agent.icon } : {}),
-        modelPickerKey: providerMenuKey({
-          kind: agent.kind,
-          presentationMode: agentPresentationMode,
-        }),
-        hiddenModelsKey: modelVisibilityKey(agent.kind, agentPresentationMode),
-        capabilities: capabilitiesForPresentation(agent.capabilities, agentPresentationMode),
-      };
-      const capabilities = filterHiddenModels(
-        menuProvider.capabilities,
-        hiddenModelsByAgent?.[providerVisibilityKey(menuProvider)],
-      );
+      const menuProvider = makeMenuProvider(agent, agentPresentationMode);
       return {
         ...menuProvider,
-        label: providerLabelForPresentation(menuProvider),
-        capabilities,
+        capabilities: filterHiddenModels(
+          menuProvider.capabilities,
+          hiddenModelsByAgent?.[providerVisibilityKey(menuProvider)],
+        ),
       };
     });
+}
+
+/**
+ * Expand an agent into one menu provider per model-visibility surface. Most
+ * agents have a single surface; Cursor exposes separate CLI (terminal) and ACP
+ * (gui) surfaces, each with its own hidden-model persistence key. Surfaces whose
+ * only model is the synthetic "auto" entry are dropped — they have nothing to
+ * toggle.
+ */
+export function expandAgentToVisibilityProviders(agent: AgentStatus): ProviderModelMenuProvider[] {
+  if (agent.kind !== "cursor") return [statusToMenuProvider(agent)];
+
+  const supported = agent.capabilities.presentationModes ?? [agent.capabilities.presentationMode];
+  return supported
+    .map((presentationMode) => makeMenuProvider(agent, presentationMode))
+    .filter((provider) => provider.capabilities.models.some((model) => model.id !== "auto"));
 }
 
 export function patchConfigForModelChange(

--- a/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
@@ -9,6 +9,7 @@ import type {
   ThreadConfig,
 } from "@/shared/contracts";
 import { Button, OptionMenu, PixelLoader } from "@/renderer/components/common";
+import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { ProviderIcon, getComposerControls } from "@/renderer/components/providers";
 import { EffortIcon } from "@/renderer/components/providers/EffortIcon";
 import { PermissionIcon } from "@/renderer/components/providers/PermissionIcon";
@@ -155,7 +156,9 @@ export function ContinueInProviderDialog(props: {
     }
   }
 
-  const hiddenTargetModelIds = useSharedSettings((s) => s.hiddenModels[selectedKind]);
+  const hiddenTargetModelIds = useSharedSettings(
+    (s) => s.hiddenModels[modelVisibilityKey(selectedKind)],
+  );
   const targetControls = (
     selectedAgent
       ? (getComposerControls(selectedKind)?.({
@@ -172,7 +175,9 @@ export function ContinueInProviderDialog(props: {
   const [extractModel, setExtractModel] = useState(thread.config.model || models[0]?.id || "");
   const [extractEffort, setExtractEffort] = useState("low");
 
-  const hiddenModelIds = useSharedSettings((s) => s.hiddenModels[thread.agentKind]);
+  const hiddenModelIds = useSharedSettings(
+    (s) => s.hiddenModels[modelVisibilityKey(thread.agentKind, thread.presentationMode)],
+  );
   const filteredSourceCaps = sourceAgent
     ? filterHiddenModels(sourceAgent.capabilities, hiddenModelIds)
     : undefined;

--- a/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
@@ -6,51 +6,17 @@ import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { getSettingsInstalledAgents } from "@/shared/agentStatus";
 import {
   buildProviderModelItems,
-  statusToMenuProvider,
-  type ProviderModelMenuProvider,
   type ProviderModelItem,
 } from "@/renderer/components/common/ProviderModelMenu";
-import { capabilitiesForPresentation } from "@/renderer/components/thread/threadComposerOptions";
+import { expandAgentToVisibilityProviders } from "@/renderer/components/thread/buildModelPickerControls";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
-import {
-  modelVisibilityKey,
-  providerLabelForPresentation,
-  providerMenuKey,
-  providerVisibilityKey,
-} from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
+import { providerVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 
 type SubGroupState = "all" | "some" | "none";
 
 interface ModelEntry {
   providerKey: string;
   modelId: string;
-}
-
-function modelVisibilityProviders(
-  agents: ReturnType<typeof getSettingsInstalledAgents>,
-): ProviderModelMenuProvider[] {
-  return agents.flatMap((agent) => {
-    if (agent.kind !== "cursor") return [statusToMenuProvider(agent)];
-
-    const supported = agent.capabilities.presentationModes ?? [agent.capabilities.presentationMode];
-    return supported
-      .map((presentationMode): ProviderModelMenuProvider => {
-        const provider: ProviderModelMenuProvider = {
-          kind: agent.kind,
-          label: agent.label,
-          presentationMode,
-          ...(agent.icon ? { icon: agent.icon } : {}),
-          modelPickerKey: providerMenuKey({ kind: agent.kind, presentationMode }),
-          hiddenModelsKey: modelVisibilityKey(agent.kind, presentationMode),
-          capabilities: capabilitiesForPresentation(agent.capabilities, presentationMode),
-        };
-        return {
-          ...provider,
-          label: providerLabelForPresentation(provider),
-        };
-      })
-      .filter((provider) => provider.capabilities.models.some((model) => model.id !== "auto"));
-  });
 }
 
 function GroupCheckIcon(props: { state: SubGroupState; className?: string }) {
@@ -180,7 +146,7 @@ export function ModelVisibilitySection() {
   const setHiddenModels = useSharedSettings((s) => s.setHiddenModels);
 
   const installedAgents = getSettingsInstalledAgents(agentStatuses, wslAgentStatuses);
-  const providers = modelVisibilityProviders(installedAgents);
+  const providers = installedAgents.flatMap(expandAgentToVisibilityProviders);
 
   const allModels: ModelEntry[] = [];
   for (const provider of providers) {

--- a/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
@@ -7,15 +7,50 @@ import { getSettingsInstalledAgents } from "@/shared/agentStatus";
 import {
   buildProviderModelItems,
   statusToMenuProvider,
+  type ProviderModelMenuProvider,
   type ProviderModelItem,
 } from "@/renderer/components/common/ProviderModelMenu";
+import { capabilitiesForPresentation } from "@/renderer/components/thread/threadComposerOptions";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
+import {
+  modelVisibilityKey,
+  providerLabelForPresentation,
+  providerMenuKey,
+  providerVisibilityKey,
+} from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 
 type SubGroupState = "all" | "some" | "none";
 
 interface ModelEntry {
-  providerKind: string;
+  providerKey: string;
   modelId: string;
+}
+
+function modelVisibilityProviders(
+  agents: ReturnType<typeof getSettingsInstalledAgents>,
+): ProviderModelMenuProvider[] {
+  return agents.flatMap((agent) => {
+    if (agent.kind !== "cursor") return [statusToMenuProvider(agent)];
+
+    const supported = agent.capabilities.presentationModes ?? [agent.capabilities.presentationMode];
+    return supported
+      .map((presentationMode): ProviderModelMenuProvider => {
+        const provider: ProviderModelMenuProvider = {
+          kind: agent.kind,
+          label: agent.label,
+          presentationMode,
+          ...(agent.icon ? { icon: agent.icon } : {}),
+          modelPickerKey: providerMenuKey({ kind: agent.kind, presentationMode }),
+          hiddenModelsKey: modelVisibilityKey(agent.kind, presentationMode),
+          capabilities: capabilitiesForPresentation(agent.capabilities, presentationMode),
+        };
+        return {
+          ...provider,
+          label: providerLabelForPresentation(provider),
+        };
+      })
+      .filter((provider) => provider.capabilities.models.some((model) => model.id !== "auto"));
+  });
 }
 
 function GroupCheckIcon(props: { state: SubGroupState; className?: string }) {
@@ -36,7 +71,7 @@ function ModelVisibilityRow(props: {
   isVisible: boolean;
   groupState?: SubGroupState;
   indent?: boolean;
-  onToggleModel: (providerKind: string, modelId: string) => void;
+  onToggleModel: (providerKey: string, modelId: string) => void;
   onToggleGroup: (headerId: string) => void;
 }) {
   const { item, isVisible, groupState, indent, onToggleModel, onToggleGroup } = props;
@@ -112,11 +147,11 @@ function ModelVisibilityRow(props: {
       className={`lightcode-menu-item group mx-1.5 flex h-7 cursor-default items-center text-foreground ${
         indent ? "pl-4" : ""
       }`}
-      onClick={() => onToggleModel(item.providerKind, item.modelId)}
+      onClick={() => onToggleModel(item.hiddenModelsKey, item.modelId)}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
-          onToggleModel(item.providerKind, item.modelId);
+          onToggleModel(item.hiddenModelsKey, item.modelId);
         }
       }}
     >
@@ -145,24 +180,26 @@ export function ModelVisibilitySection() {
   const setHiddenModels = useSharedSettings((s) => s.setHiddenModels);
 
   const installedAgents = getSettingsInstalledAgents(agentStatuses, wslAgentStatuses);
-  const providers = installedAgents.map(statusToMenuProvider);
+  const providers = modelVisibilityProviders(installedAgents);
 
   const allModels: ModelEntry[] = [];
   for (const provider of providers) {
+    const providerKey = providerVisibilityKey(provider);
     for (const model of provider.capabilities.models) {
       if (model.id === "auto") continue;
-      allModels.push({ providerKind: provider.kind, modelId: model.id });
+      allModels.push({ providerKey, modelId: model.id });
     }
   }
 
   const hiddenByProvider = new Map<string, Set<string>>();
   for (const provider of providers) {
-    hiddenByProvider.set(provider.kind, new Set(hiddenModels[provider.kind] ?? []));
+    const providerKey = providerVisibilityKey(provider);
+    hiddenByProvider.set(providerKey, new Set(hiddenModels[providerKey] ?? []));
   }
 
   const totalCount = allModels.length;
   const visibleCount = allModels.filter(
-    (m) => !(hiddenByProvider.get(m.providerKind)?.has(m.modelId) ?? false),
+    (m) => !(hiddenByProvider.get(m.providerKey)?.has(m.modelId) ?? false),
   ).length;
 
   const [isOpen, setIsOpen] = useState(false);
@@ -181,11 +218,11 @@ export function ModelVisibilitySection() {
 
   const groupModelEntries = new Map<string, ModelEntry[]>();
   {
-    let activeProvider: string | null = null;
+    let activeProviderHeaderId: string | null = null;
     let activeSubHeader: string | null = null;
     for (const item of items) {
       if (item.type === "header-provider") {
-        activeProvider = item.providerKind;
+        activeProviderHeaderId = item.id;
         activeSubHeader = null;
         if (!groupModelEntries.has(item.id)) groupModelEntries.set(item.id, []);
       } else if (item.type === "header-sub") {
@@ -194,10 +231,9 @@ export function ModelVisibilitySection() {
       } else if (item.type === "header-plain") {
         activeSubHeader = null;
       } else if (item.type === "model") {
-        const entry: ModelEntry = { providerKind: item.providerKind, modelId: item.modelId };
-        if (activeProvider) {
-          const providerHeaderId = `provider:${activeProvider}`;
-          groupModelEntries.get(providerHeaderId)?.push(entry);
+        const entry: ModelEntry = { providerKey: item.hiddenModelsKey, modelId: item.modelId };
+        if (activeProviderHeaderId) {
+          groupModelEntries.get(activeProviderHeaderId)?.push(entry);
         }
         if (activeSubHeader) {
           groupModelEntries.get(activeSubHeader)?.push(entry);
@@ -213,7 +249,7 @@ export function ModelVisibilitySection() {
       continue;
     }
     const hiddenIn = entries.filter(
-      (e) => hiddenByProvider.get(e.providerKind)?.has(e.modelId) ?? false,
+      (e) => hiddenByProvider.get(e.providerKey)?.has(e.modelId) ?? false,
     ).length;
     groupStates.set(
       headerId,
@@ -221,11 +257,11 @@ export function ModelVisibilitySection() {
     );
   }
 
-  function toggleModel(providerKind: string, modelId: string) {
-    const current = new Set(hiddenByProvider.get(providerKind) ?? []);
+  function toggleModel(providerKey: string, modelId: string) {
+    const current = new Set(hiddenByProvider.get(providerKey) ?? []);
     if (current.has(modelId)) current.delete(modelId);
     else current.add(modelId);
-    setHiddenModels(providerKind, [...current]);
+    setHiddenModels(providerKey, [...current]);
   }
 
   function toggleGroup(headerId: string) {
@@ -235,29 +271,29 @@ export function ModelVisibilitySection() {
     const hideAll = state === "all";
     const byProvider = new Map<string, Set<string>>();
     for (const entry of entries) {
-      let set = byProvider.get(entry.providerKind);
+      let set = byProvider.get(entry.providerKey);
       if (!set) {
-        set = new Set(hiddenByProvider.get(entry.providerKind) ?? []);
-        byProvider.set(entry.providerKind, set);
+        set = new Set(hiddenByProvider.get(entry.providerKey) ?? []);
+        byProvider.set(entry.providerKey, set);
       }
       if (hideAll) set.add(entry.modelId);
       else set.delete(entry.modelId);
     }
-    for (const [providerKind, set] of byProvider) {
-      setHiddenModels(providerKind, [...set]);
+    for (const [providerKey, set] of byProvider) {
+      setHiddenModels(providerKey, [...set]);
     }
   }
 
   function setAllHidden(hideAll: boolean) {
     const byProvider = new Map<string, Set<string>>();
-    for (const provider of providers) byProvider.set(provider.kind, new Set());
+    for (const provider of providers) byProvider.set(providerVisibilityKey(provider), new Set());
     if (hideAll) {
       for (const model of allModels) {
-        byProvider.get(model.providerKind)?.add(model.modelId);
+        byProvider.get(model.providerKey)?.add(model.modelId);
       }
     }
-    for (const [providerKind, set] of byProvider) {
-      setHiddenModels(providerKind, [...set]);
+    for (const [providerKey, set] of byProvider) {
+      setHiddenModels(providerKey, [...set]);
     }
   }
 
@@ -331,7 +367,7 @@ export function ModelVisibilitySection() {
                     }
                     const isVisible =
                       item.type === "model"
-                        ? !(hiddenByProvider.get(item.providerKind)?.has(item.modelId) ?? false)
+                        ? !(hiddenByProvider.get(item.hiddenModelsKey)?.has(item.modelId) ?? false)
                         : false;
                     const headerId =
                       item.type === "header-provider" || item.type === "header-sub"

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -49,6 +49,13 @@ import {
 } from "@/renderer/utils/acpRegistryAuth";
 import { Input, PixelLoader, Select } from "@/renderer/components/common";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
+import {
+  modelVisibilityKey,
+  providerLabelForPresentation,
+  providerMenuKey,
+  providerVisibilityKey,
+} from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
+import { capabilitiesForPresentation } from "@/renderer/components/thread/threadComposerOptions";
 import { SettingsPage } from "./SettingsForm";
 import {
   buildProviderModelItems,
@@ -59,6 +66,29 @@ import {
 import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
 
 const SAVED_SECRET_MASK = "***********";
+
+function settingsModelVisibilityProviders(agent: AgentStatus): ProviderModelMenuProvider[] {
+  if (agent.kind !== "cursor") return [statusToMenuProvider(agent)];
+
+  const supported = agent.capabilities.presentationModes ?? [agent.capabilities.presentationMode];
+  return supported
+    .map((presentationMode): ProviderModelMenuProvider => {
+      const provider: ProviderModelMenuProvider = {
+        kind: agent.kind,
+        label: agent.label,
+        presentationMode,
+        ...(agent.icon ? { icon: agent.icon } : {}),
+        modelPickerKey: providerMenuKey({ kind: agent.kind, presentationMode }),
+        hiddenModelsKey: modelVisibilityKey(agent.kind, presentationMode),
+        capabilities: capabilitiesForPresentation(agent.capabilities, presentationMode),
+      };
+      return {
+        ...provider,
+        label: providerLabelForPresentation(provider),
+      };
+    })
+    .filter((provider) => provider.capabilities.models.some((model) => model.id !== "auto"));
+}
 
 function AgentSettingRow(props: { agentKind: string; def: AgentSettingDef }) {
   const { agentKind, def } = props;
@@ -107,11 +137,11 @@ function AgentSettingRow(props: { agentKind: string; def: AgentSettingDef }) {
 }
 
 function ModelVisibilityDropdown(props: {
-  agentKind: string;
+  settingsKey: string;
   provider: ProviderModelMenuProvider;
 }) {
-  const { agentKind, provider } = props;
-  const hiddenIds = useSharedSettings((s) => s.hiddenModels[agentKind]);
+  const { settingsKey, provider } = props;
+  const hiddenIds = useSharedSettings((s) => s.hiddenModels[settingsKey]);
   const setHiddenModels = useSharedSettings((s) => s.setHiddenModels);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -159,7 +189,7 @@ function ModelVisibilityDropdown(props: {
     const next = new Set(hiddenSet);
     if (next.has(modelId)) next.delete(modelId);
     else next.add(modelId);
-    setHiddenModels(agentKind, [...next]);
+    setHiddenModels(settingsKey, [...next]);
   }
 
   function toggleSubGroup(headerId: string) {
@@ -173,17 +203,19 @@ function ModelVisibilityDropdown(props: {
       if (nextHidden) next.add(id);
       else next.delete(id);
     }
-    setHiddenModels(agentKind, [...next]);
+    setHiddenModels(settingsKey, [...next]);
   }
 
   function setAllHidden(hideAll: boolean) {
-    setHiddenModels(agentKind, hideAll ? allModels.map((m) => m.id) : []);
+    setHiddenModels(settingsKey, hideAll ? allModels.map((m) => m.id) : []);
   }
 
   return (
     <div className="flex items-center justify-between gap-4 py-2 border-b border-border/10 last:border-0 group">
       <div className="flex flex-col min-w-0 flex-1">
-        <p className="text-sm font-medium text-foreground">Visible models</p>
+        <p className="text-sm font-medium text-foreground">
+          {provider.kind === "cursor" ? `Visible ${provider.label} models` : "Visible models"}
+        </p>
         <p className="text-[11px] text-muted line-clamp-1 group-hover:line-clamp-none transition-all">
           Toggle models off to hide them from the selector.
         </p>
@@ -974,8 +1006,8 @@ export function SingleAgentSettings(props: { agentKind: string }) {
   const defs = (agent.capabilities.settingDefs ?? []).filter(
     (def) => !def.platforms || def.platforms.includes(platform),
   );
-  const hasSelectableModels = agent.capabilities.models.some((m) => m.id !== "auto");
-  const menuProvider = statusToMenuProvider(agent);
+  const modelVisibilityProviders = settingsModelVisibilityProviders(agent);
+  const hasSelectableModels = modelVisibilityProviders.length > 0;
 
   const versionRows: { label: string; status: AgentStatus }[] = [];
   if (platform === "win32") {
@@ -1636,7 +1668,13 @@ export function SingleAgentSettings(props: { agentKind: string }) {
 
         {hasSelectableModels && (
           <div className="mt-6">
-            <ModelVisibilityDropdown agentKind={agent.kind} provider={menuProvider} />
+            {modelVisibilityProviders.map((provider) => (
+              <ModelVisibilityDropdown
+                key={providerMenuKey(provider)}
+                settingsKey={providerVisibilityKey(provider)}
+                provider={provider}
+              />
+            ))}
           </div>
         )}
       </div>

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -50,45 +50,19 @@ import {
 import { Input, PixelLoader, Select } from "@/renderer/components/common";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
 import {
-  modelVisibilityKey,
-  providerLabelForPresentation,
   providerMenuKey,
   providerVisibilityKey,
 } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
-import { capabilitiesForPresentation } from "@/renderer/components/thread/threadComposerOptions";
+import { expandAgentToVisibilityProviders } from "@/renderer/components/thread/buildModelPickerControls";
 import { SettingsPage } from "./SettingsForm";
 import {
   buildProviderModelItems,
-  statusToMenuProvider,
   type ProviderModelItem,
   type ProviderModelMenuProvider,
 } from "@/renderer/components/common/ProviderModelMenu";
 import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
 
 const SAVED_SECRET_MASK = "***********";
-
-function settingsModelVisibilityProviders(agent: AgentStatus): ProviderModelMenuProvider[] {
-  if (agent.kind !== "cursor") return [statusToMenuProvider(agent)];
-
-  const supported = agent.capabilities.presentationModes ?? [agent.capabilities.presentationMode];
-  return supported
-    .map((presentationMode): ProviderModelMenuProvider => {
-      const provider: ProviderModelMenuProvider = {
-        kind: agent.kind,
-        label: agent.label,
-        presentationMode,
-        ...(agent.icon ? { icon: agent.icon } : {}),
-        modelPickerKey: providerMenuKey({ kind: agent.kind, presentationMode }),
-        hiddenModelsKey: modelVisibilityKey(agent.kind, presentationMode),
-        capabilities: capabilitiesForPresentation(agent.capabilities, presentationMode),
-      };
-      return {
-        ...provider,
-        label: providerLabelForPresentation(provider),
-      };
-    })
-    .filter((provider) => provider.capabilities.models.some((model) => model.id !== "auto"));
-}
 
 function AgentSettingRow(props: { agentKind: string; def: AgentSettingDef }) {
   const { agentKind, def } = props;
@@ -1006,7 +980,7 @@ export function SingleAgentSettings(props: { agentKind: string }) {
   const defs = (agent.capabilities.settingDefs ?? []).filter(
     (def) => !def.platforms || def.platforms.includes(platform),
   );
-  const modelVisibilityProviders = settingsModelVisibilityProviders(agent);
+  const modelVisibilityProviders = expandAgentToVisibilityProviders(agent);
   const hasSelectableModels = modelVisibilityProviders.length > 0;
 
   const versionRows: { label: string; status: AgentStatus }[] = [];


### PR DESCRIPTION
- Bugfix/refactor: scope hidden-model settings and provider-menu identity to each presentation mode, so Cursor CLI and Cursor ACP stay on separate visibility buckets.
- Update composer, draft, and continue-in-provider flows to read the correct hidden-model bucket for the active surface.
- Refresh provider menu selection, favorites, recents, and shortcut labeling so the right surface is handled consistently.
- Expand menu and settings tests to cover distinct terminal and GUI Cursor sections.