### PR TITLE
Handle Codex turn completion notifications without params

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -931,12 +931,11 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           return;
         }
 
-        if ((method === "turn/completed" || method === "turn/aborted") && params) {
+        if (method === "turn/completed" || method === "turn/aborted") {
           if (suppressResumeReplay) {
             return;
           }
-          const incomingThreadId =
-            "threadId" in params ? String(params.threadId) : this.remoteThreadId;
+          const incomingThreadId = readNotificationThreadId(params, this.remoteThreadId);
           if (!incomingThreadId) return;
           if (!this.isCurrentThreadNotification(incomingThreadId)) {
             return;

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -885,6 +885,46 @@ describe("CodexStructuredSession", () => {
     ]);
   });
 
+  it("emits completion idle for Codex turn completion notifications without params", () => {
+    const session = Object.create(CodexStructuredSession.prototype) as Record<string, unknown>;
+    const updates: StructuredSessionUpdate[] = [];
+    let onMessage: ((message: unknown) => void) | undefined;
+
+    session["threadId"] = "local-thread";
+    session["remoteThreadId"] = "provider-thread";
+    session["isDisposed"] = false;
+    session["currentThreadStatus"] = { type: "active", activeFlags: [] };
+    session["seenErrorMessages"] = new Set<string>();
+    session["bufferedRuntimeEvents"] = [];
+    session["pendingRequests"] = new Map();
+    session["inboundRequests"] = new Map();
+    session["resumeActiveStatusSuppressionUntil"] = new Map();
+    session["rejectPendingRequests"] = () => {};
+    session["request"] = async () => ({});
+    session["listener"] = {
+      onClose: () => {},
+      onError: () => {},
+      onUpdate: (update: StructuredSessionUpdate) => updates.push(update),
+      onRuntimeEvent: () => {},
+    };
+    session["transport"] = {
+      setListener: (next: { onMessage: (message: unknown) => void }) => {
+        onMessage = next.onMessage;
+      },
+      write: () => {},
+      formatOutput: () => "",
+    };
+
+    (session["attachTransportHandlers"] as () => void).call(session);
+
+    onMessage?.({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+    });
+
+    expect(updates).toEqual([{ status: "idle", attention: "none" }]);
+  });
+
   it("collapses a single usage-limit failure into one error event", () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
- Bugfix: treat Codex `turn/completed` and `turn/aborted` notifications as valid even when params are omitted.
- Preserve idle state updates for current Codex threads when completion notifications lack a thread ID.
- Add test coverage for parameterless Codex turn completion notifications.