### PR TITLE
Fix Antigravity usage scanning for WSL sessions

### DIFF
--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -196,6 +196,7 @@ import { generatePrSummary } from "./prSummaryGenerator";
 import { detectWindowsShell, type WindowsShellPreference } from "./shellPreference";
 import { generateTitle } from "./titleGenerator";
 import { AgentStatusService, detectWslAgentStatuses } from "./runtime/agentStatusService";
+import { createLocalUsageCollectors } from "./runtime/localUsageCollectors";
 import { UsageService } from "./runtime/usageService";
 import { type SessionRuntime, type ShellSessionRuntime } from "./runtime/sessionTypes";
 import { ThreadSessionManager, writeSubmittedPrompt } from "./runtime/threadSessionManager";
@@ -292,14 +293,6 @@ export class SupervisorRuntime {
       statusCachePath: paths.statusCachePath,
       emit,
     });
-
-    this.usageService = new UsageService({
-      emit,
-      cachePath: join(paths.cacheDir, "provider-usage.json"),
-      cacheDir: paths.cacheDir,
-      settingsPath: this.settingsPath,
-    });
-    this.usageService.startAutoRefresh();
 
     // Boot the CLI hook plugin coordinator BEFORE the thread session manager so
     // the manager can pull `resolvePluginEnvForSpawn` off it. The coordinator
