### PR TITLE
Disable Fable 5 and default new threads to Opus 4.8

### DIFF
--- a/src/supervisor/agents/claude/claude.test.ts
+++ b/src/supervisor/agents/claude/claude.test.ts
@@ -134,8 +134,12 @@ describe("createClaudeAdapter structured sessions", () => {
 });
 
 describe("claudeCapabilities", () => {
-  it("advertises Fable 5 as a 1M-only non-fast model guarded by the probe", () => {
-    expect(claudeCapabilities.models).toContainEqual({ id: "claude-fable-5", label: "Fable 5" });
+  it("keeps Fable 5 disabled (hidden from pickers) while retaining its metadata for re-enable", () => {
+    expect(claudeCapabilities.models).not.toContainEqual({
+      id: "claude-fable-5",
+      label: "Fable 5",
+    });
+    // Definition is retained so flipping FABLE_5_ENABLED re-enables it cleanly.
     expect(claudeCapabilities.modelEfforts["claude-fable-5"]).toEqual([
       "low",
       "medium",
@@ -148,8 +152,8 @@ describe("claudeCapabilities", () => {
     expect(claudeCapabilities.fastModels).not.toContain("claude-fable-5");
   });
 
-  it("lists Fable 5 first so the latest model is the default for new threads", () => {
-    expect(claudeCapabilities.models[0]).toEqual({ id: "claude-fable-5", label: "Fable 5" });
+  it("lists Opus 4.8 first so it is the default for new threads while Fable 5 is disabled", () => {
+    expect(claudeCapabilities.models[0]).toEqual({ id: "claude-opus-4-8", label: "Opus 4.8" });
   });
 });
 

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -23,9 +23,17 @@ const CLAUDE_BUILT_IN_SLASH_COMMANDS: AgentCapability["slashCommands"] = [
 /** Effort tiers shared by the frontier models (Opus 4.7/4.8 and Fable 5). */
 const PREMIUM_EFFORT_TIERS = ["low", "medium", "high", "xHigh", "max", "ultracode"];
 
+/**
+ * Master switch for the Fable 5 model. Flip to `true` to surface it again in the
+ * model pickers — its effort/context/auto metadata is retained below so
+ * re-enabling is a one-line change. While `false`, Fable 5 is hidden everywhere
+ * (the leftover keyed entries are inert without a matching `models` row).
+ */
+const FABLE_5_ENABLED = false;
+
 export const claudeCapabilities: AgentCapability = {
   models: [
-    { id: "claude-fable-5", label: "Fable 5" },
+    ...(FABLE_5_ENABLED ? [{ id: "claude-fable-5", label: "Fable 5" }] : []),
     { id: "claude-opus-4-8", label: "Opus 4.8" },
     { id: "claude-opus-4-7", label: "Opus 4.7" },
     { id: "claude-opus-4-6", label: "Opus 4.6" },


### PR DESCRIPTION
- Bugfix: keep Fable 5 hidden from model pickers while preserving its metadata for a clean re-enable path.
- Make Opus 4.8 the first available Claude model so new threads default to the supported frontier model.
- Update Claude capability tests to reflect the disabled Fable 5 behavior and the new default ordering.