### PR TITLE
Prefer brew and cask for native agent updates

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2556,6 +2556,22 @@ msgstr "Erstklassige Command Code CLI-Integration mithilfe der nativen Laufzeit 
 "von Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Erstklassige Cursor Agent-Integration mit der nativen Laufzeit von "
+"Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Erstklassige Gemini CLI-Integration mit der nativen Laufzeit von "
+"Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Erstklassige GitHub Copilot CLI-Integration mit der nativen Laufzeit "
+"von Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Erstklassige Grok Build CLI-Integration mit der nativen Laufzeit von "
 "Lightcode."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2530,6 +2530,20 @@ msgstr "First-class Command Code CLI integration using Lightcode's native "
 "runtime."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "First-class Cursor Agent integration using Lightcode's native runtime."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "First-class Gemini CLI integration using Lightcode's native runtime."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "First-class Grok Build CLI integration using Lightcode's native "
 "runtime."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2546,6 +2546,22 @@ msgstr "Integración de primera clase de Command Code CLI usando el runtime "
 "nativo de Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Integración de primera clase de Cursor Agent usando el runtime nativo "
+"de Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Integración de primera clase de Gemini CLI usando el runtime nativo de "
+"Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Integración de primera clase de GitHub Copilot CLI usando el runtime "
+"nativo de Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Integración de primera clase de Grok Build CLI usando el runtime nativo "
 "de Lightcode."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2555,6 +2555,22 @@ msgstr "Intégration CLI Command Code de première classe à l’aide du runtime
 "natif de Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Intégration de première classe de Cursor Agent utilisant le runtime "
+"natif de Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Intégration de première classe de Gemini CLI utilisant le runtime natif "
+"de Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Intégration de première classe de GitHub Copilot CLI utilisant le "
+"runtime natif de Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Intégration CLI Grok Build de première classe à l'aide du runtime natif "
 "de Lightcode."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2510,6 +2510,19 @@ msgid "First-class Command Code CLI integration using Lightcode's native "
 msgstr "Lightcode のネイティブ ランタイムを使用したファーストクラスの Command Code CLI 統合。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Lightcode のネイティブ ランタイムを使用したファーストクラスの Cursor Agent 統合。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Lightcode のネイティブ ランタイムを使用したファーストクラスの Gemini CLI 統合。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Lightcode のネイティブ ランタイムを使用したファーストクラスの GitHub Copilot CLI 統合。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Lightcode のネイティブ ランタイムを使用したファーストクラスの Grok Build CLI 統合。"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2510,6 +2510,19 @@ msgid "First-class Command Code CLI integration using Lightcode's native "
 msgstr "Lightcode의 네이티브 런타임을 사용한 최고 수준의 Command Code CLI 통합."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Lightcode의 네이티브 런타임을 사용하는 일급 Cursor Agent 통합."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Lightcode의 네이티브 런타임을 사용하는 일급 Gemini CLI 통합."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Lightcode의 네이티브 런타임을 사용하는 일급 GitHub Copilot CLI 통합."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Lightcode의 기본 런타임을 사용하는 최고 수준의 Grok Build CLI 통합."
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2546,6 +2546,22 @@ msgstr "Pierwszorzędna integracja Command Code CLI przy użyciu natywnego "
 "środowiska wykonawczego Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Pierwszorzędna integracja Cursor Agent z wykorzystaniem natywnego "
+"środowiska uruchomieniowego Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Pierwszorzędna integracja Gemini CLI z wykorzystaniem natywnego "
+"środowiska uruchomieniowego Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Pierwszorzędna integracja GitHub Copilot CLI z wykorzystaniem natywnego "
+"środowiska uruchomieniowego Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Pierwszorzędna integracja Grok Build CLI przy użyciu natywnego "
 "środowiska wykonawczego Lightcode."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2549,6 +2549,22 @@ msgstr "Integração de primeira classe da CLI Command Code usando o tempo de "
 "execução nativo do Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Integração de primeira classe do Cursor Agent usando o runtime nativo "
+"do Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Integração de primeira classe do Gemini CLI usando o runtime nativo do "
+"Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Integração de primeira classe do GitHub Copilot CLI usando o runtime "
+"nativo do Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Integração Grok Build CLI de primeira classe usando o tempo de execução "
 "nativo do Lightcode."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2546,6 +2546,22 @@ msgstr "Первоклассная интеграция Command Code CLI с ис
 "среды выполнения Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Первоклассная интеграция Cursor Agent с использованием нативной среды "
