### PR TITLE
Document renderer i18n localization workflow for agents

### DIFF
--- a/.agents/docs/i18n.md
+++ b/.agents/docs/i18n.md
@@ -1,0 +1,73 @@
+# Internationalization (i18n)
+
+Deep reference for localizing the renderer. The mandatory workflow (wrap → extract → translate) lives in [AGENTS.md → Internationalization](../../AGENTS.md#internationalization-i18n); this doc covers scope, file map, terminology, gotchas, and adding a language.
+
+## Scope & layout
+
+- **Library:** Lingui (`@lingui/*` v6). Macros are expanded by Babel in the Vite pipeline.
+- **Config:** `lingui.config.ts`. `include: ["src/renderer"]` — i18n is **renderer-only**. Main and supervisor (built by tsdown) carry no catalogs.
+- **Source locale:** `en`. **Non-English locales (12):** `es`, `ru`, `uk`, `zh-CN`, `ja`, `pt-BR`, `de`, `fr`, `ko`, `pl`, `vi`, `tr`.
+- **Catalogs:** `src/renderer/locales/{locale}/messages.po` (13 total incl. `en`). Each is **fully translated** (~1300+ filled strings), not an English fallback — so an empty `msgstr` is a visible bug.
+
+| File                                                          | Role                                                                                                                                       |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `lingui.config.ts`                                            | locales list + scan roots. Adding a language edits this.                                                                                   |
+| `src/shared/locale.ts`                                        | `SUPPORTED_LOCALES`, `SOURCE_LOCALE`, `LocaleSetting`, `resolveLocale`. Shared across processes.                                           |
+| `src/renderer/i18n/i18n.ts`                                   | `i18n` singleton, `dynamicActivate(locale)`, pre-mount `bootstrapAppLocaleFromCache()`. Import `i18n` from here for non-React translation. |
+| `src/renderer/i18n/locales.ts`                                | locale `Select` options + `detectOSLocale()`. Native language names stay untranslated.                                                     |
+| `src/renderer/i18n/sharedMessages.ts`                         | renderer-side `msg(...)` descriptors mirroring the shared catalog.                                                                         |
+| `src/shared/messages.ts`                                      | macro-free message catalog (`MessageKey`) usable by supervisor/main; renderer installs the translating resolver.                           |
+| `src/renderer/views/SettingsOverlay/parts/settingsOptions.ts` | canonical `msg`-based option lists + `useLocalizedOptions()` resolver.                                                                     |
+
+## Macro cheat-sheet
+
+| Context                               | Import                                                              | Use                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| JSX body text                         | `import { Trans } from "@lingui/react/macro"`                       | `<Trans>Some text</Trans>`                                           |
+| Strings/attrs in a component          | `import { useLingui } from "@lingui/react/macro"`                   | `const { t } = useLingui();` → `` t`Save` ``, `aria-label={t`Save`}` |
+| Module-level / lazy labels            | `import { msg } from "@lingui/core/macro"`                          | `` msg`Dark` `` → resolve with `t(descriptor)` at render             |
+| Non-React (actions, toasts, commands) | `msg` + `import { i18n } from "@/renderer/i18n/i18n"`               | ``i18n._(msg`Unable to remove worktree.`)``                          |
+| Outside renderer (supervisor/main)    | add key to `shared/messages.ts` + descriptor to `sharedMessages.ts` | `msg("git.push.failed", { detail })`                                 |
+
+Notes:
+
+- Module-level macros must use `msg`, not `t` (`t` is only valid inside a `useLingui()` render). See `settingsOptions.ts`.
+- Numeric/locale-agnostic tokens (`"2x"`, `"12px"`, version strings, `Lightcode`) stay plain strings.
+- Add a `comment` to disambiguate identical English strings with different meanings: `msg({ message: "Delete", comment: "Thread remove action: delete permanently" })`.
+
+## Commands
+
+- `pnpm i18n:extract` — scan `src/renderer`, add new msgids to every catalog, normalize `.po` wrapping, print a per-locale stats table. Run it after wrapping strings **and** again after filling translations.
+- `pnpm i18n:extract:clean` — same but prunes msgids no longer referenced. Use after removing strings.
+
+Verify the stats table reads **0 missing** for all 13 locales before finishing.
+
+## Per-language terminology
+
+Grep an existing catalog entry before translating a recurring product term so wording stays consistent. Established choices:
+
+| Term     | de       | es       | ru / uk  | zh-CN  | ja           | fr                | pt-BR              | pl             | vi           | tr            |
+| -------- | -------- | -------- | -------- | ------ | ------------ | ----------------- | ------------------ | -------------- | ------------ | ------------- |
+| worktree | Worktree | worktree | worktree | 工作树 | ワークツリー | arbre de travail  | árvore de trabalho | drzewo robocze | cây làm việc | çalışma ağacı |
+| thread   | —        | hilo     | тред     | 线程   | —            | fil de discussion | tópico             | —              | —            | Konu          |
+
+Keep literal in every locale: `Lightcode`, `.lightcode/worktrees`, `WSL`, `Dev Drive`, `Linux`, provider names (`Claude`, `Codex`, `Gemini`).
+
+## Gotchas
+
+- **Forgetting `pnpm i18n:extract`** after wrapping strings is the #1 mistake — the IDs never reach the catalogs and the new UI stays English with no error.
+- **Empty `msgstr`** ships a half-English UI because catalogs are fully translated, not fallback. Fill all 12.
+- **PO writer + leading placeholder:** `lingui extract`'s writer mangles a `msgstr` that starts with a placeholder immediately followed by a newline (`{original}\n…`), dropping the leading segment on rewrite. The `git.worktree.cleanupFailed` `msgstr` for `es/ru/uk` is hand-maintained for this reason — if you re-extract, re-apply it. `sharedMessages.test.ts` guards against the drop.
+- **Native language names are intentionally untranslated** in `locales.ts` (a language is shown in its own language); only behavioral labels like "System" / "Match app language" are translatable.
+
+## Adding a language
+
+1. Add the locale code to `locales` in `lingui.config.ts` **and** to `SUPPORTED_LOCALES` in `src/shared/locale.ts`.
+2. Add its native label to `LOCALE_SETTING_LABELS` in `src/renderer/i18n/locales.ts`.
+3. Run `pnpm i18n:extract` to scaffold `src/renderer/locales/{locale}/messages.po`.
+4. Translate every `msgstr` (the whole catalog, not just new strings).
+
+## Tests
+
+- `src/renderer/i18n/i18n.test.ts` — locale activation / bootstrap behavior.
+- `src/renderer/i18n/sharedMessages.test.ts` — shared-message resolver + the `cleanupFailed` regression guard.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Universal AI agent orchestrator — Electron desktop app managing Claude, Codex,
 - The renderer must never spawn agent processes — the supervisor runtime owns all agent processes.
 - React Compiler is the default memoization strategy. Do not add `useMemo`, `useCallback`, or `React.memo` unless escaping the compiler. Keep `babel-plugin-react-compiler` pinned to an exact version.
 - Use HeroUI v3 for all non-terminal UI. When working with HeroUI components, always load the `heroui-react` skill first (`/skill heroui-react`).
+- **Every user-facing string you add or change in `src/renderer` must be localized.** Wrap it in a Lingui macro, run `pnpm i18n:extract`, then fill the new `msgstr` in all 12 non-English catalogs — never ship empty translations (that leaves a half-English UI). See [Internationalization (i18n)](#internationalization-i18n).
 - The codebase is provider-agnostic. Providers are self-contained plugins — both supervisor adapters and renderer UI. No provider-specific if/else in shared runtime, UI, or layout code. Adding a new provider should require zero changes to existing shared files.
 - Windows projects use native Windows cwd. WSL projects run through `wsl.exe -d <distro> --cd <linuxPath> -- <agent command>`.
 
@@ -35,9 +36,79 @@ Universal AI agent orchestrator — Electron desktop app managing Claude, Codex,
 - Use `pnpm exec vitest run ...` for targeted Vitest runs; do not use Jest-only flags like `--runInBand`.
 - With `exactOptionalPropertyTypes`, avoid passing explicit `undefined` for optional props; use conditional spreads when needed.
 
+## Internationalization (i18n)
+
+Any time you add or edit a menu, button, dialog, label, placeholder, tooltip, toast, `aria-label`, or any other text the user can read, you must localize it in the same change. The renderer is localized with Lingui (`@lingui/*` v6). Source locale is `en`; there are **12 non-English catalogs** (`es`, `ru`, `uk`, `zh-CN`, `ja`, `pt-BR`, `de`, `fr`, `ko`, `pl`, `vi`, `tr`) at `src/renderer/locales/{locale}/messages.po`. Lingui scans **only `src/renderer`** — see the per-locale terminology table, gotchas, and "add a language" steps in [Internationalization (i18n)](.agents/docs/i18n.md).
+
+### Step 1 — Wrap the string in the right macro for its context
+
+**Inside a React component** — import the macros and pull `t` from the hook:
+
+```tsx
+import { Trans, useLingui } from "@lingui/react/macro";
+
+function MyPanel() {
+  const { t } = useLingui();
+  return (
+    <SettingsPage title={t`General`}>
+      {/* JSX body text → <Trans>; it handles interpolation and nested markup */}
+      <SettingRow description={<Trans>Choose the display language.</Trans>}>
+        {/* attribute / string values → t`…` */}
+        <Button aria-label={t`Save`}>{t`Save`}</Button>
+      </SettingRow>
+    </SettingsPage>
+  );
+}
+```
+
+- JSX text content → `<Trans>…</Trans>`. Attributes, `aria-label`, `title`, `placeholder`, and any plain string → `` t`…` ``.
+- Interpolate with the value inline: `` t`Discard changes in ${path}?` `` or `<Trans>Removing {count} files</Trans>`.
+
+**Module-level lists (option/menu definitions outside a component)** — `t` only exists at render time, so define labels lazily with `msg` and resolve them where they render:
+
+```ts
+import { msg } from "@lingui/core/macro";
+
+export const themeOptions = [
+  { id: "system", label: msg`System` },
+  { id: "dark", label: msg`Dark` },
+] as const;
+// resolve at render: const { t } = useLingui(); ...options.map(o => ({ ...o, label: t(o.label) }))
+// reuse the existing useLocalizedOptions() helper in views/SettingsOverlay/parts/settingsOptions.ts
+```
+
+**Non-React files (actions, command handlers, toasts)** — there is no hook, so translate eagerly through the singleton:
+
+```ts
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@/renderer/i18n/i18n";
+
+// verbatim from actions/agentLoginActions.ts and actions/projectActions.ts:
+toast.warning(i18n._(msg`Add a project before signing in.`));
+toast.danger(i18n._(msg`Stop the project's running threads before changing its folder.`));
+// interpolate inline, just like in a component:
+toast.warning(i18n._(msg`Unable to install ${label}.`));
+```
+
+**Text that originates outside the renderer (supervisor / main process)** — those processes carry no catalogs and must stay macro-free. Add a stable key to `src/shared/messages.ts`, add the matching `msg(...)` descriptor in `src/renderer/i18n/sharedMessages.ts`, and emit it with `msg("my.key", { param })`. `{param}` placeholders are interpolated by the resolver.
+
+### Step 2 — Extract, then translate every locale
+
+1. Run `pnpm i18n:extract`. This registers the new msgids across all 13 catalogs. Forgetting this is the most common mistake — the new IDs never reach the catalogs and the strings silently stay English.
+2. **The catalogs are fully translated, not English-fallback.** Open each of the 12 non-English `messages.po` files and fill the new `msgstr ""` entries with a real translation. Leaving them empty ships a half-English UI. (`en` is the source locale and needs no `msgstr`.) Match the per-language terminology already used in the catalog — grep an existing entry first; keep product nouns like `Lightcode`, `WSL`, `.lightcode/worktrees` literal. The terminology cheat-sheet is in [i18n.md](.agents/docs/i18n.md).
+3. Re-run `pnpm i18n:extract` to normalize `.po` formatting, and confirm the printed stats table shows **0 missing** for every locale.
+
+### Checklist before you finish
+
+- [ ] No raw user-facing string literals left in `src/renderer` JSX/attributes/toasts.
+- [ ] `pnpm i18n:extract` run; stats table shows 0 missing in all locales.
+- [ ] Every new `msgstr` filled in all 12 non-English catalogs (not just `en`).
+- [ ] `pnpm run typecheck` and `pnpm run lint` pass on touched files.
+
 ## Guidelines
 
 - [Architecture & Code Organization](.agents/docs/architecture.md)
 - [Agent Adapter Rules](.agents/docs/agent-adapters.md)
 - [UI Patterns & Component Reuse](.agents/docs/ui-patterns.md)
 - [Editing & React Patterns](.agents/docs/editing-rules.md)
+- [Internationalization (i18n)](.agents/docs/i18n.md)


### PR DESCRIPTION
- **Docs:** Add `.agents/docs/i18n.md` as a deep reference for Lingui scope, file layout, terminology, gotchas, and adding locales
- **AGENTS.md:** Add a critical rule requiring every user-facing renderer string to be localized in the same change
- **AGENTS.md:** Document the mandatory wrap → extract → translate workflow with macro examples for React, module-level options, and non-React code
- **AGENTS.md:** Link agent guidance to the new i18n reference and include a pre-finish localization checklist