### PR TITLE
feat(experiment): fan-out + compare + crown

### DIFF
--- a/src/renderer/actions/currentProject.ts
+++ b/src/renderer/actions/currentProject.ts
@@ -13,6 +13,7 @@ export function getCurrentProjectId(): string | undefined {
   const s = useAppStore.getState();
   const v = s.view;
   if (v.kind === "draft") return v.projectId;
+  if (v.kind === "experiment") return s.experiments[v.experimentId]?.projectId;
   if (v.kind === "thread") {
     const paneId = resolveActivePaneId(v.panes, s.focusedPaneId);
     const draftProjectId = parseDraftProjectId(paneId);

--- a/src/renderer/actions/experimentActions.test.ts
+++ b/src/renderer/actions/experimentActions.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, PromptSegment } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
+import { launchExperiment } from "./experimentActions";
+
+const { bridge } = vi.hoisted(() => ({
+  bridge: {
+    gitAddWorktree: vi.fn<() => Promise<{ path: string }>>(),
+    startThread: vi.fn<() => Promise<{ threadId: string }>>(),
+    gitWatchWorktrees: vi.fn<() => Promise<void>>(),
+  },
+}));
+const { refreshGitProject, getProjectActiveWorktreePaths } = vi.hoisted(() => ({
+  refreshGitProject: vi.fn<() => void>(),
+  getProjectActiveWorktreePaths: vi.fn<() => string[]>(),
+}));
+const { performWorktreeRemoval } = vi.hoisted(() => ({
+  performWorktreeRemoval: vi.fn<() => Promise<void>>(),
+}));
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    danger: vi.fn<() => void>(),
+    success: vi.fn<() => void>(),
+  },
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+vi.mock("@/renderer/state/gitRefresh", () => ({
+  refreshGitProject,
+  getProjectActiveWorktreePaths,
+}));
+
+vi.mock("@/renderer/actions/worktreeActions", () => ({
+  performWorktreeRemoval,
+}));
+
+vi.mock("@heroui/react", () => ({ toast }));
+
+describe("experimentActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProjectActiveWorktreePaths.mockReturnValue([]);
+    performWorktreeRemoval.mockResolvedValue(undefined);
+    bridge.gitWatchWorktrees.mockResolvedValue(undefined);
+    bridge.startThread.mockResolvedValue({ threadId: "thread" });
+    useAppStore.setState((state) => ({
+      ...state,
+      projects: [],
+      threads: [],
+      experiments: {},
+      view: { kind: "home" },
+      lastRuntimeConfigByThreadId: {},
+    }));
+  });
+
+  it("cleans up a partial launch instead of creating a one-candidate experiment", async () => {
+    bridge.gitAddWorktree
+      .mockResolvedValueOnce({ path: "/repo/.worktrees/a" })
+      .mockRejectedValueOnce(new Error("branch exists"));
+
+    const result = await launchExperiment({
+      project: makeProject(),
+      prompt: "fix the bug",
+      candidates: [
+        { agentKind: "codex", agentLabel: "Codex", config: { model: "gpt-5.4" } },
+        { agentKind: "claude", agentLabel: "Claude", config: { model: "opus" } },
+      ],
+    });
+
+    expect(result).toBeNull();
+    expect(performWorktreeRemoval).toHaveBeenCalledWith(
+      makeProject(),
+      "/repo/.worktrees/a",
+      expect.stringMatching(/^exp\//),
+    );
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().experiments).toEqual({});
+    expect(bridge.startThread).not.toHaveBeenCalled();
+  });
+
+  it("starts candidates with the original structured prompt segments", async () => {
+    bridge.gitAddWorktree
+      .mockResolvedValueOnce({ path: "/repo/.worktrees/a" })
+      .mockResolvedValueOnce({ path: "/repo/.worktrees/b" });
+    const segments: PromptSegment[] = [
+      { kind: "text", content: "fix " },
+      { kind: "file", path: "src/app.ts" },
+    ];
+
+    const result = await launchExperiment({
+      project: makeProject(),
+      prompt: "fix @src/app.ts",
+      segments,
+      candidates: [
+        { agentKind: "codex", agentLabel: "Codex", config: { model: "gpt-5.4" } },
+        { agentKind: "claude", agentLabel: "Claude", config: { model: "opus" } },
+      ],
+    });
+
+    expect(result).toEqual(expect.any(String));
+    expect(bridge.startThread).toHaveBeenCalledTimes(2);
+    expect(bridge.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "fix @src/app.ts",
+        segments,
+      }),
+    );
+  });
+});
+
+function makeProject(): Project {
+  return {
+    id: "project-1",
+    name: "Project",
+    location: { kind: "posix", path: "/repo" },
+    createdAt: "2026-06-15T00:00:00.000Z",
+  };
+}

