### PR TITLE
Fix Claude SDK process tree cleanup on dispose

### DIFF
--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -39,6 +39,10 @@ const mockBase = vi.hoisted(() => ({
     vi.fn<(distro: string, cwd: string) => Promise<Record<string, string> | undefined>>(),
 }));
 
+const mockProcessTree = vi.hoisted(() => ({
+  terminateChildProcessTree: vi.fn<(child: { pid?: number }) => void>(),
+}));
+
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: mockSdk.query,
 }));
@@ -63,6 +67,19 @@ vi.mock("node:child_process", async () => {
 vi.mock("../binaryResolver", () => ({
   resolveAgentBinaryPath: mockBinaryResolver.resolveAgentBinaryPath,
 }));
+
+vi.mock("@/shared/processTree", () => ({
+  terminateChildProcessTree: mockProcessTree.terminateChildProcessTree,
+}));
+
+// Real spawned objects are Node ChildProcess instances; ClaudeSdkSession
+// registers an `exit` listener on them to track the process for teardown.
+function makeFakeSpawnedChild(pid: number): SpawnedProcess {
+  return {
+    pid,
+    once: vi.fn<(event: string, listener: (...args: unknown[]) => void) => void>(),
+  } as unknown as SpawnedProcess;
+}
 
 function createFakeQuery(initCommands: Array<Record<string, string>> = []) {
   let closed = false;
@@ -200,7 +217,7 @@ describe("ClaudeSdkSession", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockChildProcess.spawn.mockReturnValue({} as SpawnedProcess);
+    mockChildProcess.spawn.mockReturnValue(makeFakeSpawnedChild(1234));
     mockBase.getWslProjectShellEnv.mockReturnValue(undefined);
     mockBase.primeWslProjectShellEnv.mockResolvedValue(undefined);
     mockBinaryResolver.resolveAgentBinaryPath.mockImplementation(
@@ -248,6 +265,44 @@ describe("ClaudeSdkSession", () => {
     expect(fake.setPermissionMode).not.toHaveBeenCalled();
 
     await session.dispose();
+  });
+
+  it("force-kills the spawned process tree on dispose", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const spawnedChild = makeFakeSpawnedChild(4242);
+    mockChildProcess.spawn.mockReturnValue(spawnedChild);
+
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-kill",
+      projectLocation: wslProjectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: () => {},
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+    await session.openThread(config);
+
+    // The SDK transport drives process spawning lazily through the custom hook;
+    // invoke it the way the SDK would so the session captures the child.
+    const queryInput = mockSdk.query.mock.calls[0]?.[0] as {
+      options?: { spawnClaudeCodeProcess?: (opts: SpawnOptions) => SpawnedProcess };
+    };
+    const spawnHook = queryInput.options?.spawnClaudeCodeProcess;
+    expect(spawnHook).toBeTypeOf("function");
+    expect(spawnHook!({ args: [], env: {} } as unknown as SpawnOptions)).toBe(spawnedChild);
+    expect(mockProcessTree.terminateChildProcessTree).not.toHaveBeenCalled();
+
+    await session.dispose();
+
+    expect(mockProcessTree.terminateChildProcessTree).toHaveBeenCalledTimes(1);
+    expect(mockProcessTree.terminateChildProcessTree).toHaveBeenCalledWith(
+      expect.objectContaining({ pid: 4242 }),
+    );
   });
 
   it("switches the SDK permission mode for plan turns instead of changing the base policy", async () => {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import type {
   CanUseTool,
   Options as ClaudeQueryOptions,
@@ -26,6 +26,7 @@ import type {
   TurnState,
 } from "@/shared/contracts";
 import { areAgentSlashCommandsEqual } from "@/shared/contracts";
+import { terminateChildProcessTree } from "@/shared/processTree";
 import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
 import {
   createKnownSessionRef,
@@ -419,6 +420,11 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
   private promptQueue = new AsyncPromptQueue();
   private queryRuntime: Query | undefined;
   private queryReady: Promise<Query> | undefined;
+  // OS processes the SDK spawned through our custom spawn hook (win32 native +
+  // WSL). Captured so dispose() can force-kill the whole tree; the SDK's own
+  // Query.close() only ends the immediate child after a grace window. See
+  // trackSpawnedProcess.
+  private readonly spawnedProcesses = new Set<ChildProcess>();
   private streamStarted = false;
   private disposed = false;
   private sessionId: string | undefined;
@@ -812,7 +818,43 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     } catch {
       // ignore
     }
+    // Query.close() only ends the immediate child — and only after a ~2s
+    // stdin-EOF grace — so on Windows it orphans claude's descendant tool
+    // processes, and for WSL it kills the host wsl.exe relay rather than the
+    // in-distro tree. Force-kill the captured process tree so a removed /
+    // archived / unloaded / app-closed GUI Claude thread can't keep running
+    // tools and modifying files. Mirrors the ACP and Codex structured sessions.
+    for (const child of [...this.spawnedProcesses]) {
+      this.killSpawnedProcess(child);
+    }
     this.listener?.onClose();
+  }
+
+  /**
+   * Record an OS process spawned by the SDK through our custom spawn hook so
+   * {@link dispose} can force-kill its tree. The process drops out of the set on
+   * its own exit. If a spawn races in after disposal, kill it immediately so it
+   * can't outlive the session.
+   */
+  private trackSpawnedProcess(proc: SpawnedProcess): SpawnedProcess {
+    const child = proc as unknown as ChildProcess;
+    this.spawnedProcesses.add(child);
+    const forget = (): void => {
+      this.spawnedProcesses.delete(child);
+    };
+    child.once("exit", forget);
+    if (this.disposed) {
+      this.killSpawnedProcess(child);
+    }
+    return proc;
+  }
+
+  private killSpawnedProcess(child: ChildProcess): void {
+    this.spawnedProcesses.delete(child);
+    // Windows: taskkill /T /F reaps the whole tree. POSIX: best-effort kill of
+    // the captured process (the SDK's own teardown handles the rest).
+    // terminateChildProcessTree swallows its own errors, so no guard is needed.
+    terminateChildProcessTree(child);
   }
 
   private requireQuery(): Promise<Query> {
@@ -916,12 +958,14 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       switch (this.input.projectLocation.kind) {
         case "wsl": {
           const location = this.input.projectLocation;
-          spawnClaudeCodeProcess = (spawnOptions) => spawnClaudeInWsl(location, spawnOptions);
+          spawnClaudeCodeProcess = (spawnOptions) =>
+            this.trackSpawnedProcess(spawnClaudeInWsl(location, spawnOptions));
           break;
         }
         case "windows": {
           const location = this.input.projectLocation;
-          spawnClaudeCodeProcess = (spawnOptions) => spawnClaudeNative(location, spawnOptions);
+          spawnClaudeCodeProcess = (spawnOptions) =>
+            this.trackSpawnedProcess(spawnClaudeNative(location, spawnOptions));
           break;
         }
       }


### PR DESCRIPTION
- Bugfix: ensure Claude SDK GUI sessions terminate spawned process trees during disposal.
- Prevent removed, archived, unloaded, or app-closed Claude threads from leaving tool processes running.
- Add regression coverage for tracked SDK-spawned children and dispose-time cleanup.