### PR TITLE
Refresh expired Claude OAuth tokens before usage fetch

### DIFF
--- a/packages/agents-usage/src/collectors/claude.test.ts
+++ b/packages/agents-usage/src/collectors/claude.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 import { createFakeHost, FAKE_NOW_MS } from "../testHost";
 import {
   CLAUDE_OAUTH_BETA,
+  CLAUDE_OAUTH_CLIENT_ID,
+  CLAUDE_OAUTH_TOKEN_ENDPOINT,
   CLAUDE_USAGE_ENDPOINT,
   collectClaude,
   formatClaudePlan,
+  parseClaudeRefreshResponse,
   parseClaudeUsage,
+  refreshClaudeOAuthToken,
 } from "./claude";
 
 // The Claude /api/oauth/usage endpoint reports `utilization` in percent (0-100)
@@ -116,5 +120,105 @@ describe("collectClaude", () => {
       }),
     );
     expect(unauth.status).toBe("auth-missing");
+  });
+});
+
+describe("parseClaudeRefreshResponse", () => {
+  it("maps the OAuth body and derives expiresAt from expires_in", () => {
+    const got = parseClaudeRefreshResponse(
+      { access_token: "new-acc", refresh_token: "new-ref", expires_in: 3600 },
+      FAKE_NOW_MS,
+      "old-ref",
+    );
+    expect(got).toEqual({
+      accessToken: "new-acc",
+      refreshToken: "new-ref",
+      expiresAt: FAKE_NOW_MS + 3600 * 1000,
+    });
+  });
+
+  it("retains the current refresh token when the body omits a new one", () => {
+    const got = parseClaudeRefreshResponse(
+      { access_token: "new-acc", expires_in: 100 },
+      FAKE_NOW_MS,
+      "keep-ref",
+    );
+    expect(got?.refreshToken).toBe("keep-ref");
+  });
+
+  it("returns undefined without an access token", () => {
+    expect(parseClaudeRefreshResponse({ refresh_token: "r" }, FAKE_NOW_MS, "old")).toBeUndefined();
+  });
+
+  it("rejects a non-string access token rather than corrupting the creds file", () => {
+    expect(
+      parseClaudeRefreshResponse(
+        { access_token: { nested: "oops" }, expires_in: 3600 },
+        FAKE_NOW_MS,
+        "old",
+      ),
+    ).toBeUndefined();
+    expect(
+      parseClaudeRefreshResponse({ access_token: 12345, expires_in: 3600 }, FAKE_NOW_MS, "old"),
+    ).toBeUndefined();
+  });
+
+  it("rejects a missing or non-positive expires_in (would mark the token instantly stale)", () => {
+    expect(parseClaudeRefreshResponse({ access_token: "a" }, FAKE_NOW_MS, "old")).toBeUndefined();
+    expect(
+      parseClaudeRefreshResponse({ access_token: "a", expires_in: "soon" }, FAKE_NOW_MS, "old"),
+    ).toBeUndefined();
+    expect(
+      parseClaudeRefreshResponse({ access_token: "a", expires_in: 0 }, FAKE_NOW_MS, "old"),
+    ).toBeUndefined();
+  });
+
+  it("falls back to the current refresh token when the body's is not a string", () => {
+    const got = parseClaudeRefreshResponse(
+      { access_token: "a", refresh_token: ["x"], expires_in: 100 },
+      FAKE_NOW_MS,
+      "keep-ref",
+    );
+    expect(got?.refreshToken).toBe("keep-ref");
+  });
+});
+
+describe("refreshClaudeOAuthToken", () => {
+  it("posts the refresh grant to the OAuth endpoint and returns the rotated token", async () => {
+    let captured: {
+      headers?: Record<string, string> | undefined;
+      body?: string | undefined;
+      method?: string | undefined;
+    } = {};
+    const host = createFakeHost({
+      routes: {
+        [CLAUDE_OAUTH_TOKEN_ENDPOINT]: {
+          body: JSON.stringify({ access_token: "fresh", refresh_token: "rot", expires_in: 28800 }),
+        },
+      },
+      onRequest: (req) => {
+        captured = { headers: req.headers, body: req.body, method: req.method };
+      },
+    });
+    const got = await refreshClaudeOAuthToken(host.http, "old-ref", FAKE_NOW_MS);
+    expect(got).toEqual({
+      accessToken: "fresh",
+      refreshToken: "rot",
+      expiresAt: FAKE_NOW_MS + 28800 * 1000,
+    });
+    expect(captured.method).toBe("POST");
+    expect(captured.headers?.["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(captured.body ?? "{}")).toEqual({
+      grant_type: "refresh_token",
+      refresh_token: "old-ref",
+      client_id: CLAUDE_OAUTH_CLIENT_ID,
+    });
+  });
+
+  it("returns undefined on a non-2xx response", async () => {
+    const host = createFakeHost({
+      routes: { [CLAUDE_OAUTH_TOKEN_ENDPOINT]: { status: 400, body: "{}" } },
+    });
+    expect(await refreshClaudeOAuthToken(host.http, "old-ref", FAKE_NOW_MS)).toBeUndefined();
   });
 });

