### PR TITLE
Dismiss browser panel when the last tab closes

### DIFF
--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useBrowserSync.ts
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useBrowserSync.ts
@@ -17,7 +17,12 @@ export function useBrowserSync(): void {
     let cancelled = false;
     const unsub = readBridge().onBrowserEvent((event) => {
       if (event.type === "state") {
+        const hadTabs = useBrowserPanelStore.getState().tabs.length > 0;
         setState(event.state);
+        if (hadTabs && event.state.tabs.length === 0) {
+          // Closing the last tab dismisses the browser panel and overlay.
+          usePanelStore.getState().setBrowserPanelOpen(false);
+        }
       } else if (event.type === "tab-updated") {
         upsertTab(event.tab);
       } else if (event.type === "tab-attention") {


### PR DESCRIPTION
- Bugfix: keep the browser panel and overlay aligned with browser tab state.
- Close the panel automatically when the final browser tab is removed so users do not land on an empty browser surface.
- Preserve browser sync updates for tab state changes while only changing the dismissal behavior at the zero-tab edge.