### PR TITLE
Hide redundant system labels in agent discovery

### DIFF
--- a/src/renderer/components/thread/AgentDiscoveryScreen.tsx
+++ b/src/renderer/components/thread/AgentDiscoveryScreen.tsx
@@ -169,7 +169,10 @@ export function AgentDiscoveryScreen(props: {
           <div>Provider</div>
           {statusTargets.map((target) => (
             <div key={target.key} className="text-center">
-              {target.label}
+              {/* The per-system label (e.g. "Windows", "WSL: …") only disambiguates
+                  when there are multiple environment columns. With a single column —
+                  always the case on macOS/Linux — it is redundant noise, so omit it. */}
+              {useMatrixLayout ? target.label : null}
             </div>
           ))}
         </div>


### PR DESCRIPTION
- Bugfix: omit per-system labels when agent discovery shows a single environment column, reducing redundant noise.
- Keep the labels in matrix layouts, where they still help distinguish between multiple environments.