### PR TITLE
Fix Claude SDK spawn path for Windows npm .cmd shims

### DIFF
--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -626,6 +626,69 @@ describe("ClaudeSdkSession", () => {
     await session.dispose();
   });
 
+  it.skipIf(process.platform !== "win32")(
+    "wraps native Windows SDK .cmd shims instead of spawning them directly",
+    async () => {
+      const fake = createFakeQuery();
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const signal = new AbortController().signal;
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-windows-shim",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: () => {},
+        onUpdate: () => {},
+        onError: () => {},
+        onClose: () => {},
+      });
+
+      await session.openThread(config);
+      const queryInput = mockSdk.query.mock.calls[0]?.[0] as {
+        options?: {
+          spawnClaudeCodeProcess?: (spawnOptions: SpawnOptions) => SpawnedProcess;
+        };
+      };
+      const spawnClaudeCodeProcess = queryInput.options?.spawnClaudeCodeProcess;
+      expect(spawnClaudeCodeProcess).toEqual(expect.any(Function));
+
+      spawnClaudeCodeProcess?.({
+        command: "C:\\Users\\demo\\AppData\\Roaming\\npm\\claude.cmd",
+        args: ["chat", "--json"],
+        cwd: "C:\\repo\\subdir",
+        env: {
+          CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode",
+          FOO: "bar",
+          PATH: "C:\\Windows\\System32",
+        },
+        signal,
+      });
+
+      expect(mockChildProcess.spawn).toHaveBeenCalledTimes(1);
+      const [command, _args, options] = mockChildProcess.spawn.mock.calls[0] as [
+        string,
+        string[],
+        Record<string, unknown>,
+      ];
+      expect(command).not.toBe("C:\\Users\\demo\\AppData\\Roaming\\npm\\claude.cmd");
+      expect(options).toMatchObject({
+        cwd: "C:\\repo\\subdir",
+        env: expect.objectContaining({
+          CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode",
+          FOO: "bar",
+          PATH: "C:\\Windows\\System32",
+        }),
+        signal,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+
+      await session.dispose();
+    },
+  );
+
   it("surfaces live SDK slash commands on GUI sessions", async () => {
     const fake = createFakeQuery([
       {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -29,6 +29,7 @@ import { areAgentSlashCommandsEqual } from "@/shared/contracts";
 import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
 import {
   createKnownSessionRef,
+  buildAgentCommand,
   getWslCommand,
   getPrimedPosixEnv,
   getProjectShellEnv,
@@ -97,6 +98,8 @@ type CompletedClaudeTurn = {
   resumeSessionAt: string | undefined;
 };
 
+type WindowsProjectLocation = Extract<ProjectLocation, { kind: "windows" }>;
+
 function projectCwd(location: ProjectLocation): string {
   switch (location.kind) {
     case "wsl":
@@ -160,6 +163,14 @@ function filteredEnv(env: Record<string, string | undefined>): Record<string, st
   return out;
 }
 
+function definedEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
 function buildDirectWslEnvCommandArgs(
   command: string,
   args: string[],
@@ -201,14 +212,35 @@ function spawnClaudeInWsl(location: ProjectLocation, options: SpawnOptions): Spa
   }) as unknown as SpawnedProcess;
 }
 
-function spawnClaudeNative(location: ProjectLocation, options: SpawnOptions): SpawnedProcess {
+function spawnClaudeNative(
+  location: WindowsProjectLocation,
+  options: SpawnOptions,
+): SpawnedProcess {
   const command = options.command || resolveAgentBinaryPath(location, "claude") || "claude";
+  const cwd = options.cwd ?? location.path;
+  if (process.platform === "win32") {
+    const env = definedEnv(options.env);
+    const spec = buildAgentCommand(
+      { ...location, path: cwd },
+      command,
+      options.args,
+      undefined,
+      env,
+    );
+    return spawn(spec.command, spec.args, {
+      ...(spec.env ? { env: spec.env } : Object.keys(env).length > 0 ? { env } : {}),
+      signal: options.signal,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+      cwd: spec.cwd,
+    }) as unknown as SpawnedProcess;
+  }
   return spawn(command, options.args, {
     env: options.env,
     signal: options.signal,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
-    ...(options.cwd ? { cwd: options.cwd } : {}),
+    cwd,
   }) as unknown as SpawnedProcess;
 }
 
@@ -872,6 +904,19 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
         this.currentConfig.browserMcp === true,
         this.input.browserMcp,
       );
+      let spawnClaudeCodeProcess: ((spawnOptions: SpawnOptions) => SpawnedProcess) | undefined;
+      switch (this.input.projectLocation.kind) {
+        case "wsl": {
+          const location = this.input.projectLocation;
+          spawnClaudeCodeProcess = (spawnOptions) => spawnClaudeInWsl(location, spawnOptions);
+          break;
+        }
+        case "windows": {
+          const location = this.input.projectLocation;
+          spawnClaudeCodeProcess = (spawnOptions) => spawnClaudeNative(location, spawnOptions);
+          break;
+        }
+      }
       const options: ClaudeQueryOptions = {
         cwd: projectCwd(this.input.projectLocation),
         model,
@@ -903,17 +948,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
         ...(browserMcpServers
           ? ({ mcpServers: browserMcpServers } as Partial<ClaudeQueryOptions>)
           : {}),
-        ...(this.input.projectLocation.kind === "wsl"
-          ? {
-              spawnClaudeCodeProcess: (spawnOptions) =>
-                spawnClaudeInWsl(this.input.projectLocation, spawnOptions),
-            }
-          : this.input.projectLocation.kind === "windows"
-            ? {
-                spawnClaudeCodeProcess: (spawnOptions) =>
-                  spawnClaudeNative(this.input.projectLocation, spawnOptions),
-              }
-            : {}),
+        ...(spawnClaudeCodeProcess ? { spawnClaudeCodeProcess } : {}),
       };
 
       this.queryRuntime = query({ prompt: this.promptQueue, options });


### PR DESCRIPTION
- **Bugfix:** Route native Windows Claude SDK spawns through `buildAgentCommand` so npm-installed `.cmd` shims start reliably instead of being executed directly.
- Wire a custom `spawnClaudeCodeProcess` for both WSL and Windows GUI sessions, unifying how the SDK delegates process creation by project location.
- Add a Windows-only regression test in `sdkSession.test.ts` that asserts `.cmd` shims are wrapped rather than passed straight to `spawn`.