### PR TITLE
Surface live background workflow status

### DIFF
--- a/src/renderer/components/providers/codex/CodexStatusIcon.test.ts
+++ b/src/renderer/components/providers/codex/CodexStatusIcon.test.ts
@@ -48,4 +48,30 @@ describe("getStatusTone", () => {
       ).toBe("done");
     }
   });
+
+  it("shows a live background workflow as working over a settled status", () => {
+    for (const status of ["idle", "finished"] as const) {
+      expect(getStatusTone({ done: false, status }, { hasLiveWorkflow: true })).toBe("working");
+    }
+  });
+
+  it("never lets a live workflow mask error or attention statuses", () => {
+    expect(getStatusTone({ done: false, status: "error" }, { hasLiveWorkflow: true })).toBe(
+      "error",
+    );
+    expect(
+      getStatusTone({ done: false, status: "needs_approval" }, { hasLiveWorkflow: true }),
+    ).toBe("attention");
+    expect(getStatusTone({ done: false, status: "inactive" }, { hasLiveWorkflow: true })).toBe(
+      "inactive",
+    );
+    expect(getStatusTone({ done: true, status: "idle" }, { hasLiveWorkflow: true })).toBe("done");
+  });
+
+  it("is unchanged when no workflow flag is passed", () => {
+    expect(getStatusTone({ done: false, status: "finished" })).toBe("finished");
+    expect(getStatusTone({ done: false, status: "idle" }, { hasLiveWorkflow: false })).toBe(
+      "active",
+    );
+  });
 });

--- a/src/renderer/components/providers/statusTone.ts
+++ b/src/renderer/components/providers/statusTone.ts
@@ -9,7 +9,10 @@ export type StatusTone =
   | "attention"
   | "done";
 