--- a/packages/agents-usage/src/collectors/claude.ts
+++ b/packages/agents-usage/src/collectors/claude.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_CLIENT_VERSIONS } from "../clientVersions";
 import { toEpochMs } from "../formatters";
-import type { CollectOptions, HostPort } from "../host";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse } from "../host";
 import type { UsageSnapshot, UsageWindow, UsageWindowId } from "../types";
 
 /**
@@ -183,4 +183,104 @@ export async function collectClaude(
 
   const plan = formatClaudePlan(token.subscriptionType);
   return parseClaudeUsage(parsed, now, plan ? { plan } : {});
+}
+
+/**
+ * Claude Code OAuth token endpoint and public client id, used to exchange a
+ * stored refresh token for a fresh access token — the same grant the CLI runs.
+ * The access token is short-lived (~8h); when no running CLI keeps it fresh it
+ * expires and the usage endpoint 401s, so a caller that can persist the rotated
+ * token uses {@link refreshClaudeOAuthToken} to renew it before collecting.
+ */
+export const CLAUDE_OAUTH_TOKEN_ENDPOINT = "https://console.anthropic.com/v1/oauth/token";
+export const CLAUDE_OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+
+export interface ClaudeRefreshedToken {
+  accessToken: string;
+  refreshToken: string;
+  /** Epoch milliseconds. */
+  expiresAt: number;
+}
+
+interface ClaudeRefreshResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+/**
+ * Pure: map a parsed `/v1/oauth/token` refresh response to a token bundle.
+ * Anthropic rotates the refresh token but may omit it from the body, in which
+ * case the current one is retained. Every field is type-checked at runtime (the
+ * body is untrusted network JSON, not the `as`-cast shape) so a malformed 200 —
+ * e.g. from a proxy or captive portal — yields undefined (a failed refresh that
+ * keeps the stale token) instead of writing garbage into the credentials file.
+ * Requires a finite, positive `expires_in`; otherwise the derived expiry would
+ * be "now", marking the token instantly stale and re-refreshing every cycle.
+ */
+export function parseClaudeRefreshResponse(
+  body: unknown,
+  nowMs: number,
+  currentRefreshToken: string,
+): ClaudeRefreshedToken | undefined {
+  const data = (body ?? {}) as ClaudeRefreshResponse;
+  if (typeof data.access_token !== "string" || !data.access_token) return undefined;
+  if (
+    typeof data.expires_in !== "number" ||
+    !Number.isFinite(data.expires_in) ||
+    data.expires_in <= 0
+  ) {
+    return undefined;
+  }
+  const refreshToken =
+    typeof data.refresh_token === "string" && data.refresh_token
+      ? data.refresh_token
+      : currentRefreshToken;
+  return {
+    accessToken: data.access_token,
+    refreshToken,
+    expiresAt: nowMs + data.expires_in * 1000,
+  };
+}
+
+/**
+ * Exchange a Claude Code refresh token for a fresh access token via the same
+ * OAuth endpoint + public client id the CLI uses. Returns undefined on any
+ * network error, non-2xx, or unparseable body — the caller then keeps the
+ * existing (stale) token, which degrades to "not signed in" exactly as before.
+ * Secrets are never logged.
+ */
+export async function refreshClaudeOAuthToken(
+  http: HttpClient,
+  refreshToken: string,
+  nowMs: number,
+  clientVersion?: string,
+): Promise<ClaudeRefreshedToken | undefined> {
+  const version = clientVersion ?? DEFAULT_CLIENT_VERSIONS.claudeCode;
+  let res: HttpResponse;
+  try {
+    res = await http.request({
+      method: "POST",
+      url: CLAUDE_OAUTH_TOKEN_ENDPOINT,
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        "User-Agent": `claude-code/${version}`,
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: CLAUDE_OAUTH_CLIENT_ID,
+      }),
+      timeoutMs: 15_000,
+    });
+  } catch {
+    return undefined;
+  }
+  if (res.status < 200 || res.status >= 300) return undefined;
+  try {
+    return parseClaudeRefreshResponse(JSON.parse(res.body), nowMs, refreshToken);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -31,9 +31,14 @@ export {
   collectClaude,
   parseClaudeUsage,
   formatClaudePlan,
+  parseClaudeRefreshResponse,
+  refreshClaudeOAuthToken,
   CLAUDE_USAGE_ENDPOINT,
   CLAUDE_OAUTH_BETA,
+  CLAUDE_OAUTH_TOKEN_ENDPOINT,
+  CLAUDE_OAUTH_CLIENT_ID,
 } from "./collectors/claude";
+export type { ClaudeRefreshedToken } from "./collectors/claude";
 export {
   collectCodex,
   parseCodexUsage,

--- a/src/shared/coalesce.test.ts
+++ b/src/shared/coalesce.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { coalesceByKey } from "./coalesce";
+
+describe("coalesceByKey", () => {
+  it("shares one in-flight promise per key and evicts it once settled", async () => {
+    const inFlight = new Map<string, Promise<number>>();
+    let calls = 0;
+    let resolve!: (n: number) => void;
+    const run = () => {
+      calls++;
+      return new Promise<number>((r) => {
+        resolve = r;
+      });
+    };
+
+    const a = coalesceByKey(inFlight, "k", run);
+    const b = coalesceByKey(inFlight, "k", run);
+    expect(a).toBe(b); // second caller shares the first's promise
+    expect(calls).toBe(1);
+    expect(inFlight.has("k")).toBe(true);
+
+    resolve(7);
+    expect(await a).toBe(7);
+    expect(inFlight.has("k")).toBe(false); // evicted on settle
+
+    // A later call for the same key runs fresh.
+    const c = coalesceByKey(inFlight, "k", run);
+    expect(calls).toBe(2);
+    resolve(9);
+    expect(await c).toBe(9);
+  });
+
+  it("keys work independently", async () => {
+    const inFlight = new Map<string, Promise<string>>();
+    const a = coalesceByKey(inFlight, "a", () => Promise.resolve("A"));
+    const b = coalesceByKey(inFlight, "b", () => Promise.resolve("B"));
+    expect(await a).toBe("A");
+    expect(await b).toBe("B");
+  });
+});

--- a/src/shared/coalesce.ts
+++ b/src/shared/coalesce.ts
@@ -1,0 +1,20 @@
+/**
+ * Coalesce concurrent async work by key: callers with the same key share one
+ * in-flight promise instead of each starting the work. The entry clears itself
+ * on settle, guarded by promise identity so a stale settle never evicts a newer
+ * run. Used to avoid double-hitting rate-limited endpoints or burning a
+ * single-use token when two triggers race for the same resource.
+ */
+export function coalesceByKey<K, V>(
+  inFlight: Map<K, Promise<V>>,
+  key: K,
+  run: () => Promise<V>,
+): Promise<V> {
+  const existing = inFlight.get(key);
+  if (existing) return existing;
+  const tracked = run().finally(() => {
+    if (inFlight.get(key) === tracked) inFlight.delete(key);
+  });
+  inFlight.set(key, tracked);
+  return tracked;
+}

--- a/src/supervisor/runtime/claudeCredentials.ts
+++ b/src/supervisor/runtime/claudeCredentials.ts
@@ -1,8 +1,15 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { OAuthToken } from "@lightcode/agents-usage";
+import {
+  type ClaudeRefreshedToken,
+  type OAuthToken,
+  refreshClaudeOAuthToken,
+} from "@lightcode/agents-usage";
+import { writeFileAtomic } from "@/shared/atomicFile";
+import { coalesceByKey } from "@/shared/coalesce";
 import { readClaudeCredentialsFromMacKeychain } from "./macClaudeKeychain";
+import { createNodeHttpClient } from "./usageHttpClient";
 import { readClaudeCredentialsFromWindowsVault } from "./windowsClaudeVault";
 import { readClaudeCredsFromWsl } from "./wslCredentials";
 
@@ -73,13 +80,24 @@ function hasExplicitClaudeConfig(env: ClaudeCredentialEnv): boolean {
 
 export async function resolveClaudeToken(
   env: ClaudeCredentialEnv = process.env,
+  deps: ClaudeRefreshDeps = prodClaudeRefreshDeps(),
 ): Promise<OAuthToken | undefined> {
   for (const dir of claudeConfigDirs(env)) {
     const path = join(dir, ".credentials.json");
     if (!existsSync(path)) continue;
     try {
-      const token = parseClaudeCredentials(readFileSync(path, "utf8"));
-      if (token) return token;
+      const content = readFileSync(path, "utf8");
+      const token = parseClaudeCredentials(content);
+      // File-backed creds are the only source we can persist a rotated token to,
+      // so refresh is scoped here (covers every Claude profile + the common base
+      // case). Keychain/vault/WSL sources below are returned as-is. Coalesce per
+      // path so the base "claude" resolver and a profile aliasing the same file
+      // share one refresh instead of both POSTing (and burning) the refresh token.
+      if (token) {
+        return await coalesceByKey(claudeRefreshInFlight, path, () =>
+          refreshClaudeFileTokenIfExpired(path, content, token, deps),
+        );
+      }
     } catch {
       // try the next candidate dir
     }
@@ -114,4 +132,129 @@ export async function resolveClaudeToken(
     }
   }
   return undefined;
+}
+
+/**
+ * Self-refresh of an expired Claude OAuth access token, the way the Claude Code
+ * CLI does it: POST the stored refresh token to Anthropic's OAuth endpoint and
+ * rewrite the credentials file with the rotated token. The access token has a
+ * short (~8h) TTL; when no running CLI keeps it fresh it expires, the usage
+ * endpoint 401s, and the provider card flips to "Not signed in" until the
+ * account is used again. Refreshing here keeps usage live for idle accounts.
+ *
+ * Refresh tokens are single-use, and the on-disk file is shared with the Claude
+ * Code CLI (anthropics/claude-code#24317), so this is deliberately conservative:
+ *  - It only fires once the token is *past* expiry plus a grace window — never
+ *    while it is still valid — so a CLI that refreshes proactively always wins
+ *    the rotation and we step in only for genuinely idle/dead tokens.
+ *  - Concurrent refreshes of one file are coalesced per path (in-process) and
+ *    the file is re-read after the network call to defer to a rotation another
+ *    writer just performed instead of clobbering it.
+ *  - Any failure returns the original token (degrades to "not signed in",
+ *    exactly as before). Secrets are never logged.
+ *
+ * A residual race remains and is inherent to single-use refresh tokens: a CLI
+ * that has been running but idle *past* the access-token expiry holds the old
+ * refresh token in memory, so our rotation can force it to re-login when it next
+ * wakes. We accept this (rare) case rather than not refreshing at all.
+ */
+
+/** Refresh only once the token is this far PAST expiry (lets a live CLI rotate first). */
+const EXPIRY_GRACE_MS = 30_000;
+
+export function isClaudeTokenExpired(
+  token: Pick<OAuthToken, "expiresAt">,
+  nowMs: number,
+  graceMs = EXPIRY_GRACE_MS,
+): boolean {
+  return typeof token.expiresAt === "number" && token.expiresAt + graceMs <= nowMs;
+}
+
+/**
+ * Merge a refreshed token into the original credentials JSON, preserving the
+ * file's wrapper shape (`{ claudeAiOauth: {...} }` or a bare object) and every
+ * other field (subscriptionType, scopes, …). Returns the serialized JSON.
+ */
+export function mergeClaudeCredentialsJson(
+  originalContent: string,
+  refreshed: ClaudeRefreshedToken,
+): string {
+  const parsed = JSON.parse(originalContent) as Record<string, unknown>;
+  const wrapped = typeof parsed?.claudeAiOauth === "object" && parsed.claudeAiOauth !== null;
+  const oauth = (wrapped ? parsed.claudeAiOauth : parsed) as Record<string, unknown>;
+  oauth.accessToken = refreshed.accessToken;
+  oauth.refreshToken = refreshed.refreshToken;
+  oauth.expiresAt = refreshed.expiresAt;
+  return JSON.stringify(parsed);
+}
+
+/** Injectable I/O for {@link refreshClaudeFileTokenIfExpired}; defaulted for prod. */
+export interface ClaudeRefreshDeps {
+  now(): number;
+  refresh(refreshToken: string, nowMs: number): Promise<ClaudeRefreshedToken | undefined>;
+  readFile(path: string): string;
+  writeFile(path: string, content: string): void;
+}
+
+export function defaultClaudeRefreshDeps(): ClaudeRefreshDeps {
+  const http = createNodeHttpClient();
+  return {
+    now: () => Date.now(),
+    refresh: (refreshToken, nowMs) => refreshClaudeOAuthToken(http, refreshToken, nowMs),
+    readFile: (path) => readFileSync(path, "utf8"),
+    // Atomic write with owner-only perms (cleans up its temp file on failure),
+    // so a torn or crashed write never corrupts or leaks the credentials file.
+    writeFile: (path, content) => writeFileAtomic(path, content, { encoding: "utf8", mode: 0o600 }),
+  };
+}
+
+/** Built once and reused so the http client isn't rebuilt on every resolve. */
+let cachedRefreshDeps: ClaudeRefreshDeps | undefined;
+function prodClaudeRefreshDeps(): ClaudeRefreshDeps {
+  return (cachedRefreshDeps ??= defaultClaudeRefreshDeps());
+}
+
+/** In-flight refresh per resolved creds path, so same-tick callers share one POST. */
+const claudeRefreshInFlight = new Map<string, Promise<OAuthToken>>();
+
+/**
+ * Given the credentials file content the caller just read and its parsed token,
+ * refresh + persist when the access token is (grace-)expired. Returns the token
+ * the collector should use: the rotated one on success, the original otherwise.
+ */
+export async function refreshClaudeFileTokenIfExpired(
+  path: string,
+  originalContent: string,
+  token: OAuthToken,
+  deps: ClaudeRefreshDeps,
+): Promise<OAuthToken> {
+  if (!token.refreshToken || !isClaudeTokenExpired(token, deps.now())) return token;
+
+  const refreshed = await deps.refresh(token.refreshToken, deps.now());
+  if (!refreshed) return token;
+
+  // Re-read after the network round-trip (up to ~15s): if another writer rotated
+  // the token while we were in flight, return theirs rather than clobbering it
+  // with a write derived from now-stale content.
+  let latestContent = originalContent;
+  try {
+    latestContent = deps.readFile(path);
+    const after = parseClaudeCredentials(latestContent);
+    if (after?.accessToken && !isClaudeTokenExpired(after, deps.now())) return after;
+  } catch {
+    // Re-read failed; merge into the content the caller already gave us.
+  }
+
+  try {
+    deps.writeFile(path, mergeClaudeCredentialsJson(latestContent, refreshed));
+  } catch {
+    // Persisting failed (read-only fs, perms). Still return the fresh token so
+    // this fetch succeeds; the next cycle re-refreshes from the unchanged file.
+  }
+  return {
+    ...token,
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+    expiresAt: refreshed.expiresAt,
+  };
 }

--- a/src/supervisor/runtime/claudeTokenRefresh.test.ts
+++ b/src/supervisor/runtime/claudeTokenRefresh.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ClaudeRefreshedToken, OAuthToken } from "@lightcode/agents-usage";
+import {
+  type ClaudeRefreshDeps,
+  isClaudeTokenExpired,
+  mergeClaudeCredentialsJson,
+  refreshClaudeFileTokenIfExpired,
+} from "./claudeCredentials";
+
+const NOW = 1_700_000_000_000;
+const PATH = "/home/u/.claude/.credentials.json";
+
+function credsFile(oauth: object): string {
+  return JSON.stringify({ claudeAiOauth: oauth });
+}
+
+/** Deps backed by a single in-memory file, with a refresh spy. */
+function makeDeps(opts: {
+  file: string;
+  refreshed?: ClaudeRefreshedToken | undefined;
+  now?: number;
+}): ClaudeRefreshDeps & {
+  written: { content?: string };
+  refresh: ReturnType<typeof vi.fn>;
+} {
+  const store = { content: opts.file };
+  const written: { content?: string } = {};
+  const refresh = vi.fn<
+    (refreshToken: string, nowMs: number) => Promise<ClaudeRefreshedToken | undefined>
+  >(async () => opts.refreshed);
+  return {
+    now: () => opts.now ?? NOW,
+    refresh,
+    readFile: () => store.content,
+    writeFile: (_path, content) => {
+      store.content = content;
+      written.content = content;
+    },
+    written,
+  };
+}
+
+describe("isClaudeTokenExpired", () => {
+  it("only reports expiry once the token is past expiry plus the grace window", () => {
+    expect(isClaudeTokenExpired({ expiresAt: NOW - 60_000 }, NOW)).toBe(true); // 60s past expiry
+    // Still valid, and just-barely-past-expiry tokens are left for a live CLI to rotate first.
+    expect(isClaudeTokenExpired({ expiresAt: NOW - 10_000 }, NOW)).toBe(false); // within 30s grace
+    expect(isClaudeTokenExpired({ expiresAt: NOW + 30_000 }, NOW)).toBe(false); // not yet expired
+    expect(isClaudeTokenExpired({ expiresAt: NOW + 5 * 60_000 }, NOW)).toBe(false);
+  });
+
+  it("never reports expiry when expiresAt is absent", () => {
+    expect(isClaudeTokenExpired({}, NOW)).toBe(false);
+  });
+});
+
+describe("mergeClaudeCredentialsJson", () => {
+  const refreshed: ClaudeRefreshedToken = {
+    accessToken: "A2",
+    refreshToken: "R2",
+    expiresAt: NOW + 1000,
+  };
+
+  it("rewrites the oauth fields inside the wrapper, preserving other fields", () => {
+    const out = mergeClaudeCredentialsJson(
+      credsFile({ accessToken: "A1", refreshToken: "R1", expiresAt: 1, subscriptionType: "max" }),
+      refreshed,
+    );
+    expect(JSON.parse(out)).toEqual({
+      claudeAiOauth: {
+        accessToken: "A2",
+        refreshToken: "R2",
+        expiresAt: NOW + 1000,
+        subscriptionType: "max",
+      },
+    });
+  });
+
+  it("handles a bare (unwrapped) oauth object", () => {
+    const out = mergeClaudeCredentialsJson(
+      JSON.stringify({ accessToken: "A1", refreshToken: "R1", expiresAt: 1 }),
+      refreshed,
+    );
+    expect(JSON.parse(out)).toEqual({
+      accessToken: "A2",
+      refreshToken: "R2",
+      expiresAt: NOW + 1000,
+    });
+  });
+});
+
+describe("refreshClaudeFileTokenIfExpired", () => {
+  const fresh: OAuthToken = { accessToken: "A1", refreshToken: "R1", expiresAt: NOW + 5 * 60_000 };
+  // Well past expiry + grace, so refresh is eligible to fire.
+  const expired: OAuthToken = {
+    accessToken: "A1",
+    refreshToken: "R1",
+    expiresAt: NOW - 5 * 60_000,
+    subscriptionType: "max",
+  };
+
+  it("returns the token untouched when it is not expired", async () => {
+    const deps = makeDeps({ file: credsFile(fresh) });
+    const out = await refreshClaudeFileTokenIfExpired(PATH, credsFile(fresh), fresh, deps);
+    expect(out).toBe(fresh);
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it("returns the token untouched when there is no refresh token", async () => {
+    const noRef: OAuthToken = { accessToken: "A1", expiresAt: NOW - 5 * 60_000 };
+    const deps = makeDeps({ file: credsFile(noRef) });
+    expect(await refreshClaudeFileTokenIfExpired(PATH, credsFile(noRef), noRef, deps)).toBe(noRef);
+    expect(deps.refresh).not.toHaveBeenCalled();
+  });
+
+  it("refreshes, persists the rotated token, and returns it", async () => {
+    const refreshed: ClaudeRefreshedToken = {
+      accessToken: "A2",
+      refreshToken: "R2",
+      expiresAt: NOW + 8 * 60 * 60_000,
+    };
+    const deps = makeDeps({ file: credsFile(expired), refreshed });
+    const out = await refreshClaudeFileTokenIfExpired(PATH, credsFile(expired), expired, deps);
+
+    expect(deps.refresh).toHaveBeenCalledWith("R1", NOW);
+    expect(out.accessToken).toBe("A2");
+    expect(out.refreshToken).toBe("R2");
+    expect(out.expiresAt).toBe(refreshed.expiresAt);
+    // subscriptionType from the original token is preserved.
+    expect(out.subscriptionType).toBe("max");
+    // The file was rewritten with the rotated token.
+    expect(JSON.parse(deps.written.content ?? "{}").claudeAiOauth).toMatchObject({
+      accessToken: "A2",
+      refreshToken: "R2",
+      expiresAt: refreshed.expiresAt,
+    });
+  });
+
+  it("defers to a token another writer rotated DURING the network refresh (no clobber)", async () => {
+    const refreshed: ClaudeRefreshedToken = {
+      accessToken: "A2",
+      refreshToken: "R2",
+      expiresAt: NOW + 1000,
+    };
+    const winner = credsFile({
+      accessToken: "WIN",
+      refreshToken: "RWIN",
+      expiresAt: NOW + 5 * 60_000,
+    });
+    const store = { content: credsFile(expired) };
+    let written: string | undefined;
+    const deps: ClaudeRefreshDeps = {
+      now: () => NOW,
+      readFile: () => store.content,
+      writeFile: (_path, content) => {
+        store.content = content;
+        written = content;
+      },
+      refresh: async () => {
+        // Simulate the CLI rotating the on-disk token while we're in flight.
+        store.content = winner;
+        return refreshed;
+      },
+    };
+    const out = await refreshClaudeFileTokenIfExpired(PATH, credsFile(expired), expired, deps);
+    expect(out.accessToken).toBe("WIN");
+    expect(written).toBeUndefined();
+  });
+
+  it("keeps the original token when the refresh fails", async () => {
+    const deps = makeDeps({ file: credsFile(expired), refreshed: undefined });
+    const out = await refreshClaudeFileTokenIfExpired(PATH, credsFile(expired), expired, deps);
+    expect(out).toStrictEqual(expired);
+    expect(deps.written.content).toBeUndefined();
+  });
+
+  it("still returns the fresh token when persisting fails", async () => {
+    const refreshed: ClaudeRefreshedToken = {
+      accessToken: "A2",
+      refreshToken: "R2",
+      expiresAt: NOW + 1000,
+    };
+    const deps = makeDeps({ file: credsFile(expired), refreshed });
+    deps.writeFile = () => {
+      throw new Error("EROFS");
+    };
+    const out = await refreshClaudeFileTokenIfExpired(PATH, credsFile(expired), expired, deps);
+    expect(out.accessToken).toBe("A2");
+  });
+});

--- a/src/supervisor/runtime/usageHost.ts
+++ b/src/supervisor/runtime/usageHost.ts
@@ -1,13 +1,8 @@
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type {
-  HostPort,
-  HttpClient,
-  HttpRequest,
-  HttpResponse,
-  Logger,
-} from "@lightcode/agents-usage";
+import type { HostPort, Logger } from "@lightcode/agents-usage";
 import { createNativeCredentialStore } from "./usageCredentials";
+import { createNodeHttpClient } from "./usageHttpClient";
 
 /**
  * Node implementation of the usage-collection HostPort. Supplies real HTTP
@@ -15,42 +10,6 @@ import { createNativeCredentialStore } from "./usageCredentials";
  * only place the otherwise-pure `@lightcode/agents-usage` package touches the
  * outside world.
  */
-
-const DEFAULT_TIMEOUT_MS = 15_000;
-
-function headersToRecord(headers: Headers): Record<string, string> {
-  const record: Record<string, string> = {};
-  headers.forEach((value, key) => {
-    record[key.toLowerCase()] = value;
-  });
-  return record;
-}
-
-function createNodeHttpClient(): HttpClient {
-  return {
-    async request(req: HttpRequest): Promise<HttpResponse> {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), req.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-      try {
-        const res = await fetch(req.url, {
-          method: req.method ?? "GET",
-          ...(req.headers ? { headers: req.headers } : {}),
-          ...(req.bodyBytes !== undefined
-            ? { body: Buffer.from(req.bodyBytes) }
-            : req.body !== undefined
-              ? { body: req.body }
-              : {}),
-          signal: controller.signal,
-        });
-        const bodyBytes = new Uint8Array(await res.arrayBuffer());
-        const body = Buffer.from(bodyBytes).toString("utf8");
-        return { status: res.status, headers: headersToRecord(res.headers), body, bodyBytes };
-      } finally {
-        clearTimeout(timeout);
-      }
-    },
-  };
-}
 
 /** Dev-only file logger: dumps collector debug payloads to `<cacheDir>/usage-debug.json`. */
 function createDevFileLogger(cacheDir: string): Logger {

--- a/src/supervisor/runtime/usageHttpClient.ts
+++ b/src/supervisor/runtime/usageHttpClient.ts
@@ -1,0 +1,44 @@
+import type { HttpClient, HttpRequest, HttpResponse } from "@lightcode/agents-usage";
+
+/**
+ * Node implementation of the usage HostPort's HTTP client: global fetch with an
+ * abort-based timeout. Extracted to its own leaf module (no other local imports)
+ * so both the usage host and the Claude OAuth refresh path can reuse it without
+ * an import cycle.
+ */
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+function headersToRecord(headers: Headers): Record<string, string> {
+  const record: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    record[key.toLowerCase()] = value;
+  });
+  return record;
+}
+
+export function createNodeHttpClient(): HttpClient {
+  return {
+    async request(req: HttpRequest): Promise<HttpResponse> {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), req.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+      try {
+        const res = await fetch(req.url, {
+          method: req.method ?? "GET",
+          ...(req.headers ? { headers: req.headers } : {}),
+          ...(req.bodyBytes !== undefined
+            ? { body: Buffer.from(req.bodyBytes) }
+            : req.body !== undefined
+              ? { body: req.body }
+              : {}),
+          signal: controller.signal,
+        });
+        const bodyBytes = new Uint8Array(await res.arrayBuffer());
+        const body = Buffer.from(bodyBytes).toString("utf8");
+        return { status: res.status, headers: headersToRecord(res.headers), body, bodyBytes };
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+}

--- a/src/supervisor/runtime/usageService.ts
+++ b/src/supervisor/runtime/usageService.ts
@@ -9,6 +9,7 @@ import {
   type UsageCollectorRegistry,
   type UsageSnapshot,
 } from "@lightcode/agents-usage";
+import { coalesceByKey } from "@/shared/coalesce";
 import { claudeProfileKind, parseClaudeProfileInstanceConfig } from "@/shared/contracts";
 import type { ProviderUsagePayload, ProviderUsageResponse } from "@/shared/contracts";
 import type { SupervisorEvent } from "@/shared/ipc";
@@ -189,15 +190,7 @@ export class UsageService {
     // endpoints. Keyed by the sorted ids so it holds for any subset, not just the
     // full default set.
     const key = [...ids].sort().join(",");
-    const existing = this.refreshesInFlight.get(key);
-    if (existing) return existing;
-
-    // Track the SAME promise we store so the finally clears the right entry.
-    const tracked: Promise<ProviderUsageResponse> = this.runRefresh(ids).finally(() => {
-      if (this.refreshesInFlight.get(key) === tracked) this.refreshesInFlight.delete(key);
-    });
-    this.refreshesInFlight.set(key, tracked);
-    return tracked;
+    return coalesceByKey(this.refreshesInFlight, key, () => this.runRefresh(ids));
   }
 
   private async runRefresh(ids: string[]): Promise<ProviderUsageResponse> {


### PR DESCRIPTION
- **Feature:** Refresh expired Claude OAuth access tokens before usage collection so usage data still loads when no CLI session is keeping tokens warm
- Add OAuth token refresh and response parsing to `agents-usage`, with strict validation to avoid writing malformed credentials
- Refresh file-backed Claude credentials in the supervisor, persist rotated tokens atomically, and coalesce concurrent refreshes per credentials path
- Extract a shared Node HTTP client for usage and credential refresh, and reuse a generic `coalesceByKey` helper in usage refresh coalescing
- Add tests for refresh parsing, credential merge/expiry handling, and concurrent coalescing behavior