+"выполнения Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Первоклассная интеграция Gemini CLI с использованием нативной среды "
+"выполнения Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Первоклассная интеграция GitHub Copilot CLI с использованием нативной "
+"среды выполнения Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Первоклассная интеграция Grok Build CLI с использованием нативной среды "
 "выполнения Lightcode."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2545,6 +2545,22 @@ msgstr "Lightcode'un yerel çalışma zamanını kullanan birinci sınıf Comman
 "CLI entegrasyonu."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Lightcode'un yerel çalışma zamanını kullanan birinci sınıf Cursor Agent "
+"entegrasyonu."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Lightcode'un yerel çalışma zamanını kullanan birinci sınıf Gemini CLI "
+"entegrasyonu."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Lightcode'un yerel çalışma zamanını kullanan birinci sınıf GitHub "
+"Copilot CLI entegrasyonu."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Lightcode'un yerel çalışma zamanını kullanan birinci sınıf Grok Build "
 "CLI entegrasyonu."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2545,6 +2545,22 @@ msgstr "Першокласна інтеграція Command Code CLI з вико
 "середовища виконання Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Першокласна інтеграція Cursor Agent із використанням нативного "
+"середовища виконання Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Першокласна інтеграція Gemini CLI із використанням нативного середовища "
+"виконання Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Першокласна інтеграція GitHub Copilot CLI із використанням нативного "
+"середовища виконання Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Першокласна інтеграція Grok Build CLI з використанням нативного "
 "середовища виконання Lightcode."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2541,6 +2541,19 @@ msgstr "Tích hợp CLI Command Code hạng nhất bằng thời gian chạy g�
 "Lightcode."
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "Tích hợp Cursor Agent hạng nhất bằng runtime gốc của Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "Tích hợp Gemini CLI hạng nhất bằng runtime gốc của Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "Tích hợp GitHub Copilot CLI hạng nhất bằng runtime gốc của Lightcode."
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "Tích hợp Grok Build CLI hạng nhất bằng cách sử dụng thời gian chạy gốc "
 "của Lightcode."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2507,6 +2507,19 @@ msgid "First-class Command Code CLI integration using Lightcode's native "
 msgstr "使用 Lightcode 的本机运行时实现一流的 Command Code CLI 集成。"
 
 #: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Cursor Agent integration using Lightcode's native runtime."
+msgstr "使用 Lightcode 原生运行时的一流 Cursor Agent 集成。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class Gemini CLI integration using Lightcode's native runtime."
+msgstr "使用 Lightcode 原生运行时的一流 Gemini CLI 集成。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+msgid "First-class GitHub Copilot CLI integration using Lightcode's native "
+"runtime."
+msgstr "使用 Lightcode 原生运行时的一流 GitHub Copilot CLI 集成。"
+
+#: src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
 msgid "First-class Grok Build CLI integration using Lightcode's native runtime."
 msgstr "使用 Lightcode 的本机运行时进行一流的 Grok Build CLI 集成。"
 

