### PR TITLE
Stabilize pane resizing and image previews

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -42,6 +42,13 @@ if (process.env.LIGHTCODE_CDP_PORT) {
   app.commandLine.appendSwitch("remote-debugging-port", process.env.LIGHTCODE_CDP_PORT);
 }
 
+// Windows HDR can make DWM acrylic visibly change opacity when Chromium starts
+// compositing image content in the display color space. Keep Chromium in sRGB so
+// acrylic stays translucent without breathing as image planes appear/disappear.
+if (process.platform === "win32") {
+  app.commandLine.appendSwitch("force-color-profile", "srgb");
+}
+
 const chromeLikeUserAgent = buildChromeLikeUserAgent(app.userAgentFallback);
 app.userAgentFallback = chromeLikeUserAgent;
 

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -21,6 +21,7 @@ import { clearRuntimeItemStoreSelectorCacheForThread } from "./components/thread
 
 import { useAppHydration } from "@/renderer/hooks/useAppHydration";
 import { AppProvider } from "./components/ui/provider";
+import { ImageLightboxHost } from "./components/composer";
 import { MainView } from "@/renderer/views/MainView/MainView";
 import { CommandPalette } from "@/renderer/commands/CommandPalette";
 import {
@@ -286,6 +287,7 @@ export function App() {
     <AppProvider contentReady>
       <MainView storeHydrated={storeHydrated} loadT0={loadT0} />
       <CommandPalette />
+      <ImageLightboxHost />
     </AppProvider>
   );
 }

