### PR TITLE
Show project-relative paths in chat file rows

### DIFF
--- a/src/renderer/components/common/PathDisplay.tsx
+++ b/src/renderer/components/common/PathDisplay.tsx
@@ -10,6 +10,9 @@ interface PathDisplayProps {
   /** Inline content rendered between the basename and the muted directory,
    *  e.g. status badges that should follow the filename. */
   trailing?: ReactNode;
+  /** Overrides the hover tooltip (defaults to `path`). Lets callers show the
+   *  full path while the visible text is shortened/relativized. */
+  title?: string;
 }
 
 /**
@@ -24,6 +27,7 @@ export function PathDisplay({
   basenameClassName = "text-foreground",
   dirClassName = "text-muted/60",
   trailing,
+  title,
 }: PathDisplayProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const fixedRef = useRef<HTMLSpanElement>(null);
@@ -74,7 +78,7 @@ export function PathDisplay({
     <span
       ref={containerRef}
       className={`flex min-w-0 items-center whitespace-nowrap overflow-hidden ${className ?? ""}`}
-      title={path}
+      title={title ?? path}
     >
       <span ref={fixedRef} className="flex shrink-0 items-center">
         <span className={basenameClassName}>{basename}</span>

--- a/src/renderer/components/thread/ChatPane/chatPathUtils.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPathUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeChatProjectPath } from "./chatPathUtils";
+import { normalizeChatProjectPath, toProjectRelativeDisplayPath } from "./chatPathUtils";
 
 describe("normalizeChatProjectPath", () => {
   it("normalizes Windows project-absolute paths to project-relative paths", () => {
@@ -70,5 +70,72 @@ describe("normalizeChatProjectPath", () => {
         },
       ),
     ).toBe("src/supervisor/agents/acp/session.ts:945");
+  });
+});
+
+describe("toProjectRelativeDisplayPath", () => {
+  it("relativizes a Windows worktree-absolute path to a project-relative path", () => {
+    expect(
+      toProjectRelativeDisplayPath(
+        "C:\\Users\\me\\.lightcode\\worktrees\\repo-abc\\src\\renderer\\App.tsx",
+        { kind: "windows", path: "C:\\Users\\me\\.lightcode\\worktrees\\repo-abc" },
+      ),
+    ).toBe("src/renderer/App.tsx");
+  });
+
+  it("relativizes a POSIX project-absolute path", () => {
+    expect(
+      toProjectRelativeDisplayPath("/home/me/repo/packages/agents-usage/src/types.ts", {
+        kind: "posix",
+        path: "/home/me/repo",
+      }),
+    ).toBe("packages/agents-usage/src/types.ts");
+  });
+
+  it("relativizes WSL Linux and UNC paths", () => {
+    const location = {
+      kind: "wsl" as const,
+      distro: "Ubuntu",
+      linuxPath: "/home/me/repo",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\me\\repo",
+    };
+    expect(toProjectRelativeDisplayPath("/home/me/repo/src/main.ts", location)).toBe("src/main.ts");
+    expect(
+      toProjectRelativeDisplayPath("\\\\wsl$\\Ubuntu\\home\\me\\repo\\src\\main.ts", location),
+    ).toBe("src/main.ts");
+  });
+
+  it("keeps out-of-root Windows paths absolute with their original separators", () => {
+    const outside = "C:\\Users\\me\\other-project\\notes.md";
+    expect(
+      toProjectRelativeDisplayPath(outside, {
+        kind: "windows",
+        path: "C:\\Users\\me\\.lightcode\\worktrees\\repo-abc",
+      }),
+    ).toBe(outside);
+  });
+
+  it("keeps out-of-root POSIX paths absolute", () => {
+    expect(
+      toProjectRelativeDisplayPath("/etc/hosts", { kind: "posix", path: "/home/me/repo" }),
+    ).toBe("/etc/hosts");
+  });
+
+  it("passes already-relative paths through unchanged", () => {
+    expect(
+      toProjectRelativeDisplayPath("src/renderer/App.tsx", {
+        kind: "windows",
+        path: "C:\\Users\\me\\repo",
+      }),
+    ).toBe("src/renderer/App.tsx");
+  });
+
+  it('renders the working dir itself as "."', () => {
+    expect(
+      toProjectRelativeDisplayPath("C:\\Users\\me\\repo", {
+        kind: "windows",
+        path: "C:\\Users\\me\\repo",
+      }),
+    ).toBe(".");
   });
 });

--- a/src/renderer/components/thread/ChatPane/chatPathUtils.ts
+++ b/src/renderer/components/thread/ChatPane/chatPathUtils.ts
@@ -24,13 +24,39 @@ function normalizeChatPath(raw: string, options: { preserveAbsolute: boolean }):
 }
 
 export function normalizeChatProjectPath(raw: string, projectLocation: ProjectLocation): string {
+  const { normalized, relative } = relativizeAgainstProjectRoots(raw, projectLocation);
+  return relative ?? normalized;
+}
+
+/**
+ * Display helper for chat tool-call rows: render a path relative to the agent's
+ * working directory (the project / worktree root) when it lives inside it, and
+ * the original absolute path otherwise. Unlike {@link normalizeChatProjectPath},
+ * out-of-root paths are returned untouched (original separators preserved) so an
+ * external file still reads as a plain `C:\…` / `/…` absolute path.
+ */
+export function toProjectRelativeDisplayPath(
+  raw: string,
+  projectLocation: ProjectLocation,
+): string {
+  const { relative } = relativizeAgainstProjectRoots(raw, projectLocation);
+  if (relative === null) return raw;
+  // A path that *is* the root (e.g. an action targeting the working dir itself)
+  // collapses to an empty remainder — show "." so the row never renders blank.
+  return relative.length > 0 ? relative : ".";
+}
+
+function relativizeAgainstProjectRoots(
+  raw: string,
+  projectLocation: ProjectLocation,
+): { normalized: string; relative: string | null } {
   const normalized = normalizeChatPath(raw, { preserveAbsolute: true });
   const projectRoots = getProjectRoots(projectLocation).map((root) =>
     normalizeChatPath(root, { preserveAbsolute: true }),
   );
   const root = projectRoots.find((candidate) => pathStartsWithRoot(normalized, candidate));
-  if (!root) return normalized;
-  return normalized.slice(root.length).replace(/^\/+/, "");
+  if (!root) return { normalized, relative: null };
+  return { normalized, relative: normalized.slice(root.length).replace(/^\/+/, "") };
 }
 
 function getProjectRoots(projectLocation: ProjectLocation): string[] {

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatFilePath.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatFilePath.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps } from "react";
+import { PathDisplay } from "@/renderer/components/common";
+import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { toProjectRelativeDisplayPath } from "../../chatPathUtils";
+
+type ChatFilePathProps = Omit<ComponentProps<typeof PathDisplay>, "title">;
+
+/**
+ * `PathDisplay` for chat tool-call / file-change rows. Renders the path relative
+ * to the agent's working directory (the project / worktree root) when it sits
+ * inside it, and the absolute path otherwise — so files in the current project
+ * read as `src/foo/bar.ts` instead of the full
+ * `C:\Users\…\worktree\src\foo\bar.ts`. The absolute path stays available as the
+ * hover tooltip.
+ *
+ * The relativization is purely cosmetic: callers keep handing it the absolute
+ * `path` from the tool payload, which the rest of the row still uses for disk
+ * reads, diffs, and language detection.
+ */
+export function ChatFilePath({ path, ...rest }: ChatFilePathProps) {
+  const projectLocation = useChatPaneActions()?.projectLocation;
+  const displayPath = projectLocation ? toProjectRelativeDisplayPath(path, projectLocation) : path;
+  return <PathDisplay {...rest} path={displayPath} title={path} />;
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
@@ -1,7 +1,7 @@
 import { Disclosure, Tooltip } from "@heroui/react";
 import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
-import { PathDisplay } from "@/renderer/components/common";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { ChatFilePath } from "./ChatFilePath";
 
 export interface ChatItemAccordionProps {
   /** Leading icon (sized 12px to match the command row icon). */
@@ -96,7 +96,7 @@ export function ChatItemAccordion({
     <code className={`${codeClass} flex items-baseline overflow-hidden`}>
       <span className="shrink-0 whitespace-pre">{titleParts.prefix}</span>
       {titleParts.filePath ? (
-        <PathDisplay
+        <ChatFilePath
           className="flex-1"
           path={titleParts.path}
           basenameClassName="!text-[color:var(--foreground)]"

--- a/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
@@ -4,12 +4,12 @@ import { useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { CircleAlert, FileEdit } from "lucide-react";
 import type { FileChangePayload } from "@/shared/contracts";
-import { PathDisplay } from "@/renderer/components/common";
 import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { ChatFilePath } from "./ChatFilePath";
 import { ChatItemAccordion } from "./ChatItemAccordion";
 import { CommandOutputViewport } from "./CommandOutputViewport";
 import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
@@ -92,7 +92,7 @@ export const FileChange = memo(function FileChange({ item }: FileChangeProps) {
     <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
       <span className="shrink-0 !text-[color:var(--muted)]">{kindLabel}</span>
       {hasPath ? (
-        <PathDisplay
+        <ChatFilePath
           className="flex-1"
           path={payload.path}
           basenameClassName="!text-[color:var(--foreground)]"

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
@@ -5,7 +5,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { Bot, ChevronDown, ChevronRight, CircleAlert, type LucideIcon } from "lucide-react";
 import type { ToolCallPayload, WorkflowRun } from "@/shared/contracts";
-import { PathDisplay, PixelLoader } from "@/renderer/components/common";
+import { PixelLoader } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
 import {
   getRuntimeItemPayload,
@@ -16,6 +16,7 @@ import { formatTokenCount } from "@/renderer/components/thread/formatTokenCount"
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { getChildItemIdsStoreSelector } from "../../chatPaneSelectors";
 import { extractAcpResultPart } from "./acpToolPayload";
+import { ChatFilePath } from "./ChatFilePath";
 import { ItemMarkdown } from "./ItemMarkdown";
 import { SubAgentProgressMeta, hasSubAgentProgressMeta } from "./subAgentProgressMeta";
 import { deriveToolDisplay, isWorkflowTool } from "./toolDisplay";
@@ -99,7 +100,7 @@ export const SubAgentToolCall = memo(function SubAgentToolCall({
           <code className="flex min-w-0 flex-1 items-baseline overflow-hidden font-mono text-[color:var(--muted)]">
             <span className="shrink-0 whitespace-pre">{display.parts.prefix}</span>
             {display.parts.filePath ? (
-              <PathDisplay
+              <ChatFilePath
                 className="flex-1"
                 path={display.parts.path}
                 basenameClassName="!text-[color:var(--foreground)]"

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -21,13 +21,14 @@ import type {
   ToolCallPayload,
   WebSearchPayload,
 } from "@/shared/contracts";
-import { PathDisplay, PixelLoader } from "@/renderer/components/common";
+import { PixelLoader } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
 import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { ChatFilePath } from "./ChatFilePath";
 import { CommandOutputViewport } from "./CommandOutputViewport";
 import { iconForCommandIntent } from "./CommandExecution";
 import { isContextCompactionToolCall } from "./ContextCompaction";
@@ -191,7 +192,7 @@ function SameFileEditGroupTitle({ summary }: { summary: SameFileEditGroupSummary
         <code className="font-mono tabular-nums !text-[color:var(--muted)]">{label}</code>
       </span>
       <code className="flex min-w-0 flex-1 font-mono !text-[color:var(--muted)]">
-        <PathDisplay
+        <ChatFilePath
           className="flex-1"
           path={summary.path}
           basenameClassName="!text-[color:var(--foreground)]"
@@ -333,7 +334,7 @@ function InlineRowTitle({
         {titleParts.filePath ? (
           <>
             <span className="sr-only">{titleParts.path}</span>
-            <PathDisplay
+            <ChatFilePath
               className="flex-1"
               path={titleParts.path}
               basenameClassName="!text-[color:var(--foreground)]"


### PR DESCRIPTION
- Chat tool-call and file-change rows now show paths relative to the project/worktree root (e.g. `src/foo/bar.ts`) instead of long absolute worktree paths, so in-project files are easier to scan.
- Adds `toProjectRelativeDisplayPath` and shared relativization logic for Windows, POSIX, and WSL paths; out-of-project paths stay absolute, and the working directory itself renders as `.`.
- Introduces `ChatFilePath` to apply display relativization while keeping the original absolute path for tool payloads, diffs, and hover tooltips.
- Extends `PathDisplay` with an optional `title` override so shortened visible paths can still expose the full path on hover.
- Wires `ChatFilePath` through chat accordions, file changes, sub-agent tool calls, and tool-call groups for consistent path presentation.