-export function getStatusTone(thread: Pick<Thread, "status" | "done">): StatusTone {
+export function getStatusTone(
+  thread: Pick<Thread, "status" | "done">,
+  opts?: { hasLiveWorkflow?: boolean },
+): StatusTone {
   if (thread.done) {
     return "done";
   }
@@ -23,6 +26,13 @@ export function getStatusTone(thread: Pick<Thread, "status" | "done">): StatusTo
   }
 
   if (thread.status === "working") {
+    return "working";
+  }
+
+  // A live background workflow keeps a settled thread visually working without
+  // changing `thread.status`. Keep it below error/attention and do not mask an
+  // explicitly inactive thread.
+  if (opts?.hasLiveWorkflow && (thread.status === "idle" || thread.status === "finished")) {
     return "working";
   }
 

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/renderer/state/fileCheckpointActions";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useProjectRootNames } from "@/renderer/state/projectRootNamesStore";
+import { useThreadHasLiveWorkflow } from "@/renderer/state/threadLiveWorkflowStore";
 import { useProjectTreeStore } from "@/renderer/state/projectTreeStore";
 import {
   buildFileEditorContext,
@@ -209,6 +210,12 @@ export function ChatPane(props: ChatPaneProps) {
 
   const isEmpty = timelineEntries.length === 0 && !hasSupplementaryContent;
   const isLive = isThreadTurnActive(status);
+  // A detached background workflow keeps the thread doing real work after the
+  // foreground turn settles. Treat that as "still working" for the tail-loader
+  // timer (so it keeps ticking "Working for ...") without touching `status` -
+  // composer interrupt/steer and notifications stay on the raw status.
+  const hasLiveWorkflow = useThreadHasLiveWorkflow(threadId);
+  const showWorkingTimer = isLive || hasLiveWorkflow;
   const hasOpenRuntimeRequest = useAppStore(
     (s) => (s.runtimeRequestsByThread[threadId]?.length ?? 0) > 0,
   );
@@ -216,22 +223,22 @@ export function ChatPane(props: ChatPaneProps) {
   // disappear in the gap between an item flipping to `completed` and the next
   // `item.started` arriving, even though the runtime was still working the
   // turn.
-  const turn = resolveTurnTiming(thread);
+  const turn = resolveTurnTiming(thread, showWorkingTimer);
   const mostRecentDisplayableCompletedTurn = useAppStore((s) =>
-    isLive
+    showWorkingTimer
       ? null
       : selectMostRecentDisplayableCompletedTurn(s.runtimeCompletedTurnsByThread[threadId]),
   );
   const mostRecentCompletedTurnAnchor = mostRecentDisplayableCompletedTurn?.anchorItemId ?? null;
   const completedTurnCanRenderInTail =
-    !isLive &&
+    !showWorkingTimer &&
     (turn?.endedAt != null || mostRecentDisplayableCompletedTurn !== null) &&
     isCompletedTurnAnchorAtTimelineTail(mostRecentCompletedTurnAnchor, timelineEntries);
   const tailTurn =
     completedTurnCanRenderInTail && mostRecentDisplayableCompletedTurn
       ? mostRecentDisplayableCompletedTurn
       : turn;
-  const showTailLoader = isLive || completedTurnCanRenderInTail;
+  const showTailLoader = showWorkingTimer || completedTurnCanRenderInTail;
   // The agent is not actually working while it waits for a user answer, so the
   // tail loader keeps rendering but its elapsed-time counter freezes for the
   // duration of the wait and resumes once the user submits a response. Anchor
@@ -648,11 +655,17 @@ function parseTurnTimestamp(iso: string | undefined): number | null {
  * Derives the current or last completed run window from persisted thread timing
  * so reopening a thread doesn't reseed the footer timer from mount time.
  */
-function resolveTurnTiming(thread: Thread): TurnTiming | null {
-  const isLive = isThreadTurnActive(thread.status);
+function resolveTurnTiming(thread: Thread, forceLive = false): TurnTiming | null {
+  const isLive = forceLive || isThreadTurnActive(thread.status);
 
   if (isLive) {
-    const startedAt = parseTurnTimestamp(thread.activeTurnStartedAt ?? thread.createdAt);
+    // When only a background workflow keeps the thread live, the foreground
+    // turn has ended and `activeTurnStartedAt` is cleared - fall back to the
+    // just-completed turn's start so the timer continues from there instead of
+    // reseeding at mount time.
+    const startedAt = parseTurnTimestamp(
+      thread.activeTurnStartedAt ?? thread.lastTurnStartedAt ?? thread.createdAt,
+    );
     return startedAt === null ? null : { startedAt, endedAt: null };
   }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
@@ -4,6 +4,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { Bot, Check, GitBranch, X } from "lucide-react";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useThreadSubAgentDockStore } from "@/renderer/state/threadSubAgentDockStore";
+import { useThreadLiveWorkflowStore } from "@/renderer/state/threadLiveWorkflowStore";
 import { useWorkflowRun } from "@/renderer/state/useWorkflowRun";
 import {
   getChildItemIdsStoreSelector,
@@ -12,6 +13,7 @@ import {
 } from "../../chatPaneSelectors";
 import { getRuntimeItemPayload } from "@/renderer/state/slices/runtimeEventSlice";
 import type { ProjectLocation, ToolCallPayload, WorkflowRun } from "@/shared/contracts";
+import { isLiveWorkflowRunStatus } from "@/shared/contracts";
 import { deriveToolDisplay, isWorkflowTool } from "./toolDisplay";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { formatTokenCount } from "@/renderer/components/thread/formatTokenCount";
@@ -111,6 +113,8 @@ function ActiveSubAgentRow({
   const childCount = useAppStore(getChildItemIdsStoreSelector(threadId, itemId)).length;
   const openSubAgent = useAppStore((s) => s.openSubAgent);
   const dismiss = useThreadSubAgentDockStore((s) => s.dismiss);
+  const registerLiveWorkflow = useThreadLiveWorkflowStore((s) => s.register);
+  const markWorkflowTerminal = useThreadLiveWorkflowStore((s) => s.markTerminal);
 
   const payload = item ? getRuntimeItemPayload<ToolCallPayload>(item, "tool_call") : undefined;
   const workflow = payload && isWorkflowTool(payload) ? parseWorkflowInfo(payload) : null;
@@ -124,11 +128,11 @@ function ActiveSubAgentRow({
   // A background workflow is "live" from the moment the SDK reports its
   // launch tool call as completed (because the work is in flight in a
   // separate process). The manifest takes a few seconds to appear on disk,
-  // during which `workflowRun` is null — we MUST NOT flip the row to done
+  // during which `workflowRun` is null - we MUST NOT flip the row to done
   // in that gap, otherwise the composer dock shows ✓ while the chat row
   // still says "starting…".
   const workflowIsBackground = workflow !== null && !!workflow.manifestPath;
-  const workflowIsTerminal = workflowRun !== null && !isLiveWorkflowStatus(workflowRun.status);
+  const workflowIsTerminal = workflowRun !== null && !isLiveWorkflowRunStatus(workflowRun.status);
   const workflowIsLive = workflowIsBackground && !workflowIsTerminal;
 
   // Auto-dismiss workflows once their manifest reports a terminal status. We
@@ -140,6 +144,38 @@ function ActiveSubAgentRow({
     const timer = setTimeout(() => dismiss(threadId, itemId), 1500);
     return () => clearTimeout(timer);
   }, [workflow, workflowIsTerminal, dismiss, threadId, itemId]);
+
+  // Publish this workflow's liveness to the thread-level tracker so the sidebar
+  // row and chat header keep showing the working spinner after the foreground
+  // turn ends - and even after this dock unmounts (the tracker polls on its
+  // own). We register (not unregister) on unmount: the tracker clears the entry
+  // when its own poll sees a terminal status, so dismissing the dock or
+  // switching threads doesn't drop a still-running workflow.
+  const liveWorkflowManifestPath = workflow?.manifestPath;
+  const liveWorkflowTranscriptDir = workflow?.transcriptDir;
+  useEffect(() => {
+    if (!liveWorkflowManifestPath || !projectLocation) return;
+    if (workflowIsTerminal) {
+      markWorkflowTerminal(threadId, itemId);
+      return;
+    }
+    registerLiveWorkflow({
+      threadId,
+      itemId,
+      manifestPath: liveWorkflowManifestPath,
+      location: projectLocation,
+      ...(liveWorkflowTranscriptDir ? { transcriptDir: liveWorkflowTranscriptDir } : {}),
+    });
+  }, [
+    liveWorkflowManifestPath,
+    liveWorkflowTranscriptDir,
+    projectLocation,
+    workflowIsTerminal,
+    threadId,
+    itemId,
+    registerLiveWorkflow,
+    markWorkflowTerminal,
+  ]);
 
   if (!item || !payload?.name) return null;
 
@@ -226,10 +262,6 @@ function WorkflowDockStats({ run }: { run: WorkflowRun }) {
       {parts.join(" · ")}
     </span>
   );
-}
-
-function isLiveWorkflowStatus(status: WorkflowRun["status"]): boolean {
-  return status === "running" || status === "unknown";
 }
 
 function countDoneWorkflowAgents(run: WorkflowRun): number {

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
@@ -4,7 +4,11 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { Bot, ChevronDown, ChevronRight, CircleAlert, type LucideIcon } from "lucide-react";
-import type { ToolCallPayload, WorkflowRun } from "@/shared/contracts";
+import {
+  isLiveWorkflowRunStatus,
+  type ToolCallPayload,
+  type WorkflowRun,
+} from "@/shared/contracts";
 import { PixelLoader } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
 import {
@@ -74,7 +78,7 @@ export const SubAgentToolCall = memo(function SubAgentToolCall({
   const workflowIsBackground = workflow !== null && !!workflow.manifestPath;
   const workflowIsLive =
     workflowIsBackground &&
-    (workflowRun.run === null || isLiveWorkflowStatus(workflowRun.run.status));
+    (workflowRun.run === null || isLiveWorkflowRunStatus(workflowRun.run.status));
   const status = resolveStatus(
     item,
     payload,
@@ -267,10 +271,6 @@ function resolveStatus(
   };
 }
 
-function isLiveWorkflowStatus(status: WorkflowRun["status"]): boolean {
-  return status === "running" || status === "unknown";
-}
-
 function WorkflowRunStats({ run }: { run: WorkflowRun }) {
   const { t } = useLingui();
   const completed = countDoneAgents(run);
@@ -281,7 +281,7 @@ function WorkflowRunStats({ run }: { run: WorkflowRun }) {
   // an empty `0/0 agents` while the workflow is genuinely running.
   const trackedAgents = sumTrackedAgents(run);
   const total = Math.max(run.agentCount, trackedAgents);
-  const isLive = run.status === "running" || run.status === "unknown";
+  const isLive = isLiveWorkflowRunStatus(run.status);
   const parts: string[] = [];
   if (total > 0) {
     parts.push(`${completed}/${total} agents`);

--- a/src/renderer/components/thread/ThreadHeaderStatus.tsx
+++ b/src/renderer/components/thread/ThreadHeaderStatus.tsx
@@ -4,18 +4,24 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import type { Thread, ThreadStatusSource } from "@/shared/contracts";
 import { ProviderIcon, getStatusTone } from "@/renderer/components/providers";
 import { useThread } from "@/renderer/state/useThread";
+import { useThreadHasLiveWorkflow } from "@/renderer/state/threadLiveWorkflowStore";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 
-export function threadRuntimeStatusLabel(thread: Thread, t: TranslateFn): string {
+export function threadRuntimeStatusLabel(
+  thread: Thread,
+  t: TranslateFn,
+  opts?: { hasLiveWorkflow?: boolean },
+): string {
   const { status, attention } = thread;
   if (status === "launching") return t(msg`Launching…`);
   if (status === "inactive") return t(msg`Inactive`);
   if (status === "error") return t(msg`Error`);
-  if (status === "finished") return t(msg`Finished`);
+  // A settled thread with a live background workflow still reads as "Working".
+  if (status === "finished") return opts?.hasLiveWorkflow ? t(msg`Working`) : t(msg`Finished`);
   if (status === "needs_approval" || attention === "needs_approval") return t(msg`Needs approval`);
   if (status === "needs_reply" || attention === "needs_reply") return t(msg`Needs reply`);
   if (status === "working" || attention === "working") return t(msg`Working`);
-  if (status === "idle") return t(msg`Idle`);
+  if (status === "idle") return opts?.hasLiveWorkflow ? t(msg`Working`) : t(msg`Idle`);
   return status;
 }
 
@@ -66,7 +72,8 @@ function ThreadStatusSupportDetail({ source }: { source: ThreadStatusSource | un
 export function ThreadHeaderStatusTooltipBody(props: { thread: Thread }) {
   const { thread } = props;
   const { t } = useLingui();
-  const runtime = threadRuntimeStatusLabel(thread, t);
+  const hasLiveWorkflow = useThreadHasLiveWorkflow(thread.id);
+  const runtime = threadRuntimeStatusLabel(thread, t, { hasLiveWorkflow });
   const source = thread.threadStatusSource;
   const isServer = source === "server";
   const errorMessage = thread.status === "error" ? thread.errorMessage?.trim() : undefined;
@@ -115,8 +122,9 @@ export function ThreadHeaderStatusButton(props: {
 }) {
   const { t } = useLingui();
   const thread = useThread(props.threadId) ?? props.fallbackThread;
+  const hasLiveWorkflow = useThreadHasLiveWorkflow(props.threadId);
   const agentLabel = props.agentLabel ?? props.fallbackAgentKind;
-  const statusLabel = threadRuntimeStatusLabel(thread, t);
+  const statusLabel = threadRuntimeStatusLabel(thread, t, { hasLiveWorkflow });
 
   return (
     <Tooltip delay={0}>
@@ -133,7 +141,7 @@ export function ThreadHeaderStatusButton(props: {
             kind={thread.agentKind}
             {...(props.agentIcon ? { icon: props.agentIcon } : {})}
             fallbackLabel={props.agentLabel}
-            tone={getStatusTone(thread)}
+            tone={getStatusTone(thread, { hasLiveWorkflow })}
             className="size-3.5 shrink-0"
           />
         </button>

--- a/src/renderer/state/threadLiveWorkflowStore.test.ts
+++ b/src/renderer/state/threadLiveWorkflowStore.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+
+const { workflowGetRun } = vi.hoisted(() => ({
+  workflowGetRun: vi.fn<(payload: unknown) => Promise<{ run: unknown }>>(),
+}));
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({ workflowGetRun }),
+}));
+
+import { useThreadLiveWorkflowStore } from "./threadLiveWorkflowStore";
+
+const POLL_MS = 4000;
+const location: ProjectLocation = { kind: "windows", path: "C:/repo" };
+const { register, markTerminal } = useThreadLiveWorkflowStore.getState();
+const isLive = (threadId: string) =>
+  useThreadLiveWorkflowStore.getState().liveThreadIds.has(threadId);
+const running = { run: { status: "running", phases: [], unphasedAgents: [], agentCount: 0 } };
+const completed = { run: { status: "completed", phases: [], unphasedAgents: [], agentCount: 0 } };
+
+beforeEach(() => {
+  workflowGetRun.mockReset();
+  workflowGetRun.mockResolvedValue({ run: null });
+});
+
+describe("threadLiveWorkflowStore", () => {
+  it("marks a thread live on register and clears on terminal", () => {
+    register({ threadId: "t1", itemId: "i1", manifestPath: "/m1.json", location });
+    expect(isLive("t1")).toBe(true);
+
+    markTerminal("t1", "i1");
+    expect(isLive("t1")).toBe(false);
+  });
+
+  it("keeps a thread live until all its concurrent workflows go terminal", () => {
+    register({ threadId: "t2", itemId: "a", manifestPath: "/a.json", location });
+    register({ threadId: "t2", itemId: "b", manifestPath: "/b.json", location });
+    expect(isLive("t2")).toBe(true);
+
+    markTerminal("t2", "a");
+    expect(isLive("t2")).toBe(true);
+    markTerminal("t2", "b");
+    expect(isLive("t2")).toBe(false);
+  });
+
+  it("is idempotent when the same workflow re-registers", () => {
+    register({ threadId: "t3", itemId: "i", manifestPath: "/m.json", location });
+    register({ threadId: "t3", itemId: "i", manifestPath: "/m-updated.json", location });
+    expect(isLive("t3")).toBe(true);
+
+    markTerminal("t3", "i");
+    expect(isLive("t3")).toBe(false);
+  });
+
+  describe("manifest poller", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("stays working while the manifest is missing, well past the old 30s cliff", async () => {
+      workflowGetRun.mockResolvedValue({ run: null });
+      register({ threadId: "slow", itemId: "i", manifestPath: "/m.json", location });
+      expect(isLive("slow")).toBe(true);
+
+      // The first manifest write can lag the launch; a slow start must NOT be
+      // mistaken for a dead launch and dropped.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(workflowGetRun).toHaveBeenCalled();
+      expect(isLive("slow")).toBe(true);
+
+      // Once the manifest finally reports terminal, the spinner clears.
+      workflowGetRun.mockResolvedValue(completed);
+      await vi.advanceTimersByTimeAsync(POLL_MS + 1);
+      expect(isLive("slow")).toBe(false);
+
+      markTerminal("slow", "i");
+    });
+
+    it("clears a dead launch whose manifest never appears", async () => {
+      workflowGetRun.mockResolvedValue({ run: null });
+      register({ threadId: "dead", itemId: "i", manifestPath: "/never.json", location });
+      expect(isLive("dead")).toBe(true);
+
+      // Past the 10-minute launch deadline with no manifest -> treated as failed.
+      await vi.advanceTimersByTimeAsync(11 * 60_000);
+      expect(isLive("dead")).toBe(false);
+    });
+
+    it("clears a dead launch whose manifest read keeps failing", async () => {
+      workflowGetRun.mockRejectedValue(new Error("parse failed"));
+      register({ threadId: "error", itemId: "i", manifestPath: "/broken.json", location });
+      expect(isLive("error")).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(11 * 60_000);
+      expect(isLive("error")).toBe(false);
+    });
+
+    it("keeps polling a running manifest and never overlaps ticks", async () => {
+      workflowGetRun.mockResolvedValue(running);
+      register({ threadId: "live", itemId: "i", manifestPath: "/m.json", location });
+
+      await vi.advanceTimersByTimeAsync(POLL_MS * 3 + 1);
+      expect(isLive("live")).toBe(true);
+
+      workflowGetRun.mockResolvedValue(completed);
+      await vi.advanceTimersByTimeAsync(POLL_MS + 1);
+      expect(isLive("live")).toBe(false);
+    });
+  });
+});

--- a/src/renderer/state/threadLiveWorkflowStore.ts
+++ b/src/renderer/state/threadLiveWorkflowStore.ts
@@ -1,0 +1,188 @@
+import { create } from "zustand";
+import { shallow } from "zustand/shallow";
+import { isLiveWorkflowRunStatus, type ProjectLocation } from "@/shared/contracts";
+import { readBridge } from "@/renderer/bridge";
+
+/**
+ * Per-thread tracker for live background workflows.
+ *
+ * A thread's foreground agent turn ends the instant the `Workflow` tool call
+ * returns - the orchestration runs as a detached background process - so
+ * `thread.status` settles to idle/finished while the workflow keeps running.
+ * The composer's `ActiveSubAgentTile` already polls each workflow's on-disk
+ * manifest, but only while the thread is open. This store lifts that liveness
+ * to the THREAD level and keeps polling after the dock unmounts / the user
+ * navigates away, so the sidebar row and chat header can keep showing the
+ * working spinner until the workflow actually finishes.
+ *
+ * Presentation only: it never touches `thread.status`, so composer
+ * interrupt/steer semantics, turn timing, and notifications are unaffected.
+ *
+ * Coverage: entries are registered from the open thread's dock, so any thread
+ * opened this session is covered (including after you switch away). Threads
+ * never opened this session - or carried across an app restart - are not; full
+ * coverage would require a supervisor-side watcher.
+ */
+
+const POLL_MS = 4000;
+// A launched workflow writes its manifest within ~seconds, on its first
+// progress event (see workflowRunStore). Treat a never-seen manifest as a dead
+// launch only after this generous window, so a merely slow first phase isn't
+// mistaken for a failure. Once any manifest is seen, liveness follows the
+// manifest status (running until terminal) rather than this deadline.
+const LAUNCH_DEADLINE_MS = 10 * 60_000;
+// Backstop for a workflow whose manifest was seen but never reaches a terminal
+// status (e.g. the runtime crashed mid-run leaving it pinned "running"). Long
+// enough not to cut off legitimately long orchestrations.
+const MAX_ENTRY_AGE_MS = 3 * 60 * 60 * 1000;
+
+interface LiveWorkflowEntry {
+  threadId: string;
+  itemId: string;
+  manifestPath: string;
+  transcriptDir: string | undefined;
+  location: ProjectLocation;
+  registeredAt: number;
+  manifestSeen: boolean;
+}
+
+interface RegisterInput {
+  threadId: string;
+  itemId: string;
+  manifestPath: string;
+  location: ProjectLocation;
+  transcriptDir?: string;
+}
+
+interface ThreadLiveWorkflowStore {
+  /** Threads with at least one live background workflow they launched. */
+  liveThreadIds: ReadonlySet<string>;
+  /** Begin (or refresh) tracking a thread's background workflow. Idempotent. */
+  register: (input: RegisterInput) => void;
+  /** Stop tracking a workflow (e.g. the dock already observed terminal status). */
+  markTerminal: (threadId: string, itemId: string) => void;
+}
+
+// Entries and the shared timer live at module scope (like workflowRunStore's
+// pollers) so mutating them never forces a store re-render; only the derived
+// `liveThreadIds` snapshot does.
+const entries = new Map<string, LiveWorkflowEntry>();
+let timer: ReturnType<typeof setTimeout> | null = null;
+let ticking = false;
+
+function entryKey(threadId: string, itemId: string): string {
+  return `${threadId} ${itemId}`;
+}
+
+function isExpired(entry: LiveWorkflowEntry): boolean {
+  const maxAge = entry.manifestSeen ? MAX_ENTRY_AGE_MS : LAUNCH_DEADLINE_MS;
+  return Date.now() - entry.registeredAt > maxAge;
+}
+
+export const useThreadLiveWorkflowStore = create<ThreadLiveWorkflowStore>((set, get) => {
+  function recomputeLiveThreads(): void {
+    const next = new Set<string>();
+    for (const entry of entries.values()) next.add(entry.threadId);
+    // Only publish a new snapshot when membership actually changes, so the
+    // sidebar (which reads the whole set) doesn't re-render every poll tick.
+    if (shallow(get().liveThreadIds, next)) return;
+    set({ liveThreadIds: next });
+  }
+
+  function removeEntry(key: string): void {
+    if (entries.delete(key)) recomputeLiveThreads();
+    if (entries.size === 0 && timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  // Self-rescheduling chain (never setInterval): the next tick is only armed
+  // AFTER the previous one's IPC batch settles, so a slow/contended disk can't
+  // stack overlapping polls. `ticking` guards against a register() arming a
+  // fresh timer while a batch is mid-flight.
+  function scheduleTick(): void {
+    if (timer || ticking || entries.size === 0) return;
+    timer = setTimeout(() => void runTick(), POLL_MS);
+  }
+
+  async function runTick(): Promise<void> {
+    timer = null;
+    ticking = true;
+    try {
+      await Promise.all([...entries.keys()].map((key) => pollEntry(key)));
+    } finally {
+      ticking = false;
+    }
+    scheduleTick();
+  }
+
+  async function pollEntry(key: string): Promise<void> {
+    const entry = entries.get(key);
+    if (!entry) return;
+    try {
+      const result = await readBridge().workflowGetRun({
+        manifestPath: entry.manifestPath,
+        location: entry.location,
+        ...(entry.transcriptDir ? { transcriptDir: entry.transcriptDir } : {}),
+      });
+      // The entry may have been removed (terminal/markTerminal) while in flight.
+      const current = entries.get(key);
+      if (!current) return;
+      if (result.run) {
+        current.manifestSeen = true;
+        // Drop on terminal status, or as an ultimate backstop for a manifest
+        // that never reaches one.
+        if (!isLiveWorkflowRunStatus(result.run.status) || isExpired(current)) {
+          removeEntry(key);
+        }
+        return;
+      }
+      // No manifest on disk yet. Normal right after launch - keep showing
+      // "working" (mirrors the dock, which never drops on a null run). Only
+      // give up if one never appears within the launch window.
+      if (isExpired(current)) removeEntry(key);
+    } catch {
+      const current = entries.get(key);
+      if (current && isExpired(current)) removeEntry(key);
+    }
+  }
+
+  return {
+    liveThreadIds: new Set<string>(),
+    register(input) {
+      const key = entryKey(input.threadId, input.itemId);
+      const existing = entries.get(key);
+      if (existing) {
+        // Refresh mutable fields in case the manifest path/location resolved
+        // after the first registration; leave registeredAt/manifestSeen intact.
+        existing.manifestPath = input.manifestPath;
+        existing.location = input.location;
+        existing.transcriptDir = input.transcriptDir;
+        return;
+      }
+      entries.set(key, {
+        threadId: input.threadId,
+        itemId: input.itemId,
+        manifestPath: input.manifestPath,
+        transcriptDir: input.transcriptDir,
+        location: input.location,
+        registeredAt: Date.now(),
+        manifestSeen: false,
+      });
+      // Light the spinner immediately - the dock only registers once it has
+      // confirmed a background workflow, so we trust it until a poll says
+      // otherwise (avoids a non-working flicker during the launch gap).
+      recomputeLiveThreads();
+      scheduleTick();
+    },
+    markTerminal(threadId, itemId) {
+      removeEntry(entryKey(threadId, itemId));
+    },
+  };
+});
+
+/** True while the thread has at least one background workflow still running. */
+export function useThreadHasLiveWorkflow(threadId: string): boolean {
+  return useThreadLiveWorkflowStore((s) => s.liveThreadIds.has(threadId));
+}

--- a/src/renderer/state/workflowRunStore.ts
+++ b/src/renderer/state/workflowRunStore.ts
@@ -1,5 +1,9 @@
 import { create } from "zustand";
-import type { ProjectLocation, WorkflowRun } from "@/shared/contracts";
+import {
+  isLiveWorkflowRunStatus,
+  type ProjectLocation,
+  type WorkflowRun,
+} from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 
 /**
@@ -80,7 +84,7 @@ export const useWorkflowRunStore = create<WorkflowRunStore>((set, get) => {
       // Keep polling at the active cadence rather than backing off; the
       // file usually shows up within a couple of seconds of launch.
       setEntry(itemId, { run: result.run, loading: false, error: null });
-      const isLive = !result.run || isLiveStatus(result.run.status);
+      const isLive = !result.run || isLiveWorkflowRunStatus(result.run.status);
       if (isLive) {
         poller.timer = setTimeout(() => void tick(itemId), ACTIVE_POLL_MS);
       } else {
@@ -156,10 +160,6 @@ export const useWorkflowRunStore = create<WorkflowRunStore>((set, get) => {
     },
   };
 });
-
-function isLiveStatus(status: WorkflowRun["status"]): boolean {
-  return status === "running" || status === "unknown";
-}
 
 export function selectWorkflowRun(
   state: WorkflowRunStore,

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
@@ -10,6 +10,7 @@ import { ChevronDown } from "lucide-react";
 import { useDragSource } from "@/renderer/dnd";
 import { openNewThread, openNewThreadSideBySide } from "@/renderer/actions/threadActions";
 import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarUiStore";
+import { useThreadLiveWorkflowStore } from "@/renderer/state/threadLiveWorkflowStore";
 import { SidebarButton } from "@/renderer/components/common";
 import { NewThreadButton } from "./NewThreadButton";
 import { buildSidebarProjectRows, type SidebarRow } from "./sidebarProjectRows";
@@ -30,6 +31,7 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
   const currentThreadCount = useCurrentThreadIdsCount();
   const isDraftActive = useIsCurrentProjectDraft(project.id);
   const source = useDragSource();
+  const liveWorkflowThreadIds = useThreadLiveWorkflowStore((s) => s.liveThreadIds);
 
   const rows = buildSidebarProjectRows({
     projectId: project.id,
@@ -37,6 +39,7 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
     sortMode,
     collapsedWorktrees,
     visibleLimit,
+    liveWorkflowThreadIds,
   });
 
   return (

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -30,6 +30,7 @@ import {
   useIsCurrentThread,
   useProjectAgentStatuses,
 } from "@/renderer/hooks/uiSelectors";
+import { useThreadHasLiveWorkflow } from "@/renderer/state/threadLiveWorkflowStore";
 import { openGitReview } from "@/renderer/actions/panelActions";
 import {
   gitPull,
@@ -106,7 +107,8 @@ export function SortableThreadItem(props: {
 
   const isDragging = useIsDraggingThread(thread.id);
 
-  const statusTone = getStatusTone(thread);
+  const hasLiveWorkflow = useThreadHasLiveWorkflow(thread.id);
+  const statusTone = getStatusTone(thread, { hasLiveWorkflow });
 
   return (
     <div ref={ref} className="relative w-full pb-0.5">
@@ -298,7 +300,9 @@ export function SortableThreadItem(props: {
         <SidebarButton
           size="xs"
           statusTone={statusTone}
-          icon={<ThreadProviderIcon thread={thread} className="size-3.5 shrink-0" />}
+          icon={
+            <ThreadProviderIcon thread={thread} tone={statusTone} className="size-3.5 shrink-0" />
+          }
           label={
             editingThreadId === thread.id ? (
               <InlineRenameInput

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
@@ -35,6 +35,8 @@ export type SidebarRow =
 /** Default number of list items shown per project before the "See more" row. */
 export const SIDEBAR_THREAD_LIST_PAGE_SIZE = 10;
 
+const EMPTY_THREAD_ID_SET: ReadonlySet<string> = new Set();
+
 function isRecent(iso: string): boolean {
   return Date.now() - new Date(iso).getTime() < 24 * 60 * 60 * 1000;
 }
@@ -53,13 +55,21 @@ function entryIsStarred(entry: ThreadListEntry): boolean {
 }
 
 /** Pinned or attention-needing threads are never hidden behind "See more". */
-function threadIsProtected(thread: Thread): boolean {
-  return thread.starred || isThreadTurnActive(thread.status) || thread.status === "error";
+function threadIsProtected(thread: Thread, liveWorkflowThreadIds: ReadonlySet<string>): boolean {
+  return (
+    thread.starred ||
+    isThreadTurnActive(thread.status) ||
+    thread.status === "error" ||
+    liveWorkflowThreadIds.has(thread.id)
+  );
 }
 
-function entryIsProtected(entry: ThreadListEntry): boolean {
-  if (entry.kind === "thread") return threadIsProtected(entry.thread);
-  return entry.group.threads.some(threadIsProtected);
+function entryIsProtected(
+  entry: ThreadListEntry,
+  liveWorkflowThreadIds: ReadonlySet<string>,
+): boolean {
+  if (entry.kind === "thread") return threadIsProtected(entry.thread, liveWorkflowThreadIds);
+  return entry.group.threads.some((t) => threadIsProtected(t, liveWorkflowThreadIds));
 }
 
 /**
@@ -161,18 +171,19 @@ export function buildSidebarProjectRows(input: {
   collapsedWorktrees: Record<string, boolean>;
   /** Max list items shown before "See more"; protected items are always kept. */
   visibleLimit: number;
+  /** Threads with a live background workflow — kept visible like working ones. */
+  liveWorkflowThreadIds?: ReadonlySet<string>;
 }): SidebarRow[] {
   const rows: SidebarRow[] = [];
   const dndGroup = `project-entries:${input.projectId}`;
+  const liveWorkflowThreadIds = input.liveWorkflowThreadIds ?? EMPTY_THREAD_ID_SET;
 
   if (input.sortMode === "manual") {
     const orderedThreads = [...input.projectThreads].sort(
       (a, b) => Number(b.starred) - Number(a.starred),
     );
-    const { visible, hiddenCount } = selectVisible(
-      orderedThreads,
-      input.visibleLimit,
-      threadIsProtected,
+    const { visible, hiddenCount } = selectVisible(orderedThreads, input.visibleLimit, (t) =>
+      threadIsProtected(t, liveWorkflowThreadIds),
     );
     orderedThreads.forEach((thread, idx) => {
       if (!visible.has(thread)) return;
@@ -202,7 +213,7 @@ export function buildSidebarProjectRows(input: {
   const { visible, hiddenCount } = selectVisible(
     [...starredEntries, ...recentEntries, ...olderEntries],
     input.visibleLimit,
-    entryIsProtected,
+    (e) => entryIsProtected(e, liveWorkflowThreadIds),
   );
   const starredVisible = starredEntries.filter((e) => visible.has(e));
   const recentVisible = recentEntries.filter((e) => visible.has(e));

--- a/src/shared/contracts/workflowTranscript.ts
+++ b/src/shared/contracts/workflowTranscript.ts
@@ -83,3 +83,14 @@ export const workflowRunSchema = z.object({
   unphasedAgents: z.array(workflowAgentSchema),
 });
 export type WorkflowRun = z.infer<typeof workflowRunSchema>;
+
+/**
+ * A workflow run is "live" while its manifest reports `running` - or `unknown`,
+ * the pre-manifest / can't-parse state that precedes the first on-disk write.
+ * Terminal states are `completed` / `failed` / `cancelled`. Shared so the
+ * per-item dock poller, the chat row, and the per-thread live-workflow tracker
+ * all agree on what counts as still in flight.
+ */
+export function isLiveWorkflowRunStatus(status: WorkflowRunStatus): boolean {
+  return status === "running" || status === "unknown";
+}


### PR DESCRIPTION
- Type: Feature
- Keep detached background workflows visibly working in chat, header, provider icon, and sidebar until they finish.
- Keep live workflow threads visible in sidebar lists so active work is not hidden behind “See more”.
- Share workflow liveness semantics across workflow UI and add coverage for status tone and live workflow tracking.