### PR TITLE
Fix Windows agent executable launches

### DIFF
--- a/src/supervisor/agents/base.windows-shell.test.ts
+++ b/src/supervisor/agents/base.windows-shell.test.ts
@@ -79,6 +79,16 @@ describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
     expect(script).toContain(quotePowerShellLiteral(SPICY_PROMPT));
   });
 
+  it("spawns absolute Windows executables directly", () => {
+    const spec = buildWindowsCommand("C:\\repo", "C:\\Tools\\codex.exe", ["app-server"]);
+
+    expect(spec).toEqual({
+      command: "C:\\Tools\\codex.exe",
+      args: ["app-server"],
+      cwd: "C:\\repo",
+    });
+  });
+
   it("falls back to powershell.exe (PS 5.1) when pwsh is missing", () => {
     const resolvePath = vi.fn<(name: string) => string | undefined>((name) =>
       name === "powershell.exe"
@@ -128,12 +138,9 @@ describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
       ["debug", "prompt-input", "hi\n1\n2"],
       shimPath,
     );
-    const script = decodePowerShellEncoded(spec.args.at(-1)!);
 
-    expect(script).toContain(quotePowerShellLiteral(nodePath));
-    expect(script).toContain(quotePowerShellLiteral(scriptPath));
-    expect(script).toContain(quotePowerShellLiteral("hi\n1\n2"));
-    expect(script).not.toContain(quotePowerShellLiteral(shimPath));
+    expect(spec.command).toBe(nodePath);
+    expect(spec.args).toEqual([scriptPath, "debug", "prompt-input", "hi\n1\n2"]);
   });
 });
 

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -139,8 +139,25 @@ export function injectWslEnv(
   return { ...spec, args };
 }
 
+/**
+ * Drop `undefined` values so an `env` record matches the `Record<string, string>`
+ * shape that `buildAgentCommand` expects (the SDK's `SpawnOptions.env` allows
+ * `undefined` values).
+ */
+export function definedEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
 function encodePowerShellCommand(script: string): string {
   return Buffer.from(script, "utf16le").toString("base64");
+}
+
+function isWindowsDirectExecutable(command: string): boolean {
+  return /^(?:[a-zA-Z]:[\\/]|\\\\)/.test(command) && /\.(?:exe|com)$/i.test(command);
 }
 
 /** Detect the best available shell. Returns a shell path on Windows (pwsh > powershell > cmd), or `true` on Unix (default shell). */
