### PR TITLE
Add a CDP smoke-test bridge and simplify update copy

### DIFF
--- a/.agents/skills/interactive-testing/SKILL.md
+++ b/.agents/skills/interactive-testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: interactive-testing
 description: Smoke-test the running Lightcode Electron app end-to-end via Chrome DevTools Protocol. Use when the user asks to "smoke test", "test the app", "verify the refactor in the UI", "open the app and click through", or otherwise wants Claude to drive the real running app instead of relying on unit tests. Boots dev server + Electron with CDP enabled, uses raw CDP or agent-browser as appropriate, walks the surfaces most relevant to the current diff (provider selector, ThreadDraftView, ChatPane, ThreadRuntimeRequestPanel, Browser panel), and reports findings with screenshots.
-allowed-tools: Bash(pnpm:*), Bash(node:*), Bash(npx:*), Bash(agent-browser:*), Bash(git:*), Bash(taskkill:*), Bash(tasklist:*), Read, Edit, Grep, Glob
+allowed-tools: Bash(pnpm:*), Bash(node:*), Bash(npx:*), Bash(agent-browser:*), Bash(git:*), Bash(lsof:*), Bash(curl:*), Bash(env:*), Bash(taskkill:*), Bash(tasklist:*), Read, Edit, Grep, Glob
 ---
 
 # Interactive Testing — Lightcode
@@ -19,6 +19,128 @@ Drive the real running Electron app via Chrome DevTools Protocol (CDP) to verify
 - Pure logic bugs that have a failing unit test reproduction — fix the test instead.
 - Backend-only changes (database, supervisor process internals) with no renderer-visible surface.
 - When the user asks a quick question — don't spin up the whole app to answer "what does this function do".
+
+## Quick path (macOS/POSIX) — read this first
+
+The detailed sections below are written for PowerShell/Windows. On macOS/Linux the flow
+is identical but the commands differ. This is the copy-pasteable POSIX path for the most
+common job: **boot the app and screenshot/verify a renderer change.** Each numbered item
+maps to friction that has actually cost time — follow it and skip the rediscovery.
+
+### The two tools
+
+1. **`lightcode-cdp.mjs`** (preferred for boot-wait, state driving, screenshots) — runs
+   entirely through `node` (always on PATH; no agent-browser/shell quirks). Pairs with the
+   DEV bridge (Patch 3). Set `H=.agents/skills/interactive-testing/scripts/lightcode-cdp.mjs` once per Bash call:
+
+   ```sh
+   node $H wait [--timeout 120]      # block until the app CDP target is up (run_in_background)
+   node $H nav <section>             # open Settings deep-linked: about | usage | appearance | …
+   node $H back                      # close Settings
+   node $H update '<json>'           # patch the app-update store (phase/version/progress)
+   node $H eval '<js>'               # Runtime.evaluate, prints JSON (drive any store via window.__lightcodeDev)
+   node $H shot <selector|-> <out>   # element (CSS selector) or full-viewport (-) PNG, written to <out>
+   node $H reset                     # restore driven state before teardown
+   ```
+
+2. **`agent-browser`** (for the accessibility tree + clicking real controls) — via
+   `npx --no-install agent-browser --cdp 9222 …`; use `snapshot -i` to list refs and
+   `click "@eNN"` to click. Only reach for it when you must drive a real control the bridge
+   can't set directly.
+
+Most visual checks are: `node $H wait` → `node $H nav <section>` (or `update …`) → tag +
+`node $H shot` → read the PNG inline → `node $H reset`. No clicking, no temp edits.
+
+### 0. Shell & tooling caveats (these cost the most)
+
+- **The Bash tool's shell may not match the environment header.** It has executed as
+  `zsh` even when the header said `fish` (tell-tale: `(eval):N: command not found` /
+  `parse error near ')'`). Write **POSIX sh only**: `for i in $(seq 1 90)`,
+  `case "$x" in *foo*) … ;; esac`. Avoid fish builtins (`string match`, `set -x VAR`,
+  `(seq …)`) and zsh-only assumptions.
+- **A variable holding a multi-word command does NOT word-split in zsh** — `AB="npx … "; $AB click` fails with "command not found". Use a function instead:
+  ```sh
+  ab(){ npx --no-install agent-browser --cdp 9222 "$@"; }   # redefine in each Bash call
+  ```
+  (Shell functions/vars do not persist across separate Bash tool calls — redefine `ab()` at the top of each call that needs it.)
+- **`agent-browser` is usually NOT on PATH.** Don't hunt for the binary —
+  `npx --no-install agent-browser …` resolves it from the npx cache. The bare
+  `agent-browser` and even `agent-browser disconnect` may not exist.
+- **Set env inline with `env`:** `env LIGHTCODE_CDP_PORT=9222 pnpm run dev`.
+
+### 1. Boot (background) + wait on the CDP target, not the log
+
+`pnpm run dev` is long-running → launch with `run_in_background: true`:
+
+```sh
+env LIGHTCODE_CDP_PORT=9222 pnpm run dev          # Bash run_in_background: true
+```
+
+Then wait with a **single** background `until` loop that polls the CDP target list — the
+page target appearing is the true "ready" signal, more reliable than grepping Vite's log.
+Per the Monitor tool's own contract, a one-shot "tell me when ready" wait is a background
+Bash loop, **not** a Monitor:
+
+```sh
+for i in $(seq 1 90); do
+  case "$(curl -s http://127.0.0.1:9222/json/list)" in
+    *127.0.0.1:3100*) echo "READY"; exit 0;;
+  esac
+  sleep 2
+done; echo "TIMEOUT"; exit 1                       # Bash run_in_background: true
+```
+
+Cold first boot ~20–40s (incl. native rebuild); warm reboots ~2–5s.
+
+### 2. Attach & confirm
+
+```sh
+ab get url                               # expect http://127.0.0.1:3100/
+ab eval "JSON.stringify({url:location.href})"
+ab --color-scheme dark snapshot -i       # dark is the app default
+```
+
+### 3. Fast visual-only path (skip seeding & WelcomeOverlay)
+
+If the change is a **renderer visual** tweak and the user's dev app is **not running**
+(ports free — check `lsof -nP -iTCP:3100 -sTCP:LISTEN` and `:9222`), you may boot against
+the real `~/.lightcode-dev` profile by **omitting `LIGHTCODE_BASE_DIR`**. The app opens
+straight to the user's existing projects — no seeding, no WelcomeOverlay. Rules:
+
+- **Read-only:** navigate and screenshot only; never send a chat into a real thread.
+- **Restore persisted UI state you change.** Sidebar collapse, panel sizes, etc. persist
+  to that profile — if you collapse the sidebar for a shot, re-expand it before teardown.
+- **Reset any injected store state** (see Patch 3) back to its resting value.
+
+For anything that mutates data (threads, settings), use the isolated + seeded path instead.
+
+### 4. Element / component screenshots
+
+`screenshot` takes an optional **CSS selector** to capture one element — far cleaner than
+full-window shots. If the component has no stable selector, tag it via eval first, then
+read the PNG back to view it inline:
+
+```sh
+ab eval "(()=>{const h=[...document.querySelectorAll('h1')].find(e=>e.textContent.trim()==='About'); h.closest('div').parentElement.id='shot'; return 'ok';})()"
+ab screenshot "#shot" "$HOME/.lightcode-smoke/shots/about.png"   # write OUTSIDE the repo
+```
+
+Write shots **outside the repo** (`$HOME/.lightcode-smoke/…`) so the file write doesn't
+trigger an `electronmon` restart.
+
+### 5. Finding controls to click
+
+`ab snapshot -i` lists refs (`ref=eNN`); click with `ab click "@eNN"`. Grep the snapshot
+for the accessible name. **Caveat:** icon-only buttons (collapsed sidebar rail, toolbar
+icons) get their name from a **tooltip, not `aria-label`/text** — text finders miss them.
+Fall back to a ref from the open snapshot, or DOM traversal (`rail.lastElementChild`, nth
+button, etc.).
+
+### 6. Teardown
+
+Stop the dev server by its background **task id** with `TaskStop` (not by killing
+electron). Confirm ports freed (`lsof -nP -iTCP:9222 -sTCP:LISTEN` → empty). Revert any
+temporary source hooks and `git status` to confirm the tree is clean.
 
 ## Prerequisites — one-time source patches
 
