### PR TITLE
Add Z.ai usage provider with API key authentication

### DIFF
--- a/packages/agents-usage/src/collectors/zai.test.ts
+++ b/packages/agents-usage/src/collectors/zai.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "vitest";
+import type { HttpRequest } from "../host";
+import { createFakeHost, FAKE_NOW_MS } from "../testHost";
+import {
+  collectZai,
+  parseZaiUsage,
+  resolveZaiQuotaUrl,
+  ZAI_BIGMODEL_QUOTA_ENDPOINT,
+  ZAI_GLOBAL_QUOTA_ENDPOINT,
+} from "./zai";
+
+const SESSION_RESET = FAKE_NOW_MS + 60 * 60 * 1000;
+const WEEKLY_RESET = FAKE_NOW_MS + 3 * 24 * 60 * 60 * 1000;
+
+/** A two-window GLM Coding Plan quota body: 5-hour + weekly token limits. */
+const QUOTA_BODY = JSON.stringify({
+  code: 200,
+  msg: "success",
+  success: true,
+  data: {
+    planName: "GLM Coding Max",
+    limits: [
+      {
+        type: "TOKENS_LIMIT",
+        unit: 3, // hours
+        number: 5,
+        usage: 1_000_000, // total cap
+        currentValue: 250_000,
+        remaining: 750_000,
+        percentage: 99, // deliberately wrong — computed value must win
+        nextResetTime: SESSION_RESET,
+      },
+      {
+        type: "TOKENS_LIMIT",
+        unit: 6, // weeks
+        number: 1,
+        usage: 20_000_000,
+        currentValue: 4_000_000,
+        remaining: 16_000_000,
+        percentage: 0,
+        nextResetTime: WEEKLY_RESET,
+      },
+    ],
+  },
+});
+
+describe("parseZaiUsage", () => {
+  it("maps two token limits onto session-5h (shortest) and weekly (longest)", () => {
+    const snap = parseZaiUsage(JSON.parse(QUOTA_BODY).data, FAKE_NOW_MS);
+    expect(snap.providerId).toBe("zai");
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("GLM Coding Max");
+
+    const session = snap.windows.find((w) => w.id === "session-5h")!;
+    const weekly = snap.windows.find((w) => w.id === "weekly")!;
+    // 250k of 1M used → 25% (computed beats the bogus `percentage: 99`).
+    expect(session.usedPercent).toBeCloseTo(25);
+    expect(session.resetsAt).toBe(SESSION_RESET);
+    // 4M of 20M used → 20%.
+    expect(weekly.usedPercent).toBeCloseTo(20);
+    expect(weekly.resetsAt).toBe(WEEKLY_RESET);
+  });
+
+  it("falls back to the API percentage when the cap is absent", () => {
+    const snap = parseZaiUsage(
+      { limits: [{ type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 42 }] },
+      FAKE_NOW_MS,
+    );
+    expect(snap.windows[0]!.usedPercent).toBe(42);
+  });
+
+  it("places a lone token limit by its own duration and folds TIME_LIMIT into monthly", () => {
+    const snap = parseZaiUsage(
+      {
+        limits: [
+          { type: "TOKENS_LIMIT", unit: 6, number: 1, usage: 100, currentValue: 30 },
+          { type: "TIME_LIMIT", unit: 5, number: 1, usage: 10, currentValue: 1 },
+        ],
+      },
+      FAKE_NOW_MS,
+    );
+    expect(snap.windows.find((w) => w.id === "weekly")?.usedPercent).toBeCloseTo(30);
+    expect(snap.windows.find((w) => w.id === "monthly")?.usedPercent).toBeCloseTo(10);
+  });
+
+  it("surfaces the TIME_LIMIT as the monthly MCP quota (5h tokens + MCP, like the dashboard)", () => {
+    // Mirrors a real coding-plan response: a 5-hour TOKENS_LIMIT plus the monthly
+    // MCP TIME_LIMIT whose currentValue (102) overshoots the cap (100) -> clamp 100%.
+    const snap = parseZaiUsage(
+      {
+        planName: "Pro",
+        limits: [
+          {
+            type: "TOKENS_LIMIT",
+            unit: 3,
+            number: 5,
+            usage: 40_000_000,
+            currentValue: 0,
+            remaining: 40_000_000,
+            percentage: 0,
+            nextResetTime: SESSION_RESET,
+          },
+          {
+            type: "TIME_LIMIT",
+            unit: 5,
+            number: 1,
+            usage: 100,
+            currentValue: 102,
+            remaining: 0,
+            percentage: 100,
+            nextResetTime: WEEKLY_RESET,
+            usageDetails: [
+              { modelCode: "search-prime", usage: 95 },
+              { modelCode: "web-reader", usage: 1 },
+              { modelCode: "zread", usage: 0 },
+            ],
+          },
+        ],
+      },
+      FAKE_NOW_MS,
+    );
+    const session = snap.windows.find((w) => w.id === "session-5h")!;
+    expect(session.usedPercent).toBe(0);
+    const mcp = snap.windows.find((w) => w.id === "monthly")!;
+    expect(mcp.label).toBe("MCP");
+    expect(mcp.usedPercent).toBe(100); // 102/100 clamped
+    expect(mcp.resetsAt).toBe(WEEKLY_RESET);
+  });
+
+  it("reads the plan tier from `level` (real Pro response) and title-cases it", () => {
+    expect(parseZaiUsage({ level: "pro", limits: [] }, FAKE_NOW_MS).plan).toBe("Pro");
+    expect(parseZaiUsage({ level: "max", limits: [] }, FAKE_NOW_MS).plan).toBe("Max");
+    // A name key still wins over `level` when both are present.
+    expect(parseZaiUsage({ planName: "Team", level: "pro", limits: [] }, FAKE_NOW_MS).plan).toBe(
+      "Team",
+    );
+  });
+
+  it("parses the verbatim Pro coding-plan response (5h tokens + monthly MCP)", () => {
+    // Exact shape returned by api.z.ai for a Pro plan: the 5h token limit carries
+    // only `percentage`, and the plan tier is in `level` (not planName).
+    const snap = parseZaiUsage(
+      {
+        limits: [
+          {
+            type: "TIME_LIMIT",
+            unit: 5,
+            number: 1,
+            usage: 1000,
+            currentValue: 16,
+            remaining: 984,
+            percentage: 1,
+            nextResetTime: 1782722490998,
+            usageDetails: [
+              { modelCode: "search-prime", usage: 15 },
+              { modelCode: "web-reader", usage: 1 },
+              { modelCode: "zread", usage: 0 },
+            ],
+          },
+          { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 0 },
+        ],
+        level: "pro",
+      },
+      FAKE_NOW_MS,
+    );
+    expect(snap.plan).toBe("Pro");
+    expect(snap.windows.map((w) => w.id).sort()).toEqual(["monthly", "session-5h"]);
+    const session = snap.windows.find((w) => w.id === "session-5h")!;
+    expect(session.usedPercent).toBe(0);
+    expect(session.resetsAt).toBeUndefined();
+    const mcp = snap.windows.find((w) => w.id === "monthly")!;
+    expect(mcp.label).toBe("MCP");
+    expect(mcp.usedPercent).toBeCloseTo(1.6); // 16 / 1000 (computed beats the floored `percentage: 1`)
+    expect(mcp.resetsAt).toBe(1782722490998);
+  });
+
+  it("maps a three-limit plan (5h + weekly tokens + MCP) to all three windows", () => {
+    // Verbatim from CodexBar's three-limit fixture: higher/other plans return a
+    // weekly TOKENS_LIMIT (unit:6=weeks) in addition to the 5h token + MCP time limit.
+    const snap = parseZaiUsage(
+      {
+        limits: [
+          {
+            type: "TOKENS_LIMIT",
+            unit: 3,
+            number: 5,
+            percentage: 25,
+            nextResetTime: 1775020168897,
+          },
+          { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 9, nextResetTime: 1775588029998 },
+          {
+            type: "TIME_LIMIT",
+            unit: 5,
+            number: 1,
+            usage: 1000,
+            currentValue: 224,
+            remaining: 776,
+            percentage: 22,
+            nextResetTime: 1777575229998,
+            usageDetails: [
+              { modelCode: "search-prime", usage: 210 },
+              { modelCode: "web-reader", usage: 14 },
+            ],
+          },
+        ],
+        level: "max",
+      },
+      FAKE_NOW_MS,
+    );
+    expect(snap.plan).toBe("Max");
+    expect(snap.windows.map((w) => w.id).sort()).toEqual(["monthly", "session-5h", "weekly"]);
+    expect(snap.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(25);
+    expect(snap.windows.find((w) => w.id === "weekly")?.usedPercent).toBe(9);
+    const mcp = snap.windows.find((w) => w.id === "monthly")!;
+    expect(mcp.label).toBe("MCP");
+    expect(mcp.usedPercent).toBeCloseTo(22.4); // 224 / 1000 (computed)
+    expect(mcp.resetsAt).toBe(1777575229998);
+  });
+
+  it("tolerates an empty body", () => {
+    const empty = parseZaiUsage(undefined, FAKE_NOW_MS);
+    expect(empty.status).toBe("ok");
+    expect(empty.windows).toEqual([]);
+    expect(empty.plan).toBeUndefined();
+  });
+});
+
+describe("resolveZaiQuotaUrl", () => {
+  it("defaults to the global endpoint", () => {
+    expect(resolveZaiQuotaUrl(undefined)).toBe(ZAI_GLOBAL_QUOTA_ENDPOINT);
+  });
+
+  it("derives the quota path from an apiHost override", () => {
+    expect(resolveZaiQuotaUrl({ accessToken: "k", raw: { apiHost: "open.bigmodel.cn" } })).toBe(
+      ZAI_BIGMODEL_QUOTA_ENDPOINT,
+    );
+  });
+
+  it("uses a full quotaUrl override verbatim", () => {
+    const override = "https://open.bigmodel.cn/api/coding/paas/v4";
+    expect(resolveZaiQuotaUrl({ accessToken: "k", raw: { quotaUrl: override } })).toBe(override);
+  });
+});
+
+describe("collectZai", () => {
+  it("returns auth-missing when neither a pasted key nor a native token exists", async () => {
+    const snap = await collectZai(createFakeHost());
+    expect(snap.status).toBe("auth-missing");
+    expect(snap.windows).toEqual([]);
+  });
+
+  it("collects via a pasted API key and sends a Bearer header", async () => {
+    let seen: HttpRequest | undefined;
+    const host = createFakeHost({
+      secrets: { zai: { apiKey: "zai-pasted" } },
+      routes: { [ZAI_GLOBAL_QUOTA_ENDPOINT]: { body: QUOTA_BODY } },
+      onRequest: (req) => {
+        seen = req;
+      },
+    });
+    const snap = await collectZai(host);
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("GLM Coding Max");
+    expect(snap.windows.map((w) => w.id).sort()).toEqual(["session-5h", "weekly"]);
+    expect(seen?.headers?.Authorization).toBe("Bearer zai-pasted");
+  });
+
+  it("collects via the native (env/config) token when no key is pasted", async () => {
+    const host = createFakeHost({
+      tokens: { zai: { accessToken: "zai-env" } },
+      routes: { [ZAI_GLOBAL_QUOTA_ENDPOINT]: { body: QUOTA_BODY } },
+    });
+    const snap = await collectZai(host);
+    expect(snap.status).toBe("ok");
+  });
+
+  it("prefers the pasted key over the native token", async () => {
+    let seen: HttpRequest | undefined;
+    const host = createFakeHost({
+      secrets: { zai: { apiKey: "pasted-wins" } },
+      tokens: { zai: { accessToken: "env-loses" } },
+      routes: { [ZAI_GLOBAL_QUOTA_ENDPOINT]: { body: QUOTA_BODY } },
+      onRequest: (req) => {
+        seen = req;
+      },
+    });
+    await collectZai(host);
+    expect(seen?.headers?.Authorization).toBe("Bearer pasted-wins");
+  });
+
+  it("maps a 401 to auth-missing", async () => {
+    const host = createFakeHost({
+      secrets: { zai: { apiKey: "bad" } },
+      routes: { [ZAI_GLOBAL_QUOTA_ENDPOINT]: { status: 401, body: "" } },
+    });
+    expect((await collectZai(host)).status).toBe("auth-missing");
+  });
+
+  it("treats a 200 success:false auth message as auth-missing", async () => {
+    const host = createFakeHost({
+      secrets: { zai: { apiKey: "bad" } },
+      routes: {
+        [ZAI_GLOBAL_QUOTA_ENDPOINT]: {
+          body: JSON.stringify({ code: 401, success: false, msg: "Unauthorized token" }),
+        },
+      },
+    });
+    expect((await collectZai(host)).status).toBe("auth-missing");
+  });
+
+  it("treats a non-auth success:false as an error", async () => {
+    const host = createFakeHost({
+      secrets: { zai: { apiKey: "k" } },
+      routes: {
+        [ZAI_GLOBAL_QUOTA_ENDPOINT]: {
+          body: JSON.stringify({ code: 500, success: false, msg: "internal error" }),
+        },
+      },
+    });
+    const snap = await collectZai(host);
+    expect(snap.status).toBe("error");
+    expect(snap.error).toBe("internal error");
+  });
+});

--- a/packages/agents-usage/src/collectors/zai.ts
+++ b/packages/agents-usage/src/collectors/zai.ts
@@ -1,0 +1,310 @@
+import { toEpochMs } from "../formatters";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse, OAuthToken } from "../host";
+import type { UsageSnapshot, UsageWindow, UsageWindowId } from "../types";
+
+/**
+ * z.ai / Zhipu GLM Coding Plan. The plan's quota lives behind the same private
+ * monitoring API the official tools call; it authenticates with a long-lived
+ * API key (Bearer), not a browser cookie. Lightcode sources that key two ways
+ * (mirroring CodexBar, github.com/steipete/CodexBar): the native `Z_AI_API_KEY`
+ * environment / config resolved host-side (`getOAuthToken`), or a key the user
+ * pasted into the in-app sign-in (`getSecret(id,"apiKey")`). The pasted key wins.
+ *
+ *   GET {host}/api/monitor/usage/quota/limit
+ *     headers: Authorization: Bearer <key>, Accept: application/json
+ *     → { code, msg, success, data: { limits: [...], planName? } }
+ *
+ * `data.limits[]` carries `TOKENS_LIMIT` entries (the 5-hour and weekly token
+ * windows) and an optional `TIME_LIMIT` entry (the MCP/monthly marker). Each
+ * entry's `usage` is the TOTAL cap, `remaining`/`currentValue` the consumption,
+ * `number`+`unit` the window length, and `nextResetTime` an epoch-ms reset. The
+ * endpoint is private and may rotate without notice; responses are normalized
+ * into the shared `UsageSnapshot` shape.
+ */
+
+export const ZAI_PROVIDER_ID = "zai" as const;
+
+export const ZAI_GLOBAL_QUOTA_ENDPOINT = "https://api.z.ai/api/monitor/usage/quota/limit";
+export const ZAI_BIGMODEL_QUOTA_ENDPOINT = "https://open.bigmodel.cn/api/monitor/usage/quota/limit";
+const ZAI_QUOTA_PATH = "api/monitor/usage/quota/limit";
+
+/** z.ai limit `unit` codes (see CodexBar's ZaiLimitUnit). */
+const ZAI_UNIT_DAYS = 1;
+const ZAI_UNIT_HOURS = 3;
+const ZAI_UNIT_MINUTES = 5;
+const ZAI_UNIT_WEEKS = 6;
+
+interface ZaiLimitRaw {
+  type?: string;
+  unit?: number;
+  number?: number;
+  /** TOTAL cap for the window (confusingly named on the wire). */
+  usage?: number;
+  currentValue?: number;
+  remaining?: number;
+  /** API-provided utilization, 0-100. Used only when we can't compute it. */
+  percentage?: number;
+  /** Epoch milliseconds. */
+  nextResetTime?: number;
+}
+
+interface ZaiQuotaData {
+  limits?: ZaiLimitRaw[];
+  planName?: string;
+  plan?: string;
+  plan_type?: string;
+  packageName?: string;
+  /** The coding-plan tier on real responses, lowercase (e.g. "pro"). */
+  level?: string;
+}
+
+export interface ZaiQuotaResponse {
+  code?: number;
+  msg?: string;
+  success?: boolean;
+  data?: ZaiQuotaData;
+}
+
+function finite(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+/** Window length in minutes from a limit's `unit` + `number`, or undefined. */
+function windowMinutes(raw: ZaiLimitRaw): number | undefined {
+  const number = finite(raw.number);
+  if (number === undefined || number <= 0) return undefined;
+  switch (raw.unit) {
+    case ZAI_UNIT_MINUTES:
+      return number;
+    case ZAI_UNIT_HOURS:
+      return number * 60;
+    case ZAI_UNIT_DAYS:
+      return number * 24 * 60;
+    case ZAI_UNIT_WEEKS:
+      return number * 7 * 24 * 60;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Utilization for a limit entry. Mirrors CodexBar: prefer a value computed from
+ * the real cap (`usage`) and consumption (`remaining`/`currentValue`) over the
+ * API's own `percentage`, and never invent missing fields (which would read as
+ * 100% used). Returns the API `percentage` as a fallback when the cap is absent.
+ */
+function usedPercentFor(raw: ZaiLimitRaw): number {
+  const limit = finite(raw.usage);
+  if (limit !== undefined && limit > 0) {
+    const remaining = finite(raw.remaining);
+    const currentValue = finite(raw.currentValue);
+    let usedRaw: number | undefined;
+    if (remaining !== undefined) {
+      const fromRemaining = limit - remaining;
+      usedRaw = currentValue !== undefined ? Math.max(fromRemaining, currentValue) : fromRemaining;
+    } else if (currentValue !== undefined) {
+      usedRaw = currentValue;
+    }
+    if (usedRaw !== undefined) {
+      const used = Math.max(0, Math.min(limit, usedRaw));
+      return clampPercent((used / limit) * 100);
+    }
+  }
+  return clampPercent(finite(raw.percentage) ?? 0);
+}
+
+const WINDOW_LABELS: Record<string, string> = {
+  "session-5h": "Session (5h)",
+  weekly: "Weekly",
+  monthly: "Monthly",
+};
+
+// The TIME_LIMIT entry is z.ai's monthly MCP-tools quota — the dashboard's
+// "Total Monthly Web Search / Reader / Zread Quota". It rides the `monthly`
+// window id (so it reuses calendar-month pacing) but carries this label so the
+// panel shows "MCP" instead of the generic "Monthly" (and so it never collides
+// with a token-based monthly window's "Monthly" label). Matches CodexBar's card.
+export const ZAI_MCP_LABEL = "MCP";
+
+function toWindow(raw: ZaiLimitRaw, id: UsageWindowId, label?: string): UsageWindow {
+  const resetsAt = toEpochMs(raw.nextResetTime);
+  const window: UsageWindow = {
+    id,
+    label: label ?? WINDOW_LABELS[id] ?? id,
+    usedPercent: usedPercentFor(raw),
+  };
+  if (resetsAt !== undefined) window.resetsAt = resetsAt;
+  return window;
+}
+
+/** Map a single token window's duration onto a canonical window id. */
+function tokenWindowId(minutes: number | undefined): UsageWindowId {
+  if (minutes !== undefined && minutes <= 6 * 60) return "session-5h";
+  if (minutes !== undefined && minutes <= 10 * 24 * 60) return "weekly";
+  return "monthly";
+}
+
+// z.ai coding-plan tiers arrive lowercase in `level` ("lite"/"pro"/"max");
+// title-case the known ones for display. The name keys are shown as-is.
+const ZAI_LEVEL_LABELS: Record<string, string> = { lite: "Lite", pro: "Pro", max: "Max" };
+
+function planLabel(data: ZaiQuotaData): string | undefined {
+  for (const candidate of [data.planName, data.plan, data.plan_type, data.packageName]) {
+    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+    if (trimmed) return trimmed;
+  }
+  // Real responses carry the tier in `level` (none of the name keys above).
+  const level = typeof data.level === "string" ? data.level.trim() : "";
+  if (level) return ZAI_LEVEL_LABELS[level.toLowerCase()] ?? level;
+  return undefined;
+}
+
+/**
+ * Pure: map a parsed `data` block (the `data` field of the quota response) to a
+ * `UsageSnapshot`. Two `TOKENS_LIMIT` entries become the shorter window
+ * (`session-5h`) and the longer one (`weekly`); a lone token entry is placed by
+ * its own duration. The `TIME_LIMIT` entry is the monthly MCP-tools quota and
+ * surfaces as a `monthly` window labeled "MCP".
+ */
+export function parseZaiUsage(data: unknown, nowMs: number): UsageSnapshot {
+  const block = (data ?? {}) as ZaiQuotaData;
+  const limits = Array.isArray(block.limits) ? block.limits : [];
+
+  const tokenLimits: { raw: ZaiLimitRaw; minutes: number | undefined }[] = [];
+  let timeLimit: ZaiLimitRaw | undefined;
+  for (const raw of limits) {
+    if (!raw || typeof raw !== "object") continue;
+    if (raw.type === "TOKENS_LIMIT") tokenLimits.push({ raw, minutes: windowMinutes(raw) });
+    else if (raw.type === "TIME_LIMIT") timeLimit = raw;
+  }
+
+  const windows: UsageWindow[] = [];
+  if (tokenLimits.length >= 2) {
+    const sorted = [...tokenLimits].sort(
+      (a, b) => (a.minutes ?? Number.POSITIVE_INFINITY) - (b.minutes ?? Number.POSITIVE_INFINITY),
+    );
+    windows.push(toWindow(sorted[0]!.raw, "session-5h"));
+    windows.push(toWindow(sorted[sorted.length - 1]!.raw, "weekly"));
+  } else if (tokenLimits.length === 1) {
+    windows.push(toWindow(tokenLimits[0]!.raw, tokenWindowId(tokenLimits[0]!.minutes)));
+  }
+  if (timeLimit) windows.push(toWindow(timeLimit, "monthly", ZAI_MCP_LABEL));
+
+  const plan = planLabel(block);
+  const snapshot: UsageSnapshot = {
+    providerId: ZAI_PROVIDER_ID,
+    status: "ok",
+    windows,
+    fetchedAt: nowMs,
+  };
+  if (plan) snapshot.plan = plan;
+  return snapshot;
+}
+
+/** Append the quota path to a host/base URL the way CodexBar's `quotaURL` does. */
+function buildQuotaUrl(value: string): string {
+  const withScheme = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  let url: URL;
+  try {
+    url = new URL(withScheme);
+  } catch {
+    return ZAI_GLOBAL_QUOTA_ENDPOINT;
+  }
+  if (url.pathname === "" || url.pathname === "/") {
+    url.pathname = `/${ZAI_QUOTA_PATH}`;
+  }
+  return url.toString();
+}
+
+/**
+ * Resolve the quota endpoint. A host-side resolver may attach `quotaUrl` (a full
+ * URL override, e.g. a coding-plan endpoint) or `apiHost` (BigModel CN) to the
+ * token's `raw` bag from the `Z_AI_QUOTA_URL` / `Z_AI_API_HOST` environment
+ * overrides; absent those, the global endpoint is used.
+ */
+export function resolveZaiQuotaUrl(token: OAuthToken | undefined): string {
+  const raw = token?.raw as { quotaUrl?: unknown; apiHost?: unknown } | undefined;
+  const quotaUrl = typeof raw?.quotaUrl === "string" ? raw.quotaUrl.trim() : "";
+  if (quotaUrl) return buildQuotaUrl(quotaUrl);
+  const apiHost = typeof raw?.apiHost === "string" ? raw.apiHost.trim() : "";
+  if (apiHost) return buildQuotaUrl(apiHost);
+  return ZAI_GLOBAL_QUOTA_ENDPOINT;
+}
+
+function zaiRequest(http: HttpClient, url: string, apiKey: string): Promise<HttpResponse> {
+  return http.request({
+    method: "GET",
+    url,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: "application/json",
+    },
+    timeoutMs: 15_000,
+  });
+}
+
+function authMissing(now: number, error?: string): UsageSnapshot {
+  return {
+    providerId: ZAI_PROVIDER_ID,
+    status: "auth-missing",
+    windows: [],
+    fetchedAt: now,
+    ...(error ? { error } : {}),
+  };
+}
+
+function errorSnapshot(now: number, error: string): UsageSnapshot {
+  return { providerId: ZAI_PROVIDER_ID, status: "error", windows: [], fetchedAt: now, error };
+}
+
+/**
+ * Collect z.ai GLM Coding Plan usage. Reads the pasted API key first (an explicit
+ * user action), then the host-resolved native key; returns `auth-missing` when
+ * neither is present so the card can prompt for sign-in.
+ */
+export async function collectZai(host: HostPort, _opts?: CollectOptions): Promise<UsageSnapshot> {
+  const now = host.now();
+  const pasted = (await host.credentials.getSecret(ZAI_PROVIDER_ID, "apiKey"))?.trim();
+  const token = await host.credentials.getOAuthToken(ZAI_PROVIDER_ID);
+  const apiKey = pasted || token?.accessToken?.trim();
+  if (!apiKey) return authMissing(now);
+
+  const res = await zaiRequest(host.http, resolveZaiQuotaUrl(token), apiKey);
+  if (res.status === 401 || res.status === 403) {
+    return authMissing(now, `token rejected (${res.status})`);
+  }
+  if (res.status === 429) {
+    return { providerId: ZAI_PROVIDER_ID, status: "rate-limited", windows: [], fetchedAt: now };
+  }
+  if (res.status < 200 || res.status >= 300) {
+    return errorSnapshot(now, `HTTP ${res.status}`);
+  }
+
+  const body = res.body?.trim();
+  if (!body) {
+    // A 200 with an empty body usually means the wrong region/host or a stale token.
+    return errorSnapshot(now, "empty response (check API region or token)");
+  }
+
+  let parsed: ZaiQuotaResponse;
+  try {
+    parsed = JSON.parse(body) as ZaiQuotaResponse;
+  } catch {
+    return errorSnapshot(now, "invalid JSON response");
+  }
+
+  // Some auth failures arrive as HTTP 200 with `success:false`.
+  if (parsed.success === false || (typeof parsed.code === "number" && parsed.code !== 200)) {
+    const msg =
+      typeof parsed.msg === "string" && parsed.msg.trim() ? parsed.msg.trim() : "request failed";
+    if (/auth|token|unauth|forbidden|login|鉴权|登录/i.test(msg)) return authMissing(now, msg);
+    return errorSnapshot(now, msg);
+  }
+  if (!parsed.data) return errorSnapshot(now, "missing data");
+
+  return parseZaiUsage(parsed.data, now);
+}

--- a/packages/agents-usage/src/formatters.test.ts
+++ b/packages/agents-usage/src/formatters.test.ts
@@ -5,8 +5,25 @@ import {
   projectWindowUsage,
   toEpochMs,
   usageTone,
+  usageWindowDisplayLabel,
   windowDurationMs,
 } from "./formatters";
+import type { UsageWindow } from "./types";
+
+describe("usageWindowDisplayLabel", () => {
+  it("uses the canonical label for known window ids", () => {
+    const monthly: UsageWindow = { id: "monthly", label: "Monthly", usedPercent: 0 };
+    expect(usageWindowDisplayLabel(monthly)).toBe("Monthly");
+    expect(usageWindowDisplayLabel({ id: "session-5h", label: "x", usedPercent: 0 })).toBe(
+      "Session (5h)",
+    );
+  });
+
+  it("honors a collector's custom monthly label (e.g. z.ai 'MCP')", () => {
+    const mcp: UsageWindow = { id: "monthly", label: "MCP", usedPercent: 1.6 };
+    expect(usageWindowDisplayLabel(mcp)).toBe("MCP");
+  });
+});
 
 describe("usageTone", () => {
   it("applies normal/warning/danger thresholds", () => {

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -70,5 +70,14 @@ export {
   GEMINI_LOAD_ENDPOINT,
   GEMINI_QUOTA_ENDPOINT,
 } from "./collectors/gemini";
+export {
+  collectZai,
+  parseZaiUsage,
+  resolveZaiQuotaUrl,
+  ZAI_PROVIDER_ID,
+  ZAI_GLOBAL_QUOTA_ENDPOINT,
+  ZAI_BIGMODEL_QUOTA_ENDPOINT,
+} from "./collectors/zai";
+export type { ZaiQuotaResponse } from "./collectors/zai";
 export { antigravityPool, antigravityPoolWindows } from "./collectors/antigravity";
 export type { AntigravityModelQuota } from "./collectors/antigravity";

--- a/packages/agents-usage/src/registry.test.ts
+++ b/packages/agents-usage/src/registry.test.ts
@@ -10,14 +10,14 @@ describe("createUsageCollectorRegistry", () => {
         .descriptors()
         .map((d) => d.id)
         .sort(),
-    ).toEqual(["claude", "codex", "commandcode", "copilot", "cursor", "gemini", "grok"]);
+    ).toEqual(["claude", "codex", "commandcode", "copilot", "cursor", "gemini", "grok", "zai"]);
     expect(reg.has("claude")).toBe(true);
     expect(reg.has("nope")).toBe(false);
   });
 
   it("collectAll returns one snapshot per provider, auth-missing without tokens", async () => {
     const snaps = await createUsageCollectorRegistry().collectAll(undefined, createFakeHost());
-    expect(snaps).toHaveLength(7);
+    expect(snaps).toHaveLength(8);
     expect(snaps.every((s) => s.status === "auth-missing")).toBe(true);
   });
 

--- a/packages/agents-usage/src/registry.ts
+++ b/packages/agents-usage/src/registry.ts
@@ -5,6 +5,7 @@ import { collectCopilot } from "./collectors/copilot";
 import { collectCursor } from "./collectors/cursor";
 import { collectGemini } from "./collectors/gemini";
 import { collectGrok } from "./collectors/grok";
+import { collectZai } from "./collectors/zai";
 import type { CollectOptions, HostPort } from "./host";
 import type { UsageProviderDescriptor, UsageSnapshot } from "./types";
 
@@ -96,6 +97,19 @@ const COMMANDCODE_COLLECTOR: UsageCollector = {
   collect: collectCommandCode,
 };
 
+const ZAI_COLLECTOR: UsageCollector = {
+  descriptor: {
+    id: "zai",
+    label: "z.ai",
+    // HTTP collector reading a Bearer API key — native (`Z_AI_API_KEY`) or a key
+    // pasted into the in-app sign-in. `needsLogin` drives that sign-in affordance.
+    mechanism: "api-key",
+    needsLogin: true,
+    windowIds: ["session-5h", "weekly", "monthly"],
+  },
+  collect: collectZai,
+};
+
 // Antigravity is collected supervisor-side from its local language server
 // (LS-only), not here; see src/supervisor/runtime/antigravityUsageScanner.ts.
 
@@ -107,6 +121,7 @@ const BUILT_IN: UsageCollector[] = [
   GROK_COLLECTOR,
   GEMINI_COLLECTOR,
   COMMANDCODE_COLLECTOR,
+  ZAI_COLLECTOR,
 ];
 
 /** Descriptors for the built-in HTTP collectors, in registration order. */

--- a/packages/agents-usage/src/types.ts
+++ b/packages/agents-usage/src/types.ts
@@ -133,6 +133,7 @@ export const usageMechanismSchema = z.enum([
   "oauth-endpoint",
   "cli-jsonrpc",
   "cookie",
+  "api-key",
   "local-log",
 ]);
 export type UsageMechanism = z.infer<typeof usageMechanismSchema>;

--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -357,6 +357,11 @@ export function createLocalIpcHandlers(
         options.requireLightcodePaths,
         options.getBrowserPanelManager,
       ).clearLogin(payload.providerId),
+    submitUsageApiKey: (payload) =>
+      getUsageLoginManager(
+        options.requireLightcodePaths,
+        options.getBrowserPanelManager,
+      ).submitApiKey(payload.providerId, payload.apiKey),
     resolveUsageLoginConfirmation: (payload) => {
       requireBrowserPanel(options.getBrowserPanelManager).resolveUsageLoginConfirmation(payload);
     },

--- a/src/main/usageLogin/UsageLoginManager.test.ts
+++ b/src/main/usageLogin/UsageLoginManager.test.ts
@@ -144,3 +144,40 @@ describe("UsageLoginManager GitHub device flow", () => {
     expect(hasUsageSecret(cacheDir, "copilot")).toBe(false);
   });
 });
+
+describe("UsageLoginManager API-key flow", () => {
+  it("seals a pasted key and reports it stored", async () => {
+    const manager = newManager(makePanel());
+    await expect(manager.submitApiKey("zai", "  zai-secret  ")).resolves.toEqual({ ok: true });
+    expect(hasUsageSecret(cacheDir, "zai")).toBe(true);
+  });
+
+  it("rejects an empty key without storing anything", async () => {
+    const manager = newManager(makePanel());
+    await expect(manager.submitApiKey("zai", "   ")).resolves.toMatchObject({ ok: false });
+    expect(hasUsageSecret(cacheDir, "zai")).toBe(false);
+  });
+
+  it("rejects submitApiKey for a non-api-key provider", async () => {
+    const manager = newManager(makePanel());
+    await expect(manager.submitApiKey("grok", "x")).resolves.toMatchObject({ ok: false });
+    expect(hasUsageSecret(cacheDir, "grok")).toBe(false);
+  });
+
+  it("startLogin on an api-key provider returns a guard error, no browser step", async () => {
+    const panel = makePanel();
+    const manager = newManager(panel);
+    const result = await manager.startLogin("zai");
+    expect(result.ok).toBe(false);
+    expect(panel.captureLoginCookies).not.toHaveBeenCalled();
+    expect(hasUsageSecret(cacheDir, "zai")).toBe(false);
+  });
+
+  it("clears a stored api-key secret on sign-out", async () => {
+    const manager = newManager(makePanel());
+    await manager.submitApiKey("zai", "zai-secret");
+    expect(hasUsageSecret(cacheDir, "zai")).toBe(true);
+    await expect(manager.clearLogin("zai")).resolves.toEqual({ ok: true });
+    expect(hasUsageSecret(cacheDir, "zai")).toBe(false);
+  });
+});

--- a/src/main/usageLogin/UsageLoginManager.ts
+++ b/src/main/usageLogin/UsageLoginManager.ts
@@ -45,13 +45,24 @@ interface GitHubDeviceLoginConfig {
   scope: string;
 }
 
-type ProviderLoginConfig = CookieLoginConfig | GitHubDeviceLoginConfig;
+/**
+ * The provider authenticates its usage API with a long-lived key the user pastes
+ * in (z.ai). There is no browser/OAuth step — the key is sealed via
+ * {@link submitApiKey} and read back by the collector — but the provider still
+ * lives in `PROVIDER_CONFIGS` so its stored-secret state surfaces like any login.
+ */
+interface ApiKeyLoginConfig {
+  kind: "api-key";
+}
+
+type ProviderLoginConfig = CookieLoginConfig | GitHubDeviceLoginConfig | ApiKeyLoginConfig;
 
 const PROVIDER_LABELS: Record<string, string> = {
   commandcode: "Command Code",
   copilot: "GitHub Copilot",
   grok: "Grok",
   opencode: "OpenCode",
+  zai: "z.ai",
 };
 
 const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
@@ -91,6 +102,10 @@ const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
     // actually authenticates before prompting.
     validateSession: isOpenCodeLoginCookieLive,
   },