@@ -411,6 +404,17 @@ export class SupervisorRuntime {
     this.sessions = this.threadSessionManager.sessions;
     this.shellSessions = this.threadSessionManager.shellSessions;
 
+    this.usageService = new UsageService({
+      emit,
+      cachePath: join(paths.cacheDir, "provider-usage.json"),
+      cacheDir: paths.cacheDir,
+      settingsPath: this.settingsPath,
+      localCollectors: createLocalUsageCollectors({
+        getActiveAntigravityWslDistros: () => this.getActiveAntigravityWslDistros(),
+      }),
+    });
+    this.usageService.startAutoRefresh();
+
     // One-time-per-machine icon repair: localize any acp-generic icon still on
     // a remote CDN URL so sidebar rows paint from disk instead of flickering
     // through a network round-trip on every start. No-op (no network) once all
@@ -420,6 +424,17 @@ export class SupervisorRuntime {
 
   async listWslDistros(): Promise<string[]> {
     return this.agentStatusService.listWslDistros();
+  }
+
+  /** Distinct WSL distros hosting a live `antigravity` session (the only
+   * locations the usage scanner needs — native scanning is host-wide). */
+  private getActiveAntigravityWslDistros(): string[] {
+    const distros = new Set<string>();
+    for (const session of this.sessions.values()) {
+      if (session.agentKind !== "antigravity" || session.ptyExited) continue;
+      if (session.projectLocation.kind === "wsl") distros.add(session.projectLocation.distro);
+    }
+    return [...distros];
   }
 
   /**

--- a/src/supervisor/runtime/antigravityProcessScan.test.ts
+++ b/src/supervisor/runtime/antigravityProcessScan.test.ts
@@ -3,6 +3,8 @@ import {
   isAntigravityRoot,
   parseLsof,
   parsePortLines,
+  parseWslProcessLines,
+  parseWslSs,
   type ProcInfo,
   resolveTargets,
 } from "./antigravityProcessScan";
@@ -53,5 +55,28 @@ describe("parseLsof", () => {
       { pid: 1234, port: 51000 },
       { pid: 9999, port: 8080 },
     ]);
+  });
+});
+
+describe("WSL process scan parsers", () => {
+  it("offsets WSL pids into a separate namespace", () => {
+    const procs = parseWslProcessLines(
+      "91558 91550 /home/demo/.local/bin/agy --csrf-token tok\nbad line",
+    );
+    expect(procs).toEqual([
+      {
+        pid: 1_000_091_558,
+        ppid: 1_000_091_550,
+        haystack: "/home/demo/.local/bin/agy --csrf-token tok",
+        csrf: "tok",
+      },
+    ]);
+    expect(resolveTargets(procs).pids.has(1_000_091_558)).toBe(true);
+  });
+
+  it("parses WSL ss listeners with the same pid offset", () => {
+    expect(
+      parseWslSs('LISTEN 0 4096 127.0.0.1:36775 0.0.0.0:* users:(("agy",pid=91558,fd=12))'),
+    ).toEqual([{ pid: 1_000_091_558, port: 36775 }]);
   });
 });

--- a/src/supervisor/runtime/antigravityProcessScan.ts
+++ b/src/supervisor/runtime/antigravityProcessScan.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { batchWslCommandsAsync } from "../agents/base";
 import { windowsPowershellPath } from "./windowsPowershell";
 
 /**
@@ -12,6 +13,7 @@ import { windowsPowershellPath } from "./windowsPowershell";
  */
 
 const execFileAsync = promisify(execFile);
+const WSL_PID_OFFSET = 1_000_000_000;
 
 export interface ProcInfo {
   pid: number;
@@ -22,7 +24,7 @@ export interface ProcInfo {
 }
 
 /** Enumerate processes as `pid|ppid|name|commandLine`; empty on any failure. */
-export async function listProcesses(): Promise<ProcInfo[]> {
+export async function listProcesses(wslDistros: readonly string[] = []): Promise<ProcInfo[]> {
   let lines: string[] = [];
   try {
     if (process.platform === "win32") {
@@ -68,6 +70,9 @@ export async function listProcesses(): Promise<ProcInfo[]> {
       csrf,
     });
   }
+  if (process.platform === "win32" && wslDistros.length > 0) {
+    procs.push(...(await listWslProcesses(wslDistros)));
+  }
   return procs;
 }
 
@@ -107,7 +112,9 @@ export function resolveTargets(procs: ProcInfo[]): { pids: Set<number>; csrfToke
 }
 
 /** Map every listening loopback port to its owning pid; empty on any failure. */
-export async function listListeningPorts(): Promise<{ pid: number; port: number }[]> {
+export async function listListeningPorts(
+  wslDistros: readonly string[] = [],
+): Promise<{ pid: number; port: number }[]> {
   try {
     if (process.platform === "win32") {
       const { stdout } = await execFileAsync(
@@ -120,7 +127,10 @@ export async function listListeningPorts(): Promise<{ pid: number; port: number 
         ],
         { timeout: 6_000, windowsHide: true, maxBuffer: 2 * 1024 * 1024 },
       );
-      return parsePortLines(stdout);
+      return [
+        ...parsePortLines(stdout),
+        ...(wslDistros.length > 0 ? await listWslListeningPorts(wslDistros) : []),
+      ];
     }
     const { stdout } = await execFileAsync("lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-FpPn"], {
       timeout: 6_000,
@@ -130,6 +140,60 @@ export async function listListeningPorts(): Promise<{ pid: number; port: number 
   } catch {
     return [];
   }
+}
+
+/** Run one command in each distro (in parallel) and flat-parse the stdout. */
+async function scanWslDistros<T>(
+  distros: readonly string[],
+  command: string,
+  parse: (stdout: string) => T[],
+): Promise<T[]> {
+  const perDistro = await Promise.all(
+    distros.map(async (distro) => {
+      const [result] = await batchWslCommandsAsync(distro, [command]);
+      return result?.ok ? parse(result.stdout) : [];
+    }),
+  );
+  return perDistro.flat();
+}
+
+const listWslProcesses = (distros: readonly string[]): Promise<ProcInfo[]> =>
+  scanWslDistros(distros, "ps -axww -o pid=,ppid=,args=", parseWslProcessLines);
+
+const listWslListeningPorts = (
+  distros: readonly string[],
+): Promise<{ pid: number; port: number }[]> =>
+  scanWslDistros(distros, "ss -ltnpH 2>/dev/null", parseWslSs);
+
+export function parseWslProcessLines(stdout: string): ProcInfo[] {
+  const procs: ProcInfo[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    const cmd = m[3] ?? "";
+    const csrf = cmd.match(/csrf[_-]?token["' =:]+([A-Za-z0-9._-]+)/i)?.[1];
+    procs.push({
+      pid: WSL_PID_OFFSET + pid,
+      ppid: Number.isFinite(ppid) ? WSL_PID_OFFSET + ppid : 0,
+      haystack: cmd.toLowerCase(),
+      csrf,
+    });
+  }
+  return procs;
+}
+
+export function parseWslSs(stdout: string): { pid: number; port: number }[] {
+  const out: { pid: number; port: number }[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const pid = Number(line.match(/\bpid=(\d+)\b/)?.[1]);
+    const parts = line.trim().split(/\s+/);
+    const port = Number(parts[3]?.match(/:(\d{2,5})$/)?.[1]);
+    if (pid > 0 && port > 0 && port <= 65535) out.push({ pid: WSL_PID_OFFSET + pid, port });
+  }
+  return out;
 }
 
 export function parsePortLines(stdout: string): { pid: number; port: number }[] {

--- a/src/supervisor/runtime/antigravityUsageScanner.ts
+++ b/src/supervisor/runtime/antigravityUsageScanner.ts
@@ -26,10 +26,13 @@ import { listListeningPorts, listProcesses, resolveTargets } from "./antigravity
  */
 
 /** Probe the running language server; undefined when none is reachable. */
-async function scanLanguageServer(nowMs: number): Promise<UsageSnapshot | undefined> {
-  const { pids, csrfTokens } = resolveTargets(await listProcesses());
+async function scanLanguageServer(
+  nowMs: number,
+  wslDistros: readonly string[],
+): Promise<UsageSnapshot | undefined> {
+  const { pids, csrfTokens } = resolveTargets(await listProcesses(wslDistros));
   if (pids.size === 0) return undefined;
-  const ports = (await listListeningPorts())
+  const ports = (await listListeningPorts(wslDistros))
     .filter((entry) => pids.has(entry.pid))
     .map((entry) => entry.port);
   for (const port of [...new Set(ports)]) {
@@ -59,8 +62,11 @@ async function scanLanguageServer(nowMs: number): Promise<UsageSnapshot | undefi
 }
 
 /** Build the Antigravity usage snapshot from its local language server. */
-export async function scanAntigravityUsage(nowMs: number): Promise<UsageSnapshot> {
-  const ls = await scanLanguageServer(nowMs).catch(() => undefined);
+export async function scanAntigravityUsage(
+  nowMs: number,
+  wslDistros: readonly string[] = [],
+): Promise<UsageSnapshot> {
+  const ls = await scanLanguageServer(nowMs, wslDistros).catch(() => undefined);
   if (ls && ls.windows.length > 0) return ls;
   // No reachable LS: `agy`/the IDE isn't running. The user may well be signed
   // in, so this is "start the app", not "sign in".

--- a/src/supervisor/runtime/localUsageCollectors.ts
+++ b/src/supervisor/runtime/localUsageCollectors.ts
@@ -17,9 +17,19 @@ export interface LocalUsageCollector {
   collect(nowMs: number, host: HostPort): Promise<UsageSnapshot>;
 }
 
-export function createLocalUsageCollectors(): LocalUsageCollector[] {
+export interface LocalUsageCollectorsOptions {
+  getActiveAntigravityWslDistros?: () => readonly string[];
+}
+
+export function createLocalUsageCollectors(
+  options: LocalUsageCollectorsOptions = {},
+): LocalUsageCollector[] {
   return [
     { id: "opencode", collect: (nowMs, host) => scanOpenCodeUsage(nowMs, host) },
-    { id: "antigravity", collect: (nowMs) => scanAntigravityUsage(nowMs) },
+    {
+      id: "antigravity",
+      collect: (nowMs) =>
+        scanAntigravityUsage(nowMs, options.getActiveAntigravityWslDistros?.() ?? []),
+    },
   ];
 }


### PR DESCRIPTION
- Bugfix: include active WSL Antigravity sessions in local usage scans.
- Detect matching WSL processes and listening ports so usage data resolves correctly.
- Add parser coverage for WSL process and port scanning behavior.