### PR TITLE
fix(changelog): decouple unread badge from note publish timing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,43 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
+      # The desktop app reads website/public/changelog.json (served by the
+      # marketing site) for the in-app "What's New" entry. Require a well-formed
+      # entry for this version BEFORE tagging, so the binary never ships ahead of
+      # its notes. Write the changelog first (use the release-notes skill) and
+      # push it to master, then run this release.
+      - name: Require changelog entry
+        run: |
+          node -e "
+            const fs = require('fs');
+            const version = '${{ steps.resolve.outputs.version }}';
+            const path = 'website/public/changelog.json';
+            let doc;
+            try {
+              doc = JSON.parse(fs.readFileSync(path, 'utf8'));
+            } catch (err) {
+              console.error('::error::Could not read ' + path + ': ' + err.message);
+              process.exit(1);
+            }
+            const releases = Array.isArray(doc.releases) ? doc.releases : [];
+            const entry = releases.find((r) => r && r.version === version);
+            if (!entry) {
+              console.error('::error::No changelog entry for ' + version + ' in ' + path + '. Add the release notes and push to master before releasing (the desktop app reads this file for the in-app changelog).');
+              process.exit(1);
+            }
+            const isoDate = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(entry.date || '');
+            const wellFormed =
+              typeof entry.title === 'string' && entry.title.trim().length > 0 &&
+              typeof entry.summary === 'string' && entry.summary.trim().length > 0 &&
+              Array.isArray(entry.changes) && entry.changes.length > 0 &&
+              isoDate;
+            if (!wellFormed) {
+              console.error('::error::Changelog entry for ' + version + ' is incomplete; it needs a title, summary, an ISO (YYYY-MM-DD) date, and at least one change.');
+              process.exit(1);
+            }
+            console.log('Changelog entry for ' + version + ' is present and well-formed.');
+          "
+
       - name: Bump package.json if needed
         run: |
           node -e "

--- a/src/renderer/state/changelogStore.ts
+++ b/src/renderer/state/changelogStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { readBridge } from "@/renderer/bridge";
 import {
   CHANGELOG_URL,
+  compareVersions,
   hasUnseenChangelog,
   parseChangelogDocument,
   releasesSince,
@@ -15,6 +16,7 @@ import {
 } from "@/renderer/utils/localStorage";
 
 const SEEN_VERSION_KEY = "lightcode-changelog-seen-version";
+const ACK_VERSION_KEY = "lightcode-changelog-ack-version";
 const HIDDEN_KEY = "lightcode-whatsnew-hidden";
 const CACHE_KEY = "lightcode-changelog-cache";
 
@@ -26,12 +28,39 @@ function currentAppVersion(): string {
   }
 }
 
