### PR TITLE
Recognize head file views in command summaries

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
@@ -160,6 +160,57 @@ describe("humanIntentTitle", () => {
     expect(commandIntentDisplay(full).kind).toBe("view");
   });
 
+  it("describes cat piped through head as viewed lines", () => {
+    const full = `cat package.json 2>/dev/null | head -100`;
+    expect(humanIntentTitle(full)).toBe("View 1:100: package.json");
+    expect(commandIntentDisplay(full).kind).toBe("view");
+    expect(commandIntentDisplay(full).parts).toEqual({
+      prefix: "View 1:100: ",
+      path: "package.json",
+    });
+  });
+
+  it("describes cat piped through head inside an && chain", () => {
+    const full = `cd /home/me/proj && echo "=== ROOT ===" && ls -la && echo "=== package.json ===" && cat package.json 2>/dev/null | head -100`;
+    const display = commandIntentDisplay(full);
+    expect(display.title).toBe("View 1:100: package.json");
+    expect(display.kind).toBe("view");
+  });
+
+  it("describes head -n N file as viewed lines", () => {
+    expect(humanIntentTitle("head -n 40 src/supervisor/runtime.ts")).toBe(
+      "View 1:40: src/supervisor/runtime.ts",
+    );
+    expect(commandIntentDisplay("head -40 src/supervisor/runtime.ts").kind).toBe("view");
+  });
+
+  it("defaults a bare head to its 10-line window", () => {
+    expect(humanIntentTitle("cat src/foo.ts | head")).toBe("View 1:10: src/foo.ts");
+  });
+
+  it("describes head with the file operand before the count flag", () => {
+    expect(humanIntentTitle("head src/foo.ts -n 40")).toBe("View 1:40: src/foo.ts");
+    expect(humanIntentTitle("head src/foo.ts -40")).toBe("View 1:40: src/foo.ts");
+  });
+
+  it("skips shell redirections when locating the head file operand", () => {
+    expect(humanIntentTitle("head 2>/dev/null -100 package.json")).toBe("View 1:100: package.json");
+  });
+
+  it("keeps grep piped through head as a search, not a view", () => {
+    expect(commandIntentDisplay('grep -n "foo" src/foo.ts | head -20').kind).toBe("search");
+  });
+
+  it("does not treat a filtered pipeline before head as a file view", () => {
+    expect(commandIntentDisplay("cat foo | grep x | head -20").kind).not.toBe("view");
+    expect(commandIntentDisplay("cat a | nl | grep x | head -20").kind).not.toBe("view");
+  });
+
+  it("does not treat head byte windows as line views", () => {
+    expect(commandIntentDisplay("cat src/foo.ts | head -c 200").kind).toBe("command");
+    expect(commandIntentDisplay("head -c-200 src/foo.ts").kind).toBe("command");
+  });
+
   it("describes numbered file output piped through sed as viewed lines", () => {
     const full = `nl -ba src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts | sed -n '1,260p'`;
     const display = commandIntentDisplay(full);

--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
@@ -189,6 +189,16 @@ function intentFromSummarizedCommand(t: string): CommandIntentDisplay | null {
     };
   }
 
+  const headFileView = parseHeadFileView(trimmed);
+  if (headFileView) {
+    const prefix = viewPrefix(headFileView.lines);
+    return {
+      title: `${prefix}${headFileView.path}`,
+      parts: { prefix, path: headFileView.path },
+      kind: "view",
+    };
+  }
+
   const grepFileView = parseGrepLikeFileView(trimmed);
   if (grepFileView) {
     const prefix = viewPrefix(grepFileView.lines);
@@ -346,6 +356,68 @@ function parsePipedFileView(command: string): PipedFileView | null {
 
   const sed = parseSedView(`${sedPart} ${path}`);
   return sed ? { path, lines: sed.lines } : null;
+}
+
+/**
+ * `head -100 file`, `head -n 40 file`, or `cat file | head -100`. `head` always
+ * reads from the top, so the window is `1..N` (default 10). Byte windows (`-c`)
+ * aren't line-addressable and fall through to the generic command label.
+ */
+function parseHeadFileView(command: string): PipedFileView | null {
+  const parts = splitShellPipeline(command);
+  // A filter between the reader and head (`cat f | grep x | head`) changes what
+  // head sees, so only the direct `<reader> | head` and bare `head file` forms
+  // map cleanly to a 1..N window of a single file.
+  if (parts.length > 2) return null;
+  const invocation = parseHeadInvocation(splitShellWords(parts[parts.length - 1]!));
+  if (!invocation) return null;
+
+  const path =
+    parts.length === 2 ? extractPipedReadableFilePath(splitShellWords(parts[0]!)) : invocation.path;
+  if (!path) return null;
+  return { path, lines: invocation.lines };
+}
+
+function parseHeadInvocation(words: string[]): { path: string | undefined; lines: string } | null {
+  const executable = words[0]?.split(/[/\\]/).pop()?.toLowerCase();
+  if (executable !== "head" && executable !== "ghead") return null;
+
+  let count = 10; // `head`'s default line count
+  let path: string | undefined;
+  for (let i = 1; i < words.length; i++) {
+    const word = words[i]!;
+    if (word === "--") {
+      path = words[i + 1] ?? path;
+      break;
+    }
+    const legacy = /^-(\d+)$/.exec(word);
+    if (legacy) {
+      count = Number(legacy[1]);
+      continue;
+    }
+    if (word === "-n" || word === "--lines") {
+      const value = readNonNegativeInteger(words[++i]);
+      if (value === undefined) return null;
+      count = value;
+      continue;
+    }
+    const attached = /^-n(\d+)$/.exec(word) ?? /^--lines=(\d+)$/.exec(word);
+    if (attached) {
+      count = Number(attached[1]);
+      continue;
+    }
+    // Byte windows aren't line-addressable (covers -c, -c200, -c-200, --bytes, --bytes=N).
+    if (/^-c/.test(word) || /^--bytes(=|$)/.test(word)) return null;
+    if (word === "-") continue; // explicit stdin
+    if (/^\d*>/.test(word)) continue; // shell redirection (e.g. 2>/dev/null), not a path
+    if (word.startsWith("-")) continue; // -q/-v/-z and other flags
+    // First file operand. Keep scanning so trailing flags still apply (GNU permutes
+    // operands and options, e.g. `head file -n 40`).
+    if (path === undefined) path = word;
+  }
+
+  if (count <= 0) return null;
+  return { path, lines: count === 1 ? "1" : `1-${count}` };
 }
 
 function parseGrepLikeFileView(command: string): PowerShellFileView | null {


### PR DESCRIPTION
- Bugfix: classify `head` file reads and direct `cat file | head` pipelines as file views.
- Show accurate `View 1:N` summaries, including default 10-line `head` output.
- Preserve generic/search summaries for byte windows and filtered pipelines.
- Add regression coverage for supported `head` forms and non-view cases.