@@ -163,6 +180,10 @@ export function buildWindowsCommand(
   args: string[],
   resolvePath: ResolveExecutablePath = resolveExecutablePath,
 ): CommandSpec {
+  if (isWindowsDirectExecutable(command)) {
+    return { command, args, cwd };
+  }
+
   const shell = detectShell(resolvePath);
   if (typeof shell === "string") {
     const script = [

--- a/src/supervisor/agents/claude/probe.test.ts
+++ b/src/supervisor/agents/claude/probe.test.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   Query,
   SDKMessage,
@@ -90,10 +93,20 @@ function createProbeQuery(): Query {
   } as unknown as Query;
 }
 
+const originalPlatform = process.platform;
+const tempDirs: string[] = [];
+
 beforeEach(() => {
   mockSdk.query.mockReset();
   mockChildProcess.spawn.mockReset();
   mockChildProcess.spawn.mockImplementation(() => makeSpawnedProcess());
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 describe("claudeCapabilitiesFromCliVersion", () => {
@@ -150,6 +163,7 @@ describe("win32PathToWslMount", () => {
 
 describe("Claude SDK probe process handling", () => {
   it("contains probe-owned stdin EPIPE from the Claude SDK child", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     mockSdk.query.mockImplementation((input: unknown) => {
       const params = input as {
         options?: {
@@ -201,5 +215,48 @@ describe("Claude SDK probe process handling", () => {
     });
 
     expect(() => child.stdin.emit("error", ebadfError())).toThrow("write EBADF");
+  });
+
+  it("wraps native Windows SDK .cmd shims instead of spawning them directly", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const dir = mkdtempSync(join(tmpdir(), "lightcode-claude-probe-shim-"));
+    tempDirs.push(dir);
+    const scriptPath = join(dir, "node_modules", "@anthropic-ai", "claude-code", "cli.mjs");
+    mkdirSync(join(scriptPath, ".."), { recursive: true });
+    writeFileSync(scriptPath, "", "utf8");
+    writeFileSync(join(dir, "node.exe"), "", "utf8");
+    const shimPath = join(dir, "claude.cmd");
+    writeFileSync(
+      shimPath,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe" "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.mjs" %*',
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    spawnClaudeProbeProcess({
+      command: shimPath,
+      args: ["--sdk-mcp-server"],
+      cwd: "C:\\repo",
+      env: { FOO: "bar" },
+      signal: new AbortController().signal,
+    });
+
+    expect(mockChildProcess.spawn).toHaveBeenCalledOnce();
+    const [command, args, options] = mockChildProcess.spawn.mock.calls[0] as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(command).not.toBe(shimPath);
+    expect(args).not.toContain(shimPath);
+    expect(options).toMatchObject({
+      cwd: "C:\\repo",
+      env: expect.objectContaining({ FOO: "bar" }),
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
   });
 });

--- a/src/supervisor/agents/claude/sdkProbeProcess.ts
+++ b/src/supervisor/agents/claude/sdkProbeProcess.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { SpawnOptions, SpawnedProcess } from "@anthropic-ai/claude-agent-sdk";
+import { buildAgentCommand, definedEnv } from "../base";
 
 function isEpipeError(error: Error): boolean {
   const code = (error as NodeJS.ErrnoException).code;
@@ -13,12 +14,32 @@ function isEpipeError(error: Error): boolean {
  * probe child while preserving all other stream errors.
  */
 export function spawnClaudeProbeProcess(options: SpawnOptions): SpawnedProcess {
-  const child = spawn(options.command, options.args, {
-    env: options.env,
+  // On Windows, route through the shared launch builder so npm `.cmd` shims are
+  // rewritten to `node.exe cli.mjs` and the probe child spawns no console window.
+  let command = options.command;
+  let args = options.args;
+  let env: Record<string, string | undefined> | undefined = options.env;
+  let cwd = options.cwd;
+  if (process.platform === "win32") {
+    const spec = buildAgentCommand(
+      { kind: "windows", path: options.cwd ?? process.cwd() },
+      options.command,
+      options.args,
+      undefined,
+      definedEnv(options.env),
+    );
+    command = spec.command;
+    args = spec.args;
+    env = spec.env;
+    cwd = spec.cwd;
+  }
+
+  const child = spawn(command, args, {
+    ...(env ? { env } : {}),
     signal: options.signal,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
-    ...(options.cwd ? { cwd: options.cwd } : {}),
+    ...(cwd ? { cwd } : {}),
   }) as unknown as SpawnedProcess;
 
   child.stdin.on("error", (error: Error) => {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -31,6 +31,7 @@ import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
 import {
   createKnownSessionRef,
   buildAgentCommand,
+  definedEnv,
   getWslCommand,
   getPrimedPosixEnv,
   getProjectShellEnv,
@@ -160,14 +161,6 @@ function filteredEnv(env: Record<string, string | undefined>): Record<string, st
     if (value === undefined) continue;
     if (WINDOWS_HOST_ENV_KEYS.has(key.toLowerCase())) continue;
     out[key] = value;
-  }
-  return out;
-}
-
-function definedEnv(env: Record<string, string | undefined>): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) out[key] = value;
   }
   return out;
 }

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -15,6 +15,7 @@ import {
   probeCodexCliSemver,
 } from "./plugin/install";
 import { buildCodexBrowserMcpArgs, buildCodexBrowserMcpEnv } from "./mcpBrowser";
+import { resolveCodexWindowsLaunchBinary } from "./windowsExecutable";
 
 const CODEX_GOALS_FEATURE_FLAG = "goals";
 const codexGoalsSupportCache = new Map<string, boolean>();
@@ -84,6 +85,7 @@ export function buildCodexArgvFor(
   sessionRef?: SessionRef,
   launchOptions?: AgentLaunchOptions,
 ): AgentArgvSpec {
+  const binary = resolveCodexWindowsLaunchBinary(location) ?? "codex";
   const browserMcpEnv = buildCodexBrowserMcpEnv(launchOptions?.browserMcp);
   const enableGoals = isCodexGoalsSupported(location);
   const baseArgsOptions: BuildCodexArgsOptions = {
@@ -106,7 +108,7 @@ export function buildCodexArgvFor(
         ]
       : baseArgs;
     return {
-      binary: "codex",
+      binary,
       args,
       ...(browserMcpEnv ? { env: browserMcpEnv } : {}),
     };
@@ -123,7 +125,7 @@ export function buildCodexArgvFor(
     : codexArgs;
 
   return {
-    binary: "codex",
+    binary,
     args,
     ...(browserMcpEnv ? { env: browserMcpEnv } : {}),
   };
@@ -175,7 +177,13 @@ export function buildCodexAppServerCommand(
       ],
     };
   }
-  return buildAgentCommand(location, "codex", args, wslExecPath, browserMcpEnv);
+  return buildAgentCommand(
+    location,
+    "codex",
+    args,
+    resolveCodexWindowsLaunchBinary(location) ?? wslExecPath,
+    browserMcpEnv,
+  );
 }
 
 function isCodexGoalsSupported(location: ProjectLocation, executablePath?: string): boolean {

--- a/src/supervisor/agents/codex/plugin/install.test.ts
+++ b/src/supervisor/agents/codex/plugin/install.test.ts
@@ -1,7 +1,20 @@
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecFileSync = vi.hoisted(() =>
+  vi.fn<(command: string, args?: string[], options?: Record<string, unknown>) => string | Buffer>(),
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: mockExecFileSync,
+  };
+});
+
 import {
   codexHooksFeatureFlagForSemver,
   getCodexPluginPaths,
@@ -9,6 +22,7 @@ import {
   isCodexSemverSupportedForHooks,
   mergeCodexHooksDocument,
   parseCodexVersionLine,
+  probeCodexCliSemver,
 } from "./install";
 import { buildNativeHookCommandHead } from "../../plugin/installerBase";
 
@@ -33,6 +47,16 @@ function commandFor(head: string, event: string): string {
   return `${head} ${event}`;
 }
 
+const originalPlatform = process.platform;
+
+beforeEach(() => {
+  mockExecFileSync.mockReset();
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+});
+
 describe("getCodexPluginPaths", () => {
   it("places Codex hooks under Lightcode's private CODEX_HOME", () => {
     const baseDir = mkdtempSync(join(tmpdir(), "lightcode-codex-paths-"));
@@ -43,6 +67,23 @@ describe("getCodexPluginPaths", () => {
     expect(paths.codexHooksPath).toBe(
       join(baseDir, "agent-plugins", "codex", "home", "hooks.json"),
     );
+  });
+});
+
+describe("probeCodexCliSemver", () => {
+  it("does not use shell:true for Windows version probes", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    mockExecFileSync.mockReturnValue("codex-cli 0.130.0");
+
+    expect(probeCodexCliSemver()).toEqual([0, 130, 0]);
+
+    const options = mockExecFileSync.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(options).toMatchObject({
+      encoding: "utf8",
+      timeout: 8000,
+      windowsHide: true,
+    });
+    expect(options).not.toHaveProperty("shell");
   });
 });
 

--- a/src/supervisor/agents/codex/plugin/install.ts
+++ b/src/supervisor/agents/codex/plugin/install.ts
@@ -11,7 +11,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { toWslUncPath } from "@/shared/wsl";
 import type { AgentEnvContext } from "../../base";
-import { execInWsl, quotePosixShellArg } from "../../base";
+import { buildAgentCommand, execInWsl, quotePosixShellArg } from "../../base";
+import { resolveAgentBinaryPath } from "../../binaryResolver";
 import {
   FORWARD_RUNTIME_FILE,
   buildNativeHookCommandHeads,
@@ -34,6 +35,7 @@ import {
   writeNativeHookWrapper,
   type PluginManifest,
 } from "../../plugin/installerBase";
+import { resolveCodexNativeExecutableForWindows } from "../windowsExecutable";
 
 export interface CodexPluginPaths {
   pluginDir: string;
@@ -268,19 +270,30 @@ function semverGte(a: [number, number, number], b: readonly [number, number, num
 /**
  * Probe `codex --version` on PATH. Returns null if unavailable or unparsable.
  *
- * On Windows the `codex` binary from npm global install is a `.cmd` shim,
- * which Node's `execFile` cannot invoke directly (`ENOENT` without `shell`,
- * `EINVAL` with the full `.cmd` path). We enable `shell: true` on win32 so
- * cmd.exe resolves PATHEXT for us. Args are hardcoded `--version` with no
- * user input, so the shell invocation carries no injection risk.
+ * On Windows the shared launch builder bypasses npm `.cmd` shims so probe
+ * grandchildren do not create visible console windows.
  */
 export function probeCodexCliSemver(): [number, number, number] | null {
   try {
-    const out = execFileSync("codex", ["--version"], {
+    const windowsLocation = { kind: "windows" as const, path: homedir() };
+    const resolvedCodexPath =
+      process.platform === "win32" ? resolveAgentBinaryPath(windowsLocation, "codex") : undefined;
+    const nativeCodexPath = resolveCodexNativeExecutableForWindows(resolvedCodexPath);
+    const spec =
+      process.platform === "win32"
+        ? buildAgentCommand(
+            windowsLocation,
+            nativeCodexPath ?? resolvedCodexPath ?? "codex",
+            ["--version"],
+            nativeCodexPath ?? resolvedCodexPath,
+          )
+        : { command: "codex", args: ["--version"] };
+    const out = execFileSync(spec.command, spec.args, {
       encoding: "utf8",
       timeout: 8000,
       windowsHide: true,
-      shell: process.platform === "win32",
+      ...(spec.cwd ? { cwd: spec.cwd } : {}),
+      ...(spec.env ? { env: spec.env } : {}),
     });
     return parseCodexVersionLine(out);
   } catch {

--- a/src/supervisor/agents/codex/windowsExecutable.test.ts
+++ b/src/supervisor/agents/codex/windowsExecutable.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCodexNativeExecutableForWindows } from "./windowsExecutable";
+
+const WINDOWS_TARGETS = {
+  x64: {
+    packageName: "@openai/codex-win32-x64",
+    targetTriple: "x86_64-pc-windows-msvc",
+  },
+  arm64: {
+    packageName: "@openai/codex-win32-arm64",
+    targetTriple: "aarch64-pc-windows-msvc",
+  },
+} as const;
+
+describe.skipIf(process.platform !== "win32")("resolveCodexNativeExecutableForWindows", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves npm Codex shims to the bundled native executable", () => {
+    const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
+    expect(target).toBeDefined();
+    if (!target) return;
+
+    const root = mkdtempSync(join(tmpdir(), "lightcode-codex-native-"));
+    tempDirs.push(root);
+    const shimPath = join(root, "codex.cmd");
+    const executablePath = join(
+      root,
+      "node_modules",
+      "@openai",
+      "codex",
+      "node_modules",
+      target.packageName,
+      "vendor",
+      target.targetTriple,
+      "bin",
+      "codex.exe",
+    );
+    mkdirSync(dirname(executablePath), { recursive: true });
+    writeFileSync(executablePath, "", "utf8");
+    writeFileSync(
+      shimPath,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%dp0%\\node.exe" "%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js" %*',
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    expect(resolveCodexNativeExecutableForWindows(shimPath)).toBe(executablePath);
+  });
+});

--- a/src/supervisor/agents/codex/windowsExecutable.ts
+++ b/src/supervisor/agents/codex/windowsExecutable.ts
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ProjectLocation } from "@/shared/contracts";
+import { resolveAgentBinaryPath } from "../binaryResolver";
+
+const WINDOWS_TARGETS = {
+  x64: {
+    packageName: "@openai/codex-win32-x64",
+    targetTriple: "x86_64-pc-windows-msvc",
+  },
+  arm64: {
+    packageName: "@openai/codex-win32-arm64",
+    targetTriple: "aarch64-pc-windows-msvc",
+  },
+} as const;
+
+function candidateShimPaths(commandPath: string | undefined): string[] {
+  if (!commandPath) return [];
+  if (/\.(?:cmd|ps1)$/i.test(commandPath)) return [commandPath];
+  return [commandPath, `${commandPath}.cmd`, `${commandPath}.ps1`];
+}
+
+function resolvePackageRootFromShim(shimPath: string): string | undefined {
+  if (!/\.(?:cmd|ps1)$/i.test(shimPath) || !existsSync(shimPath)) {
+    return undefined;
+  }
+  let body: string;
+  try {
+    body = readFileSync(shimPath, "utf8");
+  } catch {
+    return undefined;
+  }
+  if (!/node_modules[/\\]@openai[/\\]codex[/\\]bin[/\\]codex\.js/i.test(body)) {
+    return undefined;
+  }
+  return join(dirname(shimPath), "node_modules", "@openai", "codex");
+}
+
+export function resolveCodexNativeExecutableForWindows(
+  commandPath: string | undefined,
+): string | undefined {
+  if (process.platform !== "win32") return undefined;
+  if (commandPath && /codex\.exe$/i.test(commandPath) && existsSync(commandPath)) {
+    return commandPath;
+  }
+
+  const target = WINDOWS_TARGETS[process.arch as keyof typeof WINDOWS_TARGETS];
+  if (!target) return undefined;
+
+  for (const shimPath of candidateShimPaths(commandPath)) {
+    const packageRoot = resolvePackageRootFromShim(shimPath);
+    if (!packageRoot) continue;
+    const candidates = [
+      join(
+        packageRoot,
+        "node_modules",
+        target.packageName,
+        "vendor",
+        target.targetTriple,
+        "bin",
+        "codex.exe",
+      ),
+      join(packageRoot, "vendor", target.targetTriple, "bin", "codex.exe"),
+    ];
+    const executable = candidates.find((candidate) => existsSync(candidate));
+    if (executable) return executable;
+  }
+
+  return undefined;
+}
+
+export function resolveCodexWindowsLaunchBinary(location: ProjectLocation): string | undefined {
+  if (location.kind !== "windows") return undefined;
+  const resolved = resolveAgentBinaryPath(location, "codex");
+  return resolveCodexNativeExecutableForWindows(resolved) ?? resolved;
+}


### PR DESCRIPTION
- Bugfix: launch absolute Windows `.exe`/`.com` agent binaries directly.
- Resolve Codex npm shims to native Windows executables for sessions, app server, and version probes.
- Route Claude SDK probe spawning through shared Windows launch handling to avoid `.cmd` shim failures and visible consoles.
- Add coverage for Windows executable resolution, Codex probing, Claude probe spawning, and base launch behavior.