### PR TITLE
Preserve unsent composer drafts across thread switches

### DIFF
--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -74,6 +74,34 @@ const codexGuiStatus: AgentStatus = {
   },
 };
 
+const terminalThread: Thread = {
+  ...guiThread,
+  id: "thread-terminal-idle",
+  agentKind: "claude",
+  config: { model: "claude" },
+  presentationMode: "terminal",
+};
+
+const claudeTerminalStatus: AgentStatus = {
+  kind: "claude",
+  label: "Claude",
+  installed: true,
+  authState: "authenticated",
+  capabilities: {
+    models: [{ id: "claude", label: "Claude" }],
+    efforts: [],
+    modelEfforts: {},
+    modes: ["agent"],
+    approvalPolicies: [],
+    sandboxModes: [],
+    supportsResume: true,
+    supportsDirectInput: true,
+    liveInputMode: "terminal",
+    presentationMode: "terminal",
+    settingDefs: [],
+  },
+};
+
 describe("ThreadComposerSection", () => {
   beforeEach(() => {
     useSharedSettings.setState({ collapseTerminalComposer: false });
@@ -87,7 +115,158 @@ describe("ThreadComposerSection", () => {
       runtimeItemsByIdByThread: {},
       runtimeRequestsByThread: {},
       pendingSteerByThreadId: {},
+      threadDraftContents: {},
     });
+  });
+
+  function composerElement(opts?: {
+    thread?: Thread;
+    agentStatus?: AgentStatus;
+    onSubmitInput?: (prompt: string, segments?: unknown) => Promise<void>;
+  }) {
+    const thread = opts?.thread ?? guiThread;
+    const agentStatus = opts?.agentStatus ?? codexGuiStatus;
+    return (
+      <ThreadComposerSection
+        threadId={thread.id}
+        fallbackThread={thread}
+        agentStatus={agentStatus}
+        projectLocation={{ kind: "windows", path: "C:\\repo" }}
+        paneCount={1}
+        terminalPaneRef={{ current: null }}
+        todoDockCollapsed={false}
+        todoDockPlacement="composer"
+        todoDockState={null}
+        goalDockState={null}
+        errorDockStates={[]}
+        onGoalDockDismiss={() => undefined}
+        onDismissError={() => undefined}
+        onConfigChange={() => undefined}
+        onResolveServerRequest={async () => undefined}
+        onSubmitInput={opts?.onSubmitInput ?? (async () => undefined)}
+        onTodoDockCollapsedChange={() => undefined}
+        onTodoDockPlacementChange={() => undefined}
+      />
+    );
+  }
+
+  function renderComposer(opts?: {
+    thread?: Thread;
+    agentStatus?: AgentStatus;
+    onSubmitInput?: ReturnType<typeof vi.fn<(prompt: string, segments?: unknown) => Promise<void>>>;
+  }) {
+    const onSubmitInput =
+      opts?.onSubmitInput ??
+      vi.fn<(prompt: string, segments?: unknown) => Promise<void>>(() => Promise.resolve());
+    const result = render(composerElement({ ...opts, onSubmitInput }));
+    return { ...result, onSubmitInput };
+  }
+
+  it("preserves an unsent draft when the composer unmounts and restores it on remount", async () => {
+    const { unmount } = renderComposer();
+
+    const input = screen.getByRole("textbox");
+    input.appendChild(document.createTextNode("half-written thought"));
+    fireEvent.input(input);
+
+    unmount();
+
+    expect(useAppStore.getState().threadDraftContents[guiThread.id]?.segments).toEqual([
+      { kind: "text", content: "half-written thought" },
+    ]);
+
+    renderComposer();
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox").textContent).toContain("half-written thought");
+    });
+    // The draft is consumed on restore so a later real send can't resurrect it.
+    expect(useAppStore.getState().threadDraftContents[guiThread.id]).toBeUndefined();
+  });
+
+  it("does not leave a draft behind once the message is sent", async () => {
+    const { unmount, onSubmitInput } = renderComposer();
+
+    const input = screen.getByRole("textbox");
+    input.appendChild(document.createTextNode("ship it"));
+    fireEvent.input(input);
+    fireEvent.click(screen.getByText("send"));
+
+    await waitFor(() => {
+      expect(onSubmitInput).toHaveBeenCalledWith("ship it", [{ kind: "text", content: "ship it" }]);
+    });
+
+    unmount();
+
+    expect(useAppStore.getState().threadDraftContents[guiThread.id]).toBeUndefined();
+  });
+
+  it("does not re-save an in-flight terminal send as a stale draft when navigating away", async () => {
+    // Terminal threads clear the composer only after the send resolves, so the
+    // unmount cleanup must skip saving while a submit is in flight.
+    let resolveSubmit: (() => void) | undefined;
+    const onSubmitInput = vi.fn<(prompt: string, segments?: unknown) => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+    const { unmount } = renderComposer({
+      thread: terminalThread,
+      agentStatus: claudeTerminalStatus,
+      onSubmitInput,
+    });
+
+    const input = screen.getByRole("textbox");
+    input.appendChild(document.createTextNode("terminal message"));
+    fireEvent.input(input);
+    fireEvent.click(screen.getByText("send"));
+
+    await waitFor(() => {
+      expect(onSubmitInput).toHaveBeenCalledWith("terminal message", [
+        { kind: "text", content: "terminal message" },
+      ]);
+    });
+
+    // Send is still pending — navigating away must not stash the sent text.
+    unmount();
+    expect(useAppStore.getState().threadDraftContents[terminalThread.id]).toBeUndefined();
+
+    await act(async () => {
+      resolveSubmit?.();
+      await Promise.resolve();
+    });
+  });
+
+  it("defers a terminal thread's draft restore until the composer mounts after launching", async () => {
+    useAppStore.setState({
+      threadDraftContents: {
+        [terminalThread.id]: {
+          segments: [{ kind: "text", content: "resume me" }],
+          attachments: [],
+        },
+      },
+    });
+
+    const { rerender } = render(
+      composerElement({
+        thread: { ...terminalThread, status: "launching" },
+        agentStatus: claudeTerminalStatus,
+      }),
+    );
+
+    // While launching, the terminal composer (and its editor) is not rendered,
+    // so the draft must be left intact rather than silently consumed.
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(useAppStore.getState().threadDraftContents[terminalThread.id]).toBeDefined();
+
+    // Same instance leaves launching → editor mounts → draft restores + consumes.
+    rerender(composerElement({ thread: terminalThread, agentStatus: claudeTerminalStatus }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox").textContent).toContain("resume me");
+    });
+    expect(useAppStore.getState().threadDraftContents[terminalThread.id]).toBeUndefined();
   });
 
   it("clears the GUI ACP composer as soon as a direct send starts", async () => {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { Tooltip } from "@heroui/react";
 import { ChevronDown, GitFork } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
@@ -225,6 +225,29 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInterrupting, setIsInterrupting] = useState(false);
   const attachments = useAttachments();
+  // Unsent composer content survives leaving this thread: switching panes
+  // remounts this section (ThreadPane is keyed by threadId), so we save the
+  // typed segments + attachments on unmount and restore them on the next mount.
+  const saveThreadDraftContent = useAppStore((s) => s.saveThreadDraftContent);
+  const clearThreadDraftContent = useAppStore((s) => s.clearThreadDraftContent);
+  // The MentionInput owns the live editor DOM; mirror its latest serialized
+  // segments here (updated on every text change) so the unmount cleanup can read
+  // them without touching a possibly-detached editor ref. Attachments are synced
+  // every render below.
+  const latestSegmentsRef = useRef<PromptSegment[]>([]);
+  const attachmentsRef = useRef(attachments.attachments);
+  attachmentsRef.current = attachments.attachments;
+  // True only while a real submit is in flight. Terminal/CLI threads clear the
+  // composer *after* the send resolves (the synchronous pre-send clear below is
+  // GUI-only), so without this guard, navigating away mid-send would unmount and
+  // re-save the just-sent text as a stale draft. Reset every time (success or
+  // failure) because this composer is reused for the next message.
+  const submittedRef = useRef(false);
+  // Captured once at mount; consumed (and cleared) by the restore effect below.
+  const initialThreadDraftRef = useRef(useAppStore.getState().threadDraftContents[thread.id]);
+  // Guards the restore effect so it runs exactly once — when the editor first
+  // mounts — even though its dep (`editorMounted`) can flip after mount.
+  const draftRestoredRef = useRef(false);
   const pendingPickedAttachments = useBrowserAttachInbox((s) => s.itemsByThread[thread.id]);
   const addPickedRef = useRef(attachments.addPicked);
   addPickedRef.current = attachments.addPicked;
@@ -452,6 +475,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       mentionRef.current?.focus();
       setPrompt("");
       setHasContent(false);
+      latestSegmentsRef.current = [];
       return;
     }
     if (localAction?.kind === "open-control") {
@@ -462,6 +486,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       mentionRef.current?.clear();
       setPrompt("");
       setHasContent(false);
+      latestSegmentsRef.current = [];
       return;
     }
     if (localAction?.kind === "toggle-fast") {
@@ -472,6 +497,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       mentionRef.current?.focus();
       setPrompt("");
       setHasContent(false);
+      latestSegmentsRef.current = [];
       return;
     }
     const submittedInputSegments = segments;
