### PR TITLE
Preserve cached worktree stats on fetch refresh

### DIFF
--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -454,6 +454,69 @@ describe("watcher git status refresh", () => {
     expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
   });
 
+  it("preserves cached worktree diff stats during fetch refreshes", async () => {
+    const cachedWorktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      unstaged: [
+        {
+          path: "src/existing-change.ts",
+          status: "M",
+          staged: false,
+          insertions: 3,
+          deletions: 1,
+        },
+      ],
+      totalInsertions: 3,
+      totalDeletions: 1,
+    };
+    const gitWatchWorktrees = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+          detail?: "summary" | "full";
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockResolvedValue({ statuses: {} });
+    const gitProjectSnapshot = vi
+      .fn<
+        () => Promise<{
+          status: GitStatusResult;
+          branches: { current: string; branches: unknown[] };
+          worktrees: { path: string; branch: string; commit: string; isMain: boolean }[];
+          ghAvailable: boolean;
+        }>
+      >()
+      .mockResolvedValue({
+        status,
+        branches: { current: "feature/pr-checks", branches: [] },
+        worktrees: [{ path: "/repo", branch: "feature/pr-checks", commit: "abc123", isMain: true }],
+        ghAvailable: false,
+      });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        gitProjectSnapshot,
+        gitWatchWorktrees,
+        gitWorktreeStatusBatch,
+      },
+    });
+    useGitStore.getState().setWorktreeStatus("/repo-wt", cachedWorktreeStatus);
+    useAppStore.setState({ threads: [worktreeThread] });
+
+    await refreshGitProject(project, "fetch", "full");
+
+    expect(gitProjectSnapshot).toHaveBeenCalledWith({
+      projectLocation: location,
+      includeGhCheck: true,
+    });
+    expect(gitWorktreeStatusBatch).not.toHaveBeenCalled();
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(cachedWorktreeStatus);
+  });
+
   it("promotes watcher refresh to a full snapshot after a project becomes a Git repo", async () => {
     const nonRepoStatus: GitStatusResult = {
       isRepo: false,

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -540,7 +540,7 @@ export async function refreshGitProject(
           );
 
           const statusesPromise =
-            watchWorktreePaths.length === 0
+            reason === "fetch" || watchWorktreePaths.length === 0
               ? Promise.resolve()
               : readBridge()
                   .gitWorktreeStatusBatch({


### PR DESCRIPTION
- Bugfix: keep cached worktree diff totals intact when a refresh is triggered by `fetch`, so existing worktree state is not overwritten by an empty batch response.
- Preserve the cached worktree status path during fetch-driven refreshes while still allowing normal refresh flows to update live data.
- Add a regression test that covers fetch refreshes and verifies cached worktree stats remain unchanged.