### PR TITLE
Rename settings sidebar filter to search

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2495,8 +2495,8 @@ msgstr "Dateien, die mit diesen Globs übereinstimmen, werden bei der "
 "@file-Erwähnungssuche ausgeblendet."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Einstellungen filtern"
+#~ msgid "Filter settings"
+#~ msgstr "Einstellungen filtern"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5140,6 +5140,10 @@ msgstr "Repositories durchsuchen…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Laufzeitelemente durchsuchen…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Einstellungen durchsuchen"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2469,8 +2469,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "Files matching these globs are hidden from the @file mention search."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Filter settings"
+#~ msgid "Filter settings"
+#~ msgstr "Filter settings"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5095,6 +5095,10 @@ msgstr "Search repositories…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Search runtime items…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Search settings"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2485,8 +2485,8 @@ msgstr "Los archivos que coinciden con estos globs se ocultan de la búsqueda de
 "menciones @file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Filtrar ajustes"
+#~ msgid "Filter settings"
+#~ msgstr "Filtrar ajustes"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5132,6 +5132,10 @@ msgstr "Buscar repositorios…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Buscar elementos de runtime…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Buscar ajustes"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2494,8 +2494,8 @@ msgstr "Les fichiers correspondant à ces globs sont masqués dans la recherche 
 "de mention @file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Filtrer les paramètres"
+#~ msgid "Filter settings"
+#~ msgstr "Filtrer les paramètres"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5141,6 +5141,10 @@ msgstr "Rechercher des dépôts…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Rechercher des éléments d'exécution…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Rechercher dans les paramètres"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2453,8 +2453,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "これらのグロブに一致するファイルは、@file メンション検索から非表示になります。"
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "設定を絞り込む"
+#~ msgid "Filter settings"
+#~ msgstr "設定を絞り込む"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5056,6 +5056,10 @@ msgstr "リポジトリを検索…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "ランタイム項目を検索…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "設定を検索"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2453,8 +2453,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "이러한 glob과 일치하는 파일은 @file 멘션 검색에서 숨겨집니다."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "설정 필터링"
+#~ msgid "Filter settings"
+#~ msgstr "설정 필터링"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5056,6 +5056,10 @@ msgstr "저장소 검색…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "런타임 항목 검색…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "설정 검색"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2485,8 +2485,8 @@ msgstr "Pliki pasujące do tych globów są ukryte przed wyszukiwaniem wzmianek 
 "@file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Filtruj ustawienia"
+#~ msgid "Filter settings"
+#~ msgstr "Filtruj ustawienia"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5126,6 +5126,10 @@ msgstr "Przeszukaj repozytoria…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Wyszukaj elementy środowiska wykonawczego…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Szukaj ustawień"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2488,8 +2488,8 @@ msgstr "Os arquivos que correspondem a esses globs ficam ocultos na pesquisa de 
 "menção @file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Filtrar configurações"
+#~ msgid "Filter settings"
+#~ msgstr "Filtrar configurações"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5131,6 +5131,10 @@ msgstr "Pesquisar repositórios…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Pesquisar itens de tempo de execução…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Pesquisar configurações"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2485,8 +2485,8 @@ msgstr "Файлы, соответствующие этим glob-шаблона�
 "@file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Фильтр настроек"
+#~ msgid "Filter settings"
+#~ msgstr "Фильтр настроек"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5124,6 +5124,10 @@ msgstr "Поиск репозиториев…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Поиск runtime-элементов…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Поиск настроек"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2484,8 +2484,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "Bu glob'larla eşleşen dosyalar, @file bahsetme aramasında gizlenir."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Ayarları filtrele"
+#~ msgid "Filter settings"
+#~ msgstr "Ayarları filtrele"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5122,6 +5122,10 @@ msgstr "Depolarda ara…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Çalışma zamanı öğelerini ara…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Ayarları ara"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2484,8 +2484,8 @@ msgstr "Файли, що відповідають цим glob-шаблонам, 
 "@file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Фільтрувати налаштування"
+#~ msgid "Filter settings"
+#~ msgstr "Фільтрувати налаштування"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5123,6 +5123,10 @@ msgstr "Пошук репозиторіїв…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Пошук runtime-елементів…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Шукати налаштування"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2480,8 +2480,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "Các tệp khớp với các mẫu glob này sẽ bị ẩn khỏi tìm kiếm @file."
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "Lọc cài đặt"
+#~ msgid "Filter settings"
+#~ msgstr "Lọc cài đặt"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5115,6 +5115,10 @@ msgstr "Tìm kiếm kho lưu trữ…"
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "Tìm kiếm các mục thời gian chạy…"
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "Tìm kiếm cài đặt"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2450,8 +2450,8 @@ msgid "Files matching these globs are hidden from the @file mention search."
 msgstr "与这些 glob 匹配的文件在 @file 提及搜索中隐藏。"
 
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "Filter settings"
-msgstr "筛选设置"
+#~ msgid "Filter settings"
+#~ msgstr "筛选设置"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -5047,6 +5047,10 @@ msgstr "搜索存储库..."
 #: src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
 msgid "Search runtime items…"
 msgstr "搜索运行时项目..."