+  // z.ai's GLM Coding Plan quota API takes a Bearer API key, not a web cookie.
+  // The user pastes it in (see `submitApiKey`); the env/config key is resolved
+  // host-side instead and needs no entry here.
+  zai: { kind: "api-key" },
 };
 
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
@@ -156,12 +171,35 @@ export class UsageLoginManager {
     return { ok: true };
   }
 
+  /**
+   * Seal a user-pasted API key for an `api-key` provider (z.ai). The stored
+   * secret is the persistent "signed in" signal; the collector validates the key
+   * itself on the next fetch, so a bad key simply re-prompts via `auth-missing`.
+   */
+  submitApiKey(providerId: string, apiKey: string): Promise<UsageLoginResult> {
+    const config = PROVIDER_CONFIGS[providerId];
+    if (config?.kind !== "api-key") {
+      return Promise.resolve({ ok: false, error: `No API-key login for ${providerId}` });
+    }
+    const trimmed = apiKey.trim();
+    if (!trimmed) return Promise.resolve({ ok: false, error: "API key is empty" });
+    setUsageSecret(this.paths.cacheDir, providerId, "apiKey", trimmed);
+    return Promise.resolve({ ok: true });
+  }
+
   startLogin(providerId: string): Promise<UsageLoginResult> {
     const existing = this.inFlight.get(providerId);
     if (existing) return existing;
     const config = PROVIDER_CONFIGS[providerId];
     if (!config) {
       return Promise.resolve({ ok: false, error: `No usage login for ${providerId}` });
+    }
+    if (config.kind === "api-key") {
+      // API-key providers have no browser step; the renderer calls submitApiKey.
+      return Promise.resolve({
+        ok: false,
+        error: `${PROVIDER_LABELS[providerId] ?? providerId} uses a pasted API key`,
+      });
     }
     const panel = this.getBrowserPanel();
     if (!panel) {
@@ -181,6 +219,11 @@ export class UsageLoginManager {
   ): Promise<UsageLoginResult> {
     if (config.kind === "github-device") {
       return this.runGitHubDeviceLogin(providerId, config, panel);
+    }
+    if (config.kind === "api-key") {
+      // Unreachable: startLogin returns before calling runLogin for api-key
+      // providers. Present only to narrow the union to CookieLoginConfig below.
+      throw new Error(`runLogin reached for api-key provider ${providerId}`);
     }
 
     const result = await panel.captureLoginCookies({

--- a/src/renderer/components/providers/index.ts
+++ b/src/renderer/components/providers/index.ts
@@ -26,4 +26,5 @@ export * from "./antigravity";
 export * from "./commandcode";
 export * from "./cursor";
 export * from "./opencode";
+export * from "./zai";
 export * from "./acpGeneric";

--- a/src/renderer/components/providers/usageProviders.test.ts
+++ b/src/renderer/components/providers/usageProviders.test.ts
@@ -60,4 +60,25 @@ describe("usageProviders", () => {
       inner: windows[0],
     });
   });
+
+  it("rings z.ai with the 5h window only when there is no weekly (MCP/monthly stays off the ring)", () => {
+    const windows: UsageWindow[] = [
+      { id: "session-5h", label: "Session (5h)", usedPercent: 0 },
+      { id: "monthly", label: "MCP", usedPercent: 2 },
+    ];
+    const rings = pickUsageRings("zai", windows);
+    expect(rings.outer?.id).toBe("session-5h");
+    expect(rings.inner).toBeUndefined();
+  });
+
+  it("rings z.ai with 5h + weekly when a weekly window is present, never the monthly MCP window", () => {
+    const windows: UsageWindow[] = [
+      { id: "session-5h", label: "Session (5h)", usedPercent: 25 },
+      { id: "weekly", label: "Weekly", usedPercent: 9 },
+      { id: "monthly", label: "MCP", usedPercent: 22 },
+    ];
+    const rings = pickUsageRings("zai", windows);
+    expect(rings.outer?.id).toBe("session-5h");
+    expect(rings.inner?.id).toBe("weekly");
+  });
 });

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -19,6 +19,8 @@ export type UsageProvider = {
   label: string;
   /** Offers an in-app browser login (web-session cookie or OAuth device flow). */
   supportsBrowserLogin?: boolean;
+  /** Offers an in-app API-key paste sign-in (no browser step, e.g. z.ai). */
+  supportsApiKeyLogin?: boolean;
   /**
    * All windows reset on one shared clock, so the UI shows a single reset
    * countdown in the header instead of one per window (e.g. Cursor).
@@ -48,6 +50,14 @@ const RENDERER_META: Record<string, Omit<UsageProvider, "id" | "label">> = {
   cursor: { sharedWindowReset: true, rings: { outer: ["cursor-auto"], inner: ["cursor-api"] } },
   grok: { supportsBrowserLogin: true },
   opencode: { supportsBrowserLogin: true },
+  // z.ai authenticates with a pasted API key, not a browser session.
+  // The ring tracks token rate-limits only: the 5h window plus the weekly window
+  // when the plan returns one. The monthly MCP-tools quota is a different kind of
+  // limit, so it's deliberately omitted from the ring (it still shows as a card bar).
+  zai: {
+    supportsApiKeyLogin: true,
+    rings: { outer: ["session-5h"], inner: ["weekly"] },
+  },
 };
 
 const STATIC_USAGE_PROVIDERS: ReadonlyArray<UsageProvider> = allUsageProviderDescriptors().map(
@@ -101,6 +111,11 @@ export function usageProvidersForAgentInstances(
 /** Providers that expose the browser-overlay login (cookie or device flow). */
 export function supportsBrowserLogin(providerId: string): boolean {
   return rendererMeta(providerId)?.supportsBrowserLogin === true;
+}
+
+/** Providers that sign in by pasting an API key (no browser step, e.g. z.ai). */
+export function supportsApiKeyLogin(providerId: string): boolean {
+  return rendererMeta(providerId)?.supportsApiKeyLogin === true;
 }
 
 /** Providers whose windows share one reset clock (one header countdown, no per-window resets). */

--- a/src/renderer/components/providers/zai/ZaiIcon.tsx
+++ b/src/renderer/components/providers/zai/ZaiIcon.tsx
@@ -1,0 +1,17 @@
+import { createProviderIcon } from "../common/createProviderIcon";
+
+// The z.ai brand "Z": the angled top/bottom bars plus the parallelogram diagonal,
+// lifted verbatim from the official mark (z-cdn.chatglm.cn/z-ai/static/logo.svg,
+// viewBox 0 0 30 30) and merged into one compound path — dropping the rounded
+// container and gradients so the glyph tints with the provider status tone like
+// every other provider icon.
+const ZAI_PATH =
+  "M15.47,7.1l-1.3,1.85c-0.2,0.29-0.54,0.47-0.9,0.47h-7.1V7.09C6.16,7.1,15.47,7.1,15.47,7.1z" +
+  "M24.3,7.1L13.14,22.91L5.7,22.91L16.86,7.1z" +
+  "M14.53,22.91l1.31-1.86c0.2-0.29,0.54-0.47,0.9-0.47h7.09v2.33H14.53z";
+
+export const ZaiIcon = createProviderIcon({
+  cssPrefix: "lightcode-zai-icon",
+  path: ZAI_PATH,
+  viewBox: "0 0 30 30",
+});

--- a/src/renderer/components/providers/zai/index.tsx
+++ b/src/renderer/components/providers/zai/index.tsx
@@ -1,0 +1,9 @@
+export * from "./ZaiIcon";
+
+import { ZaiIcon } from "./ZaiIcon";
+import { registerProviderIcon } from "../ProviderIcon";
+
+// z.ai is a usage-only provider (no chat runtime), so it registers just its icon
+// for the usage card — deliberately NOT a provider label, which would list it as
+// a supported chat agent in the discovery screen.
+registerProviderIcon("zai", ZaiIcon);

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -249,6 +249,10 @@ msgstr "vor {hours} Std."
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# Agent bereit} other {# Agenten bereit}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} API-Schlüssel"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label}-Nutzung – Nutzungsbereich öffnen"
@@ -3832,6 +3836,10 @@ msgstr "Fügen Sie hier <0>{0}</0> ein. Zum Kopieren klicken."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "In Eingabefeld einfügen"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "{label} API-Schlüssel einfügen"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -248,6 +248,10 @@ msgstr "{hours}h ago"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} API key"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label} usage — open usage panel"
@@ -3799,6 +3803,10 @@ msgstr "Paste <0>{0}</0> here. Click to copy."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Paste in input"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Paste {label} API key"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -249,6 +249,10 @@ msgstr "hace {hours}h"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# agente listo} other {# agentes listos}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "Clave API de {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Uso de {label} — abrir panel de uso"
@@ -3826,6 +3830,10 @@ msgstr "Pega <0>{0}</0> aquí. Haz clic para copiar."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Pegar en la entrada"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Pega la clave API de {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -249,6 +249,10 @@ msgstr "il y a {hours} h"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# agent prêt} other {# agents prêts}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "Clé API {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Utilisation de {label} — ouvrir le panneau d'utilisation"
@@ -3835,6 +3839,10 @@ msgstr "Collez <0>{0}</0> ici. Cliquez pour copier."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Coller en entrée"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Collez la clé API {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -249,6 +249,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {#エージェントの準備ができています} other "
 "{#エージェントの準備ができています}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} APIキー"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label}使用量 — 使用量パネルを開く"
@@ -3767,6 +3771,10 @@ msgstr "<0>{0}</0> をここに貼り付けます。クリックしてコピー�
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "入力に貼り付けます"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "{label} APIキーを貼り付け"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -248,6 +248,10 @@ msgstr "{hours}시간 전"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# 에이전트 준비됨} other {# 에이전트 준비됨}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} API 키"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label} 사용량 — 사용량 패널 열기"
@@ -3768,6 +3772,10 @@ msgstr "여기에 <0>{0}</0>을 붙여넣으세요. 복사하려면 클릭하세
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "입력에 붙여넣기"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "{label} API 키 붙여넣기"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -251,6 +251,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# agent gotowy} few {# agenci gotowi} "
 "many {# agentów gotowych} other {# agenta gotowego}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "Klucz API {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label} – użycie — otwórz panel użycia"
@@ -3823,6 +3827,10 @@ msgstr "Wklej tutaj <0>{0}</0>. Kliknij, aby skopiować."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Wklej do pola"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Wklej klucz API {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -250,6 +250,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# agente pronto} other {# agentes "
 "prontos}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "Chave de API do {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Uso de {label} — abrir o painel de uso"
@@ -3826,6 +3830,10 @@ msgstr "Cole <0>{0}</0> aqui. Clique para copiar."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Colar na entrada"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Cole a chave de API do {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -250,6 +250,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# агент готов} few {# агента готовы} many "
 "{# агентов готовы} other {# агента готовы}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "API-ключ {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Использование {label} — открыть панель использования"
@@ -3823,6 +3827,10 @@ msgstr "Вставьте <0>{0}</0> сюда. Нажмите, чтобы ско�
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Вставить в поле ввода"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Вставьте API-ключ {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -249,6 +249,10 @@ msgstr "{hours} saat önce"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# aracı hazır} other {# aracı hazır}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} API anahtarı"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label} kullanımı — kullanım panelini aç"
@@ -3820,6 +3824,10 @@ msgstr "<0>{0}</0> öğesini buraya yapıştırın. Kopyalamak için tıklayın.
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Girişe yapıştır"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "{label} API anahtarını yapıştır"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -250,6 +250,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# агент готовий} few {# агенти готові} "
 "many {# агентів готові} other {# агента готові}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "API-ключ {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Використання {label} — відкрити панель використання"
@@ -3822,6 +3826,10 @@ msgstr "Вставте <0>{0}</0> сюди. Натисніть, щоб скоп�
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Вставити в поле введення"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Вставте API-ключ {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -250,6 +250,10 @@ msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# tác nhân đã sẵn sàng} other {# tác nhân "
 "đã sẵn sàng}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "Khóa API {label}"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "Mức sử dụng {label} — mở bảng sử dụng"
@@ -3815,6 +3819,10 @@ msgstr "Dán <0>{0}</0> vào đây. Nhấn vào đây để sao chép."
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "Dán vào đầu vào"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "Dán khóa API {label}"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -247,6 +247,10 @@ msgstr "{hours}小时前"
 msgid "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 msgstr "{installedCount, plural, one {# 个代理准备就绪} other {# 个代理准备就绪}}"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "{label} API key"
+msgstr "{label} API 密钥"
+
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "{label} usage — open usage panel"
 msgstr "{label}用法 — 打开用法面板"
@@ -3759,6 +3763,10 @@ msgstr "将 <0>{0}</0> 粘贴到此处。点击复制。"
 #: src/renderer/components/terminal/XTermSurface.tsx
 msgid "Paste in input"
 msgstr "粘贴到输入中"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+msgid "Paste {label} API key"
+msgstr "粘贴 {label} API 密钥"
 
 #: src/renderer/components/thread/ThreadGoalDock.tsx
 msgid "Paused"

--- a/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { ChevronDown, ChevronRight, GripVertical, LogOut } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -15,6 +15,7 @@ import {
 } from "@/renderer/components/providers/usageFormat";
 import { usageToneColor } from "@/renderer/components/providers/usageTone";
 import {
+  supportsApiKeyLogin,
   supportsBrowserLogin,
   usesSharedWindowReset,
 } from "@/renderer/components/providers/usageProviders";
@@ -72,7 +73,9 @@ export function UsageProviderCard(props: {
   const hasStoredSession = useHasStoredSession(id);
   const [signingIn, setSigningIn] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
-  const supportsLogin = supportsBrowserLogin(id);
+  const [apiKey, setApiKey] = useState("");
+  const isApiKeyLogin = supportsApiKeyLogin(id);
+  const supportsLogin = supportsBrowserLogin(id) || isApiKeyLogin;
   // A stored session that the latest fetch reports as rejected (expired cookie)
   // still warrants a "Sign in" to re-auth; an unauthenticated provider always does.
   // But never prompt sign-in once a fetch succeeds ("ok"): a provider authenticated
@@ -123,6 +126,25 @@ export function UsageProviderCard(props: {
       if (fresh) useProviderUsageStore.getState().mergeSnapshot(fresh);
     } finally {
       unsubscribe();
+      setSigningIn(false);
+    }
+  };
+  const handleSubmitApiKey = async (event: FormEvent) => {
+    event.preventDefault();
+    const key = apiKey.trim();
+    if (!key || signingIn) return;
+    setSigningIn(true);
+    try {
+      const outcome = await readBridge().submitUsageApiKey({ providerId: id, apiKey: key });
+      if (!outcome.ok) return;
+      setApiKey("");
+      // Mark stored immediately so the card reads as signed in regardless of
+      // whether the usage fetch below yields displayable windows.
+      useUsageLoginStateStore.getState().setStored(id, true);
+      const usage = await readBridge().refreshProviderUsage({ providerIds: [id] });
+      const fresh = usage.snapshots.find((s) => s.providerId === id);
+      if (fresh) useProviderUsageStore.getState().mergeSnapshot(fresh);
+    } finally {
       setSigningIn(false);
     }
   };
@@ -250,7 +272,30 @@ export function UsageProviderCard(props: {
           ) : (
             <div className="space-y-2">
               <p className="text-xs text-muted">{usageStatusText(snapshot, label)}</p>
-              {canSignIn ? (
+              {canSignIn && isApiKeyLogin ? (
+                <form
+                  onSubmit={(e) => void handleSubmitApiKey(e)}
+                  className="flex items-center gap-1.5"
+                >
+                  <input
+                    type="password"
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    placeholder={t`Paste ${label} API key`}
+                    aria-label={t`${label} API key`}
+                    autoComplete="off"
+                    spellCheck={false}
+                    className="min-w-0 flex-1 rounded-lg border border-[color:var(--separator)] bg-background px-2 py-1 text-xs text-foreground outline-none focus-visible:focus-ring"
+                  />
+                  <button
+                    type="submit"
+                    disabled={signingIn || apiKey.trim().length === 0}
+                    className="shrink-0 rounded-lg border border-[color:var(--separator)] bg-surface px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted/10 disabled:opacity-50"
+                  >
+                    {signingIn ? <Trans>Signing in…</Trans> : <Trans>Sign in</Trans>}
+                  </button>
+                </form>
+              ) : canSignIn ? (
                 <button
                   type="button"
                   onClick={() => void handleSignIn()}

--- a/src/shared/contracts/usage.ts
+++ b/src/shared/contracts/usage.ts
@@ -43,6 +43,14 @@ export const usageLoginPayloadSchema = z.object({
 });
 export type UsageLoginPayload = z.infer<typeof usageLoginPayloadSchema>;
 
+export const usageApiKeyPayloadSchema = z.object({
+  /** Provider whose pasted API key is being stored (e.g. "zai"). */
+  providerId: z.string(),
+  /** The API key the user pasted into the in-app sign-in. */
+  apiKey: z.string().min(1),
+});
+export type UsageApiKeyPayload = z.infer<typeof usageApiKeyPayloadSchema>;
+
 export interface UsageLoginResult {
   ok: boolean;
   /** True when the user closed the login window before completing. */

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -114,6 +114,7 @@ export const MAIN_LOCAL_PROCEDURE_NAMES = [
   "startUsageLogin",
   "cancelUsageLogin",
   "clearUsageLogin",
+  "submitUsageApiKey",
   "resolveUsageLoginConfirmation",
   "getUsageLoginState",
   "getProfileCoreStats",

--- a/src/shared/ipc/procedures/usage.ts
+++ b/src/shared/ipc/procedures/usage.ts
@@ -1,10 +1,12 @@
 import {
   providerUsagePayloadSchema,
+  usageApiKeyPayloadSchema,
   usageLoginConfirmationPayloadSchema,
   usageLoginPayloadSchema,
   usageLoginStatePayloadSchema,
   type ProviderUsagePayload,
   type ProviderUsageResponse,
+  type UsageApiKeyPayload,
   type UsageLoginConfirmationPayload,
   type UsageLoginPayload,
   type UsageLoginResult,
@@ -29,6 +31,11 @@ export const usageProcedures = {
     "clearUsageLogin",
     "main-local",
     usageLoginPayloadSchema,
+  ),
+  submitUsageApiKey: definePayloadProcedure<UsageApiKeyPayload, UsageLoginResult, "main-local">(
+    "submitUsageApiKey",
+    "main-local",
+    usageApiKeyPayloadSchema,
   ),
   resolveUsageLoginConfirmation: definePayloadProcedure<
     UsageLoginConfirmationPayload,

--- a/src/supervisor/runtime/usageCredentials.ts
+++ b/src/supervisor/runtime/usageCredentials.ts
@@ -6,6 +6,7 @@ import { resolveCopilotToken } from "./copilotCredentials";
 import { resolveCursorToken } from "./cursorCredentials";
 import { resolveGeminiToken } from "./geminiCredentials";
 import { resolveGrokToken } from "./grokCredentials";
+import { resolveZaiToken } from "./zaiCredentials";
 
 /**
  * Assembles the native (host) credential store consumed by the usage HostPort
@@ -34,6 +35,8 @@ export function createNativeCredentialStore(cacheDir?: string): CredentialStore 
           return resolveGrokToken();
         case "gemini":
           return resolveGeminiToken();
+        case "zai":
+          return resolveZaiToken();
         default:
           return undefined;
       }

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -80,6 +80,7 @@ describe("UsageService", () => {
       "gemini",
       "grok",
       "opencode",
+      "zai",
     ]);
 
     const claude = result.snapshots.find((s) => s.providerId === "claude");
@@ -90,7 +91,7 @@ describe("UsageService", () => {
 
     const perProvider = events.filter((e) => e.type === "provider-usage");
     const terminal = events.filter((e) => e.type === "provider-usage-all");
-    expect(perProvider).toHaveLength(9);
+    expect(perProvider).toHaveLength(10);
     expect(terminal).toHaveLength(1);
   });
 

--- a/src/supervisor/runtime/zaiCredentials.test.ts
+++ b/src/supervisor/runtime/zaiCredentials.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { parseZaiEnv } from "./zaiCredentials";
+
+describe("parseZaiEnv", () => {
+  it("returns undefined when no API key is set", () => {
+    expect(parseZaiEnv({})).toBeUndefined();
+    expect(parseZaiEnv({ Z_AI_API_HOST: "open.bigmodel.cn" })).toBeUndefined();
+  });
+
+  it("reads the API key and strips wrapping quotes/whitespace", () => {
+    expect(parseZaiEnv({ Z_AI_API_KEY: '  "zai-key"  ' })).toEqual({ accessToken: "zai-key" });
+  });
+
+  it("carries host overrides on raw without polluting it when absent", () => {
+    expect(parseZaiEnv({ Z_AI_API_KEY: "k" })).toEqual({ accessToken: "k" });
+    expect(parseZaiEnv({ Z_AI_API_KEY: "k", Z_AI_API_HOST: "open.bigmodel.cn" })).toEqual({
+      accessToken: "k",
+      raw: { apiHost: "open.bigmodel.cn" },
+    });
+    expect(parseZaiEnv({ Z_AI_API_KEY: "k", Z_AI_QUOTA_URL: "https://example.com/q" })).toEqual({
+      accessToken: "k",
+      raw: { quotaUrl: "https://example.com/q" },
+    });
+  });
+});

--- a/src/supervisor/runtime/zaiCredentials.ts
+++ b/src/supervisor/runtime/zaiCredentials.ts
@@ -1,0 +1,43 @@
+import type { OAuthToken } from "@lightcode/agents-usage";
+
+/**
+ * z.ai / Zhipu GLM Coding Plan credential resolution from the environment,
+ * mirroring CodexBar: the API key comes from `Z_AI_API_KEY`, with optional host
+ * overrides via `Z_AI_API_HOST` (e.g. BigModel CN) or `Z_AI_QUOTA_URL` (a full
+ * quota-endpoint override). Carried on the token's `raw` bag so the pure
+ * collector can resolve the endpoint without touching `process.env`. Users who
+ * have no env key instead paste one into the in-app sign-in. Secrets never log.
+ */
+
+export const ZAI_API_KEY_ENV = "Z_AI_API_KEY";
+export const ZAI_API_HOST_ENV = "Z_AI_API_HOST";
+export const ZAI_QUOTA_URL_ENV = "Z_AI_QUOTA_URL";
+
+/** Trim surrounding whitespace and a single layer of wrapping quotes. */
+function cleaned(raw: string | undefined): string | undefined {
+  let value = raw?.trim();
+  if (!value) return undefined;
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1).trim();
+  }
+  return value || undefined;
+}
+
+/** Pure: build the z.ai usage token from an environment bag (testable). */
+export function parseZaiEnv(env: Record<string, string | undefined>): OAuthToken | undefined {
+  const accessToken = cleaned(env[ZAI_API_KEY_ENV]);
+  if (!accessToken) return undefined;
+  const quotaUrl = cleaned(env[ZAI_QUOTA_URL_ENV]);
+  const apiHost = cleaned(env[ZAI_API_HOST_ENV]);
+  const raw: Record<string, unknown> = {};
+  if (quotaUrl) raw.quotaUrl = quotaUrl;
+  if (apiHost) raw.apiHost = apiHost;
+  return Object.keys(raw).length > 0 ? { accessToken, raw } : { accessToken };
+}
+
+export function resolveZaiToken(): Promise<OAuthToken | undefined> {
+  return Promise.resolve(parseZaiEnv(process.env));
+}


### PR DESCRIPTION
**Type:** Feature

- Add Z.ai (Zhipu GLM Coding Plan) as a usage-only provider so users can monitor coding-plan quota inside Lightcode
- Introduce API-key sign-in for usage providers: paste a key in the Usage panel, seal it via main-process login, and expose it through new IPC/contracts
- Collect session, weekly, and monthly windows from Z.ai quota endpoints, with env-based credential fallback (`Z_AI_API_KEY`) for existing CLI setups
- Register the provider in the usage collector registry and supervisor credential pipeline, including usage-ring UI rules for the 5h window
- Localize new API-key UI strings across all supported locale catalogs