### PR TITLE
Forward Antigravity model selection to agy CLI

### DIFF
--- a/src/renderer/components/thread/AgentDiscoveryScreen.tsx
+++ b/src/renderer/components/thread/AgentDiscoveryScreen.tsx
@@ -136,8 +136,8 @@ export function AgentDiscoveryScreen(props: {
   } as CSSProperties;
 
   return (
-    <div className="agent-discovery-screen flex h-full flex-col items-center justify-center gap-8 px-6 text-center">
-      <div className="flex flex-col items-center gap-3">
+    <div className="agent-discovery-screen flex h-full min-h-0 flex-col items-center gap-6 overflow-y-auto px-6 py-6 text-center">
+      <div className="flex shrink-0 flex-col items-center gap-3">
         <PixelLoader size="lg" className="text-foreground" />
         <h1 className="text-xl font-semibold tracking-tight">Discovering coding agents…</h1>
         <p className="max-w-sm text-sm text-muted">
@@ -161,9 +161,9 @@ export function AgentDiscoveryScreen(props: {
         ) : null}
       </div>
 
-      <div className="w-full max-w-[42rem] overflow-hidden rounded border border-border/60 bg-background/25 text-left">
+      <div className="flex w-full min-h-0 max-w-[42rem] flex-col overflow-hidden rounded border border-border/60 bg-background/25 text-left">
         <div
-          className="grid grid-cols-[minmax(11rem,1fr)_repeat(var(--agent-target-count),minmax(7rem,8rem))] border-b border-border/60 px-3 py-2 text-[0.6875rem] font-medium uppercase text-muted/70"
+          className="grid shrink-0 grid-cols-[minmax(11rem,1fr)_repeat(var(--agent-target-count),minmax(7rem,8rem))] border-b border-border/60 px-3 py-2 text-[0.6875rem] font-medium uppercase text-muted/70"
           style={matrixGridStyle}
         >
           <div>Provider</div>
@@ -173,7 +173,7 @@ export function AgentDiscoveryScreen(props: {
             </div>
           ))}
         </div>
-        <div>
+        <div className="min-h-0 overflow-y-auto [scrollbar-gutter:stable]">
           {providers.map(({ kind, label }) => {
             const statuses = statusesByKind.get(kind) ?? [];
             return (
@@ -204,17 +204,19 @@ export function AgentDiscoveryScreen(props: {
         </div>
       </div>
 
-      <div className="text-xs text-muted/70" aria-live="polite">
+      <div className="shrink-0 text-xs text-muted/70" aria-live="polite">
         {useMatrixLayout
           ? combinedStatusLine(discovered)
           : statusLine(discovered.length, installedCount, wslDistro)}
       </div>
 
       {props.onCancel ? (
-        <Button size="sm" variant="tertiary" onPress={props.onCancel}>
-          <X className="size-3.5" />
-          Cancel
-        </Button>
+        <div className="shrink-0">
+          <Button size="sm" variant="tertiary" onPress={props.onCancel}>
+            <X className="size-3.5" />
+            Cancel
+          </Button>
+        </div>
       ) : null}
     </div>
   );

--- a/src/supervisor/agents/antigravity/antigravity.test.ts
+++ b/src/supervisor/agents/antigravity/antigravity.test.ts
@@ -2,33 +2,67 @@ import { describe, expect, it } from "vitest";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import { createAntigravityAdapter } from ".";
 import { buildAntigravityArgs } from "./argv";
-import { ANTIGRAVITY_MANAGED_MODEL_ID } from "./detection";
+import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "./detection";
+import {
+  ANTIGRAVITY_KNOWN_MODEL_VARIANTS,
+  buildAntigravityModelCapabilities,
+  parseAntigravityModelVariantsOutput,
+  parseAntigravityModelsOutput,
+} from "./models";
 import { detectAntigravityInvalidSessionRef } from "./session";
 import { detectAntigravityTerminalStatus } from "./terminal";
 
 describe("buildAntigravityArgs", () => {
-  const config: ThreadConfig = { model: ANTIGRAVITY_MANAGED_MODEL_ID };
+  const config: ThreadConfig = { model: ANTIGRAVITY_DEFAULT_MODEL_ID };
 
-  it("uses agy prompt-interactive for initial prompts without forwarding a model", () => {
-    const args = buildAntigravityArgs({ ...config, effort: "high" }, "hello");
+  it("uses Gemini 3.5 Flash Medium by default", () => {
+    const args = buildAntigravityArgs(config, "hello");
 
-    expect(args).toEqual(["--prompt-interactive", "hello"]);
-    expect(args).not.toContain("--model");
-    expect(args).not.toContain(ANTIGRAVITY_MANAGED_MODEL_ID);
-    expect(args).not.toContain("high");
+    expect(args).toEqual(["--model", "Gemini 3.5 Flash (Medium)", "--prompt-interactive", "hello"]);
+  });
+
+  it("composes selected efforts into exact agy model strings", () => {
+    expect(
+      buildAntigravityArgs({ model: ANTIGRAVITY_DEFAULT_MODEL_ID, effort: "High" }, "hello"),
+    ).toEqual(["--model", "Gemini 3.5 Flash (High)", "--prompt-interactive", "hello"]);
+  });
+
+  it("maps legacy auto configs to Gemini 3.5 Flash Medium", () => {
+    expect(buildAntigravityArgs({ model: "auto" }, "hello")).toEqual([
+      "--model",
+      "Gemini 3.5 Flash (Medium)",
+      "--prompt-interactive",
+      "hello",
+    ]);
+  });
+
+  it("passes exact agy model display strings", () => {
+    expect(buildAntigravityArgs({ model: "Gemini 3.5 Flash (Low)" }, "hello")).toEqual([
+      "--model",
+      "Gemini 3.5 Flash (Low)",
+      "--prompt-interactive",
+      "hello",
+    ]);
   });
 
   it("uses --conversation when resuming a known conversation", () => {
     expect(buildAntigravityArgs(config, "", "conversation-id")).toEqual([
       "--conversation",
       "conversation-id",
+      "--model",
+      "Gemini 3.5 Flash (Medium)",
     ]);
   });
 
   it("maps Lightcode bypass and sandbox config to agy flags", () => {
     expect(
       buildAntigravityArgs({ ...config, approvalPolicy: "yolo", sandboxMode: "sandbox" }, ""),
-    ).toEqual(["--dangerously-skip-permissions", "--sandbox"]);
+    ).toEqual([
+      "--model",
+      "Gemini 3.5 Flash (Medium)",
+      "--dangerously-skip-permissions",
+      "--sandbox",
+    ]);
   });
 });
 
@@ -50,26 +84,34 @@ describe("createAntigravityAdapter", () => {
       ],
     });
     expect(adapter.capabilities.models).toEqual([
-      {
-        id: ANTIGRAVITY_MANAGED_MODEL_ID,
-        label: "Auto",
-        description: "Model selected by agy from the signed-in account",
-      },
+      { id: "Gemini 3.5 Flash", label: "Gemini 3.5 Flash", description: "Google DeepMind" },
+      { id: "Gemini 3.1 Pro", label: "Gemini 3.1 Pro", description: "Google DeepMind" },
+      { id: "Claude Sonnet 4.6", label: "Claude Sonnet 4.6", description: "Anthropic" },
+      { id: "Claude Opus 4.6", label: "Claude Opus 4.6", description: "Anthropic" },
+      { id: "GPT-OSS 120B", label: "GPT-OSS 120B", description: "OpenAI" },
     ]);
+    expect(adapter.capabilities.defaultEffort).toBe("Medium");
+    expect(adapter.capabilities.modelEfforts).toEqual({
+      "Gemini 3.5 Flash": ["Low", "Medium", "High"],
+      "Gemini 3.1 Pro": ["Low", "High"],
+      "Claude Sonnet 4.6": ["Thinking"],
+      "Claude Opus 4.6": ["Thinking"],
+      "GPT-OSS 120B": ["Medium"],
+    });
     expect(adapter.capabilities.approvalPolicies.map((policy) => policy.id)).toEqual([
       "default",
       "yolo",
     ]);
-    expect(adapter.defaultOneShotModel).toBe(ANTIGRAVITY_MANAGED_MODEL_ID);
+    expect(adapter.defaultOneShotModel).toBe(ANTIGRAVITY_DEFAULT_MODEL_ID);
   });
 
   it("builds agy launch, resume, and one-shot commands", () => {
     const adapter = createAntigravityAdapter();
-    const config: ThreadConfig = { model: ANTIGRAVITY_MANAGED_MODEL_ID };
+    const config: ThreadConfig = { model: ANTIGRAVITY_DEFAULT_MODEL_ID };
 
     expect(adapter.buildLaunchArgv(project, config, "hi")).toMatchObject({
       binary: "agy",
-      args: ["--prompt-interactive", "hi"],
+      args: ["--model", "Gemini 3.5 Flash (Medium)", "--prompt-interactive", "hi"],
     });
     expect(
       adapter.buildResumeArgv(project, config, "next", {
@@ -78,13 +120,20 @@ describe("createAntigravityAdapter", () => {
       }),
     ).toMatchObject({
       binary: "agy",
-      args: ["--conversation", "conversation-id", "--prompt-interactive", "next"],
+      args: [
+        "--conversation",
+        "conversation-id",
+        "--model",
+        "Gemini 3.5 Flash (Medium)",
+        "--prompt-interactive",
+        "next",
+      ],
     });
     expect(
-      adapter.buildOneShotCommand?.(ANTIGRAVITY_MANAGED_MODEL_ID, undefined, "summarize"),
+      adapter.buildOneShotCommand?.(ANTIGRAVITY_DEFAULT_MODEL_ID, undefined, "summarize"),
     ).toEqual({
       command: "agy",
-      args: ["-p", "summarize"],
+      args: ["--model", "Gemini 3.5 Flash (Medium)", "-p", "summarize"],
       stdin: "",
       // Isolate the cwd so the one-shot's last_conversations.json[cwd] write
       // can't be mistaken for the real interactive session (see index.ts).
@@ -92,6 +141,75 @@ describe("createAntigravityAdapter", () => {
       // agy print mode emits its answer only when attached to a terminal.
       pty: true,
     });
+    expect(adapter.buildOneShotCommand?.("Gemini 3.5 Flash", "Low", "summarize")).toEqual({
+      command: "agy",
+      args: ["--model", "Gemini 3.5 Flash (Low)", "-p", "summarize"],
+      stdin: "",
+      isolateCwd: true,
+      pty: true,
+    });
+  });
+});
+
+describe("parseAntigravityModelsOutput", () => {
+  it("parses JSON model objects into variants", () => {
+    expect(
+      parseAntigravityModelVariantsOutput(
+        JSON.stringify({
+          models: [
+            {
+              id: "Gemini 3.5 Flash (Medium)",
+              label: "Gemini 3.5 Flash (Medium)",
+              provider: "Google",
+            },
+            { model: "Claude Sonnet 4.6 (Thinking)", displayName: "Claude Sonnet 4.6" },
+          ],
+        }),
+      ),
+    ).toEqual([
+      {
+        model: "Gemini 3.5 Flash",
+        effort: "Medium",
+        cliModel: "Gemini 3.5 Flash (Medium)",
+        provider: "Google",
+      },
+      { model: "Claude Sonnet 4.6", effort: "Thinking", cliModel: "Claude Sonnet 4.6 (Thinking)" },
+    ]);
+  });
+
+  it("parses agy 1.0.5 display-name model output into base models", () => {
+    const raw = ANTIGRAVITY_KNOWN_MODEL_VARIANTS.map((variant) => variant.cliModel).join("\n");
+
+    expect(parseAntigravityModelsOutput(raw)).toEqual([
+      { id: "Gemini 3.5 Flash", label: "Gemini 3.5 Flash" },
+      { id: "Gemini 3.1 Pro", label: "Gemini 3.1 Pro" },
+      { id: "Claude Sonnet 4.6", label: "Claude Sonnet 4.6" },
+      { id: "Claude Opus 4.6", label: "Claude Opus 4.6" },
+      { id: "GPT-OSS 120B", label: "GPT-OSS 120B" },
+    ]);
+
+    expect(
+      buildAntigravityModelCapabilities(parseAntigravityModelVariantsOutput(raw)).modelEfforts,
+    ).toEqual({
+      "Gemini 3.5 Flash": ["Low", "Medium", "High"],
+      "Gemini 3.1 Pro": ["Low", "High"],
+      "Claude Sonnet 4.6": ["Thinking"],
+      "Claude Opus 4.6": ["Thinking"],
+      "GPT-OSS 120B": ["Medium"],
+    });
+  });
+
+  it("parses table model output", () => {
+    expect(
+      parseAntigravityModelsOutput(
+        [
+          "Available models:",
+          "| id | label | provider |",
+          "| --- | --- | --- |",
+          "| Claude Opus 4.6 (Thinking) | Claude Opus 4.6 | Anthropic |",
+        ].join("\n"),
+      ),
+    ).toEqual([{ id: "Claude Opus 4.6", label: "Claude Opus 4.6", description: "Anthropic" }]);
   });
 });
 

--- a/src/supervisor/agents/antigravity/argv.ts
+++ b/src/supervisor/agents/antigravity/argv.ts
@@ -1,4 +1,18 @@
 import type { ThreadConfig } from "@/shared/contracts";
+import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "./detection";
+import { ANTIGRAVITY_KNOWN_MODEL_VARIANTS, splitModelEffort } from "./models";
+
+export function resolveAntigravityModel(model: string | undefined, effort?: string): string {
+  const normalizedModel = !model || model === "auto" ? ANTIGRAVITY_DEFAULT_MODEL_ID : model;
+  const persisted = splitModelEffort(normalizedModel);
+  const baseModel = persisted?.model ?? normalizedModel;
+  const selectedEffort = effort ?? persisted?.effort;
+  const variant = ANTIGRAVITY_KNOWN_MODEL_VARIANTS.find(
+    (item) => item.model === baseModel && (selectedEffort ? item.effort === selectedEffort : true),
+  );
+  if (variant) return variant.cliModel;
+  return selectedEffort ? `${baseModel} (${selectedEffort})` : baseModel;
+}
 
 export function buildAntigravityArgs(
   config: ThreadConfig,
@@ -10,6 +24,7 @@ export function buildAntigravityArgs(
   if (resumeConversationId) {
     args.push("--conversation", resumeConversationId);
   }
+  args.push("--model", resolveAntigravityModel(config.model, config.effort));
   if (config.approvalPolicy === "never" || config.approvalPolicy === "yolo") {
     args.push("--dangerously-skip-permissions");
   }

--- a/src/supervisor/agents/antigravity/detection.ts
+++ b/src/supervisor/agents/antigravity/detection.ts
@@ -1,22 +1,23 @@
 import type { AgentCapability } from "@/shared/contracts";
 import { type AuthProbe, type DetectionSpec } from "../base";
+import {
+  ANTIGRAVITY_KNOWN_MODEL_VARIANTS,
+  buildAntigravityModelCapabilities,
+  probeAntigravityModels,
+} from "./models";
 import { antigravityConfigDirExists } from "./session";
 
-// `agy` does not accept `--model` and chooses a model internally based on
-// the logged-in Google account. Surface Auto so the model picker has a
-// required config value; the launch path ignores the selection.
-export const ANTIGRAVITY_MANAGED_MODEL_ID = "auto";
+export const ANTIGRAVITY_DEFAULT_MODEL_ID = "Gemini 3.5 Flash";
+
+const defaultModelCapabilities = buildAntigravityModelCapabilities(
+  ANTIGRAVITY_KNOWN_MODEL_VARIANTS,
+);
 
 export const defaultAntigravityCapabilities: AgentCapability = {
-  models: [
-    {
-      id: ANTIGRAVITY_MANAGED_MODEL_ID,
-      label: "Auto",
-      description: "Model selected by agy from the signed-in account",
-    },
-  ],
-  efforts: [],
-  modelEfforts: {},
+  models: defaultModelCapabilities.models,
+  efforts: defaultModelCapabilities.efforts,
+  defaultEffort: defaultModelCapabilities.defaultEffort,
+  modelEfforts: defaultModelCapabilities.modelEfforts,
   modes: [],
   approvalPolicies: [
     { id: "default", label: "Default" },
@@ -48,6 +49,9 @@ export const antigravityDetectionSpec: DetectionSpec = {
   binary: "agy",
   capabilities: defaultAntigravityCapabilities,
   authProbes: [configDirAuthProbe],
+  async capabilitiesProbe(ctx) {
+    return await probeAntigravityModels(ctx);
+  },
   update: {
     builtIn: { binary: "agy", args: ["update"] },
     latestVersionUrls: [

--- a/src/supervisor/agents/antigravity/index.ts
+++ b/src/supervisor/agents/antigravity/index.ts
@@ -5,9 +5,9 @@ import {
   watchSessionPaths,
   type AgentAdapter,
 } from "../base";
-import { buildAntigravityArgs } from "./argv";
+import { buildAntigravityArgs, resolveAntigravityModel } from "./argv";
 import {
-  ANTIGRAVITY_MANAGED_MODEL_ID,
+  ANTIGRAVITY_DEFAULT_MODEL_ID,
   antigravityDetectionSpec,
   defaultAntigravityCapabilities,
 } from "./detection";
@@ -158,9 +158,9 @@ export function createAntigravityAdapter(): AgentAdapter {
     detectTerminalStatus: detectAntigravityTerminalStatus,
     detectInvalidSessionRef: detectAntigravityInvalidSessionRef,
 
-    defaultOneShotModel: ANTIGRAVITY_MANAGED_MODEL_ID,
+    defaultOneShotModel: ANTIGRAVITY_DEFAULT_MODEL_ID,
 
-    buildOneShotCommand(_model, _effort, prompt) {
+    buildOneShotCommand(model, effort, prompt) {
       if (!prompt) return undefined;
       // `agy -p` persists a throwaway conversation AND rewrites
       // last_conversations.json[cwd] with its id. Running it in the project cwd
@@ -169,7 +169,13 @@ export function createAntigravityAdapter(): AgentAdapter {
       // (title gen, commit-msg, PR summary). `agy` has no flag to pre-assign a
       // conversation id, so isolate the cwd instead — the prompt is fully
       // self-contained, so the working directory is irrelevant to the output.
-      return { command: "agy", args: ["-p", prompt], stdin: "", isolateCwd: true, pty: true };
+      return {
+        command: "agy",
+        args: ["--model", resolveAntigravityModel(model, effort), "-p", prompt],
+        stdin: "",
+        isolateCwd: true,
+        pty: true,
+      };
     },
   };
 }

--- a/src/supervisor/agents/antigravity/models.ts
+++ b/src/supervisor/agents/antigravity/models.ts
@@ -1,0 +1,267 @@
+import { stripAnsi } from "@/shared/ansi";
+import type { AgentCapability, LabeledOption } from "@/shared/contracts";
+import { readAgentCommandOutput, type DetectProbeCtx } from "../base";
+
+const TEXT_MODEL_HINT = /\b(?:claude|gemini|gpt|opus|sonnet|haiku|flash|pro|oss)\b/i;
+const MARKER_RE = /^\s*(?:[-*\u2022]\s+|\d+[.)]\s+|\[[ xX]\]\s*)/;
+const EFFORT_ORDER = ["Low", "Medium", "High"];
+
+export interface AntigravityModelVariant {
+  model: string;
+  effort: string;
+  cliModel: string;
+  provider?: string;
+}
+
+export const ANTIGRAVITY_KNOWN_MODEL_VARIANTS: AntigravityModelVariant[] = [
+  {
+    model: "Gemini 3.5 Flash",
+    effort: "Medium",
+    cliModel: "Gemini 3.5 Flash (Medium)",
+    provider: "Google DeepMind",
+  },
+  {
+    model: "Gemini 3.5 Flash",
+    effort: "High",
+    cliModel: "Gemini 3.5 Flash (High)",
+    provider: "Google DeepMind",
+  },
+  {
+    model: "Gemini 3.5 Flash",
+    effort: "Low",
+    cliModel: "Gemini 3.5 Flash (Low)",
+    provider: "Google DeepMind",
+  },
+  {
+    model: "Gemini 3.1 Pro",
+    effort: "Low",
+    cliModel: "Gemini 3.1 Pro (Low)",
+    provider: "Google DeepMind",
+  },
+  {
+    model: "Gemini 3.1 Pro",
+    effort: "High",
+    cliModel: "Gemini 3.1 Pro (High)",
+    provider: "Google DeepMind",
+  },
+  {
+    model: "Claude Sonnet 4.6",
+    effort: "Thinking",
+    cliModel: "Claude Sonnet 4.6 (Thinking)",
+    provider: "Anthropic",
+  },
+  {
+    model: "Claude Opus 4.6",
+    effort: "Thinking",
+    cliModel: "Claude Opus 4.6 (Thinking)",
+    provider: "Anthropic",
+  },
+  {
+    model: "GPT-OSS 120B",
+    effort: "Medium",
+    cliModel: "GPT-OSS 120B (Medium)",
+    provider: "OpenAI",
+  },
+];
+
+function labelFromId(id: string): string {
+  if (/\s|[()]/.test(id)) return id;
+  return id
+    .split(/[\s/_-]+/)
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (/^(gpt|oss|glm|ai)$/.test(lower)) return lower.toUpperCase();
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ");
+}
+
+function cleanModelId(value: string): string {
+  return value
+    .trim()
+    .replace(/^`|`$/g, "")
+    .replace(/^['"]|['"]$/g, "")
+    .replace(/\s+\((?:default|current|selected)\)$/i, "")
+    .trim();
+}
+
+/** Split an `agy` `"Model (Effort)"` display string into its parts. */
+export function splitModelEffort(value: string): { model: string; effort: string } | undefined {
+  const match = /^(.*?)\s+\(([^()]+)\)$/.exec(value.trim());
+  const model = match?.[1]?.trim();
+  const effort = match?.[2]?.trim();
+  return model && effort ? { model, effort } : undefined;
+}
+
+function splitCliModel(value: string, provider?: string): AntigravityModelVariant | undefined {
+  const parts = splitModelEffort(cleanModelId(value));
+  if (!parts) return undefined;
+  return {
+    ...parts,
+    cliModel: `${parts.model} (${parts.effort})`,
+    ...(provider ? { provider } : {}),
+  };
+}
+
+function isSkippableLine(line: string): boolean {
+  if (!line || /^[-\u2014_=\s]+$/.test(line)) return true;
+  return /^(?:available\s+)?models?\s*:?$/i.test(line) || /^usage\b/i.test(line);
+}
+
+function candidateFromObject(value: Record<string, unknown>): AntigravityModelVariant | undefined {
+  const idValue = value.id ?? value.modelId ?? value.model ?? value.value ?? value.name;
+  if (typeof idValue !== "string") return undefined;
+  const providerValue = value.description ?? value.provider ?? value.vendor;
+  const provider =
+    typeof providerValue === "string" && providerValue.trim() ? providerValue.trim() : undefined;
+  return splitCliModel(idValue, provider);
+}
+
+function collectJsonModels(value: unknown, out: AntigravityModelVariant[]): void {
+  if (typeof value === "string") {
+    const variant = splitCliModel(value);
+    if (variant) out.push(variant);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectJsonModels(item, out);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  const obj = value as Record<string, unknown>;
+  const candidate = candidateFromObject(obj);
+  if (candidate) out.push(candidate);
+  for (const key of ["models", "items", "data", "availableModels"]) {
+    if (key in obj) collectJsonModels(obj[key], out);
+  }
+}
+
+function candidateFromTextCells(cells: string[]): AntigravityModelVariant | undefined {
+  const normalized = cells.map(cleanModelId).filter(Boolean);
+  if (normalized.length === 0) return undefined;
+  if (normalized.every((cell) => /^:?-{3,}:?$/.test(cell))) return undefined;
+  const [id, _labelCandidate, descriptionCandidate] = normalized;
+  if (!id || /^(?:id|model|name)$/i.test(id)) return undefined;
+  if (!/[\w./-]/.test(id) && !TEXT_MODEL_HINT.test(id)) return undefined;
+  return splitCliModel(id, descriptionCandidate);
+}
+
+function textLineToCandidate(line: string): AntigravityModelVariant | undefined {
+  let cleaned = line.replace(MARKER_RE, "").trim();
+  cleaned = cleaned.replace(/^\*\s*/, "").trim();
+  if (isSkippableLine(cleaned)) return undefined;
+
+  if (cleaned.startsWith("|") && cleaned.endsWith("|")) {
+    return candidateFromTextCells(
+      cleaned
+        .slice(1, -1)
+        .split("|")
+        .map((cell) => cell.trim()),
+    );
+  }
+
+  const columnCells = cleaned.split(/\s{2,}|\t+/).filter(Boolean);
+  if (columnCells.length > 1) return candidateFromTextCells(columnCells);
+
+  const separatorMatch = /^(.*?)\s+(?:[-\u2013\u2014:]|=>)\s+(.*)$/.exec(cleaned);
+  if (separatorMatch)
+    return candidateFromTextCells([separatorMatch[1] ?? "", separatorMatch[2] ?? ""]);
+
+  const id = cleanModelId(cleaned);
+  if (!id || (!TEXT_MODEL_HINT.test(id) && !/[./-]/.test(id))) return undefined;
+  return splitCliModel(id);
+}
+
+function dedupeVariants(variants: AntigravityModelVariant[]): AntigravityModelVariant[] {
+  const seen = new Set<string>();
+  const result: AntigravityModelVariant[] = [];
+  for (const variant of variants) {
+    if (seen.has(variant.cliModel)) continue;
+    seen.add(variant.cliModel);
+    result.push(variant);
+  }
+  return result;
+}
+
+function sortEfforts(efforts: string[]): string[] {
+  return [...efforts].sort((left, right) => {
+    const leftIndex = EFFORT_ORDER.indexOf(left);
+    const rightIndex = EFFORT_ORDER.indexOf(right);
+    if (leftIndex !== -1 || rightIndex !== -1) {
+      return (
+        (leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
+        (rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex)
+      );
+    }
+    return left.localeCompare(right);
+  });
+}
+
+export function buildAntigravityModelCapabilities(
+  variants: AntigravityModelVariant[],
+): Pick<AgentCapability, "models" | "efforts" | "modelEfforts" | "defaultEffort"> {
+  const models: LabeledOption[] = [];
+  const modelEfforts: Record<string, string[]> = {};
+  const seen = new Set<string>();
+  for (const variant of variants) {
+    if (!seen.has(variant.model)) {
+      seen.add(variant.model);
+      models.push({
+        id: variant.model,
+        label: labelFromId(variant.model),
+        ...(variant.provider ? { description: variant.provider } : {}),
+      });
+    }
+    modelEfforts[variant.model] = [...(modelEfforts[variant.model] ?? []), variant.effort];
+  }
+  for (const [model, efforts] of Object.entries(modelEfforts)) {
+    modelEfforts[model] = sortEfforts(efforts);
+  }
+  // Prefer "Medium" as the cross-model default when any model offers it; otherwise
+  // fall back to the lowest-ranked effort actually present so the default is never
+  // an effort no model supports.
+  const allEfforts = sortEfforts([...new Set(Object.values(modelEfforts).flat())]);
+  const defaultEffort = allEfforts.includes("Medium") ? "Medium" : allEfforts[0];
+  return { models, efforts: [], modelEfforts, defaultEffort };
+}
+
+export function parseAntigravityModelVariantsOutput(raw: string): AntigravityModelVariant[] {
+  const text = stripAnsi(raw).trim();
+  if (!text) return [];
+
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    const variants: AntigravityModelVariant[] = [];
+    collectJsonModels(parsed, variants);
+    if (variants.length > 0) return dedupeVariants(variants);
+  } catch {
+    // `agy models` is documented as a shell subcommand but not as JSON-only.
+  }
+
+  return dedupeVariants(
+    text
+      .split(/\r?\n/)
+      .map(textLineToCandidate)
+      .filter((variant): variant is AntigravityModelVariant => variant !== undefined),
+  );
+}
+
+export function parseAntigravityModelsOutput(raw: string): LabeledOption[] {
+  return buildAntigravityModelCapabilities(parseAntigravityModelVariantsOutput(raw)).models;
+}
+
+export async function probeAntigravityModels(
+  ctx: DetectProbeCtx,
+): Promise<
+  Pick<AgentCapability, "models" | "efforts" | "modelEfforts" | "defaultEffort"> | undefined
+> {
+  if (!ctx.executablePath) return undefined;
+  const result = await readAgentCommandOutput(ctx.location, ctx.executablePath, ["models"], {
+    timeoutMs: 10_000,
+    wslLinuxCwd: "/tmp",
+  });
+  if (!result.ok) return undefined;
+  const variants = parseAntigravityModelVariantsOutput(result.stdout || result.stderr);
+  return variants.length > 0 ? buildAntigravityModelCapabilities(variants) : undefined;
+}

--- a/src/supervisor/agents/antigravity/session.test.ts
+++ b/src/supervisor/agents/antigravity/session.test.ts
@@ -116,7 +116,7 @@ describe("Antigravity session files", () => {
     const { createAntigravityAdapter } = await loadAdapterModule(home);
     const adapter = createAntigravityAdapter();
 
-    adapter.buildLaunchArgv(location, { model: "auto" }, "hello");
+    adapter.buildLaunchArgv(location, { model: "Gemini 3.5 Flash" }, "hello");
     writeFileSync(
       join(configDir, "cache", "last_conversations.json"),
       JSON.stringify({ [location.path]: "conversation-new" }),
@@ -150,7 +150,7 @@ describe("Antigravity session files", () => {
 
     const { createAntigravityAdapter } = await loadAdapterModule(home);
     const adapter = createAntigravityAdapter();
-    adapter.buildLaunchArgv(location, { model: "auto" }, "hello");
+    adapter.buildLaunchArgv(location, { model: "Gemini 3.5 Flash" }, "hello");
 
     // Real interactive session for this workspace (with a decoy file:// in its
     // content), plus a concurrent one-shot (title gen) that ran in an isolated
@@ -180,7 +180,7 @@ describe("Antigravity session files", () => {
 
     const { createAntigravityAdapter } = await loadAdapterModule(home);
     const adapter = createAntigravityAdapter();
-    adapter.buildLaunchArgv(location, { model: "auto" }, "hello");
+    adapter.buildLaunchArgv(location, { model: "Gemini 3.5 Flash" }, "hello");
 
     await expect(adapter.discoverSessionRef?.(location)).resolves.toBeUndefined();
   });

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -869,7 +869,7 @@ describe("SupervisorRuntime thread input", () => {
         kind: "antigravity",
         label: "Antigravity",
         capabilities: {
-          models: [{ id: "auto", label: "Auto" }],
+          models: [{ id: "Gemini 3.5 Flash", label: "Gemini 3.5 Flash" }],
           efforts: [],
           modelEfforts: {},
           modes: [],
@@ -894,7 +894,7 @@ describe("SupervisorRuntime thread input", () => {
         path: "C:\\repo",
       },
       config: {
-        model: "auto",
+        model: "Gemini 3.5 Flash",
       },
       initialSize: {
         cols: 120,


### PR DESCRIPTION
**Type:** Feature (+ UI fix)

- Replace Antigravity’s “Auto” placeholder with explicit models and effort variants so users can choose Gemini, Claude, and GPT-OSS options in the picker
- Forward the selected model (with effort) to `agy` via `--model` for interactive launches, conversation resumes, and one-shot commands
- Probe installed `agy` models at detection time to populate capabilities and keep the picker aligned with what the CLI supports
- Fix AgentDiscoveryScreen layout so the provider matrix scrolls instead of clipping when many agents are listed