### PR TITLE
Parse line-range file views and Codex imageView in chat pane

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
@@ -56,6 +56,20 @@ describe("humanIntentTitle", () => {
     });
   });
 
+  it("describes PowerShell Get-Content array slices as viewed lines", () => {
+    const full =
+      "pwsh -Command '$lines = Get-Content src/renderer/commands/registry.ts; $lines[430..490] -join \"`n\"'";
+    const display = commandIntentDisplay(full);
+
+    expect(display.title).toBe("View 431:491: src/renderer/commands/registry.ts");
+    expect(display.kind).toBe("view");
+    expect(display.parts).toEqual({
+      prefix: "View 431:491: ",
+      path: "src/renderer/commands/registry.ts",
+      filePath: true,
+    });
+  });
+
   it("preserves Windows paths in PowerShell Get-Content -LiteralPath", () => {
     const full = String.raw`pwsh -Command 'Get-Content -LiteralPath C:\Users\sdsle\work\lightcode\src\foo.ts'`;
     const display = commandIntentDisplay(full);
@@ -99,6 +113,21 @@ describe("humanIntentTitle", () => {
     expect(humanIntentTitle(full)).toBe('Search: "agent status|AgentStatus"');
     expect(commandIntentDisplay(full).kind).toBe("search");
     expect(commandIntentDisplay(full).parts).toBeUndefined();
+  });
+
+  it("describes ripgrep all-line windows as viewed lines", () => {
+    const full = String.raw`"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command 'rg -n "''^" src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts | Select-Object -Skip 1 -First 180'`;
+    const display = commandIntentDisplay(full);
+
+    expect(display.title).toBe(
+      "View 2:181: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts",
+    );
+    expect(display.kind).toBe("view");
+    expect(display.parts).toEqual({
+      prefix: "View 2:181: ",
+      path: "src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts",
+      filePath: true,
+    });
   });
 
   it("describes plain grep commands as searches", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
@@ -189,6 +189,17 @@ function intentFromSummarizedCommand(t: string): CommandIntentDisplay | null {
     };
   }
 
+  const grepFileView = parseGrepLikeFileView(trimmed);
+  if (grepFileView) {
+    const prefix = viewPrefix(grepFileView.lines);
+    const label = grepFileView.lines ? grepFileView.path : basenameFromPath(grepFileView.path);
+    return {
+      title: `${prefix}${label}`,
+      parts: { prefix, path: grepFileView.path, filePath: true },
+      kind: "view",
+    };
+  }
+
   const grepLike = parseGrepLikeSearch(trimmed);
   if (grepLike) {
     return {
@@ -337,7 +348,22 @@ function parsePipedFileView(command: string): PipedFileView | null {
   return sed ? { path, lines: sed.lines } : null;
 }
 
+function parseGrepLikeFileView(command: string): PowerShellFileView | null {
+  const parts = splitPowerShellPipeline(command);
+  const path = extractGrepLikeFileViewPath(splitPowerShellWords(parts[0] ?? command));
+  if (!path) return null;
+
+  const lines = parts
+    .slice(1)
+    .map((part) => parseSelectObjectLineWindow(splitPowerShellWords(part)))
+    .find((lineWindow): lineWindow is string => !!lineWindow);
+  return { path, ...(lines ? { lines } : {}) };
+}
+
 function parsePowerShellGetContentView(command: string): PowerShellFileView | null {
+  const indexedView = parsePowerShellIndexedGetContentView(command);
+  if (indexedView) return indexedView;
+
   const parts = splitPowerShellPipeline(command);
   const path = extractPowerShellGetContentPath(splitPowerShellWords(parts[0] ?? command));
   if (!path) return null;
@@ -347,6 +373,69 @@ function parsePowerShellGetContentView(command: string): PowerShellFileView | nu
     .map((part) => parseSelectObjectLineWindow(splitPowerShellWords(part)))
     .find((lineWindow): lineWindow is string => !!lineWindow);
   return { path, ...(lines ? { lines } : {}) };
+}
+
+function parsePowerShellIndexedGetContentView(command: string): PowerShellFileView | null {
+  const match =
+    /^\s*(\$\w+)\s*=\s*((?:Get-Content|gc)\b.*?)\s*;\s*(\$\w+)\s*\[\s*(\d+)\s*\.\.\s*(\d+)\s*\]/i.exec(
+      command,
+    );
+  if (!match || match[1]!.toLowerCase() !== match[3]!.toLowerCase()) return null;
+
+  const path = extractPowerShellGetContentPath(splitPowerShellWords(match[2]!));
+  const startIndex = readNonNegativeInteger(match[4]);
+  const endIndex = readNonNegativeInteger(match[5]);
+  if (!path || startIndex === undefined || endIndex === undefined || endIndex < startIndex)
+    return null;
+
+  return { path, lines: `${startIndex + 1}-${endIndex + 1}` };
+}
+
+function extractGrepLikeFileViewPath(words: string[]): string | undefined {
+  const executable = words[0]?.split(/[/\\]/).pop()?.toLowerCase();
+  if (!executable || !GREP_LIKE_EXECUTABLES.has(executable)) return undefined;
+
+  let pattern: string | undefined;
+  const paths: string[] = [];
+  for (let i = 1; i < words.length; i++) {
+    const word = words[i]!;
+    if (word === "--") {
+      if (pattern === undefined) {
+        pattern = words[++i];
+      } else {
+        paths.push(...words.slice(i + 1));
+      }
+      break;
+    }
+    if (word === "-e" || word === "--regexp" || word === "-f" || word === "--file") {
+      pattern = words[++i] ?? pattern;
+      continue;
+    }
+    if (word.startsWith("--regexp=")) {
+      pattern = word.slice("--regexp=".length);
+      continue;
+    }
+    if (word.startsWith("--file=")) {
+      pattern = word.slice("--file=".length);
+      continue;
+    }
+    if (word === "-g" || word === "--glob" || word === "--type" || word === "-t") {
+      i++;
+      continue;
+    }
+    if (word.startsWith("-")) continue;
+    if (pattern === undefined) {
+      pattern = word;
+      continue;
+    }
+    paths.push(word);
+  }
+
+  return pattern && isAllLinesRegex(pattern) && paths.length === 1 ? paths[0] : undefined;
+}
+
+function isAllLinesRegex(pattern: string): boolean {
+  return pattern.replace(/^'+/u, "") === "^";
 }
 
 function extractPowerShellGetContentPath(words: string[]): string | undefined {

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
@@ -121,6 +121,19 @@ describe("deriveToolDisplay", () => {
     expect(display.Icon).toBe(ImageIcon);
   });
 
+  it("labels Codex imageView tools as image rows", () => {
+    const display = deriveToolDisplay(
+      makePayload({
+        name: "imageView",
+        args: { path: "screen.png" },
+      }),
+    );
+
+    expect(display.title).toBe("Image: screen.png");
+    expect(display.parts).toEqual({ prefix: "Image: ", path: "screen.png", filePath: true });
+    expect(display.Icon).toBe(ImageIcon);
+  });
+
   it("normalizes Claude raw read tools to view file displays", () => {
     const display = deriveToolDisplay(
       makePayload({

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -194,6 +194,8 @@ function mapClaudeRawTool(
       return { title: titleWithValue(i18n._(msg`Task output`), args, "id"), Icon: Terminal };
     case "TaskStop":
       return { title: titleWithValue(i18n._(msg`Stop task`), args, "id"), Icon: Trash2 };
+    case "imageView":
+    case "ImageView":
     case "ViewImage":
     case "Image":
       return withPath("Image", args, ["path", "file_path", "image_path", "source"], ImageIcon, {


### PR DESCRIPTION
- Show PowerShell `Get-Content` array slices as readable "View start:end: path" labels instead of raw commands
- Treat ripgrep/grep commands piped through `Select-Object` line windows as file line views in the chat pane
- Label Codex `imageView` tool calls as "Image: filename" with the image icon, matching other image tools
- Add tests covering the new command-intent and tool-display parsing paths