### PR TITLE
Add on-demand PR refresh in git review sidebar and panel

### DIFF
--- a/src/renderer/hooks/usePrWriteActions.ts
+++ b/src/renderer/hooks/usePrWriteActions.ts
@@ -4,6 +4,7 @@ import type { ProjectLocation } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { refreshSinglePr } from "@/renderer/state/gitRefresh";
 
 const ADMIN_BYPASS_RX = /--admin|base branch policy|not mergeable/i;
 
@@ -11,6 +12,10 @@ export interface UsePrWriteActionsArgs {
   projectLocation: ProjectLocation;
   localSyncLocation?: ProjectLocation | undefined;
   prKey: string | undefined;
+  /** PR head branch — required for the on-demand `handleRefreshPr` refetch. */
+  branch?: string | undefined;
+  /** Project id used to build the PR-details cache key (`${projectId}#${number}`). */
+  projectId?: string | undefined;
   onRefresh: () => void;
 }
 
@@ -20,10 +25,14 @@ export type PrWriteAction = "merge" | "close" | "ready" | "update";
 export interface UsePrWriteActionsResult {
   prLoading: boolean;
   pendingAction: PrWriteAction | null;
+  /** True while an on-demand PR refresh is in flight (independent of `prLoading`). */
+  isRefreshing: boolean;
   handleMergePr: (method: "merge" | "squash" | "rebase", admin?: boolean) => Promise<void>;
   handleClosePr: () => Promise<void>;
   handleMarkPrReady: () => Promise<void>;
   handleUpdatePrBranch: (rebase?: boolean) => Promise<void>;
+  /** Refetch this PR's data + details on demand (e.g. the PR block refresh icon). */
+  handleRefreshPr: () => Promise<void>;
 }
 
 /**
@@ -33,13 +42,35 @@ export interface UsePrWriteActionsResult {
  * stay in lockstep across surfaces.
  */
 export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteActionsResult {
-  const { projectLocation, localSyncLocation, prKey, onRefresh } = args;
+  const { projectLocation, localSyncLocation, prKey, branch, projectId, onRefresh } = args;
   const [pendingAction, setPendingAction] = useState<PrWriteAction | null>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const prLoading = pendingAction !== null;
 
   function getCurrentPrData() {
     if (!prKey) return null;
     return useGitStore.getState().prData[prKey] ?? null;
+  }
+
+  // On-demand refetch of the live PR snapshot (state, mergeability, checks) plus
+  // its details. Kept separate from `pendingAction` so the refresh spinner never
+  // disables the merge/close/update buttons. No-ops without a key + head branch.
+  async function handleRefreshPr(): Promise<void> {
+    if (!prKey || !branch || isRefreshing) return;
+    const prNumber = getCurrentPrData()?.number;
+    const detailsCacheKey = projectId && prNumber ? `${projectId}#${prNumber}` : undefined;
+    setIsRefreshing(true);
+    try {
+      await refreshSinglePr({
+        projectLocation,
+        prKey,
+        branch,
+        ...(detailsCacheKey ? { detailsCacheKey } : {}),
+        ...(prNumber ? { prNumber } : {}),
+      });
+    } finally {
+      setIsRefreshing(false);
+    }
   }
 
   async function handleMergePr(
@@ -144,9 +175,11 @@ export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteAction
   return {
     prLoading,
     pendingAction,
+    isRefreshing,
     handleMergePr,
     handleClosePr,
     handleMarkPrReady,
     handleUpdatePrBranch,
+    handleRefreshPr,
   };
 }

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -1,4 +1,9 @@
-import type { GitStatusDetail, PrData, ProjectLocation } from "@/shared/contracts";
+import type {
+  GitStatusDetail,
+  PrData,
+  ProjectLocation,
+  RemoteHostPlatform,
+} from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
@@ -34,6 +39,18 @@ export const PR_POST_PUSH_STATUS_POLL_MS = 5_000;
 
 const alwaysActive = () => true;
 
+/**
+ * A remote worth trying `gh` against: an explicit GitHub remote, an as-yet
+ * unclassified one ("unknown" — covers SSH host aliases that resolve to
+ * github.com), or one we haven't inspected yet (undefined). This is the gate
+ * every PR-fetch path checks (alongside `ghAvailable`) before paying a
+ * `gh pr list` spawn — see {@link prefetchBranchPrData} and the worktree git
+ * panel's manual refresh.
+ */
+export function mightBeGitHubRemote(platform: RemoteHostPlatform | undefined): boolean {
+  return platform === undefined || platform === "github" || platform === "unknown";
+}
+
 const BRANCH_PR_PREFETCH_THROTTLE_MS = 10_000;
 const branchPrPrefetchLastRun = new Map<string, number>();
 const branchPrPrefetchInFlight = new Set<string>();
@@ -56,8 +73,7 @@ export async function prefetchBranchPrData(project: {
   if (Date.now() - last < BRANCH_PR_PREFETCH_THROTTLE_MS) return;
   const state = useGitStore.getState();
   if (!state.ghAvailable[project.id]) return;
-  const platform = state.statuses[project.id]?.remoteInfo?.platform;
-  if (platform !== undefined && platform !== "github" && platform !== "unknown") return;
+  if (!mightBeGitHubRemote(state.statuses[project.id]?.remoteInfo?.platform)) return;
 
   branchPrPrefetchInFlight.add(project.id);
   branchPrPrefetchLastRun.set(project.id, Date.now());
@@ -294,32 +310,46 @@ function buildPendingPrRefreshTargets(
   return targets;
 }
 
+/**
+ * Fetch a single PR's data (and its details, when a number + cache key are
+ * known) and write both into the git store. Shared by the background
+ * pending-PR poll and the on-demand refresh affordances (the PR block's
+ * refresh icon and the worktree git panel's refresh button) so every surface
+ * lands the same `setPrData` / `setPrDetails` shape. Network errors are
+ * swallowed per request — a failed refresh leaves the cached snapshot intact.
+ */
+export async function refreshSinglePr(params: {
+  projectLocation: ProjectLocation;
+  prKey: string;
+  branch: string;
+  detailsCacheKey?: string;
+  prNumber?: number;
+}): Promise<void> {
+  const bridge = readBridge();
+  const prPromise = bridge
+    .ghGetPrForBranch({ projectLocation: params.projectLocation, branch: params.branch })
+    .catch(() => undefined);
+  const detailsPromise =
+    params.detailsCacheKey && params.prNumber
+      ? bridge
+          .ghGetPrDetails({ projectLocation: params.projectLocation, prNumber: params.prNumber })
+          .catch(() => undefined)
+      : Promise.resolve(undefined);
+  const [pr, details] = await Promise.all([prPromise, detailsPromise]);
+  if (pr !== undefined) {
+    useGitStore.getState().setPrData(params.prKey, pr);
+  }
+  if (params.detailsCacheKey && details) {
+    useGitStore.getState().setPrDetails(params.detailsCacheKey, details.details);
+  }
+}
+
 async function refreshPendingPr(key: string): Promise<void> {
   const entry = pendingPrRefreshEntries.get(key);
   if (!entry || entry.inFlight) return;
   entry.inFlight = true;
   try {
-    const { target } = entry;
-    const bridge = readBridge();
-    const prPromise = bridge
-      .ghGetPrForBranch({ projectLocation: target.projectLocation, branch: target.branch })
-      .catch(() => undefined);
-    const detailsPromise =
-      target.detailsCacheKey && target.prNumber
-        ? bridge
-            .ghGetPrDetails({
-              projectLocation: target.projectLocation,
-              prNumber: target.prNumber,
-            })
-            .catch(() => undefined)
-        : Promise.resolve(undefined);
-    const [pr, details] = await Promise.all([prPromise, detailsPromise]);
-    if (pr !== undefined) {
-      useGitStore.getState().setPrData(target.prKey, pr);
-    }
-    if (target.detailsCacheKey && details) {
-      useGitStore.getState().setPrDetails(target.detailsCacheKey, details.details);
-    }
+    await refreshSinglePr(entry.target);
   } finally {
     const current = pendingPrRefreshEntries.get(key);
     if (current) current.inFlight = false;

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
@@ -13,7 +13,11 @@ import type { Project, ProjectLocation, GitStatusResult } from "@/shared/contrac
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
-import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import {
+  mightBeGitHubRemote,
+  refreshGitProject,
+  refreshSinglePr,
+} from "@/renderer/state/gitRefresh";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { BranchSelector } from "@/renderer/components/common";
 import { overlaySidebarSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
@@ -93,10 +97,31 @@ export function GitReviewPanel(props: {
     setSelectedStaged(staged);
   }
 
+  // Refetch the worktree's PR (data + details) into `prData[worktreePath]` so the
+  // PR block's merge state / checks update on manual refresh — otherwise the only
+  // worktree PR refetch is the background poll, which fires only while checks are
+  // still pending. Gated on gh availability + a GitHub-ish remote so non-GitHub
+  // repos skip the `gh pr list` spawn. Hits the main project location, so it's
+  // independent of the worktree status fetch and can overlap it.
+  async function refreshWorktreePrData() {
+    if (!worktreePath || !worktreeBranch) return;
+    const gitState = useGitStore.getState();
+    if (!gitState.ghAvailable[project.id]) return;
+    if (!mightBeGitHubRemote(gitState.statuses[project.id]?.remoteInfo?.platform)) return;
+    const prNumber = gitState.prData[worktreePath]?.number;
+    await refreshSinglePr({
+      projectLocation: project.location,
+      prKey: worktreePath,
+      branch: worktreeBranch,
+      ...(prNumber ? { prNumber, detailsCacheKey: `${project.id}#${prNumber}` } : {}),
+    });
+  }
+
   async function handleRefresh() {
     setRefreshing(true);
     try {
       if (statusKey && effectiveLocation !== project.location) {
+        const prRefresh = refreshWorktreePrData();
         await readBridge()
           .gitFetch({ projectLocation: effectiveLocation, remote: "origin", prune: false })
           .catch(() => undefined);
@@ -104,6 +129,7 @@ export function GitReviewPanel(props: {
           .getGitStatus({ projectLocation: effectiveLocation })
           .catch(() => undefined);
         if (status) useGitStore.getState().setWorktreeStatus(statusKey, status);
+        await prRefresh;
         return;
       }
       // Manual refresh runs a full sync: git fetch + snapshot (status,

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
@@ -169,6 +169,8 @@ export function GitReviewSidebar(props: {
     handleClosePr,
     handleMarkPrReady,
     handleUpdatePrBranch,
+    handleRefreshPr,
+    isRefreshingPr,
     handleGeneratePrSummary,
   } = useGitReviewActions({
     project,
@@ -493,6 +495,8 @@ export function GitReviewSidebar(props: {
               handleClosePr={handleClosePr}
               handleMarkPrReady={handleMarkPrReady}
               handleUpdatePrBranch={handleUpdatePrBranch}
+              onRefreshPr={handleRefreshPr}
+              isRefreshingPr={isRefreshingPr}
             />
           )}
 

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -54,6 +54,9 @@ export function PrSection(props: {
   handleClosePr: () => Promise<void>;
   handleMarkPrReady: () => Promise<void>;
   handleUpdatePrBranch?: ((rebase?: boolean) => Promise<void>) | undefined;
+  /** Refetch this PR's live data on demand. When omitted, no refresh icon shows. */
+  onRefreshPr?: (() => void | Promise<void>) | undefined;
+  isRefreshingPr?: boolean | undefined;
 }) {
   const {
     prKey,
@@ -65,6 +68,8 @@ export function PrSection(props: {
     handleClosePr,
     handleMarkPrReady,
     handleUpdatePrBranch,
+    onRefreshPr,
+    isRefreshingPr,
   } = props;
   const state = usePrState(prKey);
   const number = usePrNumber(prKey);
@@ -92,6 +97,9 @@ export function PrSection(props: {
   const fallbackTitle = title || (state === "merged" ? "Merged" : state === "draft" ? "" : "Open");
 
   const canReview = number !== undefined && state !== "merged" && state !== "closed";
+  // Offer refresh for live PRs only — a merged/closed PR's head branch is often
+  // gone, so a by-branch refetch is pointless. Mirrors `canReview`'s exclusions.
+  const canRefresh = Boolean(onRefreshPr) && state !== "merged" && state !== "closed";
 
   return (
     <GitReviewSection>
@@ -109,6 +117,22 @@ export function PrSection(props: {
           </span>
           <ExternalLink className="size-4 shrink-0" />
         </Link>
+        {canRefresh && (
+          <Tooltip delay={300}>
+            <Tooltip.Trigger>
+              <button
+                type="button"
+                aria-label="Refresh PR"
+                className="rounded p-0.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground disabled:opacity-50"
+                disabled={isRefreshingPr}
+                onClick={() => void onRefreshPr?.()}
+              >
+                <RefreshCw className={`size-3.5 ${isRefreshingPr ? "animate-spin" : ""}`} />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Content placement="top">Refresh PR</Tooltip.Content>
+          </Tooltip>
+        )}
         {canReview && (
           <Tooltip delay={300}>
             <Tooltip.Trigger>

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
@@ -149,6 +149,8 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     projectLocation: project.location,
     localSyncLocation: getWorktreeLocation(),
     prKey: effectivePrKey,
+    branch: effectiveBranch,
+    projectId: project.id,
     onRefresh,
   });
   const prLoading = isCreatingPr || writeActions.prLoading;
@@ -670,6 +672,8 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     handleClosePr: writeActions.handleClosePr,
     handleMarkPrReady: writeActions.handleMarkPrReady,
     handleUpdatePrBranch: writeActions.handleUpdatePrBranch,
+    handleRefreshPr: writeActions.handleRefreshPr,
+    isRefreshingPr: writeActions.isRefreshing,
     handleGeneratePrSummary,
   };
 }


### PR DESCRIPTION
- Add a refresh control on live PRs in the git review sidebar so merge state, checks, and details can be updated without waiting on background polling
- Extract shared `refreshSinglePr` and `mightBeGitHubRemote` helpers so sidebar, worktree panel, and prefetch paths refetch PR data the same way and skip non-GitHub remotes
- Extend worktree git panel manual refresh to refetch PR data alongside status, closing the gap where PR info only updated while checks were still pending
- Keep on-demand refresh loading separate from merge/close/update actions so PR write controls stay usable during a refetch