--- a/src/renderer/components/common/BranchSelector/BranchSelector.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.tsx
@@ -49,6 +49,7 @@ export interface BranchSelectorProps {
   moveBranchCopyIgnoredPatterns?: string[];
   popoverPlacement?: "top" | "bottom";
   forceHideLabel?: boolean;
+  collapseTier?: number;
   iconOnly?: boolean;
   /** Hide the leading branch/fork glyph on the trigger (e.g. when a sibling control already shows it). */
   hideTriggerIcon?: boolean;
@@ -75,11 +76,13 @@ export function BranchSelector(props: BranchSelectorProps) {
     moveBranchCopyIgnoredPatterns,
     popoverPlacement = "top",
     forceHideLabel = false,
+    collapseTier,
     iconOnly = false,
     hideTriggerIcon = false,
     compact = false,
   } = props;
   const triggerIconSize = compact ? "size-3" : "size-3.5";
+  const hideLabelOnWrap = collapseTier !== undefined;
   const { t } = useLingui();
 
   const [isOpen, setIsOpen] = useState(false);
@@ -291,9 +294,10 @@ export function BranchSelector(props: BranchSelectorProps) {
                 ) : null}
                 {!iconOnly && (
                   <span
+                    data-collapse-tier={collapseTier}
                     className={
-                      forceHideLabel
-                        ? "lightcode-composer-label-hideable truncate is-hidden"
+                      hideLabelOnWrap
+                        ? `lightcode-composer-label-hideable truncate${forceHideLabel ? " is-hidden" : ""}`
                         : "truncate"
                     }
                   >
@@ -302,9 +306,10 @@ export function BranchSelector(props: BranchSelectorProps) {
                 )}
                 {!iconOnly && (
                   <ChevronDown
+                    data-collapse-tier={collapseTier}
                     className={
-                      forceHideLabel
-                        ? `lightcode-composer-label-hideable ${triggerIconSize} text-muted is-hidden`
+                      hideLabelOnWrap
+                        ? `lightcode-composer-label-hideable ${triggerIconSize} text-muted${forceHideLabel ? " is-hidden" : ""}`
                         : `${triggerIconSize} text-muted`
                     }
                   />

--- a/src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
+++ b/src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
@@ -20,6 +20,7 @@ export interface EffortContextMenuProps {
   isDisabled?: boolean;
   hideLabelOnWrap?: boolean;
   forceHideLabel?: boolean;
+  collapseTier?: number;
   openSignal?: number;
   onOpenChange?: (open: boolean) => void;
 }
@@ -39,6 +40,7 @@ export function EffortContextMenu(props: EffortContextMenuProps) {
     isDisabled,
     hideLabelOnWrap,
     forceHideLabel = false,
+    collapseTier,
     openSignal,
     onOpenChange,
   } = props;
@@ -98,6 +100,7 @@ export function EffortContextMenu(props: EffortContextMenuProps) {
     >
       {icon}
       <span
+        data-collapse-tier={collapseTier}
         className={
           hideLabelOnWrap
             ? `lightcode-composer-label-hideable truncate${forceHideLabel ? " is-hidden" : ""}`
@@ -107,6 +110,7 @@ export function EffortContextMenu(props: EffortContextMenuProps) {
         {triggerLabel}
       </span>
       <ChevronDown
+        data-collapse-tier={collapseTier}
         className={
           hideLabelOnWrap
             ? `lightcode-composer-label-hideable size-3.5 text-muted${forceHideLabel ? " is-hidden" : ""}`

--- a/src/renderer/components/common/OptionMenu.tsx
+++ b/src/renderer/components/common/OptionMenu.tsx
@@ -21,6 +21,7 @@ export interface OptionMenuProps {
   buttonVariant?: ButtonProps["variant"];
   hideLabelOnWrap?: boolean;
   forceHideLabel?: boolean;
+  collapseTier?: number;
   iconOnly?: boolean;
   tooltip?: string | undefined;
   onOpenChange?: (open: boolean) => void;
@@ -39,6 +40,7 @@ export function OptionMenu(props: OptionMenuProps) {
     buttonVariant = "secondary",
     hideLabelOnWrap = false,
     forceHideLabel = false,
+    collapseTier,
     iconOnly = false,
     tooltip,
     onOpenChange,
@@ -52,7 +54,7 @@ export function OptionMenu(props: OptionMenuProps) {
   );
   const currentValue =
     normalizedOptions.find((option) => option.id === value)?.label || value || resolvedPlaceholder;
-  const effectiveTooltip = tooltip ?? (iconOnly ? currentValue : undefined);
+  const effectiveTooltip = tooltip ?? (hideLabelOnWrap || iconOnly ? currentValue : undefined);
   const buttonProps = className ? { className } : {};
 
   const button = (
@@ -66,6 +68,7 @@ export function OptionMenu(props: OptionMenuProps) {
       {icon}
       {!iconOnly && (
         <span
+          data-collapse-tier={collapseTier}
           className={
             hideLabelOnWrap
               ? `lightcode-composer-label-hideable truncate${forceHideLabel ? " is-hidden" : ""}`
@@ -77,6 +80,7 @@ export function OptionMenu(props: OptionMenuProps) {
       )}
       {!iconOnly && (
         <ChevronDown
+          data-collapse-tier={collapseTier}
           className={
             hideLabelOnWrap
               ? `lightcode-composer-label-hideable size-3.5 text-muted${forceHideLabel ? " is-hidden" : ""}`

--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -59,6 +59,7 @@ export interface ProviderModelMenuProps {
   isDisabled?: boolean;
   hideLabelOnWrap?: boolean;
   forceHideLabel?: boolean;
+  collapseTier?: number;
   openSignal?: number;
   onChange: (next: {
     agentKind: string;
@@ -219,6 +220,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
     isDisabled,
     hideLabelOnWrap,
     forceHideLabel = false,
+    collapseTier,
     openSignal,
     onChange,
     onOpenChange,
@@ -360,6 +362,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
         className="size-3.5 shrink-0"
       />
       <span
+        data-collapse-tier={collapseTier}
         className={
           hideLabelOnWrap
             ? `lightcode-composer-label-hideable flex min-w-0 flex-col items-start justify-center gap-0.5${forceHideLabel ? " is-hidden" : ""}`
@@ -376,6 +379,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
         ) : null}
       </span>
       <ChevronDown
+        data-collapse-tier={collapseTier}
         className={
           hideLabelOnWrap
             ? `lightcode-composer-label-hideable size-3.5 text-muted${forceHideLabel ? " is-hidden" : ""}`

--- a/src/renderer/components/composer/AttachmentBar.test.tsx
+++ b/src/renderer/components/composer/AttachmentBar.test.tsx
@@ -26,6 +26,7 @@ describe("AttachmentBar", () => {
       "lightcode-attachment-bar",
       "lightcode-attachment-bar--inset",
     );
+    expect(screen.getByAltText("screenshot.png").getAttribute("loading")).toBeNull();
     expect(screen.getByText("screenshot.png")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button"));
@@ -35,6 +36,25 @@ describe("AttachmentBar", () => {
         path: "/tmp/screenshot.png",
       }),
     );
+  });
+
+  it("renders eager fixed-size image previews for inline message attachments", () => {
+    render(
+      <AttachmentBar
+        attachments={[
+          {
+            id: "image-1",
+            path: "/tmp/screenshot.png",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            isImage: true,
+          },
+        ]}
+        imagesAsPreview
+      />,
+    );
+
+    expect(screen.getByAltText("screenshot.png").getAttribute("loading")).toBeNull();
   });
 
   it("renders flush attachment bars for inline message attachments", () => {

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -90,6 +90,7 @@ function AttachmentChip(props: {
           className="lightcode-attachment-chip__thumb"
           src={toLocalFileUrl(att.path)}
           alt={att.name}
+          decoding="async"
           draggable={false}
         />
       ) : (
@@ -150,12 +151,15 @@ function ImagePreview(props: {
 }) {
   const { t } = useLingui();
   const { attachment: att, onPreviewImage } = props;
-  const img = <img src={toLocalFileUrl(att.path)} alt={att.name} draggable={false} />;
+  const img = (
+    <img src={toLocalFileUrl(att.path)} alt={att.name} decoding="async" draggable={false} />
+  );
   if (onPreviewImage) {
     return (
       <button
         type="button"
         className="lightcode-attachment-image-preview"
+        data-lightcode-attachment-image-preview="true"
         onClick={() => onPreviewImage(att)}
         aria-label={t`Preview ${att.name}`}
       >
@@ -163,7 +167,14 @@ function ImagePreview(props: {
       </button>
     );
   }
-  return <span className="lightcode-attachment-image-preview">{img}</span>;
+  return (
+    <span
+      className="lightcode-attachment-image-preview"
+      data-lightcode-attachment-image-preview="true"
+    >
+      {img}
+    </span>
+  );
 }
 
 export function AttachmentBar(props: {

--- a/src/renderer/components/composer/ImageLightbox.tsx
+++ b/src/renderer/components/composer/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
@@ -13,24 +13,73 @@ export interface LightboxImage {
   alt?: string;
 }
 
-/**
- * Attachment-backed lightbox used by the composer surfaces. Resolves each
- * attachment's local path to a renderable URL and defers to
- * {@link ImageLightboxView}.
- */
-export function ImageLightbox(props: {
-  images: Attachment[];
+type LightboxState = {
+  images: readonly LightboxImage[];
   initialIndex: number;
-  onClose: () => void;
-}) {
-  const images: LightboxImage[] = props.images.map((img) => ({
-    src: toLocalFileUrl(img.path),
-    alt: img.name,
-  }));
-  return (
-    <ImageLightboxView images={images} initialIndex={props.initialIndex} onClose={props.onClose} />
+  nonce: number;
+};
+
+let lightboxState: LightboxState | null = null;
+let lightboxNonce = 0;
+const lightboxListeners = new Set<() => void>();
+
+function emitLightboxChange() {
+  for (const listener of lightboxListeners) listener();
+}
+
+function subscribeLightbox(listener: () => void): () => void {
+  lightboxListeners.add(listener);
+  return () => {
+    lightboxListeners.delete(listener);
+  };
+}
+
+function getLightboxSnapshot(): LightboxState | null {
+  return lightboxState;
+}
+
+export function openImageLightbox(images: readonly LightboxImage[], initialIndex: number): void {
+  if (images.length === 0) return;
+  lightboxState = {
+    images: [...images],
+    initialIndex: Math.min(Math.max(0, initialIndex), images.length - 1),
+    nonce: ++lightboxNonce,
+  };
+  emitLightboxChange();
+}
+
+export function openAttachmentLightbox(
+  attachments: readonly Attachment[],
+  initialIndex: number,
+): void {
+  openImageLightbox(
+    attachments.map((img) => ({
+      src: toLocalFileUrl(img.path),
+      alt: img.name,
+    })),
+    initialIndex,
   );
 }
+
+export function closeImageLightbox(): void {
+  if (lightboxState === null) return;
+  lightboxState = null;
+  emitLightboxChange();
+}
+
+export const ImageLightboxHost = memo(function ImageLightboxHost() {
+  const state = useSyncExternalStore(subscribeLightbox, getLightboxSnapshot, getLightboxSnapshot);
+  useEffect(() => closeImageLightbox, []);
+  if (!state) return null;
+  return (
+    <ImageLightboxView
+      key={state.nonce}
+      images={state.images}
+      initialIndex={state.initialIndex}
+      onClose={closeImageLightbox}
+    />
+  );
+});
 
 /**
  * Source-agnostic fullscreen image viewer. Accepts already-resolved image URLs
@@ -39,7 +88,7 @@ export function ImageLightbox(props: {
  * chrome for multi-image galleries; a single image renders without that chrome.
  */
 export function ImageLightboxView(props: {
-  images: LightboxImage[];
+  images: readonly LightboxImage[];
   initialIndex: number;
   onClose: () => void;
 }) {
@@ -106,6 +155,7 @@ export function ImageLightboxView(props: {
         src={current.src}
         alt={current.alt ?? ""}
         onClick={(e) => e.stopPropagation()}
+        decoding="async"
         draggable={false}
       />
 

--- a/src/renderer/components/composer/index.ts
+++ b/src/renderer/components/composer/index.ts
@@ -2,6 +2,12 @@ export { MentionInput, type MentionInputHandle } from "./MentionInput";
 export { AttachmentBar, BrowserChip } from "./AttachmentBar";
 export { ComposerAddMenu } from "./ComposerAddMenu";
 export { VoiceInputButton, type VoiceInputHandle } from "./VoiceInputButton";
-export { ImageLightbox, ImageLightboxView, type LightboxImage } from "./ImageLightbox";
+export {
+  ImageLightboxHost,
+  ImageLightboxView,
+  openAttachmentLightbox,
+  openImageLightbox,
+  type LightboxImage,
+} from "./ImageLightbox";
 export { useAttachments, type Attachment } from "./useAttachments";
 export { toLocalFileUrl } from "@/shared/promptContent";

--- a/src/renderer/components/layout/SplitPaneContainer.test.ts
+++ b/src/renderer/components/layout/SplitPaneContainer.test.ts
@@ -1,10 +1,38 @@
-import { describe, expect, it } from "vitest";
+import React from "react";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaneLayout } from "@/shared/paneLayout";
-import { computeLayout } from "./SplitPaneContainer";
+import { computeLayout, SplitPaneContainer } from "./SplitPaneContainer";
+import { splitStorageKey, writeStoredSizes } from "./paneSizeStorage";
+
+vi.mock("@dnd-kit/react", () => ({
+  useDroppable: () => undefined,
+}));
+
+vi.mock("@/renderer/dnd", () => ({
+  useIsInsertSplitHighlighted: () => false,
+  useIsRootInsertHighlighted: () => false,
+}));
 
 const containerRect = { left: 0, top: 0, width: 1000, height: 600 };
 const equalSizes = (_key: string, count: number) =>
   Array.from({ length: count }, () => 100 / count);
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+
+function setElementRect(width: number, height: number) {
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
 
 describe("computeLayout", () => {
   it("emits a single full-rect pane for a leaf layout", () => {
@@ -133,5 +161,102 @@ describe("computeLayout", () => {
       expect(Number.isFinite(pane.rect.width)).toBe(true);
       expect(Number.isFinite(pane.rect.height)).toBe(true);
     }
+  });
+});
+
+describe("SplitPaneContainer", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setElementRect(1000, 600);
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  it("updates an existing divider position when panes are added at the same container size", () => {
+    const twoPanes: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: "p1" },
+        { kind: "leaf", paneId: "p2" },
+      ],
+    };
+    const threePanes: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: "p1" },
+        { kind: "leaf", paneId: "p2" },
+        { kind: "leaf", paneId: "p3" },
+      ],
+    };
+    const renderPane = (paneId: string) => React.createElement("div", { "data-pane-id": paneId });
+
+    const { container, rerender } = render(
+      React.createElement(SplitPaneContainer, { layout: twoPanes, renderPane }),
+    );
+    const divider = container.querySelector<HTMLElement>(
+      '[role="separator"][aria-orientation="vertical"]',
+    );
+    expect(divider).not.toBeNull();
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(492);
+
+    rerender(React.createElement(SplitPaneContainer, { layout: threePanes, renderPane }));
+
+    expect(container.querySelector<HTMLElement>('[role="separator"]')).toBe(divider);
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(976 / 3);
+  });
+
+  it("rereads projected sizes when returning to a previously cached layout key", () => {
+    const twoPanes: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: "left" },
+        { kind: "leaf", paneId: "right" },
+      ],
+    };
+    const fourPanes: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        {
+          kind: "split",
+          axis: "horizontal",
+          children: [
+            { kind: "leaf", paneId: "left-top" },
+            { kind: "leaf", paneId: "left-bottom" },
+          ],
+        },
+        {
+          kind: "split",
+          axis: "horizontal",
+          children: [
+            { kind: "leaf", paneId: "right-top" },
+            { kind: "leaf", paneId: "right-bottom" },
+          ],
+        },
+      ],
+    };
+    const renderPane = (paneId: string) => React.createElement("div", { "data-pane-id": paneId });
+
+    writeStoredSizes(splitStorageKey(fourPanes, "vertical"), [50, 50]);
+    const { container, rerender } = render(
+      React.createElement(SplitPaneContainer, { layout: fourPanes, renderPane }),
+    );
+    const divider = container.querySelector<HTMLElement>(
+      '[role="separator"][aria-orientation="vertical"]',
+    );
+    expect(divider).not.toBeNull();
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(492);
+
+    rerender(React.createElement(SplitPaneContainer, { layout: twoPanes, renderPane }));
+    writeStoredSizes(splitStorageKey(fourPanes, "vertical"), [35, 65]);
+
+    rerender(React.createElement(SplitPaneContainer, { layout: fourPanes, renderPane }));
+
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(344.4);
   });
 });

--- a/src/renderer/components/layout/SplitPaneContainer.tsx
+++ b/src/renderer/components/layout/SplitPaneContainer.tsx
@@ -1,18 +1,20 @@
-import React, { useEffect, useLayoutEffect, useReducer, useRef } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
 import { useDroppable } from "@dnd-kit/react";
-import { useLingui } from "@lingui/react/macro";
+import { msg } from "@lingui/core/macro";
 import { type PaneLayout, type PaneLayoutAxis } from "@/shared/paneLayout";
 import { useIsInsertSplitHighlighted, useIsRootInsertHighlighted } from "@/renderer/dnd";
+import { i18n } from "@/renderer/i18n/i18n";
+import { beginPanelResize, endPanelResize } from "@/renderer/state/panelResizeSignal";
 import {
   MIN_PANE_PERCENT,
   readStoredSizes,
+  samePath,
   splitStorageKey,
   writeStoredSizes,
 } from "./paneSizeStorage";
 
 const DIVIDER_SIZE = 8;
 const ROOT_INSERT_ZONE_INSET = DIVIDER_SIZE / 2;
-const CONTAINER_RESIZE_COMMIT_IDLE_MS = 120;
 
 export type Rect = { left: number; top: number; width: number; height: number };
 type ContainerSize = { width: number; height: number };
@@ -32,6 +34,7 @@ type ComputedDivider = {
 };
 
 type ComputedLayout = { panes: ComputedPane[]; dividers: ComputedDivider[] };
+type RenderedDivider = Pick<ComputedDivider, "zoneId" | "path" | "parentAxis" | "insertIndex">;
 
 function sameContainerSize(a: ContainerSize, b: ContainerSize): boolean {
   return a.width === b.width && a.height === b.height;
@@ -118,55 +121,89 @@ function setRectStyle(element: HTMLElement | null, rect: Rect) {
   element.style.height = `${rect.height}px`;
 }
 
-function Divider(props: {
-  divider: ComputedDivider;
-  registerRef: (zoneId: string, element: HTMLDivElement | null) => void;
-  onResizeStart: (event: React.MouseEvent, divider: ComputedDivider) => void;
-}) {
-  const { divider } = props;
-  const { t } = useLingui();
-  const elementRef = useRef<HTMLDivElement>(null);
-  useDroppable({
-    id: divider.zoneId,
-    accept: ["pane", "thread", "new-thread"],
-    data: {
-      type: "pane-insert-zone",
-      path: divider.path,
-      axis: divider.parentAxis,
-      index: divider.insertIndex,
-      zoneId: divider.zoneId,
-    },
-    element: elementRef,
-  });
-  const isHighlighted = useIsInsertSplitHighlighted(divider.zoneId);
+function layoutSignature(layout: PaneLayout): string {
+  if (layout.kind === "leaf") return `leaf:${layout.paneId}`;
+  return `${layout.axis}(${layout.children.map(layoutSignature).join(",")})`;
+}
 
+function sameRenderedDivider(a: RenderedDivider, b: RenderedDivider): boolean {
   return (
-    <div
-      ref={(element) => {
-        elementRef.current = element;
-        props.registerRef(divider.zoneId, element);
-      }}
-      className={`${
-        divider.parentAxis === "vertical"
-          ? "lightcode-pane-divider"
-          : "lightcode-pane-divider-horizontal"
-      } ${isHighlighted ? "is-highlighted" : ""}`}
-      style={{
-        position: "absolute",
-        left: divider.rect.left,
-        top: divider.rect.top,
-        width: divider.rect.width,
-        height: divider.rect.height,
-      }}
-      onMouseDown={(event) => props.onResizeStart(event, divider)}
-      role="separator"
-      aria-orientation={divider.parentAxis === "vertical" ? "vertical" : "horizontal"}
-      aria-label={divider.parentAxis === "vertical" ? t`Resize column` : t`Resize row`}
-    />
+    a.zoneId === b.zoneId &&
+    a.parentAxis === b.parentAxis &&
+    a.insertIndex === b.insertIndex &&
+    samePath(a.path, b.path)
   );
 }
 
-function RootInsertZone(props: {
+const Divider = React.memo(
+  function Divider(props: {
+    divider: RenderedDivider;
+    registerRef: (zoneId: string, element: HTMLDivElement | null) => void;
+    onResizeStart: (event: React.MouseEvent, zoneId: string) => void;
+  }) {
+    const { divider } = props;
+
+    return (
+      <div
+        ref={(element) => {
+          props.registerRef(divider.zoneId, element);
+        }}
+        className={`${
+          divider.parentAxis === "vertical"
+            ? "lightcode-pane-divider"
+            : "lightcode-pane-divider-horizontal"
+        }`}
+        style={{
+          position: "absolute",
+        }}
+        onMouseDown={(event) => props.onResizeStart(event, divider.zoneId)}
+        role="separator"
+        aria-orientation={divider.parentAxis === "vertical" ? "vertical" : "horizontal"}
+        aria-label={
+          divider.parentAxis === "vertical" ? i18n._(msg`Resize column`) : i18n._(msg`Resize row`)
+        }
+      >
+        <DividerDropZone divider={divider} />
+      </div>
+    );
+  },
+  (prev, next) => sameRenderedDivider(prev.divider, next.divider),
+);
+
+const DividerDropZone = React.memo(
+  function DividerDropZone(props: { divider: RenderedDivider }) {
+    const { divider } = props;
+    const elementRef = useRef<HTMLDivElement>(null);
+    useDroppable({
+      id: divider.zoneId,
+      accept: ["pane", "thread", "new-thread"],
+      data: {
+        type: "pane-insert-zone",
+        path: divider.path,
+        axis: divider.parentAxis,
+        index: divider.insertIndex,
+        zoneId: divider.zoneId,
+      },
+      element: elementRef,
+    });
+    const isHighlighted = useIsInsertSplitHighlighted(divider.zoneId);
+
+    return (
+      <div
+        ref={elementRef}
+        aria-hidden="true"
+        className={`lightcode-pane-divider-drop-zone ${
+          divider.parentAxis === "vertical"
+            ? "lightcode-pane-divider-drop-zone--vertical"
+            : "lightcode-pane-divider-drop-zone--horizontal"
+        } ${isHighlighted ? "is-highlighted" : ""}`}
+      />
+    );
+  },
+  (prev, next) => sameRenderedDivider(prev.divider, next.divider),
+);
+
+const RootInsertZone = React.memo(function RootInsertZone(props: {
   axis: PaneLayoutAxis;
   index: number;
   side: "top" | "right" | "bottom" | "left";
@@ -220,7 +257,7 @@ function RootInsertZone(props: {
       ) : null}
     </div>
   );
-}
+});
 
 export function SplitPaneContainer(props: {
   layout: PaneLayout;
@@ -230,6 +267,7 @@ export function SplitPaneContainer(props: {
   const overlayRef = useRef<HTMLDivElement>(null);
   const paneElementRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
   const dividerElementRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const latestDividersRef = useRef<Map<string, ComputedDivider>>(new Map());
   const containerSizeRef = useRef<ContainerSize>({ width: 0, height: 0 });
   const layoutRef = useRef(props.layout);
   layoutRef.current = props.layout;
@@ -238,6 +276,7 @@ export function SplitPaneContainer(props: {
   const committedSizesRef = useRef<Map<string, number[]>>(new Map());
   // Transient sizes during a drag — applied imperatively, not stored.
   const transientSizesRef = useRef<Map<string, number[]>>(new Map());
+  const layoutSignatureRef = useRef<string | null>(null);
   // Forces a re-render after an imperative layout commit so React's pane styles
   // converge with the DOM positions. Read isn't needed; dispatching is the side effect.
   const [, bumpLayoutTick] = useReducer((tick: number) => tick + 1, 0);
@@ -247,16 +286,10 @@ export function SplitPaneContainer(props: {
     if (!element) return;
 
     let resizeFrame: number | null = null;
-    let commitTimer: number | null = null;
-
     function cancelPendingResizeWork() {
       if (resizeFrame !== null) {
         cancelAnimationFrame(resizeFrame);
         resizeFrame = null;
-      }
-      if (commitTimer !== null) {
-        clearTimeout(commitTimer);
-        commitTimer = null;
       }
     }
 
@@ -265,16 +298,6 @@ export function SplitPaneContainer(props: {
       if (sameContainerSize(containerSizeRef.current, next)) return;
       containerSizeRef.current = next;
       bumpLayoutTick();
-    }
-
-    function scheduleCommit() {
-      if (commitTimer !== null) {
-        clearTimeout(commitTimer);
-      }
-      commitTimer = window.setTimeout(() => {
-        commitTimer = null;
-        bumpLayoutTick();
-      }, CONTAINER_RESIZE_COMMIT_IDLE_MS);
     }
 
     function scheduleLiveLayout() {
@@ -293,7 +316,6 @@ export function SplitPaneContainer(props: {
         return;
       }
       scheduleLiveLayout();
-      scheduleCommit();
     }
 
     const observer = new ResizeObserver((entries) => {
@@ -312,7 +334,7 @@ export function SplitPaneContainer(props: {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- observer lifetime is fixed; resize work reads latest layout from refs
   }, []);
 
-  function resolveSizes(storageKey: string, count: number): number[] {
+  const resolveSizes = useCallback((storageKey: string, count: number): number[] => {
     const transient = transientSizesRef.current.get(storageKey);
     if (transient && transient.length === count) return transient;
     const committed = committedSizesRef.current.get(storageKey);
@@ -320,6 +342,13 @@ export function SplitPaneContainer(props: {
     const restored = readStoredSizes(storageKey, count);
     committedSizesRef.current.set(storageKey, restored);
     return restored;
+  }, []);
+
+  const currentLayoutSignature = layoutSignature(props.layout);
+  if (layoutSignatureRef.current !== currentLayoutSignature) {
+    layoutSignatureRef.current = currentLayoutSignature;
+    committedSizesRef.current.clear();
+    transientSizesRef.current.clear();
   }
 
   // Account for the inset padding around the layout.
@@ -329,88 +358,123 @@ export function SplitPaneContainer(props: {
     containerRect.width > 0 && containerRect.height > 0
       ? computeLayout(props.layout, containerRect, resolveSizes)
       : { panes: [], dividers: [] };
+  latestDividersRef.current = new Map(
+    computed.dividers.map((divider) => [divider.zoneId, divider]),
+  );
 
-  function applyLayoutForSize(size: ContainerSize) {
-    const rect = getContainerRect(size);
-    if (rect.width <= 0 || rect.height <= 0) return;
-    const layoutNow = computeLayout(layoutRef.current, rect, resolveSizes);
-    for (const pane of layoutNow.panes) {
-      setRectStyle(paneElementRefs.current.get(pane.paneId) ?? null, pane.rect);
-    }
-    for (const divider of layoutNow.dividers) {
+  const applyLayoutForSize = useCallback(
+    (size: ContainerSize) => {
+      const rect = getContainerRect(size);
+      if (rect.width <= 0 || rect.height <= 0) return;
+      const layoutNow = computeLayout(layoutRef.current, rect, resolveSizes);
+      latestDividersRef.current = new Map(
+        layoutNow.dividers.map((divider) => [divider.zoneId, divider]),
+      );
+      for (const pane of layoutNow.panes) {
+        setRectStyle(paneElementRefs.current.get(pane.paneId) ?? null, pane.rect);
+      }
+      for (const divider of layoutNow.dividers) {
+        setRectStyle(dividerElementRefs.current.get(divider.zoneId) ?? null, divider.rect);
+      }
+    },
+    [resolveSizes],
+  );
+
+  const applyTransientLayout = useCallback(() => {
+    applyLayoutForSize(containerSizeRef.current);
+  }, [applyLayoutForSize]);
+
+  useLayoutEffect(() => {
+    for (const divider of computed.dividers) {
       setRectStyle(dividerElementRefs.current.get(divider.zoneId) ?? null, divider.rect);
     }
-  }
+  }, [computed.dividers]);
 
-  function applyTransientLayout() {
-    applyLayoutForSize(containerSizeRef.current);
-  }
+  const registerDividerRef = useCallback((zoneId: string, element: HTMLDivElement | null) => {
+    if (element) {
+      dividerElementRefs.current.set(zoneId, element);
+      const rect = latestDividersRef.current.get(zoneId)?.rect;
+      if (rect) setRectStyle(element, rect);
+    } else {
+      dividerElementRefs.current.delete(zoneId);
+    }
+  }, []);
 
   const cleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => {
     return () => cleanupRef.current?.();
   }, []);
 
-  function handleResizeStart(event: React.MouseEvent, divider: ComputedDivider) {
-    event.preventDefault();
-    cleanupRef.current?.();
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent, zoneId: string) => {
+      event.preventDefault();
+      cleanupRef.current?.();
 
-    const isVertical = divider.parentAxis === "vertical";
-    const startPos = isVertical ? event.clientX : event.clientY;
-    const initialSizes =
-      committedSizesRef.current.get(divider.storageKey) ??
-      readStoredSizes(divider.storageKey, divider.childCount);
-    const beforeIndex = divider.dividerIndex - 1;
-    const afterIndex = divider.dividerIndex;
-    const beforeStart = initialSizes[beforeIndex]!;
-    const afterStart = initialSizes[afterIndex]!;
-    const dividerSpace = DIVIDER_SIZE * (divider.childCount - 1);
-    const availableDim = Math.max(1, divider.parentDim - dividerSpace);
+      const divider = latestDividersRef.current.get(zoneId);
+      if (!divider) return;
 
-    const overlay = overlayRef.current;
-    if (overlay) {
-      overlay.style.display = "block";
-      overlay.style.cursor = isVertical ? "col-resize" : "row-resize";
-    }
+      const storageKey = divider.storageKey;
+      const isVertical = divider.parentAxis === "vertical";
+      const startPos = isVertical ? event.clientX : event.clientY;
+      const initialSizes =
+        committedSizesRef.current.get(storageKey) ??
+        readStoredSizes(storageKey, divider.childCount);
+      const beforeIndex = divider.dividerIndex - 1;
+      const afterIndex = divider.dividerIndex;
+      const beforeStart = initialSizes[beforeIndex]!;
+      const afterStart = initialSizes[afterIndex]!;
+      const dividerSpace = DIVIDER_SIZE * (divider.childCount - 1);
+      const availableDim = Math.max(1, divider.parentDim - dividerSpace);
 
-    let lastSizes = initialSizes;
-
-    function onMouseMove(ev: MouseEvent) {
-      const deltaPx = (isVertical ? ev.clientX : ev.clientY) - startPos;
-      const deltaPercent = (deltaPx / availableDim) * 100;
-      const newBefore = beforeStart + deltaPercent;
-      const newAfter = afterStart - deltaPercent;
-      if (newBefore < MIN_PANE_PERCENT || newAfter < MIN_PANE_PERCENT) return;
-      const next = [...initialSizes];
-      next[beforeIndex] = newBefore;
-      next[afterIndex] = newAfter;
-      lastSizes = next;
-      transientSizesRef.current.set(divider.storageKey, next);
-      applyTransientLayout();
-    }
-
-    function teardown() {
-      document.removeEventListener("mousemove", onMouseMove);
-      document.removeEventListener("mouseup", onMouseUp);
+      const overlay = overlayRef.current;
       if (overlay) {
-        overlay.style.display = "none";
-        overlay.style.cursor = "";
+        overlay.style.display = "block";
+        overlay.style.cursor = isVertical ? "col-resize" : "row-resize";
       }
-      cleanupRef.current = null;
-    }
 
-    function onMouseUp() {
-      teardown();
-      transientSizesRef.current.delete(divider.storageKey);
-      committedSizesRef.current.set(divider.storageKey, lastSizes);
-      writeStoredSizes(divider.storageKey, lastSizes);
-      bumpLayoutTick();
-    }
+      beginPanelResize();
 
-    cleanupRef.current = teardown;
-    document.addEventListener("mousemove", onMouseMove);
-    document.addEventListener("mouseup", onMouseUp);
-  }
+      let lastSizes = initialSizes;
+
+      function onMouseMove(ev: MouseEvent) {
+        const deltaPx = (isVertical ? ev.clientX : ev.clientY) - startPos;
+        const deltaPercent = (deltaPx / availableDim) * 100;
+        const newBefore = beforeStart + deltaPercent;
+        const newAfter = afterStart - deltaPercent;
+        if (newBefore < MIN_PANE_PERCENT || newAfter < MIN_PANE_PERCENT) return;
+        const next = [...initialSizes];
+        next[beforeIndex] = newBefore;
+        next[afterIndex] = newAfter;
+        lastSizes = next;
+        transientSizesRef.current.set(storageKey, next);
+        applyTransientLayout();
+      }
+
+      function teardown() {
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        if (overlay) {
+          overlay.style.display = "none";
+          overlay.style.cursor = "";
+        }
+        endPanelResize();
+        cleanupRef.current = null;
+      }
+
+      function onMouseUp() {
+        teardown();
+        transientSizesRef.current.delete(storageKey);
+        committedSizesRef.current.set(storageKey, lastSizes);
+        writeStoredSizes(storageKey, lastSizes);
+        bumpLayoutTick();
+      }
+
+      cleanupRef.current = teardown;
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [applyTransientLayout, bumpLayoutTick],
+  );
 
   // Root-insert-zone indices: when the root is a split aligned with the edge,
   // the index appends/prepends within that split; otherwise it wraps the layout.
@@ -460,10 +524,7 @@ export function SplitPaneContainer(props: {
           <Divider
             key={divider.zoneId}
             divider={divider}
-            registerRef={(zoneId, element) => {
-              if (element) dividerElementRefs.current.set(zoneId, element);
-              else dividerElementRefs.current.delete(zoneId);
-            }}
+            registerRef={registerDividerRef}
             onResizeStart={handleResizeStart}
           />
         ))}

--- a/src/renderer/components/layout/paneSizeStorage.test.ts
+++ b/src/renderer/components/layout/paneSizeStorage.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   migratePaneSizeStorage,
+  preservePaneSizeStorageForLayoutChange,
   readStoredSizes,
   SPLIT_SIZE_STORAGE_PREFIX,
   swapPaneIdsInStorage,
   writeStoredSizes,
 } from "./paneSizeStorage";
+import type { PaneLayout } from "@/shared/paneLayout";
 
 function key(axis: "vertical" | "horizontal", ids: string[]): string {
   return `${SPLIT_SIZE_STORAGE_PREFIX}:${axis}:${ids.join("\0")}`;
@@ -69,6 +71,72 @@ describe("paneSizeStorage", () => {
       writeStoredSizes(key("vertical", ["c", "d"]), [70, 30]);
       swapPaneIdsInStorage("a", "b");
       expect(readStoredSizes(key("vertical", ["c", "d"]), 2)).toEqual([70, 30]);
+    });
+  });
+
+  describe("preservePaneSizeStorageForLayoutChange", () => {
+    it("keeps ancestor split sizes when a pane is inserted inside one child", () => {
+      const previous: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "left" },
+          { kind: "leaf", paneId: "right" },
+        ],
+      };
+      const next: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "left" },
+          {
+            kind: "split",
+            axis: "horizontal",
+            children: [
+              { kind: "leaf", paneId: "right" },
+              { kind: "leaf", paneId: "new" },
+            ],
+          },
+        ],
+      };
+
+      writeStoredSizes(key("vertical", ["left", "right"]), [38, 62]);
+      preservePaneSizeStorageForLayoutChange(previous, next);
+
+      expect(readStoredSizes(key("vertical", ["left", "right", "new"]), 2)).toEqual([38, 62]);
+    });
+
+    it("keeps ancestor split sizes when a pane is removed inside one child", () => {
+      const previous: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "left" },
+          {
+            kind: "split",
+            axis: "horizontal",
+            children: [
+              { kind: "leaf", paneId: "top" },
+              { kind: "leaf", paneId: "bottom" },
+            ],
+          },
+        ],
+      };
+      const next: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "left" },
+          { kind: "leaf", paneId: "top" },
+        ],
+      };
+
+      writeStoredSizes(key("vertical", ["left", "top", "bottom"]), [42, 58]);
+      preservePaneSizeStorageForLayoutChange(previous, next);
+
+      const sizes = readStoredSizes(key("vertical", ["left", "top"]), 2);
+      expect(sizes[0]).toBeCloseTo(42);
+      expect(sizes[1]).toBeCloseTo(58);
     });
   });
 });

--- a/src/renderer/components/layout/paneSizeStorage.ts
+++ b/src/renderer/components/layout/paneSizeStorage.ts
@@ -106,3 +106,110 @@ export function swapPaneIdsInStorage(firstPaneId: string, secondPaneId: string):
     return id;
   });
 }
+
+type SplitStorageEntry = {
+  layout: Extract<PaneLayout, { kind: "split" }>;
+  path: number[];
+  paneIds: Set<string>;
+  childPaneIds: Set<string>[];
+};
+
+function collectSplitStorageEntries(
+  layout: PaneLayout,
+  path: number[] = [],
+  entries: SplitStorageEntry[] = [],
+): SplitStorageEntry[] {
+  if (layout.kind === "leaf") return entries;
+
+  entries.push({
+    layout,
+    path,
+    paneIds: new Set(collectPaneIds(layout)),
+    childPaneIds: layout.children.map((child) => new Set(collectPaneIds(child))),
+  });
+
+  for (let i = 0; i < layout.children.length; i++) {
+    collectSplitStorageEntries(layout.children[i]!, [...path, i], entries);
+  }
+
+  return entries;
+}
+
+function countOverlap(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const id of left) {
+    if (right.has(id)) count++;
+  }
+  return count;
+}
+
+export function samePath(left: readonly number[], right: readonly number[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function findBestPreviousSplit(
+  next: SplitStorageEntry,
+  previousEntries: SplitStorageEntry[],
+): SplitStorageEntry | undefined {
+  let best: { entry: SplitStorageEntry; score: number } | undefined;
+
+  for (const previous of previousEntries) {
+    if (previous.layout.axis !== next.layout.axis) continue;
+    const overlap = countOverlap(previous.paneIds, next.paneIds);
+    if (overlap === 0) continue;
+    const score =
+      overlap * 10 +
+      (samePath(previous.path, next.path) ? 1000 : 0) +
+      (previous.layout.children.length === next.layout.children.length ? 500 : 0);
+    if (!best || score > best.score) {
+      best = { entry: previous, score };
+    }
+  }
+
+  return best?.entry;
+}
+
+function projectSizes(previous: SplitStorageEntry, next: SplitStorageEntry): number[] {
+  const previousKey = splitStorageKey(previous.layout, previous.layout.axis);
+  const previousSizes = readStoredSizes(previousKey, previous.layout.children.length);
+
+  if (previous.layout.children.length === next.layout.children.length) {
+    return previousSizes;
+  }
+
+  const usedPreviousIndexes = new Set<number>();
+  const equalNewSize = 100 / next.layout.children.length;
+  const nextSizes = next.childPaneIds.map((nextChildIds) => {
+    let bestIndex = -1;
+    let bestOverlap = 0;
+    for (let i = 0; i < previous.childPaneIds.length; i++) {
+      if (usedPreviousIndexes.has(i)) continue;
+      const overlap = countOverlap(previous.childPaneIds[i]!, nextChildIds);
+      if (overlap > bestOverlap) {
+        bestIndex = i;
+        bestOverlap = overlap;
+      }
+    }
+    if (bestIndex === -1) return equalNewSize;
+    usedPreviousIndexes.add(bestIndex);
+    return previousSizes[bestIndex] ?? equalNewSize;
+  });
+
+  const total = nextSizes.reduce((sum, value) => sum + value, 0);
+  return total > 0 ? nextSizes.map((value) => (value / total) * 100) : equalSizes(nextSizes.length);
+}
+
+export function preservePaneSizeStorageForLayoutChange(
+  previousLayout: PaneLayout,
+  nextLayout: PaneLayout,
+): void {
+  const previousEntries = collectSplitStorageEntries(previousLayout);
+  if (previousEntries.length === 0) return;
+
+  for (const nextEntry of collectSplitStorageEntries(nextLayout)) {
+    const previousEntry = findBestPreviousSplit(nextEntry, previousEntries);
+    if (!previousEntry) continue;
+    const nextKey = splitStorageKey(nextEntry.layout, nextEntry.layout.axis);
+    writeStoredSizes(nextKey, projectSizes(previousEntry, nextEntry));
+  }
+}

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -167,7 +167,7 @@ describe("ChatPane", () => {
     await waitFor(() => expect(metrics.getScrollTop()).toBe(300));
   });
 
-  it("reconciles the virtualizer when sticky content growth pins to the bottom", async () => {
+  it("pins sticky content growth without virtualizer reconciliation", async () => {
     const thread = makeThread();
     seedAssistantMessage(thread.id, "Inspect output");
     useAppStore.setState({ projects: [project] });
@@ -194,7 +194,37 @@ describe("ChatPane", () => {
       MockResizeObserver.notify(contentElement);
     });
 
-    expect(virtualizerScrollToIndex).toHaveBeenCalledWith(0, { align: "end" });
+    expect(virtualizerScrollToIndex).not.toHaveBeenCalled();
+    expect(metrics.getScrollTop()).toBe(300);
+  });
+
+  it("reconciles the virtualizer when sticky tail content changes", async () => {
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Inspect output");
+    useAppStore.setState({ projects: [project] });
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const scrollElement = getScrollElement(container);
+    const metrics = installScrollMetrics(scrollElement, {
+      scrollHeight: 200,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    act(() => {
+      metrics.setScrollTop(200);
+      fireEvent.scroll(scrollElement);
+    });
+    virtualizerScrollToIndex.mockClear();
+
+    act(() => {
+      metrics.setScrollHeight(300);
+      appendAssistantText(thread.id, " continued");
+    });
+
+    await waitFor(() => expect(virtualizerScrollToIndex).toHaveBeenCalledWith(0, { align: "end" }));
     expect(metrics.getScrollTop()).toBe(300);
   });
 

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -19,6 +19,7 @@ import { readBridge } from "@/renderer/bridge";
 import { useShimmerRef } from "@/renderer/thinkingAnimator";
 import { useScrollFade } from "@/renderer/hooks/useScrollFade";
 import { useAppStore } from "@/renderer/state/appStore";
+import { isPanelResizing, subscribePanelResize } from "@/renderer/state/panelResizeSignal";
 import { hydrateThreadRuntimeItems } from "@/renderer/state/chatRuntimePersister";
 import {
   finalizeFileCheckpoint,
@@ -423,7 +424,7 @@ const ChatScrollControls = forwardRef<
     const el = scrollRef.current;
     if (!el) return;
     const virtualScrollToBottom = virtualScrollToBottomRef.current;
-    if ((options.reconcileVirtualizer || stickToBottomRef.current) && virtualScrollToBottom) {
+    if (options.reconcileVirtualizer && virtualScrollToBottom) {
       virtualScrollToBottom();
     }
     el.scrollTop = el.scrollHeight;
@@ -451,9 +452,26 @@ const ChatScrollControls = forwardRef<
     }
   }
 
+  function hasScheduledLayoutSync() {
+    return layoutSyncRafRef.current !== null || layoutSyncSecondRafRef.current !== null;
+  }
+
   const syncLayoutNowAndAfterPaint = useEffectEvent(() => {
+    if (hasScheduledLayoutSync()) return;
+    // During an active panel/divider drag the viewport changes every frame, and
+    // both this scroller's ResizeObserver and MessageList's totalSize effect
+    // call in here per frame. Collapse to a single coalesced rAF (no synchronous
+    // read, no chained settle passes) so the content still reflows and stays
+    // bottom-pinned live, but we do at most one forced reflow per frame instead
+    // of stacking several. The drag-end reconcile below runs the full settle.
+    if (isPanelResizing()) {
+      layoutSyncRafRef.current = requestAnimationFrame(() => {
+        layoutSyncRafRef.current = null;
+        syncLayoutNow();
+      });
+      return;
+    }
     syncLayoutNow();
-    cancelScheduledLayoutSync();
     layoutSyncRafRef.current = requestAnimationFrame(() => {
       layoutSyncRafRef.current = null;
       syncLayoutNow();
@@ -575,7 +593,7 @@ const ChatScrollControls = forwardRef<
       cancelAnimationFrame(pinRafRef.current);
     }
     if (stickToBottomRef.current) {
-      scrollToBottom();
+      scrollToBottom({ reconcileVirtualizer: true });
       if (!initialScrollSettled) {
         scheduleInitialScrollSettle();
       }
@@ -583,7 +601,7 @@ const ChatScrollControls = forwardRef<
     pinRafRef.current = requestAnimationFrame(() => {
       pinRafRef.current = null;
       if (!stickToBottomRef.current) return;
-      scrollToBottom();
+      scrollToBottom({ reconcileVirtualizer: true });
       if (!initialScrollSettled) {
         scheduleInitialScrollSettle();
       }
@@ -611,6 +629,19 @@ const ChatScrollControls = forwardRef<
     syncPinnedContentChange();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- pinning is keyed to loader visibility changes; the effect event reads latest layout refs.
   }, [tailLoaderVisible, initialScrollSettled]);
+
+  // When a panel/divider drag ends, the coalesced in-drag syncs above skipped
+  // the full settle pass. Run it once now so the final bottom-pin / scroll-down
+  // button state is correct against the settled layout.
+  useLayoutEffect(
+    () =>
+      subscribePanelResize((resizing) => {
+        if (resizing) return;
+        cancelScheduledLayoutSync();
+        syncLayoutNowAndAfterPaint();
+      }),
+    [],
+  );
 
   useEffect(() => cancelScheduledLayoutSync, []);
   useEffect(() => cancelScheduledInitialSettle, []);

--- a/src/renderer/components/thread/ChatPane/parts/CheckpointRevertControls.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/CheckpointRevertControls.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { AlertDialog, Checkbox, Tooltip } from "@heroui/react";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import { RotateCcw } from "lucide-react";
@@ -42,7 +43,11 @@ export function CheckpointRevertButton(props: {
   );
 }
 
-export function RevertCheckpointDialog(props: {
+// Memoized so it doesn't re-render with its (unconditionally mounted) parent on
+// every frame of a panel resize while closed — its props are stable then, so
+// `memo` skips the whole React-Aria overlay subtree. Kept mounted (not gated on
+// `isOpen`) so HeroUI still plays the open/close transition.
+export const RevertCheckpointDialog = memo(function RevertCheckpointDialog(props: {
   isOpen: boolean;
   dontAskAgain: boolean;
   checkpointGuard: CheckpointGuard;
@@ -115,4 +120,4 @@ export function RevertCheckpointDialog(props: {
       </AlertDialog.Container>
     </AlertDialog.Backdrop>
   );
-}
+});

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -32,6 +32,9 @@ type MockVirtualizer = {
 type MockVirtualizerOptions = {
   count: number;
   getScrollElement: () => Element | null;
+  estimateSize: (index: number) => number;
+  getItemKey: (index: number) => string | number;
+  measureElement?: unknown;
   useFlushSync?: boolean;
   useAnimationFrameWithResizeObserver?: boolean;
 };
@@ -72,6 +75,9 @@ vi.mock("./items/ChatItemRow", () => ({
     );
   },
 }));
+
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 
 describe("MessageList", () => {
   beforeEach(() => {
@@ -133,6 +139,7 @@ describe("MessageList", () => {
     const virtualizerOptions = useVirtualizerMock.mock.calls[0]![0];
     expect(virtualizerOptions.count).toBe(4);
     expect(virtualizerOptions.getScrollElement()).toBe(scrollElement);
+    expect(virtualizerOptions.measureElement).toBeUndefined();
     expect(virtualizerOptions.useFlushSync).toBe(true);
     expect(virtualizerOptions.useAnimationFrameWithResizeObserver).toBe(true);
     expect(screen.queryByText("item-1")).not.toBeInTheDocument();
@@ -152,6 +159,50 @@ describe("MessageList", () => {
       transform: "translateY(96px)",
     });
     expect(document.querySelector("[data-item-id='item-2']")).not.toHaveAttribute("style");
+  });
+
+  it("estimates inline image rows near their rendered height before measurement", () => {
+    const threadId = "thread-1";
+    useAppStore.getState().hydrateThreadRuntimeItems(threadId, [
+      {
+        id: "image-1",
+        type: "image_view",
+        state: "completed",
+        payload: {
+          name: "imageGeneration",
+          status: "success",
+          result: PNG_BASE64,
+        },
+        streams: {},
+      },
+      {
+        id: "assistant-1",
+        type: "assistant_message",
+        state: "completed",
+        payload: {
+          content: [
+            {
+              kind: "image",
+              mimeType: "image/png",
+              dataUrl: `data:image/png;base64,${PNG_BASE64}`,
+            },
+          ],
+        },
+        streams: {},
+      },
+    ]);
+
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["image-1", "assistant-1"])}
+        scrollElement={document.createElement("div")}
+      />,
+    );
+
+    const virtualizerOptions = useVirtualizerMock.mock.calls[0]![0];
+    expect(virtualizerOptions.estimateSize(0)).toBe(384);
+    expect(virtualizerOptions.estimateSize(1)).toBe(448);
   });
 
   it("never lets TanStack adjust scroll itself and compensates rows fully above the viewport on the next commit", () => {
@@ -420,7 +471,7 @@ describe("MessageList", () => {
     expect(onContentHeightChange).toHaveBeenCalledTimes(2);
   });
 
-  it("delegates height change to parent actions without calling virtualizer.measure()", () => {
+  it("delegates height change to parent actions without forcing list measurement", () => {
     const onContentHeightChange = vi.fn<() => void>();
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -445,10 +496,9 @@ describe("MessageList", () => {
 
     fireEvent.click(screen.getByText("item-2"));
 
-    // The row-action path remeasures mounted rows with measureElement.
-    // Calling virtualizer.measure() (no args) resets the entire size cache
-    // which causes translateY gaps — so it must NOT be called here.
-    expect(measureElementMock).toHaveBeenCalled();
+    // Row ResizeObservers own size recalculation. This callback is only for
+    // parent scroll pinning; forcing list measurement here creates resize churn.
+    expect(measureElementMock).not.toHaveBeenCalled();
     expect(measureMock).not.toHaveBeenCalled();
     expect(onContentHeightChange).toHaveBeenCalledOnce();
   });

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -1,11 +1,14 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { Surface } from "@heroui/react";
 import { Trans } from "@lingui/react/macro";
-import type { ProjectLocation } from "@/shared/contracts";
+import type { MessageItemPayload, ProjectLocation } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
-import type { CompletedTurnRecord } from "@/renderer/state/slices/runtimeEventSlice";
+import {
+  getRuntimeItemPayload,
+  type CompletedTurnRecord,
+} from "@/renderer/state/slices/runtimeEventSlice";
 import type { AppStoreState } from "@/renderer/state/slices/shared";
 import {
   CheckpointRevertButton,
@@ -14,11 +17,7 @@ import {
   type CheckpointGuard,
 } from "./CheckpointRevertControls";
 import { formatElapsed } from "../formatElapsed";
-import {
-  ChatPaneActionsContext,
-  type ChatPaneActions,
-  useChatPaneActions,
-} from "../chatPaneActionsContext";
+import { useChatPaneActions } from "../chatPaneActionsContext";
 import {
   selectCompletedTurnForEntry,
   selectRuntimeItemById,
@@ -26,6 +25,7 @@ import {
 } from "../chatPaneSelectors";
 import { ChatItemRow } from "./items/ChatItemRow";
 import { chatMessageSurfaceClass } from "./items/chatMessageSurface";
+import { imageViewRendersInline } from "./items/imageViewSource";
 
 interface MessageListProps {
   threadId: string;
@@ -56,6 +56,8 @@ interface MessageListProps {
 
 const CHAT_TRANSCRIPT_OVERSCAN = 8;
 const DEFAULT_ROW_ESTIMATE_PX = 96;
+const INLINE_IMAGE_ROW_ESTIMATE_PX = 384;
+const ASSISTANT_IMAGE_ROW_ESTIMATE_PX = 448;
 const SKIP_REVERT_CONFIRM_PREF_KEY = "lightcode-chat-checkpoint-revert-skip-confirm";
 
 // Intentionally not wrapped in `React.memo`: pane swaps preserve this fiber
@@ -75,7 +77,6 @@ export function MessageList({
   const virtualSizeBoxRef = useRef<HTMLDivElement | null>(null);
   const rowElementsRef = useRef(new Map<number, HTMLDivElement>());
   const pendingScrollCompensationRef = useRef(0);
-  const [measureEpoch, setMeasureEpoch] = useState(0);
   const [pendingRevertItemId, setPendingRevertItemId] = useState<string | null>(null);
   const [dontAskAgain, setDontAskAgain] = useState(false);
   const [revertError, setRevertError] = useState<string | null>(null);
@@ -181,13 +182,6 @@ export function MessageList({
     parentActions?.onContentHeightChange();
   }, [parentActions, totalSize]);
 
-  useLayoutEffect(() => {
-    if (measureEpoch === 0) return;
-    for (const element of rowElementsRef.current.values()) {
-      virtualizer.measureElement(element);
-    }
-  }, [measureEpoch, virtualizer]);
-
   const measureRowElement = useCallback(
     (index: number, element: HTMLDivElement | null) => {
       if (element) {
@@ -262,6 +256,12 @@ export function MessageList({
     [performRevert],
   );
 
+  const closeRevertDialog = useCallback(() => {
+    setPendingRevertItemId(null);
+    setDontAskAgain(false);
+    setRevertError(null);
+  }, []);
+
   const confirmRevert = useCallback(() => {
     if (!pendingRevertItemId) return;
     setRevertError(null);
@@ -285,28 +285,10 @@ export function MessageList({
       : undefined,
   );
 
-  // Row actions bubble up through ChatPaneActionsContext so disclosure rows can
-  // notify the parent scroll controls when their height changes. We do NOT call
-  // virtualizer.measure() here — that would reset the entire size cache back to
-  // estimates and cause every row to jump. TanStack Virtual's measureElement ref
-  // already attaches a ResizeObserver to each row wrapper; when a disclosure
-  // expands or collapses the observer fires automatically and recalculates only
-  // the affected row's position.
-  const rowActions = useMemo<ChatPaneActions | null>(() => {
-    if (!parentActions) return null;
-    return {
-      ...parentActions,
-      onContentHeightChange: () => {
-        setMeasureEpoch((epoch) => epoch + 1);
-        parentActions.onContentHeightChange();
-      },
-    };
-  }, [parentActions]);
-
   if (!hasItems) return null;
 
   return (
-    <ChatPaneActionsContext.Provider value={rowActions}>
+    <>
       <div className="mx-auto w-full max-w-[920px] pb-1">
         <div
           ref={virtualSizeBoxRef}
@@ -354,14 +336,10 @@ export function MessageList({
         canRestoreFiles={projectLocation !== undefined && pendingCheckpoint !== undefined}
         errorMessage={revertError ?? undefined}
         onDontAskAgainChange={setDontAskAgain}
-        onClose={() => {
-          setPendingRevertItemId(null);
-          setDontAskAgain(false);
-          setRevertError(null);
-        }}
+        onClose={closeRevertDialog}
         onConfirm={confirmRevert}
       />
-    </ChatPaneActionsContext.Provider>
+    </>
   );
 }
 
@@ -542,6 +520,7 @@ function estimateRuntimeItemSize(item: ReturnType<typeof selectRuntimeItemById>)
   if (!item) return DEFAULT_ROW_ESTIMATE_PX;
   switch (item.type) {
     case "assistant_message":
+      if (assistantMessageHasImageContent(item)) return ASSISTANT_IMAGE_ROW_ESTIMATE_PX;
       return item.state === "completed" ? 168 : 208;
     case "user_message":
       return 88;
@@ -549,11 +528,13 @@ function estimateRuntimeItemSize(item: ReturnType<typeof selectRuntimeItemById>)
       return item.state === "completed" ? 52 : 128;
     case "plan":
       return 128;
-    case "command_execution":
     case "tool_call":
     case "mcp_tool_call":
     case "image_view":
     case "dynamic_tool_call":
+      if (imageViewRendersInline(item.payload)) return INLINE_IMAGE_ROW_ESTIMATE_PX;
+      return item.state === "completed" ? 56 : 132;
+    case "command_execution":
     case "file_change":
     case "web_search":
       return item.state === "completed" ? 56 : 132;
@@ -562,6 +543,13 @@ function estimateRuntimeItemSize(item: ReturnType<typeof selectRuntimeItemById>)
     default:
       return DEFAULT_ROW_ESTIMATE_PX;
   }
+}
+
+function assistantMessageHasImageContent(
+  item: NonNullable<ReturnType<typeof selectRuntimeItemById>>,
+): boolean {
+  const payload = getRuntimeItemPayload<MessageItemPayload>(item, "assistant_message");
+  return payload?.content.some((block) => block.kind === "image") ?? false;
 }
 
 function findCheckpointBeforeUserMessage(

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageView.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageView.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
+import { ImageLightboxHost } from "@/renderer/components/composer";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { ImageView } from "./ImageView";
 
@@ -35,6 +36,9 @@ describe("ImageView", () => {
     const img = screen.getByAltText("A red square") as HTMLImageElement;
     expect(img.tagName).toBe("IMG");
     expect(img.getAttribute("src")).toBe(`data:image/png;base64,${PNG_BASE64}`);
+    expect(img.getAttribute("width")).toBe("1");
+    expect(img.getAttribute("height")).toBe("1");
+    expect(img.getAttribute("loading")).toBeNull();
     // The prompt lives only on the <img> alt for a11y — it is not written as a
     // visible caption (the picture may be shared, not "generated").
     expect(screen.queryByText("A red square")).toBeNull();
@@ -47,6 +51,7 @@ describe("ImageView", () => {
     render(
       <AppProvider>
         <ImageView item={imageItem({ name: "imageGeneration", result: PNG_BASE64 })} />
+        <ImageLightboxHost />
       </AppProvider>,
     );
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageView.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageView.tsx
@@ -5,7 +5,7 @@ import { useLingui } from "@lingui/react/macro";
 import type { ToolCallPayload } from "@/shared/contracts";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { readBridge } from "@/renderer/bridge";
-import { ImageLightboxView } from "@/renderer/components/composer";
+import { openImageLightbox } from "@/renderer/components/composer";
 import { resolveImageViewSource, type ImageViewSource } from "./imageViewSource";
 import { ToolCall } from "./ToolCall";
 
@@ -40,43 +40,41 @@ export const ImageView = memo(function ImageView({ item }: ImageViewProps) {
  * The toolbar sits on a translucent backdrop so its icons stay legible over any
  * image, and reveals on hover / keyboard focus to keep the picture uncluttered.
  */
-export function ImageCard({ source }: { source: ImageViewSource }) {
+export const ImageCard = memo(function ImageCard({ source }: { source: ImageViewSource }) {
   const { t } = useLingui();
-  const [isLightboxOpen, setLightboxOpen] = useState(false);
   const imageAlt = source.alt || t`Image`;
+  const openPreview = () => openImageLightbox([{ src: source.src, alt: imageAlt }], 0);
 
   return (
-    <figure className="group relative m-0 inline-flex max-w-full overflow-hidden rounded-2xl border border-[color:var(--border)] bg-[var(--composer-surface)]">
+    <figure
+      className="lightcode-image-card group relative m-0 inline-flex max-w-full overflow-hidden rounded-2xl border border-[color:var(--border)] bg-[var(--composer-surface)]"
+      data-lightcode-image-card="true"
+    >
       <button
         type="button"
         className="block cursor-zoom-in bg-black/20"
         aria-label={t`Open image preview`}
-        onClick={() => setLightboxOpen(true)}
+        onClick={openPreview}
       >
         <img
           src={source.src}
           alt={imageAlt}
           draggable={false}
+          decoding="async"
+          {...(source.width && source.height ? { width: source.width, height: source.height } : {})}
           className="block max-h-[22rem] w-auto max-w-full object-contain"
         />
       </button>
       <div className="pointer-events-none absolute right-1.5 top-1.5 flex items-center gap-0.5 rounded-lg bg-black/50 p-0.5 opacity-0 backdrop-blur-sm transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
         <CopyImageButton source={source} />
         <DownloadImageButton src={source.src} fileName={source.fileName} />
-        <IconButton label={t`Open preview`} onClick={() => setLightboxOpen(true)}>
+        <IconButton label={t`Open preview`} onClick={openPreview}>
           <Maximize2 className="size-3.5" />
         </IconButton>
       </div>
-      {isLightboxOpen ? (
-        <ImageLightboxView
-          images={[{ src: source.src, alt: imageAlt }]}
-          initialIndex={0}
-          onClose={() => setLightboxOpen(false)}
-        />
-      ) : null}
     </figure>
   );
-}
+});
 
 function CopyImageButton({ source }: { source: ImageViewSource }) {
   const { t } = useLingui();

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -3,7 +3,11 @@ import { Link, Surface, Tooltip } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { ChevronDown, ChevronUp, Copy } from "lucide-react";
 import type { CanonicalContentBlock, MessageItemPayload } from "@/shared/contracts";
-import { AttachmentBar, ImageLightbox, type Attachment } from "@/renderer/components/composer";
+import {
+  AttachmentBar,
+  openAttachmentLightbox,
+  type Attachment,
+} from "@/renderer/components/composer";
 import { readBridge } from "@/renderer/bridge";
 import { fileNameFromPath } from "@/shared/promptContent";
 import {
@@ -51,7 +55,6 @@ export const UserMessage = memo(function UserMessage({
   // the first measurement, which is the only thing that lifts the default clamp
   // off a non-overflowing message.
   const [hasMeasured, setHasMeasured] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const hasVisualOverflowRef = useRef(false);
   const hasMeasuredRef = useRef(false);
@@ -68,7 +71,6 @@ export const UserMessage = memo(function UserMessage({
     buildUserPromptAttachments(content),
     extractSelectorPayloads(rawText),
   );
-  const imageAttachments = attachments.filter((a) => a.isImage);
 
   const syncVisualOverflow = useEffectEvent(() => {
     const element = bodyRef.current;
@@ -154,8 +156,9 @@ export const UserMessage = memo(function UserMessage({
               layout="flush"
               imagesAsPreview
               onPreviewImage={(att) => {
+                const imageAttachments = attachments.filter((a) => a.isImage);
                 const idx = imageAttachments.findIndex((a) => a.id === att.id);
-                if (idx >= 0) setLightboxIndex(idx);
+                if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
               }}
             />
           </div>
@@ -188,13 +191,6 @@ export const UserMessage = memo(function UserMessage({
         {checkpointRevertControl}
         <CopyUserMessageButton text={rawText} />
       </div>
-      {lightboxIndex !== null ? (
-        <ImageLightbox
-          images={imageAttachments}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-        />
-      ) : null}
     </Surface>
   );
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
@@ -24,6 +24,8 @@ describe("resolveImageViewSource", () => {
     expect(source?.extension).toBe("png");
     expect(source?.fileName).toBe("a-red-square.png");
     expect(source?.alt).toBe("A red square");
+    expect(source?.width).toBe(1);
+    expect(source?.height).toBe(1);
   });
 
   it("prefers payload.images (the provider-agnostic channel) over result", () => {
@@ -36,6 +38,8 @@ describe("resolveImageViewSource", () => {
     });
     expect(source?.src).toBe(`data:image/png;base64,${PNG_BASE64}`);
     expect(source?.mime).toBe("image/png");
+    expect(source?.width).toBe(1);
+    expect(source?.height).toBe(1);
   });
 
   it("passes through an existing data: URL result", () => {
@@ -43,6 +47,8 @@ describe("resolveImageViewSource", () => {
     const source = resolveImageViewSource({ name: "imageGeneration", result: dataUrl });
     expect(source?.src).toBe(dataUrl);
     expect(source?.mime).toBe("image/png");
+    expect(source?.width).toBe(1);
+    expect(source?.height).toBe(1);
   });
 
   it("strips whitespace/newlines from chunked base64", () => {
@@ -134,6 +140,8 @@ describe("imageViewSourceFromImageBlock", () => {
     expect(source?.mime).toBe("image/png");
     expect(source?.alt).toBe("diagram");
     expect(source?.fileName).toBe("diagram.png");
+    expect(source?.width).toBe(1);
+    expect(source?.height).toBe(1);
   });
 
   it("returns null for a non-image / missing data URL", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
@@ -37,6 +37,9 @@ export interface ImageViewSource {
   fileName: string;
   /** Accessible label / alt text — the prompt when available, else a generic label. */
   alt: string;
+  /** Intrinsic dimensions when cheaply readable from the image header. */
+  width?: number;
+  height?: number;
 }
 
 const EXTENSION_BY_MIME: Record<string, string> = {
@@ -115,7 +118,15 @@ export function resolveImageViewSource(payload: unknown): ImageViewSource | null
   const extension = EXTENSION_BY_MIME[mime] ?? "png";
   const promptText = readPromptText(payload);
   const alt = promptText ?? i18n._(msg`Generated image`);
-  return { src, mime, extension, fileName: buildFileName(promptText ?? "", extension), alt };
+  const dimensions = readImageDimensions(value, classification);
+  return {
+    src,
+    mime,
+    extension,
+    fileName: buildFileName(promptText ?? "", extension),
+    alt,
+    ...dimensions,
+  };
 }
 
 function findClassifiedCandidate(
@@ -163,7 +174,15 @@ export function imageViewSourceFromImageBlock(block: {
   const name =
     typeof block.name === "string" && block.name.trim().length > 0 ? block.name.trim() : undefined;
   const alt = name ?? i18n._(msg`Generated image`);
-  return { src, mime, extension, fileName: buildFileName(name ?? "", extension), alt };
+  const dimensions = readImageDimensions(block.dataUrl, classification);
+  return {
+    src,
+    mime,
+    extension,
+    fileName: buildFileName(name ?? "", extension),
+    alt,
+    ...dimensions,
+  };
 }
 
 function collectResultCandidates(result: unknown): string[] {
@@ -217,6 +236,231 @@ function buildSrc(value: string, classification: Classification): string | null 
       return clean.length > 0 ? `data:${classification.mime};base64,${clean}` : null;
     }
   }
+}
+
+function readImageDimensions(
+  value: string,
+  classification: Classification,
+): { width: number; height: number } | undefined {
+  if (classification.mime === "image/svg+xml") return readSvgDimensions(value, classification);
+  const bytes = readBase64BytesPrefix(value, classification, 8192);
+  if (!bytes) return undefined;
+  switch (classification.mime) {
+    case "image/png":
+      return readPngDimensions(bytes);
+    case "image/jpeg":
+      return readJpegDimensions(bytes);
+    case "image/gif":
+      return readGifDimensions(bytes);
+    case "image/webp":
+      return readWebpDimensions(bytes);
+    default:
+      return undefined;
+  }
+}
+
+function readBase64BytesPrefix(
+  value: string,
+  classification: Classification,
+  byteCount: number,
+): Uint8Array | undefined {
+  const base64 =
+    classification.kind === "dataUrl"
+      ? readBase64DataUrlBody(value)
+      : classification.kind === "base64"
+        ? value
+        : null;
+  if (!base64) return undefined;
+  const clean = base64.replace(/\s+/g, "");
+  if (clean.length === 0) return undefined;
+  const chars = Math.ceil(byteCount / 3) * 4;
+  const slice = clean.slice(0, chars);
+  const padded = slice.padEnd(Math.ceil(slice.length / 4) * 4, "=");
+  try {
+    const binary = atob(padded);
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) out[i] = binary.charCodeAt(i);
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
+function readBase64DataUrlBody(value: string): string | null {
+  const commaIndex = value.indexOf(",");
+  if (commaIndex < 0) return null;
+  return value.slice(0, commaIndex).toLowerCase().includes(";base64")
+    ? value.slice(commaIndex + 1)
+    : null;
+}
+
+function readPngDimensions(bytes: Uint8Array) {
+  if (
+    bytes.length < 24 ||
+    bytes[0] !== 0x89 ||
+    bytes[1] !== 0x50 ||
+    bytes[2] !== 0x4e ||
+    bytes[3] !== 0x47 ||
+    bytes[12] !== 0x49 ||
+    bytes[13] !== 0x48 ||
+    bytes[14] !== 0x44 ||
+    bytes[15] !== 0x52
+  ) {
+    return undefined;
+  }
+  return readPositiveDimensions(readUint32BE(bytes, 16), readUint32BE(bytes, 20));
+}
+
+function readGifDimensions(bytes: Uint8Array) {
+  if (
+    bytes.length < 10 ||
+    bytes[0] !== 0x47 ||
+    bytes[1] !== 0x49 ||
+    bytes[2] !== 0x46 ||
+    bytes[3] !== 0x38
+  ) {
+    return undefined;
+  }
+  return readPositiveDimensions(readUint16LE(bytes, 6), readUint16LE(bytes, 8));
+}
+
+function readJpegDimensions(bytes: Uint8Array) {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return undefined;
+  let offset = 2;
+  while (offset + 9 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    const marker = bytes[offset + 1];
+    if (marker === undefined) break;
+    offset += 2;
+    if (marker === 0xda || marker === 0xd9) break;
+    if (offset + 2 > bytes.length) break;
+    const length = readUint16BE(bytes, offset);
+    if (length < 2 || offset + length > bytes.length) break;
+    if (isJpegStartOfFrame(marker)) {
+      return readPositiveDimensions(
+        readUint16BE(bytes, offset + 5),
+        readUint16BE(bytes, offset + 3),
+      );
+    }
+    offset += length;
+  }
+  return undefined;
+}
+
+function readWebpDimensions(bytes: Uint8Array) {
+  if (
+    bytes.length < 30 ||
+    bytes[0] !== 0x52 ||
+    bytes[1] !== 0x49 ||
+    bytes[2] !== 0x46 ||
+    bytes[3] !== 0x46 ||
+    bytes[8] !== 0x57 ||
+    bytes[9] !== 0x45 ||
+    bytes[10] !== 0x42 ||
+    bytes[11] !== 0x50
+  ) {
+    return undefined;
+  }
+  const chunk = String.fromCharCode(bytes[12]!, bytes[13]!, bytes[14]!, bytes[15]!);
+  if (chunk === "VP8X") {
+    const width = 1 + bytes[24]! + (bytes[25]! << 8) + (bytes[26]! << 16);
+    const height = 1 + bytes[27]! + (bytes[28]! << 8) + (bytes[29]! << 16);
+    return readPositiveDimensions(width, height);
+  }
+  if (chunk === "VP8L") {
+    const width = 1 + bytes[21]! + ((bytes[22]! & 0x3f) << 8);
+    const height = 1 + ((bytes[22]! & 0xc0) >> 6) + (bytes[23]! << 2) + ((bytes[24]! & 0x0f) << 10);
+    return readPositiveDimensions(width, height);
+  }
+  if (chunk === "VP8 " && bytes[23] === 0x9d && bytes[24] === 0x01 && bytes[25] === 0x2a) {
+    const width = readUint16LE(bytes, 26) & 0x3fff;
+    const height = readUint16LE(bytes, 28) & 0x3fff;
+    return readPositiveDimensions(width, height);
+  }
+  return undefined;
+}
+
+function readSvgDimensions(value: string, classification: Classification) {
+  const svg =
+    classification.kind === "rawSvg"
+      ? value
+      : classification.kind === "dataUrl"
+        ? readTextDataUrlBody(value)
+        : null;
+  if (!svg) return undefined;
+  const width = readSvgLength(svg, "width");
+  const height = readSvgLength(svg, "height");
+  if (width && height) return { width, height };
+  const viewBox = /\bviewBox\s*=\s*["']\s*[-.\d]+\s+[-.\d]+\s+([.\d]+)\s+([.\d]+)/i.exec(svg);
+  if (!viewBox) return undefined;
+  return readPositiveDimensions(Number(viewBox[1]), Number(viewBox[2]));
+}
+
+function readTextDataUrlBody(value: string): string | null {
+  const commaIndex = value.indexOf(",");
+  if (commaIndex < 0) return null;
+  const body = value.slice(commaIndex + 1);
+  if (value.slice(0, commaIndex).toLowerCase().includes(";base64")) {
+    try {
+      return atob(body);
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return decodeURIComponent(body);
+  } catch {
+    return body;
+  }
+}
+
+function readSvgLength(svg: string, attr: "width" | "height") {
+  const match = new RegExp(`\\b${attr}\\s*=\\s*["']\\s*([.\\d]+)`, "i").exec(svg);
+  if (!match) return undefined;
+  const value = Number(match[1]);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function isJpegStartOfFrame(marker: number) {
+  return (
+    marker === 0xc0 ||
+    marker === 0xc1 ||
+    marker === 0xc2 ||
+    marker === 0xc3 ||
+    marker === 0xc5 ||
+    marker === 0xc6 ||
+    marker === 0xc7 ||
+    marker === 0xc9 ||
+    marker === 0xca ||
+    marker === 0xcb ||
+    marker === 0xcd ||
+    marker === 0xce ||
+    marker === 0xcf
+  );
+}
+
+function readPositiveDimensions(width: number, height: number) {
+  return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0
+    ? { width, height }
+    : undefined;
+}
+
+function readUint16BE(bytes: Uint8Array, offset: number) {
+  return (bytes[offset]! << 8) + bytes[offset + 1]!;
+}
+
+function readUint16LE(bytes: Uint8Array, offset: number) {
+  return bytes[offset]! + (bytes[offset + 1]! << 8);
+}
+
+function readUint32BE(bytes: Uint8Array, offset: number) {
+  return (
+    bytes[offset]! * 0x1000000 +
+    ((bytes[offset + 1]! << 16) | (bytes[offset + 2]! << 8) | bytes[offset + 3]!)
+  );
 }
 
 function parseDataUrlMime(value: string): string {

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -23,7 +23,7 @@ import {
   buildModelPickerControls,
   buildProviderModelMenuProviders,
 } from "./buildModelPickerControls";
-import { AttachmentBar, ImageLightbox, MentionInput, useAttachments } from "../composer";
+import { AttachmentBar, MentionInput, openAttachmentLightbox, useAttachments } from "../composer";
 import type { MentionInputHandle } from "../composer";
 import { flattenSegments } from "../composer/serializeMentions";
 import { PresentationModeTabs } from "./PresentationModeTabs";
@@ -268,10 +268,8 @@ export function ContinueInProviderDialog(props: {
   const [errorMessage, setErrorMessage] = useState("");
   const [pendingCloseOriginal, setPendingCloseOriginal] = useState(false);
   const [pendingSubmission, setPendingSubmission] = useState<PendingSubmission | null>(null);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const mentionRef = useRef<MentionInputHandle>(null);
   const attachments = useAttachments();
-  const imageAttachments = attachments.attachments.filter((a) => a.isImage);
 
   const sourceAgent = installedAgents.find((a) => a.kind === thread.agentKind);
   const selectedAgent = otherAgents.find((a) => a.kind === selectedKind);
@@ -589,8 +587,11 @@ export function ContinueInProviderDialog(props: {
                           attachments={attachments.attachments}
                           onRemove={attachments.removeAttachment}
                           onPreviewImage={(att) => {
+                            const imageAttachments = attachments.attachments.filter(
+                              (a) => a.isImage,
+                            );
                             const idx = imageAttachments.findIndex((a) => a.id === att.id);
-                            if (idx >= 0) setLightboxIndex(idx);
+                            if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
                           }}
                         />
                       }
@@ -710,13 +711,6 @@ export function ContinueInProviderDialog(props: {
           </Modal.Dialog>
         </Modal.Container>
       </Modal.Backdrop>
-      {lightboxIndex !== null && imageAttachments.length > 0 ? (
-        <ImageLightbox
-          images={imageAttachments}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-        />
-      ) : null}
     </>
   );
 }

--- a/src/renderer/components/thread/ThreadComposer.test.tsx
+++ b/src/renderer/components/thread/ThreadComposer.test.tsx
@@ -85,14 +85,31 @@ function visibleText(text: string): HTMLElement {
   return visible!;
 }
 
-function setProbeMeasurements(container: HTMLElement, widths: readonly number[]) {
+function setProbeMeasurements(
+  container: HTMLElement,
+  widths: readonly number[],
+  clientWidth = 100,
+) {
   const probes = [...container.querySelectorAll<HTMLElement>(".probe-wrap-container")];
   for (const [index, probe] of probes.entries()) {
     Object.defineProperties(probe, {
-      clientWidth: { configurable: true, get: () => 100 },
+      clientWidth: { configurable: true, get: () => clientWidth },
       scrollWidth: { configurable: true, get: () => widths[index] ?? 100 },
     });
   }
+}
+
+function composerToolbar(container: HTMLElement): HTMLElement {
+  const toolbar = container.querySelector<HTMLElement>(".lightcode-composer-toolbar");
+  expect(toolbar).not.toBeNull();
+  return toolbar!;
+}
+
+function setToolbarWidth(container: HTMLElement, width: number) {
+  Object.defineProperty(composerToolbar(container), "clientWidth", {
+    configurable: true,
+    get: () => width,
+  });
 }
 
 describe("ThreadComposer", () => {
@@ -125,8 +142,85 @@ describe("ThreadComposer", () => {
       MockResizeObserver.notify(controls!);
     });
 
-    expect(visibleText("Auto")).toHaveClass("is-hidden");
-    expect(visibleText("Plan")).toHaveClass("is-hidden");
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "1");
+    expect(visibleText("Auto")).toHaveAttribute("data-collapse-tier", "1");
+    expect(visibleText("Plan")).toHaveAttribute("data-collapse-tier", "1");
+  });
+
+  it("does not expand collapsed labels again at the same measured width", () => {
+    const { container } = renderComposer();
+    const controls = container.querySelector<HTMLElement>(
+      ".lightcode-composer-toolbar > .relative",
+    );
+    expect(controls).not.toBeNull();
+
+    setProbeMeasurements(container, [101, 100, 100, 100, 100, 100]);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "1");
+
+    setProbeMeasurements(container, [100, 100, 100, 100, 100, 100]);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "1");
+
+    setProbeMeasurements(container, [101, 100, 100, 100, 100, 100], 101);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "0");
+  });
+
+  it("does not expand labels while the outer toolbar width is decreasing", () => {
+    const { container } = renderComposer();
+    const controls = container.querySelector<HTMLElement>(
+      ".lightcode-composer-toolbar > .relative",
+    );
+    expect(controls).not.toBeNull();
+
+    setToolbarWidth(container, 200);
+    setProbeMeasurements(container, [100, 100, 100, 100, 100, 100]);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "0");
+
+    setToolbarWidth(container, 120);
+    setProbeMeasurements(container, [121, 100, 100, 100, 100, 100]);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "1");
+    expect(composerToolbar(container)).toHaveAttribute("data-width-decreasing");
+
+    setProbeMeasurements(container, [110, 100, 100, 100, 100, 100], 130);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "1");
+
+    setToolbarWidth(container, 121);
+
+    act(() => {
+      MockResizeObserver.notify(controls!);
+    });
+
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "0");
+    expect(composerToolbar(container)).not.toHaveAttribute("data-width-decreasing");
   });
 
   it("can collapse permission labels before mode labels", () => {
@@ -158,8 +252,9 @@ describe("ThreadComposer", () => {
       MockResizeObserver.notify(controls!);
     });
 
-    expect(visibleText("Full access")).toHaveClass("is-hidden");
-    expect(visibleText("Work")).not.toHaveClass("is-hidden");
+    expect(composerToolbar(container)).toHaveAttribute("data-wrap-level", "2");
+    expect(visibleText("Full access")).toHaveAttribute("data-collapse-tier", "2");
+    expect(visibleText("Work")).toHaveAttribute("data-collapse-tier", "3");
   });
 
   it("labels a thinking-only effort context control", () => {

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -154,8 +154,57 @@ function shouldHideControlLabel(
   forceShowLabels: boolean,
 ): boolean {
   if (forceShowLabels) return false;
-  if (!control.hideLabelOnWrap && control.tier === undefined) return false;
-  return targetWrapLevel >= (control.tier ?? DEFAULT_LABEL_COLLAPSE_LEVEL);
+  const collapseTier = getControlCollapseTier(control);
+  if (collapseTier === undefined) return false;
+  return targetWrapLevel >= collapseTier;
+}
+
+function getControlCollapseTier(control: ComposerControl): number | undefined {
+  if (!control.hideLabelOnWrap && control.tier === undefined) return undefined;
+  return control.tier ?? DEFAULT_LABEL_COLLAPSE_LEVEL;
+}
+
+function getOptionLabel(option: OptionMenuOption): string {
+  return typeof option === "string" ? option : option.label;
+}
+
+function resolveControlProbeLabel(control: ComposerControl, thinkingLabel: string): string {
+  if (control.kind === "provider-model") {
+    const provider =
+      control.providers.find((candidate) => candidate.kind === control.currentAgentKind) ??
+      control.providers[0];
+    return (
+      provider?.capabilities.models.find((model) => model.id === control.currentModel)?.label ??
+      control.currentModel
+    );
+  }
+
+  if (control.kind === "effort-context") {
+    const effortLabel =
+      control.efforts.find((option) => option.id === control.effortValue)?.label ??
+      control.effortValue ??
+      "";
+    const contextLabel =
+      control.contextSizes.find((option) => option.id === control.contextValue)?.label ??
+      control.contextValue ??
+      "";
+    return (
+      [effortLabel, contextLabel].filter((part) => part.length > 0).join(" · ") || thinkingLabel
+    );
+  }
+
+  if (control.kind === "toggle") return control.label;
+  if (control.kind === "static") return control.value;
+  const selectedOption = control.options.find(
+    (option) => (typeof option === "string" ? option : option.id) === control.value,
+  );
+  return selectedOption ? getOptionLabel(selectedOption) : control.value;
+}
+
+function hasProbeIcon(control: ComposerControl): boolean {
+  if (control.kind === "provider-model" || control.kind === "effort-context") return true;
+  if (control.kind === "static") return Boolean(control.icon);
+  return Boolean(control.icon || control.iconKind);
 }
 
 export function ThreadComposer(props: {
@@ -213,9 +262,9 @@ export function ThreadComposer(props: {
   } = props;
   const { t } = useLingui();
 
-  const [wrapLevel, setWrapLevel] = useState(0);
   const [isAttachmentDropActive, setIsAttachmentDropActive] = useState(false);
   const controlsRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const probeContainerRef = useRef<HTMLDivElement>(null);
   const editorHostRef = useRef<HTMLDivElement>(null);
   const attachmentDragDepthRef = useRef(0);
@@ -259,6 +308,15 @@ export function ThreadComposer(props: {
 
   // Use a ref to track the current wrapping level to avoid unnecessary state updates
   const wrapLevelRef = useRef(0);
+  const lastCollapseWidthRef = useRef<number | undefined>(undefined);
+  const lastToolbarWidthRef = useRef<number | undefined>(undefined);
+  const isToolbarWidthDecreasingRef = useRef(false);
+
+  const applyWrapLevel = (level: number) => {
+    wrapLevelRef.current = level;
+    toolbarRef.current?.setAttribute("data-wrap-level", String(level));
+    controlsRef.current?.classList.toggle("is-wrapping", level > 0);
+  };
 
   // Stable check function to find the best wrapLevel (0-5)
   // Each wrap level corresponds to a tier of controls collapsing.
@@ -267,21 +325,53 @@ export function ThreadComposer(props: {
     const probes = probeContainerRef.current.children;
     if (probes.length === 0) return;
 
+    const currentLevel = wrapLevelRef.current;
+    let availableWidth = 0;
+
     // Find the first wrap level that fits on one row.
     // We check from level 0 (all expanded) up to 5 (all collapsed).
     let bestLevel = 5;
     for (let level = 0; level <= 5; level++) {
       const probeToolbar = probes[level] as HTMLElement;
       const wrappingContainer = probeToolbar?.querySelector(".probe-wrap-container") as HTMLElement;
-      if (wrappingContainer && wrappingContainer.scrollWidth <= wrappingContainer.clientWidth) {
+      if (!wrappingContainer) continue;
+
+      availableWidth ||= wrappingContainer.clientWidth;
+      if (wrappingContainer.scrollWidth <= wrappingContainer.clientWidth) {
         bestLevel = level;
         break;
       }
     }
 
-    if (bestLevel !== wrapLevelRef.current) {
-      wrapLevelRef.current = bestLevel;
-      setWrapLevel(bestLevel);
+    const toolbarWidth = toolbarRef.current?.clientWidth || availableWidth;
+    const previousToolbarWidth = lastToolbarWidthRef.current;
+    if (toolbarWidth > 0) {
+      if (previousToolbarWidth !== undefined) {
+        if (toolbarWidth < previousToolbarWidth) {
+          isToolbarWidthDecreasingRef.current = true;
+        } else if (toolbarWidth > previousToolbarWidth) {
+          isToolbarWidthDecreasingRef.current = false;
+        }
+      }
+      lastToolbarWidthRef.current = toolbarWidth;
+    }
+    toolbarRef.current?.toggleAttribute(
+      "data-width-decreasing",
+      isToolbarWidthDecreasingRef.current,
+    );
+
+    if (bestLevel !== currentLevel) {
+      const isExpanding = bestLevel < currentLevel;
+      if (
+        isExpanding &&
+        (isToolbarWidthDecreasingRef.current ||
+          (lastCollapseWidthRef.current !== undefined &&
+            toolbarWidth <= lastCollapseWidthRef.current))
+      ) {
+        return;
+      }
+      lastCollapseWidthRef.current = bestLevel > currentLevel ? toolbarWidth : undefined;
+      applyWrapLevel(bestLevel);
     }
   };
 
@@ -326,6 +416,8 @@ export function ThreadComposer(props: {
     targetWrapLevel: number,
     forceShowLabels: boolean,
   ) => {
+    const collapseTier = getControlCollapseTier(control);
+    const hideOnWrap = collapseTier !== undefined;
     const shouldHideLabel = shouldHideControlLabel(control, targetWrapLevel, forceShowLabels);
     if (control.kind === "provider-model") {
       return (
@@ -338,10 +430,11 @@ export function ThreadComposer(props: {
           {...(control.presentationMode ? { presentationMode: control.presentationMode } : {})}
           {...(control.isDisabled !== undefined ? { isDisabled: control.isDisabled } : {})}
           {...(control.openSignal !== undefined ? { openSignal: control.openSignal } : {})}
-          {...(control.hideLabelOnWrap || shouldHideLabel
+          {...(hideOnWrap || shouldHideLabel
             ? {
                 hideLabelOnWrap: true,
                 forceHideLabel: shouldHideLabel,
+                ...(collapseTier !== undefined ? { collapseTier } : {}),
               }
             : {})}
           onChange={control.onChange}
@@ -370,10 +463,11 @@ export function ThreadComposer(props: {
           {...(control.icon ? { icon: control.icon } : {})}
           {...(control.isDisabled !== undefined ? { isDisabled: control.isDisabled } : {})}
           {...(control.openSignal !== undefined ? { openSignal: control.openSignal } : {})}
-          {...(control.hideLabelOnWrap || shouldHideLabel
+          {...(hideOnWrap || shouldHideLabel
             ? {
                 hideLabelOnWrap: true,
                 forceHideLabel: shouldHideLabel,
+                ...(collapseTier !== undefined ? { collapseTier } : {}),
               }
             : {})}
           onOpenChange={(open) => {
@@ -385,22 +479,21 @@ export function ThreadComposer(props: {
 
     if (control.kind === "static") {
       const hideLabel = control.iconOnly || shouldHideLabel;
+      const labelClassName = hideOnWrap
+        ? `lightcode-composer-label-hideable truncate${hideLabel ? " is-hidden" : ""}`
+        : "truncate";
       const content = (
         <div key={`${control.value}-${index}`} className="lightcode-composer-static min-w-0 px-2.5">
           {control.icon}
           {!control.iconOnly && (
-            <span
-              className={
-                hideLabel ? "lightcode-composer-label-hideable truncate is-hidden" : "truncate"
-              }
-            >
+            <span data-collapse-tier={collapseTier} className={labelClassName}>
               {control.value}
             </span>
           )}
         </div>
       );
 
-      if (control.iconOnly || (hideLabel && targetWrapLevel > 0)) {
+      if (control.iconOnly || hideOnWrap || (hideLabel && targetWrapLevel > 0)) {
         return (
           <Tooltip key={`static-tooltip-${index}`}>
             {content}
@@ -414,6 +507,9 @@ export function ThreadComposer(props: {
 
     if (control.kind === "toggle") {
       const hideLabel = control.iconOnly || shouldHideLabel;
+      const labelClassName = hideOnWrap
+        ? `lightcode-composer-label-hideable${hideLabel ? " is-hidden" : ""}`
+        : undefined;
       // `label` is the stable English logic key; `displayLabel` (when present)
       // is the localized text actually shown to the user.
       const toggleLabel = control.displayLabel ? t(control.displayLabel) : control.label;
@@ -440,14 +536,18 @@ export function ThreadComposer(props: {
         >
           {resolveIcon(control)}
           {!control.iconOnly && (
-            <span className={hideLabel ? "lightcode-composer-label-hideable is-hidden" : undefined}>
+            <span data-collapse-tier={collapseTier} className={labelClassName}>
               {toggleLabel}
             </span>
           )}
         </ToggleButton>
       );
 
-      const tooltipText = gated ? control.disabledReason : hideLabel ? toggleLabel : undefined;
+      const tooltipText = gated
+        ? control.disabledReason
+        : hideOnWrap || hideLabel
+          ? toggleLabel
+          : undefined;
       if (tooltipText) {
         return (
           <Tooltip key={`toggle-tooltip-${index}`} delay={0}>
@@ -466,11 +566,12 @@ export function ThreadComposer(props: {
       ...(control.iconOnly ? { iconOnly: control.iconOnly } : {}),
       ...(control.placeholder ? { placeholder: control.placeholder } : {}),
       ...(control.isDisabled !== undefined ? { isDisabled: control.isDisabled } : {}),
-      ...(control.hideLabelOnWrap || shouldHideLabel
+      ...(hideOnWrap || shouldHideLabel
         ? {
             hideLabelOnWrap: true,
             forceHideLabel: shouldHideLabel,
-            tooltip: shouldHideLabel && targetWrapLevel > 0 ? control.value : undefined,
+            ...(collapseTier !== undefined ? { collapseTier } : {}),
+            tooltip: control.value,
           }
         : {}),
     };
@@ -496,11 +597,50 @@ export function ThreadComposer(props: {
       renderControlItem(control, index, targetWrapLevel, forceShowLabels),
     );
 
+  const renderProbeControlItem = (
+    control: ComposerControl,
+    index: number,
+    targetWrapLevel: number,
+    forceShowLabels: boolean,
+  ) => {
+    const hideLabel = shouldHideControlLabel(control, targetWrapLevel, forceShowLabels);
+    const iconOnly =
+      control.kind !== "provider-model" &&
+      control.kind !== "effort-context" &&
+      control.iconOnly === true;
+    const isStatic = control.kind === "static";
+    const isToggle = control.kind === "toggle";
+    const probeClassName = isStatic
+      ? "lightcode-composer-static min-w-0 px-2.5"
+      : isToggle
+        ? `lightcode-composer-toggle inline-flex min-w-0 items-center gap-[0.35rem] px-2.5 ${
+            control.iconOnly ? "min-w-9 px-2" : ""
+          }`
+        : "lightcode-composer-menu inline-flex min-w-0 items-center gap-[0.35rem] px-2.5";
+    const label = resolveControlProbeLabel(control, t`Thinking`);
+
+    return (
+      <div key={`probe-control-${index}`} className={probeClassName}>
+        {hasProbeIcon(control) ? <span className="size-4 shrink-0" /> : null}
+        {!iconOnly && !hideLabel ? (
+          <span className="truncate whitespace-nowrap">{label}</span>
+        ) : null}
+        {!isStatic && !isToggle && !iconOnly && !hideLabel ? (
+          <span className="size-3.5 shrink-0" />
+        ) : null}
+      </div>
+    );
+  };
+
+  const renderProbeControlsList = (targetWrapLevel: number, forceShowLabels = false) =>
+    controls.map((control, index) =>
+      renderProbeControlItem(control, index, targetWrapLevel, forceShowLabels),
+    );
+
   const probeContentCacheKey = `${effectiveToolbarLayoutKey}|compact=${compact}`;
   if (!probeContentCacheRef.current || probeContentCacheRef.current.key !== probeContentCacheKey) {
-    // The hidden probe tree renders a full copy of the toolbar for every
-    // collapse level. Rebuild it only when layout-affecting inputs change;
-    // state-only toggles such as Plan/Work can reuse the previous probe tree.
+    // The hidden probe tree uses cheap geometry stubs for controls instead of
+    // mounting full menu/popover trigger trees for every collapse level.
     probeContentCacheRef.current = {
       key: probeContentCacheKey,
       content: (
@@ -513,6 +653,7 @@ export function ThreadComposer(props: {
           {COLLAPSE_LEVELS.map((level) => (
             <div
               key={`probe-${level}`}
+              data-wrap-level={level}
               className={toolbarClassName.replace("relative", "")}
               style={{ position: "absolute", inset: 0 }}
             >
@@ -525,7 +666,7 @@ export function ThreadComposer(props: {
                 className="probe-wrap-container flex min-w-0 flex-1 flex-nowrap items-center gap-1 overflow-hidden [&>*]:shrink-0"
                 style={{ height: "2.25rem" }}
               >
-                {renderControlsList(level)}
+                {renderProbeControlsList(level)}
               </div>
               <div className="flex shrink-0 items-end gap-2">
                 {typeof afterControls === "function" ? afterControls(level) : afterControls}
@@ -541,17 +682,17 @@ export function ThreadComposer(props: {
 
   const renderControls = () => (
     <div className="relative min-w-0 flex-1">
-      {/* Real controls: wraps and respects wrapLevel state.
+      {/* Real controls: wrap collapse is applied through DOM attributes/classes.
          Fixed height + overflow-hidden prevents a visible two-row blink
          while labels collapse — wrapped items are clipped, not shown. */}
       <div
         ref={controlsRef}
         className={`flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden [&>*]:shrink-0 ${
-          wrapLevel > 0 ? "is-wrapping" : ""
+          wrapLevelRef.current > 0 ? "is-wrapping" : ""
         }`}
         style={{ height: "2.25rem" }}
       >
-        {renderControlsList(wrapLevel)}
+        {renderControlsList(0)}
       </div>
     </div>
   );
@@ -676,15 +817,15 @@ export function ThreadComposer(props: {
   };
 
   const toolbar = (
-    <div className={toolbarClassName}>
+    <div ref={toolbarRef} className={toolbarClassName} data-wrap-level={wrapLevelRef.current}>
       {leadingControls && (
         <div className="flex shrink-0 items-end gap-2">
-          {typeof leadingControls === "function" ? leadingControls(wrapLevel) : leadingControls}
+          {typeof leadingControls === "function" ? leadingControls(0) : leadingControls}
         </div>
       )}
       {renderControls()}
       <div className="flex shrink-0 items-end gap-2">
-        {typeof afterControls === "function" ? afterControls(wrapLevel) : afterControls}
+        {typeof afterControls === "function" ? afterControls(0) : afterControls}
         {renderSendButton()}
       </div>
       {/* Probes: invisible, each represents a collapse level for the entire toolbar layout. */}

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -549,9 +549,14 @@ export function ThreadComposer(props: {
           ? toggleLabel
           : undefined;
       if (tooltipText) {
+        // Place the ToggleButton directly inside <Tooltip> (no <Tooltip.Trigger>
+        // wrapper) so the tooltip attaches to the button itself. Wrapping a
+        // focusable control in <Tooltip.Trigger> would add a redundant
+        // `role="button"` host element, duplicating the toggle in the
+        // accessibility tree. Mirrors the OptionMenu tooltip pattern.
         return (
           <Tooltip key={`toggle-tooltip-${index}`} delay={0}>
-            <Tooltip.Trigger>{toggle}</Tooltip.Trigger>
+            {toggle}
             <Tooltip.Content placement="top">{tooltipText}</Tooltip.Content>
           </Tooltip>
         );

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -16,8 +16,8 @@ import { migrateCursorBaseId, parseCursorModelId } from "@/shared/cursorModelId"
 import {
   AttachmentBar,
   ComposerAddMenu,
-  ImageLightbox,
   MentionInput,
+  openAttachmentLightbox,
   VoiceInputButton,
   useAttachments,
 } from "../composer";
@@ -271,8 +271,6 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     nonce: number;
   } | null>(null);
   const [contextDockOpen, setContextDockOpen] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-  const imageAttachments = attachments.attachments.filter((a) => a.isImage);
   const presentationMode =
     thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal";
   const usesTerminalPresentation = presentationMode === "terminal";
@@ -848,8 +846,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                       attachments={attachments.attachments}
                       onRemove={attachments.removeAttachment}
                       onPreviewImage={(att) => {
+                        const imageAttachments = attachments.attachments.filter((a) => a.isImage);
                         const idx = imageAttachments.findIndex((a) => a.id === att.id);
-                        if (idx >= 0) setLightboxIndex(idx);
+                        if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
                       }}
                     />
                   }
@@ -954,7 +953,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         : undefined
                   }
                   {...(() => {
-                    const renderExtras = (level: number) => (
+                    const renderExtras = () => (
                       <>
                         {showContextIndicator ? (
                           <ThreadContextIndicator
@@ -983,9 +982,17 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                               <Tooltip.Trigger tabIndex={-1} role="none">
                                 <div className="lightcode-composer-static lightcode-composer-worktree min-w-0 max-w-48 px-2.5">
                                   <GitFork className="size-3.5 text-muted" />
-                                  {level < 3 && <span className="truncate">{branchName}</span>}
-                                  {level < 3 && thread.prNumber ? (
-                                    <span className="shrink-0 text-muted/60">
+                                  <span
+                                    data-collapse-tier={3}
+                                    className="lightcode-composer-label-hideable truncate"
+                                  >
+                                    {branchName}
+                                  </span>
+                                  {thread.prNumber ? (
+                                    <span
+                                      data-collapse-tier={3}
+                                      className="lightcode-composer-label-hideable shrink-0 text-muted/60"
+                                    >
                                       PR #{thread.prNumber}
                                     </span>
                                   ) : null}
@@ -1008,8 +1015,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                                       project.scripts.worktreeCopyPatterns,
                                   }
                                 : {})}
-                              forceHideLabel={level >= 3}
-                              iconOnly={level >= 3}
+                              collapseTier={3}
                             />
                           )
                         ) : null}
@@ -1038,9 +1044,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                     return isCliThread
                       ? { leadingControls: renderExtras, afterControls: renderVoiceInput }
                       : {
-                          afterControls: (level: number) => (
+                          afterControls: () => (
                             <>
-                              {renderExtras(level)}
+                              {renderExtras()}
                               {renderVoiceInput()}
                             </>
                           ),
@@ -1075,14 +1081,6 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
             </div>
           ) : null}
         </div>
-      ) : null}
-
-      {lightboxIndex !== null && imageAttachments.length > 0 ? (
-        <ImageLightbox
-          images={imageAttachments}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-        />
       ) : null}
     </>
   );

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -17,8 +17,8 @@ import {
   AttachmentBar,
   BrowserChip,
   ComposerAddMenu,
-  ImageLightbox,
   MentionInput,
+  openAttachmentLightbox,
   VoiceInputButton,
   type MentionInputHandle,
   type VoiceInputHandle,
@@ -234,7 +234,6 @@ export function ThreadDraftComposerArea(props: {
       });
     }
   }, [pendingPickedAttachments, inboxKey]);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const [branchSelection, setBranchSelection] = useState<BranchSelection | null>(
     () => useAppStore.getState().pendingDraftWorktreeSelections[props.project.id] ?? null,
   );
@@ -248,7 +247,6 @@ export function ThreadDraftComposerArea(props: {
     target: "model" | "effort";
     nonce: number;
   } | null>(null);
-  const imageAttachments = attachments.attachments.filter((a) => a.isImage);
   const saveDraftContent = useAppStore((s) => s.saveDraftContent);
   const clearDraftContent = useAppStore((s) => s.clearDraftContent);
   const latestSegmentsRef = useRef<PromptSegment[]>([]);
@@ -555,8 +553,9 @@ export function ThreadDraftComposerArea(props: {
             attachments={attachments.attachments}
             onRemove={attachments.removeAttachment}
             onPreviewImage={(att) => {
+              const imageAttachments = attachments.attachments.filter((a) => a.isImage);
               const idx = imageAttachments.findIndex((a) => a.id === att.id);
-              if (idx >= 0) setLightboxIndex(idx);
+              if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
             }}
             leading={
               props.config.browserMcp === true ? (
@@ -696,13 +695,6 @@ export function ThreadDraftComposerArea(props: {
               : {})}
           />
         </div>
-      ) : null}
-      {lightboxIndex !== null && imageAttachments.length > 0 ? (
-        <ImageLightbox
-          images={imageAttachments}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-        />
       ) : null}
     </>
   );

--- a/src/renderer/hooks/useScrollFade.ts
+++ b/src/renderer/hooks/useScrollFade.ts
@@ -48,6 +48,7 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
 ): ScrollFadeHandles<T> {
   const { contentRef, maxFadePx = DEFAULT_MAX_FADE_PX } = options ?? {};
   const scrollRef = useRef<T | null>(null);
+  const resizeFrameRef = useRef<number | null>(null);
   const [scrollEl, setScrollEl] = useState<T | null>(null);
 
   // Stable identity: an inline closure would cycle the ref null→element on
@@ -68,11 +69,18 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
       el.style.setProperty("--top-fade-size", `${topFade}px`);
       el.style.setProperty("--bottom-fade-size", `${bottomFade}px`);
     };
+    const scheduleUpdate = () => {
+      if (resizeFrameRef.current !== null) return;
+      resizeFrameRef.current = requestAnimationFrame(() => {
+        resizeFrameRef.current = null;
+        update();
+      });
+    };
 
     update();
     el.addEventListener("scroll", update, { passive: true });
 
-    const observer = new ResizeObserver(update);
+    const observer = new ResizeObserver(scheduleUpdate);
     observer.observe(el);
     const contentEl = contentRef?.current;
     if (contentEl) observer.observe(contentEl);
@@ -80,6 +88,10 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
     return () => {
       el.removeEventListener("scroll", update);
       observer.disconnect();
+      if (resizeFrameRef.current !== null) {
+        cancelAnimationFrame(resizeFrameRef.current);
+        resizeFrameRef.current = null;
+      }
     };
   }, [scrollEl, contentRef, maxFadePx]);
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -110,15 +110,24 @@ function showCrash(
   }
 }
 
-window.addEventListener("error", (event) => {
-  if (!(event instanceof ErrorEvent)) return;
-  if (isIgnorableWindowError(event)) {
-    event.preventDefault();
-    return;
-  }
-  // Sentry's Electron renderer integration already captures global errors; this only swaps UI.
-  showCrash("uncaught", event.error ?? event.message, buildSource(event), { capture: false });
-});
+// Capture phase so this runs before other window `error` listeners (e.g. Vite's
+// dev overlay): for the benign "ResizeObserver loop … undelivered notifications"
+// warning we stopImmediatePropagation so it never reaches the dev overlay, which
+// would otherwise flood with it during panel resizes. Already harmless in prod.
+window.addEventListener(
+  "error",
+  (event) => {
+    if (!(event instanceof ErrorEvent)) return;
+    if (isIgnorableWindowError(event)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    // Sentry's Electron renderer integration already captures global errors; this only swaps UI.
+    showCrash("uncaught", event.error ?? event.message, buildSource(event), { capture: false });
+  },
+  { capture: true },
+);
 
 window.addEventListener("unhandledrejection", (event) => {
   if (isIgnorableRejection(event.reason)) {

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HOME_PROJECT_ID, HOME_PROJECT_NAME } from "@/shared/homeScope";
 import type { PaneLayout } from "@/shared/paneLayout";
+import {
+  readStoredSizes,
+  splitStorageKey,
+  writeStoredSizes,
+} from "@/renderer/components/layout/paneSizeStorage";
 import { useAppStore } from "./appStore";
 
 describe("appStore runtime config sync", () => {
@@ -1452,6 +1457,69 @@ describe("grid layout actions", () => {
         { kind: "leaf", paneId: ids[2] },
       ],
     });
+  });
+
+  it("splitPaneById preserves ancestor split sizes", () => {
+    const ids = createThreads(3);
+    const initialLayout: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: ids[0]! },
+        { kind: "leaf", paneId: ids[1]! },
+      ],
+    };
+    useAppStore.setState((s) => ({
+      ...s,
+      view: {
+        kind: "thread",
+        panes: [ids[0]!, ids[1]!] as [string, ...string[]],
+        paneLayout: initialLayout,
+      },
+    }));
+    writeStoredSizes(splitStorageKey(initialLayout, "vertical"), [40, 60]);
+
+    useAppStore.getState().splitPaneById(ids[2]!, ids[1]!, "bottom");
+
+    const view = useAppStore.getState().view;
+    expect(view.kind).toBe("thread");
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(readStoredSizes(splitStorageKey(view.paneLayout, "vertical"), 2)).toEqual([40, 60]);
+  });
+
+  it("closePane preserves ancestor split sizes", () => {
+    const ids = createThreads(3);
+    const initialLayout: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: ids[0]! },
+        {
+          kind: "split",
+          axis: "horizontal",
+          children: [
+            { kind: "leaf", paneId: ids[1]! },
+            { kind: "leaf", paneId: ids[2]! },
+          ],
+        },
+      ],
+    };
+    useAppStore.setState((s) => ({
+      ...s,
+      view: {
+        kind: "thread",
+        panes: [ids[0]!, ids[1]!, ids[2]!] as [string, ...string[]],
+        paneLayout: initialLayout,
+      },
+    }));
+    writeStoredSizes(splitStorageKey(initialLayout, "vertical"), [35, 65]);
+
+    useAppStore.getState().closePane(ids[2]!);
+
+    const view = useAppStore.getState().view;
+    expect(view.kind).toBe("thread");
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(readStoredSizes(splitStorageKey(view.paneLayout, "vertical"), 2)).toEqual([35, 65]);
   });
 
   it("insertPaneAtLayoutTarget can create a global second row", () => {

--- a/src/renderer/state/panelResizeSignal.ts
+++ b/src/renderer/state/panelResizeSignal.ts
@@ -1,0 +1,45 @@
+// Process-wide signal for "a panel/divider drag is currently in progress".
+//
+// Panel resizing (AppShell sidebar/right/git/bottom panels and the
+// SplitPaneContainer dividers) drives a width/height change on every animation
+// frame. Subscribers that normally do synchronous layout reconciliation in
+// response to size changes (the chat scroll-sync in `ChatPane`) use this to
+// switch to a cheaper, coalesced path for the duration of the drag — so the
+// content still reflows and stays bottom-pinned live, but we avoid stacking
+// several forced reflows (`scrollHeight` reads) per frame.
+//
+// Only one pointer drag can be active at a time, so a single boolean suffices.
+
+let resizing = false;
+const listeners = new Set<(resizing: boolean) => void>();
+
+function setDocumentPanelResizing(next: boolean): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.dataset.panelResizing = next ? "on" : "off";
+}
+
+export function isPanelResizing(): boolean {
+  return resizing;
+}
+
+export function beginPanelResize(): void {
+  if (resizing) return;
+  resizing = true;
+  setDocumentPanelResizing(true);
+  for (const listener of listeners) listener(true);
+}
+
+export function endPanelResize(): void {
+  if (!resizing) return;
+  resizing = false;
+  setDocumentPanelResizing(false);
+  for (const listener of listeners) listener(false);
+}
+
+/** Subscribe to resize start/end transitions. Returns an unsubscribe fn. */
+export function subscribePanelResize(listener: (resizing: boolean) => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/renderer/state/slices/helpers.ts
+++ b/src/renderer/state/slices/helpers.ts
@@ -19,7 +19,10 @@ import {
   paneIndexToRowCol,
   removeIndicesFromRowLayout,
 } from "@/shared/rowLayout";
-import { migratePaneSizeStorage } from "@/renderer/components/layout/paneSizeStorage";
+import {
+  migratePaneSizeStorage,
+  preservePaneSizeStorageForLayoutChange,
+} from "@/renderer/components/layout/paneSizeStorage";
 import type { SavedGroupLayout } from "./types";
 
 /**
@@ -265,14 +268,21 @@ export function removePaneFromView(
   view: Extract<AppView, { kind: "thread" }>,
   paneId: string,
 ): AppView {
+  const previousLayout = currentPaneLayout(view);
   if (view.paneLayout) {
-    return viewFromPaneLayout(removePaneFromLayout(view.paneLayout, paneId), view.activeGroupId);
+    const layout = removePaneFromLayout(view.paneLayout, paneId);
+    if (layout) preservePaneSizeStorageForLayoutChange(previousLayout, layout);
+    return viewFromPaneLayout(layout, view.activeGroupId);
   }
 
   const idx = view.panes.indexOf(paneId);
   const remaining = view.panes.filter((id) => id !== paneId);
   if (remaining.length === 0) return { kind: "home" };
-  return viewAfterPaneRemoval(view, remaining, new Set(idx !== -1 ? [idx] : []));
+  const nextView = viewAfterPaneRemoval(view, remaining, new Set(idx !== -1 ? [idx] : []));
+  if (nextView.kind === "thread") {
+    preservePaneSizeStorageForLayoutChange(previousLayout, currentPaneLayout(nextView));
+  }
+  return nextView;
 }
 
 export type { AppView, Thread, ThreadAttention, ThreadStatus };

--- a/src/renderer/state/slices/viewSlice.ts
+++ b/src/renderer/state/slices/viewSlice.ts
@@ -9,7 +9,10 @@ import {
   swapPaneIdsInLayout,
   type PaneLayoutInsertTarget,
 } from "@/shared/paneLayout";
-import { swapPaneIdsInStorage } from "@/renderer/components/layout/paneSizeStorage";
+import {
+  preservePaneSizeStorageForLayoutChange,
+  swapPaneIdsInStorage,
+} from "@/renderer/components/layout/paneSizeStorage";
 import { reorderIds, type ReorderPlacement } from "../reorder";
 import {
   clearFinishedAndDone,
@@ -101,6 +104,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const draftPaneId = makeDraftPaneId(projectId);
       const existing = state.view.panes;
       if (state.view.paneLayout) {
+        const previousLayout = currentPaneLayout(state.view);
         const layout = insertPaneInLayout(
           state.view.paneLayout,
           {
@@ -113,6 +117,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
           },
           draftPaneId,
         );
+        preservePaneSizeStorageForLayoutChange(previousLayout, layout);
         return {
           view: {
             kind: "thread",
@@ -123,12 +128,18 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       }
       const rl = state.view.rowLayout;
       const newRl = rl ? [...rl.slice(0, -1), rl[rl.length - 1]! + 1] : undefined;
+      const nextPanes = [...existing, draftPaneId] as [string, ...string[]];
+      const nextView: AppView = {
+        ...state.view,
+        panes: nextPanes,
+        ...(newRl ? { rowLayout: newRl } : {}),
+      };
+      preservePaneSizeStorageForLayoutChange(
+        currentPaneLayout(state.view),
+        currentPaneLayout(nextView),
+      );
       return {
-        view: {
-          ...state.view,
-          panes: [...existing, draftPaneId] as [string, ...string[]],
-          ...(newRl ? { rowLayout: newRl } : {}),
-        },
+        view: nextView,
       };
     }),
   openHome: () => set({ view: { kind: "home" } }),
@@ -151,6 +162,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
                 }
               : { path: [] as number[], axis: "vertical" as const, index: 1 };
           const newLayout = insertPaneInLayout(layout, insertTarget, threadId);
+          preservePaneSizeStorageForLayoutChange(layout, newLayout);
           const nextView: AppView = {
             kind: "thread",
             panes: collectPaneIds(newLayout),
@@ -213,6 +225,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         return cleared ? { threads: cleared } : {};
       }
       if (state.view.paneLayout) {
+        const previousLayout = currentPaneLayout(state.view);
         const layout = insertPaneInLayout(
           state.view.paneLayout,
           {
@@ -225,6 +238,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
           },
           threadId,
         );
+        preservePaneSizeStorageForLayoutChange(previousLayout, layout);
         const panes = collectPaneIds(layout);
         const nextView: AppView = {
           kind: "thread",
@@ -243,6 +257,10 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         panes: nextPanes,
         ...(newRl ? { rowLayout: newRl } : {}),
       };
+      preservePaneSizeStorageForLayoutChange(
+        currentPaneLayout(state.view),
+        currentPaneLayout(nextView),
+      );
       const cleared = clearFinishedAndDone(state.threads, nextPanes);
       return cleared ? { view: nextView, threads: cleared } : { view: nextView };
     }),
@@ -319,6 +337,10 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         panes: nextPanes as [string, ...string[]],
         ...(newRl ? { rowLayout: newRl } : {}),
       };
+      preservePaneSizeStorageForLayoutChange(
+        currentPaneLayout(state.view),
+        currentPaneLayout(nextView),
+      );
       const cleared = clearFinishedAndDone(state.threads, nextPanes);
       return cleared ? { view: nextView, threads: cleared } : { view: nextView };
     }),
@@ -340,12 +362,17 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         clampedIndex,
         edge,
       );
+      const nextView: AppView = {
+        ...state.view,
+        panes: nextPanes as [string, ...string[]],
+        ...(nextRowLayout ? { rowLayout: nextRowLayout } : {}),
+      };
+      preservePaneSizeStorageForLayoutChange(
+        currentPaneLayout(state.view),
+        currentPaneLayout(nextView),
+      );
       return {
-        view: {
-          ...state.view,
-          panes: nextPanes as [string, ...string[]],
-          ...(nextRowLayout ? { rowLayout: nextRowLayout } : {}),
-        },
+        view: nextView,
       };
     }),
   replacePaneById: (threadId, targetPaneId) =>
@@ -373,7 +400,9 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       if (state.view.panes.includes(threadId) || !state.view.panes.includes(targetPaneId)) {
         return {};
       }
-      const layout = splitPaneInLayout(currentPaneLayout(state.view), targetPaneId, threadId, edge);
+      const previousLayout = currentPaneLayout(state.view);
+      const layout = splitPaneInLayout(previousLayout, targetPaneId, threadId, edge);
+      preservePaneSizeStorageForLayoutChange(previousLayout, layout);
       const panes = collectPaneIds(layout);
       const nextView: AppView = {
         kind: "thread",
@@ -392,7 +421,9 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         return cleared ? { view: nextView, threads: cleared } : { view: nextView };
       }
       if (state.view.panes.includes(threadId)) return {};
-      const layout = insertPaneInLayout(currentPaneLayout(state.view), target, threadId);
+      const previousLayout = currentPaneLayout(state.view);
+      const layout = insertPaneInLayout(previousLayout, target, threadId);
+      preservePaneSizeStorageForLayoutChange(previousLayout, layout);
       const panes = collectPaneIds(layout);
       const nextView: AppView = {
         kind: "thread",
@@ -423,6 +454,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
               adjustInsertTargetForRemoval(layout, paneId, target),
               paneId,
             );
+      preservePaneSizeStorageForLayoutChange(layout, nextLayout);
       return {
         view: {
           kind: "thread",

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1267,6 +1267,22 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
   background: var(--accent);
 }
 
+.lightcode-pane-divider-drop-zone {
+  position: absolute;
+  inset: 0;
+}
+
+.lightcode-pane-divider-drop-zone--vertical.is-highlighted::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--accent);
+}
+
 .lightcode-pane-divider-horizontal {
   height: 8px;
   cursor: row-resize;
@@ -1291,6 +1307,17 @@ html[data-platform="darwin"] .lightcode-content-over-drag-region--drag {
 .lightcode-pane-divider-horizontal:hover::after,
 .lightcode-pane-divider-horizontal.is-highlighted::after {
   height: 2px;
+  background: var(--accent);
+}
+
+.lightcode-pane-divider-drop-zone--horizontal.is-highlighted::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  left: 0;
+  top: 50%;
+  height: 2px;
+  transform: translateY(-50%);
   background: var(--accent);
 }
 
@@ -1804,6 +1831,39 @@ html[data-app-unfocused] .lightcode-provider-icon--finished {
 }
 
 .lightcode-composer-label-hideable.is-hidden {
+  display: none;
+}
+
+.lightcode-composer-toolbar[data-wrap-level="1"]
+  .lightcode-composer-label-hideable[data-collapse-tier="1"],
+.lightcode-composer-toolbar[data-wrap-level="2"]
+  .lightcode-composer-label-hideable[data-collapse-tier="1"],
+.lightcode-composer-toolbar[data-wrap-level="2"]
+  .lightcode-composer-label-hideable[data-collapse-tier="2"],
+.lightcode-composer-toolbar[data-wrap-level="3"]
+  .lightcode-composer-label-hideable[data-collapse-tier="1"],
+.lightcode-composer-toolbar[data-wrap-level="3"]
+  .lightcode-composer-label-hideable[data-collapse-tier="2"],
+.lightcode-composer-toolbar[data-wrap-level="3"]
+  .lightcode-composer-label-hideable[data-collapse-tier="3"],
+.lightcode-composer-toolbar[data-wrap-level="4"]
+  .lightcode-composer-label-hideable[data-collapse-tier="1"],
+.lightcode-composer-toolbar[data-wrap-level="4"]
+  .lightcode-composer-label-hideable[data-collapse-tier="2"],
+.lightcode-composer-toolbar[data-wrap-level="4"]
+  .lightcode-composer-label-hideable[data-collapse-tier="3"],
+.lightcode-composer-toolbar[data-wrap-level="4"]
+  .lightcode-composer-label-hideable[data-collapse-tier="4"],
+.lightcode-composer-toolbar[data-wrap-level="5"]
+  .lightcode-composer-label-hideable[data-collapse-tier="1"],
+.lightcode-composer-toolbar[data-wrap-level="5"]
+  .lightcode-composer-label-hideable[data-collapse-tier="2"],
+.lightcode-composer-toolbar[data-wrap-level="5"]
+  .lightcode-composer-label-hideable[data-collapse-tier="3"],
+.lightcode-composer-toolbar[data-wrap-level="5"]
+  .lightcode-composer-label-hideable[data-collapse-tier="4"],
+.lightcode-composer-toolbar[data-wrap-level="5"]
+  .lightcode-composer-label-hideable[data-collapse-tier="5"] {
   display: none;
 }
 
@@ -2417,6 +2477,7 @@ html[data-app-unfocused] .lightcode-provider-icon--finished {
   border-radius: 0.4rem;
   overflow: hidden;
   cursor: var(--interactive-cursor);
+  contain: layout paint;
 }
 
 .lightcode-attachment-image-preview img {
@@ -2425,6 +2486,10 @@ html[data-app-unfocused] .lightcode-provider-icon--finished {
   height: 100%;
   object-fit: cover;
   user-select: none;
+}
+
+.lightcode-image-card {
+  contain: layout paint;
 }
 
 /* ── Image Lightbox ──────────────────────────────────────── */

--- a/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  memo,
   type ReactNode,
   type RefObject,
   useContext,
@@ -311,9 +312,8 @@ function ShellSidebarResizeHandle(props: {
   hasHeaders: boolean;
   hasContentHeader: boolean;
   forceSidebarExpanded: boolean;
-  onMouseEnter: () => void;
-  onMouseLeave: () => void;
-  onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onHoverChange: (hovered: boolean) => void;
+  onResizeStart: (event: React.MouseEvent<HTMLDivElement>) => void;
 }) {
   const { t } = useLingui();
   const { isCollapsed, isOverlay } = useSidebarOverlayStore(
@@ -338,15 +338,20 @@ function ShellSidebarResizeHandle(props: {
             }
           : undefined
       }
-      onMouseEnter={props.onMouseEnter}
-      onMouseLeave={props.onMouseLeave}
-      onMouseDown={props.onMouseDown}
+      onMouseEnter={() => props.onHoverChange(true)}
+      onMouseLeave={() => props.onHoverChange(false)}
+      onMouseDown={(event) => {
+        props.onHoverChange(false);
+        props.onResizeStart(event);
+      }}
       role="separator"
       aria-orientation="vertical"
       aria-label={t`Resize sidebar`}
     />
   );
 }
+
+const MemoShellSidebarResizeHandle = memo(ShellSidebarResizeHandle);
 
 export function AppShell(props: {
   sidebar: ReactNode;
@@ -552,16 +557,12 @@ export function AppShell(props: {
         forceSidebarExpanded={forceSidebarExpanded}
       />
 
-      <ShellSidebarResizeHandle
+      <MemoShellSidebarResizeHandle
         hasHeaders={hasHeaders}
         hasContentHeader={hasContentHeader}
         forceSidebarExpanded={forceSidebarExpanded}
-        onMouseEnter={() => setIsSidebarHandleHovered(true)}
-        onMouseLeave={() => setIsSidebarHandleHovered(false)}
-        onMouseDown={(event) => {
-          setIsSidebarHandleHovered(false);
-          handleSidebarResizeStart(event);
-        }}
+        onHoverChange={setIsSidebarHandleHovered}
+        onResizeStart={handleSidebarResizeStart}
       />
 
       <div

--- a/src/renderer/views/MainView/parts/AppShell/parts/useResizablePanels.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/useResizablePanels.ts
@@ -2,6 +2,7 @@ import type React from "react";
 import type { RefObject } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { readStoredNumber } from "@/renderer/utils/localStorage";
+import { beginPanelResize, endPanelResize } from "@/renderer/state/panelResizeSignal";
 
 // Wide enough to fit a Home-row suffix button (terminal icon) plus a few
 // characters of an active thread title without truncating to ellipses.
@@ -223,6 +224,8 @@ export function useResizablePanels(refs: {
         overlay.style.cursor = target === "panel-bottom" ? "row-resize" : "col-resize";
       }
 
+      beginPanelResize();
+
       let rafId: number | null = null;
       let pendingX = startX;
       let pendingY = startY;
@@ -287,6 +290,7 @@ export function useResizablePanels(refs: {
           overlay.style.display = "none";
           overlay.style.cursor = "";
         }
+        endPanelResize();
         endResizeRef.current = null;
       }
 
@@ -317,21 +321,33 @@ export function useResizablePanels(refs: {
     ],
   );
 
-  function handleSidebarResizeStart(e: React.MouseEvent) {
-    startResize("sidebar", e);
-  }
+  const handleSidebarResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      startResize("sidebar", e);
+    },
+    [startResize],
+  );
 
-  function handlePanelResizeStart(e: React.MouseEvent) {
-    startResize("panel", e);
-  }
+  const handlePanelResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      startResize("panel", e);
+    },
+    [startResize],
+  );
 
-  function handlePanelBottomResizeStart(e: React.MouseEvent) {
-    startResize("panel-bottom", e);
-  }
+  const handlePanelBottomResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      startResize("panel-bottom", e);
+    },
+    [startResize],
+  );
 
-  function handleGitPanelResizeStart(e: React.MouseEvent) {
-    startResize("git-panel", e);
-  }
+  const handleGitPanelResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      startResize("git-panel", e);
+    },
+    [startResize],
+  );
 
   return {
     sidebarWidth,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,8 +61,43 @@ function reactDevtoolsStandalone(): Plugin {
   };
 }
 
+function resizeObserverLoopErrorFilter(): Plugin {
+  return {
+    name: "lightcode:resize-observer-loop-error-filter",
+    apply: "serve",
+    transformIndexHtml() {
+      return [
+        {
+          tag: "script",
+          children: `
+(function () {
+  var resizeObserverLoopMessages = {
+    "ResizeObserver loop completed with undelivered notifications.": true,
+    "ResizeObserver loop limit exceeded": true
+  };
+  window.addEventListener("error", function (event) {
+    var message =
+      event && event.error && typeof event.error.message === "string"
+        ? event.error.message
+        : event && typeof event.message === "string"
+          ? event.message
+          : "";
+    if (!resizeObserverLoopMessages[message]) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }, { capture: true });
+})();
+          `.trim(),
+          injectTo: "head-prepend",
+        },
+      ];
+    },
+  };
+}
+
 export default defineConfig(({ mode }) => ({
   plugins: [
+    resizeObserverLoopErrorFilter(),
     reactDevtoolsStandalone(),
     react(),
     // The Lingui macro must expand BEFORE the React Compiler. Babel applies


### PR DESCRIPTION
- Bugfix: stabilize pane resizing, split-size persistence, and divider drop feedback so layouts stay steady while panes move.
- Keep chat scrolling and virtualized message lists from over-reconciling during resize, including ResizeObserver loop noise.
- Improve image attachments, chat image views, and lightbox previews so images render with correct sizing and less flicker.
- Refine composer control collapse behavior across branch, model, effort, and option menus for narrow panes.
- Keep Windows acrylic translucency stable when image content appears.