### PR TITLE
Apply aside divider border only when docked panel is open

### DIFF
--- a/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
@@ -58,11 +58,21 @@ export function AsideSlot(props: {
       minWidth: targetWidth,
     };
   } else {
+    // A docked panel collapses its width/height to 0 when closed, but a
+    // `border-t`/`border-l` on a border-box element still reserves a 1px edge even
+    // at size 0. That leaves a 1px strip between `main` and the window edge; with
+    // the translucent shell (native material) the shell behind it is transparent,
+    // so the strip reveals the backdrop as a stray hairline along the content's
+    // bottom/right. Only apply the divider border while the panel is open so a
+    // closed panel occupies no space and `main` reaches the edge.
+    const borderClass = isOpen
+      ? isHorizontal
+        ? "border-t border-[color:var(--border)]"
+        : "border-l border-[color:var(--border)]"
+      : "";
     asideClassName = `relative overflow-hidden bg-[var(--content-background)] ${
-      isHorizontal
-        ? "min-w-0 border-t border-[color:var(--border)]"
-        : "min-h-0 border-l border-[color:var(--border)]"
-    }`;
+      isHorizontal ? "min-w-0" : "min-h-0"
+    } ${borderClass}`;
     asideStyle = {
       ...(isHorizontal
         ? { height: dockedDisplayHeight, minHeight: dockedDisplayHeight }


### PR DESCRIPTION
- **Bugfix:** Remove a stray 1px hairline along the main content edge when the docked aside panel is closed.
- Closed panels collapse to zero size, but `border-t`/`border-l` on a border-box element still reserves a 1px edge and leaves a visible strip.
- On the translucent app shell, that strip exposes the backdrop behind the content area.
- Show the aside divider border only while the panel is open so closed panels take no space and main content reaches the window edge.