### PR TITLE
Add worktree transfer options and branch PR prefetch

### DIFF
--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -912,6 +912,8 @@ describe("App", () => {
         createBranch: true,
         startPoint: "main",
         copyIgnoredPatterns: [".env", ".env.*"],
+        transferUncommitted: false,
+        keepChangesInSource: false,
       });
     });
 

--- a/src/renderer/components/common/BranchSelector/BranchSelector.test.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BranchSelector } from "./BranchSelector";
+
+const bridge = vi.hoisted(() => ({
+  gitAddWorktree:
+    vi.fn<(payload: unknown) => Promise<{ path: string; changesTransferred?: boolean }>>(),
+}));
+
+const refreshGitProject = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+const prefetchBranchPrData = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
+const openNewThreadInWorktree = vi.hoisted(() => vi.fn<(input: unknown) => void>());
+const deleteWorktreeGroup = vi.hoisted(() => vi.fn<(...args: unknown[]) => void>());
+const useBranchListMock = vi.hoisted(() =>
+  vi.fn<(params: { projectId: string; search: string }) => unknown>(),
+);
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+vi.mock("@/renderer/state/gitRefresh", () => ({
+  refreshGitProject,
+  prefetchBranchPrData,
+}));
+
+vi.mock("@/renderer/actions/threadActions", () => ({
+  openNewThreadInWorktree,
+}));
+
+vi.mock("@/renderer/actions/worktreeActions", () => ({
+  deleteWorktreeGroup,
+}));
+
+vi.mock("./parts/useBranchList", () => ({
+  useBranchList: useBranchListMock,
+}));
+
+const emptyBranchList = {
+  items: [],
+  hasLocal: false,
+  hasRemote: false,
+  worktreeBranches: new Set<string>(),
+  branchWorktreePath: new Map<string, string>(),
+  threadsByBranch: new Map<string, unknown>(),
+  projectLocation: { kind: "windows", path: "C:\\repo" },
+};
+
+describe("BranchSelector", () => {
+  beforeEach(() => {
+    bridge.gitAddWorktree.mockReset();
+    bridge.gitAddWorktree.mockResolvedValue({
+      path: "C:\\Users\\demo\\.lightcode\\worktrees\\repo\\feature-x",
+      changesTransferred: true,
+    });
+    refreshGitProject.mockReset();
+    refreshGitProject.mockResolvedValue(undefined);
+    prefetchBranchPrData.mockReset();
+    prefetchBranchPrData.mockResolvedValue(undefined);
+    openNewThreadInWorktree.mockReset();
+    deleteWorktreeGroup.mockReset();
+    useBranchListMock.mockReset();
+    useBranchListMock.mockReturnValue(emptyBranchList);
+  });
+
+  it("moves the current changes into a new worktree, leaving the current branch clean", async () => {
+    render(
+      <BranchSelector
+        projectId="project-1"
+        currentBranch="feature/x"
+        value="feature/x"
+        showMoveBranchAction
+        moveBranchCopyIgnoredPatterns={[".env", ".env.*"]}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Select branch"));
+    fireEvent.click(await screen.findByText("Move changes to a new worktree"));
+
+    await waitFor(() => {
+      expect(bridge.gitAddWorktree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectLocation: { kind: "windows", path: "C:\\repo" },
+          // A new branch is forked from the current branch and the work is moved
+          // into it (transferUncommitted), leaving the current branch clean.
+          branch: expect.any(String),
+          createBranch: true,
+          startPoint: "feature/x",
+          transferUncommitted: true,
+          copyIgnoredPatterns: [".env", ".env.*"],
+        }),
+      );
+    });
+  });
+
+  it("confirms before removing a worktree branch, then reuses deleteWorktreeGroup", async () => {
+    useBranchListMock.mockReturnValue({
+      ...emptyBranchList,
+      hasLocal: true,
+      items: [
+        { type: "header", id: "header-local", name: "Local" },
+        {
+          type: "branch",
+          id: "feature/x",
+          branch: { name: "feature/x", current: false, commit: "abc123", isRemote: false },
+        },
+      ],
+      worktreeBranches: new Set(["feature/x"]),
+      branchWorktreePath: new Map([["feature/x", "/wt/feature-x"]]),
+      threadsByBranch: new Map([
+        ["feature/x", [{ id: "t1", projectId: "project-1", status: "idle", done: false }]],
+      ]),
+    });
+
+    render(<BranchSelector projectId="project-1" currentBranch="main" value="main" />);
+
+    fireEvent.click(screen.getByLabelText("Select branch"));
+    fireEvent.click(await screen.findByRole("button", { name: "Delete feature/x" }));
+
+    // Removal does not run until the confirmation is accepted.
+    expect(deleteWorktreeGroup).not.toHaveBeenCalled();
+    fireEvent.click(await screen.findByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(deleteWorktreeGroup).toHaveBeenCalledWith("project-1", "/wt/feature-x", ["t1"]);
+    });
+  });
+});

--- a/src/renderer/components/common/BranchSelector/BranchSelector.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.tsx
@@ -5,13 +5,27 @@ import type { GitBranchInfo } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { prefetchBranchPrData, refreshGitProject } from "@/renderer/state/gitRefresh";
+import { buildBranchNamePrKey } from "@/renderer/state/gitSelectors";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { openNewThreadInWorktree } from "@/renderer/actions/threadActions";
+import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 import { Button } from "../Button";
+import { ConfirmDialog } from "../ConfirmDialog";
 import { useBranchList } from "./parts/useBranchList";
-import { BranchListBox } from "./parts/BranchListBox";
+import { BranchListBox, type OpenPrReviewArgs } from "./parts/BranchListBox";
 import { BranchFooterActions } from "./parts/BranchFooterActions";
+import { generateWorktreeBranch } from "./parts/generateWorktreeBranch";
 import type { BranchSelection } from "./parts/types";
 
 export type { BranchSelection };
