### PR TITLE
fix(runtime-event): make streamed text append-only, drop chunk dedup

### DIFF
--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -30,6 +30,10 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     store.getState().applyRuntimeEvent(threadId, event);
   }
 
+  function applyBatch(threadId: string, events: RuntimeEvent[]) {
+    store.getState().applyRuntimeEvents(threadId, events);
+  }
+
   it("appends a new item on item.started", () => {
     apply("t1", {
       type: "item.started",
@@ -190,29 +194,30 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     });
   });
 
-  it("deduplicates overlapping streamed chunks", () => {
-    apply("t1", {
-      type: "item.started",
-      threadId: "t1",
-      itemId: "i1",
-      itemType: "assistant_message",
-    });
-    apply("t1", {
+  // Streams are append-only: a delta boundary that lands on a repeated
+  // character (e.g. "aws s" + "so login") must not be deduplicated. Both the
+  // per-event reducer and the batch coalescer must preserve it.
+  const repeatedCharChunks: RuntimeEvent[] = [
+    { type: "item.started", threadId: "t1", itemId: "i1", itemType: "assistant_message" },
+    { type: "content.delta", threadId: "t1", itemId: "i1", stream: "assistant_text", delta: "aws s" },
+    {
       type: "content.delta",
       threadId: "t1",
       itemId: "i1",
       stream: "assistant_text",
-      delta: "WorkingWorking through through tasks tasks.",
-    });
-    apply("t1", {
-      type: "content.delta",
-      threadId: "t1",
-      itemId: "i1",
-      stream: "assistant_text",
-      delta: " tasks tasks. What What do do you you need need done done??",
-    });
+      delta: "so login --profile DataScience-Team-228",
+    },
+    { type: "content.delta", threadId: "t1", itemId: "i1", stream: "assistant_text", delta: "889582725" },
+  ];
+  const repeatedCharResult = "aws sso login --profile DataScience-Team-228889582725";
+
+  it.each([
+    ["applied one at a time", (events: RuntimeEvent[]) => events.forEach((e) => apply("t1", e))],
+    ["coalesced as a batch", (events: RuntimeEvent[]) => applyBatch("t1", events)],
+  ])("preserves repeated characters across streamed chunk boundaries (%s)", (_label, deliver) => {
+    deliver(repeatedCharChunks);
     expect(store.getState().runtimeItemsByIdByThread["t1"]?.["i1"]?.streams.assistant_text).toBe(
-      "WorkingWorking through through tasks tasks. What What do do you you need need done done??",
+      repeatedCharResult,
     );
   });
 

--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -199,7 +199,13 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
   // per-event reducer and the batch coalescer must preserve it.
   const repeatedCharChunks: RuntimeEvent[] = [
     { type: "item.started", threadId: "t1", itemId: "i1", itemType: "assistant_message" },
-    { type: "content.delta", threadId: "t1", itemId: "i1", stream: "assistant_text", delta: "aws s" },
+    {
+      type: "content.delta",
+      threadId: "t1",
+      itemId: "i1",
+      stream: "assistant_text",
+      delta: "aws s",
+    },
     {
       type: "content.delta",
       threadId: "t1",
@@ -207,7 +213,13 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
       stream: "assistant_text",
       delta: "so login --profile DataScience-Team-228",
     },
-    { type: "content.delta", threadId: "t1", itemId: "i1", stream: "assistant_text", delta: "889582725" },
+    {
+      type: "content.delta",
+      threadId: "t1",
+      itemId: "i1",
+      stream: "assistant_text",
+      delta: "889582725",
+    },
   ];
   const repeatedCharResult = "aws sso login --profile DataScience-Team-228889582725";
 

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -687,7 +687,7 @@ function applyRuntimeEventToRuntimeState(
       const next: RuntimeChatItem = {
         ...prev,
         state: prev.state === "completed" ? "completed" : "updated",
-        streams: { ...prev.streams, [event.stream]: mergeStreamChunk(prevStream, event.delta) },
+        streams: { ...prev.streams, [event.stream]: prevStream + event.delta },
       };
       items[event.itemId] = next;
       return {
@@ -817,7 +817,7 @@ function coalesceRuntimeEvents(events: RuntimeEvent[]): RuntimeEvent[] {
     ) {
       pendingDelta = {
         ...pendingDelta,
-        delta: mergeStreamChunk(pendingDelta.delta, event.delta),
+        delta: pendingDelta.delta + event.delta,
       };
       continue;
     }
@@ -919,40 +919,4 @@ function mergePayload(prev: unknown, next: unknown): unknown {
   if (!prev || typeof prev !== "object") return next;
   if (!next || typeof next !== "object") return next;
   return { ...(prev as Record<string, unknown>), ...(next as Record<string, unknown>) };
-}
-
-/**
- * Some providers emit overlapping text chunks (next chunk starts with the tail
- * of the previous chunk) rather than strict append-only deltas. Merge the
- * largest shared suffix/prefix so streamed text stays stable.
- *
- * Append-only is by far the common case (Codex/Copilot ACP, OpenCode, Claude),
- * so the algorithm is biased to bail out cheaply when no overlap is possible:
- * we use `indexOf` to find candidate suffix-start positions in O(N) total
- * rather than iterating overlap sizes from `maxOverlap` down to 1 (each step
- * doing an O(K) `endsWith` check, which was O(N²) for long messages).
- */
-function mergeStreamChunk(existing: string, incoming: string): string {
-  if (!incoming) return existing;
-  if (!existing) return incoming;
-  if (existing.endsWith(incoming)) return existing;
-  if (incoming.startsWith(existing)) return incoming;
-
-  const maxOverlap = Math.min(existing.length, incoming.length);
-  const firstChar = incoming[0]!;
-  // Scan existing's tail (length up to maxOverlap) for positions where the
-  // first character of `incoming` appears. The leftmost match yields the
-  // largest possible overlap, so we accept the first one whose suffix matches
-  // and short-circuit. When `firstChar` doesn't appear in the tail at all
-  // (the typical append-only case), `indexOf` returns -1 and we skip the
-  // body entirely — O(N) at worst, O(1) in the fast path.
-  let candidate = existing.indexOf(firstChar, existing.length - maxOverlap);
-  while (candidate !== -1) {
-    const overlap = existing.length - candidate;
-    if (existing.slice(candidate) === incoming.slice(0, overlap)) {
-      return existing + incoming.slice(overlap);
-    }
-    candidate = existing.indexOf(firstChar, candidate + 1);
-  }
-  return existing + incoming;
 }


### PR DESCRIPTION
- Stop deduplicating overlapping streamed deltas; the per-event reducer and the batch coalescer now append chunks verbatim so text streams are strictly append-only.
- Fixes corruption where a delta boundary landing on a repeated character (e.g. `aws s` + `so login`) was wrongly collapsed, dropping characters from the rendered output.
- Remove the now-unused `mergeStreamChunk` suffix/prefix-overlap helper.
- Update tests to assert repeated characters are preserved across chunk boundaries, covering both one-at-a-time and batch-coalesced delivery.