### PR TITLE
Add Codex approvals reviewer override support

### DIFF
--- a/src/renderer/components/providers/codex/index.tsx
+++ b/src/renderer/components/providers/codex/index.tsx
@@ -80,13 +80,23 @@ const CODEX_PERMISSION_PRESETS = [
     label: msg`Default permissions`,
     hint: msg`Use config`,
     approvalPolicies: [],
+    approvalsReviewer: "",
     sandboxModes: [],
+  },
+  {
+    id: "review-on-request",
+    label: msg`Ask for approval`,
+    hint: msg`Prompts`,
+    approvalPolicies: ["on-request"],
+    approvalsReviewer: "user",
+    sandboxModes: ["workspace-write"],
   },
   {
     id: "auto-review",
     label: msg`Auto-review`,
     hint: msg`Review on request`,
     approvalPolicies: ["on-request"],
+    approvalsReviewer: "auto_review",
     sandboxModes: ["workspace-write"],
   },
   {
@@ -94,35 +104,52 @@ const CODEX_PERMISSION_PRESETS = [
     label: msg`Full access`,
     hint: msg`No prompts`,
     approvalPolicies: ["never"],
+    approvalsReviewer: "",
     sandboxModes: ["danger-full-access"],
   },
 ] as const;
 
 type CodexPermissionPreset = (typeof CODEX_PERMISSION_PRESETS)[number];
+type ResolvedCodexPermissionPreset = Omit<CodexPermissionPreset, "approvalsReviewer"> & {
+  approvalPolicy: string;
+  approvalsReviewer: string;
+  sandboxMode: string;
+};
 
 function resolveCodexPermissionPreset(
   preset: CodexPermissionPreset,
   approvalIds: Set<string>,
   sandboxIds: Set<string>,
-): { approvalPolicy: string; sandboxMode: string } | undefined {
+): { approvalPolicy: string; approvalsReviewer: string; sandboxMode: string } | undefined {
   if (preset.approvalPolicies.length === 0 && preset.sandboxModes.length === 0) {
-    return { approvalPolicy: "", sandboxMode: "" };
+    return { approvalPolicy: "", approvalsReviewer: preset.approvalsReviewer, sandboxMode: "" };
   }
 
   const approvalPolicy = preset.approvalPolicies.find((id) => approvalIds.has(id));
   const sandboxMode = preset.sandboxModes.find((id) => sandboxIds.has(id));
-  return approvalPolicy && sandboxMode ? { approvalPolicy, sandboxMode } : undefined;
+  return approvalPolicy && sandboxMode
+    ? { approvalPolicy, approvalsReviewer: preset.approvalsReviewer, sandboxMode }
+    : undefined;
 }
 
 function isCodexPermissionPresetSelected(
-  preset: CodexPermissionPreset & { approvalPolicy: string; sandboxMode: string },
-  config: { approvalPolicy?: string | undefined; sandboxMode?: string | undefined },
+  preset: ResolvedCodexPermissionPreset,
+  config: {
+    approvalPolicy?: string | undefined;
+    approvalsReviewer?: string | undefined;
+    sandboxMode?: string | undefined;
+  },
 ): boolean {
   if (!preset.approvalPolicy && !preset.sandboxMode) {
-    return !config.approvalPolicy && !config.sandboxMode;
+    return !config.approvalPolicy && !config.approvalsReviewer && !config.sandboxMode;
   }
+  const effectiveReviewer = config.approvalsReviewer || "user";
+  const reviewerMatches =
+    !preset.approvalsReviewer || preset.approvalsReviewer === effectiveReviewer;
   return (
-    preset.approvalPolicy === config.approvalPolicy && preset.sandboxMode === config.sandboxMode
+    preset.approvalPolicy === config.approvalPolicy &&
+    reviewerMatches &&
+    preset.sandboxMode === config.sandboxMode
   );
 }
 