+
+interface PendingDelete {
+  branch: GitBranchInfo;
+  worktreePath?: string;
+  threadIds: string[];
+  threadCount: number;
+}
 
 export interface BranchSelectorProps {
   projectId: string;
@@ -26,9 +40,17 @@ export interface BranchSelectorProps {
   isDisabled?: boolean;
   trigger?: ReactNode;
   hideWorktreeToggle?: boolean;
+  /** Show the "Move changes to a new worktree" action in the popover footer. */
+  showMoveBranchAction?: boolean;
+  /** Project copy patterns to preserve when moving the current branch. */
+  moveBranchCopyIgnoredPatterns?: string[];
   popoverPlacement?: "top" | "bottom";
   forceHideLabel?: boolean;
   iconOnly?: boolean;
+  /** Hide the leading branch/fork glyph on the trigger (e.g. when a sibling control already shows it). */
+  hideTriggerIcon?: boolean;
+  /** Render a shorter trigger for secondary control rows. */
+  compact?: boolean;
   className?: string;
 }
 
@@ -46,16 +68,23 @@ export function BranchSelector(props: BranchSelectorProps) {
     isDisabled,
     trigger,
     hideWorktreeToggle,
+    showMoveBranchAction = false,
+    moveBranchCopyIgnoredPatterns,
     popoverPlacement = "top",
     forceHideLabel = false,
     iconOnly = false,
+    hideTriggerIcon = false,
+    compact = false,
   } = props;
+  const triggerIconSize = compact ? "size-3" : "size-3.5";
 
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [newBranchName, setNewBranchName] = useState("");
   const [deletingBranch, setDeletingBranch] = useState<string | null>(null);
+  const [isMovingBranch, setIsMovingBranch] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const createRef = useRef<HTMLInputElement>(null);
 
@@ -63,9 +92,9 @@ export function BranchSelector(props: BranchSelectorProps) {
     items,
     hasLocal,
     hasRemote,
-    activeWorktreeBranches,
     worktreeBranches,
     branchWorktreePath,
+    threadsByBranch,
     projectLocation,
   } = useBranchList({ projectId, search });
 
@@ -75,6 +104,11 @@ export function BranchSelector(props: BranchSelectorProps) {
       setIsCreating(false);
       setNewBranchName("");
       setTimeout(() => searchRef.current?.focus(), 50);
+      // Refresh PR status for all branches in the background; cached icons show
+      // immediately (prefetch self-throttles + dedupes).
+      if (projectLocation) {
+        void prefetchBranchPrData({ id: projectId, location: projectLocation });
+      }
     }
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps -- only on open/close
 
@@ -125,21 +159,43 @@ export function BranchSelector(props: BranchSelectorProps) {
     setNewBranchName("");
   }
 
-  async function handleDeleteBranch(branch: GitBranchInfo) {
-    if (!projectLocation) return;
+  function handleRequestDelete(branch: GitBranchInfo) {
+    const worktreePath = branch.isRemote ? undefined : branchWorktreePath.get(branch.name);
+    const threads = threadsByBranch.get(branch.name) ?? [];
+    setIsOpen(false);
+    setPendingDelete({
+      branch,
+      ...(worktreePath ? { worktreePath } : {}),
+      threadIds: threads.map((t) => t.id),
+      threadCount: threads.length,
+    });
+  }
+
+  function handleOpenPrReview(args: OpenPrReviewArgs) {
+    setIsOpen(false);
+    usePanelStore.getState().setPrReviewContext({
+      projectId,
+      prNumber: args.prNumber,
+      ...(args.worktreePath
+        ? { worktreePath: args.worktreePath }
+        : { prKey: buildBranchNamePrKey(projectId, args.branch) }),
+    });
+  }
+
+  async function confirmDelete() {
+    const target = pendingDelete;
+    setPendingDelete(null);
+    if (!target || !projectLocation) return;
+    const { branch, worktreePath, threadIds } = target;
+    // Worktree branches reuse the sidebar's removal path (closes linked threads,
+    // runs the cleanup script, removes the worktree, then deletes the branch).
+    if (worktreePath) {
+      deleteWorktreeGroup(projectId, worktreePath, threadIds);
+      return;
+    }
+    // Plain local or remote branch with no worktree — delete the ref directly.
     setDeletingBranch(branch.name);
     try {
-      if (!branch.isRemote) {
-        const wtPath = branchWorktreePath.get(branch.name);
-        if (wtPath) {
-          await readBridge().gitRemoveWorktree({
-            projectLocation,
-            path: wtPath,
-            force: true,
-            deleteBranch: false,
-          });
-        }
-      }
       await readBridge().gitDeleteBranch({
         projectLocation,
         branch: branch.name,
@@ -164,6 +220,46 @@ export function BranchSelector(props: BranchSelectorProps) {
     }
   }
 
+  async function handleMoveBranchToWorktree() {
+    if (!projectLocation || isMovingBranch) return;
+    setIsMovingBranch(true);
+    setIsOpen(false);
+    try {
+      const newBranch = generateWorktreeBranch();
+      const result = await readBridge().gitAddWorktree({
+        projectLocation,
+        branch: newBranch,
+        createBranch: true,
+        startPoint: currentBranch,
+        transferUncommitted: true,
+        // This action MOVES the changes — leave the current branch clean.
+        keepChangesInSource: false,
+        ...(moveBranchCopyIgnoredPatterns?.length
+          ? { copyIgnoredPatterns: moveBranchCopyIgnoredPatterns }
+          : {}),
+      });
+      await refreshGitProject({ id: projectId, location: projectLocation }, "manual", "full");
+      openNewThreadInWorktree({
+        projectId,
+        worktreePath: result.path,
+        worktreeBranch: newBranch,
+      });
+      if (result.changesTransferred === false) {
+        toast.danger(
+          `Created a worktree on "${newBranch}", but the changes conflicted and remain in a git stash — resolve them in the worktree.`,
+        );
+      } else {
+        toast.success(
+          `Moved your changes into a new worktree on "${newBranch}". "${currentBranch}" is now clean.`,
+        );
+      }
+    } catch (error) {
+      toast.danger(friendlyError(error));
+    } finally {
+      setIsMovingBranch(false);
+    }
+  }
+
   return (
     <div className={`flex items-center gap-1 ${props.className ?? ""}`}>
       {worktreeMode && <span className="shrink-0 text-xs text-muted">from</span>}
@@ -176,13 +272,17 @@ export function BranchSelector(props: BranchSelectorProps) {
                 isDisabled={isDisabled ?? false}
                 size="sm"
                 variant="ghost"
-                className="lightcode-composer-menu min-w-0 max-w-48 px-2.5"
+                className={`lightcode-composer-menu min-w-0 max-w-48 ${
+                  compact ? "lightcode-composer-menu--compact px-2" : "px-2.5"
+                }`}
               >
-                {isWorktree || worktreeMode ? (
-                  <GitFork className="size-3.5 text-muted" />
-                ) : (
-                  <GitBranch className="size-3.5 text-muted" />
-                )}
+                {!hideTriggerIcon || iconOnly ? (
+                  isWorktree || worktreeMode ? (
+                    <GitFork className={`${triggerIconSize} text-muted`} />
+                  ) : (
+                    <GitBranch className={`${triggerIconSize} text-muted`} />
+                  )
+                ) : null}
                 {!iconOnly && (
                   <span
                     className={
@@ -198,8 +298,8 @@ export function BranchSelector(props: BranchSelectorProps) {
                   <ChevronDown
                     className={
                       forceHideLabel
-                        ? "lightcode-composer-label-hideable size-3.5 text-muted is-hidden"
-                        : "size-3.5 text-muted"
+                        ? `lightcode-composer-label-hideable ${triggerIconSize} text-muted is-hidden`
+                        : `${triggerIconSize} text-muted`
                     }
                   />
                 )}
@@ -235,6 +335,7 @@ export function BranchSelector(props: BranchSelectorProps) {
 
             <div className="flex-1 overflow-hidden pb-1.5">
               <BranchListBox
+                projectId={projectId}
                 items={items}
                 hasLocal={hasLocal}
                 hasRemote={hasRemote}
@@ -244,10 +345,12 @@ export function BranchSelector(props: BranchSelectorProps) {
                 isWorktree={isWorktree}
                 worktreeMode={worktreeMode}
                 deletingBranch={deletingBranch}
-                activeWorktreeBranches={activeWorktreeBranches}
                 worktreeBranches={worktreeBranches}
+                branchWorktreePath={branchWorktreePath}
+                threadsByBranch={threadsByBranch}
                 onSelect={handleSelectBranch}
-                onDelete={(b) => void handleDeleteBranch(b as GitBranchInfo)}
+                onDelete={(b) => handleRequestDelete(b as GitBranchInfo)}
+                onOpenPrReview={handleOpenPrReview}
               />
             </div>
 
@@ -267,10 +370,33 @@ export function BranchSelector(props: BranchSelectorProps) {
               isWorktree={isWorktree}
               branchWorktreePath={branchWorktreePath}
               onSelect={onSelect}
+              showMoveBranch={showMoveBranchAction}
+              isMovingBranch={isMovingBranch}
+              onMoveBranchToWorktree={() => void handleMoveBranchToWorktree()}
             />
           </Popover.Dialog>
         </Popover.Content>
       </Popover>
+      <ConfirmDialog
+        isOpen={pendingDelete !== null}
+        title={pendingDelete?.worktreePath ? "Remove worktree?" : "Delete branch?"}
+        body={
+          pendingDelete?.worktreePath
+            ? `This removes the worktree on "${pendingDelete.branch.name}"${
+                pendingDelete.threadCount > 0
+                  ? ` and closes ${pendingDelete.threadCount} linked thread${
+                      pendingDelete.threadCount === 1 ? "" : "s"
+                    }`
+                  : ""
+              }, then deletes the branch.`
+            : `This permanently deletes the branch "${pendingDelete?.branch.name ?? ""}"${
+                pendingDelete?.branch.isRemote ? " from its remote" : ""
+              }.`
+        }
+        confirmLabel={pendingDelete?.worktreePath ? "Remove" : "Delete"}
+        onConfirm={() => void confirmDelete()}
+        onClose={() => setPendingDelete(null)}
+      />
     </div>
   );
 }

--- a/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.test.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.test.tsx
@@ -27,6 +27,9 @@ describe("BranchFooterActions", () => {
           new Map([["feature/x", "C:\\Users\\demo\\.lightcode\\worktrees\\repo\\feature-x"]])
         }
         onSelect={onSelect}
+        showMoveBranch={false}
+        isMovingBranch={false}
+        onMoveBranchToWorktree={vi.fn<() => void>()}
       />,
     );
 

--- a/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchFooterActions.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from "react";
-import { GitFork, Plus } from "lucide-react";
+import { FolderInput, GitFork, Plus } from "lucide-react";
 import { Checkbox, Label, ListBox } from "@heroui/react";
 import type { BranchSelection } from "./types";
 
@@ -19,6 +19,9 @@ export function BranchFooterActions(props: {
   isWorktree: boolean | undefined;
   branchWorktreePath: Map<string, string>;
   onSelect: ((selection: BranchSelection) => void) | undefined;
+  showMoveBranch: boolean;
+  isMovingBranch: boolean;
+  onMoveBranchToWorktree: () => void;
 }) {
   const {
     isCreating,
@@ -36,6 +39,9 @@ export function BranchFooterActions(props: {
     isWorktree,
     branchWorktreePath,
     onSelect,
+    showMoveBranch,
+    isMovingBranch,
+    onMoveBranchToWorktree,
   } = props;
 
   return (
@@ -154,6 +160,28 @@ export function BranchFooterActions(props: {
                 <Checkbox.Indicator />
               </Checkbox.Control>
             </Checkbox>
+          </ListBox.Item>
+        </ListBox>
+      )}
+
+      {/* Move the current uncommitted changes into a new worktree */}
+      {showMoveBranch && (
+        <ListBox
+          aria-label="Move changes to a new worktree"
+          className="lightcode-menu"
+          selectionMode="none"
+          disabledKeys={isMovingBranch ? ["move-branch"] : []}
+          onAction={() => onMoveBranchToWorktree()}
+        >
+          <ListBox.Item
+            id="move-branch"
+            textValue="Move changes to a new worktree"
+            className="focus-visible:outline-none"
+          >
+            <FolderInput className="size-3.5 shrink-0 text-muted" />
+            <Label className="flex-1">
+              {isMovingBranch ? "Moving changes…" : "Move changes to a new worktree"}
+            </Label>
           </ListBox.Item>
         </ListBox>
       )}

--- a/src/renderer/components/common/BranchSelector/parts/BranchListBox.test.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchListBox.test.tsx
@@ -1,12 +1,65 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { BranchListBox } from "./BranchListBox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PrData, Thread } from "@/shared/contracts";
+import { buildBranchNamePrKey } from "@/renderer/state/gitSelectors";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { BranchListBox, type OpenPrReviewArgs } from "./BranchListBox";
+
+function makePr(overrides: Partial<PrData> & Pick<PrData, "number" | "state">): PrData {
+  return {
+    title: "Some PR",
+    url: "https://example.com/pr",
+    baseBranch: "main",
+    isDraft: false,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<Thread> & Pick<Thread, "id" | "projectId">): Thread {
+  return {
+    title: "Thread",
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function baseProps() {
+  return {
+    projectId: "p1",
+    hasLocal: false,
+    hasRemote: true,
+    currentBranch: "main",
+    value: "main",
+    baseBranch: undefined,
+    isWorktree: false,
+    worktreeMode: false,
+    deletingBranch: null,
+    worktreeBranches: new Set<string>(),
+    branchWorktreePath: new Map<string, string>(),
+    threadsByBranch: new Map<string, Thread[]>(),
+    onSelect: vi.fn<(branchName: string) => void>(),
+    onDelete: vi.fn<(branch: { name: string; remote?: string; isRemote?: boolean }) => void>(),
+    onOpenPrReview: vi.fn<(args: OpenPrReviewArgs) => void>(),
+  };
+}
+
+afterEach(() => {
+  useGitStore.setState({ prData: {} });
+});
 
 describe("BranchListBox", () => {
   it("fires delete for a remote branch row", () => {
-    const onDelete =
-      vi.fn<(branch: { name: string; remote?: string; isRemote?: boolean }) => void>();
-    const onSelect = vi.fn<(branchName: string) => void>();
+    const props = baseProps();
     const branch = {
       name: "feature/x",
       current: false,
@@ -17,28 +70,76 @@ describe("BranchListBox", () => {
 
     render(
       <BranchListBox
+        {...props}
         items={[
           { type: "header", id: "header-remote", name: "Remote" },
           { type: "branch", id: branch.name, branch },
         ]}
-        hasLocal={false}
-        hasRemote
-        currentBranch="main"
-        value="main"
-        baseBranch={undefined}
-        isWorktree={false}
-        worktreeMode={false}
-        deletingBranch={null}
-        activeWorktreeBranches={new Set()}
-        worktreeBranches={new Set()}
-        onSelect={onSelect}
-        onDelete={onDelete}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Delete feature/x" }));
 
-    expect(onDelete).toHaveBeenCalledWith(branch);
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(props.onDelete).toHaveBeenCalledWith(branch);
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("renders a PR icon and opens review on click for a branch without a worktree", () => {
+    const props = baseProps();
+    const branch = {
+      name: "feature/x",
+      current: false,
+      commit: "abc123",
+      isRemote: true,
+      remote: "origin",
+    };
+    useGitStore
+      .getState()
+      .setPrData(buildBranchNamePrKey("p1", "feature/x"), makePr({ number: 42, state: "open" }));
+
+    render(
+      <BranchListBox
+        {...props}
+        items={[
+          { type: "header", id: "header-remote", name: "Remote" },
+          { type: "branch", id: branch.name, branch },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Review PR #42 for feature/x" }));
+
+    expect(props.onOpenPrReview).toHaveBeenCalledWith({ branch: "feature/x", prNumber: 42 });
+    expect(props.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("marks worktree branches with a fork icon and a thread-count badge", () => {
+    const props = baseProps();
+    const branch = {
+      name: "feature/x",
+      current: false,
+      commit: "abc123",
+      isRemote: false,
+    };
+
+    const { container } = render(
+      <BranchListBox
+        {...props}
+        hasLocal
+        hasRemote={false}
+        worktreeBranches={new Set(["feature/x"])}
+        branchWorktreePath={new Map([["feature/x", "/wt/feature-x"]])}
+        threadsByBranch={new Map([["feature/x", [makeThread({ id: "t1", projectId: "p1" })]]])}
+        items={[
+          { type: "header", id: "header-local", name: "Local" },
+          { type: "branch", id: branch.name, branch },
+        ]}
+      />,
+    );
+
+    // Worktree kind is conveyed by the leading fork glyph, not a "worktree" label.
+    expect(container.querySelector(".lucide-git-fork")).not.toBeNull();
+    expect(screen.queryByText("worktree")).not.toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
+++ b/src/renderer/components/common/BranchSelector/parts/BranchListBox.tsx
@@ -1,5 +1,23 @@
-import { Check, GitBranch, Globe, Trash2 } from "lucide-react";
-import { Header, Label, ListBox, ListLayout, Virtualizer } from "@heroui/react";
+import {
+  Check,
+  GitBranch,
+  GitFork,
+  GitPullRequest,
+  Globe,
+  MessageSquare,
+  Trash2,
+} from "lucide-react";
+import { Header, Label, ListBox, ListLayout, Tooltip, Virtualizer } from "@heroui/react";
+import type { Thread } from "@/shared/contracts";
+import {
+  buildBranchNamePrKey,
+  usePrChecksStatus,
+  usePrNumber,
+  usePrState,
+  usePrTitle,
+} from "@/renderer/state/gitSelectors";
+import { getPrStatusTone, PR_TONE_TEXT_CLASS } from "@/renderer/utils/prStatus";
+import { getStatusTone, type StatusTone } from "@/renderer/components/providers/statusTone";
 import {
   COMPACT_DROPDOWN_ROW_HEIGHT,
   VIRTUALIZED_COMPACT_DROPDOWN_ITEM_CLASS,
@@ -7,7 +25,24 @@ import {
 import { PixelLoader } from "../../PixelLoader";
 import type { BranchListItem } from "./useBranchList";
 
+const STATUS_DOT_CLASS: Record<StatusTone, string> = {
+  inactive: "bg-muted/40",
+  active: "bg-success",
+  working: "bg-warning",
+  finished: "bg-success",
+  error: "bg-danger",
+  attention: "bg-warning",
+  done: "bg-muted/40",
+};
+
+export interface OpenPrReviewArgs {
+  branch: string;
+  prNumber: number;
+  worktreePath?: string;
+}
+
 export function BranchListBox(props: {
+  projectId: string;
   items: BranchListItem[];
   hasLocal: boolean;
   hasRemote: boolean;
@@ -17,12 +52,15 @@ export function BranchListBox(props: {
   isWorktree: boolean | undefined;
   worktreeMode: boolean;
   deletingBranch: string | null;
-  activeWorktreeBranches: Set<string>;
   worktreeBranches: Set<string>;
+  branchWorktreePath: Map<string, string>;
+  threadsByBranch: Map<string, Thread[]>;
   onSelect: (branchName: string) => void;
   onDelete: (branch: { name: string; remote?: string; isRemote?: boolean }) => void;
+  onOpenPrReview: (args: OpenPrReviewArgs) => void;
 }) {
   const {
+    projectId,
     items,
     hasLocal,
     hasRemote,
@@ -32,15 +70,19 @@ export function BranchListBox(props: {
     isWorktree,
     worktreeMode,
     deletingBranch,
-    activeWorktreeBranches,
     worktreeBranches,
+    branchWorktreePath,
+    threadsByBranch,
     onSelect,
     onDelete,
+    onOpenPrReview,
   } = props;
 
   if (!hasLocal && !hasRemote) {
     return <div className="px-3 py-3 text-center text-sm text-muted">No branches found</div>;
   }
+
+  const selectedKey = isWorktree || worktreeMode ? (baseBranch ?? value) : value;
 
   return (
     <Virtualizer
@@ -83,9 +125,12 @@ export function BranchListBox(props: {
             );
           }
           const { branch } = item;
-          const canDelete =
-            branch.name !== currentBranch && !activeWorktreeBranches.has(branch.name);
+          const isCurrent = branch.name === currentBranch;
           const isDeleting = deletingBranch === branch.name;
+          const worktreePath = branchWorktreePath.get(branch.name);
+          const isWorktreeBranch = worktreeBranches.has(branch.name) && !isCurrent;
+          const threads = threadsByBranch.get(branch.name) ?? [];
+          const isSelected = branch.name === selectedKey;
           return (
             <ListBox.Item
               key={branch.name}
@@ -93,45 +138,149 @@ export function BranchListBox(props: {
               textValue={branch.name}
               className="group focus-visible:outline-none"
             >
-              <ListBox.ItemIndicator>
-                {({ isSelected }) => {
-                  if (isDeleting) {
-                    return <PixelLoader size="xs" className="text-muted" />;
-                  }
-                  return isSelected ? <Check className="size-3" /> : null;
-                }}
-              </ListBox.ItemIndicator>
-              {branch.isRemote ? (
-                <Globe className="size-3.5 shrink-0 text-muted" />
-              ) : (
-                <GitBranch className="size-3.5 shrink-0 text-muted" />
-              )}
-              <Label className="flex-1 truncate">{branch.name}</Label>
-              {branch.name === currentBranch && (
-                <span className="text-[10px] text-muted">current</span>
-              )}
-              {worktreeBranches.has(branch.name) && branch.name !== currentBranch && (
-                <span className="text-[10px] text-muted">worktree</span>
-              )}
-              {canDelete && !isDeleting && (
-                <button
-                  type="button"
-                  aria-label={`Delete ${branch.name}`}
-                  className="ms-auto flex items-center justify-center rounded border-0 bg-transparent p-0 text-muted/55 opacity-0 transition hover:text-danger group-hover:opacity-100"
-                  onPointerDown={(e) => e.stopPropagation()}
-                  onPointerUp={(e) => e.stopPropagation()}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(branch);
-                  }}
-                >
-                  <Trash2 className="size-3.5" />
-                </button>
-              )}
+              <BranchRowBody
+                branch={branch}
+                projectId={projectId}
+                isCurrent={isCurrent}
+                isSelected={isSelected}
+                isWorktreeBranch={isWorktreeBranch}
+                {...(worktreePath ? { worktreePath } : {})}
+                threads={threads}
+                isDeleting={isDeleting}
+                onDelete={onDelete}
+                onOpenPrReview={onOpenPrReview}
+              />
             </ListBox.Item>
           );
         }}
       </ListBox>
     </Virtualizer>
+  );
+}
+
+function BranchRowBody(props: {
+  branch: { name: string; isRemote: boolean; remote?: string };
+  projectId: string;
+  isCurrent: boolean;
+  isSelected: boolean;
+  isWorktreeBranch: boolean;
+  worktreePath?: string;
+  threads: Thread[];
+  isDeleting: boolean;
+  onDelete: (branch: { name: string; remote?: string; isRemote?: boolean }) => void;
+  onOpenPrReview: (args: OpenPrReviewArgs) => void;
+}) {
+  const {
+    branch,
+    projectId,
+    isCurrent,
+    isSelected,
+    isWorktreeBranch,
+    worktreePath,
+    threads,
+    isDeleting,
+    onDelete,
+    onOpenPrReview,
+  } = props;
+  const canDelete = !isCurrent;
+
+  const prKey = worktreePath ?? buildBranchNamePrKey(projectId, branch.name);
+  const prState = usePrState(prKey);
+  const prChecksStatus = usePrChecksStatus(prKey);
+  const prNumber = usePrNumber(prKey);
+  const prTitle = usePrTitle(prKey);
+  const showPr = prState !== undefined && prState !== "closed" && prNumber !== undefined;
+
+  // The leading glyph carries the row's kind: a fork for worktree branches, a
+  // globe for remote ones, a plain branch otherwise. The current branch keeps
+  // its glyph but brightens to foreground (white) instead of a "current" label.
+  const LeadingIcon = branch.isRemote ? Globe : isWorktreeBranch ? GitFork : GitBranch;
+
+  return (
+    <>
+      <LeadingIcon
+        className={`size-3.5 shrink-0 ${isCurrent ? "text-foreground" : "text-muted"}`}
+      />
+      <Label className="flex-1 truncate">{branch.name}</Label>
+      <div className="flex shrink-0 items-center gap-1.5">
+        {threads.length > 0 && (
+          <Tooltip delay={150}>
+            <Tooltip.Trigger
+              tabIndex={-1}
+              role="none"
+              className="flex items-center gap-0.5 text-[10px] text-muted"
+            >
+              <span className="flex items-center gap-0.5">
+                <MessageSquare className="size-3 shrink-0" />
+                {threads.length}
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content placement="top" className="max-w-[16rem]">
+              <div className="flex flex-col gap-1 py-0.5">
+                {threads.map((t) => (
+                  <div key={t.id} className="flex items-center gap-1.5 text-xs">
+                    <span
+                      className={`size-1.5 shrink-0 rounded-full ${STATUS_DOT_CLASS[getStatusTone(t)]}`}
+                    />
+                    <span className="truncate">{t.title}</span>
+                  </div>
+                ))}
+              </div>
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+        {showPr && (
+          <Tooltip delay={150}>
+            <Tooltip.Trigger tabIndex={-1} role="none">
+              <button
+                type="button"
+                aria-label={`Review PR #${prNumber} for ${branch.name}`}
+                className={`flex items-center rounded border-0 bg-transparent p-0.5 transition hover:bg-[var(--row-hover)] ${PR_TONE_TEXT_CLASS[getPrStatusTone(prState, prChecksStatus)]}`}
+                onPointerDown={(e) => e.stopPropagation()}
+                onPointerUp={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenPrReview({
+                    branch: branch.name,
+                    prNumber,
+                    ...(worktreePath ? { worktreePath } : {}),
+                  });
+                }}
+              >
+                <GitPullRequest className="size-3.5" />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content placement="top" className="max-w-[18rem]">
+              <div className="flex min-w-0 flex-col gap-0.5">
+                <span className="truncate font-medium">{prTitle || `PR #${prNumber}`}</span>
+                <span className="text-[10px] text-muted">
+                  #{prNumber} · {prState}
+                </span>
+              </div>
+            </Tooltip.Content>
+          </Tooltip>
+        )}
+        {isSelected && !isDeleting && <Check className="size-3.5 shrink-0 text-foreground" />}
+        <div className="flex w-5 shrink-0 items-center justify-center">
+          {isDeleting ? (
+            <PixelLoader size="xs" className="text-muted" />
+          ) : canDelete ? (
+            <button
+              type="button"
+              aria-label={`Delete ${branch.name}`}
+              className="flex items-center justify-center rounded border-0 bg-transparent p-0 text-muted/55 opacity-0 transition hover:text-danger group-hover:opacity-100"
+              onPointerDown={(e) => e.stopPropagation()}
+              onPointerUp={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(branch);
+              }}
+            >
+              <Trash2 className="size-3.5" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/renderer/components/common/BranchSelector/parts/types.ts
+++ b/src/renderer/components/common/BranchSelector/parts/types.ts
@@ -3,4 +3,6 @@ export interface BranchSelection {
   baseBranch?: string;
   isWorktree: boolean;
   worktreePath?: string;
+  /** Carry the main checkout's uncommitted changes into the new worktree. */
+  transferUncommitted?: boolean;
 }

--- a/src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+++ b/src/renderer/components/common/BranchSelector/parts/useBranchList.ts
@@ -22,15 +22,24 @@ export function useBranchList(params: { projectId: string; search: string }) {
   const { projectId, search } = params;
   const branchData = useGitStore((s) => s.branches[projectId]);
   const worktrees = useGitStore((s) => s.worktrees[projectId]);
-  const activeWorktreeBranchNames = useAppStore(
-    useShallow((s) => getActiveWorktreeBranchNames(s.threads, projectId)),
+  const projectThreads = useAppStore(
+    useShallow((s) =>
+      s.threads.filter((t) => t.projectId === projectId && !t.archived && t.worktreeBranch),
+    ),
   );
   const projectLocation = useProject(projectId)?.location;
 
-  const activeWorktreeBranches = useMemo(
-    () => new Set(activeWorktreeBranchNames),
-    [activeWorktreeBranchNames],
-  );
+  const threadsByBranch = useMemo(() => {
+    const map = new Map<string, Thread[]>();
+    for (const t of projectThreads) {
+      const branch = t.worktreeBranch;
+      if (!branch) continue;
+      const list = map.get(branch);
+      if (list) list.push(t);
+      else map.set(branch, [t]);
+    }
+    return map;
+  }, [projectThreads]);
   const worktreeBranches = useMemo(
     () => new Set(worktrees?.filter((w) => !w.isMain).map((w) => w.branch) ?? []),
     [worktrees],
@@ -90,9 +99,9 @@ export function useBranchList(params: { projectId: string; search: string }) {
     items,
     hasLocal,
     hasRemote,
-    activeWorktreeBranches,
     worktreeBranches,
     branchWorktreePath,
+    threadsByBranch,
     projectLocation,
   };
 }

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -898,6 +898,13 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                               onSelect={handleBranchSelect}
                               onSwitchBranch={handleSwitchBranch}
                               hideWorktreeToggle
+                              showMoveBranchAction
+                              {...(project?.scripts?.worktreeCopyPatterns
+                                ? {
+                                    moveBranchCopyIgnoredPatterns:
+                                      project.scripts.worktreeCopyPatterns,
+                                  }
+                                : {})}
                               forceHideLabel={level >= 3}
                               iconOnly={level >= 3}
                             />

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -34,6 +34,7 @@ import {
   type BranchSelection,
 } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { ThreadCommandPanel } from "./ThreadCommandPanel";
 import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
@@ -48,6 +49,7 @@ import {
   resolveLocalSlashCommandAction,
 } from "./threadSlashCommands";
 import { handleComposerControlShortcut } from "./threadComposerShortcuts";
+import { WorktreeModeSelect, type WorktreeMode } from "./WorktreeModeSelect";
 
 export type DraftStartInput = {
   agentKind: AgentStatus["kind"];
@@ -58,6 +60,7 @@ export type DraftStartInput = {
   worktreeBranch?: string;
   worktreeBaseBranch?: string;
   worktreeIsNewBranch?: boolean;
+  worktreeTransferUncommitted?: boolean;
   presentationMode?: ThreadPresentationMode;
 };
 
@@ -265,6 +268,47 @@ export function ThreadDraftComposerArea(props: {
   const authRequired = props.selectedAgent.authState === "missing";
   const isHomeScope = isHomeProjectId(props.project.id);
   const browserMcpScope = getBrowserMcpScope(props.selectedAgent.kind, props.presentationMode);
+
+  // Worktree creation lives in the composer toolbar. The "bring over uncommitted
+  // changes" affordance only appears when the new worktree forks from the
+  // current (dirty) checkout — the only case where transferring is meaningful.
+  const projectStatus = useGitStore((s) => s.statuses[props.project.id]);
+  const hasUncommittedChanges =
+    !!projectStatus && projectStatus.staged.length + projectStatus.unstaged.length > 0;
+  const worktreeBase = branchSelection?.baseBranch ?? branchSelection?.branch ?? props.gitBranch;
+  // The worktree dropdown's "+ changes" choice is offered whenever the current
+  // (dirty) checkout would be the worktree's fork point — independent of whether
+  // worktree mode is already on, since selecting it also turns worktree mode on.
+  const canBringChanges = hasUncommittedChanges && worktreeBase === props.gitBranch;
+  // Transferring is only meaningful once worktree mode is actually on.
+  const canTransferUncommitted = props.worktreeMode && canBringChanges;
+  const shouldTransferUncommitted =
+    canTransferUncommitted && branchSelection?.transferUncommitted === true;
+
+  const worktreeSelected = branchSelection?.isWorktree ?? props.worktreeMode;
+  const worktreeMode: WorktreeMode = !worktreeSelected
+    ? "none"
+    : shouldTransferUncommitted
+      ? "new-with-changes"
+      : "new";
+
+  function selectNewWorktree(overrides?: Partial<BranchSelection>) {
+    const base = worktreeBase ?? props.gitBranch ?? "";
+    setBranchSelection({ branch: base, baseBranch: base, isWorktree: true, ...overrides });
+  }
+
+  function handleWorktreeModeChange(mode: WorktreeMode) {
+    if (mode === "none") {
+      props.onWorktreeModeChange(false);
+      setBranchSelection(null);
+      return;
+    }
+    props.onWorktreeModeChange(true);
+    // Keep an existing worktree selection (e.g. a worktreePath from "New thread
+    // in worktree") intact rather than rebuilding it into a brand-new branch.
+    if (branchSelection?.worktreePath) return;
+    selectNewWorktree({ transferUncommitted: mode === "new-with-changes" });
+  }
   const controls: ComposerControl[] = controlOpenRequest
     ? props.controls.map((control) => {
         if (controlOpenRequest.target === "model" && control.kind === "provider-model") {
@@ -292,6 +336,7 @@ export function ThreadDraftComposerArea(props: {
     branchSelection?.branch ?? "",
     branchSelection?.baseBranch ?? "",
     branchSelection?.isWorktree ? "selection-worktree" : "selection-branch",
+    canTransferUncommitted ? "can-transfer" : "no-transfer",
     controlKinds,
   ].join("|");
   function resetDraftRefs() {
@@ -366,6 +411,7 @@ export function ThreadDraftComposerArea(props: {
                 ? { worktreeBaseBranch: branchSelection.baseBranch }
                 : {}),
               worktreeIsNewBranch: true,
+              ...(shouldTransferUncommitted ? { worktreeTransferUncommitted: true } : {}),
             }
         : {}),
     });
@@ -564,7 +610,7 @@ export function ThreadDraftComposerArea(props: {
           const segments = mentionRef.current?.serializeSegments() ?? [];
           submitSegments([...attachments.toSegments(), ...segments], prompt);
         }}
-        afterControls={(level) => (
+        afterControls={() => (
           <>
             <ComposerAddMenu
               browserMcpEnabled={props.config.browserMcp === true}
@@ -578,21 +624,6 @@ export function ThreadDraftComposerArea(props: {
               }}
               onToggleBrowserMcp={(next) => props.onConfigChange({ browserMcp: next })}
             />
-            {props.gitBranch ? (
-              <BranchSelector
-                projectId={props.project.id}
-                currentBranch={props.gitBranch}
-                value={branchSelection?.branch ?? props.gitBranch}
-                isWorktree={branchSelection?.isWorktree}
-                baseBranch={branchSelection?.baseBranch}
-                worktreeMode={props.worktreeMode}
-                onWorktreeModeChange={props.onWorktreeModeChange}
-                onSelect={setBranchSelection}
-                onSwitchBranch={props.onSwitchBranch}
-                forceHideLabel={level >= 3}
-                iconOnly={level >= 3}
-              />
-            ) : null}
             {showVoiceInputButton ? (
               <VoiceInputButton
                 isDisabled={authRequired || agentUpdating || isSubmitting}
@@ -610,6 +641,36 @@ export function ThreadDraftComposerArea(props: {
           </>
         )}
       />
+      {props.gitBranch ? (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1 px-1">
+          <WorktreeModeSelect
+            mode={worktreeMode}
+            canBringChanges={canBringChanges}
+            onChange={handleWorktreeModeChange}
+            compact
+          />
+          <BranchSelector
+            projectId={props.project.id}
+            currentBranch={props.gitBranch}
+            value={branchSelection?.branch ?? props.gitBranch}
+            isWorktree={branchSelection?.isWorktree}
+            baseBranch={branchSelection?.baseBranch}
+            worktreeMode={props.worktreeMode}
+            onWorktreeModeChange={props.onWorktreeModeChange}
+            onSelect={setBranchSelection}
+            onSwitchBranch={props.onSwitchBranch}
+            hideWorktreeToggle
+            hideTriggerIcon
+            compact
+            showMoveBranchAction
+            {...(props.project.scripts?.worktreeCopyPatterns
+              ? {
+                  moveBranchCopyIgnoredPatterns: props.project.scripts.worktreeCopyPatterns,
+                }
+              : {})}
+          />
+        </div>
+      ) : null}
       {lightboxIndex !== null && imageAttachments.length > 0 ? (
         <ImageLightbox
           images={imageAttachments}

--- a/src/renderer/components/thread/WorktreeModeSelect.tsx
+++ b/src/renderer/components/thread/WorktreeModeSelect.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { Check, ChevronDown, GitBranch, GitFork } from "lucide-react";
+import { Label, ListBox, Popover } from "@heroui/react";
+import { Button } from "@/renderer/components/common";
+
+export type WorktreeMode = "none" | "new" | "new-with-changes";
+
+interface WorktreeModeOption {
+  id: WorktreeMode;
+  label: string;
+  description: string;
+  icon: typeof GitFork;
+}
+
+export function WorktreeModeSelect(props: {
+  mode: WorktreeMode;
+  /** Whether to offer the "carry uncommitted changes" variant. */
+  canBringChanges: boolean;
+  onChange: (mode: WorktreeMode) => void;
+  isDisabled?: boolean;
+  /** Render a shorter trigger for secondary control rows. */
+  compact?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const iconSize = props.compact ? "size-3" : "size-3.5";
+
+  const options: WorktreeModeOption[] = [
+    {
+      id: "none",
+      label: "No worktree",
+      description: "Work in the current checkout",
+      icon: GitBranch,
+    },
+    {
+      id: "new",
+      label: "Worktree",
+      description: "Run in a separate worktree",
+      icon: GitFork,
+    },
+    ...(props.canBringChanges
+      ? [
+          {
+            id: "new-with-changes" as const,
+            label: "Worktree + changes",
+            description: "Copy uncommitted changes here (keeps them on this branch)",
+            icon: GitFork,
+          },
+        ]
+      : []),
+  ];
+
+  const selected = options.find((option) => option.id === props.mode) ?? options[0]!;
+  const SelectedIcon = selected.icon;
+
+  return (
+    <Popover isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Popover.Trigger className="flex min-w-0 items-center">
+        <Button
+          aria-label="Worktree mode"
+          isDisabled={props.isDisabled ?? false}
+          size="sm"
+          variant="ghost"
+          className={`lightcode-composer-menu min-w-0 max-w-56 ${
+            props.compact ? "lightcode-composer-menu--compact px-2" : "px-2.5"
+          }`}
+        >
+          <SelectedIcon className={`${iconSize} text-muted`} />
+          <span className="truncate">{selected.label}</span>
+          <ChevronDown className={`${iconSize} text-muted`} />
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="top" className="w-64 p-0">
+        <Popover.Dialog className="!p-0 !py-1">
+          <ListBox
+            aria-label="Worktree mode"
+            className="lightcode-menu"
+            selectionMode="none"
+            onAction={(key) => {
+              props.onChange(key as WorktreeMode);
+              setIsOpen(false);
+            }}
+          >
+            {options.map((option) => {
+              const OptionIcon = option.icon;
+              return (
+                <ListBox.Item
+                  key={option.id}
+                  id={option.id}
+                  textValue={option.label}
+                  className="focus-visible:outline-none"
+                >
+                  <OptionIcon className="size-3.5 shrink-0 text-muted" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <Label className="truncate">{option.label}</Label>
+                    <span className="truncate text-xs text-muted">{option.description}</span>
+                  </div>
+                  {option.id === props.mode ? (
+                    <Check className="size-3.5 shrink-0 text-foreground" />
+                  ) : null}
+                </ListBox.Item>
+              );
+            })}
+          </ListBox>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -3,7 +3,7 @@ import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useGitStore } from "@/renderer/state/gitStore";
-import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
+import { buildBranchNamePrKey, buildBranchPrKey } from "@/renderer/state/gitSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -33,6 +33,49 @@ export const PR_POST_PUSH_STATUS_WAIT_MS = 15_000;
 export const PR_POST_PUSH_STATUS_POLL_MS = 5_000;
 
 const alwaysActive = () => true;
+
+const BRANCH_PR_PREFETCH_THROTTLE_MS = 10_000;
+const branchPrPrefetchLastRun = new Map<string, number>();
+const branchPrPrefetchInFlight = new Set<string>();
+
+/**
+ * Bulk-fetch PR status for every branch of a project in one `gh pr list` call and
+ * cache it under branch-name keys (see {@link buildBranchNamePrKey}) so the branch
+ * selector can show PR-status icons for remote/local branches that aren't checked
+ * out as a worktree. Dedupes in-flight calls, throttles (so dropdown opens + the
+ * refresh cycle don't spam `gh`), and self-gates on gh availability + a GitHub
+ * remote. Results persist for free via the gitStore prData snapshot, so cached
+ * icons show instantly and refresh in place.
+ */
+export async function prefetchBranchPrData(project: {
+  id: string;
+  location: ProjectLocation;
+}): Promise<void> {
+  if (branchPrPrefetchInFlight.has(project.id)) return;
+  const last = branchPrPrefetchLastRun.get(project.id) ?? 0;
+  if (Date.now() - last < BRANCH_PR_PREFETCH_THROTTLE_MS) return;
+  const state = useGitStore.getState();
+  if (!state.ghAvailable[project.id]) return;
+  const platform = state.statuses[project.id]?.remoteInfo?.platform;
+  if (platform !== undefined && platform !== "github" && platform !== "unknown") return;
+
+  branchPrPrefetchInFlight.add(project.id);
+  branchPrPrefetchLastRun.set(project.id, Date.now());
+  try {
+    const { prs } = await readBridge().ghListPrs({ projectLocation: project.location });
+    const updates: Record<string, PrData | null> = {};
+    for (const [branch, pr] of Object.entries(prs)) {
+      updates[buildBranchNamePrKey(project.id, branch)] = pr;
+    }
+    if (Object.keys(updates).length > 0) {
+      useGitStore.getState().setPrDataBatch(updates);
+    }
+  } catch (err) {
+    console.warn(`[git-refresh] ghListPrs failed project=${project.id}`, err);
+  } finally {
+    branchPrPrefetchInFlight.delete(project.id);
+  }
+}
 
 function getWorktreeStatusDetail(reason: GitRefreshReason): GitStatusDetail {
   return reason === "fetch" || reason === "poll" ? "summary" : "full";
@@ -517,6 +560,14 @@ export async function refreshGitProject(
 
         const statusPromise = snapshotPromise.then((snap) => snap?.status ?? undefined);
         const worktreesPromise = snapshotPromise.then((snap) => snap?.worktrees ?? undefined);
+
+        // Once the snapshot has set gh availability + remote platform, bulk-prefetch
+        // PR status for every branch (one gh call) for the branch-selector icons.
+        // Fire-and-forget: it writes branch-keyed prData independently of this refresh.
+        void snapshotPromise.then(() => {
+          if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
+          void prefetchBranchPrData(project);
+        });
 
         const ghAvailablePromise: Promise<boolean> = cachedGhAvailable
           ? Promise.resolve(true)

--- a/src/renderer/state/gitSelectors.ts
+++ b/src/renderer/state/gitSelectors.ts
@@ -40,6 +40,16 @@ export function resolvePrKey(projectId: string, worktreePath: string | undefined
   return worktreePath ?? buildBranchPrKey(projectId);
 }
 
+/**
+ * Key for a PR discovered by the bulk branch-PR prefetch (`ghListPrs`), addressed
+ * by branch name. Distinct from {@link buildBranchPrKey} (the checked-out main
+ * branch) and worktree-path keys, so branch-selector rows can show PR status for
+ * remote/local branches that aren't checked out as a worktree.
+ */
+export function buildBranchNamePrKey(projectId: string, branch: string): string {
+  return `__branchname:${projectId}:${branch}`;
+}
+
 type PrField<K extends keyof PrData> = PrData[K] | undefined;
 
 function makePrFieldSelector<K extends keyof PrData>(field: K) {

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -11,6 +11,13 @@ export interface PrReviewContext {
   projectId: string;
   worktreePath?: string;
   prNumber: number;
+  /**
+   * Explicit prData key override for selectors (title/url/checks). Set when
+   * opening a PR for a branch that has no worktree, so the overlay reads the
+   * branch-keyed prefetch entry instead of the main-branch key. Defaults to
+   * `resolvePrKey(projectId, worktreePath)` when omitted.
+   */
+  prKey?: string;
 }
 
 export interface FilesPanelContext {
@@ -154,7 +161,8 @@ export const usePanelStore = create<PanelState>((set) => ({
           ctx !== null &&
           prev.projectId === ctx.projectId &&
           prev.worktreePath === ctx.worktreePath &&
-          prev.prNumber === ctx.prNumber)
+          prev.prNumber === ctx.prNumber &&
+          prev.prKey === ctx.prKey)
       ) {
         return {};
       }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1740,6 +1740,13 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   gap: 0.35rem;
 }
 
+/* Compact variant for secondary control rows (e.g. the worktree row under the composer). */
+.lightcode-composer-menu--compact {
+  height: 1.625rem;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+}
+
 .lightcode-composer-static {
   display: inline-flex;
   height: 2.25rem;

--- a/src/renderer/views/GitReviewOverlay/GitReviewOverlay.tsx
+++ b/src/renderer/views/GitReviewOverlay/GitReviewOverlay.tsx
@@ -176,6 +176,10 @@ export function GitReviewOverlay(props: {
                     value={gitStatus.branch}
                     onSwitchBranch={handleSwitchBranch}
                     hideWorktreeToggle
+                    showMoveBranchAction
+                    {...(project.scripts?.worktreeCopyPatterns
+                      ? { moveBranchCopyIgnoredPatterns: project.scripts.worktreeCopyPatterns }
+                      : {})}
                     popoverPlacement="bottom"
                     trigger={
                       <Button

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
@@ -174,6 +174,10 @@ export function GitReviewPanel(props: {
                     value={gitStatus.branch}
                     onSwitchBranch={handleSwitchBranch}
                     hideWorktreeToggle
+                    showMoveBranchAction
+                    {...(project.scripts?.worktreeCopyPatterns
+                      ? { moveBranchCopyIgnoredPatterns: project.scripts.worktreeCopyPatterns }
+                      : {})}
                     popoverPlacement="bottom"
                     trigger={
                       <button
@@ -265,6 +269,10 @@ export function GitReviewPanel(props: {
                     value={gitStatus.branch}
                     onSwitchBranch={handleSwitchBranch}
                     hideWorktreeToggle
+                    showMoveBranchAction
+                    {...(project.scripts?.worktreeCopyPatterns
+                      ? { moveBranchCopyIgnoredPatterns: project.scripts.worktreeCopyPatterns }
+                      : {})}
                     popoverPlacement="bottom"
                     trigger={
                       <button

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -71,6 +71,7 @@ export function AppContent() {
       worktreeBranch?: string;
       worktreeBaseBranch?: string;
       worktreeIsNewBranch?: boolean;
+      worktreeTransferUncommitted?: boolean;
       presentationMode?: import("@/shared/contracts").ThreadPresentationMode;
     },
     replacePaneIdParam?: string,
@@ -84,6 +85,7 @@ export function AppContent() {
       worktreeBranch,
       worktreeBaseBranch,
       worktreeIsNewBranch,
+      worktreeTransferUncommitted,
       presentationMode,
     } = input;
     const isHomeScope = isHomeProject(project);
@@ -111,9 +113,18 @@ export function AppContent() {
           createBranch: worktreeIsNewBranch ?? false,
           startPoint: worktreeBaseBranch,
           copyIgnoredPatterns: project.scripts?.worktreeCopyPatterns,
+          transferUncommitted: worktreeTransferUncommitted ?? false,
+          // The composer's "Worktree + changes" option copies the changes and
+          // keeps them on the current branch (vs. the "Move changes" action).
+          keepChangesInSource: worktreeTransferUncommitted ?? false,
         });
         worktreePath = result.path;
         newWorktreeSetupPath = result.path;
+        if (worktreeTransferUncommitted && result.changesTransferred === false) {
+          toast.danger(
+            "Couldn't copy your uncommitted changes into the new worktree — they remain on the current branch.",
+          );
+        }
       } catch (err) {
         console.error("[renderer] failed to create worktree:", err);
         return;
@@ -483,6 +494,7 @@ function DraftViewContent(props: {
     worktreeBranch?: string;
     worktreeBaseBranch?: string;
     worktreeIsNewBranch?: boolean;
+    worktreeTransferUncommitted?: boolean;
   }) => void;
 }) {
   const { project, lastDraftConfig, onStart } = props;

--- a/src/renderer/views/MainView/parts/AppContent/parts/DraftPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/DraftPane.tsx
@@ -32,6 +32,7 @@ export function DraftPane(props: {
       worktreeBranch?: string;
       worktreeBaseBranch?: string;
       worktreeIsNewBranch?: boolean;
+      worktreeTransferUncommitted?: boolean;
       presentationMode?: import("@/shared/contracts").ThreadPresentationMode;
     },
   ) => void;

--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -150,7 +150,10 @@ export function AppOverlays() {
             <PrReviewOverlay
               project={prReviewProject}
               prNumber={prReviewContext.prNumber}
-              prKey={resolvePrKey(prReviewContext.projectId, prReviewContext.worktreePath)}
+              prKey={
+                prReviewContext.prKey ??
+                resolvePrKey(prReviewContext.projectId, prReviewContext.worktreePath)
+              }
               {...(prReviewContext.worktreePath
                 ? {
                     locationOverride: buildWorktreeLocation(

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -296,6 +296,12 @@ export interface GitWorktreeListResult {
 
 export interface GitAddWorktreeResult {
   path: string;
+  /**
+   * When `transferUncommitted` was requested: whether the changes landed in the
+   * new worktree. `false` means the apply conflicted — for a copy they remain on
+   * the source branch; for a move they remain in a git stash (source still clean).
+   */
+  changesTransferred?: boolean;
 }
 
 export const getGitBranchesPayloadSchema = z.object({
@@ -324,6 +330,16 @@ export const gitAddWorktreePayloadSchema = z.object({
   startPoint: z.string().optional(),
   /** Gitignore-style patterns for ignored files to copy from the main project. */
   copyIgnoredPatterns: z.array(z.string()).optional(),
+  /**
+   * Bring the main checkout's uncommitted changes (including untracked files)
+   * into the new worktree.
+   */
+  transferUncommitted: z.boolean().default(false),
+  /**
+   * When transferring: keep a copy of the changes on the source branch (COPY).
+   * Defaults to false, which leaves the source branch clean (MOVE).
+   */
+  keepChangesInSource: z.boolean().default(false),
 });
 export type GitAddWorktreePayload = z.infer<typeof gitAddWorktreePayloadSchema>;
 

--- a/src/shared/contracts/github.ts
+++ b/src/shared/contracts/github.ts
@@ -131,6 +131,16 @@ export const ghGetPrForBranchPayloadSchema = z.object({
 });
 export type GhGetPrForBranchPayload = z.infer<typeof ghGetPrForBranchPayloadSchema>;
 
+export const ghListPrsPayloadSchema = z.object({
+  projectLocation: projectLocationSchema,
+});
+export type GhListPrsPayload = z.infer<typeof ghListPrsPayloadSchema>;
+
+export interface GhListPrsResult {
+  /** Latest PR per head branch, keyed by head branch name. */
+  prs: Record<string, PrData>;
+}
+
 export const ghMergePrPayloadSchema = z.object({
   projectLocation: projectLocationSchema,
   prNumber: z.number().int().min(1),

--- a/src/shared/ipc/procedures/github.ts
+++ b/src/shared/ipc/procedures/github.ts
@@ -7,6 +7,7 @@ import {
   ghGetPrDiffPayloadSchema,
   ghGetPrFilesPayloadSchema,
   ghGetPrForBranchPayloadSchema,
+  ghListPrsPayloadSchema,
   ghMarkPrReadyPayloadSchema,
   ghMergePrPayloadSchema,
   ghPostPrCommentPayloadSchema,
@@ -28,6 +29,8 @@ import type {
   GhGetPrFilesPayload,
   GhGetPrFilesResult,
   GhGetPrForBranchPayload,
+  GhListPrsPayload,
+  GhListPrsResult,
   GhMarkPrReadyPayload,
   GhMergePrPayload,
   GhPostPrCommentPayload,
@@ -54,6 +57,11 @@ export const githubProcedures = {
     "ghGetPrForBranch",
     "supervisor",
     ghGetPrForBranchPayloadSchema,
+  ),
+  ghListPrs: definePayloadProcedure<GhListPrsPayload, GhListPrsResult, "supervisor">(
+    "ghListPrs",
+    "supervisor",
+    ghListPrsPayloadSchema,
   ),
   ghMergePr: definePayloadProcedure<GhMergePrPayload, void, "supervisor">(
     "ghMergePr",

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -248,6 +248,262 @@ describe("GitService.addWorktree", () => {
   });
 });
 
+describe("GitService.addWorktree (transfer uncommitted changes)", () => {
+  const location = {
+    kind: "windows" as const,
+    path: "C:\\Users\\demo\\work\\lightcode",
+  };
+  const worktreePath = "C:\\Users\\demo\\.lightcode\\worktrees\\lightcode-12345678\\feature-x";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mkdirMock.mockResolvedValue(undefined);
+  });
+
+  it("moves the stash into the worktree, drops it, and leaves the source clean", async () => {
+    let stashPushed = false;
+    mockGitCommands((args) => {
+      if (args[0] === "status" && args[1] === "--porcelain") return { stdout: " M src/file.ts\n" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { stdout: "master\n" };
+      if (args[0] === "stash" && args[1] === "push") {
+        stashPushed = true;
+        return { stdout: "" };
+      }
+      // The transfer stash is only pinned once `stash push` actually creates it.
+      if (args[0] === "rev-parse" && args.includes("stash@{0}")) {
+        return stashPushed ? { stdout: "stashsha\n" } : { error: new Error("unknown revision") };
+      }
+      if (args[0] === "stash" && args[1] === "list") return { stdout: "stashsha stash@{0}\n" };
+      return { stdout: "" };
+    });
+
+    const result = await new GitService().addWorktree(
+      location,
+      worktreePath,
+      "feature/x",
+      true,
+      "master",
+      undefined,
+      true,
+    );
+
+    expect(result.changesTransferred).toBe(true);
+
+    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    expect(commands.some((c) => c.startsWith("stash push -u"))).toBe(true);
+    expect(commands.some((c) => c.startsWith("worktree add -b feature/x"))).toBe(true);
+    // Never relies on stash@{0}: apply/drop are pinned to the captured SHA.
+    expect(commands).not.toContain("stash pop");
+
+    // Move semantics: the pinned stash is applied ONLY inside the worktree (the
+    // source is left clean — not re-applied), then dropped.
+    const applyCwds = execFileMock.mock.calls
+      .filter(
+        (c: unknown[]) =>
+          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "stash apply --index stashsha",
+      )
+      .map((c: unknown[]) => (c[2] as { cwd?: string }).cwd);
+    expect(applyCwds).toEqual([worktreePath]);
+    expect(applyCwds).not.toContain(location.path);
+    expect(commands).toContain("stash drop stash@{0}");
+  });
+
+  it("copies the stash into the worktree and restores the source when keepChangesInSource is set", async () => {
+    let stashPushed = false;
+    mockGitCommands((args) => {
+      if (args[0] === "status" && args[1] === "--porcelain") return { stdout: " M src/file.ts\n" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { stdout: "master\n" };
+      if (args[0] === "stash" && args[1] === "push") {
+        stashPushed = true;
+        return { stdout: "" };
+      }
+      // The transfer stash is only pinned once `stash push` actually creates it.
+      if (args[0] === "rev-parse" && args.includes("stash@{0}")) {
+        return stashPushed ? { stdout: "stashsha\n" } : { error: new Error("unknown revision") };
+      }
+      if (args[0] === "stash" && args[1] === "list") return { stdout: "stashsha stash@{0}\n" };
+      return { stdout: "" };
+    });
+
+    const result = await new GitService().addWorktree(
+      location,
+      worktreePath,
+      "feature/x",
+      true,
+      "master",
+      undefined,
+      true,
+      true,
+    );
+
+    expect(result.changesTransferred).toBe(true);
+
+    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    expect(commands).not.toContain("stash pop");
+
+    // Copy semantics: the pinned stash is applied into BOTH the worktree and the
+    // source, then dropped — the source keeps its changes.
+    const applyCwds = execFileMock.mock.calls
+      .filter(
+        (c: unknown[]) =>
+          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "stash apply --index stashsha",
+      )
+      .map((c: unknown[]) => (c[2] as { cwd?: string }).cwd);
+    expect(applyCwds).toContain(worktreePath);
+    expect(applyCwds).toContain(location.path);
+    expect(commands).toContain("stash drop stash@{0}");
+  });
+
+  it("keeps the changes stashed (changesTransferred=false) when the worktree apply conflicts", async () => {
+    let stashPushed = false;
+    mockGitCommands((args) => {
+      if (args[0] === "status" && args[1] === "--porcelain") return { stdout: " M src/file.ts\n" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { stdout: "master\n" };
+      if (args[0] === "stash" && args[1] === "push") {
+        stashPushed = true;
+        return { stdout: "" };
+      }
+      if (args[0] === "rev-parse" && args.includes("stash@{0}")) {
+        return stashPushed ? { stdout: "stashsha\n" } : { error: new Error("unknown revision") };
+      }
+      if (args[0] === "stash" && args[1] === "apply") {
+        return { error: new Error("CONFLICT (content): Merge conflict in src/file.ts") };
+      }
+      return { stdout: "" };
+    });
+
+    const result = await new GitService().addWorktree(
+      location,
+      worktreePath,
+      "feature/x",
+      true,
+      "master",
+      undefined,
+      true,
+    );
+
+    // The source was already left clean by the stash push; a conflicting apply
+    // keeps the work recoverable in the stash rather than dropping it.
+    expect(result.changesTransferred).toBe(false);
+    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    expect(commands.some((c) => c.startsWith("stash drop"))).toBe(false);
+  });
+
+  it("skips the transfer when the working tree is clean", async () => {
+    mockGitCommands((args) => {
+      if (args[0] === "status" && args[1] === "--porcelain") return { stdout: "" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { stdout: "master\n" };
+      return { stdout: "" };
+    });
+
+    await new GitService().addWorktree(
+      location,
+      worktreePath,
+      "feature/x",
+      true,
+      "master",
+      undefined,
+      true,
+    );
+
+    const stashCall = execFileMock.mock.calls.find(
+      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[])[0] === "stash",
+    );
+    expect(stashCall).toBeUndefined();
+  });
+
+  it("never touches a pre-existing stash when `git stash push` saves nothing (e.g. dirty submodule)", async () => {
+    // `git status` reports dirty (a dirty submodule), but `git stash push` is a
+    // no-op, and an UNRELATED user stash already sits on top of the shared list.
+    mockGitCommands((args) => {
+      if (args[0] === "status" && args[1] === "--porcelain") return { stdout: " M sub\n" };
+      if (args[0] === "branch" && args[1] === "--show-current") return { stdout: "master\n" };
+      // push saves nothing → the top-of-stack SHA is unchanged before and after.
+      if (args[0] === "rev-parse" && args.includes("stash@{0}")) return { stdout: "userstash\n" };
+      return { stdout: "" };
+    });
+
+    const result = await new GitService().addWorktree(
+      location,
+      worktreePath,
+      "feature/x",
+      true,
+      "master",
+      undefined,
+      true,
+    );
+
+    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    // The worktree is still created, but the unrelated stash is never applied or
+    // dropped — no data loss.
+    expect(commands.some((c) => c.startsWith("worktree add -b feature/x"))).toBe(true);
+    expect(commands.some((c) => c.startsWith("stash apply"))).toBe(false);
+    expect(commands.some((c) => c.startsWith("stash drop"))).toBe(false);
+    expect(result.changesTransferred).toBeUndefined();
+  });
+
+  it("applies transferred changes to WSL worktrees with a UNC filesystem path", async () => {
+    const wslLocation = {
+      kind: "wsl" as const,
+      distro: "Ubuntu",
+      linuxPath: "/home/demo/work/lightcode",
+      uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\work\\lightcode",
+    };
+    const wslWorktreePath = "/home/demo/.lightcode/worktrees/lightcode/feature-x";
+    const bridgeMkdir = vi.fn<() => Promise<void>>(async () => undefined);
+    let stashPushed = false;
+    const gitExec = vi.fn<
+      (location: WslLocation, input: WslGitExecInput) => Promise<WslGitExecResult>
+    >(async (_location, input) => {
+      const args = input.args;
+      if (args[0] === "status" && args[1] === "--porcelain") {
+        return { ok: true, stdout: " M src/file.ts\n", stderr: "", exitCode: 0 };
+      }
+      if (args[0] === "stash" && args[1] === "push") {
+        stashPushed = true;
+        return { ok: true, stdout: "", stderr: "", exitCode: 0 };
+      }
+      if (args[0] === "rev-parse" && args.includes("stash@{0}")) {
+        return stashPushed
+          ? { ok: true, stdout: "stashsha\n", stderr: "", exitCode: 0 }
+          : { ok: false, stdout: "", stderr: "", exitCode: 1 };
+      }
+      if (args[0] === "stash" && args[1] === "list") {
+        return { ok: true, stdout: "stashsha stash@{0}\n", stderr: "", exitCode: 0 };
+      }
+      return { ok: true, stdout: "", stderr: "", exitCode: 0 };
+    });
+    const service = new GitService();
+    service.setWslClient({ gitExec, mkdir: bridgeMkdir } as unknown as WslBridgeClient);
+
+    try {
+      await service.addWorktree(
+        wslLocation,
+        wslWorktreePath,
+        "feature/x",
+        true,
+        "main",
+        undefined,
+        true,
+      );
+
+      const applyCalls = gitExec.mock.calls.filter(
+        ([, input]) => input.args.join(" ") === "stash apply --index stashsha",
+      );
+      expect(applyCalls[0]?.[0]).toMatchObject({
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: wslWorktreePath,
+        uncPath:
+          "\\\\wsl.localhost\\Ubuntu\\home\\demo\\.lightcode\\worktrees\\lightcode\\feature-x",
+      });
+      expect(applyCalls[0]?.[1]).toMatchObject({ cwd: wslWorktreePath });
+    } finally {
+      service.setWslClient(undefined);
+    }
+  });
+});
+
 describe("GitService.revert", () => {
   const location = {
     kind: "windows" as const,

--- a/src/supervisor/git.ts
+++ b/src/supervisor/git.ts
@@ -300,6 +300,8 @@ export class GitService {
     createBranch?: boolean,
     startPoint?: string,
     copyIgnoredPatterns?: string[],
+    transferUncommitted?: boolean,
+    keepChangesInSource?: boolean,
   ): Promise<GitAddWorktreeResult> {
     return this.worktreeService.addWorktree(
       location,
@@ -308,6 +310,8 @@ export class GitService {
       createBranch,
       startPoint,
       copyIgnoredPatterns,
+      transferUncommitted,
+      keepChangesInSource,
     );
   }
 

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -11,10 +11,12 @@ import {
 } from "@/shared/contracts";
 import { msg } from "@/shared/messages";
 import { resolveLightcodePaths } from "@/shared/lightcodePaths";
+import { buildWorktreeLocation } from "@/shared/worktree";
 import {
   computeDefaultWorktreePath,
   ensureWorktreeParentExists,
   execGit,
+  GIT_HOOK_TIMEOUT,
   GIT_NETWORK_TIMEOUT,
   GIT_STATUS_TIMEOUT,
   normalizeWorktreePath,
@@ -161,6 +163,8 @@ export class GitWorktreeService {
     createBranch?: boolean,
     startPoint?: string,
     copyIgnoredPatterns?: string[],
+    transferUncommitted?: boolean,
+    keepChangesInSource?: boolean,
   ): Promise<GitAddWorktreeResult> {
     const resolvedPath =
       path ?? (branch ? await computeDefaultWorktreePath(location, branch) : undefined);
@@ -168,13 +172,53 @@ export class GitWorktreeService {
       throw new Error(msg("git.worktree.noBranch"));
     }
     await ensureWorktreeParentExists(location, resolvedPath);
+
+    // Optionally bring the main checkout's uncommitted changes into the new
+    // worktree: stash (including untracked files), create the worktree, then
+    // apply the stash into it. With `keepChangesInSource` we also re-apply the
+    // stash in the source (a COPY); otherwise the source is left clean (a MOVE).
+    // The stash list is shared across a repository's worktrees, so we pin the
+    // exact stash commit by SHA rather than trusting `stash@{0}`.
+    const carryChanges =
+      transferUncommitted === true && (await this.hasUncommittedChanges(location));
+    const stashSha = carryChanges
+      ? await this.pushTransferStash(
+          location,
+          `Lightcode: ${keepChangesInSource ? "copy" : "move"} changes to ${branch ?? resolvedPath}`,
+        )
+      : undefined;
+
     const args = ["worktree", "add"];
     if (createBranch && branch) {
       args.push("-b", branch, resolvedPath, ...(startPoint ? [startPoint] : []));
     } else {
       args.push(resolvedPath, ...(branch ? [branch] : []));
     }
-    await execGit(location, args);
+    try {
+      await execGit(location, args);
+    } catch (error) {
+      // Creation failed — put the changes back on the source before bailing out.
+      if (stashSha) await this.restoreSourceStash(location, stashSha);
+      throw error;
+    }
+
+    let changesTransferred: boolean | undefined;
+    if (stashSha) {
+      changesTransferred = await this.applyStashInto(
+        buildWorktreeLocation(location, resolvedPath),
+        stashSha,
+      );
+      if (keepChangesInSource) {
+        // Copy: restore the source working tree (then drop the stash). This is
+        // independent of the worktree apply, so the source keeps its changes
+        // even if the worktree apply conflicted.
+        await this.restoreSourceStash(location, stashSha);
+      } else if (changesTransferred) {
+        // Move: drop the stash on success; a conflicting apply keeps it so the
+        // work stays recoverable (reported via `changesTransferred: false`).
+        await this.dropStashBySha(location, stashSha);
+      }
+    }
 
     if (branch && createBranch) {
       const sourceBranch = startPoint ?? (await this.getCurrentBranch(location));
@@ -192,7 +236,10 @@ export class GitWorktreeService {
       }
     }
 
-    return { path: resolvedPath };
+    return {
+      path: resolvedPath,
+      ...(changesTransferred !== undefined ? { changesTransferred } : {}),
+    };
   }
 
   async removeWorktree(
@@ -465,6 +512,85 @@ export class GitWorktreeService {
       return result.trim() || null;
     } catch {
       return null;
+    }
+  }
+
+  private async hasUncommittedChanges(location: ProjectLocation): Promise<boolean> {
+    const status = await execGit(location, ["status", "--porcelain"], {
+      timeout: GIT_STATUS_TIMEOUT,
+    });
+    return status.trim().length > 0;
+  }
+
+  /** Resolve the SHA of the topmost stash entry, or null when the list is empty. */
+  private async topStashSha(location: ProjectLocation): Promise<string | null> {
+    try {
+      const out = await execGit(location, ["rev-parse", "--verify", "--quiet", "stash@{0}"]);
+      return out.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Stash the working tree (including untracked files) and return the concrete
+   * stash commit SHA so callers can pin operations to it instead of `stash@{0}`
+   * (which a concurrent stash in another worktree could shadow).
+   *
+   * Returns undefined when the push saved nothing — `git status` can report a
+   * dirty tree that `git stash push` ignores (e.g. a dirty submodule). We detect
+   * that by comparing the top-of-stack SHA before and after the push; without
+   * this guard, pinning `stash@{0}` would latch onto an unrelated pre-existing
+   * user stash and later drop it, destroying work the operation never touched.
+   */
+  private async pushTransferStash(
+    location: ProjectLocation,
+    message: string,
+  ): Promise<string | undefined> {
+    const before = await this.topStashSha(location);
+    await execGit(location, ["stash", "push", "-u", "-m", message]);
+    const after = await this.topStashSha(location);
+    if (!after || after === before) return undefined;
+    return after;
+  }
+
+  /** Apply a specific stash commit into a checkout. Returns whether it applied cleanly. */
+  private async applyStashInto(location: ProjectLocation, stashSha: string): Promise<boolean> {
+    try {
+      await execGit(location, ["stash", "apply", "--index", stashSha], {
+        timeout: GIT_HOOK_TIMEOUT,
+      });
+      return true;
+    } catch (err) {
+      console.warn("[supervisor] failed to apply transferred changes:", err);
+      return false;
+    }
+  }
+
+  /**
+   * Re-apply the transfer stash into the source checkout and drop it. The drop
+   * only runs if the apply succeeded, so a failed restore never discards the
+   * user's only copy of the changes.
+   */
+  private async restoreSourceStash(location: ProjectLocation, stashSha: string): Promise<void> {
+    const restored = await this.applyStashInto(location, stashSha);
+    if (restored) await this.dropStashBySha(location, stashSha);
+  }
+
+  /** Drop the stash entry whose commit matches {@link stashSha}, resolved by SHA. */
+  private async dropStashBySha(location: ProjectLocation, stashSha: string): Promise<void> {
+    try {
+      const list = await execGit(location, ["stash", "list", "--format=%H %gd"]);
+      // Each line is "<full-sha> stash@{N}"; both fields are space-free.
+      for (const line of list.split("\n")) {
+        const [hash, ref] = line.trim().split(" ");
+        if (hash === stashSha && ref) {
+          await execGit(location, ["stash", "drop", ref]);
+          return;
+        }
+      }
+    } catch (err) {
+      console.warn("[supervisor] failed to drop transfer stash:", err);
     }
   }
 }

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -288,6 +288,99 @@ describe("GitHubService", () => {
     });
   });
 
+  describe("listPrs", () => {
+    it("keys PRs by head branch and maps PR data", async () => {
+      const prJson = JSON.stringify([
+        {
+          number: 42,
+          headRefName: "feature/x",
+          url: "https://github.com/owner/repo/pull/42",
+          state: "OPEN",
+          title: "Add feature",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-03T10:00:00Z",
+        },
+        {
+          number: 43,
+          headRefName: "feature/y",
+          url: "https://github.com/owner/repo/pull/43",
+          state: "MERGED",
+          title: "Other",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-02T10:00:00Z",
+        },
+      ]);
+      execFileAsyncMock.mockResolvedValue({ stdout: prJson });
+
+      const result = await new GitHubService().listPrs(location);
+
+      const ghArgs = buildAgentCommandMock.mock.calls[0]![2] as string[];
+      expect(ghArgs).toEqual([
+        "pr",
+        "list",
+        "--state",
+        "all",
+        "--limit",
+        "100",
+        "--json",
+        expect.stringContaining("headRefName"),
+      ]);
+      expect(result["feature/x"]).toMatchObject({ number: 42, state: "open" });
+      expect(result["feature/y"]).toMatchObject({ number: 43, state: "merged" });
+    });
+
+    it("keeps the latest PR per branch", async () => {
+      const prJson = JSON.stringify([
+        {
+          number: 10,
+          headRefName: "feature/x",
+          url: "u",
+          state: "CLOSED",
+          title: "old",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-01T10:00:00Z",
+        },
+        {
+          number: 12,
+          headRefName: "feature/x",
+          url: "u",
+          state: "OPEN",
+          title: "new",
+          baseRefName: "main",
+          isDraft: false,
+          updatedAt: "2026-04-02T10:00:00Z",
+        },
+      ]);
+      execFileAsyncMock.mockResolvedValue({ stdout: prJson });
+
+      const result = await new GitHubService().listPrs(location);
+
+      expect(Object.keys(result)).toEqual(["feature/x"]);
+      expect(result["feature/x"]).toMatchObject({ number: 12, state: "open" });
+    });
+
+    it("returns an empty map when no PRs exist", async () => {
+      execFileAsyncMock.mockResolvedValue({ stdout: "[]" });
+
+      const result = await new GitHubService().listPrs(location);
+
+      expect(result).toEqual({});
+    });
+
+    it("returns an empty map when the remote repo doesn't exist on GitHub", async () => {
+      execFileAsyncMock.mockRejectedValue(
+        new Error("GraphQL: Could not resolve to a Repository with the name 'owner/missing'."),
+      );
+
+      const result = await new GitHubService().listPrs(location);
+
+      expect(result).toEqual({});
+    });
+  });
+
   describe("createPr", () => {
     it("creates a PR using body-file and returns data from pr view", async () => {
       const viewJson = JSON.stringify({

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -32,6 +32,10 @@ const CREATE_PR_STATUS_WAIT_MS = 15_000;
 const CREATE_PR_STATUS_POLL_MS = 5_000;
 const PR_VIEW_FIELDS =
   "number,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus,author";
+// Bulk list: adds `headRefName` (to key per branch) and drops `author` (the icon
+// doesn't need viewerDidAuthor, so we skip the extra `gh api user` lookup).
+const PR_LIST_FIELDS =
+  "number,headRefName,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus";
 
 function selectLatestPr(items: unknown[]): Record<string, unknown> | null {
   return items.reduce<Record<string, unknown> | null>((latest, item) => {
@@ -576,6 +580,40 @@ export class GitHubService {
       return latest ? mapPrData(latest, viewerLogin) : null;
     } catch (err) {
       if (isRepoNotFoundError(err)) return null;
+      throw classifyError(err, "pr list");
+    }
+  }
+
+  /**
+   * List every PR in the repo in a single `gh` call, keyed by head branch name
+   * (latest PR per branch). Powers PR-status icons for all branches in the
+   * branch selector without a per-branch fetch.
+   */
+  async listPrs(location: ProjectLocation): Promise<Record<string, PrData>> {
+    const args = ["pr", "list", "--state", "all", "--limit", "100", "--json", PR_LIST_FIELDS];
+    try {
+      const stdout = await this.runGh(location, args);
+      const items = JSON.parse(stdout);
+      if (!Array.isArray(items)) return {};
+      // Group PRs by head branch, then reuse the single-branch "highest PR number
+      // wins" rule (selectLatestPr) to pick one per branch.
+      const byBranch = new Map<string, unknown[]>();
+      for (const item of items) {
+        if (!item || typeof item !== "object") continue;
+        const branch = (item as Record<string, unknown>).headRefName;
+        if (typeof branch !== "string" || !branch) continue;
+        const group = byBranch.get(branch);
+        if (group) group.push(item);
+        else byBranch.set(branch, [item]);
+      }
+      const result: Record<string, PrData> = {};
+      for (const [branch, group] of byBranch) {
+        const latest = selectLatestPr(group);
+        if (latest) result[branch] = mapPrData(latest);
+      }
+      return result;
+    } catch (err) {
+      if (isRepoNotFoundError(err)) return {};
       throw classifyError(err, "pr list");
     }
   }

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -99,6 +99,7 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
     ghCheckAvailable: (payload) => runtime.ghCheckAvailable(payload),
     ghCreatePr: (payload) => runtime.ghCreatePr(payload),
     ghGetPrForBranch: (payload) => runtime.ghGetPrForBranch(payload),
+    ghListPrs: (payload) => runtime.ghListPrs(payload),
     ghMergePr: (payload) => runtime.ghMergePr(payload),
     ghClosePr: (payload) => runtime.ghClosePr(payload),
     ghReopenPr: (payload) => runtime.ghReopenPr(payload),

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -46,6 +46,8 @@ import type {
   GhGetPrFilesPayload,
   GhGetPrFilesResult,
   GhGetPrForBranchPayload,
+  GhListPrsPayload,
+  GhListPrsResult,
   GhMergePrPayload,
   GhClosePrPayload,
   GhMarkPrReadyPayload,
@@ -1016,6 +1018,8 @@ export class SupervisorRuntime {
       payload.createBranch,
       payload.startPoint,
       payload.copyIgnoredPatterns,
+      payload.transferUncommitted,
+      payload.keepChangesInSource,
     );
   }
 
@@ -1194,6 +1198,10 @@ export class SupervisorRuntime {
 
   async ghGetPrForBranch(payload: GhGetPrForBranchPayload): Promise<PrData | null> {
     return this.githubService.getPrForBranch(payload.projectLocation, payload.branch);
+  }
+
+  async ghListPrs(payload: GhListPrsPayload): Promise<GhListPrsResult> {
+    return { prs: await this.githubService.listPrs(payload.projectLocation) };
   }
 
   async ghMergePr(payload: GhMergePrPayload): Promise<void> {


### PR DESCRIPTION
- Feature + refactor: add worktree creation modes for carrying uncommitted changes into a new worktree or leaving them in the source checkout.
- Prefetch PRs by head branch so branch selector rows and review overlays can show PR state even when a branch is not currently checked out as a worktree.
- Thread the new worktree and PR metadata through the renderer, shared contracts, IPC, and supervisor git/GitHub services.
- Update composer, branch selector, and overlay UI plus tests to cover the new flows and state handling.