### PR TITLE
Allow slower Windows job helper startup

### DIFF
--- a/src/main/windowsJobObject.test.ts
+++ b/src/main/windowsJobObject.test.ts
@@ -159,10 +159,16 @@ describe("WindowsJobObjectManager", () => {
 
     const manager = new WindowsJobObjectManager();
     const pending = manager.start();
+    let startupError: unknown;
+    const handledPending = pending.catch((error: unknown) => {
+      startupError = error;
+    });
 
     await vi.advanceTimersByTimeAsync(30_000);
 
-    await expect(pending).rejects.toThrow(/timed out after 30000ms/i);
+    await handledPending;
+    expect(startupError).toBeInstanceOf(Error);
+    expect((startupError as Error).message).toMatch(/timed out after 30000ms/i);
   });
 
   it("sends an exit command and ends stdin on dispose", async () => {

--- a/src/main/windowsJobObject.test.ts
+++ b/src/main/windowsJobObject.test.ts
@@ -70,7 +70,7 @@ function createMockChild() {
   return child;
 }
 
-describe.skipIf(process.platform !== "win32")("WindowsJobObjectManager", () => {
+describe("WindowsJobObjectManager", () => {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
   beforeEach(() => {
@@ -136,6 +136,33 @@ describe.skipIf(process.platform !== "win32")("WindowsJobObjectManager", () => {
     child.emit("exit", 1, null);
 
     await expect(pending).rejects.toThrow(/failed to start/i);
+  });
+
+  it("allows slow helper startup beyond the old five second watchdog", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const manager = new WindowsJobObjectManager();
+    const pending = manager.start();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    child.stdout.write('{"type":"ready"}\n');
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it("rejects startup when the helper never becomes ready", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const manager = new WindowsJobObjectManager();
+    const pending = manager.start();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(pending).rejects.toThrow(/timed out after 30000ms/i);
   });
 
   it("sends an exit command and ends stdin on dispose", async () => {

--- a/src/main/windowsJobObject.ts
+++ b/src/main/windowsJobObject.ts
@@ -25,7 +25,7 @@ interface HelperErrorMessage {
 
 type HelperMessage = HelperReadyMessage | HelperAssignedMessage | HelperErrorMessage;
 
-const START_TIMEOUT_MS = 5_000;
+const START_TIMEOUT_MS = 30_000;
 const DISPOSE_GRACE_MS = 500;
 
 function buildHelperScript(): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Summary

- Increased the Windows Job Object helper startup watchdog from 5s to 30s.
- Enabled and expanded `WindowsJobObjectManager` tests under mocked `win32` behavior.

# Motivation

Avoid false startup failures on slower Windows machines where PowerShell and inline C# compilation can take longer than 5 seconds before the helper emits `ready`.

# Testing

- [x] `pnpm run typecheck`
- [ ] `pnpm run lint`
- [ ] `pnpm run fmt:check`
- [ ] `pnpm run test`
- [x] `pnpm exec vitest run src/main/windowsJobObject.test.ts`
- [x] `pnpm exec oxlint --type-aware --deny-warnings src/main/windowsJobObject.ts src/main/windowsJobObject.test.ts`
- [ ] Not run; reason: full lint/format/test suites were not run because this is a focused Windows helper change and targeted checks cover the changed code path.

# Screenshots

Not applicable; runtime-only change.

# Linked issue

Closes #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7b9decc-f695-4b3d-a683-feb72f240a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7b9decc-f695-4b3d-a683-feb72f240a1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

