### PR TITLE
Add 7d/30d/all profile stats windows and improve skill tracking

### DIFF
--- a/src/main/profile/coreStats.ts
+++ b/src/main/profile/coreStats.ts
@@ -11,7 +11,14 @@ import {
   type ProfileTotals,
 } from "@/shared/contracts";
 import { dbGetAllUsageEvents, getProfileDataGeneration, type UsageEventRow } from "../db";
-import { buildHeatmap, dayKeyFromIndex, localDayIndex, localHour } from "./heatmap";
+import {
+  buildHeatmap,
+  dayKeyFromIndex,
+  localDayIndex,
+  localHour,
+  statsWindowDays,
+  windowStartIndex,
+} from "./heatmap";
 import { getProfileIdentity, recordCurrentDevice, resolveProfileDevice } from "./identity";
 import { accountLabel, providerLabel, titleCase } from "./labels";
 
@@ -33,6 +40,20 @@ function hourLabel(hour: number): string {
 
 function round1(value: number): number {
   return Math.round(value * 10) / 10;
+}
+
+function filterRowsByWindow(
+  rows: UsageEventRow[],
+  todayIndex: number,
+  offset: number,
+  windowDays: number | undefined,
+): UsageEventRow[] {
+  if (!windowDays) return rows;
+  const startIndex = windowStartIndex(todayIndex, windowDays);
+  return rows.filter((row) => {
+    const dayIndex = localDayIndex(row.ts, offset);
+    return dayIndex >= startIndex && dayIndex <= todayIndex;
+  });
 }
 
 function rank(
@@ -163,8 +184,8 @@ function computeSkills(rows: UsageEventRow[]): {
       .slice(0, MAX_SKILLS)
       .map(([name, runCount]) => ({ name, displayName: display(name), kind, runCount }));
 
-  const skills = topBy(skillCounts, "skill", (n) => `$${n}`);
-  const subagents = topBy(subagentCounts, "subagent", (n) => `@${n}`);
+  const skills = topBy(skillCounts, "skill", (n) => n);
+  const subagents = topBy(subagentCounts, "subagent", (n) => n);
   const mcps = topBy(mcpCounts, "mcp", (n) => n);
   // "Explored" / "total" still span skills + subagents, matching the Activity
   // insights labels (a subagent run is a skill-like invocation for that metric).
@@ -204,7 +225,7 @@ function emptyCoreStats(
   generatedAt: number,
   todayIndex: number,
 ): ProfileCoreStats {
-  const { heatmap } = buildHeatmap(new Map(), todayIndex, "prompts");
+  const { heatmap } = buildHeatmap(new Map(), todayIndex, "prompts", statsWindowDays(req.window));
   return {
     scope: req.scope ?? "device",
     device,
@@ -238,7 +259,7 @@ export function computeProfileCoreStats(req: ProfileStatsRequest): ProfileCoreSt
   const todayIndex = localDayIndex(generatedAt, offset);
 
   const generation = getProfileDataGeneration();
-  const cacheKey = `${offset}|${todayIndex}|${req.scope ?? "device"}|${req.deviceId ?? "current"}|${req.provider ?? "all"}`;
+  const cacheKey = `${offset}|${todayIndex}|${req.scope ?? "device"}|${req.deviceId ?? "current"}|${req.provider ?? "all"}|${req.window ?? "all"}`;
   const cached = coreCache.get(cacheKey);
   if (cached && cached.generation === generation) return cached.result;
 
@@ -261,7 +282,9 @@ export function computeProfileCoreStats(req: ProfileStatsRequest): ProfileCoreSt
   // filter, so selecting one account doesn't collapse the picker to itself.
   const availableAccounts = collectAccounts(allRows);
   // Scope every downstream aggregation to the selected account (whole page).
-  const rows = req.provider ? allRows.filter((r) => r.provider === req.provider) : allRows;
+  const providerRows = req.provider ? allRows.filter((r) => r.provider === req.provider) : allRows;
+  const windowDays = statsWindowDays(req.window);
+  const rows = filterRowsByWindow(providerRows, todayIndex, offset, windowDays);
 
   // -- thread starts -> totals + mode breakdown --
   const modeCounts = new Map<string, number>();
@@ -320,7 +343,12 @@ export function computeProfileCoreStats(req: ProfileStatsRequest): ProfileCoreSt
     }
   }
 
-  const { heatmap: promptHeatmap, activeDays } = buildHeatmap(countsByDay, todayIndex, "prompts");
+  const { heatmap: promptHeatmap, activeDays } = buildHeatmap(
+    countsByDay,
+    todayIndex,
+    "prompts",
+    windowDays,
+  );
   const { current: currentStreakDays, longest: longestStreakDays } = computeStreaks(
     activeDayIndices,
     todayIndex,

--- a/src/main/profile/heatmap.ts
+++ b/src/main/profile/heatmap.ts
@@ -2,11 +2,24 @@ import type {
   ProfileHeatmap,
   ProfileHeatmapCell,
   ProfileHeatmapIntensity,
+  ProfileStatsWindow,
 } from "@/shared/contracts";
 
 /** 52 weeks - a full GitHub-style contribution grid. */
 export const HEATMAP_WINDOW_DAYS = 364;
 const DAY_MS = 86_400_000;
+
+/** Days a stats window spans; undefined = unbounded (lifetime / "all"). */
+export function statsWindowDays(window: ProfileStatsWindow | undefined): number | undefined {
+  if (window === "7d") return 7;
+  if (window === "30d") return 30;
+  return undefined;
+}
+
+/** First day index included in a `windowDays`-long window ending today. */
+export function windowStartIndex(todayIndex: number, windowDays: number): number {
+  return todayIndex - (windowDays - 1);
+}
 
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : String(n);
@@ -45,8 +58,9 @@ export function buildHeatmap(
   countsByDay: Map<string, number>,
   todayIndex: number,
   metric: ProfileHeatmap["metric"],
+  windowDays = HEATMAP_WINDOW_DAYS,
 ): { heatmap: ProfileHeatmap; activeDays: number } {
-  const startIndex = todayIndex - (HEATMAP_WINDOW_DAYS - 1);
+  const startIndex = windowStartIndex(todayIndex, windowDays);
   let max = 0;
   let activeDays = 0;
   const raw: Array<{ day: string; count: number }> = [];
@@ -62,5 +76,5 @@ export function buildHeatmap(
     count: c.count,
     intensity: intensityFor(c.count, max),
   }));
-  return { heatmap: { metric, windowDays: HEATMAP_WINDOW_DAYS, cells, max }, activeDays };
+  return { heatmap: { metric, windowDays, cells, max }, activeDays };
 }

--- a/src/main/profile/tokenStats.ts
+++ b/src/main/profile/tokenStats.ts
@@ -6,7 +6,14 @@ import {
   type ProfileTokenStats,
 } from "@/shared/contracts";
 import { dbGetAllUsageEvents, getProfileDataGeneration } from "../db";
-import { buildHeatmap, dayKeyFromIndex, HEATMAP_WINDOW_DAYS, localDayIndex } from "./heatmap";
+import {
+  buildHeatmap,
+  dayKeyFromIndex,
+  HEATMAP_WINDOW_DAYS,
+  localDayIndex,
+  statsWindowDays,
+  windowStartIndex,
+} from "./heatmap";
 import { recordCurrentDevice, resolveProfileDevice } from "./identity";
 import { accountLabel, providerLabel } from "./labels";
 
@@ -28,14 +35,15 @@ function emptyTokenStats(
   nowMs: number,
   todayIndex: number,
 ): ProfileTokenStats {
-  const { heatmap } = buildHeatmap(new Map(), todayIndex, "tokens");
+  const windowDays = statsWindowDays(req.window) ?? HEATMAP_WINDOW_DAYS;
+  const { heatmap } = buildHeatmap(new Map(), todayIndex, "tokens", windowDays);
   return {
     available: false,
     scope: req.scope ?? "device",
     device,
     generatedAt: nowMs,
     timezoneOffsetMinutes: req.utcOffsetMinutes,
-    windowDays: HEATMAP_WINDOW_DAYS,
+    windowDays,
     lifetimeTokens: 0,
     peakDayTokens: 0,
     providers: [],
@@ -55,7 +63,7 @@ export function computeProfileTokenStats(req: ProfileStatsRequest): ProfileToken
   // Reuse the last aggregation until a usage write bumps the generation, so
   // repeated opens don't re-scan the log.
   const generation = getProfileDataGeneration();
-  const cacheKey = `${offset}|${todayIndex}|${req.scope ?? "device"}|${req.deviceId ?? "current"}|${req.provider ?? "all"}`;
+  const cacheKey = `${offset}|${todayIndex}|${req.scope ?? "device"}|${req.deviceId ?? "current"}|${req.provider ?? "all"}|${req.window ?? "all"}`;
   const cached = tokenCache.get(cacheKey);
   if (cached && cached.generation === generation) return cached.result;
 
@@ -73,13 +81,19 @@ export function computeProfileTokenStats(req: ProfileStatsRequest): ProfileToken
   const perAccount = new Map<string, number>();
   const perModel = new Map<string, number>();
   let lifetimeTokens = 0;
+  const windowDays = statsWindowDays(req.window);
+  const startDayIndex = windowDays ? windowStartIndex(todayIndex, windowDays) : undefined;
 
   for (const row of dbGetAllUsageEvents()) {
     if (row.kind !== "tokens" || row.value <= 0) continue;
     // Scope to the selected account (exact account-kind match) when filtering.
     if (req.provider && row.provider !== req.provider) continue;
+    const dayIndex = localDayIndex(row.ts, offset);
+    if (startDayIndex !== undefined && (dayIndex < startDayIndex || dayIndex > todayIndex)) {
+      continue;
+    }
     lifetimeTokens += row.value;
-    const day = dayKeyFromIndex(localDayIndex(row.ts, offset));
+    const day = dayKeyFromIndex(dayIndex);
     perDay.set(day, (perDay.get(day) ?? 0) + row.value);
     if (row.provider) {
       const base = baseAgentKind(row.provider);
@@ -89,7 +103,7 @@ export function computeProfileTokenStats(req: ProfileStatsRequest): ProfileToken
     if (row.model) perModel.set(row.model, (perModel.get(row.model) ?? 0) + row.value);
   }
 
-  const { heatmap: tokenHeatmap } = buildHeatmap(perDay, todayIndex, "tokens");
+  const { heatmap: tokenHeatmap } = buildHeatmap(perDay, todayIndex, "tokens", windowDays);
 
   let peakDay: string | undefined;
   let peakDayTokens = 0;
@@ -135,7 +149,7 @@ export function computeProfileTokenStats(req: ProfileStatsRequest): ProfileToken
     device: currentDevice,
     generatedAt: nowMs,
     timezoneOffsetMinutes: offset,
-    windowDays: HEATMAP_WINDOW_DAYS,
+    windowDays: windowDays ?? HEATMAP_WINDOW_DAYS,
     lifetimeTokens,
     peakDayTokens,
     ...(peakDay ? { peakDay } : {}),

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -350,6 +350,14 @@ msgstr "~{money}{tokens} · {0} · geschätzt"
 msgid "≈{0}% by reset"
 msgstr "≈{0}% bis zum Reset"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30 T"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7 T"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "ein unterstützter Codierungsagent"
@@ -584,6 +592,10 @@ msgstr "KI-Agenten-Orchestrator – Codierungsagenten über Terminal und natives
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "KI-Git-Aktionen"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Alle"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3902,6 +3914,10 @@ msgstr "Vorheriges Bild"
 msgid "Profile"
 msgstr "Profil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Statistikzeitraum des Profils"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Profile"
@@ -4871,13 +4887,21 @@ msgstr "Wird abgemeldet. Erkannte Agenten werden aktualisiert, wenn der Vorgang 
 msgid "Skill: {skill}"
 msgstr "Fähigkeit: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Verwendete Skills/Subagenten insgesamt"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Skills"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Erkundete Skills"
+#~ msgid "Skills explored"
+#~ msgstr "Erkundete Skills"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Erkundete Skills/Subagenten"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5427,12 +5451,20 @@ msgid "Total prompts"
 msgstr "Prompts insgesamt"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Verwendete Skills insgesamt"
+#~ msgid "Total skills used"
+#~ msgstr "Verwendete Skills insgesamt"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Threads insgesamt"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "Tokens im Zeitraum"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Tokens im Zeitraum"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -349,6 +349,14 @@ msgstr "~{money}{tokens} · {0} · est."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% by reset"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30d"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7d"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "a supported coding agent"
@@ -581,6 +589,10 @@ msgstr "AI agent orchestrator — manage coding agents via Terminal and Native "
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git actions"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "All"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3868,6 +3880,10 @@ msgstr "Previous image"
 msgid "Profile"
 msgstr "Profile"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Profile stats range"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Profiles"
@@ -4823,13 +4839,21 @@ msgstr "Signing out. Detected agents will refresh when it finishes."
 msgid "Skill: {skill}"
 msgstr "Skill: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Skill/subagent runs"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Skills"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Skills explored"
+#~ msgid "Skills explored"
+#~ msgstr "Skills explored"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Skills/subagents explored"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5370,12 +5394,20 @@ msgid "Total prompts"
 msgstr "Total prompts"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Total skills used"
+#~ msgid "Total skills used"
+#~ msgstr "Total skills used"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Total threads"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "total tokens"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Total tokens"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -350,6 +350,14 @@ msgstr "~{money}{tokens} · {0} · est."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% para el restablecimiento"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30d"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7d"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "un agente de codificación compatible"
@@ -583,6 +591,10 @@ msgstr "Orquestador de agentes de IA: gestiona agentes de programación mediante
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Acciones de git con IA"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Todo"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3896,6 +3908,10 @@ msgstr "Imagen anterior"
 msgid "Profile"
 msgstr "Perfil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Rango de estadísticas del perfil"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Perfiles"
@@ -4861,13 +4877,21 @@ msgstr "Cerrando sesión. Los agentes detectados se actualizarán al finalizar."
 msgid "Skill: {skill}"
 msgstr "Habilidad: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Ejecuciones de skills/subagentes"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Skills"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Skills exploradas"
+#~ msgid "Skills explored"
+#~ msgstr "Skills exploradas"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Skills/subagentes explorados"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5412,12 +5436,20 @@ msgid "Total prompts"
 msgstr "Total de prompts"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Total de skills usadas"
+#~ msgid "Total skills used"
+#~ msgstr "Total de skills usadas"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Total de hilos"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "tokens del periodo"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Tokens del periodo"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -350,6 +350,14 @@ msgstr "~{money}{tokens} · {0} · est."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% par remise à zéro"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30 j"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7 j"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "un agent de codage pris en charge"
@@ -584,6 +592,10 @@ msgstr "Orchestrateur d'agents IA : gérez les agents de codage via Terminal et
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Actions git IA"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Tout"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3905,6 +3917,10 @@ msgstr "Image précédente"
 msgid "Profile"
 msgstr "Profil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Plage des statistiques du profil"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Profils"
@@ -4873,13 +4889,21 @@ msgstr "Déconnexion. Les agents détectés seront actualisés une fois l'opéra
 msgid "Skill: {skill}"
 msgstr "Compétence :{skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Exécutions de compétences/sous-agents"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Compétences"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Compétences explorées"
+#~ msgid "Skills explored"
+#~ msgstr "Compétences explorées"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Compétences/sous-agents explorés"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5424,12 +5448,20 @@ msgid "Total prompts"
 msgstr "Total des prompts"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Total des compétences utilisées"
+#~ msgid "Total skills used"
+#~ msgstr "Total des compétences utilisées"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Total des fils"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "total des tokens"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Total des tokens"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -349,6 +349,14 @@ msgstr "~{money}{tokens}·{0}· 推定。"
 msgid "≈{0}% by reset"
 msgstr "≈{0}% (リセットまでに)"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30日"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7日"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "サポートされているコーディング エージェント"
@@ -580,6 +588,10 @@ msgstr "AI エージェント オーケストレーター — ターミナルお
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AIによるgit操作"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "全期間"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3837,6 +3849,10 @@ msgstr "前の画像"
 msgid "Profile"
 msgstr "プロフィール"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "プロフィール統計の期間"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "プロファイル"
@@ -4788,13 +4804,21 @@ msgstr "サインアウトしています。検出されたエージェントは
 msgid "Skill: {skill}"
 msgstr "スキル:{skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "スキル/サブエージェントの使用回数"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "スキル"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "試したスキル数"
+#~ msgid "Skills explored"
+#~ msgstr "試したスキル数"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "試したスキル/サブエージェント数"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5329,12 +5353,20 @@ msgid "Total prompts"
 msgstr "プロンプト総数"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "使用したスキルの総数"
+#~ msgid "Total skills used"
+#~ msgstr "使用したスキルの総数"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "スレッド総数"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "合計トークン"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "合計トークン"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -349,6 +349,14 @@ msgstr "~{money}{tokens} · {0} · 예상"
 msgid "≈{0}% by reset"
 msgstr "재설정 시 ≈{0}%"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30일"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7일"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "지원되는 코딩 에이전트"
@@ -580,6 +588,10 @@ msgstr "AI 에이전트 오케스트레이터 — 터미널 및 기본 ACP를 �
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git 작업"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "전체"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3838,6 +3850,10 @@ msgstr "이전 이미지"
 msgid "Profile"
 msgstr "프로필"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "프로필 통계 기간"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "프로필"
@@ -4787,13 +4803,21 @@ msgstr "로그아웃합니다. 감지된 에이전트는 완료되면 새로 고
 msgid "Skill: {skill}"
 msgstr "스킬: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "사용한 전체 스킬/서브에이전트"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "스킬"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "탐색한 스킬"
+#~ msgid "Skills explored"
+#~ msgstr "탐색한 스킬"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "탐색한 스킬/서브에이전트"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5328,12 +5352,20 @@ msgid "Total prompts"
 msgstr "전체 프롬프트"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "사용한 전체 스킬"
+#~ msgid "Total skills used"
+#~ msgstr "사용한 전체 스킬"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "전체 스레드"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "전체 토큰"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "전체 토큰"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -354,6 +354,14 @@ msgstr "~{money}{tokens} · {0} · szac."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% do resetu"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30d"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7d"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "obsługiwany agent kodujący"
@@ -586,6 +594,10 @@ msgstr "Koordynator agentów AI — zarządzaj agentami kodującymi za pośredni
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Akcje AI w git"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Wszystko"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3893,6 +3905,10 @@ msgstr "Poprzedni obraz"
 msgid "Profile"
 msgstr "Profil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Zakres statystyk profilu"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Profile"
@@ -4854,13 +4870,21 @@ msgstr "Wylogowanie. Wykryci agenci zostaną odświeżeni po zakończeniu."
 msgid "Skill: {skill}"
 msgstr "Umiejętność: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Uruchomienia umiejętności/subagentów"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Umiejętności"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Poznane umiejętności"
+#~ msgid "Skills explored"
+#~ msgstr "Poznane umiejętności"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Poznane umiejętności/subagenty"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5406,12 +5430,20 @@ msgid "Total prompts"
 msgstr "Łączna liczba promptów"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Łączna liczba użytych umiejętności"
+#~ msgid "Total skills used"
+#~ msgstr "Łączna liczba użytych umiejętności"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Łączna liczba wątków"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "łączna liczba tokenów"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Łączna liczba tokenów"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -351,6 +351,14 @@ msgstr "~{money}{tokens} · {0} · est."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% até a redefinição"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30d"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7d"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "um agente de codificação compatível"
@@ -583,6 +591,10 @@ msgstr "Orquestrador de agentes de IA — gerencie agentes de codificação via 
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Ações de git com IA"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Tudo"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3896,6 +3908,10 @@ msgstr "Imagem anterior"
 msgid "Profile"
 msgstr "Perfil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Período das estatísticas do perfil"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Perfis"
@@ -4860,13 +4876,21 @@ msgstr "Saindo. Os agentes detectados serão atualizados quando terminar."
 msgid "Skill: {skill}"
 msgstr "Habilidade: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Execuções de skills/subagentes"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Skills"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Skills exploradas"
+#~ msgid "Skills explored"
+#~ msgstr "Skills exploradas"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Skills/subagentes explorados"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5412,12 +5436,20 @@ msgid "Total prompts"
 msgstr "Total de prompts"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Total de skills usadas"
+#~ msgid "Total skills used"
+#~ msgstr "Total de skills usadas"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Total de threads"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "total de tokens"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Total de tokens"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -353,6 +353,14 @@ msgstr "~{money}{tokens} · {0} · прибл."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% к сбросу"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30 дн"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7 дн"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "поддерживаемый агент кодирования"
@@ -585,6 +593,10 @@ msgstr "Оркестратор AI-агентов — управление код
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Действия ИИ в Git"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Всё"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3893,6 +3905,10 @@ msgstr "Предыдущее изображение"
 msgid "Profile"
 msgstr "Профиль"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Диапазон статистики профиля"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Профили"
@@ -4854,13 +4870,21 @@ msgstr "Выход. Обнаруженные агенты обновятся п�
 msgid "Skill: {skill}"
 msgstr "Навык: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Запусков навыков/субагентов"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Навыки"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Изучено навыков"
+#~ msgid "Skills explored"
+#~ msgstr "Изучено навыков"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Изучено навыков/субагентов"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5404,12 +5428,20 @@ msgid "Total prompts"
 msgstr "Всего запросов"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Всего использовано навыков"
+#~ msgid "Total skills used"
+#~ msgstr "Всего использовано навыков"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Всего тредов"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "токенов всего"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Токенов всего"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -350,6 +350,14 @@ msgstr "~{money}{tokens} · {0} · tahmini"
 msgid "≈{0}% by reset"
 msgstr "sıfırlamaya kadar ≈%{0}"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30g"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7g"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "desteklenen bir kodlama aracısı"
@@ -583,6 +591,10 @@ msgstr "AI aracı orkestratörü — kodlama aracılarını Terminal ve Yerel AC
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Yapay zeka git işlemleri"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Tümü"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3889,6 +3901,10 @@ msgstr "Önceki resim"
 msgid "Profile"
 msgstr "Profil"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Profil istatistikleri aralığı"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Profiller"
@@ -4853,13 +4869,21 @@ msgstr "Çıkış yapılıyor. Algılanan aracılar tamamlandığında yenilenec
 msgid "Skill: {skill}"
 msgstr "Beceri: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Beceri/alt aracı çalıştırmaları"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Beceriler"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Keşfedilen beceriler"
+#~ msgid "Skills explored"
+#~ msgstr "Keşfedilen beceriler"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Keşfedilen beceri/alt aracılar"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5404,12 +5428,20 @@ msgid "Total prompts"
 msgstr "Toplam istem"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Kullanılan toplam beceri"
+#~ msgid "Total skills used"
+#~ msgstr "Kullanılan toplam beceri"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Toplam konuşma"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "token toplamı"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Token toplamı"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -353,6 +353,14 @@ msgstr "~{money}{tokens} · {0} · прибл."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% до скидання"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30 дн"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7 дн"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "підтримуваний агент кодування"
@@ -585,6 +593,10 @@ msgstr "Оркестратор AI-агентів — керуйте агента
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Дії AI у git"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Усі"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3891,6 +3903,10 @@ msgstr "Попереднє зображення"
 msgid "Profile"
 msgstr "Профіль"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Діапазон статистики профілю"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Профілі"
@@ -4852,13 +4868,21 @@ msgstr "Вихід. Виявлені агенти оновляться післ�
 msgid "Skill: {skill}"
 msgstr "Навичка: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Запусків навичок/субагентів"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Навички"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Опрацьовано навичок"
+#~ msgid "Skills explored"
+#~ msgstr "Опрацьовано навичок"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Опрацьовано навичок/субагентів"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5401,12 +5425,20 @@ msgid "Total prompts"
 msgstr "Усього запитів"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Усього використано навичок"
+#~ msgid "Total skills used"
+#~ msgstr "Усього використано навичок"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Усього гілок"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "усього токенів"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Усього токенів"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -351,6 +351,14 @@ msgstr "~{money}{tokens} · {0} · ước tính."
 msgid "≈{0}% by reset"
 msgstr "≈{0}% khi đặt lại"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30 ngày"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7 ngày"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "một tác nhân mã hóa được hỗ trợ"
@@ -583,6 +591,10 @@ msgstr "Trình điều phối tác nhân AI - quản lý các tác nhân mã hó
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Thao tác git bằng AI"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "Tất cả"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3884,6 +3896,10 @@ msgstr "Hình ảnh trước đó"
 msgid "Profile"
 msgstr "Hồ sơ"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "Phạm vi thống kê hồ sơ"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "Hồ sơ"
@@ -4844,13 +4860,21 @@ msgstr "Đang đăng xuất. Các tác nhân được phát hiện sẽ làm m�
 msgid "Skill: {skill}"
 msgstr "Kỹ năng: {skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "Tổng số lần chạy skill/subagent"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "Skill"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "Skill đã khám phá"
+#~ msgid "Skills explored"
+#~ msgstr "Skill đã khám phá"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "Skill/subagent đã khám phá"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5394,12 +5418,20 @@ msgid "Total prompts"
 msgstr "Tổng số prompt"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "Tổng số skill đã dùng"
+#~ msgid "Total skills used"
+#~ msgstr "Tổng số skill đã dùng"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "Tổng số luồng"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "tổng số tokens"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "Tổng số tokens"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -348,6 +348,14 @@ msgstr "~{money}{tokens} · {0} · 预计"
 msgid "≈{0}% by reset"
 msgstr "≈{0}% 重置时"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "30d"
+msgstr "30天"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "7d"
+msgstr "7天"
+
 #: src/renderer/components/thread/threadDraftViewHelpers.ts
 msgid "a supported coding agent"
 msgstr "支持的编码代理"
@@ -578,6 +586,10 @@ msgstr "AI 代理协调器 — 通过终端和本机 ACP 管理编码代理。"
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git操作"
+
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "All"
+msgstr "全部"
 
 #: src/renderer/views/ProfileOverlay/parts/AccountFilter.tsx
 msgid "All accounts"
@@ -3829,6 +3841,10 @@ msgstr "上一张图片"
 msgid "Profile"
 msgstr "个人资料"
 
+#: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+msgid "Profile stats range"
+msgstr "个人资料统计范围"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Profiles"
 msgstr "配置文件"
@@ -4776,13 +4792,21 @@ msgstr "正在退出。检测到的代理将在完成后刷新。"
 msgid "Skill: {skill}"
 msgstr "技能：{skill}"
 
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skill/subagent runs"
+msgstr "技能/子代理运行次数"
+
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Skills"
 msgstr "技能"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Skills explored"
-msgstr "已探索技能"
+#~ msgid "Skills explored"
+#~ msgstr "已探索技能"
+
+#: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+msgid "Skills/subagents explored"
+msgstr "已探索技能/子代理"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Some checks are failing or pending."
@@ -5315,12 +5339,20 @@ msgid "Total prompts"
 msgstr "提示总数"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
-msgid "Total skills used"
-msgstr "已用技能总数"
+#~ msgid "Total skills used"
+#~ msgstr "已用技能总数"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Total threads"
 msgstr "对话总数"
+
+#: src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+msgid "total tokens"
+msgstr "token总数"
+
+#: src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+msgid "Total tokens"
+msgstr "token总数"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Track {label} usage"

--- a/src/renderer/state/usageRecorder.test.ts
+++ b/src/renderer/state/usageRecorder.test.ts
@@ -37,8 +37,9 @@ function emittedTokenValues(provider: string): number[] {
     .map((event) => event.value ?? 0);
 }
 
-function emittedEvents(): UsageEventInputPayload[] {
-  return bridgeMock.appendUsageEvents.mock.calls.flatMap((call) => call[0].events);
+function emittedEvents(kind?: string): UsageEventInputPayload[] {
+  const events = bridgeMock.appendUsageEvents.mock.calls.flatMap((call) => call[0].events);
+  return kind === undefined ? events : events.filter((event) => event.kind === kind);
 }
 
 describe("usageRecorder token baseline", () => {
@@ -76,6 +77,114 @@ describe("usageRecorder token baseline", () => {
     recordRuntimeUsage("new-thread", [contextUpdated("new-thread", 1_200)], [thread]);
     flushNow();
     expect(emittedTokenValues(provider)).toEqual([1_200]);
+  });
+
+  it("records a skill name from the completed payload when the start was generic", () => {
+    const thread = makeThread("skill-thread", "skill-provider");
+    recordRuntimeUsage(
+      "skill-thread",
+      [
+        {
+          type: "item.started",
+          threadId: "skill-thread",
+          itemId: "skill-item",
+          itemType: "dynamic_tool_call",
+          payload: { name: "Skill", status: "running" },
+        },
+        {
+          type: "item.completed",
+          threadId: "skill-thread",
+          itemId: "skill-item",
+          payload: {
+            name: "Skill",
+            title: "Loaded skill: heroui-react",
+            args: { name: "heroui-react" },
+            status: "success",
+          },
+        },
+      ],
+      [thread],
+    );
+
+    flushNow();
+    expect(emittedEvents("skill")).toMatchObject([{ name: "heroui-react" }]);
+  });
+
+  it("records the subagent type from a later payload instead of the generic label", () => {
+    const thread = makeThread("subagent-thread", "subagent-provider");
+    recordRuntimeUsage(
+      "subagent-thread",
+      [
+        {
+          type: "item.started",
+          threadId: "subagent-thread",
+          itemId: "subagent-item",
+          itemType: "tool_call",
+          payload: { name: "Agent", isSubAgent: true, status: "running" },
+        },
+        {
+          type: "item.updated",
+          threadId: "subagent-thread",
+          itemId: "subagent-item",
+          payload: {
+            name: "Agent",
+            isSubAgent: true,
+            args: { description: "Review", subagent_type: "general-purpose" },
+            status: "running",
+          },
+        },
+        {
+          type: "item.completed",
+          threadId: "subagent-thread",
+          itemId: "subagent-item",
+          payload: {
+            name: "Agent",
+            isSubAgent: true,
+            args: { description: "Review", subagent_type: "general-purpose" },
+            status: "success",
+          },
+        },
+      ],
+      [thread],
+    );
+
+    flushNow();
+    expect(emittedEvents("subagent")).toMatchObject([{ name: "general-purpose" }]);
+  });
+
+  it("does not duplicate a skill that started with a specific name", () => {
+    const thread = makeThread("specific-skill-thread", "skill-provider");
+    recordRuntimeUsage(
+      "specific-skill-thread",
+      [
+        {
+          type: "item.started",
+          threadId: "specific-skill-thread",
+          itemId: "specific-skill-item",
+          itemType: "dynamic_tool_call",
+          payload: {
+            name: "Skill",
+            args: { name: "interactive-testing" },
+            status: "running",
+          },
+        },
+        {
+          type: "item.completed",
+          threadId: "specific-skill-thread",
+          itemId: "specific-skill-item",
+          payload: {
+            name: "Skill",
+            args: { name: "interactive-testing" },
+            status: "success",
+          },
+        },
+      ],
+      [thread],
+    );
+
+    flushNow();
+    expect(emittedEvents("skill")).toMatchObject([{ name: "interactive-testing" }]);
+    expect(emittedEvents("skill")).toHaveLength(1);
   });
 });
 

--- a/src/renderer/state/usageRecorder.ts
+++ b/src/renderer/state/usageRecorder.ts
@@ -54,6 +54,8 @@ const pendingTokens = new Map<
 >();
 const seenItems = new Set<string>();
 const seenTurns = new Set<string>();
+const pendingItemHits = new Map<string, ItemHit>();
+const itemTypesById = new Map<string, string>();
 
 function flush(): void {
   if (scheduled) {
@@ -109,6 +111,14 @@ function remember(set: Set<string>, id: string): boolean {
   return true;
 }
 
+// Insert into a bounded item-lifecycle map. Entries are normally evicted on
+// item.completed, but an item that starts and never completes (aborted turn,
+// dropped frame) would otherwise leak forever - so cap like the dedup sets.
+function rememberInMap<V>(map: Map<string, V>, key: string, value: V): void {
+  if (map.size >= DEDUP_CAP && !map.has(key)) map.clear();
+  map.set(key, value);
+}
+
 // Don't lose buffered events when the window is hidden or closed.
 if (typeof window !== "undefined") {
   window.addEventListener("pagehide", flush);
@@ -141,14 +151,38 @@ function metaOf(thread: Thread): Meta {
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
 }
-function str(obj: Record<string, unknown> | undefined, key: string): string | undefined {
-  const v = obj?.[key];
-  return typeof v === "string" && v.trim() ? v.trim() : undefined;
+function str(obj: Record<string, unknown> | undefined, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const v = obj?.[key];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return undefined;
 }
 
 interface ItemHit {
   kind: "message" | "goal" | "skill" | "subagent" | "mcp";
   name?: string;
+}
+
+function genericName(kind: ItemHit["kind"], name: string | undefined): boolean {
+  const normalized = name?.trim().toLowerCase();
+  if (!normalized) return true;
+  if (kind === "skill") return normalized === "skill";
+  if (kind === "subagent") {
+    return normalized === "subagent" || normalized === "agent" || normalized === "task";
+  }
+  if (kind === "mcp") return normalized === "mcp";
+  return false;
+}
+
+function isSpecificToolHit(hit: ItemHit): boolean {
+  if (hit.kind === "message" || hit.kind === "goal") return true;
+  return !genericName(hit.kind, hit.name);
+}
+
+function betterHit(current: ItemHit | undefined, next: ItemHit): ItemHit {
+  if (!current) return next;
+  return isSpecificToolHit(next) ? next : current;
 }
 
 function classifyItem(itemType: string, payload: unknown): ItemHit | undefined {
@@ -195,6 +229,7 @@ function classifyItem(itemType: string, payload: unknown): ItemHit | undefined {
       title
         .replace(/^(loaded|using) skill[:\s]*/i, "")
         .replace(/^skill:\s*/i, "")
+        .replace(/^Skill$/i, "")
         .trim();
     return { kind: "skill", name: skill || "skill" };
   }
@@ -285,6 +320,25 @@ export function recordThreadStarted(thread: Thread): void {
   });
 }
 
+function recordItemHit(itemId: string, hit: ItemHit, meta: Meta, ts: number, final: boolean): void {
+  const next = betterHit(pendingItemHits.get(itemId), hit);
+  if (!isSpecificToolHit(next) && !final) {
+    rememberInMap(pendingItemHits, itemId, next);
+    return;
+  }
+  if (!remember(seenItems, itemId)) return;
+  pendingItemHits.delete(itemId);
+  push({
+    ts,
+    kind: next.kind,
+    provider: meta.provider,
+    model: meta.model,
+    mode: meta.mode,
+    ...(next.name ? { name: next.name } : {}),
+    value: 1,
+  });
+}
+
 /**
  * Derive durable usage events from a batch of canonical runtime events. Thread
  * metadata is resolved lazily so a pure `content.delta` frame (the streaming
@@ -364,20 +418,39 @@ export function recordRuntimeUsage(
         break;
       }
       case "item.started": {
+        rememberInMap(itemTypesById, event.itemId, event.itemType);
         const hit = classifyItem(event.itemType, event.payload);
         if (!hit) break;
-        if (!remember(seenItems, event.itemId)) break;
         const m = getMeta();
         if (!m) break;
-        push({
-          ts: now,
-          kind: hit.kind,
-          provider: m.provider,
-          model: m.model,
-          mode: m.mode,
-          ...(hit.name ? { name: hit.name } : {}),
-          value: 1,
-        });
+        recordItemHit(event.itemId, hit, m, now, false);
+        break;
+      }
+      case "item.updated": {
+        const itemType = itemTypesById.get(event.itemId);
+        if (!itemType || seenItems.has(event.itemId)) break;
+        const hit = classifyItem(itemType, event.payload);
+        if (!hit) break;
+        const m = getMeta();
+        if (!m) break;
+        recordItemHit(event.itemId, hit, m, now, false);
+        break;
+      }
+      case "item.completed": {
+        const itemType = itemTypesById.get(event.itemId);
+        if (!itemType || seenItems.has(event.itemId)) {
+          itemTypesById.delete(event.itemId);
+          pendingItemHits.delete(event.itemId);
+          break;
+        }
+        const hit = event.payload ? classifyItem(itemType, event.payload) : undefined;
+        const pending = pendingItemHits.get(event.itemId);
+        const best = hit ? betterHit(pending, hit) : pending;
+        if (best) {
+          const m = getMeta();
+          if (m) recordItemHit(event.itemId, best, m, now, true);
+        }
+        itemTypesById.delete(event.itemId);
         break;
       }
       default:

--- a/src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
@@ -82,9 +82,44 @@ function buildColumns(
   return { columns, monthLabels };
 }
 
+function HeatmapLegend() {
+  const { t } = useLingui();
+  return (
+    <div className="flex items-center justify-end gap-1.5 pt-1 text-[10px] text-muted">
+      <span>{t`Less`}</span>
+      {([0, 1, 2, 3, 4] as ProfileHeatmapIntensity[]).map((level) => (
+        <div
+          key={level}
+          className="size-2.5 rounded-[2px]"
+          style={{ backgroundColor: colorFor(level) }}
+        />
+      ))}
+      <span>{t`More`}</span>
+    </div>
+  );
+}
+
 export function ActivityHeatmap(props: { heatmap: ProfileHeatmap }) {
   const { t, i18n } = useLingui();
   const { heatmap } = props;
+  if (heatmap.windowDays <= 30) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="flex justify-end gap-[3px]">
+          {heatmap.cells.map((cell) => (
+            <div
+              key={cell.day}
+              className="size-3 rounded-[2px]"
+              style={{ backgroundColor: colorFor(cell.intensity) }}
+              title={tooltipFor(cell, heatmap.metric, t)}
+            />
+          ))}
+        </div>
+        <HeatmapLegend />
+      </div>
+    );
+  }
+
   const monthFormatter = new Intl.DateTimeFormat(i18n.locale, {
     month: "short",
     timeZone: "UTC",
@@ -121,17 +156,7 @@ export function ActivityHeatmap(props: { heatmap: ProfileHeatmap }) {
           </div>
         ))}
       </div>
-      <div className="flex items-center justify-end gap-1.5 pt-1 text-[10px] text-muted">
-        <span>{t`Less`}</span>
-        {([0, 1, 2, 3, 4] as ProfileHeatmapIntensity[]).map((level) => (
-          <div
-            key={level}
-            className="size-2.5 rounded-[2px]"
-            style={{ backgroundColor: colorFor(level) }}
-          />
-        ))}
-        <span>{t`More`}</span>
-      </div>
+      <HeatmapLegend />
     </div>
   );
 }

--- a/src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
@@ -32,8 +32,8 @@ export function ActivityInsights(props: { core: ProfileCoreStats }) {
         <Row label={t`Most active hour`} value={activeHour} />
         <Row label={t`Messages sent`} value={totals.messagesSent.toLocaleString()} />
         <Row label={t`Goals set`} value={totals.goalsSet.toLocaleString()} />
-        <Row label={t`Skills explored`} value={String(insights.skillsExplored)} />
-        <Row label={t`Total skills used`} value={insights.totalSkillsUsed.toLocaleString()} />
+        <Row label={t`Skills/subagents explored`} value={String(insights.skillsExplored)} />
+        <Row label={t`Skill/subagent runs`} value={insights.totalSkillsUsed.toLocaleString()} />
         <Row label={t`Total threads`} value={totals.totalThreads.toLocaleString()} />
         <Row label={t`Total prompts`} value={totals.totalPrompts.toLocaleString()} />
       </div>

--- a/src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
@@ -91,8 +91,8 @@ export function ProfileHeader(props: {
             const provider = selection.provider ? { provider: selection.provider } : {};
             onSelect(
               id === ALL_DEVICES
-                ? { scope: "all", ...provider }
-                : { scope: "device", deviceId: id, ...provider },
+                ? { scope: "all", window: selection.window, ...provider }
+                : { scope: "device", deviceId: id, window: selection.window, ...provider },
             );
           }}
         />

--- a/src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/ShareCard.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import type { ProfileCoreStats, ProfileTokenStats } from "@/shared/contracts";
+import type { ProfileCoreStats, ProfileStatsWindow, ProfileTokenStats } from "@/shared/contracts";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { formatCompact, initialsFor } from "../format";
@@ -31,8 +31,9 @@ export const ShareCard = forwardRef<
     core: ProfileCoreStats;
     tokens: ProfileTokenStats | null;
     metric: ActivityMetric;
+    window: ProfileStatsWindow;
   }
->(function ShareCard({ core, tokens, metric }, ref) {
+>(function ShareCard({ core, tokens, metric, window }, ref) {
   const { t } = useLingui();
   const { identity, totals, insights, promptHeatmap } = core;
   const provider = insights.topProvider;
@@ -74,7 +75,7 @@ export const ShareCard = forwardRef<
       <ActivityHeatmap heatmap={heatmap} />
 
       <div className="grid grid-cols-4 gap-2 border-t border-separator pt-4">
-        <Stat value={lifetime} label={t`lifetime tokens`} />
+        <Stat value={lifetime} label={window === "all" ? t`lifetime tokens` : t`total tokens`} />
         <Stat value={peak} label={t`peak day`} />
         <Stat value={formatDaysLabel(totals.currentStreakDays, t)} label={t`current streak`} />
         <Stat value={formatDaysLabel(totals.longestStreakDays, t)} label={t`longest streak`} />

--- a/src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/ShareDialog.tsx
@@ -4,7 +4,7 @@ import { Check, Copy } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Button } from "@/renderer/components/common";
 import { readBridge } from "@/renderer/bridge";
-import type { ProfileCoreStats, ProfileTokenStats } from "@/shared/contracts";
+import type { ProfileCoreStats, ProfileStatsWindow, ProfileTokenStats } from "@/shared/contracts";
 import { ShareCard } from "./ShareCard";
 import type { ActivityMetric } from "./ActivitySection";
 
@@ -13,10 +13,11 @@ export function ShareDialog(props: {
   core: ProfileCoreStats;
   tokens: ProfileTokenStats | null;
   metric: ActivityMetric;
+  window: ProfileStatsWindow;
   onClose: () => void;
 }) {
   const { t } = useLingui();
-  const { open, core, tokens, metric, onClose } = props;
+  const { open, core, tokens, metric, window, onClose } = props;
   const cardRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
 
@@ -44,7 +45,13 @@ export function ShareDialog(props: {
             </h2>
 
             <div className="flex justify-center">
-              <ShareCard ref={cardRef} core={core} tokens={tokens} metric={metric} />
+              <ShareCard
+                ref={cardRef}
+                core={core}
+                tokens={tokens}
+                metric={metric}
+                window={window}
+              />
             </div>
 
             <div className="flex justify-center">

--- a/src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
+++ b/src/renderer/views/ProfileOverlay/parts/StatStrip.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
-import type { ProfileCoreStats, ProfileTokenStats } from "@/shared/contracts";
+import type { ProfileCoreStats, ProfileStatsWindow, ProfileTokenStats } from "@/shared/contracts";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { formatCompact, formatDayLabel, formatDuration } from "../format";
 
@@ -34,9 +34,10 @@ export function StatStrip(props: {
   core: ProfileCoreStats;
   tokens: ProfileTokenStats | null;
   tokensLoading: boolean;
+  window: ProfileStatsWindow;
 }) {
   const { t } = useLingui();
-  const { core, tokens, tokensLoading } = props;
+  const { core, tokens, tokensLoading, window } = props;
   const totals = core.totals;
   const pending = tokensLoading && !tokens;
 
@@ -57,7 +58,7 @@ export function StatStrip(props: {
 
   return (
     <div className="grid grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border sm:grid-cols-3 lg:grid-cols-5">
-      <Tile value={lifetime} label={t`Lifetime tokens`} />
+      <Tile value={lifetime} label={window === "all" ? t`Lifetime tokens` : t`Total tokens`} />
       <Tile
         value={peak}
         label={t`Peak day`}

--- a/src/renderer/views/ProfileOverlay/useProfileData.ts
+++ b/src/renderer/views/ProfileOverlay/useProfileData.ts
@@ -5,6 +5,7 @@ import type {
   ProfileDevice,
   ProfileIdentity,
   ProfileStatScope,
+  ProfileStatsWindow,
   ProfileTokenStats,
 } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
@@ -15,6 +16,7 @@ export interface ProfileSelection {
   deviceId?: string;
   /** Account-scoped provider filter; undefined = all accounts. */
   provider?: string;
+  window: ProfileStatsWindow;
 }
 
 export interface ProfileData {
@@ -41,7 +43,7 @@ export function useProfileData(): ProfileData {
   const { t } = useLingui();
   const [devices, setDevices] = useState<ProfileDevice[]>([]);
   const [currentDeviceId, setCurrentDeviceId] = useState<string | null>(null);
-  const [selection, setSelection] = useState<ProfileSelection>({ scope: "device" });
+  const [selection, setSelection] = useState<ProfileSelection>({ scope: "device", window: "all" });
   const [core, setCore] = useState<ProfileCoreStats | null>(null);
   const [coreLoading, setCoreLoading] = useState(true);
   const [tokens, setTokens] = useState<ProfileTokenStats | null>(null);
@@ -66,13 +68,14 @@ export function useProfileData(): ProfileData {
     };
   }, []);
 
-  const { scope, deviceId, provider } = selection;
+  const { scope, deviceId, provider, window } = selection;
   useEffect(() => {
     let active = true;
     const utcOffsetMinutes = -new Date().getTimezoneOffset();
     const req = {
       utcOffsetMinutes,
       scope,
+      window,
       ...(deviceId ? { deviceId } : {}),
       ...(provider ? { provider } : {}),
     };
@@ -114,7 +117,7 @@ export function useProfileData(): ProfileData {
     return () => {
       active = false;
     };
-  }, [scope, deviceId, provider, t]);
+  }, [scope, deviceId, provider, window, t]);
 
   async function saveIdentity(identity: ProfileIdentity): Promise<void> {
     const response = await readBridge().setProfileIdentity(identity);

--- a/src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
 import { Pencil, Share2 } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { ProfileBreakdownEntry, ProfileTokenProvider } from "@/shared/contracts";
-import { Button, PixelLoader } from "@/renderer/components/common";
+import type {
+  ProfileBreakdownEntry,
+  ProfileStatsWindow,
+  ProfileTokenProvider,
+} from "@/shared/contracts";
+import {
+  Button,
+  LightballTabs,
+  PixelLoader,
+  type LightballTab,
+} from "@/renderer/components/common";
 import { useProfileData } from "@/renderer/views/ProfileOverlay/useProfileData";
 import { ProfileHeader } from "@/renderer/views/ProfileOverlay/parts/ProfileHeader";
 import { StatStrip } from "@/renderer/views/ProfileOverlay/parts/StatStrip";
@@ -47,6 +56,11 @@ export function ProfileSettings() {
       ? "prompts"
       : (pickedMetric ?? (tokensAvailable ? "tokens" : "prompts"));
   const handleMetricChange = (next: ActivityMetric) => setPickedMetric(next);
+  const windowTabs: ReadonlyArray<LightballTab<ProfileStatsWindow>> = [
+    { id: "7d", label: t`7d` },
+    { id: "30d", label: t`30d` },
+    { id: "all", label: t`All` },
+  ];
 
   if (coreLoading && !core) {
     return (
@@ -89,6 +103,7 @@ export function ProfileSettings() {
         onChange={(provider) =>
           data.setSelection({
             scope: data.selection.scope,
+            window: data.selection.window,
             ...(data.selection.deviceId ? { deviceId: data.selection.deviceId } : {}),
             ...(provider ? { provider } : {}),
           })
@@ -121,7 +136,25 @@ export function ProfileSettings() {
           filter={accountFilter}
           actions={headerActions}
         />
-        <StatStrip core={core} tokens={tokens} tokensLoading={tokensLoading} />
+        <div className="flex flex-col gap-3">
+          <div className="flex justify-center">
+            <LightballTabs
+              tabs={windowTabs}
+              active={data.selection.window}
+              onChange={(window) => data.setSelection({ ...data.selection, window })}
+              ariaLabel={t`Profile stats range`}
+              className="w-[180px]"
+              equalWidth
+              shape="rounded"
+            />
+          </div>
+          <StatStrip
+            core={core}
+            tokens={tokens}
+            tokensLoading={tokensLoading}
+            window={data.selection.window}
+          />
+        </div>
         <ActivitySection
           promptHeatmap={core.promptHeatmap}
           tokenHeatmap={tokens?.tokenHeatmap ?? null}
@@ -188,6 +221,7 @@ export function ProfileSettings() {
         core={core}
         tokens={tokens}
         metric={metric}
+        window={data.selection.window}
         onClose={() => setShareOpen(false)}
       />
     </div>

--- a/src/shared/contracts/profile.ts
+++ b/src/shared/contracts/profile.ts
@@ -28,6 +28,9 @@ export const profileStatScopeSchema = z.enum(["device", "all"]);
 /** "device" = this install only; "all" = merged across the user's devices (Cloud). */
 export type ProfileStatScope = z.infer<typeof profileStatScopeSchema>;
 
+export const profileStatsWindowSchema = z.enum(["7d", "30d", "all"]);
+export type ProfileStatsWindow = z.infer<typeof profileStatsWindowSchema>;
+
 export interface ProfileDevice {
   /** Stable per-install id (generated once, persisted in app_state). */
   id: string;
@@ -128,7 +131,7 @@ export interface ProfileInsights {
 
 export interface ProfileSkillUsage {
   name: string;
-  /** `$skill` for skills, `@agent` for subagents, raw name for plain tools/MCP. */
+  /** User-facing label for the skill, subagent, tool, or MCP server. */
   displayName: string;
   kind: "skill" | "subagent" | "tool" | "mcp";
   runCount: number;
@@ -194,9 +197,9 @@ export interface ProfileCoreStats {
   models: ProfileBreakdownEntry[];
   /** Threads started by presentation mode (chat vs CLI). */
   modes: ProfileBreakdownEntry[];
-  /** Top skills by run count (`$skill`). */
+  /** Top skills by run count. */
   skills: ProfileSkillUsage[];
-  /** Top subagents by run count (`@agent`). */
+  /** Top subagents by run count. */
   subagents: ProfileSkillUsage[];
   /** Top MCP servers by tool-call count. */
   mcps: ProfileSkillUsage[];
@@ -261,6 +264,7 @@ export const profileStatsRequestSchema = z.object({
    * matches exactly, e.g. "claude" or "claude:work". Omit for all accounts.
    */
   provider: z.string().optional(),
+  window: profileStatsWindowSchema.optional(),
 });
 export type ProfileStatsRequest = z.infer<typeof profileStatsRequestSchema>;
 


### PR DESCRIPTION
- **Feature:** Add selectable 7-day, 30-day, and all-time windows for profile stats so users can view recent activity or lifetime totals from settings.
- Extend shared profile contracts and main-process aggregation (core stats, token stats, heatmaps) to filter usage events by the selected window.
- Improve skill and subagent usage recording so runs are attributed to real names from completed payloads, with clearer display labels in insights and breakdowns.
- Update profile UI (window tabs, compact short-window heatmaps, window-aware token labels, share card) and preserve the selected window when switching device or provider scope.