### PR TITLE
Add Claude profile support across settings and runtime

### DIFF
--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -140,10 +140,23 @@ export function createLocalIpcHandlers(
       // Preserve supervisor-managed fields so the renderer's persist cycle
       // doesn't clobber writes made out-of-band by the supervisor.
       const onDisk = readSharedSettingsFile(settingsPath);
+      const rendererManagedInstances = Object.fromEntries(
+        Object.entries(settings.agentInstances).filter(
+          ([, instance]) => instance.driver !== "acp-generic",
+        ),
+      );
+      const supervisorManagedInstances = Object.fromEntries(
+        Object.entries(onDisk.agentInstances).filter(
+          ([, instance]) => instance.driver === "acp-generic",
+        ),
+      );
       writeSharedSettingsFile(settingsPath, {
         ...settings,
         acpRegistryInstalledAgents: onDisk.acpRegistryInstalledAgents,
-        agentInstances: onDisk.agentInstances,
+        agentInstances: {
+          ...rendererManagedInstances,
+          ...supervisorManagedInstances,
+        },
         agentHookSupport: onDisk.agentHookSupport,
       });
       options.updatePowerSaveBlocker();

--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
@@ -389,6 +389,30 @@ describe("ProviderModelMenu", () => {
     });
   });
 
+  it("shows Claude profile models under the profile subprovider row", async () => {
+    const provider = makeNamedProvider("claude:work", "Claude Work", 2);
+    provider.capabilities.subProviders = [{ id: "claude-profile", label: "Work" }];
+    provider.capabilities.modelSubProvider = {
+      "model-1": "claude-profile",
+      "model-2": "claude-profile",
+    };
+
+    render(
+      <ProviderModelMenu
+        providers={[provider]}
+        currentAgentKind="claude:work"
+        currentModel="model-1"
+        onChange={vi.fn<(next: { agentKind: string; model: string }) => void>()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+    const listbox = await screen.findByRole("listbox", { name: "Models" });
+
+    expect(within(listbox).getByText("Work")).toBeInTheDocument();
+    expect(within(listbox).getByText("Model 2")).toBeInTheDocument();
+  });
+
   it("resets the window when a long list shrinks so rows do not render blank", async () => {
     const { rerender } = render(
       <ProviderModelMenu

--- a/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
@@ -1,4 +1,9 @@
-import type { AgentCapability, AgentStatus, ThreadPresentationMode } from "@/shared/contracts";
+import {
+  baseAgentKind,
+  type AgentCapability,
+  type AgentStatus,
+  type ThreadPresentationMode,
+} from "@/shared/contracts";
 import { deriveSubProvider, listSubProviderOrder } from "./deriveSubProvider";
 import {
   formatShortcutFallbackLabel,
@@ -86,7 +91,7 @@ function makeProviderSortKey(userOrder: readonly string[] | undefined): (kind: s
   const trimmed = userOrder?.filter((k) => k.length > 0) ?? [];
   if (trimmed.length === 0) {
     return (kind) => {
-      const idx = PROVIDER_ORDER.indexOf(kind);
+      const idx = PROVIDER_ORDER.indexOf(baseAgentKind(kind));
       return idx < 0 ? PROVIDER_ORDER.length : idx;
     };
   }
@@ -98,7 +103,7 @@ function makeProviderSortKey(userOrder: readonly string[] | undefined): (kind: s
   return (kind) => {
     const fromUser = userIndex.get(kind);
     if (fromUser !== undefined) return fromUser;
-    const fromDefault = PROVIDER_ORDER.indexOf(kind);
+    const fromDefault = PROVIDER_ORDER.indexOf(baseAgentKind(kind));
     return userTailBase + (fromDefault < 0 ? PROVIDER_ORDER.length : fromDefault);
   };
 }

--- a/src/renderer/components/composer/browserMcpScope.ts
+++ b/src/renderer/components/composer/browserMcpScope.ts
@@ -1,4 +1,4 @@
-import type { ThreadPresentationMode } from "@/shared/contracts";
+import { baseAgentKind, type ThreadPresentationMode } from "@/shared/contracts";
 
 /**
  * How a given (agentKind, presentationMode) pair gates Browser MCP per-thread.
@@ -20,12 +20,13 @@ export function getBrowserMcpScope(
   agentKind: string,
   presentationMode: ThreadPresentationMode,
 ): BrowserMcpScope {
+  const baseKind = baseAgentKind(agentKind);
   if (presentationMode === "gui") {
-    if (agentKind === "claude") return "always";
-    if (agentKind === "opencode" || agentKind === "antigravity" || agentKind === "commandcode")
+    if (baseKind === "claude") return "always";
+    if (baseKind === "opencode" || baseKind === "antigravity" || baseKind === "commandcode")
       return "none";
     return "launch";
   }
-  if (agentKind === "codex") return "launch";
+  if (baseKind === "codex") return "launch";
   return "none";
 }

--- a/src/renderer/components/providers/ProviderIcon.test.tsx
+++ b/src/renderer/components/providers/ProviderIcon.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProviderIcon } from "./ProviderIcon";
+import "./claude";
+
+describe("ProviderIcon", () => {
+  it("uses the Claude profile label for the profile badge initial", () => {
+    render(<ProviderIcon kind="claude:home" fallbackLabel="Claude Home" />);
+
+    expect(screen.getByText("H")).toBeInTheDocument();
+    expect(screen.queryByText("C")).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/providers/ProviderIcon.tsx
+++ b/src/renderer/components/providers/ProviderIcon.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
+import { baseAgentKind } from "@/shared/contracts";
 import type { StatusTone } from "./statusTone";
 import {
   getUtilityTaskCandidates,
@@ -74,6 +75,22 @@ function fallbackInitial(label: string | undefined): string {
   return (raw.match(/[A-Za-z0-9]/)?.[0] ?? "?").toUpperCase();
 }
 
+function claudeProfileBadgeLabel(kind: string, fallbackLabel: string | undefined): string {
+  const profileId = kind.slice("claude:".length);
+  const label = fallbackLabel?.trim();
+  if (!label) return profileId;
+  const profileLabel = label.replace(/^claude\s+/i, "").trim();
+  return profileLabel || profileId;
+}
+
+/** Registry lookup that falls back to the base kind for instance-scoped kinds. */
+function lookupByKind<T>(registry: Map<string, T>, kind: string): T | undefined {
+  const exact = registry.get(kind);
+  if (exact !== undefined) return exact;
+  const baseKind = baseAgentKind(kind);
+  return baseKind !== kind ? registry.get(baseKind) : undefined;
+}
+
 function GenericProviderIcon(props: { label?: string; tone: StatusTone; className?: string }) {
   return (
     <span
@@ -103,7 +120,7 @@ export function ProviderIcon(props: {
    */
   pending?: boolean | undefined;
 }) {
-  const Icon = ICON_REGISTRY.get(props.kind);
+  const Icon = lookupByKind(ICON_REGISTRY, props.kind);
   const tone = props.tone ?? "inactive";
   if (!Icon) {
     if (props.icon) {
@@ -126,7 +143,20 @@ export function ProviderIcon(props: {
       />
     );
   }
-  return <Icon tone={tone} {...(props.className ? { className: props.className } : {})} />;
+  const rendered = (
+    <Icon tone={tone} {...(props.className ? { className: props.className } : {})} />
+  );
+  if (props.kind.startsWith("claude:")) {
+    return (
+      <span className={`relative inline-flex ${props.className ?? ""}`}>
+        {rendered}
+        <span className="absolute -bottom-0.5 -right-0.5 flex size-2.5 items-center justify-center rounded-full border border-background bg-surface text-[6px] font-semibold leading-none text-foreground">
+          {fallbackInitial(claudeProfileBadgeLabel(props.kind, props.fallbackLabel))}
+        </span>
+      </span>
+    );
+  }
+  return rendered;
 }
 
 // --- Provider label registry ---
@@ -202,12 +232,7 @@ export function registerComposerControls(kind: string, registration: ComposerCon
 }
 
 export function getComposerControls(kind: string): ComposerControlsFactory | undefined {
-  const separatorIndex = kind.indexOf(":");
-  const registration =
-    COMPOSER_CONTROLS_REGISTRY.get(kind) ??
-    (separatorIndex > 0
-      ? COMPOSER_CONTROLS_REGISTRY.get(kind.slice(0, separatorIndex))
-      : undefined);
+  const registration = lookupByKind(COMPOSER_CONTROLS_REGISTRY, kind);
   if (!registration) return undefined;
   if (typeof registration === "function") return registration;
   return (input) => {
@@ -252,7 +277,7 @@ export function registerGuiSlashCommands(kind: string, registration: GuiSlashCom
 }
 
 export function getGuiSlashCommands(kind: string): GuiSlashCommandRegistration | undefined {
-  return GUI_SLASH_COMMAND_REGISTRY.get(kind);
+  return lookupByKind(GUI_SLASH_COMMAND_REGISTRY, kind);
 }
 
 // --- Config normalizer registry ---
@@ -276,7 +301,7 @@ export function registerConfigNormalizer(kind: string, normalizer: ConfigNormali
 }
 
 export function getConfigNormalizer(kind: string): ConfigNormalizer | undefined {
-  return CONFIG_NORMALIZER_REGISTRY.get(kind);
+  return lookupByKind(CONFIG_NORMALIZER_REGISTRY, kind);
 }
 
 // --- Trigger word registry ---
@@ -303,10 +328,7 @@ export function getTriggerWords(
   model: string | undefined,
 ): readonly TriggerWordDef[] {
   if (!kind) return [];
-  const separatorIndex = kind.indexOf(":");
-  const matcher =
-    TRIGGER_WORD_REGISTRY.get(kind) ??
-    (separatorIndex > 0 ? TRIGGER_WORD_REGISTRY.get(kind.slice(0, separatorIndex)) : undefined);
+  const matcher = lookupByKind(TRIGGER_WORD_REGISTRY, kind);
   return matcher ? matcher(model) : [];
 }
 
@@ -321,7 +343,7 @@ export function registerCommitGenDefaults(kind: string, defaults: CommitGenDefau
 }
 
 export function getCommitGenDefaults(kind: string): CommitGenDefaults | undefined {
-  return COMMIT_GEN_REGISTRY.get(kind);
+  return lookupByKind(COMMIT_GEN_REGISTRY, kind);
 }
 
 export function getCommitGenDefaultsHint(): string | undefined {
@@ -339,7 +361,7 @@ export function registerTitleGenDefaults(kind: string, defaults: TitleGenDefault
 }
 
 export function getTitleGenDefaults(kind: string): TitleGenDefaults | undefined {
-  return TITLE_GEN_REGISTRY.get(kind);
+  return lookupByKind(TITLE_GEN_REGISTRY, kind);
 }
 
 export function getTitleGenDefaultsHint(): string | undefined {
@@ -357,7 +379,7 @@ export function registerConflictResolverDefaults(kind: string, defaults: Conflic
 }
 
 export function getConflictResolverDefaults(kind: string): ConflictResolverDefaults | undefined {
-  return CONFLICT_RESOLVER_REGISTRY.get(kind);
+  return lookupByKind(CONFLICT_RESOLVER_REGISTRY, kind);
 }
 
 export function getConflictResolverDefaultsHint(): string | undefined {

--- a/src/renderer/components/providers/ProviderUsageRail.tsx
+++ b/src/renderer/components/providers/ProviderUsageRail.tsx
@@ -140,6 +140,7 @@ export function ProviderUsageRail(props: { orientation?: "row" | "column" }) {
   const showInSidebar = useSharedSettings((s) => s.usage.showInSidebar);
   const disabledProviders = useSharedSettings((s) => s.usage.disabledProviders);
   const providerOrder = useSharedSettings((s) => s.usage.providerOrder);
+  const agentInstances = useSharedSettings((s) => s.agentInstances);
   const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
 
   useEffect(() => {
@@ -166,7 +167,7 @@ export function ProviderUsageRail(props: { orientation?: "row" | "column" }) {
     KeyboardSensor,
   ];
 
-  const providers = resolveDisplayedProviders(providerOrder, disabledProviders);
+  const providers = resolveDisplayedProviders(providerOrder, disabledProviders, agentInstances);
 
   if (!showInSidebar || providers.length === 0) return null;
 

--- a/src/renderer/components/providers/claude/index.test.tsx
+++ b/src/renderer/components/providers/claude/index.test.tsx
@@ -68,4 +68,15 @@ describe("Claude composer controls", () => {
       "bypassPermissions",
     );
   });
+
+  it("uses the Claude composer controls for profile-backed Claude providers", () => {
+    const controls = getComposerControls("claude:work")?.({
+      capabilities,
+      config: { model: "claude-fable-5" },
+      isDisabled: false,
+      onConfigChange: () => undefined,
+    });
+
+    expect(controls?.some(isPermissionControl)).toBe(true);
+  });
 });

--- a/src/renderer/components/providers/usageProviders.test.ts
+++ b/src/renderer/components/providers/usageProviders.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { UsageWindow } from "@lightcode/agents-usage";
+import type { AgentInstanceConfigMap } from "@/shared/contracts";
+import {
+  pickUsageRings,
+  resolveDisplayedProviders,
+  usageProvidersForAgentInstances,
+} from "./usageProviders";
+
+const agentInstances: AgentInstanceConfigMap = {
+  work: {
+    id: "work",
+    driver: "claude",
+    displayName: "Work",
+    config: { configDir: "~/.lightcode/claude-profiles/work" },
+  },
+  home: {
+    id: "home",
+    driver: "claude",
+    displayName: "Home",
+    config: { configDir: "~/.lightcode/claude-profiles/home" },
+  },
+  disabled: {
+    id: "disabled",
+    driver: "claude",
+    displayName: "Disabled",
+    enabled: false,
+    config: { configDir: "~/.lightcode/claude-profiles/disabled" },
+  },
+};
+
+describe("usageProviders", () => {
+  it("adds Claude profile providers after the base Claude provider", () => {
+    const providers = usageProvidersForAgentInstances(agentInstances);
+    const claudeIndex = providers.findIndex((provider) => provider.id === "claude");
+
+    expect(providers.slice(claudeIndex, claudeIndex + 3).map((provider) => provider.id)).toEqual([
+      "claude",
+      "claude:home",
+      "claude:work",
+    ]);
+    expect(providers.find((provider) => provider.id === "claude:home")?.label).toBe("Claude Home");
+  });
+
+  it("orders, disables, and rings Claude profiles like Claude", () => {
+    const providers = resolveDisplayedProviders(
+      ["claude:work", "claude"],
+      ["claude:home"],
+      agentInstances,
+    );
+    expect(providers.slice(0, 2).map((provider) => provider.id)).toEqual(["claude:work", "claude"]);
+    expect(providers.some((provider) => provider.id === "claude:home")).toBe(false);
+
+    const windows: UsageWindow[] = [
+      { id: "weekly", label: "Weekly", usedPercent: 20, unit: "percent" },
+      { id: "session-5h", label: "Session", usedPercent: 60, unit: "percent" },
+    ];
+    expect(pickUsageRings("claude:work", windows)).toEqual({
+      outer: windows[1],
+      inner: windows[0],
+    });
+  });
+});

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -1,4 +1,10 @@
 import { allUsageProviderDescriptors, type UsageWindow } from "@lightcode/agents-usage";
+import {
+  baseAgentKind,
+  claudeProfileKind,
+  parseClaudeProfileInstanceConfig,
+  type AgentInstanceConfigMap,
+} from "@/shared/contracts";
 
 /**
  * Providers the usage tracker shows in the renderer. The canonical id + label +
@@ -44,18 +50,62 @@ const RENDERER_META: Record<string, Omit<UsageProvider, "id" | "label">> = {
   opencode: { supportsBrowserLogin: true },
 };
 
-export const USAGE_PROVIDERS: ReadonlyArray<UsageProvider> = allUsageProviderDescriptors().map(
+const STATIC_USAGE_PROVIDERS: ReadonlyArray<UsageProvider> = allUsageProviderDescriptors().map(
   (d) => ({ id: d.id, label: d.label, ...RENDERER_META[d.id] }),
 );
 
+export const USAGE_PROVIDERS: ReadonlyArray<UsageProvider> = STATIC_USAGE_PROVIDERS;
+
+function rendererMeta(providerId: string): Omit<UsageProvider, "id" | "label"> | undefined {
+  return RENDERER_META[providerId] ?? RENDERER_META[baseAgentKind(providerId)];
+}
+
+function claudeProfileUsageProviders(
+  agentInstances: AgentInstanceConfigMap | undefined,
+): UsageProvider[] {
+  if (!agentInstances) return [];
+  const profiles: UsageProvider[] = [];
+  for (const instance of Object.values(agentInstances)) {
+    if (instance.enabled === false || instance.driver !== "claude") continue;
+    try {
+      parseClaudeProfileInstanceConfig(instance.config);
+    } catch {
+      continue;
+    }
+    const label = instance.displayName ?? instance.id;
+    profiles.push({
+      id: claudeProfileKind(instance.id),
+      label: `Claude ${label}`,
+      ...rendererMeta("claude"),
+    });
+  }
+  profiles.sort((a, b) => a.label.localeCompare(b.label));
+  return profiles;
+}
+
+export function usageProvidersForAgentInstances(
+  agentInstances: AgentInstanceConfigMap | undefined,
+): UsageProvider[] {
+  const profiles = claudeProfileUsageProviders(agentInstances);
+  if (profiles.length === 0) return [...STATIC_USAGE_PROVIDERS];
+  const out: UsageProvider[] = [];
+  for (const provider of STATIC_USAGE_PROVIDERS) {
+    out.push(provider);
+    if (provider.id === "claude") {
+      out.push(...profiles);
+    }
+  }
+  return out;
+}
+
 /** Providers that expose the browser-overlay login (cookie or device flow). */
 export function supportsBrowserLogin(providerId: string): boolean {
-  return USAGE_PROVIDERS.some((p) => p.id === providerId && p.supportsBrowserLogin === true);
+  return rendererMeta(providerId)?.supportsBrowserLogin === true;
 }
 
 /** Providers whose windows share one reset clock (one header countdown, no per-window resets). */
 export function usesSharedWindowReset(providerId: string): boolean {
-  return USAGE_PROVIDERS.some((p) => p.id === providerId && p.sharedWindowReset === true);
+  return rendererMeta(providerId)?.sharedWindowReset === true;
 }
 
 function firstWindowMatching(
@@ -80,7 +130,7 @@ export function pickUsageRings(
   windows: readonly UsageWindow[] | undefined,
 ): { outer?: UsageWindow; inner?: UsageWindow } {
   if (!windows || windows.length === 0) return {};
-  const spec = USAGE_PROVIDERS.find((p) => p.id === providerId)?.rings;
+  const spec = rendererMeta(providerId)?.rings;
   if (spec) {
     const outer = firstWindowMatching(windows, spec.outer);
     const inner = firstWindowMatching(windows, spec.inner);
@@ -100,8 +150,11 @@ export function pickUsageRings(
 export function resolveDisplayedProviders(
   providerOrder: readonly string[],
   disabledProviders: readonly string[],
+  agentInstances?: AgentInstanceConfigMap,
 ): UsageProvider[] {
-  const enabled = USAGE_PROVIDERS.filter((p) => !disabledProviders.includes(p.id));
+  const enabled = usageProvidersForAgentInstances(agentInstances).filter(
+    (p) => !disabledProviders.includes(p.id),
+  );
   const byId = new Map(enabled.map((p) => [p.id, p]));
   const ordered: UsageProvider[] = [];
   const seen = new Set<string>();

--- a/src/renderer/components/providers/utilityTask.ts
+++ b/src/renderer/components/providers/utilityTask.ts
@@ -1,3 +1,5 @@
+import { baseAgentKind } from "@/shared/contracts";
+
 export interface UtilityTaskDefaults {
   label?: string;
   hint?: string;
@@ -53,7 +55,7 @@ export const AUTO_PROVIDER_PREFERENCE_ORDER: readonly string[] = [
 
 export function sortByAutoPreference<T extends { kind: string }>(items: readonly T[]): T[] {
   const rank = (kind: string) => {
-    const idx = AUTO_PROVIDER_PREFERENCE_ORDER.indexOf(kind);
+    const idx = AUTO_PROVIDER_PREFERENCE_ORDER.indexOf(baseAgentKind(kind));
     return idx < 0 ? AUTO_PROVIDER_PREFERENCE_ORDER.length : idx;
   };
   return [...items].sort((a, b) => rank(a.kind) - rank(b.kind));

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -74,11 +74,14 @@ function statusesEqual(a: AgentStatus[], b: AgentStatus[]): boolean {
   return a.every(
     (x, i) =>
       x.kind === b[i]!.kind &&
+      x.label === b[i]!.label &&
       x.installed === b[i]!.installed &&
       x.icon === b[i]!.icon &&
       x.version === b[i]!.version &&
       x.authState === b[i]!.authState &&
       x.loginCommand === b[i]!.loginCommand &&
+      x.envKind === b[i]!.envKind &&
+      x.envDistro === b[i]!.envDistro &&
       JSON.stringify(x.authMethods ?? []) === JSON.stringify(b[i]!.authMethods ?? []) &&
       areAgentProviderMetadataEqual(x.providerMetadata, b[i]!.providerMetadata) &&
       capabilitiesEqual(x.capabilities, b[i]!.capabilities),

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -15,6 +15,14 @@ describe("sharedSettingsStore", () => {
         useWebGpu: true,
       },
       providerConfigs: {},
+      agentInstances: {},
+      hiddenModels: {},
+      agentSettings: {},
+      lastPresentationModeByAgent: {},
+      disabledAgents: [],
+      favoriteModels: [],
+      recentModels: [],
+      providerOrder: [],
       lastUsedProjectDirs: {},
     });
   });
@@ -79,5 +87,43 @@ describe("sharedSettingsStore", () => {
     useSharedSettings.getState().setLastUsedProjectDir("native", "/Users/me/b");
 
     expect(useSharedSettings.getState().lastUsedProjectDirs.native).toBe("/Users/me/b");
+  });
+
+  it("adds and removes Claude profile instances with their profile-scoped settings", () => {
+    useSharedSettings.getState().setAgentInstance({
+      id: "work",
+      driver: "claude",
+      displayName: "Work",
+      config: { configDir: "~/.lightcode/claude-profiles/work" },
+    });
+    useSharedSettings.setState({
+      providerConfigs: {
+        claude: { model: "sonnet" },
+        "claude:work": { model: "haiku" },
+      },
+      hiddenModels: { "claude:work": ["sonnet"] },
+      agentSettings: { "claude:work": { noFlicker: true } },
+      lastPresentationModeByAgent: { "claude:work": "gui" },
+      disabledAgents: ["claude:work"],
+      favoriteModels: [{ agentKind: "claude:work", modelId: "haiku", presentationMode: "gui" }],
+      recentModels: [{ agentKind: "claude:work", modelId: "sonnet", presentationMode: "gui" }],
+      providerOrder: ["claude", "claude:work"],
+    });
+
+    expect(useSharedSettings.getState().agentInstances.work?.displayName).toBe("Work");
+
+    useSharedSettings.getState().removeAgentInstance("work");
+
+    const state = useSharedSettings.getState();
+    expect(state.agentInstances.work).toBeUndefined();
+    expect(state.providerConfigs.claude).toEqual({ model: "sonnet" });
+    expect(state.providerConfigs["claude:work"]).toBeUndefined();
+    expect(state.hiddenModels["claude:work"]).toBeUndefined();
+    expect(state.agentSettings["claude:work"]).toBeUndefined();
+    expect(state.lastPresentationModeByAgent["claude:work"]).toBeUndefined();
+    expect(state.disabledAgents).not.toContain("claude:work");
+    expect(state.favoriteModels).toEqual([]);
+    expect(state.recentModels).toEqual([]);
+    expect(state.providerOrder).toEqual(["claude"]);
   });
 });

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -8,6 +8,7 @@ import {
 } from "@/shared/settings";
 import type {
   GitReviewMode,
+  AgentInstanceConfig,
   InstalledAcpRegistryAgent,
   NewThreadMode,
   NotificationFilter,
@@ -76,6 +77,8 @@ interface SharedSettingsState extends SharedSettings {
   setNotificationSound: (value: boolean) => void;
   setNotificationFilter: (value: NotificationFilter) => void;
   syncAcpRegistryInstalledAgents: (installed: InstalledAcpRegistryAgent[]) => void;
+  setAgentInstance: (instance: AgentInstanceConfig) => void;
+  removeAgentInstance: (instanceId: string) => void;
   setNotificationStatuses: (value: {
     done?: boolean;
     needsAttention?: boolean;
@@ -412,6 +415,33 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
       ),
     });
     cacheSettingsSnapshot(selectSharedSettings(get()));
+  },
+  setAgentInstance: (instance) => {
+    const current = get().agentInstances;
+    set({ agentInstances: { ...current, [instance.id]: instance } });
+    persistSettings(selectSharedSettings(get()));
+  },
+  removeAgentInstance: (instanceId) => {
+    const current = get().agentInstances;
+    if (!current[instanceId]) return;
+    const { [instanceId]: _removed, ...agentInstances } = current;
+    const prefix = `claude:${instanceId}`;
+    const removeProfileKey = (values: Record<string, unknown>) =>
+      Object.fromEntries(Object.entries(values).filter(([key]) => key !== prefix));
+    set({
+      agentInstances,
+      providerConfigs: removeProfileKey(get().providerConfigs) as SharedSettings["providerConfigs"],
+      hiddenModels: removeProfileKey(get().hiddenModels) as SharedSettings["hiddenModels"],
+      agentSettings: removeProfileKey(get().agentSettings) as SharedSettings["agentSettings"],
+      lastPresentationModeByAgent: removeProfileKey(
+        get().lastPresentationModeByAgent,
+      ) as SharedSettings["lastPresentationModeByAgent"],
+      disabledAgents: get().disabledAgents.filter((kind) => kind !== prefix),
+      favoriteModels: get().favoriteModels.filter((entry) => entry.agentKind !== prefix),
+      recentModels: get().recentModels.filter((entry) => entry.agentKind !== prefix),
+      providerOrder: get().providerOrder.filter((kind) => kind !== prefix),
+    });
+    persistSettings(selectSharedSettings(get()));
   },
   setNotificationStatuses: (partial) => {
     const current = get().notificationStatuses;

--- a/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/UsagePanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/UsagePanel.tsx
@@ -26,6 +26,7 @@ export function UsagePanel() {
   const providerOrder = useSharedSettings((s) => s.usage.providerOrder);
   const disabledProviders = useSharedSettings((s) => s.usage.disabledProviders);
   const collapsedProviders = useSharedSettings((s) => s.usage.collapsedProviders);
+  const agentInstances = useSharedSettings((s) => s.agentInstances);
   const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
   const snapshots = useProviderUsageStore((s) => s.snapshots);
   const [nowTick, setNowTick] = useState(() => Date.now());
@@ -35,7 +36,7 @@ export function UsagePanel() {
     maxFadePx: 10,
   });
 
-  const displayed = resolveDisplayedProviders(providerOrder, disabledProviders);
+  const displayed = resolveDisplayedProviders(providerOrder, disabledProviders, agentInstances);
 
   // Hydrate the store from the supervisor cache on open (and let the cache's
   // staleness trigger a background refresh whose events update the cards live).

--- a/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
@@ -16,10 +16,11 @@ export function UsagePanelHeaderActions(props: { dragControlClass: string }) {
   const providerOrder = useSharedSettings((s) => s.usage.providerOrder);
   const disabledProviders = useSharedSettings((s) => s.usage.disabledProviders);
   const collapsedProviders = useSharedSettings((s) => s.usage.collapsedProviders);
+  const agentInstances = useSharedSettings((s) => s.agentInstances);
   const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const displayed = resolveDisplayedProviders(providerOrder, disabledProviders);
+  const displayed = resolveDisplayedProviders(providerOrder, disabledProviders, agentInstances);
   const allCollapsed =
     displayed.length > 0 && displayed.every((p) => collapsedProviders.includes(p.id));
 

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -252,6 +252,40 @@ describe("SettingsOverlay", () => {
     expect(screen.getByText("Agent Registry Settings")).toBeInTheDocument();
   });
 
+  it("groups Claude profile providers under Claude Code in the agents sidebar", () => {
+    statusesState.agentStatuses = [
+      makeStatus("claude", {
+        label: "Claude Code",
+        envKind: "posix",
+      }),
+      makeStatus("codex", {
+        label: "Codex",
+        envKind: "posix",
+      }),
+      makeStatus("claude:home", {
+        label: "Claude Home",
+        envKind: "posix",
+      }),
+    ];
+
+    render(<SettingsOverlay onClose={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Agents" }));
+
+    const buttons = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent)
+      .filter(Boolean);
+    expect(buttons.slice(buttons.indexOf("Claude Code"), buttons.indexOf("Codex") + 1)).toEqual([
+      "Claude Code",
+      "Home",
+      "Codex",
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Home" }));
+    expect(screen.getByText("Agent claude:home")).toBeInTheDocument();
+  });
+
   it("opens Agents on General and toggles closed on a second click", () => {
     statusesState.agentStatuses = [
       makeStatus("claude", {

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentInstanceConfig } from "@/shared/contracts";
+
+const toastMock = vi.hoisted(() => ({
+  danger: vi.fn<(message: string) => void>(),
+  success: vi.fn<(message: string) => void>(),
+}));
+
+vi.mock("@heroui/react", () => ({
+  Button: (props: {
+    children?: ReactNode;
+    "aria-label"?: string;
+    isDisabled?: boolean;
+    onPress?: () => void;
+  }) => (
+    <button
+      type="button"
+      aria-label={props["aria-label"]}
+      disabled={props.isDisabled}
+      onClick={props.onPress}
+    >
+      {props.children}
+    </button>
+  ),
+  toast: toastMock,
+}));
+
+vi.mock("@/renderer/components/common", () => ({
+  Input: (props: {
+    "aria-label"?: string;
+    placeholder?: string;
+    value?: string;
+    onChange?: (event: { target: { value: string } }) => void;
+  }) => (
+    <input
+      aria-label={props["aria-label"]}
+      placeholder={props.placeholder}
+      value={props.value}
+      onChange={props.onChange}
+    />
+  ),
+}));
+
+const refreshAgentStatusesMock = vi.hoisted(() => vi.fn<() => Promise<void>>());
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({ refreshAgentStatuses: refreshAgentStatusesMock }),
+}));
+
+vi.mock("@/renderer/utils/acpRegistryAuth", () => ({
+  currentWslDistros: () => [],
+}));
+
+const settingsState = {
+  agentInstances: {} as Record<string, AgentInstanceConfig>,
+  setAgentInstance: vi.fn<(instance: AgentInstanceConfig) => void>(),
+  removeAgentInstance: vi.fn<(id: string) => void>(),
+};
+
+vi.mock("@/renderer/state/sharedSettingsStore", () => ({
+  useSharedSettings: (selector: (state: typeof settingsState) => unknown) =>
+    selector(settingsState),
+}));
+
+import { ClaudeProfileSettings } from "./ClaudeProfileSettings";
+
+describe("ClaudeProfileSettings", () => {
+  beforeEach(() => {
+    settingsState.agentInstances = {};
+    settingsState.setAgentInstance.mockReset();
+    settingsState.removeAgentInstance.mockReset();
+    refreshAgentStatusesMock.mockReset().mockResolvedValue();
+    toastMock.success.mockReset();
+    toastMock.danger.mockReset();
+  });
+
+  it("hides the add form until the add button is pressed", () => {
+    render(<ClaudeProfileSettings />);
+    expect(screen.queryByLabelText("New Claude profile name")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /add profile/i }));
+
+    expect(screen.getByLabelText("New Claude profile name")).toHaveValue("");
+    expect(screen.getByLabelText("New Claude profile name")).toHaveAttribute(
+      "placeholder",
+      "e.g. Work",
+    );
+    expect(screen.getByLabelText("New Claude profile config directory")).toHaveAttribute(
+      "placeholder",
+      "~/.lightcode/claude-profiles/profile",
+    );
+  });
+
+  it("disables Add until a name is typed and derives the dir placeholder from it", () => {
+    render(<ClaudeProfileSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /add profile/i }));
+
+    const addButton = screen.getByRole("button", { name: "Add Claude profile" });
+    expect(addButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("New Claude profile name"), {
+      target: { value: "Work" },
+    });
+
+    expect(addButton).toBeEnabled();
+    expect(screen.getByLabelText("New Claude profile config directory")).toHaveAttribute(
+      "placeholder",
+      "~/.lightcode/claude-profiles/work",
+    );
+  });
+
+  it("adds a profile with the derived config dir when the dir is left empty", () => {
+    render(<ClaudeProfileSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /add profile/i }));
+    fireEvent.change(screen.getByLabelText("New Claude profile name"), {
+      target: { value: "Work" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Claude profile" }));
+
+    expect(settingsState.setAgentInstance).toHaveBeenCalledWith({
+      id: "work",
+      driver: "claude",
+      displayName: "Work",
+      config: { configDir: "~/.lightcode/claude-profiles/work" },
+    });
+    // The form collapses back to the add button after a successful add.
+    expect(screen.queryByLabelText("New Claude profile name")).not.toBeInTheDocument();
+    expect(toastMock.success).toHaveBeenCalledWith("Claude Work profile added.");
+  });
+
+  it("discards the draft on cancel", () => {
+    render(<ClaudeProfileSettings />);
+    fireEvent.click(screen.getByRole("button", { name: /add profile/i }));
+    fireEvent.change(screen.getByLabelText("New Claude profile name"), {
+      target: { value: "Work" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel new Claude profile" }));
+
+    expect(screen.queryByLabelText("New Claude profile name")).not.toBeInTheDocument();
+    expect(settingsState.setAgentInstance).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /add profile/i }));
+    expect(screen.getByLabelText("New Claude profile name")).toHaveValue("");
+  });
+});

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react";
+import { Button, toast } from "@heroui/react";
+import { Check, Plus, RefreshCw, Save, Trash2, X } from "lucide-react";
+import {
+  claudeProfileKind,
+  parseClaudeProfileInstanceConfig,
+  type AgentInstanceConfig,
+} from "@/shared/contracts";
+import { readBridge } from "@/renderer/bridge";
+import { Input } from "@/renderer/components/common";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { currentWslDistros } from "@/renderer/utils/acpRegistryAuth";
+
+function slugifyProfileName(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, "-")
+      .replace(/^-+|-+$/gu, "") || "profile"
+  );
+}
+
+function defaultConfigDir(name: string): string {
+  return `~/.lightcode/claude-profiles/${slugifyProfileName(name)}`;
+}
+
+function uniqueProfileId(name: string, existing: Readonly<Record<string, unknown>>): string {
+  const base = slugifyProfileName(name);
+  let candidate = base;
+  let index = 2;
+  while (existing[candidate]) {
+    candidate = `${base}-${index}`;
+    index += 1;
+  }
+  return candidate;
+}
+
+function refreshClaudeProfile(kind?: string): void {
+  window.setTimeout(() => {
+    void readBridge()
+      .refreshAgentStatuses(currentWslDistros(), kind ? { agentKinds: [kind] } : undefined)
+      .catch((error) =>
+        toast.danger(error instanceof Error ? error.message : "Unable to refresh Claude profiles."),
+      );
+  }, 50);
+}
+
+function ClaudeProfileRow(props: {
+  instance: AgentInstanceConfig;
+  configDir: string;
+  onSave: (instance: AgentInstanceConfig) => void;
+  onRemove: (id: string) => void;
+}) {
+  const [name, setName] = useState(props.instance.displayName ?? props.instance.id);
+  const [configDir, setConfigDir] = useState(props.configDir);
+  const trimmedName = name.trim();
+  const trimmedConfigDir = configDir.trim();
+  const changed =
+    trimmedName !== (props.instance.displayName ?? props.instance.id) ||
+    trimmedConfigDir !== props.configDir;
+  const canSave = trimmedName.length > 0 && trimmedConfigDir.length > 0 && changed;
+
+  return (
+    <div className="col-span-3 grid grid-cols-subgrid items-center border-b border-border/10 py-2 last:border-0">
+      <Input
+        aria-label="Claude profile name"
+        className="min-w-0"
+        value={name}
+        onChange={(event) => setName(event.target.value)}
+      />
+      <Input
+        aria-label="Claude profile config directory"
+        className="min-w-0"
+        value={configDir}
+        onChange={(event) => setConfigDir(event.target.value)}
+      />
+      <div className="flex shrink-0 items-center gap-1 justify-self-end">
+        <Button
+          isIconOnly
+          aria-label="Save Claude profile"
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 min-w-7"
+          isDisabled={!canSave}
+          onPress={() => {
+            props.onSave({
+              ...props.instance,
+              displayName: trimmedName,
+              config: { configDir: trimmedConfigDir },
+            });
+          }}
+        >
+          <Save className="size-3.5" />
+        </Button>
+        <Button
+          isIconOnly
+          aria-label="Remove Claude profile"
+          size="sm"
+          variant="ghost"
+          className="h-7 w-7 min-w-7 text-danger"
+          onPress={() => props.onRemove(props.instance.id)}
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function ClaudeProfileSettings() {
+  const agentInstances = useSharedSettings((s) => s.agentInstances ?? {});
+  const setAgentInstance = useSharedSettings((s) => s.setAgentInstance);
+  const removeAgentInstance = useSharedSettings((s) => s.removeAgentInstance);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newConfigDir, setNewConfigDir] = useState("");
+
+  const profiles: Array<{ instance: AgentInstanceConfig; configDir: string }> = [];
+  for (const instance of Object.values(agentInstances)) {
+    if (instance.driver !== "claude") continue;
+    try {
+      const parsed = parseClaudeProfileInstanceConfig(instance.config);
+      profiles.push({ instance, configDir: parsed.configDir });
+    } catch {
+      // Ignore malformed records here; the supervisor skips them too.
+    }
+  }
+  profiles.sort((a, b) =>
+    (a.instance.displayName ?? a.instance.id).localeCompare(
+      b.instance.displayName ?? b.instance.id,
+    ),
+  );
+
+  const canAdd = newName.trim().length > 0;
+  // Live default shown as the dir placeholder; used verbatim when left empty.
+  const suggestedConfigDir = defaultConfigDir(newName);
+
+  function closeAddForm(): void {
+    setIsAdding(false);
+    setNewName("");
+    setNewConfigDir("");
+  }
+
+  function addProfile(): void {
+    const displayName = newName.trim();
+    const configDir = newConfigDir.trim() || suggestedConfigDir;
+    if (!displayName) return;
+    const id = uniqueProfileId(displayName, agentInstances);
+    const instance: AgentInstanceConfig = {
+      id,
+      driver: "claude",
+      displayName,
+      config: { configDir },
+    };
+    setAgentInstance(instance);
+    refreshClaudeProfile(claudeProfileKind(id));
+    closeAddForm();
+    toast.success(`Claude ${displayName} profile added.`);
+  }
+
+  return (
+    <div className="border-t border-border/10 pt-4">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">Profiles</p>
+          <p className="text-xs text-muted">Separate Claude Code accounts by config directory.</p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 min-h-7 gap-1 px-2 text-[11px]"
+          onPress={() => refreshClaudeProfile()}
+        >
+          <RefreshCw className="size-3" />
+          Refresh
+        </Button>
+      </div>
+
+      {profiles.length === 0 && !isAdding ? (
+        <p className="py-2 text-xs text-muted">No additional Claude profiles.</p>
+      ) : null}
+
+      {/* One grid for saved rows AND the draft row (subgrid rows), so the
+          action column — and therefore the input columns — stay aligned. */}
+      <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto] gap-x-2">
+        {profiles.map(({ instance, configDir }) => (
+          <ClaudeProfileRow
+            key={instance.id}
+            instance={instance}
+            configDir={configDir}
+            onSave={(next) => {
+              setAgentInstance(next);
+              refreshClaudeProfile(claudeProfileKind(next.id));
+              toast.success(`Claude ${next.displayName ?? next.id} profile saved.`);
+            }}
+            onRemove={(id) => {
+              removeAgentInstance(id);
+              refreshClaudeProfile();
+              toast.success("Claude profile removed.");
+            }}
+          />
+        ))}
+
+        {isAdding ? (
+          <div className="col-span-3 grid grid-cols-subgrid items-center py-2">
+            <Input
+              // Focus the name field when the form is revealed by the explicit
+              // "Add profile" press (the accepted exception to no-autofocus).
+              ref={(node: HTMLInputElement | null) => node?.focus()}
+              aria-label="New Claude profile name"
+              className="min-w-0"
+              placeholder="e.g. Work"
+              value={newName}
+              onChange={(event) => setNewName(event.target.value)}
+            />
+            <Input
+              aria-label="New Claude profile config directory"
+              className="min-w-0"
+              placeholder={suggestedConfigDir}
+              value={newConfigDir}
+              onChange={(event) => setNewConfigDir(event.target.value)}
+            />
+            {/* Icon-only actions matching the saved rows' save/delete pair, so
+                the action column keeps the same width when the draft opens. */}
+            <div className="flex shrink-0 items-center gap-1 justify-self-end">
+              <Button
+                isIconOnly
+                aria-label="Add Claude profile"
+                size="sm"
+                variant="ghost"
+                className="h-7 w-7 min-w-7"
+                isDisabled={!canAdd}
+                onPress={addProfile}
+              >
+                <Check className="size-3.5" />
+              </Button>
+              <Button
+                isIconOnly
+                aria-label="Cancel new Claude profile"
+                size="sm"
+                variant="ghost"
+                className="h-7 w-7 min-w-7"
+                onPress={closeAddForm}
+              >
+                <X className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      {!isAdding ? (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="mt-2 h-7 min-h-7 gap-1 px-2 text-[11px]"
+          onPress={() => setIsAdding(true)}
+        >
+          <Plus className="size-3" />
+          Add profile
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -21,7 +21,7 @@ import {
   Sparkles,
   TerminalSquare,
 } from "lucide-react";
-import type { AgentStatus } from "@/shared/contracts";
+import { isClaudeProfileKind, type AgentStatus } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
   overlaySidebarColumnClass,
@@ -35,6 +35,29 @@ import { PixelLoader, SidebarButton } from "@/renderer/components/common";
 import { useSidebar } from "@/renderer/views/MainView/parts/AppShell/AppShell";
 import { isDevApp } from "@/renderer/bridge";
 import type { SettingsSection } from "./types";
+
+function claudeProfileSidebarLabel(agent: AgentStatus): string {
+  return agent.label.replace(/^Claude\s+/iu, "").trim() || agent.label;
+}
+
+function renderAgentIcon(
+  agent: AgentStatus,
+  options: {
+    disabled: boolean;
+    className?: string;
+  },
+) {
+  return (
+    <ProviderIcon
+      kind={agent.kind}
+      icon={agent.icon}
+      fallbackLabel={
+        isClaudeProfileKind(agent.kind) ? claudeProfileSidebarLabel(agent) : agent.label
+      }
+      className={`${options.className ?? "size-4"} ${options.disabled ? "opacity-35" : ""}`}
+    />
+  );
+}
 
 export function SettingsSidebar(props: {
   activeSection: SettingsSection;
@@ -56,6 +79,8 @@ export function SettingsSidebar(props: {
   } = props;
   const { isCollapsed, collapse, expand } = useSidebar();
   const disabledAgents = useSharedSettings((s) => s.disabledAgents);
+  const primaryAgents = installedAgents.filter((agent) => !isClaudeProfileKind(agent.kind));
+  const claudeProfileAgents = installedAgents.filter((agent) => isClaudeProfileKind(agent.kind));
   const isAgentsActive =
     activeSection === "agents" ||
     activeSection === "acpRegistry" ||
@@ -176,29 +201,53 @@ export function SettingsSidebar(props: {
               />
             )}
             {isAgentsActive &&
-              installedAgents.map((agent) => {
+              primaryAgents.map((agent) => {
                 const needsAttention = attentionAgentKinds.has(agent.kind);
                 return (
-                  <SidebarButton
-                    key={agent.kind}
-                    iconOnly
-                    icon={
-                      <span className="relative flex size-4 items-center justify-center">
-                        <ProviderIcon
-                          kind={agent.kind}
-                          icon={agent.icon}
-                          fallbackLabel={agent.label}
-                          className={`size-4 ${disabledAgents.includes(agent.kind) ? "opacity-35" : ""}`}
-                        />
-                        {needsAttention ? (
-                          <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
-                        ) : null}
-                      </span>
-                    }
-                    label={agent.label}
-                    isActive={activeSection === `agents:${agent.kind}`}
-                    onPress={() => onSectionChange(`agents:${agent.kind}`)}
-                  />
+                  <div key={agent.kind} className="space-y-0.5">
+                    <SidebarButton
+                      iconOnly
+                      icon={
+                        <span className="relative flex size-4 items-center justify-center">
+                          {renderAgentIcon(agent, {
+                            disabled: disabledAgents.includes(agent.kind),
+                          })}
+                          {needsAttention ? (
+                            <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
+                          ) : null}
+                        </span>
+                      }
+                      label={agent.label}
+                      isActive={activeSection === `agents:${agent.kind}`}
+                      onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                    />
+                    {agent.kind === "claude"
+                      ? claudeProfileAgents.map((profile) => {
+                          const profileNeedsAttention = attentionAgentKinds.has(profile.kind);
+                          return (
+                            <SidebarButton
+                              key={profile.kind}
+                              iconOnly
+                              className="ml-3 h-7 w-7"
+                              icon={
+                                <span className="relative flex size-3.5 items-center justify-center">
+                                  {renderAgentIcon(profile, {
+                                    disabled: disabledAgents.includes(profile.kind),
+                                    className: "size-3.5",
+                                  })}
+                                  {profileNeedsAttention ? (
+                                    <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
+                                  ) : null}
+                                </span>
+                              }
+                              label={profile.label}
+                              isActive={activeSection === `agents:${profile.kind}`}
+                              onPress={() => onSectionChange(`agents:${profile.kind}`)}
+                            />
+                          );
+                        })
+                      : null}
+                  </div>
                 );
               })}
             <SidebarButton
@@ -353,30 +402,55 @@ export function SettingsSidebar(props: {
                   isActive={activeSection === "acpRegistry"}
                   onPress={() => onSectionChange("acpRegistry")}
                 />
-                {installedAgents.map((agent) => {
+                {primaryAgents.map((agent) => {
                   const agentDisabled = disabledAgents.includes(agent.kind);
                   const needsAttention = attentionAgentKinds.has(agent.kind);
                   return (
-                    <SidebarButton
-                      key={agent.kind}
-                      icon={
-                        <ProviderIcon
-                          kind={agent.kind}
-                          icon={agent.icon}
-                          fallbackLabel={agent.label}
-                          className={`size-4 ${agentDisabled ? "opacity-35" : ""}`}
-                        />
-                      }
-                      label={agent.label}
-                      suffix={
-                        needsAttention ? (
-                          <AlertTriangle aria-hidden="true" className="size-3.5 text-warning" />
-                        ) : null
-                      }
-                      className={agentDisabled ? "opacity-50" : ""}
-                      isActive={activeSection === `agents:${agent.kind}`}
-                      onPress={() => onSectionChange(`agents:${agent.kind}`)}
-                    />
+                    <div key={agent.kind} className="space-y-0.5">
+                      <SidebarButton
+                        icon={renderAgentIcon(agent, {
+                          disabled: agentDisabled,
+                        })}
+                        label={agent.label}
+                        suffix={
+                          needsAttention ? (
+                            <AlertTriangle aria-hidden="true" className="size-3.5 text-warning" />
+                          ) : null
+                        }
+                        className={agentDisabled ? "opacity-50" : ""}
+                        isActive={activeSection === `agents:${agent.kind}`}
+                        onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                      />
+                      {agent.kind === "claude" && claudeProfileAgents.length > 0 ? (
+                        <div className="space-y-0.5 pl-5">
+                          {claudeProfileAgents.map((profile) => {
+                            const profileDisabled = disabledAgents.includes(profile.kind);
+                            const profileNeedsAttention = attentionAgentKinds.has(profile.kind);
+                            return (
+                              <SidebarButton
+                                key={profile.kind}
+                                icon={renderAgentIcon(profile, {
+                                  disabled: profileDisabled,
+                                  className: "size-3.5",
+                                })}
+                                label={claudeProfileSidebarLabel(profile)}
+                                suffix={
+                                  profileNeedsAttention ? (
+                                    <AlertTriangle
+                                      aria-hidden="true"
+                                      className="size-3.5 text-warning"
+                                    />
+                                  ) : null
+                                }
+                                className={`text-xs ${profileDisabled ? "opacity-50" : ""}`}
+                                isActive={activeSection === `agents:${profile.kind}`}
+                                onPress={() => onSectionChange(`agents:${profile.kind}`)}
+                              />
+                            );
+                          })}
+                        </div>
+                      ) : null}
+                    </div>
                   );
                 })}
               </div>

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings.tsx
@@ -61,6 +61,7 @@ import {
   type ProviderModelMenuProvider,
 } from "@/renderer/components/common/ProviderModelMenu";
 import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
+import { ClaudeProfileSettings } from "./ClaudeProfileSettings";
 
 const SAVED_SECRET_MASK = "***********";
 
@@ -1451,6 +1452,8 @@ export function SingleAgentSettings(props: { agentKind: string }) {
       </div>
 
       <div className="space-y-4">
+        {props.agentKind === "claude" ? <ClaudeProfileSettings /> : null}
+
         {hasAuthSettings && (
           <div className="space-y-2">
             {envVarAuthMethod && acpInstanceId ? (

--- a/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -10,7 +10,7 @@ import {
   usageStatusText,
 } from "@/renderer/components/providers/usageFormat";
 import { UsageWindowBars } from "@/renderer/components/providers/UsageWindowBars";
-import { USAGE_PROVIDERS } from "@/renderer/components/providers/usageProviders";
+import { usageProvidersForAgentInstances } from "@/renderer/components/providers/usageProviders";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useProviderUsage, useProviderUsageStore } from "@/renderer/state/providerUsageStore";
 import { SettingRow, SettingsPage } from "./SettingsForm";
@@ -97,8 +97,10 @@ export function UsageSettings() {
   const refreshIntervalMinutes = useSharedSettings((s) => s.usage.refreshIntervalMinutes);
   const showInSidebar = useSharedSettings((s) => s.usage.showInSidebar);
   const showEstimatedCost = useSharedSettings((s) => s.usage.showEstimatedCost);
+  const agentInstances = useSharedSettings((s) => s.agentInstances);
   const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const usageProviders = usageProvidersForAgentInstances(agentInstances);
 
   // Hydrate the store from the supervisor cache on open (and let the cache's
   // staleness trigger a background refresh whose events update the rows live).
@@ -217,7 +219,7 @@ export function UsageSettings() {
           Turn tracking on or off per provider. Disabled providers are skipped by the auto-refresh.
         </p>
         <div>
-          {USAGE_PROVIDERS.map((p) => (
+          {usageProviders.map((p) => (
             <UsageProviderRow key={p.id} id={p.id} label={p.label} />
           ))}
         </div>

--- a/src/shared/contracts/agentInstance.test.ts
+++ b/src/shared/contracts/agentInstance.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { agentInstanceConfigSchema, parseAcpGenericInstanceConfig } from "./agentInstance";
+import {
+  agentInstanceConfigSchema,
+  claudeProfileKind,
+  extractClaudeProfileInstanceId,
+  isClaudeProfileKind,
+  parseAcpGenericInstanceConfig,
+  parseClaudeProfileInstanceConfig,
+} from "./agentInstance";
 
 /**
  * `parseAcpGenericInstanceConfig` parses user-supplied JSON from settings, so
@@ -54,6 +61,28 @@ describe("parseAcpGenericInstanceConfig", () => {
     // `binary` though — the second call should throw with a Zod message.
     expect(() => parseAcpGenericInstanceConfig(undefined)).toThrow(Error);
     expect(() => parseAcpGenericInstanceConfig(null)).toThrow(Error);
+  });
+});
+
+describe("Claude profile instance helpers", () => {
+  it("parses a Claude profile config directory", () => {
+    expect(
+      parseClaudeProfileInstanceConfig({
+        configDir: "~/.lightcode/claude-profiles/work",
+      }),
+    ).toEqual({ configDir: "~/.lightcode/claude-profiles/work" });
+  });
+
+  it("rejects an empty Claude profile config directory", () => {
+    expect(() => parseClaudeProfileInstanceConfig({ configDir: "" })).toThrow(Error);
+  });
+
+  it("maps profile ids to synthetic Claude provider kinds", () => {
+    expect(claudeProfileKind("work")).toBe("claude:work");
+    expect(isClaudeProfileKind("claude:work")).toBe(true);
+    expect(isClaudeProfileKind("claude")).toBe(false);
+    expect(extractClaudeProfileInstanceId("claude:work")).toBe("work");
+    expect(extractClaudeProfileInstanceId("codex")).toBeUndefined();
   });
 });
 

--- a/src/shared/contracts/agentInstance.ts
+++ b/src/shared/contracts/agentInstance.ts
@@ -35,6 +35,8 @@ export const KNOWN_AGENT_DRIVERS = {
   acpGeneric: "acp-generic" as AgentDriverKind,
 } as const;
 
+export const CLAUDE_PROFILE_KIND_PREFIX = "claude:";
+
 export const agentInstanceIdSchema = z
   .string()
   .min(1)
@@ -112,4 +114,40 @@ export type AgentInstanceConfigMap = z.infer<typeof agentInstanceConfigMapSchema
 
 export function parseAcpGenericInstanceConfig(value: unknown): AcpGenericInstanceConfig {
   return acpGenericInstanceConfigSchema.parse(value ?? {});
+}
+
+// ── claude profile driver config ────────────────────────────────────────
+
+export const claudeProfileInstanceConfigSchema = z.object({
+  /**
+   * Directory passed to Claude Code as CLAUDE_CONFIG_DIR. A leading "~/" is
+   * resolved against the target runtime environment (native home or WSL home).
+   */
+  configDir: z.string().min(1),
+});
+export type ClaudeProfileInstanceConfig = z.infer<typeof claudeProfileInstanceConfigSchema>;
+
+export function parseClaudeProfileInstanceConfig(value: unknown): ClaudeProfileInstanceConfig {
+  return claudeProfileInstanceConfigSchema.parse(value ?? {});
+}
+
+export function claudeProfileKind(instanceId: string): AgentDriverKind {
+  return `${CLAUDE_PROFILE_KIND_PREFIX}${instanceId}` as AgentDriverKind;
+}
+
+export function isClaudeProfileKind(kind: string): boolean {
+  return kind.startsWith(CLAUDE_PROFILE_KIND_PREFIX);
+}
+
+export function extractClaudeProfileInstanceId(kind: string): string | undefined {
+  return isClaudeProfileKind(kind) ? kind.slice(CLAUDE_PROFILE_KIND_PREFIX.length) : undefined;
+}
+
+/**
+ * Strips the instance suffix from an instance-scoped kind (e.g.
+ * "claude:work" → "claude"). Kinds without a suffix are returned unchanged.
+ */
+export function baseAgentKind(kind: string): string {
+  const separatorIndex = kind.indexOf(":");
+  return separatorIndex > 0 ? kind.slice(0, separatorIndex) : kind;
 }

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -497,18 +497,30 @@ export async function readAgentCommandOutput(
   location: ProjectLocation,
   executablePath: string,
   args: string[],
-  options?: { timeoutMs?: number; wslLinuxCwd?: string; posixCwd?: string },
+  options?: {
+    timeoutMs?: number;
+    wslLinuxCwd?: string;
+    posixCwd?: string;
+    env?: Record<string, string>;
+  },
 ): Promise<{ ok: boolean; stdout: string; stderr: string }> {
   if (location.kind === "wsl") {
+    const wslOptions =
+      options?.timeoutMs !== undefined || options?.env
+        ? {
+            ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
+            ...(options?.env ? { env: options.env } : {}),
+          }
+        : undefined;
     return readWslLoginShellCommandOutputAsync(
       location.distro,
       options?.wslLinuxCwd ?? location.linuxPath,
       executablePath,
       args,
-      options?.timeoutMs ? { timeout: options.timeoutMs } : undefined,
+      wslOptions,
     );
   }
-  const spec = buildAgentCommand(location, executablePath, args);
+  const spec = buildAgentCommand(location, executablePath, args, undefined, options?.env);
   const effectiveCwd = options?.posixCwd ?? spec.cwd;
   const runOptions = {
     ...(effectiveCwd ? { cwd: effectiveCwd } : {}),

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -113,6 +113,7 @@ export interface CreateStructuredSessionInput {
   projectLocation: ProjectLocation;
   config: ThreadConfig;
   agentSettings?: Record<string, boolean | string>;
+  env?: Record<string, string>;
   browserMcp?: BrowserMcpHttpConfig;
   sessionRef?: SessionRef;
   presentationMode?: ThreadPresentationMode;
@@ -281,15 +282,23 @@ export interface AgentOneShotRunner {
     model: string,
     effort?: string,
     prompt?: string,
+    location?: ProjectLocation,
   ):
-    | { command: string; args: string[]; stdin?: string; isolateCwd?: boolean; pty?: boolean }
+    | {
+        command: string;
+        args: string[];
+        stdin?: string;
+        isolateCwd?: boolean;
+        pty?: boolean;
+        env?: Record<string, string>;
+      }
     | undefined;
   runOneShot?(input: RunOneShotInput): Promise<string>;
   buildContextExtractionCommand?(
     sessionRef: SessionRef,
     location: ProjectLocation,
     model?: string,
-  ): { command: string; args: string[]; stdin?: string } | undefined;
+  ): { command: string; args: string[]; stdin?: string; env?: Record<string, string> } | undefined;
 }
 
 /**

--- a/src/supervisor/agents/claude/claude.test.ts
+++ b/src/supervisor/agents/claude/claude.test.ts
@@ -1,5 +1,7 @@
+import { homedir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { createClaudeAdapter } from "./index";
+import { createClaudeAdapter, createClaudeProfileAdapter } from "./index";
 import { claudeCapabilities, parseClaudeAuthStatusJson } from "./detection";
 import type { OscNotification, OscTitle } from "@/shared/osc";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
@@ -163,6 +165,42 @@ describe("createClaudeAdapter buildAcpLogoutCommand", () => {
     expect(rendered).toMatch(/claude/i);
     expect(rendered).toContain("auth");
     expect(rendered).toContain("logout");
+  });
+});
+
+describe("createClaudeProfileAdapter", () => {
+  const projectLocation: ProjectLocation = { kind: "posix", path: "/repo" };
+
+  it("creates a distinct Claude adapter backed by a separate config directory", () => {
+    const adapter = createClaudeProfileAdapter({
+      id: "work",
+      driver: "claude",
+      displayName: "Work",
+      config: { configDir: "~/.lightcode/claude-profiles/work" },
+    });
+
+    expect(adapter.kind).toBe("claude:work");
+    expect(adapter.label).toBe("Claude Work");
+    expect(adapter.capabilities.subProviders).toContainEqual({
+      id: "claude-profile",
+      label: "Work",
+    });
+    expect(adapter.capabilities.modelSubProvider?.sonnet).toBe("claude-profile");
+
+    const expectedConfigDir = path.join(homedir(), ".lightcode/claude-profiles/work");
+    expect(
+      adapter.buildLaunchArgv(projectLocation, { model: "sonnet" }, "hello").env?.CLAUDE_CONFIG_DIR,
+    ).toBe(expectedConfigDir);
+    expect(
+      adapter.buildOneShotCommand?.("haiku", undefined, "Summarize", projectLocation)?.env
+        ?.CLAUDE_CONFIG_DIR,
+    ).toBe(expectedConfigDir);
+    expect(
+      adapter.buildContextExtractionCommand?.(
+        { providerSessionId: "session-1", discoveredAt: "test" },
+        projectLocation,
+      )?.env?.CLAUDE_CONFIG_DIR,
+    ).toBe(expectedConfigDir);
   });
 });
 

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -161,7 +161,10 @@ export function parseClaudeAuthStatusJson(output: string): StatusProbeResult | u
   };
 }
 
-async function probeClaudeStatus(ctx: Parameters<NonNullable<DetectionSpec["statusProbe"]>>[0]) {
+export async function probeClaudeStatus(
+  ctx: Parameters<NonNullable<DetectionSpec["statusProbe"]>>[0],
+  options?: { env?: Record<string, string> },
+) {
   if (!ctx.executablePath) return undefined;
   const result = await readAgentCommandOutput(
     ctx.location,
@@ -169,6 +172,7 @@ async function probeClaudeStatus(ctx: Parameters<NonNullable<DetectionSpec["stat
     ["auth", "status"],
     {
       posixCwd: getAgentProbeCwd(ctx.location),
+      ...(options?.env ? { env: options.env } : {}),
     },
   );
   const parsed = parseClaudeAuthStatusJson(result.stdout || result.stderr);

--- a/src/supervisor/agents/claude/index.ts
+++ b/src/supervisor/agents/claude/index.ts
@@ -1,18 +1,30 @@
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import path, { posix as posixPath } from "node:path";
 
-import type { PromptSegment } from "@/shared/contracts";
+import type {
+  AgentCapability,
+  AgentInstanceConfig,
+  ProjectLocation,
+  PromptSegment,
+} from "@/shared/contracts";
+import { claudeProfileKind, parseClaudeProfileInstanceConfig } from "@/shared/contracts";
 import {
   brailleSpinnerOscTitleHint,
-  buildAgentLogoutCommand,
+  buildAgentCommand,
   createKnownSessionRef,
   detectAgentInstall,
+  detectProbeLocation,
   iterm2ProgressOscHint,
+  resolveWslHomeDirectory,
   shortenHomePath,
   type AgentAdapter,
   type CreateStructuredSessionInput,
+  type DetectProbeCtx,
 } from "../base";
 import { buildClaudeArgs } from "./argv";
-import { claudeCapabilities, claudeDetectionSpec } from "./detection";
+import { claudeCapabilities, claudeDetectionSpec, probeClaudeStatus } from "./detection";
+import { probeClaudeCapabilities } from "./probe";
 import { ClaudeSdkSession } from "./sdkSession";
 import { resolveInstallNodePath, warnIfPluginManifestMissing } from "../plugin/installerBase";
 import {
@@ -30,18 +42,80 @@ const CLAUDE_PLUGIN_VERSION = readBundledClaudePluginVersion();
 
 warnIfPluginManifestMissing("claude", CLAUDE_PLUGIN_VERSION);
 
-export function createClaudeAdapter(): AgentAdapter {
+interface ClaudeAdapterOptions {
+  kind?: string;
+  label?: string;
+  profileLabel?: string;
+  configDir?: string;
+}
+
+function resolveTildePath(rawPath: string, location: ProjectLocation): string {
+  const trimmed = rawPath.trim();
+  if (trimmed !== "~" && !trimmed.startsWith("~/")) {
+    return trimmed;
+  }
+  const suffix = trimmed === "~" ? "" : trimmed.slice(2);
+  if (location.kind === "wsl") {
+    const home = resolveWslHomeDirectory(location.distro);
+    return home ? posixPath.join(home, suffix) : trimmed;
+  }
+  return path.join(homedir(), suffix);
+}
+
+function profileEnvForLocation(
+  configDir: string | undefined,
+  location: ProjectLocation,
+): Record<string, string> | undefined {
+  if (!configDir?.trim()) return undefined;
+  return { CLAUDE_CONFIG_DIR: resolveTildePath(configDir, location) };
+}
+
+function capabilitiesWithProfile(
+  capabilities: AgentCapability,
+  profileLabel: string | undefined,
+): AgentCapability {
+  const label = profileLabel?.trim();
+  if (!label) return capabilities;
+  const subProviderId = "claude-profile";
   return {
-    kind: "claude",
-    label: "Claude Code",
+    ...capabilities,
+    subProviders: [
+      ...(capabilities.subProviders?.filter((entry) => entry.id !== subProviderId) ?? []),
+      { id: subProviderId, label },
+    ],
+    modelSubProvider: {
+      ...(capabilities.modelSubProvider ?? {}),
+      ...Object.fromEntries(capabilities.models.map((model) => [model.id, subProviderId])),
+    },
+  };
+}
+
+export function createClaudeProfileAdapter(instance: AgentInstanceConfig): AgentAdapter {
+  const cfg = parseClaudeProfileInstanceConfig(instance.config);
+  const profileLabel = instance.displayName ?? instance.id;
+  return createClaudeAdapter({
+    kind: claudeProfileKind(instance.id),
+    label: `Claude ${profileLabel}`,
+    profileLabel,
+    configDir: cfg.configDir,
+  });
+}
+
+export function createClaudeAdapter(options: ClaudeAdapterOptions = {}): AgentAdapter {
+  const kind = options.kind ?? "claude";
+  const label = options.label ?? "Claude Code";
+  const baseCapabilities = capabilitiesWithProfile(claudeCapabilities, options.profileLabel);
+  const profileEnv = (location: ProjectLocation) =>
+    profileEnvForLocation(options.configDir, location);
+
+  return {
+    kind,
+    label,
     binary: "claude",
-    capabilities: claudeCapabilities,
+    capabilities: baseCapabilities,
     ...(claudeDetectionSpec.update ? { update: claudeDetectionSpec.update } : {}),
     // WSL OAuth flows try to open a browser; no-op it so the PTY doesn't hang.
     spawnEnv: { wsl: { BROWSER: "/bin/true" } },
-    detectInstall(ctx) {
-      return detectAgentInstall(ctx, claudeDetectionSpec);
-    },
     // ── CLI hook plugin support ──────────────────────────────────────────
     pluginId: "lightcode-status@claude",
     pluginVersion: CLAUDE_PLUGIN_VERSION,
@@ -72,27 +146,66 @@ export function createClaudeAdapter(): AgentAdapter {
       const paths = getClaudePluginPaths(ctx);
       return { args: ["--settings", paths.settingsPath] };
     },
-    buildLaunchArgv(_location, config, prompt, _sessionRef, _launchOptions) {
+    async detectInstall(ctx) {
+      const spec =
+        options.configDir === undefined
+          ? claudeDetectionSpec
+          : {
+              ...claudeDetectionSpec,
+              kind,
+              label,
+              capabilities: baseCapabilities,
+              statusProbe: (probeCtx: DetectProbeCtx) => {
+                const env = profileEnv(probeCtx.location);
+                return probeClaudeStatus(probeCtx, env ? { env } : undefined);
+              },
+              capabilitiesProbe: (probeCtx: DetectProbeCtx) => {
+                const env = profileEnv(probeCtx.location);
+                return probeClaudeCapabilities(probeCtx, env ? { env } : undefined);
+              },
+            };
+      const status = await detectAgentInstall(ctx, spec);
+      return {
+        ...status,
+        kind,
+        label,
+        capabilities: capabilitiesWithProfile(status.capabilities, options.profileLabel),
+      };
+    },
+    buildLaunchArgv(location, config, prompt, _sessionRef, _launchOptions) {
       const assignedId = randomUUID();
       const args = buildClaudeArgs(config, prompt, undefined, assignedId);
+      const env = profileEnv(location);
       return {
         binary: "claude",
         args,
+        ...(env ? { env } : {}),
         sessionRef: createKnownSessionRef(assignedId),
       };
     },
-    buildResumeArgv(_location, config, prompt, sessionRef, _launchOptions) {
+    buildResumeArgv(location, config, prompt, sessionRef, _launchOptions) {
       const args = buildClaudeArgs(config, prompt, sessionRef.providerSessionId);
-      return { binary: "claude", args };
+      const env = profileEnv(location);
+      return { binary: "claude", args, ...(env ? { env } : {}) };
     },
     createInitialSessionRef() {
       return undefined;
     },
     async createStructuredSession(input: CreateStructuredSessionInput) {
       if (input.presentationMode !== "gui") return undefined;
-      return ClaudeSdkSession.create(input);
+      const env = profileEnv(input.projectLocation);
+      return ClaudeSdkSession.create({ ...input, ...(env ? { env } : {}) });
     },
-    buildAcpLogoutCommand: buildAgentLogoutCommand("claude", ["auth", "logout"]),
+    async buildAcpLogoutCommand(ctx) {
+      const location = detectProbeLocation(ctx);
+      return buildAgentCommand(
+        location,
+        "claude",
+        ["auth", "logout"],
+        undefined,
+        profileEnv(location),
+      );
+    },
     buildDirectInput(prompt, segments) {
       const attachmentCount = segments?.filter((s) => s.kind === "attachment").length ?? 0;
       const wait = attachmentCount > 0 ? 800 + (attachmentCount - 1) * 150 : 60;
@@ -113,7 +226,7 @@ export function createClaudeAdapter(): AgentAdapter {
     oscHintsDeferToHookPlugin: true,
     workingSilenceTimeoutMs: null,
     defaultOneShotModel: "haiku",
-    buildOneShotCommand(model, effort, prompt) {
+    buildOneShotCommand(model, effort, prompt, location) {
       if (!prompt) return undefined;
       // --no-session-persistence keeps title/commit/PR-summary calls out of
       // the `/resume` picker. --fallback-model auto-degrades to Haiku if the
@@ -131,9 +244,15 @@ export function createClaudeAdapter(): AgentAdapter {
       if (effort) {
         args.push("--effort", effort);
       }
-      return { command: "claude", args, stdin: "" };
+      const env = location ? profileEnv(location) : undefined;
+      return {
+        command: "claude",
+        args,
+        stdin: "",
+        ...(env ? { env } : {}),
+      };
     },
-    buildContextExtractionCommand(sessionRef, _location, model) {
+    buildContextExtractionCommand(sessionRef, location, model) {
       // The resumed session is read-only here; --no-session-persistence
       // prevents the extraction turn from being written back to disk.
       const args = [
@@ -144,7 +263,12 @@ export function createClaudeAdapter(): AgentAdapter {
         model ?? "haiku",
         "--no-session-persistence",
       ];
-      return { command: "claude", args };
+      const env = profileEnv(location);
+      return {
+        command: "claude",
+        args,
+        ...(env ? { env } : {}),
+      };
     },
   };
 }

--- a/src/supervisor/agents/claude/probe.ts
+++ b/src/supervisor/agents/claude/probe.ts
@@ -1,6 +1,6 @@
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AgentAuthMethod, AgentCapability } from "@/shared/contracts";
+import type { AgentCapability, AgentTerminalAuthMethod } from "@/shared/contracts";
 import type { SlashCommand } from "@anthropic-ai/claude-agent-sdk";
 import {
   readWslLoginShellCommandOutputAsync,
@@ -13,12 +13,16 @@ import { resolveFastAvailability } from "./fastModeProbe";
 import { AsyncPromptQueue } from "./promptQueue";
 import { spawnClaudeProbeProcess } from "./sdkProbeProcess";
 
-const CLAUDE_TERMINAL_AUTH_METHOD: AgentAuthMethod = {
+const CLAUDE_TERMINAL_AUTH_METHOD: AgentTerminalAuthMethod = {
   type: "terminal",
   id: "claude-login",
   name: "Claude login",
   args: ["auth", "login"],
 };
+
+export function claudeTerminalAuthMethod(env?: Record<string, string>): AgentTerminalAuthMethod {
+  return env ? { ...CLAUDE_TERMINAL_AUTH_METHOD, env } : CLAUDE_TERMINAL_AUTH_METHOD;
+}
 
 const MIN_CLAUDE_OPUS_47_CLI = [2, 1, 111] as const;
 const MIN_CLAUDE_OPUS_48_CLI = [2, 1, 154] as const;
@@ -147,6 +151,7 @@ export function win32PathToWslMount(winPath: string): string {
 async function probeClaudeSdkPartialNative(
   executablePath: string,
   timeoutMs: number,
+  envOverrides?: Record<string, string>,
 ): Promise<Partial<AgentCapability> | undefined> {
   try {
     const { query } = await import("@anthropic-ai/claude-agent-sdk");
@@ -161,6 +166,7 @@ async function probeClaudeSdkPartialNative(
           pathToClaudeCodeExecutable: executablePath,
           persistSession: false,
           cwd: process.platform === "win32" ? (process.env.USERPROFILE ?? process.cwd()) : "/tmp",
+          ...(envOverrides ? { env: { ...process.env, ...envOverrides } } : {}),
           settingSources: ["user", "project", "local"],
           allowedTools: [],
           stderr: () => {},
@@ -204,6 +210,7 @@ async function probeClaudeSdkPartialNative(
 async function probeClaudeSdkPartialWsl(
   ctx: DetectProbeCtx,
   timeoutMs: number,
+  envOverrides?: Record<string, string>,
 ): Promise<Partial<AgentCapability> | undefined> {
   if (ctx.location.kind !== "wsl" || !ctx.executablePath) return undefined;
 
@@ -222,7 +229,10 @@ async function probeClaudeSdkPartialWsl(
     "/tmp",
     "node",
     [workerWslPath, ctx.executablePath, String(timeoutMs), cacheWslPath],
-    { timeout: timeoutMs + 3000 },
+    {
+      timeout: timeoutMs + 3000,
+      ...(envOverrides ? { env: envOverrides } : {}),
+    },
   );
 
   if (!result.ok) {
@@ -258,6 +268,7 @@ async function probeClaudeSdkPartialWsl(
 
 export async function probeClaudeCapabilities(
   ctx: DetectProbeCtx,
+  options?: { env?: Record<string, string> },
 ): Promise<CapabilitiesProbeResult | undefined> {
   if (!ctx.executablePath) return undefined;
 
@@ -266,8 +277,8 @@ export async function probeClaudeCapabilities(
   const timeoutMs = process.platform === "win32" ? 25_000 : 20_000;
   const sdkPartial =
     ctx.location.kind === "wsl"
-      ? await probeClaudeSdkPartialWsl(ctx, timeoutMs)
-      : await probeClaudeSdkPartialNative(ctx.executablePath, timeoutMs);
+      ? await probeClaudeSdkPartialWsl(ctx, timeoutMs, options?.env)
+      : await probeClaudeSdkPartialNative(ctx.executablePath, timeoutMs, options?.env);
 
   const versionPartial = claudeCapabilitiesFromCliVersion(ctx.version);
 
@@ -278,7 +289,7 @@ export async function probeClaudeCapabilities(
   return {
     ...(sdkPartial ?? {}),
     ...(versionPartial ?? {}),
-    authMethods: [CLAUDE_TERMINAL_AUTH_METHOD],
+    authMethods: [claudeTerminalAuthMethod(options?.env)],
     authLogoutSupported: true,
   };
 }

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -857,8 +857,16 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
           : undefined;
       const env =
         this.input.projectLocation.kind === "wsl"
-          ? { CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode", BROWSER: "/bin/true" }
-          : { ...(posixEnv ?? process.env), CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode" };
+          ? {
+              CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode",
+              BROWSER: "/bin/true",
+              ...(this.input.env ?? {}),
+            }
+          : {
+              ...(posixEnv ?? process.env),
+              CLAUDE_AGENT_SDK_CLIENT_APP: "lightcode",
+              ...(this.input.env ?? {}),
+            };
       // Posix builds ship without the SDK's bundled `claude` SEA binary
       // (electron-builder strips `@anthropic-ai/claude-agent-sdk-*` from the
       // asar). The SDK falls back to that binary when `pathToClaudeCodeExecutable`

--- a/src/supervisor/agents/registry.ts
+++ b/src/supervisor/agents/registry.ts
@@ -15,7 +15,7 @@ import type { AgentInstanceConfig } from "@/shared/contracts";
 import { createAcpGenericAdapter } from "./acp-generic";
 import { createAntigravityAdapter } from "./antigravity";
 import type { AgentAdapter } from "./base";
-import { createClaudeAdapter } from "./claude";
+import { createClaudeAdapter, createClaudeProfileAdapter } from "./claude";
 import { createCommandCodeAdapter } from "./commandcode";
 import { createCopilotAdapter } from "./copilot";
 import { createCodexAdapter } from "./codex";
@@ -48,7 +48,21 @@ export function buildAgentRegistry(userInstances: AgentInstanceConfig[]): AgentA
   const userAdapters = userInstances
     .filter((inst) => inst.enabled !== false && inst.driver === "acp-generic")
     .map((inst) => createAcpGenericAdapter(inst));
-  const adapters = [...builtIns, ...userAdapters];
+  const claudeProfileAdapters = userInstances
+    .filter((inst) => inst.enabled !== false && inst.driver === "claude")
+    .flatMap((inst) => {
+      try {
+        return [createClaudeProfileAdapter(inst)];
+      } catch (error) {
+        console.warn(
+          `[agents] skipping Claude profile ${inst.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return [];
+      }
+    });
+  const adapters = [...builtIns, ...claudeProfileAdapters, ...userAdapters];
   const kinds = new Set(adapters.map((a) => a.kind));
   if (kinds.size !== adapters.length) {
     throw new Error("Duplicate agent kind in registry");

--- a/src/supervisor/commitMessageGenerator.test.ts
+++ b/src/supervisor/commitMessageGenerator.test.ts
@@ -207,12 +207,13 @@ describe("generateCommitMessage", () => {
     const pending = generateCommitMessage(windowsProject, createAdapter());
     await flushPromises();
 
-    expect(buildAgentCommandMock).toHaveBeenCalledWith(windowsProject, "codex", [
-      "exec",
-      "-m",
-      "gpt-5.4-mini",
-      "-",
-    ]);
+    expect(buildAgentCommandMock).toHaveBeenCalledWith(
+      windowsProject,
+      "codex",
+      ["exec", "-m", "gpt-5.4-mini", "-"],
+      undefined,
+      undefined,
+    );
     expect(spawnMock).toHaveBeenCalledWith(
       "codex",
       ["exec", "-m", "gpt-5.4-mini", "-"],
@@ -238,12 +239,13 @@ describe("generateCommitMessage", () => {
     const pending = generateCommitMessage(wslProject, createAdapter());
     await flushPromises();
 
-    expect(buildAgentCommandMock).toHaveBeenCalledWith(wslProject, "codex", [
-      "exec",
-      "-m",
-      "gpt-5.4-mini",
-      "-",
-    ]);
+    expect(buildAgentCommandMock).toHaveBeenCalledWith(
+      wslProject,
+      "codex",
+      ["exec", "-m", "gpt-5.4-mini", "-"],
+      undefined,
+      undefined,
+    );
 
     child.stdout.emit("data", Buffer.from("fix(wsl): route commit generation through WSL"));
     child.emit("close", 0);

--- a/src/supervisor/contextExtractor.ts
+++ b/src/supervisor/contextExtractor.ts
@@ -60,7 +60,9 @@ export async function extractContext(
   if (adapter.buildContextExtractionCommand) {
     const cmd = adapter.buildContextExtractionCommand(sessionRef, location, model);
     if (cmd) {
-      const spawnSpec = buildOneShotSpec(location, cmd.command, cmd.args);
+      const spawnSpec = buildOneShotSpec(location, cmd.command, cmd.args, {
+        ...(cmd.env ? { env: cmd.env } : {}),
+      });
       console.log(`[context-extract] spawning: ${spawnSpec.command} ${spawnSpec.args.join(" ")}`);
 
       const raw = await spawnAgent(

--- a/src/supervisor/oneShotPromptRunner.ts
+++ b/src/supervisor/oneShotPromptRunner.ts
@@ -136,7 +136,12 @@ export async function runOneShotPromptWithFallback(
     if (!options.adapter.buildOneShotCommand) {
       throw new Error(`${options.adapter.label} does not support one-shot generation`);
     }
-    const cmd = options.adapter.buildOneShotCommand(options.model, options.effort, prompt);
+    const cmd = options.adapter.buildOneShotCommand(
+      options.model,
+      options.effort,
+      prompt,
+      options.location,
+    );
     if (!cmd) {
       throw new Error(`${options.adapter.label} does not support one-shot generation`);
     }

--- a/src/supervisor/oneShotSpawn.ts
+++ b/src/supervisor/oneShotSpawn.ts
@@ -16,6 +16,7 @@ export interface OneShotSpecOptions {
    * is irrelevant to the result.
    */
   isolateCwd?: boolean | undefined;
+  env?: Record<string, string> | undefined;
 }
 
 /**
@@ -37,7 +38,7 @@ export function buildOneShotSpec(
   options?: OneShotSpecOptions,
 ): CommandSpec {
   const effectiveLocation = options?.isolateCwd ? isolatedCwdLocation(location) : location;
-  return buildAgentCommand(effectiveLocation, command, args);
+  return buildAgentCommand(effectiveLocation, command, args, undefined, options?.env);
 }
 
 /**
@@ -49,9 +50,18 @@ export function buildOneShotSpec(
  */
 export function prepareOneShot(
   location: ProjectLocation,
-  cmd: { command: string; args: string[]; isolateCwd?: boolean; pty?: boolean },
+  cmd: {
+    command: string;
+    args: string[];
+    isolateCwd?: boolean;
+    pty?: boolean;
+    env?: Record<string, string>;
+  },
 ): { spec: CommandSpec; spawn: typeof spawnAgent } {
-  const spec = buildOneShotSpec(location, cmd.command, cmd.args, { isolateCwd: cmd.isolateCwd });
+  const spec = buildOneShotSpec(location, cmd.command, cmd.args, {
+    isolateCwd: cmd.isolateCwd,
+    ...(cmd.env ? { env: cmd.env } : {}),
+  });
   return { spec, spawn: cmd.pty ? spawnAgentPty : spawnAgent };
 }
 

--- a/src/supervisor/prSummaryGenerator.test.ts
+++ b/src/supervisor/prSummaryGenerator.test.ts
@@ -137,12 +137,13 @@ describe("generatePrSummary", () => {
     );
     await flushPromises();
 
-    expect(buildAgentCommandMock).toHaveBeenCalledWith(windowsProject, "codex", [
-      "exec",
-      "-m",
-      "gpt-5.4-mini",
-      "-",
-    ]);
+    expect(buildAgentCommandMock).toHaveBeenCalledWith(
+      windowsProject,
+      "codex",
+      ["exec", "-m", "gpt-5.4-mini", "-"],
+      undefined,
+      undefined,
+    );
     expect(spawnMock).toHaveBeenCalledWith(
       "codex",
       ["exec", "-m", "gpt-5.4-mini", "-"],

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -508,10 +508,14 @@ export class SupervisorRuntime {
   }
 
   async getAgentStatuses(payload: GetAgentStatusesPayload): Promise<AgentStatusesResponse> {
+    this.sharedSettingsCache.invalidate();
+    this.refreshAgentRegistryAdapters();
     return this.agentStatusService.getAgentStatuses(payload);
   }
 
   async refreshAgentStatuses(payload: GetAgentStatusesPayload): Promise<AgentStatusesResponse> {
+    this.sharedSettingsCache.invalidate();
+    this.refreshAgentRegistryAdapters();
     return this.agentStatusService.refreshAgentStatuses(payload);
   }
 

--- a/src/supervisor/runtime/claudeCredentials.ts
+++ b/src/supervisor/runtime/claudeCredentials.ts
@@ -20,6 +20,12 @@ interface ClaudeOAuthBlob {
   rateLimitTier?: string;
 }
 
+export interface ClaudeCredentialEnv {
+  CLAUDE_CONFIG_DIR?: string | undefined;
+  CLAUDE_SECURESTORAGE_CONFIG_DIR?: string | undefined;
+  CLAUDE_CODE_CUSTOM_OAUTH_URL?: string | undefined;
+}
+
 /**
  * Parse a Claude credential blob into an OAuth token bundle. Accepts either the
  * `~/.claude/.credentials.json` shape (a `claudeAiOauth` wrapper) or a bare
@@ -45,17 +51,30 @@ export function parseClaudeCredentials(content: string): OAuthToken | undefined 
   };
 }
 
-function claudeCredentialDirs(): string[] {
-  const dirs: string[] = [];
-  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim();
-  if (configDir) dirs.push(configDir);
-  dirs.push(join(homedir(), ".claude"));
-  dirs.push(join(homedir(), ".config", "claude"));
-  return dirs;
+/**
+ * Candidate Claude Code config dirs, honoring an explicit CLAUDE_CONFIG_DIR
+ * override. Shared by credential lookup and the local cost scanner.
+ */
+export function claudeConfigDirs(
+  env: { CLAUDE_CONFIG_DIR?: string | undefined } = process.env,
+): string[] {
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (configDir) {
+    return [configDir];
+  }
+  return [join(homedir(), ".claude"), join(homedir(), ".config", "claude")];
 }
 
-export async function resolveClaudeToken(): Promise<OAuthToken | undefined> {
-  for (const dir of claudeCredentialDirs()) {
+function hasExplicitClaudeConfig(env: ClaudeCredentialEnv): boolean {
+  return Boolean(
+    env.CLAUDE_CONFIG_DIR?.trim() || env.CLAUDE_SECURESTORAGE_CONFIG_DIR !== undefined,
+  );
+}
+
+export async function resolveClaudeToken(
+  env: ClaudeCredentialEnv = process.env,
+): Promise<OAuthToken | undefined> {
+  for (const dir of claudeConfigDirs(env)) {
     const path = join(dir, ".credentials.json");
     if (!existsSync(path)) continue;
     try {
@@ -68,11 +87,14 @@ export async function resolveClaudeToken(): Promise<OAuthToken | undefined> {
   // Current native Claude Code builds on macOS store the same JSON payload in
   // the login keychain instead of writing `~/.claude/.credentials.json`.
   if (process.platform === "darwin") {
-    const blob = await readClaudeCredentialsFromMacKeychain();
+    const blob = await readClaudeCredentialsFromMacKeychain(env);
     if (blob) {
       const token = parseClaudeCredentials(blob);
       if (token) return token;
     }
+  }
+  if (hasExplicitClaudeConfig(env)) {
+    return undefined;
   }
   // On native Windows, Claude Code may store the OAuth token in the Windows
   // Credential Manager rather than a file (Win-CodexBar issue #22). Best-effort

--- a/src/supervisor/runtime/macClaudeKeychain.ts
+++ b/src/supervisor/runtime/macClaudeKeychain.ts
@@ -56,10 +56,12 @@ export function claudeKeychainServiceNames(env: KeychainEnv = process.env): stri
   );
 }
 
-export async function readClaudeCredentialsFromMacKeychain(): Promise<string | undefined> {
+export async function readClaudeCredentialsFromMacKeychain(
+  env: KeychainEnv = process.env,
+): Promise<string | undefined> {
   if (process.platform !== "darwin") return undefined;
   const account = claudeKeychainAccount();
-  for (const service of claudeKeychainServiceNames()) {
+  for (const service of claudeKeychainServiceNames(env)) {
     try {
       const { stdout } = await execFileAsync(
         "security",

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -30,6 +30,7 @@ import {
   type WriteTerminalPayload,
   type RuntimeEvent,
   areAgentSlashCommandsEqual,
+  isClaudeProfileKind,
   isThreadConfigEqual,
 } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
@@ -113,6 +114,10 @@ function shouldPrimeNativeProjectShellEnv(
   location: ProjectLocation,
 ): location is Extract<ProjectLocation, { kind: "windows" | "posix" }> {
   return location.kind === "posix" || (process.platform === "win32" && location.kind === "windows");
+}
+
+function isClaudeAdapterKind(kind: string): boolean {
+  return kind === "claude" || isClaudeProfileKind(kind);
 }
 
 export class ThreadSessionManager {
@@ -967,7 +972,7 @@ export class ThreadSessionManager {
     config: ThreadConfig,
     projectLocation: ProjectLocation,
   ): Promise<string[]> {
-    if (adapter.kind !== "claude") return args;
+    if (!isClaudeAdapterKind(adapter.kind)) return args;
     const flags: Record<string, unknown> = {};
     if (config.effort === "ultracode") flags.ultracode = true;
     if (config.fast === true) flags.fastMode = true;
@@ -994,25 +999,24 @@ export class ThreadSessionManager {
       return args;
     }
 
-    switch (adapter.kind) {
-      case "codex": {
-        let trailingPositionals = 0;
-        if (args[0] === "resume" || sessionRef) {
-          trailingPositionals += 1;
-        }
-        if (prompt.trim().length > 0) {
-          trailingPositionals += 1;
-        }
-        const insertAt = Math.max(args.length - trailingPositionals, args[0] === "resume" ? 1 : 0);
-        return [...args.slice(0, insertAt), ...extraArgs, ...args.slice(insertAt)];
+    if (adapter.kind === "codex") {
+      let trailingPositionals = 0;
+      if (args[0] === "resume" || sessionRef) {
+        trailingPositionals += 1;
       }
-      case "claude": {
-        const insertAt = prompt.trim().length > 0 ? args.length - 1 : args.length;
-        return [...args.slice(0, insertAt), ...extraArgs, ...args.slice(insertAt)];
+      if (prompt.trim().length > 0) {
+        trailingPositionals += 1;
       }
-      default:
-        return [...args, ...extraArgs];
+      const insertAt = Math.max(args.length - trailingPositionals, args[0] === "resume" ? 1 : 0);
+      return [...args.slice(0, insertAt), ...extraArgs, ...args.slice(insertAt)];
     }
+
+    if (isClaudeAdapterKind(adapter.kind)) {
+      const insertAt = prompt.trim().length > 0 ? args.length - 1 : args.length;
+      return [...args.slice(0, insertAt), ...extraArgs, ...args.slice(insertAt)];
+    }
+
+    return [...args, ...extraArgs];
   }
 
   /**

--- a/src/supervisor/runtime/usageCostScanner.ts
+++ b/src/supervisor/runtime/usageCostScanner.ts
@@ -1,8 +1,8 @@
 import type { Dirent } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { aggregateClaudeCost, type CostEstimate } from "@lightcode/agents-usage";
+import { claudeConfigDirs } from "./claudeCredentials";
 
 /**
  * Supervisor-side estimated-cost scanner. Reads Claude Code session JSONL from
@@ -24,13 +24,12 @@ interface FileRef {
   size: number;
 }
 
-function claudeProjectsDirs(): string[] {
-  const dirs: string[] = [];
-  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim();
-  if (configDir) dirs.push(join(configDir, "projects"));
-  dirs.push(join(homedir(), ".claude", "projects"));
-  dirs.push(join(homedir(), ".config", "claude", "projects"));
-  return dirs;
+interface ClaudeCostEnv {
+  CLAUDE_CONFIG_DIR?: string | undefined;
+}
+
+function claudeProjectsDirs(env: ClaudeCostEnv = process.env): string[] {
+  return claudeConfigDirs(env).map((dir) => join(dir, "projects"));
 }
 
 async function safeReaddir(dir: string): Promise<Dirent[]> {
@@ -41,9 +40,9 @@ async function safeReaddir(dir: string): Promise<Dirent[]> {
   }
 }
 
-async function collectRecentClaudeLogs(sinceMs: number): Promise<FileRef[]> {
+async function collectRecentClaudeLogs(sinceMs: number, env?: ClaudeCostEnv): Promise<FileRef[]> {
   const files: FileRef[] = [];
-  for (const dir of claudeProjectsDirs()) {
+  for (const dir of claudeProjectsDirs(env)) {
     for (const project of await safeReaddir(dir)) {
       if (!project.isDirectory()) continue;
       const projectDir = join(dir, project.name);
@@ -82,9 +81,9 @@ function signatureOf(files: readonly FileRef[]): string {
  * Estimate Claude 30-day cost + tokens from local logs. Memoized on the log
  * tree's signature, so repeated calls with unchanged logs are free.
  */
-export async function scanClaudeCost(nowMs: number): Promise<ClaudeCostScan> {
+export async function scanClaudeCost(nowMs: number, env?: ClaudeCostEnv): Promise<ClaudeCostScan> {
   const sinceMs = nowMs - THIRTY_DAYS_MS;
-  const files = await collectRecentClaudeLogs(sinceMs);
+  const files = await collectRecentClaudeLogs(sinceMs, env);
   const signature = signatureOf(files);
   if (cache && cache.signature === signature) return cache.result;
 

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -1,4 +1,4 @@
-import { rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -51,7 +51,7 @@ function tempCachePath(): string {
 afterEach(() => {
   for (const path of cachePaths.splice(0)) {
     try {
-      rmSync(path, { force: true });
+      rmSync(path, { force: true, recursive: true });
     } catch {
       // ignore
     }
@@ -202,5 +202,70 @@ describe("UsageService", () => {
     });
     const result = await service.refreshProviderUsage({ providerIds: ["ghost"] });
     expect(result.snapshots).toHaveLength(0);
+  });
+
+  it("collects Claude profile usage from the profile config directory", async () => {
+    const profileDir = join(tmpdir(), `lightcode-usage-claude-profile-${process.pid}`);
+    cachePaths.push(profileDir);
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "profile-token",
+          subscriptionType: "team",
+        },
+      }),
+      "utf8",
+    );
+
+    const settingsPath = tempCachePath();
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        agentInstances: {
+          home: {
+            id: "home",
+            driver: "claude",
+            displayName: "Home",
+            config: { configDir: profileDir },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    let authorization: string | undefined;
+    const host: HostPort = {
+      now: () => NOW,
+      credentials: {
+        getOAuthToken: () => Promise.resolve(undefined),
+        getSecret: () => Promise.resolve(undefined),
+      },
+      http: {
+        request: (request) => {
+          authorization = request.headers?.Authorization;
+          return Promise.resolve({ status: 200, headers: {}, body: CLAUDE_BODY });
+        },
+      },
+    };
+    const service = new UsageService({
+      emit: () => {},
+      cachePath: tempCachePath(),
+      settingsPath,
+      host,
+      localCollectors: stubLocalCollectors(),
+    });
+
+    const result = await service.refreshProviderUsage({ providerIds: ["claude:home"] });
+
+    expect(authorization).toBe("Bearer profile-token");
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]).toMatchObject({
+      providerId: "claude:home",
+      status: "ok",
+      plan: "Team Subscription",
+    });
+    expect(result.snapshots[0]?.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(0.4);
   });
 });

--- a/src/supervisor/runtime/usageService.ts
+++ b/src/supervisor/runtime/usageService.ts
@@ -1,18 +1,24 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import {
   allUsageProviderDescriptors,
+  collectClaude,
   createUsageCollectorRegistry,
   type HostPort,
   type UsageCollectorRegistry,
   type UsageSnapshot,
 } from "@lightcode/agents-usage";
+import { claudeProfileKind, parseClaudeProfileInstanceConfig } from "@/shared/contracts";
 import type { ProviderUsagePayload, ProviderUsageResponse } from "@/shared/contracts";
 import type { SupervisorEvent } from "@/shared/ipc";
 import {
   defaultSharedSettings,
   normalizeSharedSettings,
+  type SharedSettings,
   type UsageSettings,
 } from "@/shared/settings";
+import { resolveClaudeToken } from "./claudeCredentials";
 import { createLocalUsageCollectors, type LocalUsageCollector } from "./localUsageCollectors";
 import { createNodeUsageHost } from "./usageHost";
 import { scanClaudeCost } from "./usageCostScanner";
@@ -53,6 +59,18 @@ interface UsageCacheFile {
   snapshots?: UsageSnapshot[];
 }
 
+interface ClaudeUsageProfile {
+  providerId: string;
+  configDir: string;
+}
+
+function resolveNativeTildePath(rawPath: string): string {
+  const trimmed = rawPath.trim();
+  if (trimmed === "~") return homedir();
+  if (trimmed.startsWith("~/")) return join(homedir(), trimmed.slice(2));
+  return trimmed;
+}
+
 export class UsageService {
   private readonly registry: UsageCollectorRegistry = createUsageCollectorRegistry();
   private readonly localCollectors: Map<string, LocalUsageCollector>;
@@ -73,23 +91,52 @@ export class UsageService {
   }
 
   private defaultProviderIds(): string[] {
-    return [...(this.options.providerIds ?? DEFAULT_PROVIDER_IDS)];
+    const baseIds = [...(this.options.providerIds ?? DEFAULT_PROVIDER_IDS)];
+    if (this.options.providerIds) return baseIds;
+    return [...baseIds, ...this.readClaudeUsageProfiles().keys()];
+  }
+
+  /** Read shared settings from disk (defaults if absent). */
+  private readSharedSettings(): SharedSettings {
+    if (!this.options.settingsPath) return defaultSharedSettings;
+    try {
+      return normalizeSharedSettings(JSON.parse(readFileSync(this.options.settingsPath, "utf8")));
+    } catch {
+      return defaultSharedSettings;
+    }
   }
 
   /** Read the usage policy from the shared settings file (defaults if absent). */
   private readUsageSettings(): UsageSettings {
-    if (!this.options.settingsPath) return defaultSharedSettings.usage;
-    try {
-      return normalizeSharedSettings(JSON.parse(readFileSync(this.options.settingsPath, "utf8")))
-        .usage;
-    } catch {
-      return defaultSharedSettings.usage;
+    return this.readSharedSettings().usage;
+  }
+
+  private readClaudeUsageProfiles(): Map<string, ClaudeUsageProfile> {
+    const profiles = new Map<string, ClaudeUsageProfile>();
+    const { agentInstances } = this.readSharedSettings();
+    for (const instance of Object.values(agentInstances)) {
+      if (instance.enabled === false || instance.driver !== "claude") continue;
+      try {
+        const cfg = parseClaudeProfileInstanceConfig(instance.config);
+        const providerId = claudeProfileKind(instance.id);
+        profiles.set(providerId, {
+          providerId,
+          configDir: resolveNativeTildePath(cfg.configDir),
+        });
+      } catch {
+        // Malformed profile records are ignored by the agent registry too.
+      }
     }
+    return profiles;
   }
 
   /** A provider id this service can collect (package registry or supervisor-local). */
   private isSupported(id: string): boolean {
-    return this.registry.has(id) || this.localCollectors.has(id);
+    return (
+      this.registry.has(id) ||
+      this.localCollectors.has(id) ||
+      this.readClaudeUsageProfiles().has(id)
+    );
   }
 
   /** Default providers minus the user's per-provider opt-outs, intersected with what we support. */
@@ -154,20 +201,28 @@ export class UsageService {
   }
 
   private async runRefresh(ids: string[]): Promise<ProviderUsageResponse> {
+    const claudeProfiles = this.readClaudeUsageProfiles();
     const registryIds = ids.filter((id) => this.registry.has(id));
     const localIds = ids.filter((id) => this.localCollectors.has(id));
+    const claudeProfileIds = ids.filter((id) => claudeProfiles.has(id));
     // The registry HTTP batch and the supervisor-local collectors are independent
     // of each other, so run both groups concurrently rather than waiting out the
     // (rate-limited, slow) HTTP batch before starting the local scans.
-    const [registrySnaps, localSnaps] = await Promise.all([
+    const [registrySnaps, localSnaps, claudeProfileSnaps] = await Promise.all([
       this.registry.collectAll(registryIds, this.host),
       Promise.all(localIds.map((id) => this.collectLocal(id))),
+      Promise.all(
+        claudeProfileIds.flatMap((id) => {
+          const profile = claudeProfiles.get(id);
+          return profile ? [this.collectClaudeProfile(profile)] : [];
+        }),
+      ),
     ]);
-    let snapshots = [...registrySnaps, ...localSnaps].map((snap) =>
+    let snapshots = [...registrySnaps, ...localSnaps, ...claudeProfileSnaps].map((snap) =>
       this.preserveOnTransientFailure(snap),
     );
     if (this.readUsageSettings().showEstimatedCost) {
-      snapshots = await this.withEstimatedCost(snapshots);
+      snapshots = await this.withEstimatedCost(snapshots, claudeProfiles);
     }
     for (const snapshot of snapshots) {
       this.snapshots.set(snapshot.providerId, snapshot);
@@ -202,26 +257,61 @@ export class UsageService {
     return { providerId: id, status: "error", windows: [], fetchedAt: now };
   }
 
+  private async collectClaudeProfile(profile: ClaudeUsageProfile): Promise<UsageSnapshot> {
+    const now = this.host.now();
+    const scopedHost: HostPort = {
+      http: this.host.http,
+      now: () => this.host.now(),
+      credentials: {
+        getOAuthToken: () => resolveClaudeToken({ CLAUDE_CONFIG_DIR: profile.configDir }),
+        getSecret: (providerId, key) => this.host.credentials.getSecret(providerId, key),
+      },
+      ...(this.host.clientVersions ? { clientVersions: this.host.clientVersions } : {}),
+      ...(this.host.log ? { log: this.host.log } : {}),
+    };
+    try {
+      const snapshot = await collectClaude(scopedHost);
+      return { ...snapshot, providerId: profile.providerId };
+    } catch (error) {
+      return {
+        providerId: profile.providerId,
+        status: "error",
+        windows: [],
+        fetchedAt: now,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
   /**
    * Merge estimated 30-day cost + tokens (from local logs at API rates) into the
    * Claude snapshot. Best-effort and cached; never throws into the refresh.
    */
-  private async withEstimatedCost(snapshots: UsageSnapshot[]): Promise<UsageSnapshot[]> {
-    const index = snapshots.findIndex((s) => s.providerId === "claude");
-    if (index === -1) return snapshots;
-    try {
-      const scan = await scanClaudeCost(this.host.now());
-      if (!scan.estimate) return snapshots;
-      const next = [...snapshots];
-      next[index] = {
-        ...next[index]!,
-        cost: scan.estimate.cost,
-        tokens: scan.estimate.tokens,
-      };
-      return next;
-    } catch {
-      return snapshots;
-    }
+  private async withEstimatedCost(
+    snapshots: UsageSnapshot[],
+    profiles: Map<string, ClaudeUsageProfile>,
+  ): Promise<UsageSnapshot[]> {
+    return Promise.all(
+      snapshots.map(async (snapshot) => {
+        const profile = profiles.get(snapshot.providerId);
+        const isBaseClaude = snapshot.providerId === "claude";
+        if (!isBaseClaude && !profile) return snapshot;
+        try {
+          const scan = await scanClaudeCost(
+            this.host.now(),
+            profile ? { CLAUDE_CONFIG_DIR: profile.configDir } : undefined,
+          );
+          if (!scan.estimate) return snapshot;
+          return {
+            ...snapshot,
+            cost: scan.estimate.cost,
+            tokens: scan.estimate.tokens,
+          };
+        } catch {
+          return snapshot;
+        }
+      }),
+    );
   }
 
   /**

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -102,7 +102,7 @@ async function runViaCli(
   effort: string | undefined,
   prompt: string,
 ): Promise<string> {
-  const cmd = adapter.buildOneShotCommand!(model, effort, prompt);
+  const cmd = adapter.buildOneShotCommand!(model, effort, prompt, location);
   if (!cmd) {
     throw new Error(`${adapter.label} does not support one-shot generation`);
   }


### PR DESCRIPTION
- Feature/refactor: add Claude profile support end-to-end so profile-backed Claude agents are selectable and tracked separately from the base provider.
- Preserve Claude profile state through settings syncs and surface it consistently in the settings overlay, provider menus, usage panels, icons, and status grouping.
- Make supervisor/runtime flows profile-aware for credentials, environment, one-shot commands, and usage collection so Claude work runs in the right context.
- Expand tests around profile parsing, persistence, grouping, and usage/status behavior.