@@ -62,19 +184,62 @@ lightcodePaths = prepareLightcodeDataRoot(
 
 This propagates automatically: `supervisorClient.start(lightcodePaths.baseDir)` (further down in `main.ts`) hands the same path to the supervisor, so sqlite, settings, attachments, worktrees, and agent plugins all relocate together. The `app.setPath("userData", ...)` line prevents stale renderer `localStorage` (collapsed sidebar, terminal position, git cache, etc.) from leaking into fresh smoke runs.
 
+### Patch 3 — Dev state bridge ✅ already wired
+
+State-dependent UI — update phases (`checking`/`downloading`/`downloaded`), button
+variants, error/empty/loading states — is painful to reach through real flows, and some
+states (a live download with specific byte counts) you essentially **cannot** trigger on
+demand. So the renderer exposes its Zustand stores + a few helpers on
+`window.__lightcodeDev` in dev — no clicking, no waiting on real async, and **no
+per-iteration source edits / extra boots.**
+
+This already ships: `src/renderer/devBridge.ts` (`installDevBridge()`), called from
+`src/renderer/main.tsx` under an `import.meta.env.DEV` guard (dead-code eliminated from
+prod). The shape:
+
+```ts
+window.__lightcodeDev = {
+  stores: { update, app, panel, sidebarUi, sharedSettings },  // raw Zustand: .getState()/.setState()
+  openSettings(section?),   // deep-link Settings, e.g. "about" | "usage" | "appearance"
+  closeSettings(),
+  setUpdate(patch),         // patch the app-update store (phase/version/progress)
+  reset(),                  // restore driven state to baseline — call before teardown
+};
+```
+
+Drive it through the **`lightcode-cdp.mjs` helper** (preferred — see Quick path) or any
+`eval`:
+
+```sh
+H=.agents/skills/interactive-testing/scripts/lightcode-cdp.mjs
+node $H nav about
+node $H update '{"phase":"downloading","version":"1.2.3","downloadPercent":42,"downloadTransferred":30618419,"downloadTotal":113554636}'
+node $H shot "#shot" "$HOME/.lightcode-smoke/shots/downloading.png"   # tag #shot first (Quick path §4)
+node $H reset
+```
+
+To drive a state not covered by a helper, reach the store directly:
+`node $H eval "window.__lightcodeDev.stores.panel.setState({threadSearchOpen:true})"`.
+If you genuinely need a store that isn't exposed, add it to the `stores` map in
+`devBridge.ts` (one line) rather than temp-hacking the store module.
+
 ### Verify `agent-browser`
 
 ```bash
-agent-browser --version || npx agent-browser --version
+npx --no-install agent-browser --version    # resolves from npx cache; bare `agent-browser` is usually NOT on PATH
 ```
 
-If neither resolves, install via `npm i -g @anthropic-ai/agent-browser` (or use `npx agent-browser` everywhere).
+If that fails, `npm i -g @anthropic-ai/agent-browser` then retry — but prefer
+`npx --no-install agent-browser …` in every command (don't waste calls hunting for a
+global binary).
 
 Current CLI notes:
 
 - Use `agent-browser eval`, not `agent-browser evaluate`.
-- In PowerShell, quote refs: `npx agent-browser click '@e24'`; unquoted `@e24` is parsed by PowerShell.
-- `agent-browser connect 9222` can drift to `about:blank` with Electron. Prefer `npx agent-browser --cdp 9222 ...` for quick checks, and use the Browser-panel raw CDP script below for Browser panel work.
+- `screenshot` takes an optional CSS **selector** and **path**: `… screenshot "#sel" ./out.png` captures just that element (see Quick path §4). `--full` for the whole page.
+- There is no `disconnect` subcommand on all versions — just stop the dev server (TaskStop) at teardown; the CDP attach is stateless.
+- macOS/zsh: `@eNN` refs are safe unquoted, but quoting (`"@e24"`) is harmless and matches the PowerShell guidance. In PowerShell, quoting is **required** (`'@e24'`).
+- `agent-browser connect 9222` can drift to `about:blank` with Electron. Prefer `npx --no-install agent-browser --cdp 9222 …`, and use the Browser-panel raw CDP script below for Browser panel work.
 
 ### Fallback if patches aren't accepted
 
@@ -120,11 +285,12 @@ Current CLI notes:
    - `wait-on tcp:3100 dist/main/main.cjs` gates the app launch.
    - Electron starts after Vite is up and `dist/main/main.cjs` exists.
 
-4. **Wait for "ready" signals** before attaching. Watch the background task output for:
-   - `Local:   http://127.0.0.1:3100/` (Vite ready)
-   - Lightcode main window logs (e.g. supervisor init lines)
-
-   Use the `Monitor` tool against the background bash task — do not blanket-sleep.
+4. **Wait for "ready" before attaching.** The reliable signal is the CDP page target
+   appearing in `/json/list`, not a Vite log line. Use a **single background Bash `until`
+   loop** that polls it (see Quick path §1) — this is the one-shot "ready" pattern from the
+   Monitor tool's own contract. Don't blanket-sleep, and don't use `Monitor` for this
+   (Monitor is for ongoing event streams, not a one-time readiness check). Cold boot
+   ~20–40s; warm reboot ~2–5s.
 
 5. **Attach/check CDP target**:
 
@@ -271,8 +437,8 @@ Execute in order. After each step, `snapshot -i` (or `screenshot`) and verify ou
 
 7. **Teardown**
    - Stop the thread (if still running) via UI.
-   - Disconnect agent-browser: `agent-browser disconnect`.
-   - Leave the dev server running unless the user asked you to stop it. If stopping: kill the background bash task; do NOT kill all `electron.exe` processes blindly (the user may have other Electron apps open — VS Code, Slack, etc.).
+   - Revert any temporary source hooks; reset any injected store state to its resting value.
+   - Leave the dev server running unless the user asked you to stop it. If stopping: stop the background bash task by id with `TaskStop` (the CDP attach is stateless — no `disconnect` needed); do NOT kill all `electron.exe`/`Electron` processes blindly (the user may have other Electron apps open — VS Code, Slack, etc.). Confirm ports freed with `lsof -nP -iTCP:9222 -sTCP:LISTEN`.
    - **Clean up the smoke workspace**: by default, leave `$smokeRoot` on disk so the user can inspect what happened. If the user asked for a clean run-and-purge, delete `$smokeRoot` (the isolated data dir + project) — confirm before doing so. Never delete `~/.lightcode-dev` itself; the smoke run never wrote to it.
 
 ## Targeted scenarios
@@ -362,7 +528,7 @@ Do not narrate every snapshot in the final summary — that goes to chat as you 
 - **Never run destructive prompts** through the smoke test. If you must trigger a permission panel, choose a request like "list files in cwd" not "delete X". Always click Deny on real permission prompts unless the user told you otherwise.
 - **Default to the isolated workspace.** With `LIGHTCODE_BASE_DIR` set and the `userData` patch in place, the app starts with empty sqlite/settings and isolated renderer storage — no risk of touching real threads or leaking old `localStorage`. If a smoke run is asked to use the user's actual `~/.lightcode-dev` (e.g. to repro a real bug), always create a fresh thread and never send into an existing one without explicit confirmation.
 - **Do not commit anything** during a smoke test — the dev session may have modified files (cache, settings). Leave git state untouched and report any unexpected modifications.
-- **Dev server is long-running.** Always launch with `run_in_background: true`. Do not sleep-loop waiting for it; use `Monitor` on the background task and let the harness notify you on log lines like `Local:   http://127.0.0.1:3100/`.
+- **Dev server is long-running.** Always launch with `run_in_background: true`. Do not foreground sleep-loop waiting for it; wait with a separate background Bash `until` loop polling the CDP target (Quick path §1). Stop it at teardown with `TaskStop` by task id, never by blanket-killing electron.
 - **Single instance lock**: in dev mode `main.ts` bypasses `requestSingleInstanceLock`, so multiple electron instances can coexist — but don't spawn two dev sessions at once anyway; port 9222 collides.
 
 ## Troubleshooting
@@ -376,3 +542,8 @@ Do not narrate every snapshot in the final summary — that goes to chat as you 
 - **App didn't pick up `LIGHTCODE_BASE_DIR`**: confirm patch 2 landed in `main.ts` (`grep LIGHTCODE_BASE_DIR src/main/main.ts`) and that `app.setPath("userData", join(baseDirOverride, "userData"))` exists. Also confirm `$env:LIGHTCODE_BASE_DIR` was set in the _same_ PowerShell session that ran `pnpm run dev` — `concurrently` inherits env from that parent.
 - **Smoke screenshots cause app restarts**: screenshots were probably written inside the repo. Use `$env:LIGHTCODE_SMOKE_OUT_DIR` under `$HOME\.lightcode-smoke\...`; `electronmon` may see repo-local artifact writes as renderer file changes.
 - **Seeded project does not appear**: confirm the seed script wrote `$env:LIGHTCODE_BASE_DIR\state.sqlite`, confirm the app was launched from the same shell with that `LIGHTCODE_BASE_DIR`, and confirm the seeded path exists on disk.
+- **`command not found` / `parse error near ')'` on a Bash call**: the shell isn't what the environment header claims (it has run as zsh while the header said fish). Rewrite in POSIX sh — no `(seq …)`, no `string match`, no relying on `$VAR` word-splitting a multi-word command (use an `ab(){ …; }` function). See Quick path §0.
+- **`agent-browser: command not found`**: it's not on PATH in the Bash shell. Use `npx --no-install agent-browser …` (resolves from the npx cache); don't go looking for the binary.
+- **Can't reach a state-dependent UI (download progress, error, loading, a specific variant)**: don't try to trigger it through real async — drive the store via the dev bridge (Patch 3), or temporarily expose the store on `window` and reset it before teardown.
+- **Icon-only button not clickable by name**: collapsed-rail / toolbar icon buttons expose their label via a **tooltip**, not `aria-label`/text — your text-based ref finder returns nothing. Take a ref from the open `snapshot -i`, or traverse the DOM (`container.lastElementChild`, nth `button`). See Quick path §5.
+- **Left the user's dev app in a changed state**: when using the fast real-`~/.lightcode-dev` path, sidebar collapse / panel sizes persist. Re-expand the sidebar and reset injected store state before teardown. See Quick path §3.

--- a/.agents/skills/interactive-testing/scripts/lightcode-cdp.mjs
+++ b/.agents/skills/interactive-testing/scripts/lightcode-cdp.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Shell-agnostic CDP helper for the interactive-testing skill.
+ *
+ * Everything runs through `node` (always on PATH) using raw CDP over the
+ * built-in WebSocket — no `agent-browser` PATH/shell quirks, no fish/zsh
+ * word-splitting traps. Pairs with the DEV bridge (`window.__lightcodeDev`,
+ * see src/renderer/devBridge.ts) for instant state/navigation.
+ *
+ * Port defaults to $LIGHTCODE_CDP_PORT or 9222.
+ *
+ *   node lightcode-cdp.mjs wait [--timeout 90]        # block until the app CDP target is up
+ *   node lightcode-cdp.mjs eval '<js>' [--await]      # Runtime.evaluate, prints JSON result
+ *   node lightcode-cdp.mjs shot <selector|-> <out>    # element (CSS selector) or full-viewport (-) PNG
+ *   node lightcode-cdp.mjs nav <section>              # open Settings deep-linked (e.g. about, usage) [needs bridge]
+ *   node lightcode-cdp.mjs back                       # close Settings overlay [needs bridge]
+ *   node lightcode-cdp.mjs update '<json>'            # patch the app-update store [needs bridge]
+ *   node lightcode-cdp.mjs reset                      # reset driven state to baseline [needs bridge]
+ *
+ * Examples:
+ *   node lightcode-cdp.mjs wait
+ *   node lightcode-cdp.mjs nav about
+ *   node lightcode-cdp.mjs update '{"phase":"downloading","version":"1.2.3","downloadPercent":42,"downloadTransferred":30618419,"downloadTotal":113554636}'
+ *   node lightcode-cdp.mjs shot "#shot-about" ~/.lightcode-smoke/shots/about.png
+ *   node lightcode-cdp.mjs reset
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
+
+const { flags, pos } = parse(process.argv.slice(2));
+const cmd = pos[0];
+const port = Number(flags.port ?? process.env.LIGHTCODE_CDP_PORT ?? 9222);
+const appUrl = String(flags.appUrl ?? "http://127.0.0.1:3100/");
+const commandTimeoutMs = Number(flags.commandTimeoutMs ?? 8000);
+
+try {
+  await main();
+} catch (error) {
+  console.error(`ERROR: ${error?.message ?? error}`);
+  process.exit(1);
+}
+
+async function main() {
+  switch (cmd) {
+    case "wait": {
+      const timeoutS = Number(flags.timeout ?? 90);
+      const target = await waitForTarget(timeoutS * 1000);
+      console.log(target ? "READY" : "TIMEOUT");
+      if (!target) process.exit(1);
+      return;
+    }
+    case "eval": {
+      const expr = required(pos[1], "eval needs a <js> expression");
+      const client = await connect();
+      try {
+        const value = await evaluate(client, expr, flags.await === true);
+        console.log(JSON.stringify(value));
+      } finally {
+        client.close();
+      }
+      return;
+    }
+    case "shot": {
+      const selector = required(pos[1], "shot needs a <selector|-> and <out> path");
+      const out = absOut(required(pos[2], "shot needs an <out> path"));
+      const client = await connect();
+      try {
+        await screenshot(client, selector, out);
+        console.log(out);
+      } finally {
+        client.close();
+      }
+      return;
+    }
+    case "nav": {
+      const section = required(pos[1], "nav needs a <section> id (e.g. about)");
+      await bridgeCall(`window.__lightcodeDev.openSettings(${JSON.stringify(section)})`);
+      console.log(`nav:${section}`);
+      return;
+    }
+    case "back": {
+      await bridgeCall(`window.__lightcodeDev.closeSettings()`);
+      console.log("back");
+      return;
+    }
+    case "update": {
+      const json = required(pos[1], "update needs a '<json>' patch");
+      const patch = JSON.parse(json); // validate before injecting
+      await bridgeCall(`window.__lightcodeDev.setUpdate(${JSON.stringify(patch)})`);
+      console.log("update:ok");
+      return;
+    }
+    case "reset": {
+      await bridgeCall(`window.__lightcodeDev.reset()`);
+      console.log("reset:ok");
+      return;
+    }
+    default:
+      console.error(
+        "Usage: node lightcode-cdp.mjs <wait|eval|shot|nav|back|update|reset> ...\n" +
+          "See the header of this file for examples.",
+      );
+      process.exit(2);
+  }
+}
+
+/** Eval a dev-bridge call, asserting the bridge exists (clearer error than a TypeError). */
+async function bridgeCall(expr) {
+  const client = await connect();
+  try {
+    const present = await evaluate(client, "typeof window.__lightcodeDev");
+    if (present !== "object") {
+      throw new Error(
+        "window.__lightcodeDev is missing — is the app a DEV build with installDevBridge() wired in main.tsx?",
+      );
+    }
+    return await evaluate(client, `(${expr}, "ok")`);
+  } finally {
+    client.close();
+  }
+}
+
+async function connect() {
+  const target = await waitForTarget(10000);
+  if (!target) throw new Error(`no app CDP target at ${appUrl} on port ${port}`);
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  const pending = new Map();
+  let id = 0;
+  await new Promise((done, reject) => {
+    ws.onopen = done;
+    ws.onerror = () => reject(new Error("WebSocket error connecting to CDP target"));
+  });
+  ws.addEventListener("message", (message) => {
+    const payload = JSON.parse(message.data);
+    if (!payload.id) return;
+    const item = pending.get(payload.id);
+    if (!item) return;
+    pending.delete(payload.id);
+    if (payload.error) item.reject(new Error(`${item.method}: ${JSON.stringify(payload.error)}`));
+    else item.resolve(payload.result);
+  });
+  return {
+    send(method, params = {}) {
+      id += 1;
+      const requestId = id;
+      ws.send(JSON.stringify({ id: requestId, method, params }));
+      return new Promise((done, reject) => {
+        const timeout = setTimeout(() => {
+          pending.delete(requestId);
+          reject(new Error(`CDP timeout (${commandTimeoutMs}ms): ${method}`));
+        }, commandTimeoutMs);
+        pending.set(requestId, {
+          method,
+          resolve: (v) => (clearTimeout(timeout), done(v)),
+          reject: (e) => (clearTimeout(timeout), reject(e)),
+        });
+      });
+    },
+    close: () => ws.close(),
+  };
+}
+
+async function evaluate(client, expression, awaitPromise = false) {
+  const result = await client.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise,
+  });
+  if (result.exceptionDetails) {
+    throw new Error(result.exceptionDetails.exception?.description ?? result.exceptionDetails.text);
+  }
+  return result.result.value;
+}
+
+async function screenshot(client, selector, out) {
+  const params = { format: "png", fromSurface: true, captureBeyondViewport: true };
+  if (selector !== "-") {
+    const rect = await evaluate(
+      client,
+      `(() => { const el = document.querySelector(${JSON.stringify(selector)});` +
+        ` if (!el) return null; const r = el.getBoundingClientRect();` +
+        ` return { x: r.x, y: r.y, width: r.width, height: r.height }; })()`,
+    );
+    if (!rect) throw new Error(`selector not found: ${selector}`);
+    params.clip = {
+      x: Math.max(0, Math.round(rect.x)),
+      y: Math.max(0, Math.round(rect.y)),
+      width: Math.max(1, Math.ceil(rect.width)),
+      height: Math.max(1, Math.ceil(rect.height)),
+      scale: 1,
+    };
+  }
+  const res = await client.send("Page.captureScreenshot", params);
+  await mkdir(dirname(out), { recursive: true });
+  await writeFile(out, Buffer.from(res.data, "base64"));
+}
+
+async function waitForTarget(timeoutMs) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+      if (res.ok) {
+        const targets = await res.json();
+        const hit = targets.find((t) => t.type === "page" && t.url === appUrl);
+        if (hit) return hit;
+      }
+    } catch {
+      // CDP endpoint not up yet — keep polling.
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return null;
+}
+
+function absOut(p) {
+  const expanded = p.startsWith("~/") ? resolvePath(homedir(), p.slice(2)) : p;
+  return isAbsolute(expanded) ? expanded : resolvePath(process.cwd(), expanded);
+}
+
+function required(value, message) {
+  if (value === undefined) throw new Error(message);
+  return value;
+}
+
+function parse(argv) {
+  const parsedFlags = {};
+  const parsedPos = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) parsedFlags[key] = true;
+      else {
+        parsedFlags[key] = next;
+        i += 1;
+      }
+    } else {
+      parsedPos.push(a);
+    }
+  }
+  return { flags: parsedFlags, pos: parsedPos };
+}

