### PR TITLE
Fix PowerShell variable range command summaries

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
@@ -70,6 +70,19 @@ describe("humanIntentTitle", () => {
     });
   });
 
+  it("describes PowerShell Get-Content variable paths with range loops as viewed lines", () => {
+    const full = String.raw`"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command '$p='"'src/supervisor/agents/base/index.ts'; "'$lines=Get-Content -LiteralPath $p; foreach($range in @(@(250,315),@(380,430),@(610,650))){ for($i=$range[0];$i -le $range[1];$i++){ if($i -le $lines.Length){ '"'{0}: {1}' -f "'$i,$lines[$i-1] }} }'`;
+    const display = commandIntentDisplay(full);
+
+    expect(display.title).toBe("View 250:315,380:430,610:650: src/supervisor/agents/base/index.ts");
+    expect(display.kind).toBe("view");
+    expect(display.parts).toEqual({
+      prefix: "View 250:315,380:430,610:650: ",
+      path: "src/supervisor/agents/base/index.ts",
+      filePath: true,
+    });
+  });
+
   it("preserves Windows paths in PowerShell Get-Content -LiteralPath", () => {
     const full = String.raw`pwsh -Command 'Get-Content -LiteralPath C:\Users\sdsle\work\lightcode\src\foo.ts'`;
     const display = commandIntentDisplay(full);

--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
@@ -69,11 +69,25 @@ function collapseWhitespace(s: string): string {
 function extractPowerShellQuotedCommand(s: string): string | null {
   const re = /-Command\s+'((?:''|[^'])*)'/i;
   const m = re.exec(s);
-  if (m?.[1] != null) return m[1]!.replace(/''/g, "'");
+  if (m?.[1] != null) {
+    const next = s[m.index + m[0].length];
+    if (next === "'" || next === '"') {
+      const joined = extractPowerShellCommandShellWord(s);
+      if (joined) return joined;
+    }
+    return m[1]!.replace(/''/g, "'");
+  }
   const reDq = /-Command\s+"((?:\\.|[^"\\])*)"/i;
   const m2 = reDq.exec(s);
   if (m2?.[1] != null) return m2[1]!.replace(/\\"/g, '"').replace(/\\n/g, "\n");
   return null;
+}
+
+function extractPowerShellCommandShellWord(s: string): string | null {
+  const words = splitShellWords(s);
+  const commandIndex = words.findIndex((word) => word.toLowerCase() === "-command");
+  const command = commandIndex >= 0 ? words[commandIndex + 1] : undefined;
+  return command && command.trim().length > 0 ? command : null;
 }
 
 /** `-c '…'` / `-c "…"` (pwsh/bash). */
@@ -338,7 +352,7 @@ function parseSedView(command: string): SedView | null {
 }
 
 function formatLineRange(lines: string): string {
-  return lines.replace("-", ":");
+  return lines.replace(/-/g, ":");
 }
 
 function parsePipedFileView(command: string): PipedFileView | null {
@@ -438,12 +452,26 @@ function parsePowerShellGetContentView(command: string): PowerShellFileView | nu
 
   const parts = splitPowerShellPipeline(command);
   const path = extractPowerShellGetContentPath(splitPowerShellWords(parts[0] ?? command));
+  if (path) {
+    const lines = parts
+      .slice(1)
+      .map((part) => parseSelectObjectLineWindow(splitPowerShellWords(part)))
+      .find((lineWindow): lineWindow is string => !!lineWindow);
+    return { path, ...(lines ? { lines } : {}) };
+  }
+
+  return parsePowerShellScriptGetContentView(command);
+}
+
+function parsePowerShellScriptGetContentView(command: string): PowerShellFileView | null {
+  const match = /(?:^|;)\s*(?:\$\w+\s*=\s*)?((?:Get-Content|gc)\b[^;|]*)/i.exec(command);
+  if (!match?.[1]) return null;
+
+  const variables = extractPowerShellStringAssignments(command);
+  const path = extractPowerShellGetContentPath(splitPowerShellWords(match[1]), variables);
   if (!path) return null;
 
-  const lines = parts
-    .slice(1)
-    .map((part) => parseSelectObjectLineWindow(splitPowerShellWords(part)))
-    .find((lineWindow): lineWindow is string => !!lineWindow);
+  const lines = parsePowerShellForeachLineRanges(command);
   return { path, ...(lines ? { lines } : {}) };
 }
 
