### PR TITLE
fix(browser): keep app product token in UA so Google sign-in works in-app

### DIFF
--- a/src/main/browser/userAgent.test.ts
+++ b/src/main/browser/userAgent.test.ts
@@ -1,35 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { buildChromeLikeUserAgent } from "./userAgent";
+import { buildBrowserUserAgent } from "./userAgent";
 
-describe("buildChromeLikeUserAgent", () => {
-  it("removes Electron while preserving the current Chromium user agent", () => {
+describe("buildBrowserUserAgent", () => {
+  it("removes the Electron product token", () => {
     expect(
-      buildChromeLikeUserAgent(
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Electron/41.7.0 Safari/537.36",
+      buildBrowserUserAgent(
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Electron/41.7.0 Safari/537.36",
       ),
     ).toBe(
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
     );
   });
 
-  it("removes an app product token before Chrome", () => {
+  it("keeps the app product token before Chrome (Google rejects a bare Chrome UA from an embedded browser)", () => {
     expect(
-      buildChromeLikeUserAgent(
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode/1.2.1 Chrome/141.0.0.0 Electron/41.7.0 Safari/537.36",
+      buildBrowserUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode/1.3.2 Chrome/146.0.0.0 Electron/41.7.0 Safari/537.36",
       ),
     ).toBe(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode/1.3.2 Chrome/146.0.0.0 Safari/537.36",
     );
   });
 
-  it("matches the equivalent real Chrome user agent", () => {
-    const realChromeLinuxUserAgent =
-      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36";
-
+  it("preserves a channel-suffixed app token such as Lightcode Nightly", () => {
     expect(
-      buildChromeLikeUserAgent(
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode/1.2.1 Chrome/141.0.0.0 Electron/41.7.0 Safari/537.36",
+      buildBrowserUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode Nightly/1.3.2 Chrome/146.0.0.0 Electron/41.7.0 Safari/537.36",
       ),
-    ).toBe(realChromeLinuxUserAgent);
+    ).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Lightcode Nightly/1.3.2 Chrome/146.0.0.0 Safari/537.36",
+    );
   });
 });

--- a/src/main/browser/userAgent.ts
+++ b/src/main/browser/userAgent.ts
@@ -1,9 +1,22 @@
+// Electron's default user agent looks like
+//   ...(KHTML, like Gecko) Lightcode/1.3.2 Chrome/146.0.0.0 Electron/41.7.0 Safari/537.36
+// Google sign-in (and other "is this a secure browser?" gates) reject any user
+// agent that contains the `Electron/<version>` product token, showing
+// "Couldn't sign you in — this browser or app may not be secure".
+//
+// The fix is to drop ONLY the `Electron/...` token. It is tempting to also strip
+// the host app's own product token (`Lightcode/1.3.2`) to make the UA look like
+// stock Chrome, but that backfires: Google rejects a *bare* `Chrome/...` UA
+// coming from an embedded browser as a spoofed/unsupported browser, while it
+// accepts a Chromium UA that honestly identifies the host app. Keeping the app
+// token is precisely what lets Google sign-in complete inside the in-app browser
+// (verified against the live flow; this is also why Codex / T3 Code embedded
+// browsers, which keep their app token and only drop Electron, are accepted).
 const ELECTRON_PRODUCT_RE = /\sElectron\/[^\s]+/g;
-const APP_PRODUCT_BEFORE_CHROME_RE =
-  /(\(KHTML, like Gecko\)\s+)(?:(?!Chrome\/)\S+\/\S+\s+)+(Chrome\/)/;
 
-export function buildChromeLikeUserAgent(defaultUserAgent: string): string {
-  const withoutElectron = defaultUserAgent.replace(ELECTRON_PRODUCT_RE, "");
-  const withoutAppProduct = withoutElectron.replace(APP_PRODUCT_BEFORE_CHROME_RE, "$1$2");
-  return withoutAppProduct.replace(/\s{2,}/g, " ").trim();
+export function buildBrowserUserAgent(defaultUserAgent: string): string {
+  return defaultUserAgent
+    .replace(ELECTRON_PRODUCT_RE, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -18,7 +18,7 @@ import {
   installPickerProtocolHandler,
   registerPickerProtocolScheme,
 } from "./browser";
-import { buildChromeLikeUserAgent } from "./browser/userAgent";
+import { buildBrowserUserAgent } from "./browser/userAgent";
 import { SupervisorClient } from "./supervisor/SupervisorClient";
 import { createAutoUpdaterController } from "./updates/autoUpdater";
 import { createMainWindow } from "./window/createMainWindow";
@@ -49,8 +49,8 @@ if (process.platform === "win32") {
   app.commandLine.appendSwitch("force-color-profile", "srgb");
 }
 
-const chromeLikeUserAgent = buildChromeLikeUserAgent(app.userAgentFallback);
-app.userAgentFallback = chromeLikeUserAgent;
+const browserUserAgent = buildBrowserUserAgent(app.userAgentFallback);
+app.userAgentFallback = browserUserAgent;
 
 if (baseDirOverride) {
   app.setPath("userData", join(baseDirOverride, "userData"));
@@ -190,7 +190,7 @@ function createBrowserExtractWindow(): BrowserWindow {
     posthogKey,
     sentryEnabled,
     windowChromeHeight: WINDOW_CHROME_HEIGHT,
-    browserUserAgent: chromeLikeUserAgent,
+    browserUserAgent,
     appearance: windowChrome.appearance,
     sidebarTranslucency: windowChrome.sidebarTranslucency,
     openDevTools: false,
@@ -291,7 +291,7 @@ if (!hasSingleInstanceLock) {
 
     installLocalFileProtocolHandler();
     installPickerProtocolHandler();
-    electronSession.fromPartition("persist:lightcode-browser").setUserAgent(chromeLikeUserAgent);
+    electronSession.fromPartition("persist:lightcode-browser").setUserAgent(browserUserAgent);
 
     lightcodePaths = prepareLightcodeDataRoot(
       baseDirOverride ??
@@ -366,7 +366,7 @@ if (!hasSingleInstanceLock) {
       },
     );
 
-    browserPanelManager = new BrowserPanelManager(lightcodePaths, chromeLikeUserAgent, {
+    browserPanelManager = new BrowserPanelManager(lightcodePaths, browserUserAgent, {
       isExtracted: () => browserExtractWindow !== null && !browserExtractWindow.isDestroyed(),
       focusExtractedWindow: focusBrowserExtractWindow,
     });
@@ -411,7 +411,7 @@ if (!hasSingleInstanceLock) {
       posthogKey,
       sentryEnabled,
       windowChromeHeight: WINDOW_CHROME_HEIGHT,
-      browserUserAgent: chromeLikeUserAgent,
+      browserUserAgent,
       appearance: windowChrome.appearance,
       sidebarTranslucency: windowChrome.sidebarTranslucency,
       ...(process.env.VITE_DEV_SERVER_URL ? { devServerUrl: process.env.VITE_DEV_SERVER_URL } : {}),
@@ -502,7 +502,7 @@ if (!hasSingleInstanceLock) {
           posthogKey,
           sentryEnabled,
           windowChromeHeight: WINDOW_CHROME_HEIGHT,
-          browserUserAgent: chromeLikeUserAgent,
+          browserUserAgent,
           appearance: reopenChrome.appearance,
           sidebarTranslucency: reopenChrome.sidebarTranslucency,
           ...(process.env.VITE_DEV_SERVER_URL


### PR DESCRIPTION
## Problem

Google sign-in failed inside Lightcode's in-app browser: after entering an email it returned **"Couldn't sign you in — this browser or app may not be secure"** at the identifier step (`/v3/signin/rejected`), before the account was even checked.

## Root cause

`buildChromeLikeUserAgent` stripped **both** the `Electron/x.y.z` token **and** the app's own product token (`Lightcode/1.3.2`), producing a **bare `Chrome/…`** user agent. Google rejects a bare-Chrome UA coming from an embedded browser as a spoofed/unsupported browser. This was the regression from the earlier "Chrome-like user agent" change (commit `2725f4f`).

I verified the rule directly against the live Google flow:

| User agent | Result |
|---|---|
| `… Chrome/146…` (bare) | ❌ rejected |
| `… Lightcode/1.3.2 Chrome/146…` | ✅ accepted (reaches password/passkey) |
| `… Lightcode Nightly/1.3.2 Chrome/146…` | ✅ accepted |

I also drove **T3 Code's** live embedded browser via CDP — it keeps its app token (`T3Code(Alpha)/41.5.0 Chrome/…`, its `t3code` strip regex silently no-ops on the capitalized name) and Google accepts it. Same pattern as Codex.

## Fix

Strip **only** the `Electron/…` token; keep the host app's product token. Renamed `buildChromeLikeUserAgent` → `buildBrowserUserAgent` for accuracy. The value already flows to the browser session, the `persist:lightcode-browser` partition, and each `BrowserTab`'s `webContents.setUserAgent`, so every in-app tab now identifies as `…Lightcode/x.y.z Chrome/… Safari/537.36`.

## Verification

- `userAgent.test.ts` rewritten for the new behavior — 3/3 pass; full browser suite 57/57 pass.
- `typecheck` + `oxlint` clean on touched files.
- The exact UA the fixed code emits confirmed accepted by the live Google sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)