-/** Persist "seen up to the current version" + "hidden", returning that version. */
-function persistSeenAndHidden(): string {
+/**
+ * The newest release the user can have actually read right now: the latest entry
+ * at or below the running version, never older than what they have already seen.
+ * Crucially it does NOT jump to `current` when the notes for `current` have not
+ * been published yet — leaving the seen marker behind is what lets a
+ * late-arriving entry re-flag as unseen instead of being silently skipped.
+ */
+function advanceSeenVersion(
+  releases: readonly ChangelogRelease[],
+  current: string,
+  prevSeen: string | null,
+): string | null {
+  let best = prevSeen;
+  for (const release of releases) {
+    if (compareVersions(release.version, current) > 0) continue;
+    if (best === null || compareVersions(release.version, best) > 0) best = release.version;
+  }
+  return best;
+}
+
+/**
+ * Acknowledge the running version: record it as acknowledged (clears the
+ * version-bump flag) and advance the seen marker over any now-readable notes.
+ * Persists both and returns the state patch.
+ */
+function acknowledgeCurrent(
+  state: ChangelogState,
+): Pick<ChangelogState, "lastSeenVersion" | "acknowledgedVersion"> {
   const current = currentAppVersion();
-  writeStoredString(SEEN_VERSION_KEY, current);
-  writeStoredBoolean(HIDDEN_KEY, true);
-  return current;
+  const nextSeen = advanceSeenVersion(state.releases, current, state.lastSeenVersion);
+  writeStoredString(ACK_VERSION_KEY, current);
+  if (nextSeen !== null) writeStoredString(SEEN_VERSION_KEY, nextSeen);
+  return { lastSeenVersion: nextSeen, acknowledgedVersion: current };
 }
 
 /**
@@ -53,10 +82,17 @@ interface ChangelogState {
   /** Current releases, newest-first (cache → freshly fetched). Empty until first load. */
   releases: ChangelogRelease[];
   /**
-   * Newest version whose changelog the user has acknowledged. `null` only until
-   * the first launch initializes it (see {@link bootstrapSeenState}).
+   * Newest release version whose *content* the user has seen. Drives the
+   * dialog's unread list and the late-content badge. `null` only until the first
+   * launch initializes it (see {@link bootstrapSeenState}).
    */
   lastSeenVersion: string | null;
+  /**
+   * The app version the user last dismissed the "What's New" prompt at. Drives
+   * the version-bump badge independently of whether the notes have loaded yet.
+   * `null` only until the first launch initializes it.
+   */
+  acknowledgedVersion: string | null;
   /** Whether the "What's New" dialog is currently shown. */
   whatsNewOpen: boolean;
   /**
@@ -95,9 +131,10 @@ interface ChangelogState {
 // Changelog at the same time share one request instead of both hitting the net.
 let inFlightLoad: Promise<void> | null = null;
 
-export const useChangelogStore = create<ChangelogState>((set) => ({
+export const useChangelogStore = create<ChangelogState>((set, get) => ({
   releases: loadCachedReleases(),
   lastSeenVersion: readStoredString(SEEN_VERSION_KEY),
+  acknowledgedVersion: readStoredString(ACK_VERSION_KEY),
   whatsNewOpen: false,
   whatsNewHidden: readStoredBoolean(HIDDEN_KEY, false),
 
@@ -120,34 +157,53 @@ export const useChangelogStore = create<ChangelogState>((set) => ({
   },
 
   bootstrapSeenState: () => {
-    const lastSeen = readStoredString(SEEN_VERSION_KEY);
-    // Only initialize on a fresh profile. Existing users keep their last-seen
-    // marker so a real version bump still lights up the sidebar flag.
-    if (lastSeen !== null) return;
     const current = currentAppVersion();
-    writeStoredString(SEEN_VERSION_KEY, current);
-    set({ lastSeenVersion: current });
+    const storedSeen = readStoredString(SEEN_VERSION_KEY);
+    // Fresh profile: catch the user up to the current version so the next real
+    // update is detected, and nothing is flagged on the very first launch.
+    if (storedSeen === null) {
+      writeStoredString(SEEN_VERSION_KEY, current);
+      writeStoredString(ACK_VERSION_KEY, current);
+      set({ lastSeenVersion: current, acknowledgedVersion: current });
+      return;
+    }
+    // Existing profile upgrading into the acknowledged-version model: seed it
+    // from the last-seen content version so the update that introduced this
+    // still lights the badge.
+    if (readStoredString(ACK_VERSION_KEY) === null) {
+      writeStoredString(ACK_VERSION_KEY, storedSeen);
+      set({ acknowledgedVersion: storedSeen });
+    }
   },
 
-  openWhatsNew: () => set((state) => (state.whatsNewOpen ? {} : { whatsNewOpen: true })),
-
-  hideWhatsNew: () => set({ lastSeenVersion: persistSeenAndHidden(), whatsNewHidden: true }),
-
-  markCurrentSeen: () => {
-    const current = currentAppVersion();
-    writeStoredString(SEEN_VERSION_KEY, current);
-    set((state) => (state.lastSeenVersion === current ? {} : { lastSeenVersion: current }));
+  openWhatsNew: () => {
+    // Refresh from the source as the dialog opens, so a release whose notes
+    // landed after launch shows the latest content rather than the stale cache.
+    void get().loadChangelog();
+    set((state) => (state.whatsNewOpen ? {} : { whatsNewOpen: true }));
   },
+
+  hideWhatsNew: () =>
+    set((state) => {
+      writeStoredBoolean(HIDDEN_KEY, true);
+      return { ...acknowledgeCurrent(state), whatsNewHidden: true };
+    }),
+
+  markCurrentSeen: () => set((state) => acknowledgeCurrent(state)),
 
   dismissWhatsNew: () =>
-    set({ lastSeenVersion: persistSeenAndHidden(), whatsNewOpen: false, whatsNewHidden: true }),
+    set((state) => {
+      writeStoredBoolean(HIDDEN_KEY, true);
+      return { ...acknowledgeCurrent(state), whatsNewOpen: false, whatsNewHidden: true };
+    }),
 }));
 
 /** True when there is changelog content the user has not acknowledged yet. */
 export function useHasUnseenChangelog(): boolean {
   const releases = useChangelogStore((s) => s.releases);
   const lastSeenVersion = useChangelogStore((s) => s.lastSeenVersion);
-  return hasUnseenChangelog(releases, currentAppVersion(), lastSeenVersion);
+  const acknowledgedVersion = useChangelogStore((s) => s.acknowledgedVersion);
+  return hasUnseenChangelog(releases, currentAppVersion(), lastSeenVersion, acknowledgedVersion);
 }
 
 /** Releases the user has not seen yet (newest first); empty when caught up. */

--- a/src/shared/changelog.test.ts
+++ b/src/shared/changelog.test.ts
@@ -67,17 +67,39 @@ describe("releasesSince", () => {
 });
 
 describe("hasUnseenChangelog", () => {
-  it("never fires on a fresh install", () => {
-    expect(hasUnseenChangelog(releases, releases[0]!.version, null)).toBe(false);
+  const newest = () => releases[0]!.version;
+  const prior = () => releases[1]!.version;
+
+  it("never fires on a not-yet-initialized profile", () => {
+    expect(hasUnseenChangelog(releases, newest(), null, null)).toBe(false);
+    expect(hasUnseenChangelog(releases, newest(), newest(), null)).toBe(false);
+    expect(hasUnseenChangelog(releases, newest(), null, newest())).toBe(false);
   });
 
-  it("fires when the current version moved past the last-seen version", () => {
-    expect(hasUnseenChangelog(releases, releases[0]!.version, releases[1]!.version)).toBe(true);
+  it("fires when the current version moved past the acknowledged version", () => {
+    expect(hasUnseenChangelog(releases, newest(), prior(), prior())).toBe(true);
   });
 
-  it("does not fire when the user has already seen the current version", () => {
-    const latest = releases[0]!.version;
-    expect(hasUnseenChangelog(releases, latest, latest)).toBe(false);
+  it("fires on a version bump even when no changelog entry for it has landed yet", () => {
+    // The binary updated ahead of its notes — the badge still appears.
+    expect(hasUnseenChangelog(releases, "999.0.0", prior(), prior())).toBe(true);
+  });
+
+  it("does not fire when the user is caught up to the current version", () => {
+    expect(hasUnseenChangelog(releases, newest(), newest(), newest())).toBe(false);
+  });
+
+  it("re-fires when notes land after the version was already acknowledged", () => {
+    // Acknowledged at the current version, but `seen` lagged because the notes
+    // for it had not been published yet; now that the entry is present (≤
+    // current and newer than seen), the badge returns.
+    expect(hasUnseenChangelog(releases, newest(), prior(), newest())).toBe(true);
+  });
+
+  it("ignores notes for versions newer than the running version", () => {
+    // Running `prior` and caught up; the newer `newest` entry is a release
+    // announced ahead of its build and must not light the badge.
+    expect(hasUnseenChangelog(releases, prior(), prior(), prior())).toBe(false);
   });
 });
 

--- a/src/shared/changelog.ts
+++ b/src/shared/changelog.ts
@@ -103,15 +103,37 @@ export function releasesSince(
 }
 
 /**
- * Whether `current` is newer than `lastSeen` AND there is changelog content
- * newer than `lastSeen` to show. Gates the post-update "What's New" dialog.
+ * Whether to flag an unread changelog on the sidebar.
+ *
+ * Decoupled from the changelog *content* on purpose, so the badge is correct no
+ * matter when the notes for a release land on the marketing site relative to the
+ * binary reaching users (the two ship through independent pipelines):
+ *
+ *  - **Version bump** — `current` moved past the version the user last
+ *    acknowledged. The badge lights up the moment they update, even before the
+ *    notes for `current` have been published. This is the common case.
+ *  - **Late content** — the user already acknowledged `current`, but a release
+ *    note at or below `current` is newer than anything they have actually seen
+ *    (its publish lagged the binary). The badge returns so they do not miss it.
+ *
+ * Notes for versions newer than `current` (a release announced before its build
+ * ships) are intentionally ignored, so pushing the changelog early is harmless.
+ *
+ * `lastSeen` tracks the newest content seen; `acknowledged` tracks the version
+ * the user last dismissed at. Both are null only on a not-yet-initialized
+ * profile, where there is nothing to announce.
  */
 export function hasUnseenChangelog(
   releases: readonly ChangelogRelease[],
   current: string,
   lastSeen: string | null,
+  acknowledged: string | null,
 ): boolean {
-  if (!lastSeen) return false;
-  if (compareVersions(current, lastSeen) <= 0) return false;
-  return releases.some((release) => compareVersions(release.version, lastSeen) > 0);
+  if (lastSeen === null || acknowledged === null) return false;
+  if (compareVersions(current, acknowledged) > 0) return true;
+  return releases.some(
+    (release) =>
+      compareVersions(release.version, lastSeen) > 0 &&
+      compareVersions(release.version, current) <= 0,
+  );
 }


### PR DESCRIPTION
## What

Decouples the "unread changelog" sidebar badge from when a release's notes are actually published to the marketing site.

## Why

The badge was driven off changelog *content*, so it misbehaved whenever notes landed late relative to the build: a version bump with not-yet-published notes wouldn't flag, and a late-arriving entry could be silently skipped instead of re-flagging as unread.

## How

- Track an `acknowledgedVersion` (the app version the user last dismissed "What's New" at) separately from `lastSeenVersion` (the newest release whose content they've actually seen). The badge now fires on a version bump and **re-fires** when notes for that version land late.
- `advanceSeenVersion` no longer jumps the seen marker to `current` when that version's notes haven't been published yet — leaving the marker behind is what lets a late entry re-flag.
- Ignore notes for versions newer than the running build.
- Refresh the changelog from source when the dialog opens, so a release whose notes landed after launch shows fresh content rather than the stale cache.
- Smooth migration for existing profiles into the acknowledged-version model (seed from last-seen content version).
- CI: require a well-formed changelog entry before tagging a release.

## Files

- `src/renderer/state/changelogStore.ts` — `acknowledgedVersion` state, `acknowledgeCurrent`/`advanceSeenVersion`, dialog refresh-on-open, bootstrap migration
- `src/shared/changelog.ts` — `hasUnseenChangelog` now badge-oriented (decoupled from content timing)
- `src/shared/changelog.test.ts` — coverage for late-landing notes and version-bump cases
- `.github/workflows/release.yml` — gate tagging on a valid changelog entry
