### PR TITLE
Fix terminal theme colors for xterm

### DIFF
--- a/src/renderer/components/terminal/XTermSurface.tsx
+++ b/src/renderer/components/terminal/XTermSurface.tsx
@@ -5,6 +5,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { TerminalLinkProvider } from "./TerminalLinkProvider";
+import { resolveTerminalColor } from "./terminalColors";
 import { Terminal } from "@xterm/xterm";
 import { Button } from "@heroui/react";
 import { ArrowDown } from "lucide-react";
@@ -37,12 +38,15 @@ const TERMINAL_INTERNAL_SCROLLBAR_WIDTH = 0.01;
 
 // Terminal colors track the active theme by reading the same CSS custom
 // properties the rest of the app uses, so presets (Dracula, Nord, ...) apply to
-// the terminal too. Falls back to fixed light/dark values when a property is
-// unset or unparseable.
+// the terminal too. The raw custom-property values use modern color syntax
+// (`oklch(...)`, `color-mix(...)`) that xterm's renderer cannot parse, so each is
+// normalized to an xterm-safe `#hex`/`rgba()` string; we fall back to fixed
+// light/dark values when a property is unset or unparseable.
 function getTerminalTheme(appearance: "light" | "dark") {
   const rootStyles =
     typeof window !== "undefined" ? window.getComputedStyle(document.documentElement) : null;
-  const readVar = (name: string) => rootStyles?.getPropertyValue(name).trim() || "";
+  const readVar = (name: string) =>
+    resolveTerminalColor(rootStyles?.getPropertyValue(name).trim() ?? "");
 
   const fallback =
     appearance === "dark"

--- a/src/renderer/components/terminal/terminalColors.test.ts
+++ b/src/renderer/components/terminal/terminalColors.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { resolveTerminalColor } from "./terminalColors";
+
+// Emulate a browser's CanvasRenderingContext2D.fillStyle: a parseable color is
+// stored in a normalized form, while an unparseable value is silently ignored
+// (the previous value is kept) — the exact behavior resolveTerminalColor relies
+// on. Modern color syntaxes the real engine converts to sRGB hex are mapped to a
+// fixed hex; a wide-gamut `color(srgb ...)` parses but stays in that format.
+function emulateBrowserParse(input: string): string | null {
+  const v = input.trim().toLowerCase();
+  if (/^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/.test(v)) {
+    if (v.length === 4) {
+      return `#${v[1]}${v[1]}${v[2]}${v[2]}${v[3]}${v[3]}`;
+    }
+    return v;
+  }
+  if (/^rgb\(/.test(v)) return v.replace(/\s+/g, "").replace("rgb(", "rgb(");
+  if (/^rgba\(/.test(v)) return v.replace(/\s+/g, "");
+  // oklch()/oklab()/color-mix(...) are in-gamut here → engine yields sRGB hex.
+  if (/^(oklch|oklab|color-mix)\(/.test(v)) return "#3a6ea5";
+  // Wide-gamut color() parses but cannot be downgraded to hex/rgb.
+  if (/^color\(/.test(v)) return v;
+  return null; // unparseable: "notacolor", "var(--x)", etc.
+}
+
+let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+beforeAll(() => {
+  originalGetContext = HTMLCanvasElement.prototype.getContext;
+  let stored = "#000000";
+  const ctx = {
+    get fillStyle() {
+      return stored;
+    },
+    set fillStyle(value: string) {
+      const parsed = emulateBrowserParse(value);
+      if (parsed !== null) stored = parsed;
+    },
+  };
+  // @ts-expect-error -- partial mock; only fillStyle is exercised.
+  HTMLCanvasElement.prototype.getContext = () => ctx;
+});
+
+afterAll(() => {
+  HTMLCanvasElement.prototype.getContext = originalGetContext;
+});
+
+describe("resolveTerminalColor", () => {
+  it("converts oklch() to an xterm-safe hex string", () => {
+    // The crash that motivated this: xterm cannot parse "oklch(0.9911 0 0)".
+    expect(resolveTerminalColor("oklch(0.9911 0 0)")).toBe("#3a6ea5");
+  });
+
+  it("converts color-mix(in oklab, ...) to an xterm-safe hex string", () => {
+    expect(resolveTerminalColor("color-mix(in oklab, #ffffff 50%, #000000)")).toBe("#3a6ea5");
+  });
+
+  it("passes through and normalizes plain hex colors", () => {
+    expect(resolveTerminalColor("#abc")).toBe("#aabbcc");
+    expect(resolveTerminalColor("#1d4c89")).toBe("#1d4c89");
+  });
+
+  it("passes through rgb()/rgba() colors", () => {
+    expect(resolveTerminalColor("rgba(148, 191, 255, 0.24)")).toBe("rgba(148,191,255,0.24)");
+  });
+
+  it("returns null for an empty value so callers fall back", () => {
+    expect(resolveTerminalColor("")).toBeNull();
+  });
+
+  it("returns null for unparseable values (e.g. an unsubstituted var())", () => {
+    expect(resolveTerminalColor("var(--snow)")).toBeNull();
+    expect(resolveTerminalColor("notacolor")).toBeNull();
+  });
+
+  it("returns null for a parseable-but-xterm-unsafe wide-gamut color()", () => {
+    // Guards against handing xterm a format its parser still cannot read.
+    expect(resolveTerminalColor("color(srgb 1 0.5 0)")).toBeNull();
+  });
+
+  it("never returns a value containing modern color syntax", () => {
+    for (const input of [
+      "oklch(0.77 0.08 244)",
+      "oklch(0.19 0.004 286)",
+      "color-mix(in oklab, oklch(0.2 0.004 286) 50%, #000000)",
+    ]) {
+      const resolved = resolveTerminalColor(input);
+      expect(resolved).not.toBeNull();
+      expect(resolved).toMatch(/^(#[0-9a-f]{3,8}|rgba?\()/i);
+      expect(resolved).not.toContain("oklch");
+      expect(resolved).not.toContain("oklab");
+      expect(resolved).not.toContain("color-mix");
+    }
+  });
+});

--- a/src/renderer/components/terminal/terminalColors.ts
+++ b/src/renderer/components/terminal/terminalColors.ts
@@ -1,0 +1,45 @@
+// xterm's WebGL/canvas glyph renderer parses theme colors with its own minimal
+// CSS parser that only understands `#hex` and `rgb()/rgba()`. The app's CSS
+// custom properties are authored with modern color syntax — `oklch(...)` for the
+// base themes and `color-mix(in oklab, ...)` for presets — which xterm cannot
+// parse and which crashes the glyph rasterizer with
+// "Unexpected fillStyle color format". These helpers let the browser resolve any
+// CSS color string down to an xterm-safe `#hex`/`rgba()` value via a 2D canvas
+// context.
+
+let colorResolverCtx: CanvasRenderingContext2D | null = null;
+
+function getColorResolverCtx(): CanvasRenderingContext2D | null {
+  // Retry until a context is available rather than caching a null result, so a
+  // transient failure (or a test that installs a canvas mock after first use)
+  // doesn't permanently disable resolution.
+  if (!colorResolverCtx && typeof document !== "undefined") {
+    colorResolverCtx = document.createElement("canvas").getContext("2d");
+  }
+  return colorResolverCtx;
+}
+
+/**
+ * Resolve an arbitrary CSS color string (`oklch(...)`, `color-mix(...)`, hex,
+ * `rgb()`, named, ...) to a hex or `rgb(a)` string that xterm's color parser can
+ * understand. Returns `null` when the value is empty, unparseable, or resolves
+ * to a format xterm still wouldn't understand (e.g. a wide-gamut
+ * `color(srgb ...)`), so callers can fall back to a known-safe color.
+ */
+export function resolveTerminalColor(value: string): string | null {
+  if (!value) return null;
+  const ctx = getColorResolverCtx();
+  if (!ctx) return null;
+  // The fillStyle setter silently ignores values it cannot parse, keeping the
+  // previous value. Probe with two different sentinels: a parseable value yields
+  // the same result regardless of the sentinel, while an unparseable value
+  // echoes back each distinct sentinel.
+  ctx.fillStyle = "#000000";
+  ctx.fillStyle = value;
+  const first = ctx.fillStyle;
+  ctx.fillStyle = "#ffffff";
+  ctx.fillStyle = value;
+  const second = ctx.fillStyle;
+  if (first !== second) return null;
+  return /^#[0-9a-f]{3,8}$/i.test(first) || /^rgba?\(/i.test(first) ? first : null;
+}


### PR DESCRIPTION
- Normalize terminal theme colors before passing them to xterm so modern CSS values like `oklch()` and `color-mix()` do not trigger renderer crashes.
- Keep the terminal aligned with the active app theme while still falling back to known-safe colors when a value cannot be parsed.
- Add focused coverage for the color resolver, including modern CSS syntax, plain hex, `rgb()`/`rgba()`, and fallback behavior.