@@ -134,10 +161,12 @@ function buildCodexPermissionControl(
 ): ComposerControl | null {
   const approvalIds = new Set(capabilities.approvalPolicies.map((policy) => policy.id));
   const sandboxIds = new Set(capabilities.sandboxModes.map((mode) => mode.id));
-  const permissionPresets = CODEX_PERMISSION_PRESETS.flatMap((preset) => {
-    const resolved = resolveCodexPermissionPreset(preset, approvalIds, sandboxIds);
-    return resolved ? [{ ...preset, ...resolved }] : [];
-  });
+  const permissionPresets: ResolvedCodexPermissionPreset[] = CODEX_PERMISSION_PRESETS.flatMap(
+    (preset) => {
+      const resolved = resolveCodexPermissionPreset(preset, approvalIds, sandboxIds);
+      return resolved ? [{ ...preset, ...resolved }] : [];
+    },
+  );
   if (permissionPresets.length === 0) return null;
   const current =
     permissionPresets.find((preset) => isCodexPermissionPresetSelected(preset, config)) ??
@@ -157,6 +186,7 @@ function buildCodexPermissionControl(
       if (!preset) return;
       onConfigChange({
         approvalPolicy: preset.approvalPolicy,
+        approvalsReviewer: preset.approvalsReviewer,
         sandboxMode: preset.sandboxMode,
       });
     },

--- a/src/renderer/components/thread/ContinueInProviderDialog.tsx
+++ b/src/renderer/components/thread/ContinueInProviderDialog.tsx
@@ -146,6 +146,7 @@ function resolveDefaultConfig(
     ...(thinking ? { thinking } : {}),
     ...(mode ? { mode } : {}),
     ...(approvalPolicy ? { approvalPolicy } : {}),
+    ...(preferred?.approvalsReviewer ? { approvalsReviewer: preferred.approvalsReviewer } : {}),
     ...(sandboxMode ? { sandboxMode } : {}),
   };
 }

--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -502,6 +502,7 @@ describe("ThreadDraftView", () => {
           value?: string;
           label?: string;
           isSelected?: boolean;
+          options?: Array<{ id: string; label: string }>;
         }>;
       };
       const providerModel = props.controls.find((c) => c.kind === "provider-model");
@@ -509,7 +510,8 @@ describe("ThreadDraftView", () => {
       expect(providerModel?.currentModel).toBe("gpt-5.4");
       const effortContext = props.controls.find((c) => c.kind === "effort-context");
       expect(effortContext?.effortValue).toBe("high");
-      expect(props.controls.some((control) => control.value === "auto-review")).toBe(true);
+      const permission = props.controls.find((control) => control.value === "review-on-request");
+      expect(permission?.options?.some((option) => option.label === "Ask for approval")).toBe(true);
     });
 
     fireEvent.click(screen.getByText("set-prompt"));