+
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Search settings"
+msgstr "搜索设置"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Search shortcuts"

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -423,7 +423,7 @@ describe("SettingsOverlay", () => {
     render(<SettingsOverlay onClose={() => undefined} />);
 
     // "sleep" matches no section label, but a setting under General.
-    fireEvent.change(screen.getByPlaceholderText("Filter settings"), {
+    fireEvent.change(screen.getByPlaceholderText("Search settings"), {
       target: { value: "sleep" },
     });
 
@@ -435,7 +435,7 @@ describe("SettingsOverlay", () => {
   it("surfaces the description snippet when only the description matches", () => {
     render(<SettingsOverlay onClose={() => undefined} />);
 
-    fireEvent.change(screen.getByPlaceholderText("Filter settings"), {
+    fireEvent.change(screen.getByPlaceholderText("Search settings"), {
       target: { value: "awake" },
     });
 
@@ -447,7 +447,7 @@ describe("SettingsOverlay", () => {
   it("navigates to the section when a setting result is clicked", () => {
     render(<SettingsOverlay onClose={() => undefined} />);
 
-    fireEvent.change(screen.getByPlaceholderText("Filter settings"), {
+    fireEvent.change(screen.getByPlaceholderText("Search settings"), {
       target: { value: "sleep" },
     });
     fireEvent.click(screen.getByText("Prevent sleep while working"));
@@ -457,7 +457,7 @@ describe("SettingsOverlay", () => {
 
   it("restores the section list when the query is cleared", () => {
     render(<SettingsOverlay onClose={() => undefined} />);
-    const input = screen.getByPlaceholderText("Filter settings");
+    const input = screen.getByPlaceholderText("Search settings");
 
     fireEvent.change(input, { target: { value: "sleep" } });
     expect(screen.queryByRole("button", { name: "Audio" })).not.toBeInTheDocument();

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -482,15 +482,19 @@ export function SettingsSidebar(props: {
         className={`${overlaySidebarColumnClass} transition-opacity duration-150 ${isCollapsed ? "invisible opacity-0" : "opacity-100 delay-100"}`}
       >
         <div className={sidebarBodyScrollClass()}>
-          <div
+          {/* Transparent, sidebar-item-shaped filter: no opaque fill/border so the
+              translucent sidebar glass shows through; hover/focus use the same
+              translucent row overlays as SidebarButton. A <label> lets a click
+              anywhere (incl. icon/padding) focus the input natively. */}
+          <label
             data-lightcode-find-scope="settings"
-            className="mb-1 flex items-center gap-2 rounded-xl border border-[color:var(--border)] bg-background px-3 py-1.5"
+            className="mb-1 flex cursor-text items-center gap-2 rounded-3xl px-2 py-1.5 text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground focus-within:bg-[var(--row-active)] focus-within:text-foreground"
           >
-            <Search className="size-3.5 shrink-0 text-muted" />
+            <Search className="size-4 shrink-0" />
             <input
               ref={sectionFilterRef}
               className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted"
-              placeholder={t`Filter settings`}
+              placeholder={t`Search settings`}
               value={sectionFilter}
               onChange={(event) => setSectionFilter(event.target.value)}
               onKeyDown={(event) => {
@@ -500,7 +504,7 @@ export function SettingsSidebar(props: {
                 }
               }}
             />
-          </div>
+          </label>
           {query !== "" ? (
             <div className="space-y-0.5">
               {searchRows.length === 0 ? (

--- a/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -3,7 +3,7 @@ import type { MessageDescriptor } from "@lingui/core";
 import type { SettingsSection } from "./types";
 
 /**
- * Static index of individual settings, powering the sidebar's "Filter settings"
+ * Static index of individual settings, powering the sidebar's "Search settings"
  * search (see {@link ./SettingsSidebar}). A static index is required because
  * only the active section component is mounted at a time, so there is no live
  * DOM of other sections to scan.

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -1094,7 +1094,11 @@ describe("SupervisorRuntime thread input", () => {
     ).handlePtyData(session, "second");
 
     expect(appendFileMock).not.toHaveBeenCalled();
-    await vi.runAllTimersAsync();
+    // Only drain the timers pending right now (the 25ms dev-log buffer flush).
+    // The runtime's UsageService auto-refresh loop re-schedules itself on every
+    // tick, so `runAllTimersAsync` would chase that recurring timer forever and
+    // abort with "Aborting after running 10000 timers" (flaky under CI load).
+    await vi.runOnlyPendingTimersAsync();
     expect(appendFileMock).toHaveBeenCalledTimes(1);
     expect(appendFileMock.mock.calls[0]?.[1]).toBe("firstsecond");
     delete process.env.VITE_DEV_SERVER_URL;


### PR DESCRIPTION
- Reword the settings sidebar control to “Search settings” so the label matches what the field actually does.
- Update the sidebar styling and related search index text so the control reads cleanly and stays aligned with settings search behavior.
- Adjust the settings overlay tests to use the new placeholder text and preserve existing search-result coverage.
- Refresh all localized message catalogs so the renamed UI string stays consistent across supported languages.