--- a/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.test.tsx
@@ -170,6 +170,20 @@ const registry: AcpRegistryListResult = {
       distribution: { npx: { package: "cursor-acp" } },
     },
     {
+      id: "gemini",
+      name: "Gemini",
+      version: "1.0.0",
+      description: "Gemini through ACP",
+      distribution: { npx: { package: "gemini-acp" } },
+    },
+    {
+      id: "github-copilot",
+      name: "GitHub Copilot",
+      version: "1.0.0",
+      description: "Copilot through ACP",
+      distribution: { npx: { package: "copilot-acp" } },
+    },
+    {
       id: "grok-build",
       name: "Grok Build",
       version: "0.2.11",
@@ -246,18 +260,17 @@ describe("AcpRegistrySettings", () => {
     expect(within(codexCard as HTMLElement).queryByRole("button", { name: "Install" })).toBeNull();
   });
 
-  it("hides native-preferred ACP wrappers and tags app-supported ACP agents", async () => {
+  it("hides native-preferred ACP wrappers", async () => {
     render(<AcpRegistrySettings />);
 
     await screen.findByRole("heading", { name: "Agent Registry" });
     expect(screen.queryByText("Codex ACP")).not.toBeInTheDocument();
+    expect(screen.queryByText("Cursor through ACP")).not.toBeInTheDocument();
+    expect(screen.queryByText("Gemini through ACP")).not.toBeInTheDocument();
+    expect(screen.queryByText("Copilot through ACP")).not.toBeInTheDocument();
     expect(screen.queryByText("xAI's coding agent and CLI")).not.toBeInTheDocument();
     expect(screen.getAllByText("GLM Agent").length).toBeGreaterThan(0);
     expect(screen.queryByRole("button", { name: "Show advanced ACP" })).toBeNull();
-
-    const cursorCard = screen.getAllByText("Cursor")[0]?.closest(".rounded-lg");
-    expect(cursorCard).toBeTruthy();
-    expect(within(cursorCard as HTMLElement).getByText("Native support")).toBeInTheDocument();
   });
 
   it("opens native install commands in the terminal", async () => {
@@ -315,6 +328,33 @@ describe("AcpRegistrySettings", () => {
         }),
       ),
     ).toContain("https://antigravity.google/cli/install.sh");
+  });
+
+  it("offers app-supported providers as native installs", async () => {
+    render(<AcpRegistrySettings />);
+
+    await screen.findByRole("heading", { name: "Agent Registry" });
+
+    const cases = [
+      { pattern: /First-class Cursor Agent integration/u, label: "Cursor" },
+      { pattern: /First-class Gemini CLI integration/u, label: "Gemini" },
+      { pattern: /First-class GitHub Copilot CLI integration/u, label: "GitHub Copilot" },
+    ];
+
+    for (const expected of cases) {
+      const card = screen.getByText(expected.pattern).closest(".rounded-lg");
+      expect(card).toBeTruthy();
+
+      fireEvent.click(within(card as HTMLElement).getByRole("button", { name: "Install" }));
+
+      await waitFor(() => {
+        expect(runAgentInstallCommandMock).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            label: expected.label,
+          }),
+        );
+      });
+    }
   });
 
   it("offers Grok Build as a native Windows install", async () => {
@@ -393,6 +433,16 @@ describe("AcpRegistrySettings", () => {
     expect(entries.get("grok")?.installCommand(wslProject)).toContain(
       "curl -fsSL https://x.ai/cli/install.sh | bash",
     );
+    expect(entries.get("cursor")?.installCommand(wslProject)).toContain(
+      "curl https://cursor.com/install -fsS | bash",
+    );
+    expect(entries.get("gemini")?.installCommand(wslProject)).toContain(
+      "npm install -g @google/gemini-cli",
+    );
+    expect(entries.get("copilot")?.installCommand(wslProject)).toContain(
+      "curl -fsSL https://gh.io/copilot-install | bash",
+    );
+    expect(entries.get("copilot")?.installCommand(wslProject)).not.toContain("brew install");
 
     withHostPlatform("darwin", () => {
       expect(entries.get("codex")?.installCommand(macProject)).toContain(
@@ -404,18 +454,31 @@ describe("AcpRegistrySettings", () => {
       expect(entries.get("opencode")?.installCommand(macProject)).toContain(
         "brew install anomalyco/tap/opencode",
       );
+      expect(entries.get("gemini")?.installCommand(macProject)).not.toContain("brew install");
+      expect(entries.get("copilot")?.installCommand(macProject)).toContain(
+        "brew install --cask copilot-cli",
+      );
     });
 
     withHostPlatform("win32", () => {
-      expect(
-        entries.get("grok")?.installCommand(
-          makeProject({
-            id: "windows-project",
-            name: "Windows Project",
-            location: { kind: "windows", path: "C:\\repo" },
-          }),
-        ),
-      ).toContain("irm https://x.ai/cli/install.ps1 | iex");
+      const windowsProject = makeProject({
+        id: "windows-project",
+        name: "Windows Project",
+        location: { kind: "windows", path: "C:\\repo" },
+      });
+
+      expect(entries.get("grok")?.installCommand(windowsProject)).toContain(
+        "irm https://x.ai/cli/install.ps1 | iex",
+      );
+      expect(entries.get("cursor")?.installCommand(windowsProject)).toContain(
+        "https://cursor.com/install?win32=true",
+      );
+      expect(entries.get("gemini")?.installCommand(windowsProject)).toContain(
+        "npm install -g @google/gemini-cli",
+      );
+      expect(entries.get("copilot")?.installCommand(windowsProject)).toContain(
+        "winget install GitHub.Copilot",
+      );
     });
   });
 
@@ -577,7 +640,7 @@ describe("AcpRegistrySettings", () => {
     ).toBeNull();
   });
 
-  it("shows WSL detection for app-supported ACP registry agents", async () => {
+  it("shows WSL detection for app-supported native providers", async () => {
     statusesState.agentStatuses = [
       makeStatus("cursor", {
         label: "Cursor",
@@ -595,10 +658,13 @@ describe("AcpRegistrySettings", () => {
     render(<AcpRegistrySettings />);
 
     await screen.findByRole("heading", { name: "Agent Registry" });
-    const cursorCard = screen.getByText("Cursor through ACP").closest(".rounded-lg");
+    const cursorCard = screen
+      .getByText(/First-class Cursor Agent integration/u)
+      .closest(".rounded-lg");
     expect(cursorCard).toBeTruthy();
-    expect(within(cursorCard as HTMLElement).getByText("(Windows)")).toBeInTheDocument();
-    expect(within(cursorCard as HTMLElement).getByText("(WSL (Ubuntu))")).toBeInTheDocument();
+    expect(within(cursorCard as HTMLElement).getByText("(local)")).toBeInTheDocument();
+    expect(within(cursorCard as HTMLElement).getByText("WSL (Ubuntu)")).toBeInTheDocument();
+    expect(screen.queryByText("Cursor through ACP")).not.toBeInTheDocument();
   });
 
   it("does not label generic ACP registry agent statuses as detected", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -25,6 +25,8 @@ const MAC_MISSING_CURL_BREW_MESSAGE =
   "printf 'No supported installer found. Install curl or Homebrew first, then refresh detected agents.\\n'";
 const POSIX_MISSING_CURL_MESSAGE =
   "printf 'curl is required to install this agent. Install curl, then refresh detected agents.\\n'";
+const POSIX_MISSING_NPM_MESSAGE =
+  "printf 'npm is required to install this agent. Install Node.js/npm first, then refresh detected agents.\\n'";
 
 function isWslProject(project: Project): boolean {
   return project.location.kind === "wsl";
@@ -155,11 +157,65 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
           "if (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g command-code@latest } else { Write-Host 'No supported installer found. Install Node.js/npm first, then refresh detected agents.' }",
       }),
   },
+  {
+    id: "cursor",
+    label: "Cursor",
+    description: msg`First-class Cursor Agent integration using Lightcode's native runtime.`,
+    docsUrl: "https://cursor.com/docs/cli/installation",
+    installCommand: (project) =>
+      posixOrWindows(
+        project,
+        "if command -v curl >/dev/null 2>&1; then curl https://cursor.com/install -fsS | bash; " +
+          "else printf 'curl is required to install Cursor. Install curl, then refresh detected agents.\\n'; fi",
+        "if (Get-Command irm -ErrorAction SilentlyContinue) { irm 'https://cursor.com/install?win32=true' | iex } else { Write-Host 'No supported installer found. Install PowerShell Invoke-RestMethod first, then refresh detected agents.' }",
+      ),
+  },
+  {
+    id: "gemini",
+    label: "Gemini",
+    description: msg`First-class Gemini CLI integration using Lightcode's native runtime.`,
+    docsUrl: "https://github.com/google-gemini/gemini-cli",
+    installCommand: (project) =>
+      posixOrWindows(
+        project,
+        "if command -v npm >/dev/null 2>&1; then npm install -g @google/gemini-cli; else " +
+          POSIX_MISSING_NPM_MESSAGE +
+          "; fi",
+        "if (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g @google/gemini-cli } else { Write-Host 'No supported installer found. Install Node.js/npm first, then refresh detected agents.' }",
+      ),
+  },
+  {
+    id: "copilot",
+    label: "GitHub Copilot",
+    description: msg`First-class GitHub Copilot CLI integration using Lightcode's native runtime.`,
+    docsUrl:
+      "https://docs.github.com/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli",
+    installCommand: (project) =>
+      nativeInstallCommand(project, {
+        mac:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://gh.io/copilot-install | bash; " +
+          "elif command -v brew >/dev/null 2>&1; then brew install --cask copilot-cli; " +
+          "elif command -v npm >/dev/null 2>&1; then npm install -g @github/copilot; else " +
+          MAC_MISSING_CURL_BREW_NPM_MESSAGE +
+          "; fi",
+        posix:
+          "if command -v curl >/dev/null 2>&1; then curl -fsSL https://gh.io/copilot-install | bash; " +
+          "elif command -v npm >/dev/null 2>&1; then npm install -g @github/copilot; else " +
+          POSIX_MISSING_CURL_NPM_MESSAGE +
+          "; fi",
+        windows:
+          "if (Get-Command winget -ErrorAction SilentlyContinue) { winget install GitHub.Copilot } elseif (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g @github/copilot } else { Write-Host 'No supported installer found. Install WinGet or Node.js/npm first, then refresh detected agents.' }",
+      }),
+  },
 ];
 
 export const KNOWN_NATIVE_FAMILY_ACP_AGENT_IDS = new Set([
   "claude-acp",
   "codex-acp",
+  "cursor",
+  "gemini",
+  "github-copilot",
+  "github-copilot-cli",
   "grok-build",
   "opencode",
 ]);

--- a/src/shared/agents/updateResolver.test.ts
+++ b/src/shared/agents/updateResolver.test.ts
@@ -15,6 +15,12 @@ const codexUpdate = {
 
 const geminiUpdate = {
   npm: "@google/gemini-cli",
+  brew: "gemini-cli",
+};
+
+const cursorUpdate = {
+  builtIn: { binary: "cursor-agent", args: ["update"] },
+  homebrewCask: "cursor-cli",
 };
 
 describe("resolveSharedUpdateCommand", () => {
@@ -93,6 +99,46 @@ describe("resolveSharedUpdateCommand", () => {
       args: ["install", "-g", "@google/gemini-cli@latest"],
       strategy: "npm-global",
     });
+  });
+
+  it("uses brew when a formula-backed executable lives under Homebrew", () => {
+    expect(
+      resolveSharedUpdateCommand({
+        update: geminiUpdate,
+        executablePath: "/opt/homebrew/bin/gemini",
+        envKind: "posix",
+      }),
+    ).toEqual({
+      binary: "brew",
+      args: ["upgrade", "gemini-cli"],
+      strategy: "brew",
+    });
+  });
+
+  it("uses brew cask when a cask-backed executable lives under Homebrew", () => {
+    expect(
+      resolveSharedUpdateCommand({
+        update: cursorUpdate,
+        executablePath: "/opt/homebrew/bin/cursor-agent",
+        envKind: "posix",
+        skipBuiltIn: true,
+      }),
+    ).toEqual({
+      binary: "brew",
+      args: ["upgrade", "--cask", "cursor-cli"],
+      strategy: "brew",
+    });
+  });
+
+  it("does not guess a cask updater when the path is not Homebrew-managed", () => {
+    expect(
+      resolveSharedUpdateCommand({
+        update: cursorUpdate,
+        executablePath: "/home/user/.local/bin/cursor-agent",
+        envKind: "posix",
+        skipBuiltIn: true,
+      }),
+    ).toBeUndefined();
   });
 
   it("falls back to npm-global when path is unrecognised but provider publishes on npm", () => {

--- a/src/shared/agents/updateResolver.ts
+++ b/src/shared/agents/updateResolver.ts
@@ -112,9 +112,13 @@ export function resolveSharedUpdateCommand(
   }
 
   const path = input.executablePath;
+  const isBrewPath = looksLikeBrewPath(path);
 
-  if (pkg.brew && looksLikeBrewPath(path)) {
+  if (pkg.brew && isBrewPath) {
     return { binary: "brew", args: ["upgrade", pkg.brew], strategy: "brew" };
+  }
+  if (pkg.homebrewCask && isBrewPath) {
+    return { binary: "brew", args: ["upgrade", "--cask", pkg.homebrewCask], strategy: "brew" };
   }
   if (pkg.winget && looksLikeWingetPath(path) && input.envKind === "windows") {
     return {

--- a/src/supervisor/agents/copilot/detection.ts
+++ b/src/supervisor/agents/copilot/detection.ts
@@ -295,6 +295,8 @@ export const copilotDetectionSpec: DetectionSpec = {
   update: {
     builtIn: { binary: "copilot", args: ["update"] },
     npm: "@github/copilot",
+    homebrewCask: "copilot-cli",
+    winget: "GitHub.Copilot",
   },
   authProbes: [envVarAuthProbe(["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"]), ghAuthProbe],
   async capabilitiesProbe(ctx) {

--- a/src/supervisor/agents/gemini/detection.ts
+++ b/src/supervisor/agents/gemini/detection.ts
@@ -134,6 +134,7 @@ export const geminiDetectionSpec: DetectionSpec = {
   capabilities: defaultGeminiCapabilities,
   update: {
     npm: "@google/gemini-cli",
+    brew: "gemini-cli",
   },
   statusProbe: probeGeminiMetadata,
   authProbes: [envVarAuthProbe(["GEMINI_API_KEY"]), configDirAuthProbe],

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -20,6 +20,7 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
   },
   gemini: {
     npm: "@google/gemini-cli",
+    brew: "gemini-cli",
   },
   opencode: {
     builtIn: { binary: "opencode", args: ["upgrade"] },
@@ -28,6 +29,12 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
   cursor: {
     builtIn: { binary: "cursor-agent", args: ["update"] },
     homebrewCask: "cursor-cli",
+  },
+  copilot: {
+    builtIn: { binary: "copilot", args: ["update"] },
+    npm: "@github/copilot",
+    homebrewCask: "copilot-cli",
+    winget: "GitHub.Copilot",
   },
   grok: {
     builtIn: { binary: "grok", args: ["update"] },
@@ -184,6 +191,60 @@ describe("resolveUpdateCommand", () => {
     expect(command?.strategy).toBe("npm-global");
     expect(command?.binary).toBe("npm");
     expect(command?.args).toEqual(["install", "-g", "@google/gemini-cli@latest"]);
+  });
+
+  it("uses brew for Homebrew-installed Gemini", () => {
+    const adapter = makeAdapter("gemini");
+    const status = makeStatus({
+      kind: "gemini",
+      executablePath: "/opt/homebrew/bin/gemini",
+    });
+    const command = resolveUpdateCommand(adapter, status, NATIVE_POSIX);
+    expect(command).toEqual({
+      binary: "brew",
+      args: ["upgrade", "gemini-cli"],
+      strategy: "brew",
+    });
+  });
+
+  it("uses Copilot's built-in updater with package-manager fallbacks", () => {
+    const adapter = makeAdapter("copilot");
+    const wingetStatus = makeStatus({
+      kind: "copilot",
+      executablePath:
+        "C:\\Users\\me\\AppData\\Local\\Microsoft\\WinGet\\Packages\\GitHub.Copilot\\copilot.exe",
+    });
+    expect(resolveUpdateCommand(adapter, wingetStatus, NATIVE_WIN)).toEqual({
+      binary: "copilot",
+      args: ["update"],
+      strategy: "built-in",
+    });
+    expect(resolveUpdateCommand(adapter, wingetStatus, NATIVE_WIN, { skipBuiltIn: true })).toEqual({
+      binary: "winget",
+      args: ["upgrade", "--id", "GitHub.Copilot", "--silent", "--accept-package-agreements"],
+      strategy: "winget",
+    });
+
+    const brewStatus = makeStatus({
+      kind: "copilot",
+      executablePath: "/opt/homebrew/bin/copilot",
+    });
+    expect(resolveUpdateCommand(adapter, brewStatus, NATIVE_POSIX, { skipBuiltIn: true })).toEqual({
+      binary: "brew",
+      args: ["upgrade", "--cask", "copilot-cli"],
+      strategy: "brew",
+    });
+  });
+
+  it("does not use a Homebrew cask fallback for non-Homebrew Cursor installs", () => {
+    const adapter = makeAdapter("cursor");
+    const status = makeStatus({
+      kind: "cursor",
+      executablePath: "/home/user/.local/bin/cursor-agent",
+    });
+    expect(
+      resolveUpdateCommand(adapter, status, NATIVE_POSIX, { skipBuiltIn: true }),
+    ).toBeUndefined();
   });
 
   it("falls back to npm-global when the path doesn't match a known pattern but the kind has an npm package", () => {


### PR DESCRIPTION
- Resolve native agent updates through Homebrew when the installed binary lives under a brew path, including cask-backed apps, instead of falling back to less accurate update commands.
- Add update metadata for Gemini and GitHub Copilot so their native installers are recognized across macOS and Windows.
- Expand test coverage for shared update resolution and supervisor agent update behavior, especially around brew, cask, and winget cases.
- Update the settings registry copy and localized catalogs to cover the newly supported native agent integrations.