@@ -522,6 +524,53 @@ describe("ThreadDraftView", () => {
         effort: "high",
         mode: "agent",
         approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      },
+      presentationMode: "gui",
+      prompt: "hello world",
+    });
+  });
+
+  it("submits the Codex Auto-review reviewer override", async () => {
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    render(
+      <ThreadDraftView project={project} agentStatuses={[dualModeCodexStatus]} onStart={onStart} />,
+    );
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        controls: Array<{ value?: string; onChange?: (value: string) => void }>;
+      };
+      expect(props.controls.some((control) => control.value === "review-on-request")).toBe(true);
+    });
+
+    const props = composerSpy.mock.lastCall?.[0] as {
+      controls: Array<{ value?: string; onChange?: (value: string) => void }>;
+    };
+    const permission = props.controls.find((control) => control.value === "review-on-request");
+    act(() => {
+      permission?.onChange?.("auto-review");
+    });
+
+    await waitFor(() => {
+      const nextProps = composerSpy.mock.lastCall?.[0] as {
+        controls: Array<{ value?: string }>;
+      };
+      expect(nextProps.controls.some((control) => control.value === "auto-review")).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("set-prompt"));
+    fireEvent.click(screen.getByText("submit"));
+
+    expect(onStart).toHaveBeenCalledWith({
+      agentKind: "codex",
+      config: {
+        model: "gpt-5.4",
+        effort: "high",
+        mode: "agent",
+        approvalPolicy: "on-request",
+        approvalsReviewer: "auto_review",
         sandboxMode: "workspace-write",
       },
       presentationMode: "gui",
@@ -592,7 +641,7 @@ describe("ThreadDraftView", () => {
       const providerModel = props.controls.find((c) => c.kind === "provider-model");
       expect(providerModel?.currentAgentKind).toBe("codex");
       expect(providerModel?.currentModel).toBe("gpt-5.4");
-      expect(props.controls.some((control) => control.value === "auto-review")).toBe(true);
+      expect(props.controls.some((control) => control.value === "review-on-request")).toBe(true);
     });
 
     fireEvent.click(screen.getByText("set-prompt"));

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -205,6 +205,7 @@ export function ThreadDraftView(props: {
   const [thinking, setThinking] = useState(false);
   const [mode, setMode] = useState<"agent" | "plan" | "autopilot">("agent");
   const [approvalPolicy, setApprovalPolicy] = useState("");
+  const [approvalsReviewer, setApprovalsReviewer] = useState("");
   const [sandboxMode, setSandboxMode] = useState("");
   // Not persisted across drafts — each new thread starts off.
   const [browserMcp, setBrowserMcp] = useState(false);
@@ -354,6 +355,7 @@ export function ThreadDraftView(props: {
     const nextThinking = resolved.thinking ?? false;
     const nextMode = (resolved.mode ?? "agent") as "agent" | "plan" | "autopilot";
     const nextApproval = resolved.approvalPolicy ?? "";
+    const nextReviewer = resolved.approvalsReviewer ?? "";
     const nextSandbox = resolved.sandboxMode ?? "";
 
     setModel(nextModel);
@@ -363,6 +365,7 @@ export function ThreadDraftView(props: {
     setThinking(nextThinking);
     setMode(nextMode);
     setApprovalPolicy(nextApproval);
+    setApprovalsReviewer(nextReviewer);
     setSandboxMode(nextSandbox);
     lastAppliedAgentKindRef.current = effectiveAgentKind;
 
@@ -380,6 +383,7 @@ export function ThreadDraftView(props: {
       ...(nextThinking ? { thinking: nextThinking } : {}),
       mode: nextMode,
       approvalPolicy: nextApproval,
+      approvalsReviewer: nextReviewer,
       sandboxMode: nextSandbox,
       worktreeMode: effectiveWorktreeMode,
     });
@@ -442,6 +446,7 @@ export function ThreadDraftView(props: {
         ...(nextThinking ? { thinking: nextThinking } : {}),
         mode,
         approvalPolicy,
+        approvalsReviewer,
         sandboxMode,
         worktreeMode: effectiveWorktreeMode,
       });
@@ -456,6 +461,7 @@ export function ThreadDraftView(props: {
     effectiveAgentKind,
     mode,
     approvalPolicy,
+    approvalsReviewer,
     sandboxMode,
     effectiveWorktreeMode,
     isHomeScope,
@@ -489,6 +495,7 @@ export function ThreadDraftView(props: {
     const nextThinking = resolved.thinking ?? false;
     const nextMode = (resolved.mode ?? "agent") as "agent" | "plan" | "autopilot";
     const nextApproval = resolved.approvalPolicy ?? "";
+    const nextReviewer = resolved.approvalsReviewer ?? "";
     const nextSandbox = resolved.sandboxMode ?? "";
 
     if (
@@ -499,6 +506,7 @@ export function ThreadDraftView(props: {
       nextThinking === thinking &&
       nextMode === mode &&
       nextApproval === approvalPolicy &&
+      nextReviewer === approvalsReviewer &&
       nextSandbox === sandboxMode
     ) {
       return;
@@ -511,6 +519,7 @@ export function ThreadDraftView(props: {
     setThinking(nextThinking);
     setMode(nextMode);
     setApprovalPolicy(nextApproval);
+    setApprovalsReviewer(nextReviewer);
     setSandboxMode(nextSandbox);
     lastAppliedAgentKindRef.current = effectiveAgentKind;
 
@@ -522,6 +531,7 @@ export function ThreadDraftView(props: {
       saved.thinking !== nextThinking ||
       saved.mode !== nextMode ||
       saved.approvalPolicy !== nextApproval ||
+      saved.approvalsReviewer !== nextReviewer ||
       saved.sandboxMode !== nextSandbox
     ) {
       providerConfigsRef.current[effectiveAgentKind] = resolved;
@@ -537,6 +547,7 @@ export function ThreadDraftView(props: {
       ...(nextThinking ? { thinking: nextThinking } : {}),
       mode: nextMode,
       approvalPolicy: nextApproval,
+      approvalsReviewer: nextReviewer,
       sandboxMode: nextSandbox,
       worktreeMode: effectiveWorktreeMode,
     });
@@ -552,6 +563,7 @@ export function ThreadDraftView(props: {
     thinking,
     mode,
     approvalPolicy,
+    approvalsReviewer,
     sandboxMode,
     project.id,
     effectiveWorktreeMode,
@@ -609,6 +621,7 @@ export function ThreadDraftView(props: {
       ...(patch.thinking !== undefined ? { thinking: patch.thinking } : { thinking }),
       mode: patch.mode ?? mode,
       approvalPolicy: patch.approvalPolicy ?? approvalPolicy,
+      approvalsReviewer: patch.approvalsReviewer ?? approvalsReviewer,
       sandboxMode: patch.sandboxMode ?? sandboxMode,
     });
 
@@ -619,6 +632,7 @@ export function ThreadDraftView(props: {
     setThinking(resolved.thinking ?? false);
     setMode((resolved.mode ?? "agent") as "agent" | "plan" | "autopilot");
     setApprovalPolicy(resolved.approvalPolicy ?? "");
+    setApprovalsReviewer(resolved.approvalsReviewer ?? "");
     setSandboxMode(resolved.sandboxMode ?? "");
 
     // Keep local state and persisted config in one transaction so menu
@@ -637,6 +651,7 @@ export function ThreadDraftView(props: {
         ...(resolved.thinking ? { thinking: resolved.thinking } : {}),
         mode: resolved.mode,
         approvalPolicy: resolved.approvalPolicy,
+        approvalsReviewer: resolved.approvalsReviewer,
         sandboxMode: resolved.sandboxMode,
         worktreeMode: effectiveWorktreeMode,
       });
@@ -669,6 +684,7 @@ export function ThreadDraftView(props: {
           ...(thinking ? { thinking } : {}),
           mode,
           approvalPolicy,
+          approvalsReviewer,
           sandboxMode,
         };
         persistProviderConfig(effectiveAgentKind, snapshot);
@@ -686,6 +702,7 @@ export function ThreadDraftView(props: {
       setThinking(resolved.thinking ?? false);
       setMode((resolved.mode ?? "agent") as "agent" | "plan" | "autopilot");
       setApprovalPolicy(resolved.approvalPolicy ?? "");
+      setApprovalsReviewer(resolved.approvalsReviewer ?? "");
       setSandboxMode(resolved.sandboxMode ?? "");
       lastAppliedAgentKindRef.current = nextKind as AgentStatus["kind"];
       setAgentKind(nextKind as AgentStatus["kind"]);
@@ -698,6 +715,7 @@ export function ThreadDraftView(props: {
         ...(resolved.thinking ? { thinking: resolved.thinking } : {}),
         mode: resolved.mode,
         approvalPolicy: resolved.approvalPolicy,
+        approvalsReviewer: resolved.approvalsReviewer,
         sandboxMode: resolved.sandboxMode,
         worktreeMode: effectiveWorktreeMode,
       });
@@ -749,6 +767,7 @@ export function ThreadDraftView(props: {
         ...(thinking ? { thinking } : {}),
         mode,
         approvalPolicy,
+        approvalsReviewer,
         sandboxMode,
       },
       presentationMode,
@@ -766,6 +785,7 @@ export function ThreadDraftView(props: {
     thinking,
     mode,
     approvalPolicy,
+    approvalsReviewer,
     sandboxMode,
     presentationMode,
   ]);
@@ -855,6 +875,7 @@ export function ThreadDraftView(props: {
         ...(thinking ? { thinking } : {}),
         mode,
         approvalPolicy,
+        approvalsReviewer,
         sandboxMode,
       },
       presentationMode: next,
@@ -928,6 +949,7 @@ export function ThreadDraftView(props: {
               ...(thinking ? { thinking } : {}),
               ...(mode ? { mode } : {}),
               ...(approvalPolicy ? { approvalPolicy } : {}),
+              ...(approvalsReviewer ? { approvalsReviewer } : {}),
               ...(sandboxMode ? { sandboxMode } : {}),
               ...(browserMcp ? { browserMcp: true } : {}),
             }}

--- a/src/renderer/components/thread/threadDraftViewHelpers.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.ts
@@ -191,6 +191,9 @@ export function resolveProviderDraftConfig(
     ...(nextThinking ? { thinking: nextThinking } : {}),
     mode: nextMode,
     approvalPolicy: nextApproval,
+    ...(normalizedPreferred?.approvalsReviewer !== undefined
+      ? { approvalsReviewer: normalizedPreferred.approvalsReviewer }
+      : {}),
     sandboxMode: nextSandbox,
   };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -771,6 +771,10 @@ msgstr "Fragen Sie {0} etwas zu diesem Arbeitsbereich"
 msgid "Ask each time"
 msgstr "Fragen Sie jedes Mal"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Genehmigung anfordern"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Frage stellen"
@@ -4411,6 +4415,7 @@ msgstr "Projektspezifische Überschreibungen zusätzlich zu den globalen "
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompts"
@@ -4946,7 +4951,7 @@ msgstr "Rechtes Panel"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Rechtsklicken, um den Ring zu wechseln"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5272,7 +5277,7 @@ msgstr "Tastenkürzel"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "{0} anzeigen"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -766,6 +766,10 @@ msgstr "Ask {0} anything about this workspace"
 msgid "Ask each time"
 msgstr "Ask each time"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Ask for approval"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Ask Question"
@@ -4372,6 +4376,7 @@ msgstr "Project-specific overrides on top of the global search settings."
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompts"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -768,6 +768,10 @@ msgstr "Pregunta a {0} cualquier cosa sobre este espacio de trabajo"
 msgid "Ask each time"
 msgstr "Preguntar cada vez"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Pedir aprobación"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Hacer una pregunta"
@@ -4403,6 +4407,7 @@ msgstr "Anulaciones específicas del proyecto sobre los ajustes de búsqueda "
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompts"
@@ -4938,7 +4943,7 @@ msgstr "Panel derecho"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Haz clic derecho para cambiar de anillo"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5262,7 +5267,7 @@ msgstr "Atajos"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Mostrar {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -771,6 +771,10 @@ msgstr "Posez n'importe quelle question à {0} à propos de cet espace de travai
 msgid "Ask each time"
 msgstr "Demander à chaque fois"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Demander une approbation"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Poser une question"
@@ -4412,6 +4416,7 @@ msgstr "Remplacements spécifiques au projet en plus des paramètres de recherch
 msgid "Prompt"
 msgstr "Invite"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompts"
@@ -4946,7 +4951,7 @@ msgstr "Panneau droit"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Clic droit pour changer d'anneau"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5272,7 +5277,7 @@ msgstr "Raccourcis"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Afficher {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -763,6 +763,10 @@ msgstr "このワークスペースについて{0}に何でも質問してくだ
 msgid "Ask each time"
 msgstr "毎回尋ねる"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "承認を求める"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "質問する"
@@ -4337,6 +4341,7 @@ msgstr "グローバル検索設定に加えてプロジェクト固有のオー
 msgid "Prompt"
 msgstr "プロンプト"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "プロンプト"
@@ -4868,7 +4873,7 @@ msgstr "右パネル"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "右クリックでリングを切り替え"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5186,7 +5191,7 @@ msgstr "ショートカット"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "{0}を表示"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -763,6 +763,10 @@ msgstr "이 작업 공간에 대해 {0}에게 무엇이든 물어보세요"
 msgid "Ask each time"
 msgstr "매번 물어보세요"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "승인 요청"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "질문하기"
@@ -4338,6 +4342,7 @@ msgstr "전역 검색 설정 위에 프로젝트별 재정의가 적용됩니다
 msgid "Prompt"
 msgstr "프롬프트"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "프롬프트"
@@ -4868,7 +4873,7 @@ msgstr "오른쪽 패널"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "마우스 오른쪽 버튼을 클릭해 링 전환"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5185,7 +5190,7 @@ msgstr "단축키"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "{0} 표시"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -771,6 +771,10 @@ msgstr "Zapytaj {0} o cokolwiek na temat tego obszaru roboczego"
 msgid "Ask each time"
 msgstr "Zapytaj za każdym razem"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Poproś o zatwierdzenie"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Zadaj pytanie"
@@ -4400,6 +4404,7 @@ msgstr "Zastąpienia specyficzne dla projektu ponad globalnymi ustawieniami "
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompty"
@@ -4933,7 +4938,7 @@ msgstr "Prawy panel"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Kliknij prawym przyciskiem, aby przełączyć pierścień"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5256,7 +5261,7 @@ msgstr "Skróty klawiszowe"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Pokaż {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -770,6 +770,10 @@ msgstr "Pergunte a {0} qualquer coisa sobre este espaço de trabalho"
 msgid "Ask each time"
 msgstr "Pergunte sempre"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Pedir aprovação"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Faça uma pergunta"
@@ -4403,6 +4407,7 @@ msgstr "Substituições específicas do projeto nas configurações de pesquisa 
 msgid "Prompt"
 msgstr "Prompt"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompts"
@@ -4937,7 +4942,7 @@ msgstr "Painel direito"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Clique com o botão direito para trocar o anel"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5261,7 +5266,7 @@ msgstr "Atalhos"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Mostrar {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -770,6 +770,10 @@ msgstr "Спросите {0} о чём угодно в этом рабочем �
 msgid "Ask each time"
 msgstr "Спрашивать каждый раз"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Запрашивать подтверждение"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Задать вопрос"
@@ -4399,6 +4403,7 @@ msgstr "Переопределения для конкретного проек�
 msgid "Prompt"
 msgstr "Промпт"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Запросы"
@@ -4931,7 +4936,7 @@ msgstr "Панель справа"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Щелкните правой кнопкой, чтобы переключить кольцо"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5254,7 +5259,7 @@ msgstr "Сочетания клавиш"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Показать {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -770,6 +770,10 @@ msgstr "{0} öğesine bu çalışma alanıyla ilgili her şeyi sorun"
 msgid "Ask each time"
 msgstr "Her seferinde sor"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Onay iste"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Soru Sor"
@@ -4394,6 +4398,7 @@ msgstr "Genel arama ayarlarının yanı sıra projeye özel geçersiz kılmalar.
 msgid "Prompt"
 msgstr "İstem"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "İstemler"
@@ -4928,7 +4933,7 @@ msgstr "Sağ panel"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Halkayı değiştirmek için sağ tıklayın"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5253,7 +5258,7 @@ msgstr "Kısayollar"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "{0} öğesini göster"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -770,6 +770,10 @@ msgstr "Запитайте {0} про що завгодно в цьому роб
 msgid "Ask each time"
 msgstr "Питати щоразу"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Запитувати підтвердження"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Поставити запитання"
@@ -4398,6 +4402,7 @@ msgstr "Перевизначення для конкретного проєкт�
 msgid "Prompt"
 msgstr "Промпт"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Запити"
@@ -4930,7 +4935,7 @@ msgstr "Права панель"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Клацніть правою кнопкою, щоб перемкнути кільце"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5254,7 +5259,7 @@ msgstr "Комбінації клавіш"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Показати {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -770,6 +770,10 @@ msgstr "Hỏi {0} bất cứ điều gì về không gian làm việc này"
 msgid "Ask each time"
 msgstr "Hỏi mỗi lần"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "Yêu cầu phê duyệt"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "Đặt câu hỏi"
@@ -4389,6 +4393,7 @@ msgstr "Ghi đè dành riêng cho dự án ở đầu cài đặt tìm kiếm ch
 msgid "Prompt"
 msgstr "Lời nhắc"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "Prompt"
@@ -4923,7 +4928,7 @@ msgstr "Bảng bên phải"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "Nhấp chuột phải để đổi vòng"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5245,7 +5250,7 @@ msgstr "Phím tắt"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "Hiển thị {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -761,6 +761,10 @@ msgstr "向{0}询问有关此工作区的任何信息"
 msgid "Ask each time"
 msgstr "每次都询问"
 
+#: src/renderer/components/providers/codex/index.tsx
+msgid "Ask for approval"
+msgstr "请求批准"
+
 #: src/renderer/views/WelcomeOverlay.tsx
 msgid "Ask Question"
 msgstr "提问"
@@ -4329,6 +4333,7 @@ msgstr "在全局搜索设置基础上的项目特定覆盖。"
 msgid "Prompt"
 msgstr "提示"
 
+#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivitySection.tsx
 msgid "Prompts"
 msgstr "提示"
@@ -4859,7 +4864,7 @@ msgstr "右面板"
 
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Right-click to switch ring"
-msgstr ""
+msgstr "右键点击以切换环"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -5175,7 +5180,7 @@ msgstr "快捷键"
 #. placeholder {0}: g.label
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 msgid "Show {0}"
-msgstr ""
+msgstr "显示 {0}"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Show {label} circle in sidebar"

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -193,6 +193,7 @@ function providerDraftConfigEqual(
     a.thinking === b.thinking &&
     a.mode === b.mode &&
     a.approvalPolicy === b.approvalPolicy &&
+    a.approvalsReviewer === b.approvalsReviewer &&
     a.sandboxMode === b.sandboxMode
   );
 }

--- a/src/renderer/state/slices/projectSlice.ts
+++ b/src/renderer/state/slices/projectSlice.ts
@@ -28,6 +28,7 @@ function projectDraftConfigEqual(
     a.thinking === b.thinking &&
     a.mode === b.mode &&
     a.approvalPolicy === b.approvalPolicy &&
+    a.approvalsReviewer === b.approvalsReviewer &&
     a.sandboxMode === b.sandboxMode &&
     a.worktreeMode === b.worktreeMode
   );

--- a/src/renderer/views/MainView/parts/AppContent/draftConfig.test.ts
+++ b/src/renderer/views/MainView/parts/AppContent/draftConfig.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it } from "vitest";
 import { buildProjectDraftConfig } from "./draftConfig";
 
 describe("buildProjectDraftConfig", () => {
-  it("preserves explicit empty approvalPolicy and sandboxMode so 'Default permissions' survives reload", () => {
+  it("preserves explicit empty permission fields so 'Default permissions' survives reload", () => {
     const built = buildProjectDraftConfig({
       agentKind: "codex",
       config: {
         model: "gpt-5.5",
         approvalPolicy: "",
+        approvalsReviewer: "",
         sandboxMode: "",
       },
       worktreeMode: false,
     });
     expect(built.approvalPolicy).toBe("");
+    expect(built.approvalsReviewer).toBe("");
     expect(built.sandboxMode).toBe("");
   });
 
@@ -28,6 +30,7 @@ describe("buildProjectDraftConfig", () => {
           thinking: true,
           mode: "agent",
           approvalPolicy: "default",
+          approvalsReviewer: "auto_review",
           sandboxMode: "danger-full-access",
         },
         worktreeMode: true,
@@ -41,6 +44,7 @@ describe("buildProjectDraftConfig", () => {
       thinking: true,
       mode: "agent",
       approvalPolicy: "default",
+      approvalsReviewer: "auto_review",
       sandboxMode: "danger-full-access",
       worktreeMode: true,
     });

--- a/src/renderer/views/MainView/parts/AppContent/draftConfig.ts
+++ b/src/renderer/views/MainView/parts/AppContent/draftConfig.ts
@@ -19,6 +19,9 @@ export function buildProjectDraftConfig(input: {
     // (e.g. Codex "Default permissions"). Stripping it would make reload
     // fall through to the bypass fallback and silently flip to Full access.
     ...(config.approvalPolicy !== undefined ? { approvalPolicy: config.approvalPolicy } : {}),
+    ...(config.approvalsReviewer !== undefined
+      ? { approvalsReviewer: config.approvalsReviewer }
+      : {}),
     ...(config.sandboxMode !== undefined ? { sandboxMode: config.sandboxMode } : {}),
     worktreeMode,
   };

--- a/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/Thread/parts/ContinueInProviderDialog.tsx
@@ -109,6 +109,8 @@ function resolveDefaultConfig(agent: AgentStatus, savedConfig?: ProjectDraftConf
   const policies = agent.capabilities.approvalPolicies;
   const savedApproval =
     savedConfig?.agentKind === agent.kind ? savedConfig.approvalPolicy : undefined;
+  const savedReviewer =
+    savedConfig?.agentKind === agent.kind ? savedConfig.approvalsReviewer : undefined;
   const approvalPolicy =
     savedApproval && policies.some((p) => p.id === savedApproval) ? savedApproval : policies[0]?.id;
 
@@ -116,6 +118,7 @@ function resolveDefaultConfig(agent: AgentStatus, savedConfig?: ProjectDraftConf
     model,
     ...(effort ? { effort } : {}),
     ...(approvalPolicy ? { approvalPolicy } : {}),
+    ...(savedReviewer ? { approvalsReviewer: savedReviewer } : {}),
   };
 }
 

--- a/src/shared/contracts/config.ts
+++ b/src/shared/contracts/config.ts
@@ -9,6 +9,7 @@ const threadConfigShape = {
   thinking: z.boolean().optional(),
   mode: threadModeSchema.optional(),
   approvalPolicy: z.string().optional(),
+  approvalsReviewer: z.string().optional(),
   sandboxMode: z.string().optional(),
   browserMcp: z.boolean().optional(),
 } as const;
@@ -50,6 +51,7 @@ export function isThreadConfigEqual(
     left.thinking === right.thinking &&
     left.mode === right.mode &&
     left.approvalPolicy === right.approvalPolicy &&
+    left.approvalsReviewer === right.approvalsReviewer &&
     left.sandboxMode === right.sandboxMode &&
     left.browserMcp === right.browserMcp
   );

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -471,6 +471,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     const threadOverrides = {
       model: config.model,
       ...(config.approvalPolicy ? { approvalPolicy: config.approvalPolicy } : {}),
+      ...(config.approvalsReviewer ? { approvalsReviewer: config.approvalsReviewer } : {}),
       ...(config.sandboxMode ? { sandbox: config.sandboxMode } : {}),
       config: {
         ...(config.effort ? { model_reasoning_effort: config.effort } : {}),
@@ -673,6 +674,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(config.effort ? { effort: config.effort } : {}),
         summary: "auto",
         ...(config.approvalPolicy ? { approvalPolicy: config.approvalPolicy } : {}),
+        ...(config.approvalsReviewer ? { approvalsReviewer: config.approvalsReviewer } : {}),
         ...(sandboxPolicy ? { sandboxPolicy } : {}),
         collaborationMode,
         // Fast toggle is authoritative and the server tier is sticky, so force it

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -67,6 +67,9 @@ function buildCodexArgs(opts: BuildCodexArgsOptions): string[] {
     if (config.approvalPolicy) {
       args.push("-a", config.approvalPolicy);
     }
+    if (config.approvalsReviewer) {
+      args.push("-c", `approvals_reviewer="${config.approvalsReviewer}"`);
+    }
     if (config.sandboxMode) {
       args.push("-s", config.sandboxMode);
     }

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -352,6 +352,36 @@ describe("CodexStructuredSession", () => {
     });
   });
 
+  it("passes the approvals reviewer override to Codex app-server threads and turns", async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const structuredSession = makeStructuredSession(requests);
+    const config = {
+      model: "gpt-5.4",
+      approvalPolicy: "on-request",
+      approvalsReviewer: "auto_review",
+      sandboxMode: "workspace-write",
+    };
+
+    await structuredSession.openThread(config);
+    await structuredSession.startTurn("hello", config);
+
+    expect(requests[0]).toMatchObject({
+      method: "thread/start",
+      params: {
+        approvalPolicy: "on-request",
+        approvalsReviewer: "auto_review",
+        sandbox: "workspace-write",
+      },
+    });
+    expect(requests[1]).toMatchObject({
+      method: "turn/start",
+      params: {
+        approvalPolicy: "on-request",
+        approvalsReviewer: "auto_review",
+      },
+    });
+  });
+
   it("forces serviceTier each turn: null when Fast is off (incl. the first turn), 'fast' when on", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -59,7 +59,7 @@ import {
 import { createClaudeAdapter } from "./claude";
 import { createCopilotAdapter } from "./copilot";
 import { buildCodexAppServerCommand, createCodexAdapter } from "./codex";
-import { primeCodexGoalsSupport } from "./codex/argv";
+import { buildCodexArgvFor, primeCodexGoalsSupport } from "./codex/argv";
 import { createCursorAdapter } from "./cursor";
 import { createGrokAdapter } from "./grok";
 
@@ -176,6 +176,17 @@ describe("agent command builders", () => {
     expect(cmdArgs).not.toContain("--listen");
     expect(cmdArgs).not.toContain("--remote");
     expect(cmdArgs).not.toContain("--session-source");
+  });
+
+  it("passes the Codex approvals reviewer override to terminal sessions", () => {
+    const spec = buildCodexArgvFor(
+      windowsProject,
+      { ...config, approvalsReviewer: "auto_review" },
+      "hello",
+    );
+
+    expect(spec.args).toContain("-c");
+    expect(spec.args).toContain('approvals_reviewer="auto_review"');
   });
 
   it("injects Codex browser MCP config when enabled, using a token env var", () => {

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -1094,7 +1094,7 @@ describe("SupervisorRuntime thread input", () => {
     ).handlePtyData(session, "second");
 
     expect(appendFileMock).not.toHaveBeenCalled();
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(25);
     expect(appendFileMock).toHaveBeenCalledTimes(1);
     expect(appendFileMock.mock.calls[0]?.[1]).toBe("firstsecond");
     delete process.env.VITE_DEV_SERVER_URL;

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -1524,6 +1524,7 @@ export class SupervisorRuntime {
   }
 
   async disposeAsync(): Promise<void> {
+    this.usageService.stop();
     this.lspManager.dispose();
     await this._projectWatcher?.dispose();
     await this.threadSessionManager.dispose();


### PR DESCRIPTION
- Feature + refactor: preserve Codex `approvalsReviewer` across thread/project draft config, equality checks, and continue-in-provider flows so approval choices survive reloads and handoffs.
- Add a new Codex permission preset for asking approval and surface the override in the draft UI.
- Pass the reviewer override through Codex structured sessions and CLI argv so app-server threads and turns use the same settings.
- Update tests for config persistence and Codex transport wiring, and localize the new label in all renderer catalogs.