### PR TITLE
Close optimistic GUI turns on turn completion

### DIFF
--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -727,7 +727,7 @@ describe("appStore runtime config sync", () => {
     expect(useAppStore.getState().threads[0]?.lastTurnEndedAt).toBe("2026-05-01T12:00:30.000Z");
   });
 
-  it("keeps GUI startup idle blips from closing the active turn before assistant output", () => {
+  it("closes visible GUI idle updates even before assistant output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
     const project = useAppStore.getState().addProject({
@@ -767,20 +767,19 @@ describe("appStore runtime config sync", () => {
     });
 
     expect(useAppStore.getState().threads[0]).toMatchObject({
-      status: "working",
-      attention: "working",
-      activeTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      status: "idle",
+      attention: "none",
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:00:01.000Z",
     });
-    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]).toBeUndefined();
-
-    vi.setSystemTime(new Date("2026-05-01T12:00:05.000Z"));
-    useAppStore.getState().updateThreadRuntime(thread.id, {
-      status: "working",
-      attention: "working",
-      canResumeWithConfig: true,
-    });
-
-    expect(useAppStore.getState().threads[0]?.activeTurnStartedAt).toBe("2026-05-01T12:00:00.000Z");
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]).toEqual([
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:00:01.000Z").getTime(),
+        anchorItemId: null,
+      },
+    ]);
   });
 
   it("closes an offscreen GUI thread when the transcript has not been hydrated", () => {

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -388,18 +388,6 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         ) {
           effectiveStatus = "finished";
         }
-        if (
-          input.status === "idle" &&
-          thread.presentationMode === "gui" &&
-          isThreadLiveStatus(thread.status) &&
-          input.forceCloseActiveTurn !== true &&
-          (isVisible ||
-            Object.prototype.hasOwnProperty.call(state.runtimeItemIdsByThread, thread.id)) &&
-          resolveCompletedTurnAnchorItemId(state, thread.id) === null
-        ) {
-          effectiveStatus = thread.status;
-          effectiveAttention = thread.attention;
-        }
 
         const sessionRefChanged =
           input.sessionRef !== undefined &&

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -23,6 +23,7 @@ import {
   type StartTurnOptions,
   type StructuredSessionHandle,
   type StructuredSessionListener,
+  type StructuredSessionUpdate,
   type ThreadHistory,
 } from "../base";
 import { buildCodexAppServerCommand } from "./argv";
@@ -71,6 +72,27 @@ function sleep(ms: number): Promise<void> {
 // an error message; the error status icon updates synchronously.
 const CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS = 250;
 const CODEX_RESUME_STATUS_REPLAY_SUPPRESSION_MS = 500;
+const CODEX_EVENT_DEBUG_ENV = "LIGHTCODE_DEBUG_CODEX_EVENTS";
+
+type CodexEventDebugDirection =
+  | "codex->lightcode"
+  | "lightcode->codex"
+  | "lightcode:update"
+  | "lightcode:runtime"
+  | "transport";
+
+function isCodexEventDebugEnabled(): boolean {
+  const value = process.env[CODEX_EVENT_DEBUG_ENV];
+  return value === "1" || value === "true" || value === "all";
+}
+
+function stringifyCodexEventDebugPayload(payload: unknown): string {
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    return String(payload);
+  }
+}
 
 function spawnAppServer(command: CommandSpec): ChildProcess {
   return spawn(command.command, command.args, {
@@ -241,6 +263,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       forwarded.push(event);
     }
     if (forwarded.length === 0) return;
+    for (const event of forwarded) {
+      this.logCodexEventDebug("lightcode:runtime", event);
+    }
     if (!this.listener?.onRuntimeEvent) {
       this.bufferedRuntimeEvents.push(...forwarded);
       return;
@@ -351,7 +376,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       return;
     }
     this.currentSlashCommands = commands;
-    this.listener?.onUpdate({
+    this.emitUpdate({
       ...deriveCodexStructuredState(this.currentThreadStatus),
       ...(this.remoteThreadId ? { sessionRef: toSessionRef(this.remoteThreadId) } : {}),
       slashCommands: commands,
@@ -407,11 +432,13 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       }
     }
 
-    // Re-emit current state so the listener doesn't miss updates that
-    // fired before the listener was attached.
-    if (this.activated && this.remoteThreadId) {
+    // Re-emit meaningful state so the listener doesn't miss updates that fired
+    // before attachment. Plain `idle` from thread creation is already the
+    // runtime default and should not participate in live turn status.
+    const shouldReplayStatus = this.currentThreadStatus.type !== "idle";
+    if (this.activated && this.remoteThreadId && shouldReplayStatus) {
       const sessionRef = toSessionRef(this.remoteThreadId);
-      listener.onUpdate({
+      this.emitUpdate({
         ...deriveCodexStructuredState(this.currentThreadStatus),
         sessionRef,
         ...(this.currentSlashCommands !== undefined
@@ -419,7 +446,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           : {}),
       });
     } else if (this.currentSlashCommands !== undefined) {
-      listener.onUpdate({
+      this.emitUpdate({
         ...deriveCodexStructuredState(this.currentThreadStatus),
         slashCommands: this.currentSlashCommands,
       });
@@ -620,19 +647,20 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           { type: "error", threadId: this.threadId, message },
           { type: "turn.completed", threadId: this.threadId, turnId, state: "completed" },
         ]);
-        this.listener?.onUpdate({ status: "idle", attention: "none" });
+        this.emitUpdate({ status: "idle", attention: "none" });
         return;
       }
       this.emitRuntimeEvents([
         { type: "turn.completed", threadId: this.threadId, turnId, state: "completed" },
       ]);
-      this.listener?.onUpdate({ status: "idle", attention: "none" });
+      this.emitUpdate({ status: "idle", attention: "none" });
       return;
     }
 
     this.emitRuntimeEvents(userEvents);
 
-    this.listener?.onUpdate({ status: "working", attention: "working" });
+    this.currentThreadStatus = { type: "active", activeFlags: [] };
+    this.emitUpdate({ status: "working", attention: "working" });
 
     const input = buildCodexTurnInput(prompt, segments);
     const sandboxPolicy = toCodexSandboxPolicy(config.sandboxMode);
@@ -663,7 +691,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       if (this.isDisposed) return;
       const message = error instanceof Error ? error.message : String(error);
       this.errorSticky = true;
-      this.listener?.onUpdate({ status: "error", attention: "error", errorMessage: message });
+      this.emitUpdate({ status: "error", attention: "error", errorMessage: message });
       this.emitRuntimeEvents([{ type: "error", threadId: this.threadId, message }]);
       throw error;
     }
@@ -710,7 +738,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     const result = inbound
       ? translateCodexCanonicalResponse(inbound.method, inbound.params, response)
       : response;
-    this.transport.write({
+    this.writeToCodex({
       jsonrpc: "2.0",
       id: inbound?.id ?? requestId,
       result,
@@ -745,6 +773,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   private attachTransportHandlers(): void {
     this.transport.setListener({
       onMessage: (payload) => {
+        this.logCodexEventDebug("codex->lightcode", payload);
         const message = parseCodexSocketMessage(payload);
 
         if (message.kind === "response") {
@@ -787,7 +816,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
             console.warn(
               `[codex] no canonical mapping for app-server request method "${message.method}"; replying method not found.`,
             );
-            this.transport.write({
+            this.writeToCodex({
               jsonrpc: "2.0",
               id: message.id,
               error: {
@@ -835,17 +864,12 @@ export class CodexStructuredSession implements StructuredSessionHandle {
               ? (thread.status as CodexThreadStatus)
               : { type: "idle" };
           if (this.shouldSuppressResumeActiveStatus(threadId, nextStatus)) {
-            this.listener?.onUpdate({
-              status: "idle",
-              attention: "none",
-              sessionRef: nextSessionRef,
-            });
-            void this.syncRemoteThreadState(threadId, nextSessionRef);
             return;
           }
           this.currentThreadStatus = nextStatus;
-          this.emitDerivedUpdate(nextSessionRef);
-          void this.syncRemoteThreadState(threadId, nextSessionRef);
+          if (nextStatus.type !== "idle") {
+            this.emitDerivedUpdate(nextSessionRef);
+          }
           return;
         }
 
@@ -899,7 +923,8 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           this.activeTurnId =
             extractTurnField(params, "id") ??
             (typeof params.turnId === "string" ? params.turnId : this.activeTurnId);
-          this.listener?.onUpdate({
+          this.currentThreadStatus = { type: "active", activeFlags: [] };
+          this.emitUpdate({
             status: "working",
             attention: "working",
           });
@@ -919,7 +944,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
           this.pendingTurnInterrupt = false;
           this.activeTurnId = undefined;
-          void this.syncRemoteThreadState(incomingThreadId);
+          this.currentThreadStatus = { type: "idle" };
+          if (!this.errorSticky) {
+            this.emitUpdate({ status: "idle", attention: "none" });
+          }
           return;
         }
 
@@ -932,6 +960,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         }
       },
       onClose: () => {
+        this.logCodexEventDebug("transport", {
+          event: "close",
+          output: this.transport.formatOutput(),
+        });
         this.rejectPendingRequests(
           new Error(`Codex app-server exited.${this.transport.formatOutput()}`),
         );
@@ -940,6 +972,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         }
       },
       onError: (error) => {
+        this.logCodexEventDebug("transport", {
+          event: "error",
+          message: error.message,
+        });
         this.rejectPendingRequests(error);
         if (!this.isDisposed) {
           this.listener?.onError("Codex app-server connection failed.");
@@ -971,7 +1007,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       this.updateSlashCommands(commands);
     }
 
-    this.transport.write({
+    this.writeToCodex({
       jsonrpc: "2.0",
       method: "initialized",
     });
@@ -997,12 +1033,12 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       // Preserve error status until the user starts a new turn. Still forward
       // sessionRef updates if present so resume metadata is not lost.
       if (sessionRef) {
-        this.listener?.onUpdate({ status: "error", attention: "error", sessionRef });
+        this.emitUpdate({ status: "error", attention: "error", sessionRef });
       }
       return;
     }
     const next = deriveCodexStructuredState(this.currentThreadStatus);
-    this.listener?.onUpdate({
+    this.emitUpdate({
       status: next.status,
       attention: next.attention,
       ...(sessionRef ? { sessionRef } : {}),
@@ -1058,7 +1094,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       });
     });
 
-    this.transport.write({
+    this.writeToCodex({
       jsonrpc: "2.0",
       id,
       method,
@@ -1066,6 +1102,26 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     });
 
     return pending;
+  }
+
+  private emitUpdate(update: StructuredSessionUpdate): void {
+    this.logCodexEventDebug("lightcode:update", update);
+    this.listener?.onUpdate(update);
+  }
+
+  private writeToCodex(message: Record<string, unknown>): void {
+    this.logCodexEventDebug("lightcode->codex", message);
+    this.transport.write(message);
+  }
+
+  private logCodexEventDebug(direction: CodexEventDebugDirection, payload: unknown): void {
+    if (!isCodexEventDebugEnabled()) {
+      return;
+    }
+    const remote = this.remoteThreadId ? ` remoteThreadId=${this.remoteThreadId}` : "";
+    console.log(
+      `[codex-events] ${new Date().toISOString()} ${direction} localThreadId=${this.threadId}${remote} ${stringifyCodexEventDebugPayload(payload)}`,
+    );
   }
 
   private rejectPendingRequests(error: Error): void {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -672,13 +672,7 @@ describe("CodexStructuredSession", () => {
       onRuntimeEvent: (event) => runtimeEvents.push(event),
     });
 
-    expect(updates).toEqual([
-      expect.objectContaining({
-        status: "idle",
-        attention: "none",
-        sessionRef: expect.objectContaining({ providerSessionId: "provider-thread" }),
-      }),
-    ]);
+    expect(updates).toEqual([]);
 
     onMessage?.({
       jsonrpc: "2.0",
@@ -732,6 +726,163 @@ describe("CodexStructuredSession", () => {
         attention: "working",
       }),
     );
+  });
+
+  it("keeps live status on lifecycle notifications instead of startup thread/read", async () => {
+    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const updates: StructuredSessionUpdate[] = [];
+    const runtimeEvents: RuntimeEvent[] = [];
+    const requests: CodexRequestRecord[] = [];
+    let onMessage: ((message: unknown) => void) | undefined;
+    let resolveTurnStart: (value: unknown) => void = () => {};
+    const turnStart = new Promise<unknown>((resolve) => {
+      resolveTurnStart = resolve;
+    });
+
+    session["threadId"] = "local-thread";
+    session["remoteThreadId"] = "provider-thread";
+    session["isDisposed"] = false;
+    session["currentThreadStatus"] = { type: "idle" };
+    session["seenErrorMessages"] = new Set<string>();
+    session["bufferedRuntimeEvents"] = [];
+    session["pendingRequests"] = new Map();
+    session["inboundRequests"] = new Map();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
+    session["rejectPendingRequests"] = () => {};
+    session["request"] = async (
+      method: string,
+      params: Record<string, unknown>,
+      timeoutMs?: number,
+    ) => {
+      requests.push({
+        method,
+        params,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      });
+      if (method === "turn/start") {
+        return turnStart;
+      }
+      return {};
+    };
+    session["transport"] = {
+      setListener: (next: { onMessage: (message: unknown) => void }) => {
+        onMessage = next.onMessage;
+      },
+      write: () => {},
+      formatOutput: () => "",
+    };
+
+    (session["attachTransportHandlers"] as () => void).call(session);
+    (session as unknown as CodexStructuredSession).setListener({
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (update) => updates.push(update),
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+    });
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "thread/started",
+      params: {
+        thread: {
+          id: "provider-thread",
+          status: { type: "idle" },
+        },
+      },
+    });
+
+    expect(updates).toEqual([]);
+    expect(requests).toEqual([]);
+
+    const initialTurn = (session as unknown as CodexStructuredSession).startTurn("hi", {
+      model: "gpt-5.4",
+    });
+    await Promise.resolve();
+
+    expect(updates.at(-1)).toEqual({ status: "working", attention: "working" });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+
+    resolveTurnStart({ turn: { id: "turn-1", status: "inProgress" } });
+    await initialTurn;
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "provider-thread",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(runtimeEvents).toContainEqual({
+      type: "turn.completed",
+      threadId: "local-thread",
+      turnId: "turn-1",
+      state: "completed",
+    });
+    expect(updates.at(-1)).toEqual({ status: "idle", attention: "none" });
+  });
+
+  it("emits completion idle even when a status idle already arrived", () => {
+    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const updates: StructuredSessionUpdate[] = [];
+    const runtimeEvents: RuntimeEvent[] = [];
+    let onMessage: ((message: unknown) => void) | undefined;
+
+    session["threadId"] = "local-thread";
+    session["remoteThreadId"] = "provider-thread";
+    session["isDisposed"] = false;
+    session["currentThreadStatus"] = { type: "active", activeFlags: [] };
+    session["seenErrorMessages"] = new Set<string>();
+    session["bufferedRuntimeEvents"] = [];
+    session["pendingRequests"] = new Map();
+    session["inboundRequests"] = new Map();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
+    session["rejectPendingRequests"] = () => {};
+    session["request"] = async () => ({});
+    session["listener"] = {
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (update: StructuredSessionUpdate) => updates.push(update),
+      onRuntimeEvent: (event: RuntimeEvent) => runtimeEvents.push(event),
+    };
+    session["transport"] = {
+      setListener: (next: { onMessage: (message: unknown) => void }) => {
+        onMessage = next.onMessage;
+      },
+      write: () => {},
+      formatOutput: () => "",
+    };
+
+    (session["attachTransportHandlers"] as () => void).call(session);
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "thread/status/changed",
+      params: { threadId: "provider-thread", status: { type: "idle" } },
+    });
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: {
+        threadId: "provider-thread",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    expect(runtimeEvents).toContainEqual({
+      type: "turn.completed",
+      threadId: "local-thread",
+      turnId: "turn-1",
+      state: "completed",
+    });
+    expect(updates).toEqual([
+      { status: "idle", attention: "none" },
+      { status: "idle", attention: "none" },
+    ]);
   });
 
   it("collapses a single usage-limit failure into one error event", () => {

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -1552,6 +1552,118 @@ describe("SupervisorRuntime thread input", () => {
     });
   });
 
+  it("lets canonical turn completion close an optimistic GUI launch turn without assistant items", async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    const runtime = makeRuntime((event) => {
+      emitted.push(event as Record<string, unknown>);
+    });
+    let runtimeListener:
+      | {
+          onUpdate(update: Record<string, unknown>): void;
+          onRuntimeEvent(event: RuntimeEvent): void;
+        }
+      | undefined;
+    const startTurn = vi.fn<() => Promise<void>>(async () => {
+      runtimeListener?.onRuntimeEvent({
+        type: "turn.completed",
+        threadId: "thread-gui-complete-only",
+        turnId: "turn-1",
+        state: "completed",
+      });
+      runtimeListener?.onUpdate({ status: "idle", attention: "none" });
+    });
+    const setListener = vi.fn<
+      (listener: {
+        onUpdate(update: Record<string, unknown>): void;
+        onRuntimeEvent(event: RuntimeEvent): void;
+      }) => void
+    >((listener) => {
+      runtimeListener = listener;
+      listener.onUpdate({
+        status: "idle",
+        attention: "none",
+        sessionRef: {
+          providerSessionId: "session-1",
+          discoveredAt: "2026-05-10T12:00:00.000Z",
+        },
+      });
+    });
+
+    const adapter = {
+      kind: "generic-gui" as const,
+      label: "Generic GUI Provider",
+      capabilities: {
+        models: [{ id: "gpt-5.4", label: "5.4" }],
+        efforts: ["high"],
+        modelEfforts: {},
+        modes: ["agent"],
+        approvalPolicies: [{ id: "on-request", label: "On Request" }],
+        sandboxModes: [{ id: "workspace-write", label: "Workspace Write" }],
+        supportsResume: true,
+        supportsDirectInput: true,
+        liveInputMode: "terminal" as const,
+        presentationMode: "terminal" as const,
+        presentationModes: ["terminal", "gui"] as const,
+      },
+      detectInstall: vi.fn<() => void>(),
+      buildLaunchArgv: vi.fn<() => { binary: string; args: string[] }>(() => ({
+        binary: "generic-gui",
+        args: ["should-not-spawn"],
+      })),
+      buildResumeArgv: vi.fn<() => void>(),
+      createInitialSessionRef: vi
+        .fn<() => { providerSessionId: string; discoveredAt: string } | undefined>()
+        .mockReturnValue(undefined),
+      createStructuredSession: vi.fn<() => Promise<Record<string, unknown>>>().mockResolvedValue({
+        launchOptions: { suppressResumeConfigOverrides: true, resumeThreadId: "session-1" },
+        activate: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+        openThread: vi.fn<() => Promise<string>>().mockResolvedValue("session-1"),
+        startTurn,
+        setListener,
+        dispose: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      }),
+    };
+
+    (runtime as unknown as { adapters: Map<string, typeof adapter> }).adapters.set(
+      "generic-gui",
+      adapter,
+    );
+
+    await runtime.startThread({
+      threadId: "thread-gui-complete-only",
+      projectLocation: {
+        kind: "windows",
+        path: "C:\\repo",
+      },
+      agentKind: "generic-gui",
+      config: {
+        model: "gpt-5.4",
+      },
+      prompt: "hi",
+      presentationMode: "gui",
+      initialSize: {
+        cols: 132,
+        rows: 42,
+      },
+    });
+    await Promise.resolve();
+
+    const threadStates = emitted.filter(
+      (event) => event.type === "thread-state" && event.threadId === "thread-gui-complete-only",
+    );
+    expect(threadStates[0]).toMatchObject({
+      status: "working",
+      attention: "working",
+    });
+    expect(threadStates.at(-1)).toMatchObject({
+      status: "idle",
+      attention: "none",
+      sessionRef: {
+        providerSessionId: "session-1",
+      },
+    });
+  });
+
   it("lets a quick stop close an optimistic GUI launch turn before provider output", async () => {
     const emitted: Array<Record<string, unknown>> = [];
     const runtime = makeRuntime((event) => {

--- a/src/supervisor/runtime/threadSession/helpers.ts
+++ b/src/supervisor/runtime/threadSession/helpers.ts
@@ -15,11 +15,15 @@ export function hookDebugProjectLabel(loc: ProjectLocation): string {
 
 /**
  * Startup idle suppression is only for empty sync blips; visible runtime output
- * means a follow-up idle should close the optimistic working window.
+ * or turn completion means a follow-up idle should close the optimistic working
+ * window.
  */
 export function shouldReleaseInitialStructuredIdleSuppression(event: RuntimeEvent): boolean {
   if (event.type === "item.started") {
     return event.itemType !== "user_message";
+  }
+  if (event.type === "turn.completed") {
+    return true;
   }
   return (
     event.type === "content.delta" || event.type === "request.opened" || event.type === "error"


### PR DESCRIPTION
Tickets: none
- Bugfix: stop visible GUI startup idle updates from keeping an optimistic turn open after launch.
- Treat canonical `turn.completed` events as the release signal for initial structured idle suppression, even when no assistant items were emitted.
- Tighten Codex structured-session replay so plain startup `idle` stays inert while real lifecycle notifications still carry live status.
- Update renderer store and supervisor tests to lock in the new GUI completion and session replay behavior.