### PR TITLE
Add multi-provider Claude presets and preserve external model IDs

### DIFF
--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -274,6 +274,26 @@ describe("mergeAgentStatus", () => {
   });
 });
 
+describe("removeAgentStatus", () => {
+  it("removes matching statuses from native, WSL, and discovery lists", () => {
+    const profile = makeStatus({ kind: "claude:glm" });
+    const wslProfile = makeStatus({ kind: "claude:glm", envKind: "wsl", envDistro: "Ubuntu" });
+    const codex = makeStatus({ kind: "codex" });
+    useAgentStatusesStore.setState({
+      agentStatuses: [profile, codex],
+      wslAgentStatuses: [wslProfile],
+      discoveredAgents: [profile],
+    });
+
+    useAgentStatusesStore.getState().removeAgentStatus("claude:glm");
+
+    const state = useAgentStatusesStore.getState();
+    expect(state.agentStatuses.map((status) => status.kind)).toEqual(["codex"]);
+    expect(state.wslAgentStatuses).toEqual([]);
+    expect(state.discoveredAgents).toEqual([]);
+  });
+});
+
 describe("isDetectingAgentsForLocation", () => {
   it("returns true for a windows location when windowsLoaded is false", () => {
     const loc: ProjectLocation = { kind: "windows", path: "C:\\tmp" };

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -51,6 +51,7 @@ interface AgentStatusesStore {
    * everything else lands in `agentStatuses`.
    */
   mergeAgentStatus: (status: AgentStatus) => void;
+  removeAgentStatus: (kind: string) => void;
 }
 
 function capabilitiesEqual(
@@ -213,6 +214,20 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
               ? [...prev.agentStatuses, status]
               : prev.agentStatuses.map((entry, i) => (i === idx ? status : entry));
           return { agentStatuses: next, windowsLoaded: true };
+        }),
+      removeAgentStatus: (kind) =>
+        set((prev) => {
+          const agentStatuses = prev.agentStatuses.filter((status) => status.kind !== kind);
+          const wslAgentStatuses = prev.wslAgentStatuses.filter((status) => status.kind !== kind);
+          const discoveredAgents = prev.discoveredAgents.filter((status) => status.kind !== kind);
+          if (
+            agentStatuses.length === prev.agentStatuses.length &&
+            wslAgentStatuses.length === prev.wslAgentStatuses.length &&
+            discoveredAgents.length === prev.discoveredAgents.length
+          ) {
+            return prev;
+          }
+          return { agentStatuses, wslAgentStatuses, discoveredAgents };
         }),
     }),
     {

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentInstanceConfig } from "@/shared/contracts";
+import type { AgentInstanceConfig, AgentStatus } from "@/shared/contracts";
 
 const toastMock = vi.hoisted(() => ({
   danger: vi.fn<(message: string) => void>(),
@@ -81,11 +81,22 @@ const settingsState = {
   agentInstances: {} as Record<string, AgentInstanceConfig>,
   setAgentInstance: vi.fn<(instance: AgentInstanceConfig) => void>(),
   removeAgentInstance: vi.fn<(id: string) => void>(),
+  setHiddenModels: vi.fn<(kind: string, hidden: string[]) => void>(),
+};
+const statusState = {
+  agentStatuses: [] as AgentStatus[],
+  wslAgentStatuses: [] as AgentStatus[],
+  removeAgentStatus: vi.fn<(kind: string) => void>(),
 };
 
 vi.mock("@/renderer/state/sharedSettingsStore", () => ({
   useSharedSettings: (selector: (state: typeof settingsState) => unknown) =>
     selector(settingsState),
+}));
+
+vi.mock("@/renderer/state/agentStatusesStore", () => ({
+  useAgentStatusesStore: (selector: (state: typeof statusState) => unknown) =>
+    selector(statusState),
 }));
 
 import { ClaudeProfileProviderSettings, ClaudeProfileSettings } from "./ClaudeProfileSettings";
@@ -100,11 +111,46 @@ function claudeProfile(overrides: Partial<AgentInstanceConfig> = {}): AgentInsta
   };
 }
 
+function agentStatus(overrides: Partial<AgentStatus> = {}): AgentStatus {
+  return {
+    kind: "claude:glm",
+    label: "Claude GLM",
+    installed: true,
+    authState: "authenticated",
+    capabilities: {
+      models: [
+        { id: "claude-opus-4-8", label: "Opus 4.8" },
+        { id: "claude-opus-4-7", label: "Opus 4.7" },
+        { id: "claude-opus-4-6", label: "Opus 4.6" },
+        { id: "sonnet", label: "Sonnet" },
+        { id: "haiku", label: "Haiku" },
+        { id: "glm-5.2[1m]", label: "GLM 5.2" },
+      ],
+      efforts: [],
+      modelEfforts: {},
+      modes: [],
+      approvalPolicies: [],
+      sandboxModes: [],
+      settingDefs: [],
+      supportsResume: true,
+      supportsDirectInput: true,
+      liveInputMode: "terminal",
+      presentationMode: "terminal",
+      presentationModes: ["terminal"],
+    },
+    ...overrides,
+  };
+}
+
 describe("ClaudeProfileSettings", () => {
   beforeEach(() => {
     settingsState.agentInstances = {};
     settingsState.setAgentInstance.mockReset();
     settingsState.removeAgentInstance.mockReset();
+    settingsState.setHiddenModels.mockReset();
+    statusState.agentStatuses = [agentStatus()];
+    statusState.wslAgentStatuses = [];
+    statusState.removeAgentStatus.mockReset();
     refreshAgentStatusesMock.mockReset().mockResolvedValue();
     setClaudeProfileEnvironmentMock.mockReset().mockImplementation(async () => claudeProfile());
     toastMock.success.mockReset();
@@ -202,6 +248,16 @@ describe("ClaudeProfileSettings", () => {
 
     expect(onOpenProfile).toHaveBeenCalledWith("claude:work");
   });
+
+  it("removes a profile from settings and agent statuses", () => {
+    settingsState.agentInstances = { glm: claudeProfile() };
+    render(<ClaudeProfileSettings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Claude profile" }));
+
+    expect(settingsState.removeAgentInstance).toHaveBeenCalledWith("glm");
+    expect(statusState.removeAgentStatus).toHaveBeenCalledWith("claude:glm");
+  });
 });
 
 describe("ClaudeProfileProviderSettings", () => {
@@ -239,13 +295,71 @@ describe("ClaudeProfileProviderSettings", () => {
     await waitFor(() => expect(settingsState.setAgentInstance).toHaveBeenCalled());
   });
 
-  it("fills the editor from the GLM preset", () => {
+  it("fills the editor from the z.ai preset", () => {
     render(<ClaudeProfileProviderSettings instanceId="glm" />);
 
-    fireEvent.click(screen.getByRole("button", { name: /glm preset/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "z.ai" }));
 
     expect(screen.getByDisplayValue("https://api.z.ai/api/anthropic")).toBeInTheDocument();
     expect(screen.getByDisplayValue("ANTHROPIC_AUTH_TOKEN")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("CLAUDE_CODE_AUTO_COMPACT_WINDOW")).toBeInTheDocument();
+    // The preset's GLM 5.2 picker model id keeps its [1m] suffix verbatim.
+    expect(screen.getByLabelText("Model id")).toHaveValue("glm-5.2[1m]");
+    expect(settingsState.setHiddenModels).toHaveBeenCalledWith("claude:glm", [
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "sonnet",
+      "haiku",
+    ]);
+  });
+
+  it("fills the editor from the DeepSeek preset with two models", async () => {
+    render(<ClaudeProfileProviderSettings instanceId="glm" />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "DeepSeek" }));
+
+    expect(screen.getByDisplayValue("https://api.deepseek.com/anthropic")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("ANTHROPIC_MODEL")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("CLAUDE_CODE_SUBAGENT_MODEL")).toBeInTheDocument();
+    expect(
+      screen.getAllByLabelText("Model id").map((input) => input.getAttribute("value")),
+    ).toEqual(["deepseek-v4-pro[1m]", "deepseek-v4-flash"]);
+    expect(settingsState.setAgentInstance).toHaveBeenCalledWith({
+      id: "glm",
+      driver: "claude",
+      displayName: "GLM",
+      config: {
+        configDir: "~/.lightcode/claude-profiles/glm",
+        models: [
+          { id: "deepseek-v4-pro[1m]", label: "DeepSeek V4 Pro" },
+          { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+        ],
+        efforts: ["max"],
+      },
+    });
+    expect(settingsState.setHiddenModels).toHaveBeenCalledWith("claude:glm", [
+      "claude-opus-4-8",
+      "claude-opus-4-7",
+      "claude-opus-4-6",
+      "sonnet",
+      "haiku",
+      "glm-5.2[1m]",
+    ]);
+    await waitFor(() => expect(refreshAgentStatusesMock).toHaveBeenCalled());
+  });
+
+  it("fills the editor from the MiniMax preset", () => {
+    render(<ClaudeProfileProviderSettings instanceId="glm" />);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "MiniMax" }));
+
+    expect(screen.getByDisplayValue("https://api.minimax.io/anthropic")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("CLAUDE_CODE_AUTO_COMPACT_WINDOW")).toBeInTheDocument();
+    expect(screen.getByLabelText("Model id")).toHaveValue("MiniMax-M3");
   });
 
   it("masks an already-sealed secret value", () => {

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -22,16 +22,18 @@ import { CLAUDE_EFFORT_TIERS } from "@/shared/agents/claudeEfforts";
 import { readBridge } from "@/renderer/bridge";
 import { Input } from "@/renderer/components/common";
 import { formatEffortLabel } from "@/renderer/components/thread/threadDraftViewHelpers";
+import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { currentWslDistros } from "@/renderer/utils/acpRegistryAuth";
 import {
-  appendGlmPresetRows,
+  applyPresetEnvRows,
   cleanModels,
   defaultConfigDir,
   effortsConfigFromSelection,
   environmentFromRows,
   modelsFromConfig,
   profileUsesExternalProvider,
+  PROFILE_PRESETS,
   rowsFromEnvironment,
   SAVED_SECRET_MASK,
   selectedEffortsFromConfig,
@@ -39,7 +41,16 @@ import {
   uniqueProfileId,
   type EnvRow,
   type ModelRow,
+  type ProfilePreset,
 } from "./ClaudeProfileSettingsModel";
+
+const CLAUDE_PROFILE_BASE_MODEL_IDS = [
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "sonnet",
+  "haiku",
+];
 
 function refreshClaudeProfile(kind?: string): void {
   window.setTimeout(() => {
@@ -108,6 +119,52 @@ function EffortMultiSelect(props: { selected: Set<string>; onToggle: (tier: stri
   );
 }
 
+// ── Preset selector ──────────────────────────────────────────────────────────
+
+/**
+ * Dropdown of external-provider presets (z.ai, …). Picking one seeds the editor;
+ * extend the list by adding to `PROFILE_PRESETS`.
+ */
+function PresetMenu(props: { onApply: (preset: ProfilePreset) => void }) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <Popover isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Popover.Trigger>
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label="Apply provider preset"
+          className="h-6 min-h-6 gap-1 px-1.5 text-[11px]"
+        >
+          <Wand2 className="size-3" />
+          Presets
+          <ChevronDown className="size-3 shrink-0 text-muted" />
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content placement="bottom end" className="w-40 p-0">
+        <Popover.Dialog className="!p-0">
+          <div role="menu" aria-label="Provider presets" className="lightcode-menu py-1">
+            {PROFILE_PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                type="button"
+                role="menuitem"
+                className="flex w-full items-center px-3 py-1.5 text-sm text-foreground hover:bg-surface-secondary/50"
+                onClick={() => {
+                  props.onApply(preset);
+                  setIsOpen(false);
+                }}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
 // ── Per-profile editor (rendered on the profile's own settings page) ──────────
 
 /**
@@ -133,6 +190,13 @@ function ClaudeProfileEditor(props: {
   config: ClaudeProfileInstanceConfig;
 }) {
   const setAgentInstance = useSharedSettings((s) => s.setAgentInstance);
+  const setHiddenModels = useSharedSettings((s) => s.setHiddenModels);
+  const profileKind = claudeProfileKind(props.instance.id);
+  const profileStatus = useAgentStatusesStore(
+    (s) =>
+      s.agentStatuses.find((status) => status.kind === profileKind) ??
+      s.wslAgentStatuses.find((status) => status.kind === profileKind),
+  );
   const rowIdCounter = useRef(0);
   const nextRowId = () => `r${(rowIdCounter.current += 1)}`;
 
@@ -168,7 +232,38 @@ function ClaudeProfileEditor(props: {
       { rowId: nextRowId(), key: "", value: "", sensitive: false, replacing: false },
     ]);
 
-  const applyGlmPreset = () => setEnvRows((rows) => appendGlmPresetRows(rows, nextRowId));
+  // Applying a preset seeds the editor and persists picker models so the shared
+  // "Visible models" section can refresh immediately.
+  const applyPreset = (preset: ProfilePreset) => {
+    const nextModelRows = (() => {
+      const existing = new Set(modelRows.map((row) => row.id.trim()));
+      const additions = preset.models
+        .filter((model) => !existing.has(model.id))
+        .map((model) => ({ rowId: nextRowId(), id: model.id, label: model.label }));
+      return additions.length > 0 ? [...modelRows, ...additions] : modelRows;
+    })();
+    const nextEfforts = new Set(preset.efforts);
+    const models = cleanModels(nextModelRows);
+    const efforts = effortsConfigFromSelection(nextEfforts);
+    const config: ClaudeProfileInstanceConfig = { ...props.config };
+    const presetModelIds = new Set(preset.models.map((model) => model.id));
+    const currentModelIds =
+      profileStatus?.capabilities.models.map((model) => model.id) ?? CLAUDE_PROFILE_BASE_MODEL_IDS;
+    if (models) config.models = models;
+    else delete config.models;
+    if (efforts) config.efforts = efforts;
+    else delete config.efforts;
+
+    setEnvRows((rows) => applyPresetEnvRows(preset.envRows, rows, nextRowId));
+    setSelectedEfforts(nextEfforts);
+    setModelRows(nextModelRows);
+    setAgentInstance({ ...props.instance, config });
+    setHiddenModels(
+      profileKind,
+      currentModelIds.filter((id) => id !== "auto" && !presetModelIds.has(id)),
+    );
+    refreshClaudeProfile(profileKind);
+  };
 
   const updateModelRow = (rowId: string, patch: Partial<ModelRow>) =>
     setModelRows((rows) => rows.map((row) => (row.rowId === rowId ? { ...row, ...patch } : row)));
@@ -220,7 +315,7 @@ function ClaudeProfileEditor(props: {
         <div className="min-w-0">
           <p className="text-sm font-medium text-foreground">External provider</p>
           <p className="text-xs text-muted">
-            Point this profile at a non-Anthropic provider (GLM, …) with custom env vars, model
+            Point this profile at a non-Anthropic provider (z.ai, …) with custom env vars, model
             names, and effort levels.
           </p>
         </div>
@@ -263,15 +358,7 @@ function ClaudeProfileEditor(props: {
         <div className="flex items-center justify-between gap-2">
           <p className="text-xs font-medium text-foreground">Environment variables</p>
           <div className="flex items-center gap-1">
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-6 min-h-6 gap-1 px-1.5 text-[11px]"
-              onPress={applyGlmPreset}
-            >
-              <Wand2 className="size-3" />
-              GLM preset
-            </Button>
+            <PresetMenu onApply={applyPreset} />
             <Button
               size="sm"
               variant="ghost"
@@ -383,7 +470,7 @@ function ClaudeProfileEditor(props: {
             <Input
               aria-label="Model id"
               className="min-w-0 flex-1 font-mono text-xs"
-              placeholder="glm-5.2"
+              placeholder="glm-5.2[1m]"
               value={row.id}
               onChange={(event) => updateModelRow(row.rowId, { id: event.target.value })}
             />
@@ -484,6 +571,7 @@ export function ClaudeProfileSettings(props: {
   const agentInstances = useSharedSettings((s) => s.agentInstances ?? {});
   const setAgentInstance = useSharedSettings((s) => s.setAgentInstance);
   const removeAgentInstance = useSharedSettings((s) => s.removeAgentInstance);
+  const removeAgentStatus = useAgentStatusesStore((s) => s.removeAgentStatus);
   const [isAdding, setIsAdding] = useState(false);
   const [newName, setNewName] = useState("");
   const [newConfigDir, setNewConfigDir] = useState("");
@@ -541,7 +629,7 @@ export function ClaudeProfileSettings(props: {
           <p className="text-sm font-medium text-foreground">Profiles</p>
           <p className="text-xs text-muted">
             Separate Claude Code accounts by config directory, or point a profile at an external
-            provider (GLM, …). Open a profile to configure its env vars, models, and effort.
+            provider (z.ai, …). Open a profile to configure its env vars, models, and effort.
           </p>
         </div>
         <Button
@@ -567,7 +655,9 @@ export function ClaudeProfileSettings(props: {
             config={config}
             onOpen={() => props.onOpenProfile?.(claudeProfileKind(instance.id))}
             onRemove={(id) => {
+              const kind = claudeProfileKind(id);
               removeAgentInstance(id);
+              removeAgentStatus(kind);
               refreshClaudeProfile();
               toast.success("Claude profile removed.");
             }}

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { AgentInstanceConfig } from "@/shared/contracts";
 import {
+  applyPresetEnvRows,
   cleanModels,
+  DEEPSEEK_PRESET_ROWS,
   environmentFromRows,
+  MINIMAX_PRESET_ROWS,
   profileUsesExternalProvider,
   rowsFromEnvironment,
+  ZAI_PRESET_ROWS,
+  type EnvRow,
 } from "./ClaudeProfileSettingsModel";
 
 describe("ClaudeProfileSettingsModel", () => {
@@ -48,5 +53,75 @@ describe("ClaudeProfileSettingsModel", () => {
     };
 
     expect(profileUsesExternalProvider(instance, { configDir: "x", efforts: [] })).toBe(false);
+  });
+
+  describe("applyPresetEnvRows", () => {
+    let counter = 0;
+    const nextRowId = () => `r${(counter += 1)}`;
+
+    it("adds the canonical z.ai env with 1M model ids and the auto-compact window", () => {
+      const byKey = Object.fromEntries(
+        applyPresetEnvRows(ZAI_PRESET_ROWS, [], nextRowId).map((row) => [row.key, row.value]),
+      );
+      expect(byKey.ANTHROPIC_BASE_URL).toBe("https://api.z.ai/api/anthropic");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("glm-5.2[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("glm-5.2[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("glm-4.5-air");
+      expect(byKey.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1000000");
+    });
+
+    it("adds the canonical DeepSeek env with pro and flash models", () => {
+      const byKey = Object.fromEntries(
+        applyPresetEnvRows(DEEPSEEK_PRESET_ROWS, [], nextRowId).map((row) => [row.key, row.value]),
+      );
+      expect(byKey.ANTHROPIC_BASE_URL).toBe("https://api.deepseek.com/anthropic");
+      expect(byKey.ANTHROPIC_MODEL).toBe("deepseek-v4-pro[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("deepseek-v4-pro[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("deepseek-v4-pro[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("deepseek-v4-flash");
+      expect(byKey.CLAUDE_CODE_SUBAGENT_MODEL).toBe("deepseek-v4-flash");
+      expect(byKey.CLAUDE_CODE_EFFORT_LEVEL).toBe("max");
+    });
+
+    it("adds the canonical MiniMax env with the M3 model and auto-compact window", () => {
+      const byKey = Object.fromEntries(
+        applyPresetEnvRows(MINIMAX_PRESET_ROWS, [], nextRowId).map((row) => [row.key, row.value]),
+      );
+      expect(byKey.ANTHROPIC_BASE_URL).toBe("https://api.minimax.io/anthropic");
+      expect(byKey.ANTHROPIC_MODEL).toBe("MiniMax-M3");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("MiniMax-M3");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("MiniMax-M3");
+      expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("MiniMax-M3");
+      expect(byKey.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("1");
+      expect(byKey.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("512000");
+    });
+
+    it("corrects stale preset values but keeps an existing token and extra rows", () => {
+      const existing: EnvRow[] = [
+        {
+          rowId: "a",
+          key: "ANTHROPIC_DEFAULT_OPUS_MODEL",
+          value: "glm-5.2",
+          sensitive: false,
+          replacing: false,
+        },
+        {
+          rowId: "b",
+          key: "ANTHROPIC_AUTH_TOKEN",
+          value: "lc-safe:v1:sealed",
+          sensitive: true,
+          sealed: "lc-safe:v1:sealed",
+          replacing: false,
+        },
+        { rowId: "c", key: "MY_CUSTOM", value: "keep", sensitive: false, replacing: false },
+      ];
+      const byKey = new Map(
+        applyPresetEnvRows(ZAI_PRESET_ROWS, existing, nextRowId).map((r) => [r.key, r]),
+      );
+
+      expect(byKey.get("ANTHROPIC_DEFAULT_OPUS_MODEL")?.value).toBe("glm-5.2[1m]");
+      expect(byKey.get("ANTHROPIC_AUTH_TOKEN")?.value).toBe("lc-safe:v1:sealed");
+      expect(byKey.get("MY_CUSTOM")?.value).toBe("keep");
+    });
   });
 });

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
@@ -10,17 +10,90 @@ export const SAVED_SECRET_MASK = "••••••••";
 
 const SENSITIVE_KEY_RE = /(token|secret|password|api[_-]?key|auth)/iu;
 
-export const GLM_PRESET_ROWS: ReadonlyArray<{
-  key: string;
-  value: string;
-  sensitive: boolean;
-}> = [
+/** A preset env row: the literal value for plain keys; "" for secrets (entered later). */
+export type PresetEnvRow = { key: string; value: string; sensitive: boolean };
+
+/**
+ * Canonical z.ai (GLM) environment, per https://docs.z.ai/devpack/tool/claude.
+ * `glm-5.2[1m]` is z.ai's real model name for the 1M-context GLM 5.2 — the `[1m]`
+ * is part of the id, not Lightcode's context selector, so it is sent verbatim.
+ * `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is required for the 1M context to be usable.
+ */
+export const ZAI_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
   { key: "ANTHROPIC_BASE_URL", value: "https://api.z.ai/api/anthropic", sensitive: false },
   { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
-  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "glm-5.2", sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "glm-5.2", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "glm-5.2[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "glm-5.2[1m]", sensitive: false },
   { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "glm-4.5-air", sensitive: false },
   { key: "API_TIMEOUT_MS", value: "3000000", sensitive: false },
+  { key: "CLAUDE_CODE_AUTO_COMPACT_WINDOW", value: "1000000", sensitive: false },
+];
+
+export const DEEPSEEK_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
+  { key: "ANTHROPIC_BASE_URL", value: "https://api.deepseek.com/anthropic", sensitive: false },
+  { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
+  { key: "ANTHROPIC_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "deepseek-v4-flash", sensitive: false },
+  { key: "CLAUDE_CODE_SUBAGENT_MODEL", value: "deepseek-v4-flash", sensitive: false },
+  { key: "CLAUDE_CODE_EFFORT_LEVEL", value: "max", sensitive: false },
+];
+
+export const MINIMAX_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
+  { key: "ANTHROPIC_BASE_URL", value: "https://api.minimax.io/anthropic", sensitive: false },
+  { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
+  { key: "API_TIMEOUT_MS", value: "3000000", sensitive: false },
+  { key: "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", value: "1", sensitive: false },
+  { key: "ANTHROPIC_MODEL", value: "MiniMax-M3", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "MiniMax-M3", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "MiniMax-M3", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "MiniMax-M3", sensitive: false },
+  { key: "CLAUDE_CODE_AUTO_COMPACT_WINDOW", value: "512000", sensitive: false },
+];
+
+/**
+ * An external-provider preset offered by the profile editor's preset selector.
+ * Add more entries to `PROFILE_PRESETS` to offer additional providers — the UI
+ * renders one menu item per preset. A preset only seeds env vars, picker models,
+ * and the effort allow-list; it never changes model visibility.
+ */
+export interface ProfilePreset {
+  id: string;
+  label: string;
+  envRows: ReadonlyArray<PresetEnvRow>;
+  /** Custom picker models the preset adds. */
+  models: readonly { id: string; label: string }[];
+  /** Effort tiers the preset keeps (providers often collapse the lower tiers). */
+  efforts: readonly string[];
+}
+
+export const PROFILE_PRESETS: readonly ProfilePreset[] = [
+  {
+    id: "zai",
+    label: "z.ai",
+    envRows: ZAI_PRESET_ROWS,
+    // glm-5.2[1m] is z.ai's 1M-context GLM 5.2 (the `[1m]` is part of the id).
+    models: [{ id: "glm-5.2[1m]", label: "GLM 5.2" }],
+    efforts: ["high", "max", "ultracode"],
+  },
+  {
+    id: "deepseek",
+    label: "DeepSeek",
+    envRows: DEEPSEEK_PRESET_ROWS,
+    models: [
+      { id: "deepseek-v4-pro[1m]", label: "DeepSeek V4 Pro" },
+      { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+    ],
+    efforts: ["max"],
+  },
+  {
+    id: "minimax",
+    label: "MiniMax",
+    envRows: MINIMAX_PRESET_ROWS,
+    models: [{ id: "MiniMax-M3", label: "MiniMax M3" }],
+    efforts: CLAUDE_EFFORT_TIERS,
+  },
 ];
 
 export interface EnvRow {
@@ -117,16 +190,40 @@ export function environmentFromRows(rows: readonly EnvRow[]): Record<string, Age
   return environment;
 }
 
-export function appendGlmPresetRows(rows: readonly EnvRow[], nextRowId: () => string): EnvRow[] {
-  const present = new Set(rows.map((row) => row.key.trim()));
-  const additions = GLM_PRESET_ROWS.filter((preset) => !present.has(preset.key)).map((preset) => ({
-    rowId: nextRowId(),
-    key: preset.key,
-    value: preset.value,
-    sensitive: preset.sensitive,
-    replacing: false,
-  }));
-  return [...rows, ...additions];
+/**
+ * Apply a preset to the env rows: upsert every preset key to its canonical value
+ * while preserving an already-entered secret (the auth token is never clobbered)
+ * and keeping any extra custom rows the user added.
+ */
+export function applyPresetEnvRows(
+  presetRows: ReadonlyArray<PresetEnvRow>,
+  rows: readonly EnvRow[],
+  nextRowId: () => string,
+): EnvRow[] {
+  const presetKeys = new Set(presetRows.map((preset) => preset.key));
+  const byKey = new Map(rows.map((row) => [row.key.trim(), row] as const));
+  const result: EnvRow[] = presetRows.map((preset) => {
+    const existing = byKey.get(preset.key);
+    // Keep a secret the user already supplied (plaintext or sealed) rather than
+    // wiping it with the preset's empty placeholder.
+    if (existing && preset.sensitive && (existing.value.length > 0 || existing.sealed)) {
+      return { ...existing, sensitive: true };
+    }
+    if (existing) {
+      return { ...existing, value: preset.value, sensitive: preset.sensitive, replacing: false };
+    }
+    return {
+      rowId: nextRowId(),
+      key: preset.key,
+      value: preset.value,
+      sensitive: preset.sensitive,
+      replacing: false,
+    };
+  });
+  for (const row of rows) {
+    if (!presetKeys.has(row.key.trim())) result.push(row);
+  }
+  return result;
 }
 
 export function modelsFromConfig(

--- a/src/supervisor/agents/claude/argv.test.ts
+++ b/src/supervisor/agents/claude/argv.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { applyClaudeContextSuffix } from "./argv";
+
+describe("applyClaudeContextSuffix", () => {
+  it("derives the suffix from contextSize for built-in models", () => {
+    expect(applyClaudeContextSuffix("claude-opus-4-8", "1m")).toBe("claude-opus-4-8[1m]");
+    expect(applyClaudeContextSuffix("claude-opus-4-8", "200k")).toBe("claude-opus-4-8");
+    expect(applyClaudeContextSuffix("claude-opus-4-8")).toBe("claude-opus-4-8");
+  });
+
+  it("strips a stale suffix on built-in models so the chosen contextSize wins", () => {
+    expect(applyClaudeContextSuffix("claude-opus-4-8[1m]", "200k")).toBe("claude-opus-4-8");
+    expect(applyClaudeContextSuffix("claude-opus-4-8[1m]", "1m")).toBe("claude-opus-4-8[1m]");
+  });
+
+  it("passes custom / external-provider model ids through verbatim", () => {
+    // z.ai's real model name carries the [1m] suffix (1M context). Stripping it
+    // would send "glm-5.2", which z.ai does not resolve — so it must round-trip.
+    expect(applyClaudeContextSuffix("glm-5.2[1m]", "200k")).toBe("glm-5.2[1m]");
+    expect(applyClaudeContextSuffix("glm-5.2[1m]", "1m")).toBe("glm-5.2[1m]");
+    expect(applyClaudeContextSuffix("glm-5.2[1m]")).toBe("glm-5.2[1m]");
+    expect(applyClaudeContextSuffix("glm-4.5-air", "200k")).toBe("glm-4.5-air");
+  });
+});

--- a/src/supervisor/agents/claude/argv.ts
+++ b/src/supervisor/agents/claude/argv.ts
@@ -1,13 +1,20 @@
 import type { ThreadConfig } from "@/shared/contracts";
-import { CLAUDE_DEFAULT_APPROVAL_POLICY } from "./detection";
+import { CLAUDE_CONTEXT_MANAGED_MODEL_IDS, CLAUDE_DEFAULT_APPROVAL_POLICY } from "./detection";
 
 /**
  * Re-attach the `[<size>]` suffix Claude's CLI uses to pick a context-window
- * variant. Strips any pre-existing suffix so the chosen `contextSize` always
- * wins over a stale value baked into a legacy `model` id.
+ * variant. For built-in Claude models the suffix is Lightcode's own (derived
+ * from `contextSize`), so any pre-existing suffix is stripped first to let the
+ * chosen `contextSize` win over a stale value baked into a legacy `model` id.
+ *
+ * Custom / external-provider model ids (e.g. z.ai `glm-5.2[1m]`) are NOT
+ * context-managed: their `[1m]` is part of the provider's real model name. Those
+ * pass through untouched so the upstream model still resolves — stripping it
+ * would send `glm-5.2`, which z.ai rejects.
  */
 export function applyClaudeContextSuffix(model: string, contextSize?: string): string {
   const base = model.replace(/\[[0-9]+[mk]\]$/i, "");
+  if (!CLAUDE_CONTEXT_MANAGED_MODEL_IDS.has(base)) return model;
   if (!contextSize || contextSize === "200k") return base;
   return `${base}[${contextSize}]`;
 }

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -117,6 +117,18 @@ export const claudeCapabilities: AgentCapability = {
   ],
 };
 
+/**
+ * Built-in Claude model ids whose `[<size>]` suffix Lightcode owns — it derives
+ * that suffix from the thread's `contextSize` selector (see
+ * {@link applyClaudeContextSuffix}). Any model id NOT in this set is a custom /
+ * external-provider model (e.g. z.ai `glm-5.2[1m]`) whose suffix is part of the
+ * provider's real model name and must be sent to the CLI/SDK verbatim. Keyed off
+ * `modelContextSizes` so adding a context-managed model stays a one-line change.
+ */
+export const CLAUDE_CONTEXT_MANAGED_MODEL_IDS: ReadonlySet<string> = new Set(
+  Object.keys(claudeCapabilities.modelContextSizes ?? {}),
+);
+
 interface ClaudeAuthStatusResponse {
   loggedIn?: boolean;
   authMethod?: string;


### PR DESCRIPTION
- Add z.ai, DeepSeek, and MiniMax provider presets to Claude profile settings so users can seed external-provider env and model configuration from a single menu
- Preserve external-provider model IDs (e.g. `glm-5.2[1m]`) when launching Claude so provider-specific suffixes are not stripped by context-size handling
- Remove agent status entries across native, WSL, and discovery lists when a Claude profile is deleted, keeping detection state in sync with saved profiles
- Extend preset and argv behavior with tests covering preset env rows, profile settings UI, and context-suffix rules for built-in vs external models