@@ -461,6 +489,32 @@ function parsePowerShellIndexedGetContentView(command: string): PowerShellFileVi
     return null;
 
   return { path, lines: `${startIndex + 1}-${endIndex + 1}` };
+}
+
+function extractPowerShellStringAssignments(command: string): ReadonlyMap<string, string> {
+  const variables = new Map<string, string>();
+  const re = /(?:^|;)\s*(\$\w+)\s*=\s*(?:"((?:`.|[^"`])*)"|'((?:''|[^'])*)')/gi;
+  for (const match of command.matchAll(re)) {
+    const value =
+      match[2] !== undefined ? match[2].replace(/`(.)/g, "$1") : match[3]!.replace(/''/g, "'");
+    variables.set(match[1]!.toLowerCase(), value);
+  }
+  return variables;
+}
+
+function parsePowerShellForeachLineRanges(command: string): string | undefined {
+  const match =
+    /foreach\s*\(\s*\$\w+\s+in\s+@\(\s*((?:@\(\s*\d+\s*,\s*\d+\s*\)\s*,?\s*)+)\)\s*\)/i.exec(
+      command,
+    );
+  if (!match?.[1]) return undefined;
+
+  const ranges = [...match[1].matchAll(/@\(\s*(\d+)\s*,\s*(\d+)\s*\)/g)].map((range) => {
+    const start = Number(range[1]);
+    const end = Number(range[2]);
+    return end >= start ? (start === end ? `${start}` : `${start}-${end}`) : undefined;
+  });
+  return ranges.every((range): range is string => !!range) ? ranges.join(",") : undefined;
 }
 
 function extractGrepLikeFileViewPath(words: string[]): string | undefined {
@@ -510,23 +564,37 @@ function isAllLinesRegex(pattern: string): boolean {
   return pattern.replace(/^'+/u, "") === "^";
 }
 
-function extractPowerShellGetContentPath(words: string[]): string | undefined {
+function extractPowerShellGetContentPath(
+  words: string[],
+  variables?: ReadonlyMap<string, string>,
+): string | undefined {
   const executable = words[0]?.split(/[/\\]/).pop()?.toLowerCase();
   if (executable !== "get-content" && executable !== "gc") return undefined;
 
   for (let i = 1; i < words.length; i++) {
     const word = words[i]!;
     const lower = word.toLowerCase();
-    if (lower === "-path" || lower === "-literalpath") return words[i + 1];
-    if (lower.startsWith("-path:")) return word.slice("-Path:".length);
-    if (lower.startsWith("-literalpath:")) return word.slice("-LiteralPath:".length);
+    if (lower === "-path" || lower === "-literalpath")
+      return resolvePowerShellPathOperand(words[i + 1], variables);
+    if (lower.startsWith("-path:"))
+      return resolvePowerShellPathOperand(word.slice("-Path:".length), variables);
+    if (lower.startsWith("-literalpath:"))
+      return resolvePowerShellPathOperand(word.slice("-LiteralPath:".length), variables);
     if (word.startsWith("-")) {
       if (getContentOptionConsumesValue(lower)) i++;
       continue;
     }
-    return word;
+    return resolvePowerShellPathOperand(word, variables);
   }
   return undefined;
+}
+
+function resolvePowerShellPathOperand(
+  value: string | undefined,
+  variables?: ReadonlyMap<string, string>,
+): string | undefined {
+  if (!value) return undefined;
+  return variables?.get(value.toLowerCase()) ?? value;
 }
 
 function getContentOptionConsumesValue(option: string): boolean {


### PR DESCRIPTION
- Bugfix: recognize PowerShell `Get-Content` commands that use variable paths and range loops.
- Display multi-range line views with normalized `:` separators in command summaries.
- Add coverage for PowerShell variable path range views to prevent regressions.