--- a/src/renderer/devBridge.ts
+++ b/src/renderer/devBridge.ts
@@ -1,0 +1,56 @@
+/**
+ * DEV-only bridge for the interactive-testing skill (CDP smoke tests).
+ *
+ * Exposes the renderer's Zustand stores plus a few navigation/state helpers on
+ * `window.__lightcodeDev` so an external CDP driver can put the UI into any
+ * state — app-update phases, settings sections, panels — WITHOUT clicking
+ * through real flows or waiting on real async. Some states (a live download at a
+ * specific byte count) are otherwise impossible to trigger on demand.
+ *
+ * The whole thing is guarded by `import.meta.env.DEV`, so it is dead-code
+ * eliminated from production bundles. See `.agents/skills/interactive-testing`.
+ */
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
+import { useUpdateStore } from "@/renderer/state/updateStore";
+
+type UpdateStoreState = ReturnType<typeof useUpdateStore.getState>;
+
+export function installDevBridge(): void {
+  if (!import.meta.env.DEV) return;
+
+  const target = globalThis as unknown as { __lightcodeDev?: unknown };
+  if (target.__lightcodeDev) return;
+
+  target.__lightcodeDev = {
+    /** Raw Zustand stores — call `.getState()` / `.setState()` to inspect or drive any state. */
+    stores: {
+      update: useUpdateStore,
+      app: useAppStore,
+      panel: usePanelStore,
+      sidebarUi: useSidebarUiStore,
+      sharedSettings: useSharedSettings,
+    },
+    /** Open Settings; pass a section id (e.g. "about", "usage", "appearance") to deep-link. */
+    openSettings: (section?: string) => {
+      const panel = usePanelStore.getState();
+      if (section) panel.openSettingsSection(section);
+      else panel.openSettings();
+    },
+    /** Close the Settings overlay (back to the app surface). */
+    closeSettings: () => usePanelStore.setState({ settingsOpen: false }),
+    /** Patch the app-update store (phase / version / download progress) for screenshots. */
+    setUpdate: (patch: Partial<UpdateStoreState>) => useUpdateStore.setState(patch),
+    /** Reset transient driven state to a clean baseline — call before teardown. */
+    reset: () =>
+      useUpdateStore.setState({
+        phase: "idle",
+        version: null,
+        downloadPercent: 0,
+        downloadTransferred: null,
+        downloadTotal: null,
+      }),
+  };
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2170,6 +2170,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Herunterladen in „{0}“. Bei großen Repositories kann dies einen Moment "
 "dauern."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Update wird heruntergeladen"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2180,12 +2185,12 @@ msgid "Downloading voice model..."
 msgstr "Sprachmodell wird heruntergeladen..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Herunterladen{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Herunterladen{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Herunterladen{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Herunterladen{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2150,6 +2150,11 @@ msgstr "Download image"
 msgid "Downloading into “{0}”. This can take a moment for large repositories."
 msgstr "Downloading into “{0}”. This can take a moment for large repositories."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Downloading update"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2160,12 +2165,12 @@ msgid "Downloading voice model..."
 msgstr "Downloading voice model..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Downloading{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Downloading{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Downloading{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2161,6 +2161,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Descargando en «{0}». Esto puede tardar un momento en repositorios "
 "grandes."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Descargando actualización"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2171,12 +2176,12 @@ msgid "Downloading voice model..."
 msgstr "Descargando modelo de voz..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Descargando{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Descargando{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Descargando{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Descargando{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2170,6 +2170,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Téléchargement dans « {0} ». Cela peut prendre un certain temps pour "
 "les grands dépôts."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Téléchargement de la mise à jour"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2180,12 +2185,12 @@ msgid "Downloading voice model..."
 msgstr "Téléchargement du modèle vocal..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Téléchargement{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Téléchargement{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Téléchargement de {versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Téléchargement de {versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2137,6 +2137,11 @@ msgstr "画像をダウンロード"
 msgid "Downloading into “{0}”. This can take a moment for large repositories."
 msgstr "「{0}」にダウンロード中です。大規模なリポジトリの場合、これには時間がかかることがあります。"
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "アップデートをダウンロード中"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2147,12 +2152,12 @@ msgid "Downloading voice model..."
 msgstr "音声モデルをダウンロードしています..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "ダウンロード中{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "ダウンロード中{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "{versionLabel}をダウンロード中"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "{versionLabel}をダウンロード中"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2138,6 +2138,11 @@ msgstr "이미지 다운로드"
 msgid "Downloading into “{0}”. This can take a moment for large repositories."
 msgstr "“{0}”에 다운로드 중입니다. 대규모 리포지토리의 경우 시간이 걸릴 수 있습니다."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "업데이트 다운로드 중"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2148,12 +2153,12 @@ msgid "Downloading voice model..."
 msgstr "음성 모델 다운로드 중..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "{v} 다운로드 중 — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "{v} 다운로드 중 — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "{versionLabel} 다운로드 중"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "{versionLabel} 다운로드 중"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2161,6 +2161,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Pobieranie do „{0}”. W przypadku dużych repozytoriów może to chwilę "
 "potrwać."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Pobieranie aktualizacji"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2171,12 +2176,12 @@ msgid "Downloading voice model..."
 msgstr "Pobieranie modelu głosu..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Pobieranie{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Pobieranie{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Pobieranie{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Pobieranie{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2164,6 +2164,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Baixando em “{0}”. Isso pode demorar um pouco para repositórios "
 "grandes."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Baixando atualização"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2174,12 +2179,12 @@ msgid "Downloading voice model..."
 msgstr "Baixando modelo de voz..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Baixando{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Baixando{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Baixando{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Baixando{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2162,6 +2162,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Загрузка в «{0}». Для больших репозиториев это может занять некоторое "
 "время."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Загрузка обновления"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2172,12 +2177,12 @@ msgid "Downloading voice model..."
 msgstr "Загрузка голосовой модели..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Загрузка{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Загрузка{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Загрузка{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Загрузка{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2161,6 +2161,11 @@ msgstr "Görseli indir"
 msgid "Downloading into “{0}”. This can take a moment for large repositories."
 msgstr "“{0}” içine indiriliyor. Büyük depolar için bu biraz zaman alabilir."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Güncelleme indiriliyor"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2171,12 +2176,12 @@ msgid "Downloading voice model..."
 msgstr "Ses modeli indiriliyor..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "İndiriliyor{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "İndiriliyor{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "{versionLabel} indiriliyor"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "{versionLabel} indiriliyor"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2160,6 +2160,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Завантаження до «{0}». Для великих репозиторіїв це може зайняти деякий "
 "час."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Завантаження оновлення"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2170,12 +2175,12 @@ msgid "Downloading voice model..."
 msgstr "Завантаження голосової моделі..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Завантаження{v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Завантаження{v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Завантаження{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Завантаження{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2160,6 +2160,11 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Đang tải xuống “{0}”. Việc này có thể mất một chút thời gian đối với "
 "các kho lưu trữ lớn."
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "Đang tải xuống bản cập nhật"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2170,12 +2175,12 @@ msgid "Downloading voice model..."
 msgstr "Đang tải xuống mẫu giọng nói..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "Đang tải xuống {v} — {percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "Đang tải xuống {v} — {percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "Đang tải xuống {versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "Đang tải xuống {versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2135,6 +2135,11 @@ msgstr "下载图片"
 msgid "Downloading into “{0}”. This can take a moment for large repositories."
 msgstr "下载到“{0}”。对于大型存储库，这可能需要一些时间。"
 
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+msgid "Downloading update"
+msgstr "正在下载更新"
+
 #. placeholder {0}: Math.round(downloadProgress.progress)
 #: src/renderer/components/composer/VoiceInputButton.tsx
 msgid "Downloading voice model {0}%"
@@ -2145,12 +2150,12 @@ msgid "Downloading voice model..."
 msgstr "正在下载语音模型..."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
-msgid "Downloading{v} — {percent}%{speedSuffix}"
-msgstr "下载{v}—{percent}%{speedSuffix}"
+#~ msgid "Downloading{v} — {percent}%{speedSuffix}"
+#~ msgstr "下载{v}—{percent}%{speedSuffix}"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
-msgid "Downloading{versionLabel}"
-msgstr "正在下载{versionLabel}"
+#~ msgid "Downloading{versionLabel}"
+#~ msgstr "正在下载{versionLabel}"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 msgid "Draft"

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -14,6 +14,7 @@ import {
 import { isIgnorableRejection, isIgnorableWindowError } from "./rendererGlobalErrors";
 import { bootstrapAppThemeFromCache } from "./theme/applyAppTheme";
 import { bootstrapAppLocaleFromCache } from "./i18n/i18n";
+import { installDevBridge } from "./devBridge";
 
 if (import.meta.env.DEV) {
   const warn = console.warn.bind(console);
@@ -35,6 +36,10 @@ if (import.meta.env.DEV) {
 
 document.title = getAppName(readBridge().channel, import.meta.env.DEV);
 initializeRendererSentry();
+
+// DEV-only: expose stores + nav/state helpers on window for CDP smoke tests.
+// No-op (dead-code eliminated) in production builds.
+installDevBridge();
 
 document.documentElement.dataset.platform =
   typeof window !== "undefined" && "lightcode" in window ? readBridge().platform : "unknown";

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -58,55 +58,48 @@ function UpdateButtons(props: { iconOnly?: boolean }) {
   const downloadPercent = useUpdateStore((s) => s.downloadPercent);
   const transferred = useUpdateStore((s) => s.downloadTransferred);
   const total = useUpdateStore((s) => s.downloadTotal);
-  const bytesPerSecond = useUpdateStore((s) => s.downloadBytesPerSecond);
 
   if (updatePhase !== "downloading" && updatePhase !== "downloaded") {
     return null;
   }
 
   if (updatePhase === "downloading") {
-    const versionLabel = updateVersion ? ` v${updateVersion}` : "";
+    const percent = Math.min(100, Math.max(0, Math.round(downloadPercent)));
     const byteLine =
       transferred != null && total != null && total > 0
         ? `${formatBytes(transferred)} / ${formatBytes(total)}`
         : null;
-    const speedLine =
-      bytesPerSecond != null && bytesPerSecond > 0 ? `${formatBytes(bytesPerSecond)}/s` : null;
 
     if (iconOnly) {
       return (
         <Tooltip delay={150}>
           <Tooltip.Trigger>
             <div className="flex h-8 w-8 shrink-0 items-center justify-center">
-              <Download className="size-4 animate-pulse text-accent" />
+              <Download className="size-4 animate-pulse text-muted" />
             </div>
           </Tooltip.Trigger>
           <Tooltip.Content placement="right">
-            <Trans>Downloading{versionLabel}</Trans> — {Math.round(downloadPercent)}%
-            {byteLine ? ` · ${byteLine}` : ""}
-            {speedLine ? ` · ${speedLine}` : ""}
+            <Trans>Downloading update</Trans> — {percent}%{byteLine ? ` · ${byteLine}` : ""}
           </Tooltip.Content>
         </Tooltip>
       );
     }
 
+    // Compact, fixed-height status: one line (bytes + percent) over a thin bar.
+    // The long target version is omitted — it overflowed/clipped and the About
+    // page already surfaces it. `tabular-nums` keeps the digits from reflowing.
     return (
       <div className="flex w-full items-center gap-2 rounded-3xl px-2 py-1.5 text-muted">
-        <Download className="size-4 shrink-0 animate-pulse text-accent" />
+        <Download className="size-4 shrink-0 animate-pulse text-muted" />
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <span className="truncate text-xs">
-            <Trans>Downloading{versionLabel}</Trans>
-          </span>
-          <div className="flex min-w-0 items-center justify-between gap-2 text-xs opacity-80">
-            <span className="truncate">{byteLine ?? ""}</span>
-            <span className="shrink-0 whitespace-nowrap">
-              {Math.round(downloadPercent)}%{speedLine ? ` · ${speedLine}` : ""}
-            </span>
+          <div className="flex min-w-0 items-center justify-between gap-2 text-xs tabular-nums">
+            <span className="truncate">{byteLine ?? <Trans>Downloading update</Trans>}</span>
+            <span className="shrink-0">{percent}%</span>
           </div>
-          <div className="h-1 w-full rounded-full bg-[var(--row-active)]">
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--row-active)]">
             <div
-              className="h-1 rounded-full bg-accent transition-[width] duration-300"
-              style={{ width: `${Math.round(downloadPercent)}%` }}
+              className="h-1 rounded-full bg-foreground transition-[width] duration-300"
+              style={{ width: `${percent}%` }}
             />
           </div>
         </div>
@@ -117,7 +110,7 @@ function UpdateButtons(props: { iconOnly?: boolean }) {
   return (
     <SidebarButton
       iconOnly={iconOnly}
-      icon={<RefreshCw className="size-4 text-accent" />}
+      icon={<RefreshCw className="size-4" />}
       label={updateVersion ? t`Install v${updateVersion}` : t`Install update`}
       onPress={() => void readBridge().installUpdate()}
     />

--- a/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
@@ -33,7 +33,6 @@ function UpdateButton() {
   const downloadPercent = useUpdateStore((s) => s.downloadPercent);
   const transferred = useUpdateStore((s) => s.downloadTransferred);
   const total = useUpdateStore((s) => s.downloadTotal);
-  const bytesPerSecond = useUpdateStore((s) => s.downloadBytesPerSecond);
 
   if (phase === "checking") {
     return (
@@ -45,33 +44,35 @@ function UpdateButton() {
   }
 
   if (phase === "downloading") {
-    const v = version ? ` v${version}` : "";
+    // Single-line, fixed-height status so the Version row keeps a constant
+    // height across phases (no layout jump). `tabular-nums` keeps the digits
+    // from reflowing as the numbers tick up. The target version is intentionally
+    // omitted here — the Version row already shows it and the long nightly
+    // string was what overflowed and got clipped.
+    const percent = Math.min(100, Math.max(0, Math.round(downloadPercent)));
     const byteLine =
       transferred != null && total != null && total > 0
         ? `${formatBytes(transferred)} / ${formatBytes(total)}`
         : null;
-    const speedLine =
-      bytesPerSecond != null && bytesPerSecond > 0 ? `${formatBytes(bytesPerSecond)}/s` : null;
-    const percent = Math.round(downloadPercent);
-    const speedSuffix = speedLine ? ` · ${speedLine}` : "";
 
     return (
-      <div className="flex min-w-0 max-w-[min(100%,280px)] flex-col items-stretch gap-2 text-left">
-        <div className="flex items-center gap-2 text-sm text-foreground">
-          <Download className="size-3.5 shrink-0 animate-pulse" />
-          <span className="min-w-0 truncate">
-            <Trans>
-              Downloading{v} — {percent}%{speedSuffix}
-            </Trans>
-          </span>
-        </div>
-        {byteLine ? <p className="text-xs text-muted">{byteLine}</p> : null}
-        <div className="h-1 w-full rounded-full bg-[var(--row-active)]">
+      <div
+        className="flex items-center gap-2.5 text-xs text-muted"
+        role="progressbar"
+        aria-label={t`Downloading update`}
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <Download className="size-3.5 shrink-0 animate-pulse text-foreground" />
+        {byteLine ? <span className="whitespace-nowrap tabular-nums">{byteLine}</span> : null}
+        <div className="h-1 w-20 overflow-hidden rounded-full bg-[var(--row-active)]">
           <div
-            className="h-1 rounded-full bg-accent transition-[width] duration-300"
-            style={{ width: `${Math.round(downloadPercent)}%` }}
+            className="h-full rounded-full bg-foreground transition-[width] duration-300"
+            style={{ width: `${percent}%` }}
           />
         </div>
+        <span className="w-8 text-right tabular-nums text-foreground">{percent}%</span>
       </div>
     );
   }
@@ -79,7 +80,7 @@ function UpdateButton() {
   if (phase === "downloaded") {
     const label = version ? t`Install v${version}` : t`Install update`;
     return (
-      <Button size="sm" variant="primary" onPress={() => void readBridge().installUpdate()}>
+      <Button size="sm" variant="tertiary" onPress={() => void readBridge().installUpdate()}>
         <RefreshCw className="size-3.5" />
         {label}
       </Button>


### PR DESCRIPTION
- Adds a DEV-only renderer bridge and a shell-agnostic CDP helper for interactive smoke tests, making it easier to drive Lightcode end-to-end without relying on click-through flows.
- Updates the interactive-testing skill guidance to match the new test bridge and supported tooling.
- Simplifies update-download status text in the sidebar and About settings so the version row stays stable during downloads and avoids overflow.
- Refreshes the affected localized strings across all shipped locales to keep the UI translated.