--- a/src/renderer/actions/experimentActions.ts
+++ b/src/renderer/actions/experimentActions.ts
@@ -1,0 +1,418 @@
+import { toast } from "@heroui/react";
+import type {
+  AgentInstanceId,
+  ExperimentCandidate,
+  Project,
+  PromptSegment,
+  ThreadConfig,
+  ThreadPresentationMode,
+} from "@/shared/contracts";
+import { friendlyError } from "@/shared/messages";
+import { buildWorktreeLocation, sanitizeWorktreeBranchName } from "@/shared/worktree";
+import { readBridge } from "@/renderer/bridge";
+import { makeThreadTitle, useAppStore } from "@/renderer/state/appStore";
+import { getProjectActiveWorktreePaths, refreshGitProject } from "@/renderer/state/gitRefresh";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { performWorktreeRemoval } from "@/renderer/actions/worktreeActions";
+import { runGitMergeToSource, showGitOperationFailure } from "@/renderer/actions/gitCommandRunner";
+
+/** A single agent/model the same prompt should be fanned out to. */
+export interface ExperimentCandidateSpec {
+  agentKind: string;
+  agentInstanceId?: AgentInstanceId;
+  /** Display label (provider name) captured for the board + branch names. */
+  agentLabel?: string;
+  config: ThreadConfig;
+  presentationMode?: ThreadPresentationMode;
+}
+
+export interface LaunchExperimentInput {
+  project: Project;
+  prompt: string;
+  segments?: PromptSegment[];
+  /** Branch every candidate forks from and the winner merges back into. */
+  baseBranch?: string;
+  candidates: ExperimentCandidateSpec[];
+}
+
+const DEFAULT_LAUNCH_SIZE = { cols: 120, rows: 40 } as const;
+
+function candidateLabel(spec: ExperimentCandidateSpec): string {
+  const provider = spec.agentLabel ?? spec.agentKind;
+  return spec.config.model ? `${provider} · ${spec.config.model}` : provider;
+}
+
+/**
+ * Fan one prompt out across several agent/model candidates. Each candidate runs
+ * in its own fresh worktree (branched from `baseBranch`) so their diffs can be
+ * compared side-by-side on the experiment board and the winner merged back.
+ *
+ * Returns the new experiment id, or `null` if no candidate could be launched.
+ */
+export async function launchExperiment(input: LaunchExperimentInput): Promise<string | null> {
+  const { project, prompt, segments, baseBranch, candidates } = input;
+  if (candidates.length < 2) {
+    toast.danger("Choose at least two candidates for an experiment.");
+    return null;
+  }
+
+  const experimentId = crypto.randomUUID();
+  const title = makeThreadTitle(prompt) || "Experiment";
+  const promptSlug = sanitizeWorktreeBranchName(title).slice(0, 24) || "experiment";
+  const shortId = experimentId.slice(0, 6);
+
+  interface PreparedCandidate {
+    spec: ExperimentCandidateSpec;
+    worktreePath: string;
+    worktreeBranch: string;
+    label: string;
+  }
+
+  // Create worktrees sequentially: concurrent `git worktree add` in the same
+  // repo races on index.lock. Failures skip just that candidate.
+  const prepared: PreparedCandidate[] = [];
+  const usedBranches = new Set<string>();
+  for (let i = 0; i < candidates.length; i++) {
+    const spec = candidates[i]!;
+    const agentSlug = sanitizeWorktreeBranchName(candidateLabel(spec)).slice(0, 16);
+    let branch = `exp/${promptSlug}-${agentSlug}-${shortId}`;
+    if (usedBranches.has(branch)) branch = `${branch}-${i + 1}`;
+    usedBranches.add(branch);
+    try {
+      const result = await readBridge().gitAddWorktree({
+        projectLocation: project.location,
+        branch,
+        createBranch: true,
+        ...(baseBranch ? { startPoint: baseBranch } : {}),
+        ...(project.scripts?.worktreeCopyPatterns
+          ? { copyIgnoredPatterns: project.scripts.worktreeCopyPatterns }
+          : {}),
+        transferUncommitted: false,
+        keepChangesInSource: false,
+      });
+      prepared.push({
+        spec,
+        worktreePath: result.path,
+        worktreeBranch: branch,
+        label: candidateLabel(spec),
+      });
+    } catch (err) {
+      console.error("[experiment] failed to create worktree for candidate", err);
+      toast.danger(`${candidateLabel(spec)}: ${friendlyError(err)}`);
+    }
+  }
+
+  if (prepared.length < 2) {
+    toast.danger(
+      prepared.length === 0
+        ? "Couldn't create any worktrees for the experiment."
+        : "Only one experiment worktree was created; cleaned it up instead of launching.",
+    );
+    await Promise.all(
+      prepared.map((candidate) =>
+        performWorktreeRemoval(project, candidate.worktreePath, candidate.worktreeBranch).catch(
+          (err) => console.warn("[experiment] failed to clean up partial launch", err),
+        ),
+      ),
+    );
+    void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+    return null;
+  }
+
+  const store = useAppStore.getState();
+  const threads = store.createThreadsBatch(
+    prepared.map((p) => ({
+      projectId: project.id,
+      agentKind: p.spec.agentKind,
+      ...(p.spec.agentInstanceId ? { agentInstanceId: p.spec.agentInstanceId } : {}),
+      config: p.spec.config,
+      prompt,
+      title: p.label,
+      worktreePath: p.worktreePath,
+      worktreeBranch: p.worktreeBranch,
+      groupId: experimentId,
+      groupName: title,
+      ...(p.spec.presentationMode ? { presentationMode: p.spec.presentationMode } : {}),
+    })),
+  );
+
+  const candidateRecords: ExperimentCandidate[] = threads.map((thread, idx) => {
+    const p = prepared[idx]!;
+    return {
+      threadId: thread.id,
+      agentKind: p.spec.agentKind,
+      ...(p.spec.agentLabel ? { agentLabel: p.spec.agentLabel } : {}),
+      ...(p.spec.config.model ? { model: p.spec.config.model } : {}),
+      worktreePath: p.worktreePath,
+      worktreeBranch: p.worktreeBranch,
+    };
+  });
+
+  store.createExperimentRecord({
+    id: experimentId,
+    projectId: project.id,
+    title,
+    prompt,
+    ...(baseBranch ? { baseBranch } : {}),
+    candidates: candidateRecords,
+  });
+
+  // Launch each candidate directly: the experiment board does not mount the
+  // full ThreadView, so we can't rely on its queued-launch effect. The agents
+  // run in the supervisor regardless; opening a candidate later just reattaches.
+  for (let idx = 0; idx < threads.length; idx++) {
+    const thread = threads[idx]!;
+    const p = prepared[idx]!;
+    const projectLocation = buildWorktreeLocation(project.location, p.worktreePath);
+    void readBridge()
+      .startThread({
+        threadId: thread.id,
+        projectLocation,
+        agentKind: thread.agentKind,
+        ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
+        config: thread.config,
+        prompt,
+        ...(segments ? { segments } : {}),
+        initialSize: DEFAULT_LAUNCH_SIZE,
+        ...(thread.presentationMode ? { presentationMode: thread.presentationMode } : {}),
+      })
+      .catch((err) => {
+        console.error("[experiment] failed to start candidate thread", err);
+        useAppStore.getState().updateThreadRuntime(thread.id, {
+          status: "error",
+          attention: "error",
+          canResumeWithConfig: false,
+        });
+      });
+  }
+
+  // Prime git state for the new worktrees so the board shows diff stats without
+  // waiting for the next background refresh.
+  const worktreePaths = [
+    ...new Set([
+      ...getProjectActiveWorktreePaths(project.id),
+      ...prepared.map((p) => p.worktreePath),
+    ]),
+  ].sort();
+  void readBridge()
+    .gitWatchWorktrees({ projectId: project.id, worktreePaths })
+    .catch(() => undefined);
+  void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+
+  store.openExperiment(experimentId);
+  return experimentId;
+}
+
+/**
+ * Merge the chosen candidate's branch into the experiment's base branch, then
+ * archive the losers (close their threads + remove their worktrees/branches).
+ */
+export async function mergeExperimentWinner(
+  experimentId: string,
+  winnerThreadId: string,
+): Promise<void> {
+  const state = useAppStore.getState();
+  const experiment = state.experiments[experimentId];
+  if (!experiment) return;
+  const project = state.projects.find((p) => p.id === experiment.projectId);
+  if (!project) return;
+  const winner = experiment.candidates.find((c) => c.threadId === winnerThreadId);
+  if (!winner) return;
+
+  let sourceBranch = experiment.baseBranch;
+  if (!sourceBranch) {
+    try {
+      const res = await readBridge().gitGetWorktreeSourceBranch({
+        projectLocation: project.location,
+        branch: winner.worktreeBranch,
+      });
+      sourceBranch = res.sourceBranch ?? undefined;
+    } catch {
+      // fall through to the missing-branch guard below
+    }
+  }
+  if (!sourceBranch) {
+    toast.danger("Couldn't determine which branch to merge into.");
+    return;
+  }
+
+  const worktreeLocation = buildWorktreeLocation(project.location, winner.worktreePath);
+  let result;
+  try {
+    result = await runGitMergeToSource({
+      projectLocation: project.location,
+      worktreeLocation,
+      worktreeBranch: winner.worktreeBranch,
+      sourceBranch,
+    });
+  } catch (err) {
+    toast.danger(friendlyError(err));
+    return;
+  }
+
+  if (!result.merged) {
+    showGitOperationFailure(result);
+    return;
+  }
+
+  toast.success(
+    result.fastForward
+      ? `Merged ${winner.worktreeBranch} into ${sourceBranch}`
+      : `Merged ${winner.worktreeBranch} into ${sourceBranch} (merge commit)`,
+  );
+
+  state.setExperimentWinner(experimentId, winnerThreadId);
+
+  // Archive the losers: close their agents, drop their worktrees/branches, and
+  // hide the threads from the active list (history is still recoverable).
+  const losers = experiment.candidates.filter((c) => c.threadId !== winnerThreadId);
+  await Promise.all(
+    losers.map(async (loser) => {
+      await readBridge()
+        .closeThread({ threadId: loser.threadId })
+        .catch(() => undefined);
+      useAppStore.getState().archiveThread(loser.threadId);
+      await performWorktreeRemoval(project, loser.worktreePath, loser.worktreeBranch).catch((err) =>
+        console.warn("[experiment] failed to remove loser worktree", err),
+      );
+    }),
+  );
+
+  void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+}
+
+/**
+ * Abandon an experiment without picking a winner: close every candidate, remove
+ * all worktrees/branches, and drop the experiment record.
+ */
+export async function discardExperiment(experimentId: string): Promise<void> {
+  const state = useAppStore.getState();
+  const experiment = state.experiments[experimentId];
+  if (!experiment) return;
+  const project = state.projects.find((p) => p.id === experiment.projectId);
+
+  if (state.view.kind === "experiment" && state.view.experimentId === experimentId) {
+    state.closeExperiment();
+  }
+
+  for (const candidate of experiment.candidates) {
+    await readBridge()
+      .closeThread({ threadId: candidate.threadId })
+      .catch(() => undefined);
+    useAppStore.getState().archiveThread(candidate.threadId);
+    if (project) {
+      await performWorktreeRemoval(project, candidate.worktreePath, candidate.worktreeBranch).catch(
+        (err) => console.warn("[experiment] failed to remove worktree", err),
+      );
+    }
+  }
+
+  useAppStore.getState().removeExperiment(experimentId);
+  if (project) {
+    void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+  }
+}
+
+/** Resolve a default base branch for a project from its current git status. */
+export function resolveProjectBaseBranch(projectId: string): string | undefined {
+  return useGitStore.getState().statuses[projectId]?.branch || undefined;
+}
+
+// Low-signal files the judge shouldn't waste budget on (lockfiles, minified
+// bundles, sourcemaps). Mirrors the filtering cmux applies before judging.
+const NOISE_PATH =
+  /(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|[^/]*\.lock|[^/]*\.min\.(js|css)|[^/]*\.map)$/i;
+
+/** Concatenate a worktree's staged + unstaged diffs, dropping low-signal files. */
+async function collectCandidateDiff(project: Project, worktreePath: string): Promise<string> {
+  const projectLocation = buildWorktreeLocation(project.location, worktreePath);
+  try {
+    const status = await readBridge().getGitStatus({ projectLocation });
+    const untrackedPaths = status.unstaged
+      .filter((file) => file.status === "?")
+      .map((file) => file.path);
+    const batch = await readBridge().getGitDiffBatch({ projectLocation, untrackedPaths });
+    const parts: string[] = [];
+    for (const record of [batch.unstaged, batch.staged]) {
+      for (const [path, diff] of Object.entries(record)) {
+        if (NOISE_PATH.test(path)) continue;
+        if (diff.trim()) parts.push(diff);
+      }
+    }
+    return parts.join("\n");
+  } catch (err) {
+    console.warn("[experiment] failed to collect candidate diff", err);
+    return "";
+  }
+}
+
+/**
+ * Run the LLM judge ("crown"): gather each candidate's diff, ask a model to
+ * pick the best, and record the result as an AI crown (overridable by the
+ * user). Candidate diffs are sent with anonymized labels so the judge can't be
+ * biased by which provider produced which diff. Returns true on success.
+ */
+export async function crownExperiment(experimentId: string): Promise<boolean> {
+  const state = useAppStore.getState();
+  const experiment = state.experiments[experimentId];
+  if (!experiment) return false;
+  const project = state.projects.find((p) => p.id === experiment.projectId);
+  if (!project) return false;
+  if (experiment.candidates.length < 2) {
+    toast.danger("Need at least two candidates to crown a winner.");
+    return false;
+  }
+
+  const diffs = await Promise.all(
+    experiment.candidates.map((c) => collectCandidateDiff(project, c.worktreePath)),
+  );
+  if (diffs.every((d) => !d.trim())) {
+    toast.danger("No changes yet — let the agents finish before crowning.");
+    return false;
+  }
+
+  // Judge through the first candidate's provider (reuses its auth/config); the
+  // label is anonymized but the threadId is preserved for mapping the winner.
+  const judgeAgentKind = experiment.candidates[0]!.agentKind;
+  const judgeModel = experiment.candidates[0]!.model;
+  const judgeLabel = judgeModel
+    ? `${experiment.candidates[0]!.agentLabel ?? judgeAgentKind} · ${judgeModel}`
+    : (experiment.candidates[0]!.agentLabel ?? judgeAgentKind);
+
+  let result;
+  try {
+    result = await readBridge().judgeExperiment({
+      projectLocation: project.location,
+      agentKind: judgeAgentKind,
+      ...(judgeModel ? { model: judgeModel } : {}),
+      prompt: experiment.prompt,
+      candidates: experiment.candidates.map((c, idx) => ({
+        threadId: c.threadId,
+        label: `Solution ${String.fromCharCode(65 + idx)}`,
+        diff: diffs[idx] ?? "",
+      })),
+    });
+  } catch (err) {
+    toast.danger(`Crown judge failed: ${friendlyError(err)}`);
+    return false;
+  }
+
+  useAppStore.getState().setExperimentCrown(experimentId, {
+    threadId: result.winnerThreadId,
+    rationale: result.rationale,
+    source: "ai",
+    modelLabel: judgeLabel,
+    createdAt: new Date().toISOString(),
+  });
+  return true;
+}
+
+/** Manually crown a candidate (overrides any AI crown). */
+export function setManualCrown(experimentId: string, threadId: string): void {
+  useAppStore.getState().setExperimentCrown(experimentId, {
+    threadId,
+    rationale: "Selected by you.",
+    source: "user",
+    createdAt: new Date().toISOString(),
+  });
+}

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -4,11 +4,14 @@ import type { Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 import {
   deleteThread,
   openThread,
+  openThreadStandalone,
   reopenStoredThread,
+  sweepStaleThreads,
   switchToAdjacentThread,
   toggleMarkThreadDone,
 } from "./threadActions";
@@ -41,6 +44,7 @@ vi.mock("@/renderer/state/chatRuntimePersister", () => ({
 
 describe("threadActions", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     localStorage.clear();
     hasHydratedThreadRuntimeItems.mockReturnValue(false);
@@ -55,7 +59,9 @@ describe("threadActions", () => {
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
       runtimeCompletedTurnsByThread: {},
+      experiments: {},
     }));
+    useSharedSettings.setState({ staleThreadUnloadMinutes: 0 });
     useDevTerminalStore.setState({
       isOpen: false,
       activeProjectId: null,
@@ -153,6 +159,32 @@ describe("threadActions", () => {
     });
   });
 
+  it("hydrates only the selected GUI thread when opening a standalone grouped thread", async () => {
+    const firstThread = makeThread({
+      id: "thread-group-a",
+      groupId: "group-1",
+      presentationMode: "gui",
+    });
+    const secondThread = makeThread({
+      id: "thread-group-b",
+      groupId: "group-1",
+      presentationMode: "gui",
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [firstThread, secondThread] }));
+
+    openThreadStandalone(firstThread.id);
+
+    expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(firstThread.id);
+    expect(hydrateThreadRuntimeItems).not.toHaveBeenCalledWith(secondThread.id);
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({
+        kind: "thread",
+        panes: [firstThread.id],
+      });
+    });
+  });
+
   it("queues terminal reconnects as launching when reopening", () => {
     const thread = makeThread({
       status: "inactive",
@@ -188,6 +220,49 @@ describe("threadActions", () => {
     expect(reopened?.status).toBe("idle");
     expect(reopened?.attention).toBe("none");
     expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
+  });
+
+  it("does not sweep idle experiment candidates while the board is open", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-15T12:00:00.000Z"));
+    useSharedSettings.setState({ staleThreadUnloadMinutes: 1 });
+    const candidate = makeThread({
+      id: "thread-candidate",
+      status: "idle",
+      updatedAt: "2026-06-15T11:00:00.000Z",
+      sessionRef: {
+        providerSessionId: "session-1",
+        discoveredAt: "2026-06-15T11:00:00.000Z",
+      },
+    });
+    useAppStore.setState((state) => ({
+      ...state,
+      threads: [candidate],
+      view: { kind: "experiment", experimentId: "exp-1" },
+      experiments: {
+        "exp-1": {
+          id: "exp-1",
+          projectId: candidate.projectId,
+          title: "Experiment",
+          prompt: "try",
+          candidates: [
+            {
+              threadId: candidate.id,
+              agentKind: candidate.agentKind,
+              worktreePath: "/repo/.worktrees/exp",
+              worktreeBranch: "exp/test",
+            },
+          ],
+          status: "running",
+          createdAt: "2026-06-15T11:00:00.000Z",
+          updatedAt: "2026-06-15T11:00:00.000Z",
+        },
+      },
+    }));
+
+    sweepStaleThreads();
+
+    expect(bridge.closeThread).not.toHaveBeenCalledWith({ threadId: candidate.id });
   });
 
   it("closes a live CLI thread when marking done even before a session ref is known", async () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -145,6 +145,41 @@ export function switchToAdjacentThread(current: Thread, direction: "next" | "pre
   if (nextId && nextId !== current.id) openThread(nextId);
 }
 
+export function openThreadStandalone(
+  threadId: string,
+  options?: { focusComposer?: boolean },
+): void {
+  const thread = useAppStore.getState().threads.find((item) => item.id === threadId);
+  const requestId = ++openThreadRequestId;
+  const shouldHydrate =
+    thread?.presentationMode === "gui" && !hasHydratedThreadRuntimeItems(thread.id);
+
+  const applyOpen = () => {
+    if (requestId !== openThreadRequestId) return;
+
+    startTransition(() => {
+      useAppStore.getState().openThreadStandalone(threadId);
+      if (options?.focusComposer) {
+        useAppStore.getState().requestComposerFocus(threadId);
+      }
+      if (thread?.presentationMode === "gui") {
+        useAppStore.getState().requestChatScrollToBottom(threadId);
+      }
+    });
+
+    if (thread?.status === "inactive") {
+      reopenStoredThread(threadId);
+    }
+  };
+
+  if (shouldHydrate) {
+    void hydrateThreadRuntimeItems(thread.id).then(applyOpen, applyOpen);
+    return;
+  }
+
+  applyOpen();
+}
+
 function getGuiThreadIdsToHydrateBeforeOpen(threadId: string): string[] {
   const state = useAppStore.getState();
   const clickedThread = state.threads.find((thread) => thread.id === threadId);
@@ -216,7 +251,7 @@ export function sweepStaleThreads(): void {
   if (staleThreadUnloadMinutes <= 0) return;
 
   const store = useAppStore.getState();
-  const visibleThreadIds = new Set(store.view.kind === "thread" ? store.view.panes : []);
+  const visibleThreadIds = new Set(getCurrentViewThreadIds(store));
   const staleBefore = Date.now() - staleThreadUnloadMinutes * 60_000;
 
   for (const thread of store.threads) {
@@ -232,6 +267,14 @@ export function sweepStaleThreads(): void {
 
     void unloadStoredThread(thread.id).catch(() => undefined);
   }
+}
+
+function getCurrentViewThreadIds(store: ReturnType<typeof useAppStore.getState>): string[] {
+  if (store.view.kind === "thread") return store.view.panes;
+  if (store.view.kind === "experiment") {
+    return store.experiments[store.view.experimentId]?.candidates.map((c) => c.threadId) ?? [];
+  }
+  return [];
 }
 
 export function archiveThread(threadId: string): void {

--- a/src/renderer/components/experiment/NewExperimentModal.tsx
+++ b/src/renderer/components/experiment/NewExperimentModal.tsx
@@ -1,0 +1,346 @@
+import { useState } from "react";
+import { useShallow } from "zustand/shallow";
+import { Button, Label, Modal } from "@heroui/react";
+import { FlaskConical, Loader2, Plus, X } from "lucide-react";
+import type { AgentStatus, Project, PromptSegment, ThreadConfig } from "@/shared/contracts";
+import { getProjectAgentStatuses } from "@/shared/agentStatus";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { useExperimentLauncherStore } from "@/renderer/state/experimentLauncherStore";
+import {
+  launchExperiment,
+  resolveProjectBaseBranch,
+  type ExperimentCandidateSpec,
+} from "@/renderer/actions/experimentActions";
+
+interface CandidateDraft {
+  agentKind: string;
+  model: string;
+  baseConfig: ThreadConfig | null;
+}
+
+export function NewExperimentModal() {
+  const { open, projectId, initialPrompt, initialSegments, initialCandidate, sessionId, close } =
+    useExperimentLauncherStore(
+      useShallow((s) => ({
+        open: s.open,
+        projectId: s.projectId,
+        initialPrompt: s.initialPrompt,
+        initialSegments: s.initialSegments,
+        initialCandidate: s.initialCandidate,
+        sessionId: s.sessionId,
+        close: s.close,
+      })),
+    );
+
+  return (
+    <Modal.Backdrop
+      isOpen={open}
+      onOpenChange={(next) => {
+        if (!next) close();
+      }}
+    >
+      <Modal.Container>
+        <Modal.Dialog className="sm:max-w-xl">
+          {open && projectId ? (
+            <NewExperimentModalInner
+              key={sessionId}
+              projectId={projectId}
+              initialPrompt={initialPrompt}
+              initialSegments={initialSegments}
+              initialCandidate={initialCandidate}
+              onClose={close}
+            />
+          ) : null}
+        </Modal.Dialog>
+      </Modal.Container>
+    </Modal.Backdrop>
+  );
+}
+
+function defaultModelForAgent(agent: AgentStatus | undefined): string {
+  return agent?.capabilities.models[0]?.id ?? "";
+}
+
+function defaultConfigForAgent(agent: AgentStatus | undefined, model: string): ThreadConfig {
+  const caps = agent?.capabilities;
+  return {
+    model,
+    ...(caps?.defaultEffort ? { effort: caps.defaultEffort } : {}),
+    ...(caps?.defaultApprovalPolicy ? { approvalPolicy: caps.defaultApprovalPolicy } : {}),
+    ...(caps?.defaultSandboxMode ? { sandboxMode: caps.defaultSandboxMode } : {}),
+    ...(caps?.defaultContextSize ? { contextSize: caps.defaultContextSize } : {}),
+  };
+}
+
+function NewExperimentModalInner(props: {
+  projectId: string;
+  initialPrompt: string;
+  initialSegments: PromptSegment[];
+  initialCandidate: { agentKind: string; config?: ThreadConfig; model?: string } | null;
+  onClose: () => void;
+}) {
+  const project = useAppStore(
+    useShallow((s) => s.projects.find((p) => p.id === props.projectId)),
+  ) as Project | undefined;
+
+  const agents = useAgentStatusesStore(
+    useShallow((s) =>
+      project ? getProjectAgentStatuses(project.location, s.agentStatuses, s.wslAgentStatuses) : [],
+    ),
+  );
+  const installedAgents = agents.filter((a) => a.installed && a.capabilities.models.length > 0);
+
+  const branchList = useGitStore((s) => s.branches[props.projectId]);
+  const localBranches = branchList?.branches.map((b) => b.name) ?? [];
+
+  const agentByKind = (kind: string): AgentStatus | undefined =>
+    installedAgents.find((a) => a.kind === kind);
+
+  const [prompt, setPrompt] = useState(props.initialPrompt);
+  const [baseBranch, setBaseBranch] = useState(
+    () => resolveProjectBaseBranch(props.projectId) ?? branchList?.current ?? "",
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [candidates, setCandidates] = useState<CandidateDraft[]>(() => {
+    if (installedAgents.length === 0) return [];
+    const seedKind =
+      props.initialCandidate && agentByKind(props.initialCandidate.agentKind)
+        ? props.initialCandidate.agentKind
+        : installedAgents[0]!.kind;
+    const seedAgent = agentByKind(seedKind);
+    const first: CandidateDraft = {
+      agentKind: seedKind,
+      model:
+        props.initialCandidate?.config?.model ??
+        props.initialCandidate?.model ??
+        defaultModelForAgent(seedAgent),
+      baseConfig: props.initialCandidate?.config ?? null,
+    };
+    // Seed a second row to nudge toward an actual fan-out: a different provider
+    // when one is installed, otherwise the same agent again (a "voting" run).
+    const secondAgent = installedAgents.find((a) => a.kind !== seedKind) ?? seedAgent;
+    const second: CandidateDraft = {
+      agentKind: secondAgent?.kind ?? seedKind,
+      model: defaultModelForAgent(secondAgent),
+      baseConfig: null,
+    };
+    return [first, second];
+  });
+
+  function updateCandidate(idx: number, patch: Partial<CandidateDraft>) {
+    setCandidates((prev) => prev.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+  }
+
+  function changeAgent(idx: number, agentKind: string) {
+    updateCandidate(idx, {
+      agentKind,
+      model: defaultModelForAgent(agentByKind(agentKind)),
+      baseConfig: null,
+    });
+  }
+
+  function addCandidate() {
+    const agent = installedAgents[0];
+    if (!agent) return;
+    setCandidates((prev) => [
+      ...prev,
+      { agentKind: agent.kind, model: defaultModelForAgent(agent), baseConfig: null },
+    ]);
+  }
+
+  function removeCandidate(idx: number) {
+    setCandidates((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  const canLaunch =
+    !!project &&
+    prompt.trim().length > 0 &&
+    candidates.length >= 2 &&
+    candidates.every((c) => {
+      const agent = agentByKind(c.agentKind);
+      return !!agent && agent.capabilities.models.some((m) => m.id === c.model);
+    }) &&
+    !submitting;
+
+  async function handleLaunch() {
+    if (!project || !canLaunch) return;
+    const trimmedPrompt = prompt.trim();
+    const segments =
+      props.initialSegments.length > 0 && trimmedPrompt === props.initialPrompt.trim()
+        ? props.initialSegments
+        : undefined;
+    const specs: ExperimentCandidateSpec[] = candidates.map((c) => {
+      const agent = agentByKind(c.agentKind);
+      const caps = agent?.capabilities;
+      const defaults = defaultConfigForAgent(agent, c.model);
+      return {
+        agentKind: c.agentKind,
+        ...(agent ? { agentLabel: agent.label } : {}),
+        config: {
+          ...defaults,
+          ...(c.baseConfig ?? {}),
+          model: c.model,
+        },
+        ...(caps ? { presentationMode: caps.presentationMode } : {}),
+      };
+    });
+    setSubmitting(true);
+    try {
+      const id = await launchExperiment({
+        project,
+        prompt: trimmedPrompt,
+        ...(segments ? { segments } : {}),
+        ...(baseBranch ? { baseBranch } : {}),
+        candidates: specs,
+      });
+      if (id) props.onClose();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const selectClass =
+    "rounded-md border border-[var(--hairline)] bg-transparent px-2 py-1 text-sm outline-none";
+
+  return (
+    <>
+      <Modal.CloseTrigger />
+      <Modal.Header>
+        <Modal.Heading>
+          <span className="flex items-center gap-2">
+            <FlaskConical className="size-4 text-amber-500" />
+            New experiment
+          </span>
+        </Modal.Heading>
+        <p className="mt-1 text-xs text-muted">
+          Fan one prompt out across multiple agents, then compare and merge the winner.
+        </p>
+      </Modal.Header>
+      <Modal.Body className="flex flex-col gap-4 p-4">
+        {installedAgents.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted">
+            No installed agents with selectable models for this project.
+          </p>
+        ) : (
+          <>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs font-medium text-muted">Prompt</Label>
+              <textarea
+                // eslint-disable-next-line jsx-a11y/no-autofocus -- desktop modal, expected UX
+                autoFocus
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={4}
+                placeholder="Describe the task to fan out across agents…"
+                className="resize-y rounded-md border border-[var(--hairline)] bg-transparent px-2.5 py-2 text-sm outline-none focus:border-amber-400/60"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Label className="text-xs font-medium text-muted">Fork from</Label>
+              {localBranches.length > 0 ? (
+                <select
+                  aria-label="Base branch"
+                  value={baseBranch}
+                  onChange={(e) => setBaseBranch(e.target.value)}
+                  className={`flex-1 ${selectClass}`}
+                >
+                  {!localBranches.includes(baseBranch) && baseBranch && (
+                    <option value={baseBranch}>{baseBranch}</option>
+                  )}
+                  {localBranches.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <span className="flex-1 font-mono text-sm text-foreground/80">
+                  {baseBranch || "current branch"}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label className="text-xs font-medium text-muted">
+                Candidates ({candidates.length})
+              </Label>
+              {candidates.map((candidate, idx) => {
+                const agent = agentByKind(candidate.agentKind);
+                const models = agent?.capabilities.models ?? [];
+                return (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-2 rounded-md border border-[var(--hairline)] px-2 py-1.5"
+                  >
+                    <select
+                      aria-label="Agent"
+                      value={candidate.agentKind}
+                      onChange={(e) => changeAgent(idx, e.target.value)}
+                      className={selectClass}
+                    >
+                      {installedAgents.map((a) => (
+                        <option key={a.kind} value={a.kind}>
+                          {a.label}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      aria-label="Model"
+                      value={candidate.model}
+                      onChange={(e) => updateCandidate(idx, { model: e.target.value })}
+                      className={`min-w-0 flex-1 ${selectClass}`}
+                    >
+                      {models.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {m.label}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      aria-label="Remove candidate"
+                      disabled={candidates.length <= 1}
+                      onClick={() => removeCandidate(idx)}
+                      className="shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-rose-500 disabled:cursor-not-allowed disabled:opacity-30"
+                    >
+                      <X className="size-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+              <button
+                type="button"
+                onClick={addCandidate}
+                className="inline-flex w-fit items-center gap-1 rounded-md border border-dashed border-[var(--hairline)] px-2 py-1 text-xs text-muted transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
+              >
+                <Plus className="size-3" />
+                Add candidate
+              </button>
+            </div>
+          </>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button slot="close" variant="ghost" className="text-muted">
+          Cancel
+        </Button>
+        <Button
+          variant="tertiary"
+          isDisabled={!canLaunch}
+          isPending={submitting}
+          onPress={() => void handleLaunch()}
+        >
+          {submitting ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <FlaskConical className="size-3.5" />
+          )}
+          Run experiment
+        </Button>
+      </Modal.Footer>
+    </>
+  );
+}

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Tooltip, toast } from "@heroui/react";
-import { Download, Webhook, X } from "lucide-react";
+import { Download, FlaskConical, Webhook, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   AgentHookPluginStatus,
@@ -37,6 +37,7 @@ import {
 } from "@/renderer/components/common";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { useExperimentLauncherStore } from "@/renderer/state/experimentLauncherStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { ThreadCommandPanel } from "./ThreadCommandPanel";
 import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
@@ -636,6 +637,34 @@ export function ThreadDraftComposerArea(props: {
         }}
         afterControls={() => (
           <>
+            {!isHomeScope ? (
+              <Tooltip delay={0}>
+                <Tooltip.Trigger>
+                  <button
+                    type="button"
+                    aria-label="Run as experiment"
+                    className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted/70 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
+                    onClick={() => {
+                      const segments = mentionRef.current?.serializeSegments() ?? [];
+                      const text = flattenSegments(segments) || prompt;
+                      useExperimentLauncherStore.getState().openLauncher({
+                        projectId: props.project.id,
+                        prompt: text,
+                        segments,
+                        candidate: {
+                          agentKind: props.selectedAgent.kind,
+                          config: props.config,
+                          model: props.config.model,
+                        },
+                      });
+                    }}
+                  >
+                    <FlaskConical className="size-4" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content>Run as experiment — fan out to multiple agents</Tooltip.Content>
+              </Tooltip>
+            ) : null}
             <ComposerAddMenu
               browserMcpEnabled={props.config.browserMcp === true}
               showBrowserOption={browserMcpScope !== "none"}

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -15,6 +15,7 @@ const EMPTY_THREADS: Thread[] = [];
 function selectCurrentProjectId(s: ReturnType<typeof useAppStore.getState>) {
   const v = s.view;
   if (v.kind === "draft") return v.projectId;
+  if (v.kind === "experiment") return s.experiments[v.experimentId]?.projectId;
   if (v.kind === "thread") {
     const firstPaneId = v.panes[0];
     if (!firstPaneId) return undefined;

--- a/src/renderer/hooks/useAppHydration.ts
+++ b/src/renderer/hooks/useAppHydration.ts
@@ -100,9 +100,21 @@ export function useAppHydration() {
           return;
         }
 
-        const currentView = useAppStore.getState().view;
-        const selectedIds = new Set(currentView.kind === "thread" ? currentView.panes : []);
-        const storeThreadIds = new Set(useAppStore.getState().threads.map((t) => t.id));
+        const store = useAppStore.getState();
+        const currentView = store.view;
+        // Threads referenced by the current view stay attached on reload;
+        // everything else gets its supervisor session closed. An experiment view
+        // references its candidate threads (which are still running), so include
+        // them — otherwise reloading the board would kill every candidate.
+        const viewThreadIds =
+          currentView.kind === "thread"
+            ? currentView.panes
+            : currentView.kind === "experiment"
+              ? (store.experiments[currentView.experimentId]?.candidates.map((c) => c.threadId) ??
+                [])
+              : [];
+        const selectedIds = new Set(viewThreadIds);
+        const storeThreadIds = new Set(store.threads.map((t) => t.id));
 
         for (const snapshot of snapshots) {
           if (!selectedIds.has(snapshot.threadId) && storeThreadIds.has(snapshot.threadId)) {

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -251,6 +251,45 @@ describe("appStore runtime config sync", () => {
     expect(view).toEqual({ kind: "thread", panes: [thread.id] });
   });
 
+  it("createThreadsBatch seeds launching threads without changing the current view", () => {
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    useAppStore.getState().openHome();
+
+    const threads = useAppStore.getState().createThreadsBatch([
+      {
+        projectId: project.id,
+        agentKind: "codex",
+        config: { model: "gpt-5.4", effort: "low" },
+        prompt: "try one",
+        title: "Candidate A",
+        groupId: "exp-1",
+        groupName: "Experiment",
+      },
+      {
+        projectId: project.id,
+        agentKind: "claude",
+        config: { model: "claude-test", effort: "high" },
+        prompt: "try one",
+        title: "Candidate B",
+        groupId: "exp-1",
+        groupName: "Experiment",
+      },
+    ]);
+
+    expect(useAppStore.getState().view).toEqual({ kind: "home" });
+    expect(useAppStore.getState().threads.map((thread) => thread.title)).toEqual([
+      "Candidate A",
+      "Candidate B",
+    ]);
+    expect(useAppStore.getState().lastRuntimeConfigByThreadId[threads[0]!.id]).toEqual({
+      model: "gpt-5.4",
+      effort: "low",
+    });
+  });
+
   it("openThread replaces panes[0] and keeps secondary panes", () => {
     const project = useAppStore.getState().addProject({
       kind: "windows",
@@ -299,6 +338,43 @@ describe("appStore runtime config sync", () => {
     useAppStore.getState().openThread(threadThree.id);
     const view = useAppStore.getState().view;
     expect(view).toEqual({ kind: "thread", panes: [threadThree.id, t2.id] });
+  });
+
+  it("openThreadStandalone opens one grouped thread without restoring the group split", () => {
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const groupId = "exp-1";
+    const t1 = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "a",
+      groupId,
+      groupName: "Experiment",
+    });
+    const t2 = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "m" },
+      prompt: "b",
+      groupId,
+      groupName: "Experiment",
+    });
+    useAppStore.setState((state) => ({
+      ...state,
+      groupLayouts: {
+        [groupId]: {
+          panes: [t1.id, t2.id],
+        },
+      },
+      view: { kind: "experiment", experimentId: groupId },
+    }));
+
+    useAppStore.getState().openThreadStandalone(t2.id);
+
+    expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: [t2.id] });
   });
 
   it("openThread is no-op when thread is already in panes", () => {

--- a/src/renderer/state/appStore.ts
+++ b/src/renderer/state/appStore.ts
@@ -3,6 +3,7 @@ import { persist, subscribeWithSelector } from "zustand/middleware";
 import type { Thread } from "@/shared/contracts";
 import { createDbStorage } from "./dbStorage";
 import { createDraftSlice } from "./slices/draftSlice";
+import { createExperimentSlice } from "./slices/experimentSlice";
 import { normalizeStoredThreadStatus } from "./slices/helpers";
 import { createLaunchSlice } from "./slices/launchSlice";
 import { createPendingSteerSlice } from "./slices/pendingSteerSlice";
@@ -29,6 +30,7 @@ export const useAppStore = create<AppStoreState>()(
         ...createRuntimeEventSlice(...a),
         ...createPendingSteerSlice(...a),
         ...createSubAgentOverlaySlice(...a),
+        ...createExperimentSlice(...a),
       }),
       {
         name: "lightcode-app-v2",
@@ -58,6 +60,7 @@ export const useAppStore = create<AppStoreState>()(
           threads: state.threads,
           view: state.view,
           groupLayouts: state.groupLayouts,
+          experiments: state.experiments,
         }),
       },
     ),

--- a/src/renderer/state/dbStorage.test.ts
+++ b/src/renderer/state/dbStorage.test.ts
@@ -36,29 +36,91 @@ describe("createDbStorage", () => {
       threads: unknown[];
       view: { kind: "home" };
       groupLayouts: Record<string, unknown>;
+      experiments: Record<string, unknown>;
     }>();
     const projects: unknown[] = [];
     const threads: unknown[] = [];
     const view = { kind: "home" as const };
     const groupLayouts = {};
+    const experiments = {};
 
     await storage.setItem("lightcode-app-v2", {
-      state: { projects, threads, view, groupLayouts },
+      state: { projects, threads, view, groupLayouts, experiments },
       version: 4,
     });
     await storage.setItem("lightcode-app-v2", {
-      state: { projects, threads, view, groupLayouts },
+      state: { projects, threads, view, groupLayouts, experiments },
       version: 4,
     });
 
     expect(bridge.dbSyncAll).toHaveBeenCalledTimes(1);
 
     await storage.setItem("lightcode-app-v2", {
-      state: { projects, threads: [...threads], view, groupLayouts },
+      state: { projects, threads: [...threads], view, groupLayouts, experiments },
       version: 4,
     });
 
     expect(bridge.dbSyncAll).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads experiment records from app state storage", async () => {
+    bridge.dbGetState.mockImplementation(async (key) => {
+      if (key === "view") return JSON.stringify({ kind: "experiment", experimentId: "exp-1" });
+      if (key === "experiments") {
+        return JSON.stringify({
+          "exp-1": {
+            id: "exp-1",
+            projectId: "project-1",
+            title: "Try things",
+            prompt: "fix it",
+            candidates: [],
+            status: "running",
+            createdAt: "2026-06-15T00:00:00.000Z",
+            updatedAt: "2026-06-15T00:00:00.000Z",
+          },
+        });
+      }
+      return null;
+    });
+    const storage = createDbStorage();
+
+    const value = await storage.getItem("lightcode-app-v2");
+
+    expect(value?.state).toMatchObject({
+      view: { kind: "experiment", experimentId: "exp-1" },
+      experiments: {
+        "exp-1": expect.objectContaining({ title: "Try things" }),
+      },
+    });
+  });
+
+  it("persists experiment records with app metadata", async () => {
+    const storage = createDbStorage();
+    const experiments = {
+      "exp-1": {
+        id: "exp-1",
+        projectId: "project-1",
+        title: "Try things",
+        prompt: "fix it",
+        candidates: [],
+        status: "running",
+        createdAt: "2026-06-15T00:00:00.000Z",
+        updatedAt: "2026-06-15T00:00:00.000Z",
+      },
+    };
+
+    await storage.setItem("lightcode-app-v2", {
+      state: {
+        projects: [],
+        threads: [],
+        view: { kind: "home" },
+        groupLayouts: {},
+        experiments,
+      },
+      version: 4,
+    } as never);
+
+    expect(bridge.dbSetState).toHaveBeenCalledWith("experiments", JSON.stringify(experiments));
   });
 
   it("still deduplicates generic persisted stores by serialized value", async () => {

--- a/src/renderer/state/dbStorage.ts
+++ b/src/renderer/state/dbStorage.ts
@@ -1,7 +1,7 @@
 import type { PersistStorage, StorageValue } from "zustand/middleware";
 import { readBridge } from "../bridge";
 import { captureRendererException } from "../diagnostics/sentry";
-import type { Project, Thread, AppView } from "@/shared/contracts";
+import type { AppView, Experiment, Project, Thread } from "@/shared/contracts";
 
 /**
  * Surface a persistence failure instead of silently dropping it. These writes
@@ -73,13 +73,21 @@ export function createDbStorage<S>(): PersistStorage<S> {
 
 /** Load projects + threads + view from SQLite and assemble into Zustand persist format. */
 async function loadAppStore(): Promise<StorageValue<unknown> | null> {
-  const [projects, threads, viewJson] = await Promise.all([
+  const [projects, threads, viewJson, groupLayoutsJson, experimentsJson] = await Promise.all([
     readBridge().dbGetProjects(),
     readBridge().dbGetThreads(),
     readBridge().dbGetState("view"),
+    readBridge().dbGetState("groupLayouts"),
+    readBridge().dbGetState("experiments"),
   ]);
 
-  if (projects.length === 0 && threads.length === 0 && !viewJson) {
+  if (
+    projects.length === 0 &&
+    threads.length === 0 &&
+    !viewJson &&
+    !groupLayoutsJson &&
+    !experimentsJson
+  ) {
     return null;
   }
 
@@ -93,7 +101,6 @@ async function loadAppStore(): Promise<StorageValue<unknown> | null> {
   }
 
   let groupLayouts: Record<string, unknown> = {};
-  const groupLayoutsJson = await readBridge().dbGetState("groupLayouts");
   if (groupLayoutsJson) {
     try {
       groupLayouts = JSON.parse(groupLayoutsJson) as Record<string, unknown>;
@@ -102,8 +109,17 @@ async function loadAppStore(): Promise<StorageValue<unknown> | null> {
     }
   }
 
+  let experiments: Record<string, Experiment> = {};
+  if (experimentsJson) {
+    try {
+      experiments = JSON.parse(experimentsJson) as Record<string, Experiment>;
+    } catch {
+      // corrupt — ignore
+    }
+  }
+
   return rememberStorageValue(APP_STORE_NAME, {
-    state: { projects, threads, view, groupLayouts },
+    state: { projects, threads, view, groupLayouts, experiments },
     version: 4,
   });
 }
@@ -117,6 +133,7 @@ async function saveAppStore(value: StorageValue<unknown>): Promise<void> {
           threads?: Thread[];
           view?: AppView;
           groupLayouts?: Record<string, unknown>;
+          experiments?: Record<string, Experiment>;
         }
       | undefined;
     if (!state || typeof state !== "object") return;
@@ -132,6 +149,11 @@ async function saveAppStore(value: StorageValue<unknown>): Promise<void> {
       readBridge()
         .dbSetState("groupLayouts", JSON.stringify(state.groupLayouts))
         .catch((error) => reportPersistError("group layouts", error));
+    }
+    if (state.experiments) {
+      readBridge()
+        .dbSetState("experiments", JSON.stringify(state.experiments))
+        .catch((error) => reportPersistError("experiments", error));
     }
   } catch (error) {
     // Synchronous failure (e.g. JSON.stringify on a circular structure).
@@ -182,6 +204,7 @@ function isSameAppStoreValue(
         threads?: Thread[];
         view?: AppView;
         groupLayouts?: Record<string, unknown>;
+        experiments?: Record<string, Experiment>;
       }
     | undefined;
   const nextState = next.state as
@@ -190,6 +213,7 @@ function isSameAppStoreValue(
         threads?: Thread[];
         view?: AppView;
         groupLayouts?: Record<string, unknown>;
+        experiments?: Record<string, Experiment>;
       }
     | undefined;
   if (!prevState || !nextState) return false;
@@ -197,6 +221,7 @@ function isSameAppStoreValue(
     prevState.projects === nextState.projects &&
     prevState.threads === nextState.threads &&
     prevState.view === nextState.view &&
-    prevState.groupLayouts === nextState.groupLayouts
+    prevState.groupLayouts === nextState.groupLayouts &&
+    prevState.experiments === nextState.experiments
   );
 }

--- a/src/renderer/state/experimentLauncherStore.ts
+++ b/src/renderer/state/experimentLauncherStore.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+import type { PromptSegment, ThreadConfig } from "@/shared/contracts";
+
+interface ExperimentLauncherSeedCandidate {
+  agentKind: string;
+  config?: ThreadConfig;
+  model?: string;
+}
+
+interface ExperimentLauncherState {
+  open: boolean;
+  projectId: string | null;
+  initialPrompt: string;
+  initialSegments: PromptSegment[];
+  initialCandidate: ExperimentLauncherSeedCandidate | null;
+  /** Bumped on every open so the modal can remount and re-seed its form. */
+  sessionId: number;
+  openLauncher: (input: {
+    projectId: string;
+    prompt?: string;
+    segments?: PromptSegment[];
+    candidate?: ExperimentLauncherSeedCandidate;
+  }) => void;
+  close: () => void;
+}
+
+export const useExperimentLauncherStore = create<ExperimentLauncherState>((set) => ({
+  open: false,
+  projectId: null,
+  initialPrompt: "",
+  initialSegments: [],
+  initialCandidate: null,
+  sessionId: 0,
+  openLauncher: ({ projectId, prompt, segments, candidate }) =>
+    set((state) => ({
+      open: true,
+      projectId,
+      initialPrompt: prompt ?? "",
+      initialSegments: segments ?? [],
+      initialCandidate: candidate ?? null,
+      sessionId: state.sessionId + 1,
+    })),
+  close: () =>
+    set({
+      open: false,
+      projectId: null,
+      initialPrompt: "",
+      initialSegments: [],
+      initialCandidate: null,
+    }),
+}));

--- a/src/renderer/state/slices/experimentSlice.ts
+++ b/src/renderer/state/slices/experimentSlice.ts
@@ -1,0 +1,83 @@
+import type { Experiment, ExperimentCandidate, ExperimentCrown } from "@/shared/contracts";
+import type { SliceCreator } from "./shared";
+
+export interface ExperimentSlice {
+  /** Experiment records keyed by experiment id (== the candidate threads' groupId). */
+  experiments: Record<string, Experiment>;
+  createExperimentRecord: (input: {
+    id: string;
+    projectId: string;
+    title: string;
+    prompt: string;
+    baseBranch?: string;
+    candidates: ExperimentCandidate[];
+  }) => void;
+  setExperimentCrown: (experimentId: string, crown: ExperimentCrown | undefined) => void;
+  setExperimentWinner: (experimentId: string, winnerThreadId: string) => void;
+  removeExperiment: (experimentId: string) => void;
+}
+
+export const createExperimentSlice: SliceCreator<ExperimentSlice> = (set) => ({
+  experiments: {},
+  createExperimentRecord: ({ id, projectId, title, prompt, baseBranch, candidates }) =>
+    set((state) => {
+      const now = new Date().toISOString();
+      const experiment: Experiment = {
+        id,
+        projectId,
+        title,
+        prompt,
+        ...(baseBranch ? { baseBranch } : {}),
+        candidates,
+        status: "running",
+        createdAt: now,
+        updatedAt: now,
+      };
+      return { experiments: { ...state.experiments, [id]: experiment } };
+    }),
+  setExperimentCrown: (experimentId, crown) =>
+    set((state) => {
+      const existing = state.experiments[experimentId];
+      if (!existing) return {};
+      const updatedAt = new Date().toISOString();
+      const { crown: _removedCrown, ...withoutCrown } = existing;
+      const nextExperiment = crown
+        ? { ...existing, crown, updatedAt }
+        : { ...withoutCrown, updatedAt };
+      return {
+        experiments: {
+          ...state.experiments,
+          [experimentId]: nextExperiment,
+        },
+      };
+    }),
+  setExperimentWinner: (experimentId, winnerThreadId) =>
+    set((state) => {
+      const existing = state.experiments[experimentId];
+      if (!existing) return {};
+      return {
+        experiments: {
+          ...state.experiments,
+          [experimentId]: {
+            ...existing,
+            winnerThreadId,
+            status: "decided",
+            updatedAt: new Date().toISOString(),
+          },
+        },
+      };
+    }),
+  removeExperiment: (experimentId) =>
+    set((state) => {
+      if (!(experimentId in state.experiments)) return {};
+      const { [experimentId]: _removed, ...experiments } = state.experiments;
+      const { [experimentId]: _removedLayout, ...groupLayouts } = state.groupLayouts;
+      return {
+        experiments,
+        groupLayouts,
+        ...(state.view.kind === "experiment" && state.view.experimentId === experimentId
+          ? { view: { kind: "home" as const } }
+          : {}),
+      };
+    }),
+});

--- a/src/renderer/state/slices/shared.ts
+++ b/src/renderer/state/slices/shared.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { DraftSlice } from "./draftSlice";
+import type { ExperimentSlice } from "./experimentSlice";
 import type { LaunchSlice } from "./launchSlice";
 import type { PendingSteerSlice } from "./pendingSteerSlice";
 import type { ProjectSlice } from "./projectSlice";
@@ -15,6 +16,7 @@ export type AppStoreState = ProjectSlice &
   ViewSlice &
   RuntimeEventSlice &
   PendingSteerSlice &
-  SubAgentOverlaySlice;
+  SubAgentOverlaySlice &
+  ExperimentSlice;
 
 export type SliceCreator<T> = StateCreator<AppStoreState, [], [], T>;

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -57,6 +57,28 @@ export interface ThreadSlice {
     replacePaneId?: string;
     presentationMode?: ThreadPresentationMode;
   }) => Thread;
+  /**
+   * Create several threads at once (e.g. experiment candidates) without
+   * touching `view` — the caller decides what to show next (the experiment
+   * board, not the threads). Each thread is created in `launching` status and
+   * its config is seeded into `lastRuntimeConfigByThreadId`, exactly as
+   * `createThread` does for a single thread.
+   */
+  createThreadsBatch: (
+    inputs: {
+      projectId: string;
+      agentKind: Thread["agentKind"];
+      agentInstanceId?: AgentInstanceId;
+      config: ThreadConfig;
+      prompt: string;
+      title?: string;
+      worktreePath?: string;
+      worktreeBranch?: string;
+      groupId?: string;
+      groupName?: string;
+      presentationMode?: ThreadPresentationMode;
+    }[],
+  ) => Thread[];
   deleteThread: (threadId: string) => void;
   renameThread: (threadId: string, title: string) => void;
   updateThreadConfig: (threadId: string, config: ThreadConfig) => void;
@@ -201,6 +223,50 @@ function deriveTurnTiming(
   };
 }
 
+interface BuildThreadInput {
+  projectId: string;
+  agentKind: Thread["agentKind"];
+  agentInstanceId?: AgentInstanceId;
+  config: ThreadConfig;
+  prompt: string;
+  /** Overrides the title derived from `prompt` (used for experiment candidates). */
+  title?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
+  groupId?: string;
+  groupName?: string;
+  presentationMode?: ThreadPresentationMode;
+}
+
+/** Construct a fresh `launching` thread. Shared by createThread/createThreadsBatch. */
+function buildThread(input: BuildThreadInput): Thread {
+  const now = new Date().toISOString();
+  const presentationMode = input.presentationMode ?? "terminal";
+  return {
+    id: crypto.randomUUID(),
+    projectId: input.projectId,
+    title: input.title ?? makeThreadTitle(input.prompt),
+    agentKind: input.agentKind,
+    ...(input.agentInstanceId ? { agentInstanceId: input.agentInstanceId } : {}),
+    config: input.config,
+    status: "launching",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    presentationMode,
+    threadStatusSource: presentationMode !== "terminal" ? "server" : undefined,
+    ...(input.worktreePath ? { worktreePath: input.worktreePath } : {}),
+    ...(input.worktreeBranch ? { worktreeBranch: input.worktreeBranch } : {}),
+    ...(input.groupId ? { groupId: input.groupId } : {}),
+    ...(input.groupName ? { groupName: input.groupName } : {}),
+    createdAt: now,
+    updatedAt: now,
+    activeTurnStartedAt: now,
+  };
+}
+
 export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
   threads: [],
   lastRuntimeConfigByThreadId: {},
@@ -224,43 +290,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
 
       return changed ? { threads } : {};
     }),
-  createThread: ({
-    projectId,
-    agentKind,
-    agentInstanceId,
-    config,
-    prompt,
-    worktreePath,
-    worktreeBranch,
-    groupId,
-    groupName,
-    replacePaneId: replacePaneIdParam,
-    presentationMode,
-  }) => {
-    const now = new Date().toISOString();
-    const thread: Thread = {
-      id: crypto.randomUUID(),
-      projectId,
-      title: makeThreadTitle(prompt),
-      agentKind,
-      ...(agentInstanceId ? { agentInstanceId } : {}),
-      config,
-      status: "launching",
-      attention: "none",
-      canResumeWithConfig: false,
-      archived: false,
-      done: false,
-      starred: false,
-      presentationMode: presentationMode ?? "terminal",
-      threadStatusSource: (presentationMode ?? "terminal") !== "terminal" ? "server" : undefined,
-      ...(worktreePath ? { worktreePath } : {}),
-      ...(worktreeBranch ? { worktreeBranch } : {}),
-      ...(groupId ? { groupId } : {}),
-      ...(groupName ? { groupName } : {}),
-      createdAt: now,
-      updatedAt: now,
-      activeTurnStartedAt: now,
-    };
+  createThread: ({ replacePaneId: replacePaneIdParam, ...input }) => {
+    const thread = buildThread(input);
 
     set((state) => {
       let nextView: AppView;
@@ -287,6 +318,19 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
     // Durable "thread started" usage fact (survives later delete/archive).
     recordThreadStarted(thread);
     return thread;
+  },
+  createThreadsBatch: (inputs) => {
+    const threads = inputs.map(buildThread);
+
+    set((state) => ({
+      threads: [...threads, ...state.threads],
+      lastRuntimeConfigByThreadId: {
+        ...state.lastRuntimeConfigByThreadId,
+        ...Object.fromEntries(threads.map((t) => [t.id, t.config])),
+      },
+    }));
+
+    return threads;
   },
   deleteThread: (threadId) =>
     set((state) => {

--- a/src/renderer/state/slices/viewSlice.ts
+++ b/src/renderer/state/slices/viewSlice.ts
@@ -41,9 +41,17 @@ export interface ViewSlice {
   openDraftSideBySide: (projectId: string) => void;
   openHome: () => void;
   openThread: (threadId: string) => void;
+  /**
+   * Open a single thread full-screen, ignoring any group it belongs to (unlike
+   * {@link openThread}, which restores the thread's group split). Used by the
+   * experiment board to inspect one candidate without fanning in its siblings.
+   */
+  openThreadStandalone: (threadId: string) => void;
   openThreadSideBySide: (threadId: string) => void;
   openGroupView: (groupId: string) => void;
   closeGroupView: () => void;
+  openExperiment: (experimentId: string) => void;
+  closeExperiment: () => void;
   replaceSecondPane: (threadId: string) => void;
   replacePaneAtIndex: (threadId: string, index: number) => void;
   insertPaneAtIndex: (
@@ -212,6 +220,18 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       const cleared = clearFinishedAndDone(state.threads, [threadId]);
       return cleared ? { view: nextView, threads: cleared } : { view: nextView };
     }),
+  openThreadStandalone: (threadId) =>
+    set((state) => {
+      // Save the active group's layout (mirrors openExperiment/openGroupView) so
+      // returning to it later restores the panes, then show just this thread.
+      const groupLayouts =
+        state.view.kind === "thread" && state.view.activeGroupId
+          ? saveGroupLayout(state)
+          : state.groupLayouts;
+      const cleared = clearFinishedAndDone(state.threads, [threadId]);
+      const view: AppView = { kind: "thread", panes: [threadId] };
+      return cleared ? { groupLayouts, view, threads: cleared } : { groupLayouts, view };
+    }),
   openThreadSideBySide: (threadId) =>
     set((state) => {
       if (state.view.kind !== "thread") {
@@ -286,6 +306,18 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       if (state.view.kind !== "thread" || !state.view.activeGroupId) return {};
       return { groupLayouts: saveGroupLayout(state), view: { kind: "home" } };
     }),
+  openExperiment: (experimentId) =>
+    set((state) => {
+      // Preserve any active group's split layout before leaving the thread view
+      // so returning to it later restores the panes (mirrors openGroupView).
+      const groupLayouts =
+        state.view.kind === "thread" && state.view.activeGroupId
+          ? saveGroupLayout(state)
+          : state.groupLayouts;
+      return { groupLayouts, view: { kind: "experiment", experimentId } };
+    }),
+  closeExperiment: () =>
+    set((state) => (state.view.kind === "experiment" ? { view: { kind: "home" } } : {})),
   replaceSecondPane: (threadId) =>
     set((state) => {
       if (state.view.kind !== "thread" || state.view.panes.length < 2) {

--- a/src/renderer/views/ExperimentView/ExperimentView.tsx
+++ b/src/renderer/views/ExperimentView/ExperimentView.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Crown, FlaskConical, Loader2, Trash2, X } from "lucide-react";
+import { useAppStore } from "@/renderer/state/appStore";
+import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
+import {
+  crownExperiment,
+  discardExperiment,
+  mergeExperimentWinner,
+  setManualCrown,
+} from "@/renderer/actions/experimentActions";
+import { openThreadStandalone } from "@/renderer/actions/threadActions";
+import { HomeView } from "@/renderer/views/HomeView";
+import { ExperimentCandidateCard } from "./parts/ExperimentCandidateCard";
+
+export function ExperimentView(props: { experimentId: string }) {
+  const experiment = useAppStore((s) => s.experiments[props.experimentId]);
+  const [crowning, setCrowning] = useState(false);
+
+  // The experiment was discarded/never existed — fall back to home rather than
+  // a blank pane (e.g. after reload of a stale persisted view).
+  if (!experiment) {
+    return <HomeView />;
+  }
+  // Capture a non-null binding so closures below narrow correctly.
+  const exp = experiment;
+
+  const candidates = exp.candidates;
+  const decided = exp.winnerThreadId !== undefined;
+  const crownThreadId = exp.crown?.threadId;
+
+  async function handleCrown() {
+    setCrowning(true);
+    try {
+      await crownExperiment(exp.id);
+    } finally {
+      setCrowning(false);
+    }
+  }
+
+  function openCandidate(threadId: string) {
+    // Open just this candidate full-screen, ignoring its experiment group, so it
+    // doesn't pull every sibling into a split. The board stays reachable from
+    // the sidebar.
+    openThreadStandalone(threadId);
+  }
+
+  async function handleMerge(threadId: string) {
+    const winner = candidates.find((c) => c.threadId === threadId);
+    const loserCount = candidates.length - 1;
+    const ok = window.confirm(
+      `Merge ${winner?.agentLabel ?? "this candidate"}'s changes into ${
+        exp.baseBranch ?? "the base branch"
+      }` + (loserCount > 0 ? ` and discard the other ${loserCount}?` : "?"),
+    );
+    if (!ok) return;
+    await mergeExperimentWinner(exp.id, threadId);
+  }
+
+  async function handleDiscard() {
+    const ok = window.confirm(
+      "Discard this experiment? All candidate worktrees and branches will be removed.",
+    );
+    if (!ok) return;
+    await discardExperiment(exp.id);
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div
+        className={`lightcode-content-over-drag-region ${macosTrafficLightPadClass} flex h-[env(titlebar-area-height,32px)] shrink-0 items-center gap-2 border-b border-[var(--hairline)] px-2`}
+      >
+        <FlaskConical className="size-3.5 shrink-0 text-muted" />
+        <span className="truncate text-xs font-medium">{exp.title}</span>
+        <span className="shrink-0 rounded-full bg-[var(--row-hover)] px-1.5 py-0.5 text-[10px] text-muted">
+          {candidates.length} {candidates.length === 1 ? "candidate" : "candidates"}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          {!decided && (
+            <button
+              type="button"
+              onClick={handleCrown}
+              disabled={crowning || candidates.length < 2}
+              className="inline-flex items-center gap-1 rounded-md border border-[var(--hairline)] px-2 py-0.5 text-xs transition-colors hover:bg-[var(--row-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+              title="Let an AI judge pre-select the best diff"
+            >
+              {crowning ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Crown className="size-3" />
+              )}
+              {crowning ? "Judging…" : "Crown with AI"}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleDiscard}
+            aria-label="Discard experiment"
+            className="rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-rose-500"
+            title="Discard experiment"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Close experiment"
+            className="rounded p-1 text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
+            onClick={() => useAppStore.getState().closeExperiment()}
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div className="mx-auto flex max-w-5xl flex-col gap-4">
+          <div className="rounded-lg border border-[var(--hairline)] bg-[var(--row-hover)]/30 p-3">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
+              Prompt
+            </div>
+            <p className="whitespace-pre-wrap text-sm text-foreground/90">{exp.prompt}</p>
+            {exp.baseBranch && (
+              <div className="mt-2 text-xs text-muted">
+                Forked from <span className="font-mono">{exp.baseBranch}</span>
+              </div>
+            )}
+          </div>
+
+          {decided && (
+            <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-300">
+              Winner merged. The other candidates were archived.
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            {candidates.map((candidate) => (
+              <ExperimentCandidateCard
+                key={candidate.threadId}
+                candidate={candidate}
+                isCrowned={crownThreadId === candidate.threadId}
+                isWinner={exp.winnerThreadId === candidate.threadId}
+                {...(exp.crown?.rationale ? { crownRationale: exp.crown.rationale } : {})}
+                {...(exp.crown?.source ? { crownSource: exp.crown.source } : {})}
+                decided={decided}
+                onOpen={() => openCandidate(candidate.threadId)}
+                onCrown={() => setManualCrown(exp.id, candidate.threadId)}
+                onMerge={() => void handleMerge(candidate.threadId)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/ExperimentView/parts/ExperimentCandidateCard.tsx
+++ b/src/renderer/views/ExperimentView/parts/ExperimentCandidateCard.tsx
@@ -1,0 +1,149 @@
+import { useShallow } from "zustand/shallow";
+import { useLingui } from "@lingui/react/macro";
+import { Crown, ExternalLink, GitMerge, Loader2 } from "lucide-react";
+import type { ExperimentCandidate } from "@/shared/contracts";
+import { isThreadTurnActive } from "@/shared/contracts";
+import { getStatusTone, type StatusTone } from "@/renderer/components/providers";
+import { threadRuntimeStatusLabel } from "@/renderer/components/thread/ThreadHeaderStatus";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { useThread } from "@/renderer/state/useThread";
+
+const TONE_DOT_CLASS: Record<StatusTone, string> = {
+  working: "bg-warning",
+  attention: "bg-warning",
+  active: "bg-success",
+  finished: "bg-success",
+  error: "bg-danger",
+  done: "bg-muted-foreground/40",
+  inactive: "bg-muted-foreground/40",
+};
+
+export function ExperimentCandidateCard(props: {
+  candidate: ExperimentCandidate;
+  isCrowned: boolean;
+  isWinner: boolean;
+  crownRationale?: string;
+  crownSource?: "ai" | "user";
+  decided: boolean;
+  onOpen: () => void;
+  onCrown: () => void;
+  onMerge: () => void;
+}) {
+  const { candidate, isCrowned, isWinner, crownRationale, crownSource, decided } = props;
+  const { t } = useLingui();
+  const thread = useThread(candidate.threadId);
+  const statusLabel = thread ? threadRuntimeStatusLabel(thread, t) : t`Idle`;
+  const statusTone = thread ? getStatusTone(thread) : "inactive";
+  const spinning = thread?.status === "launching" || thread?.status === "working";
+  const busy = isThreadTurnActive(thread?.status ?? "inactive");
+
+  const stats = useGitStore(
+    useShallow((s) => {
+      const st = s.worktreeStatuses[candidate.worktreePath];
+      if (!st) return null;
+      const files = new Set([...st.staged, ...st.unstaged].map((f) => f.path)).size;
+      return { insertions: st.totalInsertions, deletions: st.totalDeletions, files };
+    }),
+  );
+
+  const label = candidate.agentLabel ?? candidate.agentKind;
+
+  return (
+    <div
+      className={`flex flex-col gap-3 rounded-lg border p-3 transition-colors ${
+        isWinner
+          ? "border-amber-400/70 bg-amber-400/5"
+          : isCrowned
+            ? "border-amber-400/40 bg-amber-400/[0.03]"
+            : "border-[var(--hairline)] bg-[var(--surface,transparent)]"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-1.5">
+            {(isCrowned || isWinner) && (
+              <Crown className="size-3.5 shrink-0 text-amber-500" aria-label="Crowned" />
+            )}
+            <span className="truncate text-sm font-medium">{label}</span>
+          </div>
+          {candidate.model && (
+            <span className="block truncate text-xs text-muted">{candidate.model}</span>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5 text-xs text-muted">
+          {spinning ? (
+            <Loader2 className="size-3 animate-spin text-warning" />
+          ) : (
+            <span className={`size-2 rounded-full ${TONE_DOT_CLASS[statusTone]}`} />
+          )}
+          <span>{statusLabel}</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 text-xs">
+        {stats ? (
+          <>
+            <span className="font-mono text-success">+{stats.insertions}</span>
+            <span className="font-mono text-danger">−{stats.deletions}</span>
+            <span className="text-muted">
+              {stats.files} {stats.files === 1 ? "file" : "files"}
+            </span>
+          </>
+        ) : (
+          <span className="text-muted">{busy ? "Computing changes…" : "No changes yet"}</span>
+        )}
+        <span className="ml-auto truncate font-mono text-[11px] text-muted/70">
+          {candidate.worktreeBranch}
+        </span>
+      </div>
+
+      {isCrowned && crownRationale && (
+        <div className="rounded-md bg-amber-400/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300">
+          <span className="font-medium">{crownSource === "user" ? "Your pick" : "AI judge"}:</span>{" "}
+          {crownRationale}
+        </div>
+      )}
+
+      <div className="mt-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={props.onOpen}
+          className="inline-flex items-center gap-1 rounded-md border border-[var(--hairline)] px-2 py-1 text-xs transition-colors hover:bg-[var(--row-hover)]"
+        >
+          <ExternalLink className="size-3" />
+          Open
+        </button>
+        {!decided && (
+          <button
+            type="button"
+            onClick={props.onCrown}
+            className={`inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors ${
+              isCrowned
+                ? "text-amber-600 dark:text-amber-400"
+                : "border border-[var(--hairline)] hover:bg-[var(--row-hover)]"
+            }`}
+          >
+            <Crown className="size-3" />
+            {isCrowned ? "Crowned" : "Crown"}
+          </button>
+        )}
+        {!decided && (
+          <button
+            type="button"
+            onClick={props.onMerge}
+            className="ml-auto inline-flex items-center gap-1 rounded-md bg-emerald-600 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-700"
+          >
+            <GitMerge className="size-3" />
+            Merge winner
+          </button>
+        )}
+        {isWinner && (
+          <span className="ml-auto inline-flex items-center gap-1 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+            <GitMerge className="size-3" />
+            Merged
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/renderer/utils/shellUtils";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
 import { HomeView } from "@/renderer/views/HomeView";
+import { ExperimentView } from "@/renderer/views/ExperimentView/ExperimentView";
 import { buildProjectDraftConfig } from "./draftConfig";
 import { ThreadPane } from "./parts/ThreadPane";
 import { DraftPane } from "./parts/DraftPane";
@@ -289,6 +290,14 @@ export function AppContent() {
           lastDraftConfig={draftLastDraftConfig}
           onStart={(input) => handleDraftStart(draftProject, input)}
         />
+      </div>
+    );
+  }
+
+  if (view.kind === "experiment") {
+    return (
+      <div className="h-full">
+        <ExperimentView experimentId={view.experimentId} />
       </div>
     );
   }

--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -41,6 +41,7 @@ import { BrowserHost } from "@/renderer/views/MainView/parts/RightPanel/parts/Br
 import { LoginTerminalOverlay } from "@/renderer/views/LoginTerminalOverlay/LoginTerminalOverlay";
 import { CreateProjectModal } from "@/renderer/views/MainView/parts/CreateProject/CreateProjectModal";
 import { CloneProjectModal } from "@/renderer/views/MainView/parts/CreateProject/CloneProjectModal";
+import { NewExperimentModal } from "@/renderer/components/experiment/NewExperimentModal";
 
 export function AppOverlays() {
   const projects = useAppStore((s) => s.projects);
@@ -186,6 +187,7 @@ export function AppOverlays() {
       <LoginTerminalOverlay />
       <CreateProjectModal />
       <CloneProjectModal />
+      <NewExperimentModal />
     </>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
@@ -1,6 +1,15 @@
 import { Tooltip } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Archive, Check, ChevronRight, CircleCheck, Columns2, Pencil, Trash2 } from "lucide-react";
+import {
+  Archive,
+  Check,
+  ChevronRight,
+  CircleCheck,
+  Columns2,
+  FlaskConical,
+  Pencil,
+  Trash2,
+} from "lucide-react";
 import type { Project } from "@/shared/contracts";
 import { ContextMenu } from "@/renderer/components/common";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
@@ -21,6 +30,16 @@ export function SidebarThreadGroup(props: {
   const { entry, editingThreadId, setEditingThreadId } = props;
   const { t } = useLingui();
   const groupKey = entry.group.groupId;
+  // Experiment groups (same groupId as an experiment record) open the compact
+  // comparison board instead of fanning every candidate into split panes.
+  const isExperiment = useAppStore((s) => groupKey in s.experiments);
+  const openGroup = () => {
+    if (isExperiment) {
+      useAppStore.getState().openExperiment(groupKey);
+    } else {
+      useAppStore.getState().openGroupView(groupKey);
+    }
+  };
   const collapseKey = `group:${groupKey}`;
   const isGroupCollapsed = useIsWorktreeCollapsed(collapseKey);
   const toggleWorktreeCollapsed = useSidebarUiStore((s) => s.toggleWorktreeCollapsed);
@@ -57,9 +76,13 @@ export function SidebarThreadGroup(props: {
         items={[
           {
             id: "open-all",
-            label: t`Open All`,
-            icon: <Columns2 className="size-3.5" />,
-            isDisabled: activeThreads.length < 2,
+            label: isExperiment ? t`Open Experiment` : t`Open All`,
+            icon: isExperiment ? (
+              <FlaskConical className="size-3.5" />
+            ) : (
+              <Columns2 className="size-3.5" />
+            ),
+            isDisabled: !isExperiment && activeThreads.length < 2,
           },
           {
             id: "rename-group",
@@ -83,7 +106,7 @@ export function SidebarThreadGroup(props: {
         ]}
         onAction={(key) => {
           if (key === "open-all") {
-            useAppStore.getState().openGroupView(entry.group.groupId);
+            openGroup();
           }
           if (key === "rename-group") {
             setEditingThreadId(collapseKey);
@@ -131,6 +154,7 @@ export function SidebarThreadGroup(props: {
               />
             ) : (
               <>
+                {isExperiment && <FlaskConical className="size-3 shrink-0 text-amber-500" />}
                 <span className={`truncate ${isDone ? "opacity-50 line-through" : ""}`}>
                   {entry.group.groupName}
                 </span>
@@ -140,19 +164,25 @@ export function SidebarThreadGroup(props: {
               </>
             )}
           </button>
-          {!isRenamingGroup && activeThreads.length >= 2 && (
+          {!isRenamingGroup && (isExperiment || activeThreads.length >= 2) && (
             <Tooltip delay={300}>
               <button
                 type="button"
                 className={`flex h-[18px] shrink-0 items-center justify-center rounded text-muted/40 transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground ${hiddenGroupActionClass}`}
-                onClick={() => {
-                  useAppStore.getState().openGroupView(entry.group.groupId);
-                }}
+                onClick={openGroup}
               >
-                <Columns2 className="size-3" />
+                {isExperiment ? (
+                  <FlaskConical className="size-3" />
+                ) : (
+                  <Columns2 className="size-3" />
+                )}
               </button>
               <Tooltip.Content>
-                <Trans>Open all in group</Trans>
+                {isExperiment ? (
+                  <Trans>Open experiment board</Trans>
+                ) : (
+                  <Trans>Open all in group</Trans>
+                )}
               </Tooltip.Content>
             </Tooltip>
           )}
@@ -198,13 +228,22 @@ export function SidebarThreadGroup(props: {
 
 function clearThreadGroup(groupKey: string) {
   useAppStore.setState((state) => {
-    const updatedThreads = state.threads.map((t) =>
-      t.groupId === groupKey ? { ...t, groupId: undefined, groupName: undefined } : t,
-    );
+    const updatedThreads = state.threads.map((t) => {
+      if (t.groupId !== groupKey) return t;
+      const { groupId: _groupId, groupName: _groupName, ...thread } = t;
+      return thread;
+    });
     const view =
-      state.view.kind === "thread" && state.view.activeGroupId === groupKey
-        ? { kind: "thread" as const, panes: [state.view.panes[0]] as [string] }
-        : state.view;
-    return { threads: updatedThreads, view };
+      state.view.kind === "experiment" && state.view.experimentId === groupKey
+        ? ({ kind: "home" } as const)
+        : state.view.kind === "thread" && state.view.activeGroupId === groupKey
+          ? { kind: "thread" as const, panes: [state.view.panes[0]] as [string] }
+          : state.view;
+    if (!(groupKey in state.experiments)) {
+      return { threads: updatedThreads, view };
+    }
+    const { [groupKey]: _removedExperiment, ...experiments } = state.experiments;
+    const { [groupKey]: _removedLayout, ...groupLayouts } = state.groupLayouts;
+    return { threads: updatedThreads, view, experiments, groupLayouts };
   });
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -4,6 +4,7 @@ export * from "./contracts/agent";
 export * from "./contracts/project";
 export * from "./contracts/thread";
 export * from "./contracts/git";
+export * from "./contracts/experiment";
 export * from "./contracts/projectTree";
 export * from "./contracts/github";
 export * from "./contracts/appView";

--- a/src/shared/contracts/appView.ts
+++ b/src/shared/contracts/appView.ts
@@ -3,6 +3,7 @@ import type { PaneLayout } from "../paneLayout";
 export type AppView =
   | { kind: "home" }
   | { kind: "draft"; projectId: string }
+  | { kind: "experiment"; experimentId: string }
   | {
       kind: "thread";
       panes: [string, ...string[]];

--- a/src/shared/contracts/experiment.ts
+++ b/src/shared/contracts/experiment.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import { agentKindSchema, projectLocationSchema } from "./common";
+
+/**
+ * An "experiment" fans one prompt out across several agent/model candidates,
+ * each in its own git worktree, so the user can compare the resulting diffs
+ * side-by-side and merge the winner. Each candidate is a normal {@link Thread}
+ * linked to the experiment via `thread.groupId === experiment.id`; this record
+ * holds the extra orchestration metadata that a plain thread group lacks.
+ */
+export const experimentCandidateSchema = z.object({
+  threadId: z.string().min(1),
+  agentKind: agentKindSchema,
+  /** Human-readable provider label captured at launch (e.g. "Claude", "Codex"). */
+  agentLabel: z.string().optional(),
+  /** Model id used for this candidate, when known. */
+  model: z.string().optional(),
+  worktreePath: z.string().min(1),
+  worktreeBranch: z.string().min(1),
+});
+export type ExperimentCandidate = z.infer<typeof experimentCandidateSchema>;
+
+/** Who picked the winner and why. */
+export const experimentCrownSchema = z.object({
+  threadId: z.string().min(1),
+  /** One-line justification — from the LLM judge or the user. */
+  rationale: z.string(),
+  /** "ai" = LLM-judge pre-selection (overridable); "user" = manual choice. */
+  source: z.enum(["ai", "user"]),
+  /** Display label for the judging model, when `source === "ai"`. */
+  modelLabel: z.string().optional(),
+  createdAt: z.string().min(1),
+});
+export type ExperimentCrown = z.infer<typeof experimentCrownSchema>;
+
+export const experimentStatusSchema = z.enum(["running", "decided"]);
+export type ExperimentStatus = z.infer<typeof experimentStatusSchema>;
+
+export const experimentSchema = z.object({
+  id: z.string().min(1),
+  projectId: z.string().min(1),
+  title: z.string().min(1),
+  /** The shared prompt sent to every candidate. */
+  prompt: z.string(),
+  /** Branch every candidate worktree was forked from (the merge target). */
+  baseBranch: z.string().optional(),
+  candidates: z.array(experimentCandidateSchema),
+  /** Candidate whose worktree was merged in as the winner, once decided. */
+  winnerThreadId: z.string().optional(),
+  /** Latest crown (AI pre-selection or user pick); not necessarily merged yet. */
+  crown: experimentCrownSchema.optional(),
+  status: experimentStatusSchema,
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+});
+export type Experiment = z.infer<typeof experimentSchema>;
+
+/** One candidate's diff handed to the judge for ranking. */
+export const judgeExperimentCandidateSchema = z.object({
+  threadId: z.string().min(1),
+  label: z.string().min(1),
+  /** Unified diff (possibly truncated) of the candidate's worktree changes. */
+  diff: z.string(),
+});
+export type JudgeExperimentCandidate = z.infer<typeof judgeExperimentCandidateSchema>;
+
+export const judgeExperimentPayloadSchema = z.object({
+  projectLocation: projectLocationSchema,
+  /** Provider to run the judge call through (reuses its auth/config). */
+  agentKind: agentKindSchema,
+  model: z.string().min(1).optional(),
+  effort: z.string().min(1).optional(),
+  /** The original task prompt, so the judge knows what "best" means. */
+  prompt: z.string(),
+  candidates: z.array(judgeExperimentCandidateSchema).min(2),
+});
+export type JudgeExperimentPayload = z.infer<typeof judgeExperimentPayloadSchema>;
+
+export interface JudgeExperimentResult {
+  /** Thread id of the candidate the judge ranked best. */
+  winnerThreadId: string;
+  /** One-line rationale for the pick. */
+  rationale: string;
+}

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -1,6 +1,7 @@
 import { appProcedures } from "./procedures/app";
 import { browserProcedures } from "./procedures/browser";
 import { dbProcedures } from "./procedures/db";
+import { experimentProcedures } from "./procedures/experiment";
 import { githubProcedures } from "./procedures/github";
 import { gitProcedures } from "./procedures/git";
 import { lspProcedures } from "./procedures/lsp";
@@ -15,6 +16,7 @@ export const groupedIpcProcedures = {
   app: appProcedures,
   thread: threadProcedures,
   git: gitProcedures,
+  experiment: experimentProcedures,
   github: githubProcedures,
   projectTree: projectTreeProcedures,
   settings: settingsProcedures,
@@ -30,6 +32,7 @@ export const ipcProcedureMap = {
   ...appProcedures,
   ...threadProcedures,
   ...gitProcedures,
+  ...experimentProcedures,
   ...githubProcedures,
   ...projectTreeProcedures,
   ...settingsProcedures,

--- a/src/shared/ipc/procedures/experiment.ts
+++ b/src/shared/ipc/procedures/experiment.ts
@@ -1,0 +1,11 @@
+import { judgeExperimentPayloadSchema } from "../../contracts";
+import type { JudgeExperimentPayload, JudgeExperimentResult } from "../../contracts";
+import { definePayloadProcedure } from "../core";
+
+export const experimentProcedures = {
+  judgeExperiment: definePayloadProcedure<
+    JudgeExperimentPayload,
+    JudgeExperimentResult,
+    "supervisor"
+  >("judgeExperiment", "supervisor", judgeExperimentPayloadSchema),
+} as const;

--- a/src/supervisor/experimentJudge.test.ts
+++ b/src/supervisor/experimentJudge.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseJudgeResponse } from "./experimentJudge";
+
+describe("parseJudgeResponse", () => {
+  it("parses a clean JSON object", () => {
+    const result = parseJudgeResponse('{"winner": 2, "rationale": "Most complete fix."}', 3);
+    expect(result).toEqual({ winnerIndex: 1, rationale: "Most complete fix." });
+  });
+
+  it("strips code fences and thinking tags", () => {
+    const raw =
+      '<think>comparing diffs…</think>\n```json\n{"winner": 1, "rationale": "Cleaner."}\n```';
+    expect(parseJudgeResponse(raw, 2)).toEqual({ winnerIndex: 0, rationale: "Cleaner." });
+  });
+
+  it("extracts a JSON object embedded in prose", () => {
+    const raw = 'Here is my pick: {"winner": 3, "rationale": "Best tests."} — done.';
+    expect(parseJudgeResponse(raw, 3)).toEqual({ winnerIndex: 2, rationale: "Best tests." });
+  });
+
+  it("clamps an out-of-range winner to the first candidate", () => {
+    const result = parseJudgeResponse('{"winner": 9, "rationale": "x"}', 2);
+    expect(result.winnerIndex).toBe(0);
+  });
+
+  it("falls back to candidate 1 with a default rationale on garbage", () => {
+    const result = parseJudgeResponse("the agents all did fine honestly", 3);
+    expect(result.winnerIndex).toBe(0);
+    expect(result.rationale.length).toBeGreaterThan(0);
+  });
+
+  it("recovers winner + rationale from loose key/value text", () => {
+    const result = parseJudgeResponse("winner: 2\nrationale: solid approach", 3);
+    expect(result.winnerIndex).toBe(1);
+    expect(result.rationale).toContain("solid approach");
+  });
+});

--- a/src/supervisor/experimentJudge.ts
+++ b/src/supervisor/experimentJudge.ts
@@ -1,0 +1,138 @@
+import type {
+  JudgeExperimentCandidate,
+  JudgeExperimentResult,
+  ProjectLocation,
+} from "@/shared/contracts";
+import type { AgentAdapter } from "./agents/base";
+import { runOneShotPromptWithFallback } from "./oneShotPromptRunner";
+
+const JUDGE_TIMEOUT_MS = 120_000;
+// Per-candidate diff budget for each fallback attempt (largest first).
+const DIFF_BUDGETS = [20_000, 6_000, 1_500] as const;
+
+const SYSTEM_PROMPT =
+  "You are an expert code reviewer judging several candidate solutions to the SAME task.\n" +
+  "Each candidate is one agent's git diff. Pick the single best diff: the one that most " +
+  "correctly and completely solves the task with the cleanest, safest change.\n" +
+  "Weigh correctness and completeness first, then code quality, then minimalism.\n" +
+  'Reply with ONLY a JSON object: {"winner": <candidate number>, "rationale": "<one concise sentence>"}.\n' +
+  "Do not add any other text.\n\n";
+
+function truncate(diff: string, limit: number): string {
+  if (diff.length <= limit) return diff;
+  return `${diff.slice(0, limit)}\n… (diff truncated)`;
+}
+
+function buildJudgePrompt(
+  taskPrompt: string,
+  candidates: readonly JudgeExperimentCandidate[],
+  perCandidateLimit: number,
+): string {
+  const parts: string[] = [SYSTEM_PROMPT, `Task:\n${taskPrompt}\n`];
+  candidates.forEach((candidate, idx) => {
+    const diff = candidate.diff.trim() || "(no changes)";
+    parts.push(
+      `\n===== Candidate ${idx + 1}: ${candidate.label} =====\n` +
+        truncate(diff, perCandidateLimit),
+    );
+  });
+  parts.push(
+    `\n\nThere are ${candidates.length} candidates (1-${candidates.length}). ` +
+      'Respond with only {"winner": <number>, "rationale": "<one sentence>"}.',
+  );
+  return parts.join("\n");
+}
+
+interface ParsedJudgement {
+  winnerIndex: number;
+  rationale: string;
+}
+
+/** Pull `{ winner, rationale }` out of a possibly-noisy LLM response. */
+export function parseJudgeResponse(raw: string, candidateCount: number): ParsedJudgement {
+  const cleaned = raw
+    .replace(/<(think|antThinking)>[\s\S]*?<\/\1>/g, "")
+    .replace(/```[a-z]*\n?/gi, "")
+    .trim();
+
+  const tryObject = (text: string): ParsedJudgement | undefined => {
+    try {
+      const parsed = JSON.parse(text) as { winner?: unknown; rationale?: unknown };
+      const winner = Number(parsed.winner);
+      if (Number.isInteger(winner) && winner >= 1 && winner <= candidateCount) {
+        return {
+          winnerIndex: winner - 1,
+          rationale: typeof parsed.rationale === "string" ? parsed.rationale.trim() : "",
+        };
+      }
+    } catch {
+      // not valid JSON
+    }
+    return undefined;
+  };
+
+  const direct = tryObject(cleaned);
+  if (direct) return direct;
+
+  const objectMatch = cleaned.match(/\{[\s\S]*\}/);
+  if (objectMatch) {
+    const fromObject = tryObject(objectMatch[0]);
+    if (fromObject) return fromObject;
+  }
+
+  // Last-ditch: find the first standalone candidate number + a rationale line.
+  const winnerMatch = cleaned.match(/winner["']?\s*[:=]\s*(\d+)/i) ?? cleaned.match(/\b([1-9])\b/);
+  const winner = winnerMatch ? Number(winnerMatch[1]) : 1;
+  const winnerIndex = winner >= 1 && winner <= candidateCount ? winner - 1 : 0;
+  const rationaleMatch = cleaned.match(/rationale["']?\s*[:=]\s*["']?([^"'\n}]+)/i);
+  return {
+    winnerIndex,
+    rationale: rationaleMatch?.[1]?.trim() ?? "Selected by the AI judge.",
+  };
+}
+
+/**
+ * Ask a model to rank candidate diffs and return the winning thread id plus a
+ * one-line rationale. Reuses the one-shot runner (shared auth/config, argv
+ * fallback). Throws only if the adapter can't do one-shot generation; a noisy
+ * or unparseable response degrades to candidate 1 rather than failing.
+ */
+export async function judgeExperiment(
+  location: ProjectLocation,
+  adapter: AgentAdapter,
+  prompt: string,
+  candidates: readonly JudgeExperimentCandidate[],
+  model?: string,
+  effort?: string,
+): Promise<JudgeExperimentResult> {
+  if (candidates.length < 2) {
+    throw new Error("Need at least two candidates to judge");
+  }
+  const effectiveModel = model ?? adapter.defaultOneShotModel;
+  if (!effectiveModel) {
+    throw new Error(`No default one-shot model configured for ${adapter.label}`);
+  }
+  if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
+    throw new Error(`${adapter.label} does not support one-shot generation`);
+  }
+
+  const raw = await runOneShotPromptWithFallback({
+    location,
+    adapter,
+    model: effectiveModel,
+    effort,
+    timeoutMs: JUDGE_TIMEOUT_MS,
+    logTag: "experiment-judge",
+    attempts: DIFF_BUDGETS.map((budget, idx) => ({
+      level: idx === 0 ? "full" : `diff-${budget}`,
+      buildPrompt: () => buildJudgePrompt(prompt, candidates, budget),
+    })),
+  });
+
+  const parsed = parseJudgeResponse(raw, candidates.length);
+  const winner = candidates[parsed.winnerIndex] ?? candidates[0]!;
+  return {
+    winnerThreadId: winner.threadId,
+    rationale: parsed.rationale || "Selected by the AI judge.",
+  };
+}

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -62,6 +62,7 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
     generateCommitMessage: (payload) => runtime.generateCommitMessage(payload),
     generateTitle: (payload) => runtime.generateTitle(payload),
     generatePrSummary: (payload) => runtime.generatePrSummary(payload),
+    judgeExperiment: (payload) => runtime.judgeExperiment(payload),
     gitListBranches: (payload) => runtime.gitListBranches(payload),
     gitFetch: (payload) => runtime.gitFetch(payload),
     gitListWorktrees: (payload) => runtime.gitListWorktrees(payload),

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -28,6 +28,8 @@ import type {
   GeneratePrSummaryResult,
   GenerateTitlePayload,
   GenerateTitleResult,
+  JudgeExperimentPayload,
+  JudgeExperimentResult,
   GetAgentStatusesPayload,
   GetAgentHookPluginStatusesPayload,
   GetGitBranchesPayload,
@@ -201,6 +203,7 @@ import {
   extractContext as extractContextFn,
   extractContextFromScrollback,
 } from "./contextExtractor";
+import { judgeExperiment } from "./experimentJudge";
 import { FileIndexService } from "./fileIndex";
 import { GitService, resolveBuiltInWorktreeRoot } from "./git";
 import { resolveWorktreePlacement } from "@/shared/worktree";
@@ -1001,6 +1004,18 @@ export class SupervisorRuntime {
       payload.model,
       payload.effort,
       payload.language,
+    );
+  }
+
+  async judgeExperiment(payload: JudgeExperimentPayload): Promise<JudgeExperimentResult> {
+    const adapter = this.requireAdapter(payload.agentKind);
+    return judgeExperiment(
+      payload.projectLocation,
+      adapter,
+      payload.prompt,
+      payload.candidates,
+      payload.model,
+      payload.effort,
     );
   }
 


### PR DESCRIPTION
## Summary

Adds **experiments**: fan one prompt across multiple agent/model candidates, each in its own git worktree, then compare diffs side-by-side and merge the winner — with an optional LLM-judge **crown** that pre-selects the best diff and a one-line rationale (user-overridable).

This is mostly orchestration glue on top of existing primitives (threads, worktrees, diffs, the one-shot prompt runner). An experiment *is* a thread group (candidates share `groupId === experiment.id`) plus an `experiments` registry holding the orchestration metadata.

## How to use

1. In a project draft composer, type a prompt and click the 🧪 **Run as experiment** button.
2. The **New Experiment** modal seeds the prompt + your current agent/model, lets you add more candidates and pick a fork-from branch.
3. **Run experiment** creates one worktree + thread per candidate and opens the compact **experiment board** — status, diff stats (`+/−`, files), and per-card **Open / Crown / Merge winner**.
4. **Crown with AI** runs an LLM judge over the candidate diffs and highlights a winner with a rationale (you can override by crowning any card).
5. **Merge winner** merges that branch into the base branch and archives the losers (worktrees + branches removed).

## What's included

- **Contracts / IPC**: `experiment.ts` contract, `judgeExperiment` IPC procedure, supervisor judge (`experimentJudge.ts`) built on the existing `runOneShotPromptWithFallback`, with robust response parsing.
- **State**: `experimentSlice` (persisted), `experimentLauncherStore`, `createThreadsBatch`, and `openExperiment`/`openThreadStandalone`/`closeExperiment` view actions; new `AppView` kind `"experiment"`.
- **Orchestration** (`experimentActions.ts`): per-candidate worktree creation (sequential — avoids `index.lock` races), headless `startThread` launch, `mergeExperimentWinner` (via `gitMergeToSource` + `performWorktreeRemoval`), `discardExperiment`, `crownExperiment`.
- **UI**: `ExperimentView` board + `ExperimentCandidateCard`, `NewExperimentModal`, composer trigger, sidebar experiment-group affordance.
- **Plumbing**: hydration keeps live candidates attached on reload; project/view selectors and dbStorage handle the new view kind.

## Design notes (informed by prior art: cmux, Vibe Kanban, uzi, Crystal)

- **Advisory crown, never auto-merge** — the judge pre-selects; merge is a separate, confirmed step.
- **Anonymized candidate labels** sent to the judge ("Solution A/B/C") to avoid provider/self-enhancement bias.
- **Diff noise filtering** (lockfiles, minified, sourcemaps) before judging.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint` (touched files) ✅
- `pnpm exec vitest run` for `experimentJudge`, `appStore`, `dbStorage`, `threadActions`, and the app integration test — 99 passing ✅

## Follow-ups (not in this PR)

- Feed test/CI pass-fail signals to the judge and show them as badges.
- Auto-approve permission prompts during fan-out so candidates don't stall.
- i18n: user-facing strings in the new UI still need Lingui wrapping + catalog translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)