@@ -481,6 +507,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       mentionRef.current?.focus();
       setPrompt("");
       setHasContent(false);
+      latestSegmentsRef.current = [];
       attachments.clearAll();
     };
     const restoreSubmittedComposer = () => {
@@ -493,6 +520,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       }
     };
     let clearedBeforeSendSettled = false;
+    submittedRef.current = true;
     setIsSubmitting(true);
     if (!usesTerminalPresentation) {
       useAppStore.getState().requestChatScrollToBottom(thread.id);
@@ -559,6 +587,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         }
       })
       .finally(() => {
+        // The composer is now either cleared (success) or restored (failure);
+        // either way the refs reflect the real state, so re-arm draft-saving.
+        submittedRef.current = false;
         setIsSubmitting(false);
       });
   }
@@ -595,6 +626,51 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     setContextDockOpen(false);
     setComposerCollapsed(collapseTerminalComposerSetting);
   }, [thread.id, collapseTerminalComposerSetting]);
+
+  // Restore an unsent draft saved the last time this thread's composer was
+  // mounted. useLayoutEffect (and reading the editor via the imperative handle)
+  // runs before paint so the text never flashes empty. Consume the entry so a
+  // later real send doesn't resurrect it.
+  //
+  // A terminal thread that is still `launching` hides the whole composer (so the
+  // MentionInput — and `mentionRef` — does not exist yet). Restoring into a null
+  // editor would silently drop the text while still consuming the stored draft,
+  // so defer until the editor mounts; the effect re-runs when `editorMounted`
+  // flips, at which point `mentionRef` is attached.
+  const editorMounted = !usesTerminalPresentation || thread.status !== "launching";
+  useLayoutEffect(() => {
+    if (draftRestoredRef.current || !editorMounted) return;
+    draftRestoredRef.current = true;
+    const saved = initialThreadDraftRef.current;
+    if (!saved) return;
+    if (saved.segments.length > 0) {
+      mentionRef.current?.restoreFromSegments(saved.segments);
+      latestSegmentsRef.current = saved.segments;
+    }
+    if (saved.attachments.length > 0) {
+      attachments.restore(saved.attachments);
+    }
+    clearThreadDraftContent(thread.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- restore runs once, when the editor first mounts
+  }, [editorMounted]);
+
+  // Save whatever is left in the composer when this thread's section unmounts
+  // (navigating to another thread/pane). A cleared composer leaves both refs
+  // empty, so a just-sent message is not re-saved; an in-flight submit is
+  // skipped via submittedRef because its text has already been handed off.
+  useEffect(() => {
+    const tid = thread.id;
+    return () => {
+      if (submittedRef.current) return;
+      const segments = latestSegmentsRef.current;
+      const atts = attachmentsRef.current;
+      if (segments.length > 0 || atts.length > 0) {
+        saveThreadDraftContent(tid, { segments, attachments: atts });
+      } else {
+        clearThreadDraftContent(tid);
+      }
+    };
+  }, [thread.id, saveThreadDraftContent, clearThreadDraftContent]);
 
   useEffect(() => {
     if (thread.status !== "working") setIsInterrupting(false);
@@ -793,7 +869,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                       projectLocation={projectLocation}
                       projectId={thread.projectId}
                       triggerWords={getTriggerWords(thread.agentKind, thread.config.model)}
-                      onTextChange={setHasContent}
+                      onTextChange={(hasText) => {
+                        setHasContent(hasText);
+                        latestSegmentsRef.current = mentionRef.current?.serializeSegments() ?? [];
+                      }}
                       onSubmit={submitPrompt}
                       onPasteImage={(file) => {
                         void attachments.addClipboardImage(file, thread.id);

--- a/src/renderer/state/slices/draftSlice.ts
+++ b/src/renderer/state/slices/draftSlice.ts
@@ -15,10 +15,21 @@ export interface PendingComposerSeed {
 
 export interface DraftSlice {
   draftContents: Record<string, DraftContent>;
+  /**
+   * Unsent composer content for *already-launched* threads, keyed by threadId.
+   * Saved when a thread's composer unmounts (switching panes/threads remounts
+   * it, see ThreadPane's `key={threadId}`) and restored when it mounts again,
+   * so an in-progress message survives navigating away. In-memory only — not
+   * persisted across app restarts (see appStore `partialize`), matching the
+   * per-project `draftContents` behavior.
+   */
+  threadDraftContents: Record<string, DraftContent>;
   pendingDraftWorktreeSelections: Record<string, PendingDraftWorktreeSelection>;
   pendingComposerSeeds: Record<string, PendingComposerSeed>;
   saveDraftContent: (projectId: string, content: DraftContent) => void;
   clearDraftContent: (projectId: string) => void;
+  saveThreadDraftContent: (threadId: string, content: DraftContent) => void;
+  clearThreadDraftContent: (threadId: string) => void;
   setPendingDraftWorktreeSelection: (
     projectId: string,
     selection: PendingDraftWorktreeSelection,
@@ -30,6 +41,7 @@ export interface DraftSlice {
 
 export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
   draftContents: {},
+  threadDraftContents: {},
   pendingDraftWorktreeSelections: {},
   pendingComposerSeeds: {},
   saveDraftContent: (projectId, content) =>
@@ -41,6 +53,16 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
       if (!(projectId in state.draftContents)) return {};
       const { [projectId]: _, ...rest } = state.draftContents;
       return { draftContents: rest };
+    }),
+  saveThreadDraftContent: (threadId, content) =>
+    set((state) => ({
+      threadDraftContents: { ...state.threadDraftContents, [threadId]: content },
+    })),
+  clearThreadDraftContent: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.threadDraftContents)) return {};
+      const { [threadId]: _, ...rest } = state.threadDraftContents;
+      return { threadDraftContents: rest };
     }),
   setPendingDraftWorktreeSelection: (projectId, selection) =>
     set((state) => ({

--- a/src/renderer/state/slices/projectSlice.ts
+++ b/src/renderer/state/slices/projectSlice.ts
@@ -132,6 +132,11 @@ export const createProjectSlice: SliceCreator<ProjectSlice> = (set) => ({
       );
 
       const { [projectId]: _draft, ...nextDraftContents } = state.draftContents;
+      const nextThreadDraftContents = Object.fromEntries(
+        Object.entries(state.threadDraftContents).filter(
+          ([threadId]) => !projectThreadIds.has(threadId),
+        ),
+      );
 
       let nextView = state.view;
       if (state.view.kind === "draft" && state.view.projectId === projectId) {
@@ -152,6 +157,7 @@ export const createProjectSlice: SliceCreator<ProjectSlice> = (set) => ({
         pendingThreadLaunches: nextPendingThreadLaunches,
         pendingLaunchSegments: nextPendingLaunchSegments,
         draftContents: nextDraftContents,
+        threadDraftContents: nextThreadDraftContents,
         view: nextView,
       };
     }),

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -317,8 +317,10 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         state.lastRuntimeConfigByThreadId;
       const { [threadId]: _droppedLastViewed, ...lastViewedAtByThreadId } =
         state.lastViewedAtByThreadId;
+      const { [threadId]: _droppedThreadDraft, ...threadDraftContents } = state.threadDraftContents;
       return {
         threads: nextThreads,
+        threadDraftContents,
         pendingThreadLaunches: Object.fromEntries(
           Object.entries(state.pendingThreadLaunches).filter(([id]) => id !== threadId),
         ),


### PR DESCRIPTION
- Bugfix: preserve unsent thread composer text, segments, and attachments when navigating away and back.
- Restore saved drafts on composer remount while avoiding stale restores after successful sends.
- Clear thread draft state when threads or projects are removed.
- Add composer coverage for GUI and terminal draft preservation behavior.