### PR TITLE
feat(mcp): MCP server manager with detection and marketplace

### DIFF
--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -44,6 +44,7 @@ import {
   writeSharedSettingsFile,
 } from "../sharedSettingsFile";
 import { readKeybindingsFile, writeKeybindingsFile } from "../keybindingsFile";
+import { detectMcpServers } from "../mcp/detectMcpServers";
 import type { AutoUpdaterController } from "../updates/autoUpdater";
 import {
   defineMainLocalIpcHandlers,
@@ -186,6 +187,7 @@ export function createLocalIpcHandlers(
     getKeybindings: () => readKeybindingsFile(options.requireLightcodePaths().keybindingsPath),
     setKeybindings: (file) =>
       writeKeybindingsFile(options.requireLightcodePaths().keybindingsPath, file),
+    getDetectedMcpServers: (payload) => detectMcpServers(payload?.projectPath),
     revealProjectEntry: async (payload) => {
       shell.showItemInFolder(resolveProjectFsPath(payload));
     },

--- a/src/main/mcp/detectMcpServers.test.ts
+++ b/src/main/mcp/detectMcpServers.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { detectGlobalMcpServers, detectProjectMcpServers } from "./detectMcpServers";
+
+function tmpProject(): string {
+  return mkdtempSync(join(tmpdir(), "mcp-detect-"));
+}
+
+describe("detectProjectMcpServers", () => {
+  it("parses .mcp.json stdio + http entries", () => {
+    const dir = tmpProject();
+    writeFileSync(
+      join(dir, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          fs: { command: "npx", args: ["-y", "server-fs"], env: { A: "1" }, cwd: "/repo" },
+          remote: { type: "http", url: "https://x/mcp", headers: { Authorization: "Bearer t" } },
+        },
+      }),
+    );
+    const groups = detectProjectMcpServers(dir);
+    const mcpJson = groups.find((g) => g.source === "mcp-json");
+    expect(mcpJson).toBeDefined();
+    const fs = mcpJson!.servers.find((s) => s.name === "fs");
+    expect(fs?.transport).toEqual({
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "server-fs"],
+      env: { A: "1" },
+      cwd: "/repo",
+    });
+    const remote = mcpJson!.servers.find((s) => s.name === "remote");
+    expect(remote?.transport).toEqual({
+      type: "http",
+      url: "https://x/mcp",
+      headers: { Authorization: "Bearer t" },
+    });
+  });
+
+  it("parses VS Code .vscode/mcp.json (servers key) and JSONC comments", () => {
+    const dir = tmpProject();
+    mkdirSync(join(dir, ".vscode"));
+    writeFileSync(
+      join(dir, ".vscode", "mcp.json"),
+      `{
+        // workspace MCP servers
+        "servers": {
+          "play": { "type": "stdio", "command": "node", "args": ["play.js"] }
+        }
+      }`,
+    );
+    const groups = detectProjectMcpServers(dir);
+    const vscode = groups.find((g) => g.source === "vscode-project");
+    expect(vscode?.servers[0]?.transport).toMatchObject({ type: "stdio", command: "node" });
+  });
+
+  it("parses opencode.json local + remote entries", () => {
+    const dir = tmpProject();
+    writeFileSync(
+      join(dir, "opencode.json"),
+      JSON.stringify({
+        mcp: {
+          local1: { type: "local", command: ["bun", "x", "srv"], environment: { K: "v" } },
+          remote1: { type: "remote", url: "https://r/mcp", enabled: false },
+        },
+      }),
+    );
+    const groups = detectProjectMcpServers(dir);
+    const oc = groups.find((g) => g.source === "opencode-project");
+    const local1 = oc!.servers.find((s) => s.name === "local1");
+    expect(local1?.transport).toEqual({
+      type: "stdio",
+      command: "bun",
+      args: ["x", "srv"],
+      env: { K: "v" },
+    });
+    const remote1 = oc!.servers.find((s) => s.name === "remote1");
+    expect(remote1?.transport).toEqual({ type: "http", url: "https://r/mcp", headers: {} });
+    expect(remote1?.disabled).toBe(true);
+  });
+
+  it("returns no groups when the project has no MCP config", () => {
+    const dir = tmpProject();
+    expect(detectProjectMcpServers(dir)).toEqual([]);
+  });
+});
+
+describe("detectGlobalMcpServers", () => {
+  it("parses quoted Codex MCP server table names", () => {
+    const dir = tmpProject();
+    const codexPath = join(dir, ".codex", "config.toml");
+    mkdirSync(join(dir, ".codex"));
+    writeFileSync(
+      codexPath,
+      `
+        [mcp_servers."ctx.7"]
+        url = "https://mcp.example.com/mcp"
+      `,
+    );
+
+    const groups = detectGlobalMcpServers(undefined, dir);
+    const codex = groups.find((g) => g.source === "codex-global");
+    expect(codex?.servers[0]).toMatchObject({
+      name: "ctx.7",
+      transport: { type: "http", url: "https://mcp.example.com/mcp", headers: {} },
+    });
+  });
+});

--- a/src/main/mcp/detectMcpServers.ts
+++ b/src/main/mcp/detectMcpServers.ts
@@ -1,0 +1,397 @@
+/**
+ * Read-only discovery of MCP servers already configured in other tools, so the
+ * MCP Manager can surface what exists across agents (grouped by source) and let
+ * the user import any of them into Lightcode's own managed list.
+ *
+ * Everything here is best-effort and defensive: a malformed config file yields
+ * an empty group, never a thrown error. We never write to these files.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+  MCP_SOURCE_META,
+  type DetectedMcpGroup,
+  type DetectedMcpServer,
+  type DetectMcpServersResult,
+  type McpSource,
+  type McpTransport,
+} from "@/shared/contracts";
+
+function readJsonFile(path: string): unknown {
+  try {
+    if (!existsSync(path)) return undefined;
+    let text = readFileSync(path, "utf8");
+    // Tolerate JSONC (// and /* */) used by VS Code / OpenCode config files.
+    text = stripJsonComments(text);
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripJsonComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//gu, "")
+    .replace(/(^|[^:"'])\/\/.*$/gmu, (_m, p1: string) => p1);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function asStringRecord(value: unknown): Record<string, string> {
+  const record = asRecord(value);
+  if (!record) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(record)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Map a `mcpServers` / `servers` style entry (Claude, Cursor, Gemini, VS Code,
+ * `.mcp.json`) into a canonical transport. Returns undefined for shapes we
+ * can't represent.
+ */
+function parseStandardEntry(raw: unknown): McpTransport | undefined {
+  const entry = asRecord(raw);
+  if (!entry) return undefined;
+  const command = asString(entry.command);
+  if (command) {
+    const cwd = asString(entry.cwd);
+    return {
+      type: "stdio",
+      command,
+      args: asStringArray(entry.args),
+      env: asStringRecord(entry.env),
+      ...(cwd ? { cwd } : {}),
+    };
+  }
+  const httpUrl = asString(entry.httpUrl);
+  const url = asString(entry.url) ?? asString(entry.serverUrl);
+  const declaredType = asString(entry.type);
+  const headers = asStringRecord(entry.headers);
+  if (httpUrl) return { type: "http", url: httpUrl, headers };
+  if (url) {
+    const type = declaredType === "sse" ? "sse" : "http";
+    return { type, url, headers };
+  }
+  return undefined;
+}
+
+/** Map an OpenCode `mcp` entry (`local` / `remote`) into a canonical transport. */
+function parseOpenCodeEntry(raw: unknown): { transport?: McpTransport; disabled: boolean } {
+  const entry = asRecord(raw);
+  if (!entry) return { disabled: false };
+  const disabled = entry.enabled === false;
+  if (entry.type === "remote") {
+    const url = asString(entry.url);
+    return url
+      ? { transport: { type: "http", url, headers: asStringRecord(entry.headers) }, disabled }
+      : { disabled };
+  }
+  // local (or unspecified) → stdio. `command` is an array [cmd, ...args].
+  const command = asStringArray(entry.command);
+  if (command.length === 0) return { disabled };
+  return {
+    transport: {
+      type: "stdio",
+      command: command[0]!,
+      args: command.slice(1),
+      env: asStringRecord(entry.environment),
+    },
+    disabled,
+  };
+}
+
+function collectStandard(
+  source: McpSource,
+  filePath: string,
+  serversValue: unknown,
+): DetectedMcpServer[] {
+  const record = asRecord(serversValue);
+  if (!record) return [];
+  const out: DetectedMcpServer[] = [];
+  for (const [name, raw] of Object.entries(record)) {
+    const entry = asRecord(raw);
+    const transport = parseStandardEntry(raw);
+    out.push({
+      name,
+      source,
+      filePath,
+      ...(transport ? { transport } : {}),
+      ...(entry?.disabled === true || entry?.enabled === false ? { disabled: true } : {}),
+      raw,
+    });
+  }
+  return out;
+}
+
+function collectOpenCode(
+  source: McpSource,
+  filePath: string,
+  mcpValue: unknown,
+): DetectedMcpServer[] {
+  const record = asRecord(mcpValue);
+  if (!record) return [];
+  const out: DetectedMcpServer[] = [];
+  for (const [name, raw] of Object.entries(record)) {
+    const { transport, disabled } = parseOpenCodeEntry(raw);
+    out.push({
+      name,
+      source,
+      filePath,
+      ...(transport ? { transport } : {}),
+      ...(disabled ? { disabled: true } : {}),
+      raw,
+    });
+  }
+  return out;
+}
+
+function group(
+  source: McpSource,
+  filePath: string,
+  servers: DetectedMcpServer[],
+): DetectedMcpGroup | undefined {
+  if (servers.length === 0) return undefined;
+  const meta = MCP_SOURCE_META[source];
+  return { source, label: meta.label, scope: meta.scope, shared: meta.shared, filePath, servers };
+}
+
+/**
+ * Minimal extractor for Codex `~/.codex/config.toml` `[mcp_servers.NAME]`
+ * tables. Not a full TOML parser — handles the common stdio + remote keys so
+ * detection can list servers; the user imports/edits via the manager.
+ */
+function collectCodexToml(filePath: string): DetectedMcpServer[] {
+  let text: string;
+  try {
+    if (!existsSync(filePath)) return [];
+    text = readFileSync(filePath, "utf8");
+  } catch {
+    return [];
+  }
+  const servers = new Map<
+    string,
+    { command?: string; args: string[]; env: Record<string, string>; url?: string }
+  >();
+  let current: string | undefined;
+  for (const line of text.split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    const sectionName = parseCodexMcpSectionName(trimmed);
+    if (sectionName) {
+      current = sectionName;
+      if (!servers.has(current)) servers.set(current, { args: [], env: {} });
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      current = undefined;
+      continue;
+    }
+    if (!current) continue;
+    const kv = /^([A-Za-z0-9_]+)\s*=\s*(.+)$/u.exec(trimmed);
+    const key = kv?.[1];
+    const rawValue = kv?.[2];
+    if (!key || rawValue === undefined) continue;
+    const entry = servers.get(current)!;
+    if (key === "command") {
+      const command = parseTomlString(rawValue);
+      if (command) entry.command = command;
+    } else if (key === "url") {
+      const url = parseTomlString(rawValue);
+      if (url) entry.url = url;
+    } else if (key === "args") entry.args = parseTomlStringArray(rawValue);
+    else if (key === "env") entry.env = parseTomlInlineTable(rawValue);
+  }
+  const out: DetectedMcpServer[] = [];
+  for (const [name, entry] of servers) {
+    let transport: McpTransport | undefined;
+    if (entry.command)
+      transport = { type: "stdio", command: entry.command, args: entry.args, env: entry.env };
+    else if (entry.url) transport = { type: "http", url: entry.url, headers: {} };
+    out.push({
+      name,
+      source: "codex-global",
+      filePath,
+      ...(transport ? { transport } : {}),
+      raw: entry,
+    });
+  }
+  return out;
+}
+
+function parseTomlString(value: string): string | undefined {
+  const trimmed = value.trim().replace(/,\s*$/u, "");
+  if (trimmed.startsWith('"')) {
+    try {
+      return JSON.parse(trimmed) as string;
+    } catch {
+      return undefined;
+    }
+  }
+  const match = /^'([^']*)'$/u.exec(trimmed);
+  return match ? match[1] : undefined;
+}
+
+function parseCodexMcpSectionName(line: string): string | undefined {
+  const match = /^\[mcp_servers\.(?:"((?:[^"\\]|\\.)*)"|([A-Za-z0-9_.-]+))\]$/u.exec(line);
+  if (!match) return undefined;
+  if (match[1] !== undefined) return parseTomlString(`"${match[1]}"`);
+  return match[2];
+}
+
+function parseTomlStringArray(value: string): string[] {
+  const inner = value
+    .trim()
+    .replace(/^\[/u, "")
+    .replace(/\]\s*,?\s*$/u, "");
+  const out: string[] = [];
+  for (const part of inner.split(",")) {
+    const s = parseTomlString(part);
+    if (s !== undefined) out.push(s);
+  }
+  return out;
+}
+
+function parseTomlInlineTable(value: string): Record<string, string> {
+  const inner = value
+    .trim()
+    .replace(/^\{/u, "")
+    .replace(/\}\s*,?\s*$/u, "");
+  const out: Record<string, string> = {};
+  for (const part of inner.split(",")) {
+    const kv = /^\s*"?([A-Za-z0-9_]+)"?\s*=\s*(.+?)\s*$/u.exec(part);
+    const key = kv?.[1];
+    const rawVal = kv?.[2];
+    if (!key || rawVal === undefined) continue;
+    const v = parseTomlString(rawVal);
+    if (v !== undefined) out[key] = v;
+  }
+  return out;
+}
+
+type ServersCollector = (
+  source: McpSource,
+  filePath: string,
+  value: unknown,
+) => DetectedMcpServer[];
+
+/** Read `filePath` as JSON, pull the servers container out, and group it. */
+function jsonGroup(
+  source: McpSource,
+  filePath: string,
+  getServers: (root: Record<string, unknown> | undefined) => unknown,
+  collect: ServersCollector,
+): DetectedMcpGroup | undefined {
+  const root = asRecord(readJsonFile(filePath));
+  return group(source, filePath, collect(source, filePath, getServers(root)));
+}
+
+const mcpServersField = (root: Record<string, unknown> | undefined): unknown => root?.mcpServers;
+const mcpField = (root: Record<string, unknown> | undefined): unknown => root?.mcp;
+
+function compact(groups: (DetectedMcpGroup | undefined)[]): DetectedMcpGroup[] {
+  return groups.filter((g): g is DetectedMcpGroup => g !== undefined);
+}
+
+/**
+ * Scan all known global/user-level config files. `claudeRoot` lets the entry
+ * point share a single parse of `~/.claude.json` with the project scan.
+ */
+export function detectGlobalMcpServers(
+  claudeRoot?: Record<string, unknown> | undefined,
+  home = homedir(),
+): DetectedMcpGroup[] {
+  const claudeJsonPath = join(home, ".claude.json");
+  const claude = claudeRoot ?? asRecord(readJsonFile(claudeJsonPath));
+  const codexPath = join(home, ".codex", "config.toml");
+  return compact([
+    group(
+      "claude-global",
+      claudeJsonPath,
+      collectStandard("claude-global", claudeJsonPath, claude?.mcpServers),
+    ),
+    group("codex-global", codexPath, collectCodexToml(codexPath)),
+    jsonGroup("cursor-global", join(home, ".cursor", "mcp.json"), mcpServersField, collectStandard),
+    jsonGroup(
+      "gemini-global",
+      join(home, ".gemini", "settings.json"),
+      mcpServersField,
+      collectStandard,
+    ),
+    jsonGroup(
+      "opencode-global",
+      join(home, ".config", "opencode", "opencode.json"),
+      mcpField,
+      collectOpenCode,
+    ),
+  ]);
+}
+
+/** Scan project-level config files under `projectPath`. */
+export function detectProjectMcpServers(
+  projectPath: string,
+  claudeRoot?: Record<string, unknown> | undefined,
+): DetectedMcpGroup[] {
+  // Claude Code per-project (local) scope lives in ~/.claude.json under
+  // `projects[absolutePath].mcpServers`.
+  const claudeJsonPath = join(homedir(), ".claude.json");
+  const claude = claudeRoot ?? asRecord(readJsonFile(claudeJsonPath));
+  const projectEntry = asRecord(asRecord(claude?.projects)?.[projectPath]);
+  return compact([
+    // Shared `.mcp.json` (Claude Code project scope + several other tools).
+    jsonGroup("mcp-json", join(projectPath, ".mcp.json"), mcpServersField, collectStandard),
+    group(
+      "claude-project",
+      claudeJsonPath,
+      collectStandard("claude-project", claudeJsonPath, projectEntry?.mcpServers),
+    ),
+    jsonGroup(
+      "cursor-project",
+      join(projectPath, ".cursor", "mcp.json"),
+      mcpServersField,
+      collectStandard,
+    ),
+    jsonGroup(
+      "gemini-project",
+      join(projectPath, ".gemini", "settings.json"),
+      mcpServersField,
+      collectStandard,
+    ),
+    // VS Code workspace scope (.vscode/mcp.json) — note the key is `servers`.
+    jsonGroup(
+      "vscode-project",
+      join(projectPath, ".vscode", "mcp.json"),
+      (root) => root?.servers ?? root?.mcpServers,
+      collectStandard,
+    ),
+    jsonGroup("opencode-project", join(projectPath, "opencode.json"), mcpField, collectOpenCode),
+  ]);
+}
+
+/** Entry point used by the IPC handler. */
+export function detectMcpServers(projectPath?: string): DetectMcpServersResult {
+  // `~/.claude.json` carries both user (top-level) and per-project scopes, so
+  // parse it once and share it across both scans.
+  const claudeRoot = asRecord(readJsonFile(join(homedir(), ".claude.json")));
+  const groups = [
+    ...detectGlobalMcpServers(claudeRoot),
+    ...(projectPath ? detectProjectMcpServers(projectPath, claudeRoot) : []),
+  ];
+  return { groups };
+}

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -132,6 +132,7 @@ describe("sharedSettingsFile", () => {
         providerOrder: [],
         collapsedProviders: [],
       },
+      mcpServers: [],
     });
 
     expect(readSharedSettingsFile(settingsPath)).toEqual({
@@ -234,6 +235,7 @@ describe("sharedSettingsFile", () => {
         providerOrder: [],
         collapsedProviders: [],
       },
+      mcpServers: [],
     });
     expect(readFileSync(settingsPath, "utf8")).toContain('"themeMode": "dark"');
   });

--- a/src/renderer/components/mcp/DetectedMcpPanel.tsx
+++ b/src/renderer/components/mcp/DetectedMcpPanel.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from "react";
+import { Download, RefreshCw } from "lucide-react";
+import { readBridge } from "@/renderer/bridge";
+import {
+  isValidMcpServerName,
+  type DetectedMcpGroup,
+  type DetectedMcpServer,
+} from "@/shared/contracts";
+import { Button, PixelLoader } from "@/renderer/components/common";
+import { transportBadge, transportSummary } from "./mcpFormUtils";
+
+function loadDetectedMcpGroups(projectPath: string | undefined): Promise<DetectedMcpGroup[]> {
+  return readBridge()
+    .getDetectedMcpServers(projectPath ? { projectPath } : {})
+    .then((result) => result.groups);
+}
+
+export function DetectedMcpPanel(props: {
+  /** Absolute project path for project-scope scans; omit for global-only. */
+  projectPath?: string;
+  /** Server names already managed in the current scope (lowercased). */
+  managedNames: ReadonlySet<string>;
+  onImport: (detected: DetectedMcpServer) => void;
+}) {
+  const { projectPath, managedNames, onImport } = props;
+  const [groups, setGroups] = useState<DetectedMcpGroup[] | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+
+  const scan = () => {
+    setLoading(true);
+    void loadDetectedMcpGroups(projectPath)
+      .then(setGroups)
+      .catch(() => setGroups([]))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setGroups(undefined);
+    void loadDetectedMcpGroups(projectPath)
+      .then((nextGroups) => {
+        if (!cancelled) setGroups(nextGroups);
+      })
+      .catch(() => {
+        if (!cancelled) setGroups([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectPath]);
+
+  if (groups === undefined) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <PixelLoader size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-muted">
+          MCP servers found in other tools&apos; config files. Import any to manage it in Lightcode.
+        </p>
+        <Button size="sm" variant="tertiary" isDisabled={loading} onPress={scan}>
+          {loading ? <PixelLoader size="xs" /> : <RefreshCw className="size-3.5" />}
+          Rescan
+        </Button>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="py-6 text-center text-xs text-muted">
+          No MCP servers detected in other tools.
+        </p>
+      ) : (
+        groups.map((group) => (
+          <div key={`${group.source}:${group.filePath}`} className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-medium text-foreground">{group.label}</span>
+              <span className="rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] text-muted">
+                {group.scope}
+              </span>
+            </div>
+            <div className="space-y-1">
+              {group.servers.map((server) => {
+                const alreadyManaged = managedNames.has(server.name.toLowerCase());
+                const invalidName = !isValidMcpServerName(server.name);
+                return (
+                  <div
+                    key={server.name}
+                    className="flex items-center gap-2 rounded-md border border-[var(--hairline)] px-3 py-2"
+                  >
+                    <span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                      {server.transport ? transportBadge(server.transport) : "?"}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm text-foreground">{server.name}</div>
+                      <div className="truncate font-mono text-[11px] text-muted">
+                        {server.transport
+                          ? transportSummary(server.transport)
+                          : "Unsupported config shape"}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="tertiary"
+                      isDisabled={!server.transport || alreadyManaged || invalidName}
+                      onPress={() => onImport(server)}
+                    >
+                      <Download className="size-3.5" />
+                      {alreadyManaged
+                        ? "Managed"
+                        : invalidName
+                          ? "Invalid"
+                          : server.transport
+                            ? "Import"
+                            : "Unsupported"}
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/mcp/McpManager.tsx
+++ b/src/renderer/components/mcp/McpManager.tsx
@@ -1,0 +1,177 @@
+import { useState, type ReactNode } from "react";
+import { Switch } from "@heroui/react";
+import { Pencil, Plus, Store, Trash2, ScanSearch, Server } from "lucide-react";
+import type { DetectedMcpServer, McpServer } from "@/shared/contracts";
+import { detectedToManagedServer } from "@/shared/contracts";
+import { catalogEntryToServer, type McpCatalogEntry } from "@/shared/mcpCatalog";
+import { Button, LightballTabs } from "@/renderer/components/common";
+import { McpServerEditorDialog } from "./McpServerEditorDialog";
+import { McpMarketplace } from "./McpMarketplace";
+import { DetectedMcpPanel } from "./DetectedMcpPanel";
+import { transportBadge, transportSummary } from "./mcpFormUtils";
+
+type Tab = "servers" | "marketplace" | "detected";
+
+export function McpManager(props: {
+  servers: McpServer[];
+  onChange: (servers: McpServer[]) => void;
+  /** Absolute project path enabling project-scope detection. Omit for global. */
+  projectPath?: string;
+  /** Optional banner shown above the server list (e.g. inherited-globals note). */
+  banner?: ReactNode;
+}) {
+  const { servers, onChange, projectPath, banner } = props;
+  const [tab, setTab] = useState<Tab>("servers");
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<McpServer | undefined>(undefined);
+  const [setupHint, setSetupHint] = useState<string | undefined>(undefined);
+
+  const managedNames = new Set(servers.map((s) => s.name.toLowerCase()));
+  const installedCatalogIds = new Set(
+    servers.map((s) => s.catalogId).filter((id): id is string => Boolean(id)),
+  );
+
+  const upsert = (server: McpServer) => {
+    const idx = servers.findIndex((s) => s.id === server.id);
+    if (idx === -1) onChange([...servers, server]);
+    else onChange(servers.map((s) => (s.id === server.id ? server : s)));
+  };
+
+  const openEditor = (server: McpServer | undefined, hint?: string) => {
+    setEditing(server);
+    setSetupHint(hint);
+    setEditorOpen(true);
+  };
+  const remove = (id: string) => onChange(servers.filter((s) => s.id !== id));
+  const toggle = (id: string, enabled: boolean) =>
+    onChange(servers.map((s) => (s.id === id ? { ...s, enabled } : s)));
+
+  const addFromCatalog = (entry: McpCatalogEntry) => {
+    const server = catalogEntryToServer(entry, crypto.randomUUID());
+    upsert(server);
+    openEditor(server, entry.setupHint);
+    setTab("servers");
+  };
+
+  const importDetected = (detected: DetectedMcpServer) => {
+    const server = detectedToManagedServer(detected, crypto.randomUUID());
+    if (!server) return;
+    // Avoid clobbering an existing managed server with the same name.
+    if (managedNames.has(server.name.toLowerCase())) return;
+    upsert(server);
+    setTab("servers");
+  };
+
+  return (
+    <div className="space-y-4">
+      <LightballTabs
+        ariaLabel="MCP server views"
+        className="w-full"
+        equalWidth
+        shape="rounded"
+        active={tab}
+        onChange={setTab}
+        tabs={[
+          {
+            id: "servers",
+            icon: <Server className="size-3.5" />,
+            label: `Servers${servers.length > 0 ? ` (${servers.length})` : ""}`,
+          },
+          { id: "marketplace", icon: <Store className="size-3.5" />, label: "Marketplace" },
+          { id: "detected", icon: <ScanSearch className="size-3.5" />, label: "Detected" },
+        ]}
+      />
+
+      {tab === "servers" ? (
+        <div className="space-y-3">
+          {banner}
+          {servers.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-[var(--hairline-strong)] px-4 py-8 text-center">
+              <p className="text-sm text-foreground">No MCP servers yet</p>
+              <p className="mt-1 text-xs text-muted">
+                Add one manually, browse the Marketplace, or import a detected server.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {servers.map((server) => (
+                <div
+                  key={server.id}
+                  className="group flex items-center gap-3 rounded-lg border border-[var(--hairline)] bg-[var(--row-hover)] px-3 py-2.5"
+                >
+                  <Switch
+                    isSelected={server.enabled !== false}
+                    onChange={(selected) => toggle(server.id, selected)}
+                    aria-label={`Enable ${server.name}`}
+                  >
+                    <Switch.Content>
+                      <Switch.Control>
+                        <Switch.Thumb />
+                      </Switch.Control>
+                    </Switch.Content>
+                  </Switch>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {server.label?.trim() || server.name}
+                      </span>
+                      <span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                        {transportBadge(server.transport)}
+                      </span>
+                    </div>
+                    <div className="truncate font-mono text-[11px] text-muted">
+                      {transportSummary(server.transport)}
+                    </div>
+                  </div>
+                  <Button
+                    isIconOnly
+                    size="sm"
+                    variant="tertiary"
+                    aria-label={`Edit ${server.name}`}
+                    onPress={() => openEditor(server)}
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    size="sm"
+                    variant="tertiary"
+                    aria-label={`Remove ${server.name}`}
+                    onPress={() => remove(server.id)}
+                  >
+                    <Trash2 className="size-3.5 text-danger" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+          <Button variant="secondary" onPress={() => openEditor(undefined)}>
+            <Plus className="size-4" />
+            Add MCP server
+          </Button>
+        </div>
+      ) : null}
+
+      {tab === "marketplace" ? (
+        <McpMarketplace installedCatalogIds={installedCatalogIds} onAdd={addFromCatalog} />
+      ) : null}
+
+      {tab === "detected" ? (
+        <DetectedMcpPanel
+          {...(projectPath ? { projectPath } : {})}
+          managedNames={managedNames}
+          onImport={importDetected}
+        />
+      ) : null}
+
+      <McpServerEditorDialog
+        isOpen={editorOpen}
+        server={editing}
+        existingNames={managedNames}
+        setupHint={setupHint}
+        onSave={upsert}
+        onClose={() => setEditorOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/mcp/McpMarketplace.tsx
+++ b/src/renderer/components/mcp/McpMarketplace.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { Check, Plus } from "lucide-react";
+import { Button, Input } from "@/renderer/components/common";
+import {
+  MCP_CATALOG,
+  MCP_CATALOG_CATEGORY_LABELS,
+  type McpCatalogEntry,
+} from "@/shared/mcpCatalog";
+import { transportBadge } from "./mcpFormUtils";
+
+export function McpMarketplace(props: {
+  /** Catalog ids already installed in the current scope. */
+  installedCatalogIds: ReadonlySet<string>;
+  onAdd: (entry: McpCatalogEntry) => void;
+}) {
+  const { installedCatalogIds, onAdd } = props;
+  const [query, setQuery] = useState("");
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? MCP_CATALOG.filter(
+        (entry) =>
+          entry.title.toLowerCase().includes(normalizedQuery) ||
+          entry.name.toLowerCase().includes(normalizedQuery) ||
+          entry.description.toLowerCase().includes(normalizedQuery),
+      )
+    : MCP_CATALOG;
+
+  return (
+    <div className="space-y-3">
+      <Input
+        aria-label="Search MCP marketplace"
+        placeholder="Search servers…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {filtered.map((entry) => {
+          const installed = installedCatalogIds.has(entry.id);
+          return (
+            <div
+              key={entry.id}
+              className="flex flex-col gap-2 rounded-lg border border-[var(--hairline)] bg-[var(--row-hover)] p-3"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {entry.title}
+                    </span>
+                    <span className="shrink-0 rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-muted">
+                      {transportBadge(entry.transport)}
+                    </span>
+                  </div>
+                  <span className="text-[11px] text-muted">
+                    {MCP_CATALOG_CATEGORY_LABELS[entry.category]}
+                  </span>
+                </div>
+                <Button
+                  size="sm"
+                  variant={installed ? "tertiary" : "secondary"}
+                  isDisabled={installed}
+                  onPress={() => onAdd(entry)}
+                >
+                  {installed ? <Check className="size-3.5" /> : <Plus className="size-3.5" />}
+                  {installed ? "Added" : "Add"}
+                </Button>
+              </div>
+              <p className="text-xs text-muted">{entry.description}</p>
+            </div>
+          );
+        })}
+        {filtered.length === 0 ? (
+          <p className="col-span-full py-6 text-center text-xs text-muted">No matching servers.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/mcp/McpServerEditorDialog.tsx
+++ b/src/renderer/components/mcp/McpServerEditorDialog.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Modal } from "@heroui/react";
+import type { McpServer } from "@/shared/contracts";
+import { Button, Input, Select, TextArea } from "@/renderer/components/common";
+import {
+  formStateToServer,
+  newServerFormState,
+  serverToFormState,
+  validateForm,
+  type McpServerFormState,
+} from "./mcpFormUtils";
+
+const TRANSPORT_OPTIONS = [
+  { id: "stdio", label: "stdio (local command)" },
+  { id: "http", label: "http (streamable)" },
+  { id: "sse", label: "sse (legacy)" },
+];
+
+export function McpServerEditorDialog(props: {
+  isOpen: boolean;
+  /** The server being edited, or undefined to create a new one. */
+  server?: McpServer | undefined;
+  /** Existing server names (lowercased) used to flag duplicates. */
+  existingNames: ReadonlySet<string>;
+  setupHint?: string | undefined;
+  onSave: (server: McpServer) => void;
+  onClose: () => void;
+}) {
+  const { isOpen, server, existingNames, setupHint, onSave, onClose } = props;
+  const [state, setState] = useState<McpServerFormState>(() => newServerFormState(""));
+  const [showErrors, setShowErrors] = useState(false);
+
+  // Re-seed the form each time the dialog opens for a (possibly different) server.
+  useEffect(() => {
+    if (!isOpen) return;
+    setShowErrors(false);
+    setState(server ? serverToFormState(server) : newServerFormState(crypto.randomUUID()));
+  }, [isOpen, server]);
+
+  const validation = validateForm(state);
+  const trimmedName = state.name.trim().toLowerCase();
+  const duplicate =
+    trimmedName.length > 0 &&
+    trimmedName !== (server?.name.toLowerCase() ?? "") &&
+    existingNames.has(trimmedName);
+
+  const update = <K extends keyof McpServerFormState>(key: K, value: McpServerFormState[K]) =>
+    setState((prev) => ({ ...prev, [key]: value }));
+
+  const handleSave = () => {
+    if (!validation.ok || duplicate) {
+      setShowErrors(true);
+      return;
+    }
+    onSave(formStateToServer(state, server));
+    onClose();
+  };
+
+  const fieldError = (key: "name" | "command" | "url") =>
+    showErrors ? validation.errors[key] : undefined;
+
+  return (
+    <Modal>
+      <Modal.Backdrop isOpen={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <Modal.Container>
+          <Modal.Dialog className="sm:max-w-[620px]">
+            <Modal.CloseTrigger />
+            <Modal.Header>
+              <Modal.Heading>{server ? "Edit MCP server" : "Add MCP server"}</Modal.Heading>
+            </Modal.Header>
+            <Modal.Body className="space-y-4 px-5 pb-5 pt-2">
+              {setupHint ? (
+                <p className="rounded-md bg-warning/10 px-3 py-2 text-xs text-warning">
+                  {setupHint}
+                </p>
+              ) : null}
+
+              <Field
+                label="Name"
+                error={
+                  fieldError("name") ??
+                  (duplicate ? "A server with this name already exists." : undefined)
+                }
+              >
+                <Input
+                  aria-label="Server name"
+                  placeholder="e.g. github"
+                  value={state.name}
+                  onChange={(e) => update("name", e.target.value)}
+                />
+              </Field>
+
+              <Field label="Transport">
+                <Select
+                  aria-label="Transport type"
+                  options={TRANSPORT_OPTIONS}
+                  value={state.transportType}
+                  onChange={(value) =>
+                    update("transportType", value as McpServerFormState["transportType"])
+                  }
+                />
+              </Field>
+
+              {state.transportType === "stdio" ? (
+                <>
+                  <Field label="Command" error={fieldError("command")}>
+                    <Input
+                      aria-label="Command"
+                      className="font-mono text-xs"
+                      placeholder="npx"
+                      value={state.command}
+                      onChange={(e) => update("command", e.target.value)}
+                    />
+                  </Field>
+                  <Field label="Arguments" hint="One per line">
+                    <TextArea
+                      aria-label="Arguments"
+                      className="w-full font-mono text-xs"
+                      rows={3}
+                      placeholder={"-y\n@modelcontextprotocol/server-filesystem\n/path/to/dir"}
+                      value={state.argsText}
+                      onChange={(e) => update("argsText", e.target.value)}
+                    />
+                  </Field>
+                  <Field label="Environment" hint="KEY=VALUE per line">
+                    <TextArea
+                      aria-label="Environment variables"
+                      className="w-full font-mono text-xs"
+                      rows={2}
+                      placeholder={"API_KEY=..."}
+                      value={state.envText}
+                      onChange={(e) => update("envText", e.target.value)}
+                    />
+                  </Field>
+                </>
+              ) : (
+                <>
+                  <Field label="URL" error={fieldError("url")}>
+                    <Input
+                      aria-label="Server URL"
+                      className="font-mono text-xs"
+                      placeholder="https://example.com/mcp"
+                      value={state.url}
+                      onChange={(e) => update("url", e.target.value)}
+                    />
+                  </Field>
+                  <Field label="Headers" hint="Header-Name: value per line">
+                    <TextArea
+                      aria-label="Headers"
+                      className="w-full font-mono text-xs"
+                      rows={2}
+                      placeholder={"Authorization: Bearer ..."}
+                      value={state.headersText}
+                      onChange={(e) => update("headersText", e.target.value)}
+                    />
+                  </Field>
+                </>
+              )}
+
+              <Field label="Description" hint="Optional">
+                <Input
+                  aria-label="Description"
+                  placeholder="What this server provides"
+                  value={state.description}
+                  onChange={(e) => update("description", e.target.value)}
+                />
+              </Field>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button slot="close" variant="tertiary">
+                Cancel
+              </Button>
+              <Button variant="primary" onPress={handleSave}>
+                {server ? "Save" : "Add server"}
+              </Button>
+            </Modal.Footer>
+          </Modal.Dialog>
+        </Modal.Container>
+      </Modal.Backdrop>
+    </Modal>
+  );
+}
+
+function Field(props: {
+  label: string;
+  hint?: string | undefined;
+  error?: string | undefined;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs font-medium text-foreground">{props.label}</span>
+        {props.hint ? <span className="text-[11px] text-muted">{props.hint}</span> : null}
+      </div>
+      {props.children}
+      {props.error ? <p className="text-[11px] text-danger">{props.error}</p> : null}
+    </div>
+  );
+}

--- a/src/renderer/components/mcp/mcpFormUtils.test.ts
+++ b/src/renderer/components/mcp/mcpFormUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { McpServer } from "@/shared/contracts";
+import { formStateToServer, serverToFormState } from "./mcpFormUtils";
+
+describe("formStateToServer", () => {
+  it("preserves metadata that the editor does not expose yet", () => {
+    const server: McpServer = {
+      id: "server-id",
+      name: "filesystem",
+      enabled: true,
+      catalogId: "filesystem",
+      agentKinds: ["claude"],
+      transport: {
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/repo"],
+        env: {},
+        cwd: "/repo",
+      },
+    };
+
+    expect(formStateToServer(serverToFormState(server), server)).toMatchObject({
+      catalogId: "filesystem",
+      agentKinds: ["claude"],
+      transport: { cwd: "/repo" },
+    });
+  });
+});

--- a/src/renderer/components/mcp/mcpFormUtils.ts
+++ b/src/renderer/components/mcp/mcpFormUtils.ts
@@ -1,0 +1,151 @@
+import {
+  MCP_SERVER_NAME_PATTERN,
+  type McpServer,
+  type McpTransport,
+  type McpTransportKind,
+} from "@/shared/contracts";
+
+/** Editable form state mirroring an {@link McpServer}, with text-area buffers. */
+export interface McpServerFormState {
+  id: string;
+  name: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  transportType: McpTransportKind;
+  command: string;
+  /** One argument per line. */
+  argsText: string;
+  /** `KEY=VALUE` per line. */
+  envText: string;
+  url: string;
+  /** `Header-Name: value` per line. */
+  headersText: string;
+}
+
+export function newServerFormState(id: string): McpServerFormState {
+  return {
+    id,
+    name: "",
+    label: "",
+    description: "",
+    enabled: true,
+    transportType: "stdio",
+    command: "",
+    argsText: "",
+    envText: "",
+    url: "",
+    headersText: "",
+  };
+}
+
+function recordToLines(record: Record<string, string>, sep: string): string {
+  return Object.entries(record)
+    .map(([k, v]) => `${k}${sep}${v}`)
+    .join("\n");
+}
+
+export function serverToFormState(server: McpServer): McpServerFormState {
+  const t = server.transport;
+  return {
+    id: server.id,
+    name: server.name,
+    label: server.label ?? "",
+    description: server.description ?? "",
+    enabled: server.enabled !== false,
+    transportType: t.type,
+    command: t.type === "stdio" ? t.command : "",
+    argsText: t.type === "stdio" ? t.args.join("\n") : "",
+    envText: t.type === "stdio" ? recordToLines(t.env, "=") : "",
+    url: t.type === "stdio" ? "" : t.url,
+    headersText: t.type === "stdio" ? "" : recordToLines(t.headers, ": "),
+  };
+}
+
+function parseLines(text: string, sep: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.indexOf(sep);
+    if (idx === -1) continue;
+    const key = trimmed.slice(0, idx).trim();
+    const value = trimmed.slice(idx + sep.length).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+}
+
+function parseArgs(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+export interface McpFormValidation {
+  ok: boolean;
+  errors: Partial<Record<"name" | "command" | "url", string>>;
+}
+
+export function validateForm(state: McpServerFormState): McpFormValidation {
+  const errors: McpFormValidation["errors"] = {};
+  const name = state.name.trim();
+  if (!name) errors.name = "Name is required.";
+  else if (!MCP_SERVER_NAME_PATTERN.test(name))
+    errors.name = "Use letters, numbers, dot, dash, underscore (no spaces).";
+  if (state.transportType === "stdio") {
+    if (!state.command.trim()) errors.command = "Command is required.";
+  } else if (!state.url.trim()) {
+    errors.url = "URL is required.";
+  }
+  return { ok: Object.keys(errors).length === 0, errors };
+}
+
+export function formStateToServer(
+  state: McpServerFormState,
+  previous?: McpServer | undefined,
+): McpServer {
+  const previousCwd =
+    previous?.transport.type === "stdio" && state.transportType === "stdio"
+      ? previous.transport.cwd
+      : undefined;
+  const transport: McpTransport =
+    state.transportType === "stdio"
+      ? {
+          type: "stdio",
+          command: state.command.trim(),
+          args: parseArgs(state.argsText),
+          env: parseLines(state.envText, "="),
+          ...(previousCwd ? { cwd: previousCwd } : {}),
+        }
+      : {
+          type: state.transportType,
+          url: state.url.trim(),
+          headers: parseLines(state.headersText, ":"),
+        };
+  const label = state.label.trim();
+  const description = state.description.trim();
+  return {
+    id: state.id,
+    name: state.name.trim(),
+    enabled: state.enabled,
+    transport,
+    ...(previous?.agentKinds ? { agentKinds: [...previous.agentKinds] } : {}),
+    ...(previous?.catalogId ? { catalogId: previous.catalogId } : {}),
+    ...(label ? { label } : {}),
+    ...(description ? { description } : {}),
+  };
+}
+
+/** One-line summary of a transport for list rows. */
+export function transportSummary(transport: McpTransport): string {
+  if (transport.type === "stdio") {
+    return [transport.command, ...transport.args].join(" ");
+  }
+  return transport.url;
+}
+
+export function transportBadge(transport: McpTransport): string {
+  return transport.type.toUpperCase();
+}

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -12,6 +12,7 @@ import type {
   ThreadPresentationMode,
   ThreadServerRequestId,
 } from "@/shared/contracts";
+import { mergeMcpServers } from "@/shared/contracts";
 import { isHomeProjectId } from "@/shared/homeScope";
 import { isOpenCodeBrowserMcpEnabled } from "@/shared/opencodeSettings";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
@@ -293,6 +294,10 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
           projectLocation,
         });
       }
+      const globalMcpServers = useSharedSettings.getState().mcpServers;
+      const projectMcpServers =
+        useAppStore.getState().projects.find((p) => p.id === thread.projectId)?.mcpServers ?? [];
+      const userMcpServers = mergeMcpServers(globalMcpServers, projectMcpServers);
       await readBridge().startThread({
         threadId: thread.id,
         projectLocation,
@@ -300,6 +305,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
         config: thread.config,
         prompt: pendingLaunchPrompt,
+        ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
         ...(pendingLaunchSegments ? { segments: pendingLaunchSegments } : {}),
         initialSize: launchTerminalSize,
         ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -13,6 +13,7 @@ import type {
   AgentInstanceConfig,
   CommitDefaultAction,
   InstalledAcpRegistryAgent,
+  McpServer,
   NewThreadMode,
   NotificationFilter,
   PrCreateMode,
@@ -110,6 +111,8 @@ interface SharedSettingsState extends SharedSettings {
     error?: boolean;
   }) => void;
   setNotifyL2Cli: (value: boolean) => void;
+  /** Replace the global Lightcode-managed MCP server list. */
+  setMcpServers: (servers: McpServer[]) => void;
   toggleFavoriteModel: (
     agentKind: string,
     modelId: string,
@@ -570,6 +573,10 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({ notifyL2Cli });
     persistSettings(selectSharedSettings(get()));
   },
+  setMcpServers: (mcpServers) => {
+    set({ mcpServers });
+    persistSettings(selectSharedSettings(get()));
+  },
   toggleFavoriteModel: (agentKind, modelId, presentationMode) => {
     const current = get().favoriteModels;
     const idx = current.findIndex(
@@ -704,6 +711,7 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     browser: state.browser,
     audio: state.audio,
     usage: state.usage,
+    mcpServers: state.mcpServers,
   };
 }
 

--- a/src/renderer/state/slices/projectSlice.ts
+++ b/src/renderer/state/slices/projectSlice.ts
@@ -1,4 +1,5 @@
 import type {
+  McpServer,
   Project,
   ProjectDraftConfig,
   ProjectLocation,
@@ -40,6 +41,7 @@ export interface ProjectSlice {
   deleteProject: (projectId: string) => void;
   updateProjectDraftConfig: (projectId: string, draftConfig: ProjectDraftConfig) => void;
   updateProjectScripts: (projectId: string, scripts: ProjectScripts) => void;
+  updateProjectMcpServers: (projectId: string, mcpServers: McpServer[]) => void;
   updateProjectSearchSettings: (
     projectId: string,
     searchSettings: ProjectSearchSettings | undefined,
@@ -177,6 +179,12 @@ export const createProjectSlice: SliceCreator<ProjectSlice> = (set) => ({
     set((state) => ({
       projects: state.projects.map((project) =>
         project.id === projectId ? { ...project, scripts } : project,
+      ),
+    })),
+  updateProjectMcpServers: (projectId, mcpServers) =>
+    set((state) => ({
+      projects: state.projects.map((project) =>
+        project.id === projectId ? { ...project, mcpServers } : project,
       ),
     })),
   updateProjectSearchSettings: (projectId, searchSettings) =>

--- a/src/renderer/views/ProjectSettingsOverlay/ProjectSettingsOverlay.tsx
+++ b/src/renderer/views/ProjectSettingsOverlay/ProjectSettingsOverlay.tsx
@@ -6,6 +6,7 @@ import { SettingsSidebar } from "./parts/SettingsSidebar";
 import { GeneralSection } from "./parts/GeneralSection";
 import { ScriptsSection } from "./parts/ScriptsSection";
 import { ActionsSection } from "./parts/ActionsSection";
+import { McpSection } from "./parts/McpSection";
 import { SearchSection } from "./parts/SearchSection";
 import type { ProjectSettingsSection } from "./parts/types";
 
@@ -36,6 +37,8 @@ export function ProjectSettingsOverlay(props: { projectId: string; onClose: () =
           <ScriptsSection projectId={projectId} />
         ) : activeSection === "actions" ? (
           <ActionsSection projectId={projectId} />
+        ) : activeSection === "mcp" ? (
+          <McpSection projectId={projectId} />
         ) : activeSection === "search" ? (
           <SearchSection projectId={projectId} />
         ) : null

--- a/src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
+++ b/src/renderer/views/ProjectSettingsOverlay/parts/McpSection.tsx
@@ -1,0 +1,41 @@
+import { useAppStore } from "@/renderer/state/appStore";
+import { useProject } from "@/renderer/state/useThread";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { McpManager } from "@/renderer/components/mcp/McpManager";
+
+export function McpSection(props: { projectId: string }) {
+  const project = useProject(props.projectId);
+  const updateProjectMcpServers = useAppStore((s) => s.updateProjectMcpServers);
+  const globalCount = useSharedSettings((s) => s.mcpServers.length);
+
+  if (!project) return null;
+
+  const projectPath =
+    project.location.kind === "wsl" ? project.location.uncPath : project.location.path;
+  const servers = project.mcpServers ?? [];
+
+  return (
+    <div className="h-full min-h-0 overflow-y-auto px-6 pb-8 pt-4">
+      <div className="mx-auto max-w-[720px]">
+        <h1 className="mb-2 text-lg font-semibold text-foreground">MCP Servers</h1>
+        <p className="mb-6 text-xs text-muted">
+          Project-scoped MCP servers, merged on top of your global servers for this project. A
+          project server with the same name overrides the global one.
+        </p>
+        <McpManager
+          servers={servers}
+          onChange={(next) => updateProjectMcpServers(project.id, next)}
+          projectPath={projectPath}
+          banner={
+            globalCount > 0 ? (
+              <p className="rounded-md bg-surface-tertiary px-3 py-2 text-[11px] text-muted">
+                {globalCount} global server{globalCount === 1 ? "" : "s"} also apply to this project
+                (manage them in Settings → MCP Servers).
+              </p>
+            ) : null
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
@@ -4,6 +4,7 @@ import {
   PanelLeft,
   PanelLeftClose,
   Play,
+  Plug,
   Search,
   Settings2,
 } from "lucide-react";
@@ -32,6 +33,7 @@ export function SettingsSidebar(props: {
     { id: "general", icon: <Settings2 className="size-4" />, label: t`General` },
     { id: "worktrees", icon: <GitFork className="size-4" />, label: t`Worktrees` },
     { id: "actions", icon: <Play className="size-4" />, label: t`Actions` },
+    { id: "mcp", icon: <Plug className="size-4" />, label: t`MCP Servers` },
     { id: "search", icon: <Search className="size-4" />, label: t`Search` },
   ];
 

--- a/src/renderer/views/ProjectSettingsOverlay/parts/types.ts
+++ b/src/renderer/views/ProjectSettingsOverlay/parts/types.ts
@@ -1,1 +1,1 @@
-export type ProjectSettingsSection = "general" | "worktrees" | "actions" | "search";
+export type ProjectSettingsSection = "general" | "worktrees" | "actions" | "mcp" | "search";

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -11,6 +11,7 @@ import { getSettingsInstalledAgents } from "@/shared/agentStatus";
 import { ProfileSettings } from "./parts/ProfileSettings";
 import { AppearanceSettings } from "./parts/AppearanceSettings";
 import { BrowserSettings } from "./parts/BrowserSettings";
+import { McpServersSettings } from "./parts/McpServersSettings";
 import { UsageSettings } from "./parts/UsageSettings";
 import { AudioSettings } from "./parts/AudioSettings";
 import { GeneralSettings } from "./parts/GeneralSettings";
@@ -47,6 +48,7 @@ const SECTION_VIEWS: Partial<Record<SettingsSection, () => ReactNode>> = {
   agents: () => <AgentSettingsEmpty />,
   agentsGeneral: () => <AgentsGeneralSettings />,
   browser: () => <BrowserSettings />,
+  mcp: () => <McpServersSettings />,
   usage: () => <UsageSettings />,
   archived: () => <ArchivedThreadsSettings />,
   about: () => <AboutSettings />,

--- a/src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/McpServersSettings.tsx
@@ -1,0 +1,17 @@
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { McpManager } from "@/renderer/components/mcp/McpManager";
+import { SettingsPage } from "./SettingsForm";
+
+export function McpServersSettings() {
+  const mcpServers = useSharedSettings((s) => s.mcpServers);
+  const setMcpServers = useSharedSettings((s) => s.setMcpServers);
+
+  return (
+    <SettingsPage
+      title="MCP Servers"
+      description="Model Context Protocol servers managed by Lightcode and injected into every agent at launch (Claude, Codex, Cursor, Gemini, OpenCode, and more). Scope a server to specific agents, or add per-project servers in Project Settings."
+    >
+      <McpManager servers={mcpServers} onChange={setMcpServers} />
+    </SettingsPage>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -17,6 +17,7 @@ import {
   PanelLeft,
   PanelLeftClose,
   Palette,
+  Plug,
   RefreshCw,
   Search,
   Settings2,
@@ -180,6 +181,7 @@ export function SettingsSidebar(props: {
   ];
   const sectionsAfterAgents: { id: SettingsSection; icon: ReactNode; label: string }[] = [
     { id: "browser", icon: <Globe className="size-4" />, label: t`Browser` },
+    { id: "mcp", icon: <Plug className="size-4" />, label: t`MCP Servers` },
     { id: "usage", icon: <Gauge className="size-4" />, label: t`Usage` },
     { id: "archived", icon: <Archive className="size-4" />, label: t`Archived Threads` },
     { id: "about", icon: <Info className="size-4" />, label: t`About` },
@@ -420,6 +422,13 @@ export function SettingsSidebar(props: {
               label={t`Browser`}
               isActive={activeSection === "browser"}
               onPress={() => onSectionChange("browser")}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<Plug className="size-4" />}
+              label={t`MCP Servers`}
+              isActive={activeSection === "mcp"}
+              onPress={() => onSectionChange("mcp")}
             />
             <SidebarButton
               iconOnly

--- a/src/renderer/views/SettingsOverlay/parts/types.ts
+++ b/src/renderer/views/SettingsOverlay/parts/types.ts
@@ -15,6 +15,7 @@ export type SettingsSection =
   | "shortcuts"
   | "agents"
   | "browser"
+  | "mcp"
   | "usage"
   | "archived"
   | "about"

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -1,5 +1,6 @@
 export * from "./contracts/common";
 export * from "./contracts/config";
+export * from "./contracts/mcpServer";
 export * from "./contracts/agent";
 export * from "./contracts/project";
 export * from "./contracts/thread";

--- a/src/shared/contracts/mcpServer.test.ts
+++ b/src/shared/contracts/mcpServer.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { detectedToManagedServer } from "./mcpServer";
+
+describe("detectedToManagedServer", () => {
+  it("rejects detected names that cannot be persisted as managed MCP keys", () => {
+    expect(
+      detectedToManagedServer(
+        {
+          name: "bad name",
+          source: "mcp-json",
+          filePath: "/repo/.mcp.json",
+          transport: { type: "http", url: "https://mcp.example.com/mcp", headers: {} },
+        },
+        "id",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/shared/contracts/mcpServer.ts
+++ b/src/shared/contracts/mcpServer.ts
@@ -1,0 +1,238 @@
+import { z } from "zod";
+
+/**
+ * Canonical, provider-agnostic MCP server definition managed by Lightcode.
+ *
+ * This is the single source of truth the user edits in the MCP Manager UI
+ * (global Settings + per-project Settings). At launch the supervisor projects
+ * each enabled server into the native config format of whichever agent is
+ * starting (Claude `mcpServers`, Codex `-c mcp_servers.*`, Gemini `mcpServers`,
+ * ACP `mcpServers[]`, OpenCode `mcp`) — the same path the built-in browser MCP
+ * already travels. See `src/supervisor/agents/userMcp/`.
+ *
+ * Detected, read-only servers found in other tools' config files (e.g.
+ * `~/.claude.json`, `.cursor/mcp.json`, `~/.codex/config.toml`) are represented
+ * by {@link DetectedMcpServer}; they can be imported into a {@link McpServer}.
+ */
+
+/** Stdio transport: Lightcode/the agent spawns a child process. */
+export const mcpStdioTransportSchema = z.object({
+  type: z.literal("stdio"),
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  /** Extra env passed to the spawned server. Plaintext — avoid long-lived secrets. */
+  env: z.record(z.string(), z.string()).default({}),
+  /** Working directory; defaults to the project/cwd when omitted. */
+  cwd: z.string().optional(),
+});
+export type McpStdioTransport = z.infer<typeof mcpStdioTransportSchema>;
+
+/** Streamable-HTTP transport: a remote MCP endpoint. */
+export const mcpHttpTransportSchema = z.object({
+  type: z.literal("http"),
+  url: z.string().min(1),
+  headers: z.record(z.string(), z.string()).default({}),
+});
+export type McpHttpTransport = z.infer<typeof mcpHttpTransportSchema>;
+
+/** Legacy SSE transport: a remote MCP endpoint speaking server-sent events. */
+export const mcpSseTransportSchema = z.object({
+  type: z.literal("sse"),
+  url: z.string().min(1),
+  headers: z.record(z.string(), z.string()).default({}),
+});
+export type McpSseTransport = z.infer<typeof mcpSseTransportSchema>;
+
+export const mcpTransportSchema = z.discriminatedUnion("type", [
+  mcpStdioTransportSchema,
+  mcpHttpTransportSchema,
+  mcpSseTransportSchema,
+]);
+export type McpTransport = z.infer<typeof mcpTransportSchema>;
+export type McpTransportKind = McpTransport["type"];
+
+/** Server name characters that are safe to use as a config key across all agents. */
+export const MCP_SERVER_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/u;
+
+export function isValidMcpServerName(name: string): boolean {
+  return MCP_SERVER_NAME_PATTERN.test(name);
+}
+
+export const mcpServerSchema = z.object({
+  /** Stable Lightcode id (uuid). Never written into an agent config. */
+  id: z.string().min(1),
+  /** Server key used as the entry name in every agent's native config. */
+  name: z.string().min(1).regex(MCP_SERVER_NAME_PATTERN),
+  /** Human label; falls back to `name` in the UI when absent. */
+  label: z.string().optional(),
+  description: z.string().optional(),
+  /** When false the server is kept in the list but never injected. */
+  enabled: z.boolean().default(true),
+  transport: mcpTransportSchema,
+  /**
+   * Agent kinds this server should be injected into. Empty/undefined means
+   * "all agents". Lets a user scope, say, a Playwright server to Claude only.
+   */
+  agentKinds: z.array(z.string()).optional(),
+  /** Marketplace catalog id this server was installed from, if any. */
+  catalogId: z.string().optional(),
+});
+export type McpServer = z.infer<typeof mcpServerSchema>;
+
+export const mcpServerListSchema = z.array(mcpServerSchema).default([]);
+
+/**
+ * Origin of a server discovered on disk. `*-project` variants live inside the
+ * project tree; the rest are user/global level. `mcp-json` is the shared
+ * `<project>/.mcp.json` understood by Claude Code and several other tools.
+ */
+export const mcpSourceSchema = z.enum([
+  "lightcode-global",
+  "lightcode-project",
+  "claude-global",
+  "claude-project",
+  "mcp-json",
+  "codex-global",
+  "cursor-global",
+  "cursor-project",
+  "gemini-global",
+  "gemini-project",
+  "vscode-project",
+  "opencode-global",
+  "opencode-project",
+]);
+export type McpSource = z.infer<typeof mcpSourceSchema>;
+
+export const MCP_SOURCE_META: Record<
+  McpSource,
+  { label: string; scope: "global" | "project"; shared: boolean; agentKind?: string }
+> = {
+  "lightcode-global": { label: "Lightcode · Global", scope: "global", shared: true },
+  "lightcode-project": { label: "Lightcode · Project", scope: "project", shared: true },
+  "claude-global": {
+    label: "Claude Code · User",
+    scope: "global",
+    shared: false,
+    agentKind: "claude",
+  },
+  "claude-project": {
+    label: "Claude Code · Project",
+    scope: "project",
+    shared: false,
+    agentKind: "claude",
+  },
+  "mcp-json": { label: ".mcp.json (shared)", scope: "project", shared: true },
+  "codex-global": {
+    label: "Codex · ~/.codex/config.toml",
+    scope: "global",
+    shared: false,
+    agentKind: "codex",
+  },
+  "cursor-global": { label: "Cursor · User", scope: "global", shared: false, agentKind: "cursor" },
+  "cursor-project": {
+    label: "Cursor · .cursor/mcp.json",
+    scope: "project",
+    shared: false,
+    agentKind: "cursor",
+  },
+  "gemini-global": {
+    label: "Gemini · ~/.gemini/settings.json",
+    scope: "global",
+    shared: false,
+    agentKind: "gemini",
+  },
+  "gemini-project": {
+    label: "Gemini · .gemini/settings.json",
+    scope: "project",
+    shared: false,
+    agentKind: "gemini",
+  },
+  "vscode-project": { label: "VS Code · .vscode/mcp.json", scope: "project", shared: false },
+  "opencode-global": {
+    label: "OpenCode · User",
+    scope: "global",
+    shared: false,
+    agentKind: "opencode",
+  },
+  "opencode-project": {
+    label: "OpenCode · opencode.json",
+    scope: "project",
+    shared: false,
+    agentKind: "opencode",
+  },
+};
+
+/** A server discovered in some other tool's config file. Read-only. */
+export const detectedMcpServerSchema = z.object({
+  name: z.string(),
+  source: mcpSourceSchema,
+  /** Absolute path of the config file the entry came from. */
+  filePath: z.string(),
+  /** Parsed transport, when Lightcode could map it; absent for unsupported shapes. */
+  transport: mcpTransportSchema.optional(),
+  /** Whether the source marks this entry as disabled. */
+  disabled: z.boolean().optional(),
+  /** Raw entry as read, for display/debugging when transport can't be mapped. */
+  raw: z.unknown().optional(),
+});
+export type DetectedMcpServer = z.infer<typeof detectedMcpServerSchema>;
+
+export const detectedMcpGroupSchema = z.object({
+  source: mcpSourceSchema,
+  label: z.string(),
+  scope: z.enum(["global", "project"]),
+  shared: z.boolean(),
+  filePath: z.string(),
+  servers: z.array(detectedMcpServerSchema),
+});
+export type DetectedMcpGroup = z.infer<typeof detectedMcpGroupSchema>;
+
+export const detectMcpServersResultSchema = z.object({
+  groups: z.array(detectedMcpGroupSchema),
+});
+export type DetectMcpServersResult = z.infer<typeof detectMcpServersResultSchema>;
+
+/** True when the server is injected into the given agent kind. */
+export function mcpServerAppliesToAgent(server: McpServer, agentKind: string): boolean {
+  if (!server.agentKinds || server.agentKinds.length === 0) return true;
+  return server.agentKinds.includes(agentKind);
+}
+
+/** Filter a list down to the enabled servers that apply to `agentKind`. */
+export function resolveMcpServersForAgent(
+  servers: readonly McpServer[],
+  agentKind: string,
+): McpServer[] {
+  return servers.filter(
+    (server) => server.enabled !== false && mcpServerAppliesToAgent(server, agentKind),
+  );
+}
+
+/**
+ * Merge global + project servers, project winning on duplicate `name` so a
+ * project can override a global server. The result is deduped by `name`.
+ */
+export function mergeMcpServers(
+  global: readonly McpServer[],
+  project: readonly McpServer[],
+): McpServer[] {
+  const byName = new Map<string, McpServer>();
+  for (const server of global) byName.set(server.name, server);
+  for (const server of project) byName.set(server.name, server);
+  return [...byName.values()];
+}
+
+/** Build a fresh managed server from a detected one (for the Import action). */
+export function detectedToManagedServer(
+  detected: DetectedMcpServer,
+  id: string,
+): McpServer | undefined {
+  if (!detected.transport) return undefined;
+  if (!isValidMcpServerName(detected.name)) return undefined;
+  return {
+    id,
+    name: detected.name,
+    enabled: !detected.disabled,
+    transport: detected.transport,
+  };
+}

--- a/src/shared/contracts/project.ts
+++ b/src/shared/contracts/project.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { projectLocationSchema } from "./common";
 import { projectDraftConfigSchema } from "./config";
+import { mcpServerSchema } from "./mcpServer";
 
 export const projectActionSchema = z.object({
   id: z.string().min(1),
@@ -63,6 +64,8 @@ export const projectSchema = z.object({
   scripts: projectScriptsSchema.optional(),
   searchSettings: projectSearchSettingsSchema.optional(),
   worktreeLocation: projectWorktreeLocationSchema.optional(),
+  /** Project-scoped MCP servers managed by Lightcode (merged over global). */
+  mcpServers: z.array(mcpServerSchema).optional(),
   disabled: z.boolean().optional(),
   createdAt: z.string().min(1),
 });

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -10,6 +10,7 @@ import {
   threadStatusSchema,
 } from "./common";
 import { threadConfigSchema } from "./config";
+import { mcpServerSchema } from "./mcpServer";
 
 /** How thread status/attention is derived for terminal agents (supervisor → renderer). */
 export const threadStatusSourceSchema = z.enum(["cli_hook", "terminal_parse", "server"]);
@@ -97,6 +98,13 @@ export const startThreadPayloadSchema = z.object({
    * the duplicate. Only set for GUI threads with a fresh prompt.
    */
   userMessageItemId: z.string().min(1).optional(),
+  /**
+   * Lightcode-managed MCP servers (global merged with project-scoped) resolved
+   * by the renderer at launch. The supervisor narrows this to the enabled
+   * entries that apply to `agentKind` and projects them into the agent's native
+   * MCP config alongside the built-in browser server.
+   */
+  userMcpServers: z.array(mcpServerSchema).optional(),
 });
 export type StartThreadPayload = z.infer<typeof startThreadPayloadSchema>;
 

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -4,6 +4,7 @@ import { dbProcedures } from "./procedures/db";
 import { githubProcedures } from "./procedures/github";
 import { gitProcedures } from "./procedures/git";
 import { lspProcedures } from "./procedures/lsp";
+import { mcpProcedures } from "./procedures/mcp";
 import { profileProcedures } from "./procedures/profile";
 import { projectTreeProcedures } from "./procedures/projectTree";
 import { settingsProcedures } from "./procedures/settings";
@@ -23,6 +24,7 @@ export const groupedIpcProcedures = {
   lsp: lspProcedures,
   browser: browserProcedures,
   usage: usageProcedures,
+  mcp: mcpProcedures,
   profile: profileProcedures,
 } as const;
 
@@ -38,6 +40,7 @@ export const ipcProcedureMap = {
   ...lspProcedures,
   ...browserProcedures,
   ...usageProcedures,
+  ...mcpProcedures,
   ...profileProcedures,
 } as const;
 
@@ -125,6 +128,7 @@ export const MAIN_LOCAL_PROCEDURE_NAMES = [
   "setProfileIdentity",
   "copyShareImage",
   "appendUsageEvents",
+  "getDetectedMcpServers",
 ] as const satisfies readonly IpcProcedureName[];
 
 export type MainLocalProcedureName = (typeof MAIN_LOCAL_PROCEDURE_NAMES)[number];

--- a/src/shared/ipc/procedures/mcp.ts
+++ b/src/shared/ipc/procedures/mcp.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import type { DetectMcpServersResult } from "../../contracts";
+import { definePayloadProcedure } from "../core";
+
+export const detectMcpServersPayloadSchema = z.object({
+  /** Absolute project path to scan for project-level MCP configs. */
+  projectPath: z.string().optional(),
+});
+export type DetectMcpServersPayload = z.infer<typeof detectMcpServersPayloadSchema>;
+
+export const mcpProcedures = {
+  /** Read-only scan of other tools' MCP configs (global + optional project). */
+  getDetectedMcpServers: definePayloadProcedure<
+    DetectMcpServersPayload,
+    DetectMcpServersResult,
+    "main-local"
+  >("getDetectedMcpServers", "main-local", detectMcpServersPayloadSchema),
+} as const;

--- a/src/shared/mcpCatalog.ts
+++ b/src/shared/mcpCatalog.ts
@@ -1,0 +1,206 @@
+import type { McpServer, McpTransport } from "./contracts";
+
+/**
+ * Curated marketplace of popular MCP servers, modeled after the catalogs in
+ * VS Code / Zed / Cursor. Bundled in-app (no network) so users can one-click
+ * add a server into their Lightcode-managed list, then fill in any required
+ * paths/secrets in the editor. The list can later be backed by a remote feed.
+ */
+
+export type McpCatalogCategory = "official" | "web" | "dev" | "data" | "productivity" | "browser";
+
+export interface McpCatalogEntry {
+  /** Stable catalog id, recorded on the installed server as `catalogId`. */
+  id: string;
+  /** Default server key (the user can rename on add). */
+  name: string;
+  title: string;
+  description: string;
+  category: McpCatalogCategory;
+  homepage?: string;
+  /** Template transport; env values are blank placeholders for required keys. */
+  transport: McpTransport;
+  /** Env var names (stdio) or a one-line note the user must complete before use. */
+  requiredEnv?: string[];
+  /** Short human note about extra setup (e.g. "replace PATH with a folder"). */
+  setupHint?: string;
+}
+
+export const MCP_CATALOG: McpCatalogEntry[] = [
+  {
+    id: "filesystem",
+    name: "filesystem",
+    title: "Filesystem",
+    description: "Read and write files under one or more allowed directories.",
+    category: "official",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "PATH"],
+      env: {},
+    },
+    setupHint: "Replace PATH with an absolute directory the agent may access.",
+  },
+  {
+    id: "git",
+    name: "git",
+    title: "Git",
+    description: "Inspect and operate on a Git repository (status, diff, log, commit).",
+    category: "dev",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+    transport: { type: "stdio", command: "uvx", args: ["mcp-server-git"], env: {} },
+    setupHint: "Requires `uv` (uvx) installed.",
+  },
+  {
+    id: "fetch",
+    name: "fetch",
+    title: "Fetch",
+    description: "Fetch a URL and convert its contents to Markdown for the model.",
+    category: "web",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+    transport: { type: "stdio", command: "uvx", args: ["mcp-server-fetch"], env: {} },
+    setupHint: "Requires `uv` (uvx) installed.",
+  },
+  {
+    id: "memory",
+    name: "memory",
+    title: "Memory",
+    description: "A knowledge-graph memory the agent can read and write across turns.",
+    category: "official",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-memory"],
+      env: {},
+    },
+  },
+  {
+    id: "sequential-thinking",
+    name: "sequential-thinking",
+    title: "Sequential Thinking",
+    description: "Structured step-by-step reasoning scaffold for complex problems.",
+    category: "official",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+      env: {},
+    },
+  },
+  {
+    id: "playwright",
+    name: "playwright",
+    title: "Playwright",
+    description: "Drive a real browser (navigate, click, fill, snapshot) via Playwright.",
+    category: "browser",
+    homepage: "https://github.com/microsoft/playwright-mcp",
+    transport: { type: "stdio", command: "npx", args: ["-y", "@playwright/mcp@latest"], env: {} },
+  },
+  {
+    id: "context7",
+    name: "context7",
+    title: "Context7",
+    description: "Up-to-date, version-specific docs and code examples for libraries.",
+    category: "dev",
+    homepage: "https://github.com/upstash/context7",
+    transport: { type: "http", url: "https://mcp.context7.com/mcp", headers: {} },
+  },
+  {
+    id: "github",
+    name: "github",
+    title: "GitHub",
+    description: "Issues, PRs, code search and repo operations via the GitHub MCP server.",
+    category: "dev",
+    homepage: "https://github.com/github/github-mcp-server",
+    transport: {
+      type: "http",
+      url: "https://api.githubcopilot.com/mcp/",
+      headers: { Authorization: "Bearer " },
+    },
+    requiredEnv: ["Authorization header: Bearer <GitHub PAT>"],
+    setupHint: "Set the Authorization header to `Bearer <your GitHub personal access token>`.",
+  },
+  {
+    id: "brave-search",
+    name: "brave-search",
+    title: "Brave Search",
+    description: "Web and local search through the Brave Search API.",
+    category: "web",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-brave-search"],
+      env: { BRAVE_API_KEY: "" },
+    },
+    requiredEnv: ["BRAVE_API_KEY"],
+  },
+  {
+    id: "postgres",
+    name: "postgres",
+    title: "PostgreSQL",
+    description: "Read-only SQL access and schema inspection for a Postgres database.",
+    category: "data",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-postgres", "CONNECTION_URL"],
+      env: {},
+    },
+    setupHint: "Replace CONNECTION_URL with a postgresql://… connection string.",
+  },
+  {
+    id: "slack",
+    name: "slack",
+    title: "Slack",
+    description: "Read channels and post messages to a Slack workspace.",
+    category: "productivity",
+    homepage: "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+    transport: {
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-slack"],
+      env: { SLACK_BOT_TOKEN: "", SLACK_TEAM_ID: "" },
+    },
+    requiredEnv: ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"],
+  },
+];
+
+export const MCP_CATALOG_CATEGORY_LABELS: Record<McpCatalogCategory, string> = {
+  official: "Official",
+  web: "Web & Search",
+  dev: "Developer",
+  data: "Data",
+  productivity: "Productivity",
+  browser: "Browser",
+};
+
+/** Build a fresh managed server from a catalog entry (deep-copied template). */
+export function catalogEntryToServer(entry: McpCatalogEntry, id: string): McpServer {
+  const transport: McpTransport =
+    entry.transport.type === "stdio"
+      ? {
+          type: "stdio",
+          command: entry.transport.command,
+          args: [...entry.transport.args],
+          env: { ...entry.transport.env },
+        }
+      : {
+          type: entry.transport.type,
+          url: entry.transport.url,
+          headers: { ...entry.transport.headers },
+        };
+  return {
+    id,
+    name: entry.name,
+    label: entry.title,
+    description: entry.description,
+    enabled: true,
+    transport,
+    catalogId: entry.id,
+  };
+}

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   agentInstanceConfigMapSchema,
   installedAcpRegistryAgentSchema,
+  mcpServerSchema,
   gitReviewModeSchema,
   prCreateModeSchema,
   commitDefaultActionSchema,
@@ -352,6 +353,12 @@ export const sharedSettingsSchema = z.object({
   audio: audioSettingsSchema,
   /** Provider usage tracking (auto-refresh cadence, per-provider opt-out, cost). */
   usage: usageSettingsSchema,
+  /**
+   * Global, Lightcode-managed MCP servers projected into every agent at launch
+   * (unless scoped via `agentKinds`). Per-project servers live on the project
+   * record and are merged on top. See `contracts/mcpServer`.
+   */
+  mcpServers: z.array(mcpServerSchema).default([]),
 });
 export type SharedSettings = z.infer<typeof sharedSettingsSchema>;
 
@@ -465,6 +472,7 @@ export const defaultSharedSettings: SharedSettings = {
     providerOrder: [],
     collapsedProviders: [],
   },
+  mcpServers: [],
 };
 
 function parseSettingOrDefault<T>(schema: z.ZodType<T>, value: unknown, fallback: T): T {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -52,6 +52,7 @@ import {
 import type {
   AgentSlashCommand,
   ProjectLocation,
+  McpServer,
   PromptSegment,
   RuntimeEvent,
   SessionRef,
@@ -61,6 +62,7 @@ import type {
   ThreadStatus,
 } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
+import { buildAcpUserMcpServers } from "@/supervisor/agents/userMcp";
 import { areAgentSlashCommandsEqual, isThreadConfigEqual } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import {
@@ -445,6 +447,7 @@ export interface AcpStructuredSessionOptions {
    */
   sessionUpdateTransform?: (notification: SessionNotification) => SessionNotification;
   browserMcp?: BrowserMcpHttpConfig;
+  userMcpServers?: McpServer[];
 }
 
 export class AcpStructuredSession implements StructuredSessionHandle {
@@ -460,6 +463,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly cwd: string;
   private readonly projectLocation: ProjectLocation;
   private readonly browserMcp: BrowserMcpHttpConfig | undefined;
+  private readonly userMcpServers: McpServer[];
   /** Lightcode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
   private readonly stderrChunks: string[] = [];
@@ -545,6 +549,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       this.sessionUpdateTransform = options.sessionUpdateTransform;
     }
     this.browserMcp = options?.browserMcp;
+    this.userMcpServers = options?.userMcpServers ?? [];
   }
 
   private shouldAutoApproveSyntheticPermissionRequest(): boolean {
@@ -933,11 +938,12 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     let configOptions: unknown[] = [];
     this.currentConfig = undefined;
     this.currentSlashCommands = undefined;
-    const mcpServers = await buildAcpBrowserMcpServers(
+    const browserMcpServers = await buildAcpBrowserMcpServers(
       this.projectLocation,
       config.browserMcp === true,
       this.browserMcp,
     );
+    const mcpServers = [...browserMcpServers, ...buildAcpUserMcpServers(this.userMcpServers ?? [])];
 
     if (sessionRef) {
       if (this.agentSessionCapabilities?.resume !== undefined) {
@@ -1826,6 +1832,7 @@ export function createAcpStructuredSession(
       ? { sessionUpdateTransform: input.acpSessionUpdateTransform }
       : {}),
     ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
+    ...(input.userMcpServers !== undefined ? { userMcpServers: input.userMcpServers } : {}),
   });
 }
 

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -7,6 +7,7 @@ import type {
   AgentStatus,
   AgentUpdateInfo,
   AuthState,
+  McpServer,
   ProjectLocation,
   PromptSegment,
   RuntimeEvent,
@@ -45,6 +46,8 @@ export interface AgentEnvContext {
   baseDir?: string;
   browserMcpEnabled?: boolean;
   browserMcp?: BrowserMcpHttpConfig;
+  /** Lightcode-managed user MCP servers that apply to this agent (enabled). */
+  userMcpServers?: McpServer[];
 }
 
 export interface AgentLaunchOptions {
@@ -52,6 +55,8 @@ export interface AgentLaunchOptions {
   resumeThreadId?: string;
   agentSettings?: Record<string, boolean | string>;
   browserMcp?: BrowserMcpHttpConfig;
+  /** Lightcode-managed user MCP servers that apply to this agent (enabled). */
+  userMcpServers?: McpServer[];
 }
 
 export interface StructuredSessionUpdate {
@@ -115,6 +120,8 @@ export interface CreateStructuredSessionInput {
   agentSettings?: Record<string, boolean | string>;
   env?: Record<string, string>;
   browserMcp?: BrowserMcpHttpConfig;
+  /** Lightcode-managed user MCP servers that apply to this agent (enabled). */
+  userMcpServers?: McpServer[];
   sessionRef?: SessionRef;
   presentationMode?: ThreadPresentationMode;
   loadSessionErrorRewriter?: (error: unknown, sessionId: string) => Error;

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -28,6 +28,7 @@ import type {
 import { areAgentSlashCommandsEqual } from "@/shared/contracts";
 import { terminateChildProcessTree } from "@/shared/processTree";
 import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
+import { buildClaudeUserMcpServers } from "@/supervisor/agents/userMcp";
 import {
   createKnownSessionRef,
   buildAgentCommand,
@@ -947,6 +948,11 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
         this.currentConfig.browserMcp === true,
         this.input.browserMcp,
       );
+      const userMcpServers = buildClaudeUserMcpServers(this.input.userMcpServers ?? []);
+      const mcpServers =
+        Object.keys(userMcpServers).length > 0 || browserMcpServers
+          ? { ...userMcpServers, ...(browserMcpServers ?? {}) }
+          : undefined;
       let spawnClaudeCodeProcess: ((spawnOptions: SpawnOptions) => SpawnedProcess) | undefined;
       switch (this.input.projectLocation.kind) {
         case "wsl": {
@@ -990,9 +996,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
             }
           : {}),
         ...(claudeExecutablePath ? { pathToClaudeCodeExecutable: claudeExecutablePath } : {}),
-        ...(browserMcpServers
-          ? ({ mcpServers: browserMcpServers } as Partial<ClaudeQueryOptions>)
-          : {}),
+        ...(mcpServers ? ({ mcpServers } as Partial<ClaudeQueryOptions>) : {}),
         ...(spawnClaudeCodeProcess ? { spawnClaudeCodeProcess } : {}),
       };
 

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -397,6 +397,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(wslNodePath !== undefined ? { wslNodePath } : {}),
         browserMcpEnabled: input.config.browserMcp === true,
         ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
+        ...(input.userMcpServers !== undefined ? { userMcpServers: input.userMcpServers } : {}),
       }),
     );
     const transport = new CodexStdioTransport(appServer);

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -1,6 +1,6 @@
 import { dirname as posixDirname } from "node:path/posix";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
-import type { ProjectLocation, SessionRef, ThreadConfig } from "@/shared/contracts";
+import type { McpServer, ProjectLocation, SessionRef, ThreadConfig } from "@/shared/contracts";
 import {
   buildAgentCommand,
   DEFAULT_WSL_EXEC_PATH,
@@ -16,9 +16,19 @@ import {
 } from "./plugin/install";
 import { buildCodexBrowserMcpArgs, buildCodexBrowserMcpEnv } from "./mcpBrowser";
 import { resolveCodexWindowsLaunchBinary } from "./windowsExecutable";
+import { buildCodexUserMcp } from "@/supervisor/agents/userMcp";
 
 const CODEX_GOALS_FEATURE_FLAG = "goals";
 const codexGoalsSupportCache = new Map<string, boolean>();
+
+/** Merge the browser + user MCP bearer-token env Codex needs at spawn time. */
+function mergeCodexMcpEnv(
+  browserMcpEnv: Record<string, string> | undefined,
+  userMcpEnv: Record<string, string>,
+): { env: Record<string, string>; hasEnv: boolean } {
+  const env = { ...(browserMcpEnv ?? {}), ...userMcpEnv };
+  return { env, hasEnv: Object.keys(env).length > 0 };
+}
 
 interface BuildCodexArgsOptions {
   config: ThreadConfig;
@@ -51,6 +61,10 @@ function buildCodexArgs(opts: BuildCodexArgsOptions): string[] {
     args.push(
       ...buildCodexBrowserMcpArgs(location, config.browserMcp === true, launchOptions?.browserMcp),
     );
+  }
+
+  if (launchOptions?.userMcpServers && launchOptions.userMcpServers.length > 0) {
+    args.push(...buildCodexUserMcp(launchOptions.userMcpServers).args);
   }
 
   if (!launchOptions?.suppressResumeConfigOverrides) {
@@ -86,7 +100,10 @@ export function buildCodexArgvFor(
   launchOptions?: AgentLaunchOptions,
 ): AgentArgvSpec {
   const binary = resolveCodexWindowsLaunchBinary(location) ?? "codex";
-  const browserMcpEnv = buildCodexBrowserMcpEnv(launchOptions?.browserMcp);
+  const { env: mcpEnv, hasEnv: hasMcpEnv } = mergeCodexMcpEnv(
+    buildCodexBrowserMcpEnv(launchOptions?.browserMcp),
+    buildCodexUserMcp(launchOptions?.userMcpServers ?? []).env,
+  );
   const enableGoals = isCodexGoalsSupported(location);
   const baseArgsOptions: BuildCodexArgsOptions = {
     config,
@@ -110,7 +127,7 @@ export function buildCodexArgvFor(
     return {
       binary,
       args,
-      ...(browserMcpEnv ? { env: browserMcpEnv } : {}),
+      ...(hasMcpEnv ? { env: mcpEnv } : {}),
     };
   }
 
@@ -127,7 +144,7 @@ export function buildCodexArgvFor(
   return {
     binary,
     args,
-    ...(browserMcpEnv ? { env: browserMcpEnv } : {}),
+    ...(hasMcpEnv ? { env: mcpEnv } : {}),
   };
 }
 
@@ -138,6 +155,7 @@ export function buildCodexAppServerCommand(
     wslNodePath?: string;
     browserMcpEnabled?: boolean;
     browserMcp?: BrowserMcpHttpConfig;
+    userMcpServers?: McpServer[];
   },
 ): CommandSpec {
   const wslExecPath = options?.wslExecPath;
@@ -147,10 +165,15 @@ export function buildCodexAppServerCommand(
     options?.browserMcpEnabled === true,
     options?.browserMcp,
   );
-  const browserMcpEnv = buildCodexBrowserMcpEnv(options?.browserMcp);
+  const userMcp = buildCodexUserMcp(options?.userMcpServers ?? []);
+  const { env: mcpEnv, hasEnv: hasMcpEnv } = mergeCodexMcpEnv(
+    buildCodexBrowserMcpEnv(options?.browserMcp),
+    userMcp.env,
+  );
   const args = [
     ...(isCodexGoalsSupported(location, wslExecPath) ? ["--enable", CODEX_GOALS_FEATURE_FLAG] : []),
     ...browserMcpArgs,
+    ...userMcp.args,
     "app-server",
   ];
   if (location.kind === "wsl") {
@@ -169,9 +192,7 @@ export function buildCodexAppServerCommand(
         "--",
         "/usr/bin/env",
         `PATH=${pathSegments.join(":")}`,
-        ...(browserMcpEnv
-          ? Object.entries(browserMcpEnv).map(([name, value]) => `${name}=${value}`)
-          : []),
+        ...(hasMcpEnv ? Object.entries(mcpEnv).map(([name, value]) => `${name}=${value}`) : []),
         wslExecPath ?? "codex",
         ...args,
       ],
@@ -182,7 +203,7 @@ export function buildCodexAppServerCommand(
     "codex",
     args,
     resolveCodexWindowsLaunchBinary(location) ?? wslExecPath,
-    browserMcpEnv,
+    hasMcpEnv ? mcpEnv : undefined,
   );
 }
 

--- a/src/supervisor/agents/gemini/plugin/install.ts
+++ b/src/supervisor/agents/gemini/plugin/install.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { toWslUncPath } from "@/shared/wsl";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import { buildGeminiBrowserMcpServers } from "../mcpBrowser";
+import { buildGeminiUserMcpServers } from "@/supervisor/agents/userMcp";
 import type { AgentEnvContext } from "../../base";
 import {
   FORWARD_RUNTIME_FILE,
@@ -55,6 +56,7 @@ interface GeminiSettings {
       args?: string[];
       env?: Record<string, string>;
       httpUrl?: string;
+      url?: string;
       headers?: Record<string, string>;
       timeout?: number;
     }
@@ -148,14 +150,21 @@ export function syncGeminiBrowserMcpSettings(
   const settingsPath = resolveSettingsWritePath(ctx, paths.settingsPath);
   try {
     const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as GeminiSettings;
+    const userServers = buildGeminiUserMcpServers(ctx.userMcpServers ?? []);
+    let browserServers: Record<string, unknown> | undefined;
     if (ctx.browserMcpEnabled && browserMcp) {
       const location = isWslPluginContext(ctx)
         ? ({ kind: "wsl", distro: ctx.wslDistro } as const)
         : process.platform === "win32"
           ? ({ kind: "windows" } as const)
           : ({ kind: "posix" } as const);
-      const servers = buildGeminiBrowserMcpServers(location, browserMcp);
-      if (servers) settings.mcpServers = servers;
+      browserServers = buildGeminiBrowserMcpServers(location, browserMcp);
+    }
+    // Browser MCP is Lightcode-provided and wins on a name clash, so a user
+    // server named "browser" can't shadow the built-in one.
+    const merged = { ...userServers, ...(browserServers ?? {}) };
+    if (Object.keys(merged).length > 0) {
+      settings.mcpServers = merged as NonNullable<GeminiSettings["mcpServers"]>;
     } else {
       delete settings.mcpServers;
     }

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -1,6 +1,7 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
-import type { ProjectLocation } from "@/shared/contracts";
+import type { McpServer, ProjectLocation } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
+import { buildOpenCodeUserMcp } from "@/supervisor/agents/userMcp";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { BROWSER_MCP_SERVER_NAME } from "../browserMcp";
 import { buildOpenCodeServerCommand } from "./argv";
@@ -156,6 +157,7 @@ export interface AcquireOpenCodeServerInput {
   projectLocation: ProjectLocation;
   browserMcpEnabled?: boolean;
   browserMcp?: BrowserMcpHttpConfig;
+  userMcpServers?: McpServer[];
   /**
    * If set, the server stays alive for this many milliseconds after the last
    * release before being torn down. A re-acquire within the window reuses the
@@ -188,6 +190,27 @@ async function syncBrowserMcp(
       if (isOpenCodeConnectionLoss(err)) throw err;
     });
   await client.mcp.connect({ directory, name: BROWSER_MCP_SERVER_NAME });
+}
+
+async function syncUserMcp(
+  input: Pick<AcquireOpenCodeServerInput, "projectLocation" | "userMcpServers">,
+  client: OpencodeClient,
+): Promise<void> {
+  const servers = input.userMcpServers ?? [];
+  if (servers.length === 0) return;
+  const directory = resolveOpenCodeSessionDirectory(input.projectLocation);
+  const configs = buildOpenCodeUserMcp(servers);
+  // Servers are independent — add/connect them concurrently, keeping add→connect
+  // ordered within each server. A connection-loss rejection propagates to the
+  // acquire retry path just as the browser-MCP sync above does.
+  await Promise.all(
+    Object.entries(configs).map(async ([name, config]) => {
+      await client.mcp.add({ directory, name, config }).catch((err) => {
+        if (isOpenCodeConnectionLoss(err)) throw err;
+      });
+      await client.mcp.connect({ directory, name }).catch(() => undefined);
+    }),
+  );
 }
 
 export async function acquireOpenCodeServer(
@@ -246,9 +269,10 @@ async function acquireOpenCodeServerInner(
   const idleCloseDelayMs = input.idleCloseDelayMs;
   try {
     await syncBrowserMcp(input, snapshot.client);
+    await syncUserMcp(input, snapshot.client);
   } catch (error) {
     if (!retryMcpConnectionLoss || !isOpenCodeConnectionLoss(error)) {
-      console.warn("[opencode] failed to sync Browser MCP:", error);
+      console.warn("[opencode] failed to sync MCP servers:", error);
     } else {
       released = true;
       acquiringEntry.refCount -= 1;

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -424,6 +424,9 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
         projectLocation: this.input.projectLocation,
         browserMcpEnabled: this.browserMcpEnabled,
         ...(this.input.browserMcp !== undefined ? { browserMcp: this.input.browserMcp } : {}),
+        ...(this.input.userMcpServers !== undefined
+          ? { userMcpServers: this.input.userMcpServers }
+          : {}),
       });
     } catch (cause) {
       // Surface server-startup failures (sandbox blocks, ENOENT, port races,

--- a/src/supervisor/agents/userMcp/index.ts
+++ b/src/supervisor/agents/userMcp/index.ts
@@ -1,0 +1,14 @@
+export {
+  buildClaudeUserMcpServers,
+  buildGeminiUserMcpServers,
+  buildOpenCodeUserMcp,
+  buildAcpUserMcpServers,
+  buildCodexUserMcp,
+  codexMcpTokenEnvVar,
+  type ClaudeMcpServerConfig,
+  type GeminiMcpServerEntry,
+  type OpenCodeMcpServerConfig,
+  type AcpMcpServerConfig,
+  type AcpNamedValue,
+  type CodexUserMcp,
+} from "./translate";

--- a/src/supervisor/agents/userMcp/translate.test.ts
+++ b/src/supervisor/agents/userMcp/translate.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import type { McpServer } from "@/shared/contracts";
+import {
+  buildClaudeUserMcpServers,
+  buildGeminiUserMcpServers,
+  buildOpenCodeUserMcp,
+  buildAcpUserMcpServers,
+  buildCodexUserMcp,
+  codexMcpTokenEnvVar,
+} from "./translate";
+
+const stdio: McpServer = {
+  id: "1",
+  name: "filesystem",
+  enabled: true,
+  transport: {
+    type: "stdio",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    env: { FOO: "bar" },
+  },
+};
+
+const http: McpServer = {
+  id: "2",
+  name: "ctx7",
+  enabled: true,
+  transport: {
+    type: "http",
+    url: "https://mcp.example.com/mcp",
+    headers: { Authorization: "Bearer secret-token", "X-Extra": "1" },
+  },
+};
+
+const sse: McpServer = {
+  id: "3",
+  name: "legacy",
+  enabled: true,
+  transport: { type: "sse", url: "https://sse.example.com/sse", headers: {} },
+};
+
+describe("buildClaudeUserMcpServers", () => {
+  it("maps every transport into the SDK shape", () => {
+    const out = buildClaudeUserMcpServers([stdio, http, sse]);
+    expect(out.filesystem).toEqual({
+      type: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      env: { FOO: "bar" },
+    });
+    expect(out.ctx7).toEqual({
+      type: "http",
+      url: "https://mcp.example.com/mcp",
+      headers: { Authorization: "Bearer secret-token", "X-Extra": "1" },
+    });
+    expect(out.legacy).toEqual({ type: "sse", url: "https://sse.example.com/sse", headers: {} });
+  });
+});
+
+describe("buildGeminiUserMcpServers", () => {
+  it("uses command for stdio, httpUrl for http, url for sse", () => {
+    const out = buildGeminiUserMcpServers([stdio, http, sse]);
+    expect(out.filesystem).toMatchObject({ command: "npx" });
+    const ctx7 = out.ctx7!;
+    expect(ctx7.httpUrl).toBe("https://mcp.example.com/mcp");
+    expect(ctx7.url).toBeUndefined();
+    const legacy = out.legacy!;
+    expect(legacy.url).toBe("https://sse.example.com/sse");
+    expect(legacy.httpUrl).toBeUndefined();
+  });
+});
+
+describe("buildOpenCodeUserMcp", () => {
+  it("maps stdio to local command array and remote for http/sse", () => {
+    const out = buildOpenCodeUserMcp([stdio, http, sse]);
+    expect(out.filesystem).toEqual({
+      type: "local",
+      command: ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      environment: { FOO: "bar" },
+      enabled: true,
+    });
+    expect(out.ctx7).toEqual({
+      type: "remote",
+      url: "https://mcp.example.com/mcp",
+      headers: { Authorization: "Bearer secret-token", "X-Extra": "1" },
+      enabled: true,
+    });
+    expect(out.legacy).toEqual({
+      type: "remote",
+      url: "https://sse.example.com/sse",
+      enabled: true,
+    });
+  });
+});
+
+describe("buildAcpUserMcpServers", () => {
+  it("emits stdio without a type field and remote with type + header arrays", () => {
+    const out = buildAcpUserMcpServers([stdio, http, sse]);
+    expect(out[0]).toEqual({
+      name: "filesystem",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      env: [{ name: "FOO", value: "bar" }],
+    });
+    expect(out[1]).toEqual({
+      type: "http",
+      name: "ctx7",
+      url: "https://mcp.example.com/mcp",
+      headers: [
+        { name: "Authorization", value: "Bearer secret-token" },
+        { name: "X-Extra", value: "1" },
+      ],
+    });
+    expect(out[2]).toMatchObject({
+      type: "sse",
+      name: "legacy",
+      url: "https://sse.example.com/sse",
+    });
+  });
+});
+
+describe("buildCodexUserMcp", () => {
+  it("serializes stdio command/args/env as TOML overrides", () => {
+    const { args, env } = buildCodexUserMcp([stdio]);
+    expect(args).toEqual([
+      "-c",
+      `mcp_servers.filesystem.command="npx"`,
+      "-c",
+      `mcp_servers.filesystem.args=["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]`,
+      "-c",
+      `mcp_servers.filesystem.env={ "FOO" = "bar" }`,
+    ]);
+    expect(env).toEqual({});
+  });
+
+  it("enables the rmcp client once and routes bearer tokens through env", () => {
+    const { args, env } = buildCodexUserMcp([http, sse]);
+    expect(args.filter((a) => a === "experimental_use_rmcp_client=true")).toHaveLength(1);
+    expect(args).toContain(`mcp_servers.ctx7.url="https://mcp.example.com/mcp"`);
+    const tokenVar = codexMcpTokenEnvVar(http);
+    expect(args).toContain(`mcp_servers.ctx7.bearer_token_env_var="${tokenVar}"`);
+    expect(env[tokenVar]).toBe("secret-token");
+    // sse server without auth still registers its url.
+    expect(args).toContain(`mcp_servers.legacy.url="https://sse.example.com/sse"`);
+  });
+
+  it("quotes dotted server names as a single TOML key segment", () => {
+    const server: McpServer = {
+      ...http,
+      id: "dot-id",
+      name: "ctx.7",
+    };
+    const { args } = buildCodexUserMcp([server]);
+    expect(args).toContain(`mcp_servers."ctx.7".url="https://mcp.example.com/mcp"`);
+  });
+
+  it("keeps bearer-token env vars unique after name normalization", () => {
+    const first: McpServer = { ...http, id: "one", name: "foo-bar" };
+    const second: McpServer = { ...http, id: "two", name: "foo_bar" };
+
+    expect(codexMcpTokenEnvVar(first)).not.toBe(codexMcpTokenEnvVar(second));
+  });
+
+  it("does not treat non-Bearer Authorization headers as Codex bearer tokens", () => {
+    const server: McpServer = {
+      ...http,
+      id: "basic-id",
+      name: "basic",
+      transport: {
+        type: "http",
+        url: "https://mcp.example.com/mcp",
+        headers: { Authorization: "Basic abc123" },
+      },
+    };
+    const { args, env } = buildCodexUserMcp([server]);
+
+    expect(args.some((arg) => arg.startsWith("mcp_servers.basic.bearer_token_env_var"))).toBe(
+      false,
+    );
+    expect(env).toEqual({});
+  });
+});

--- a/src/supervisor/agents/userMcp/translate.ts
+++ b/src/supervisor/agents/userMcp/translate.ts
@@ -1,0 +1,212 @@
+/**
+ * Translate Lightcode's canonical {@link McpServer} list into each agent's
+ * native MCP config shape. This generalizes the browser-MCP injection path
+ * (see `src/supervisor/agents/browserMcp`) to arbitrary user-defined servers.
+ *
+ * Every function here is a pure mapping: callers are responsible for filtering
+ * to the enabled servers that apply to the target agent (see
+ * `resolveMcpServersForAgent` in `contracts/mcpServer`). The browser server is
+ * still appended separately by each adapter, so these maps never include it.
+ */
+
+import type { McpServer } from "@/shared/contracts";
+
+// ---------------------------------------------------------------------------
+// Claude Agent SDK (`mcpServers` record). Supports stdio / sse / http.
+// ---------------------------------------------------------------------------
+
+export type ClaudeMcpServerConfig =
+  | { type: "stdio"; command: string; args: string[]; env: Record<string, string> }
+  | { type: "sse"; url: string; headers: Record<string, string> }
+  | { type: "http"; url: string; headers: Record<string, string> };
+
+export function buildClaudeUserMcpServers(
+  servers: readonly McpServer[],
+): Record<string, ClaudeMcpServerConfig> {
+  const out: Record<string, ClaudeMcpServerConfig> = {};
+  for (const server of servers) {
+    const t = server.transport;
+    if (t.type === "stdio") {
+      out[server.name] = { type: "stdio", command: t.command, args: t.args, env: t.env };
+    } else {
+      out[server.name] = { type: t.type, url: t.url, headers: t.headers };
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Gemini CLI (`mcpServers` record). httpUrl = streamable HTTP, url = SSE.
+// ---------------------------------------------------------------------------
+
+export interface GeminiMcpServerEntry {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  httpUrl?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  timeout?: number;
+}
+
+export function buildGeminiUserMcpServers(
+  servers: readonly McpServer[],
+): Record<string, GeminiMcpServerEntry> {
+  const out: Record<string, GeminiMcpServerEntry> = {};
+  for (const server of servers) {
+    const t = server.transport;
+    if (t.type === "stdio") {
+      out[server.name] = { command: t.command, args: t.args, env: t.env };
+    } else if (t.type === "http") {
+      out[server.name] = { httpUrl: t.url, headers: t.headers, timeout: 30_000 };
+    } else {
+      out[server.name] = { url: t.url, headers: t.headers, timeout: 30_000 };
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// OpenCode SDK (`mcp` record). local = stdio, remote = streamable HTTP/SSE.
+// ---------------------------------------------------------------------------
+
+export type OpenCodeMcpServerConfig =
+  | { type: "local"; command: string[]; environment?: Record<string, string>; enabled: boolean }
+  | { type: "remote"; url: string; headers?: Record<string, string>; enabled: boolean };
+
+export function buildOpenCodeUserMcp(
+  servers: readonly McpServer[],
+): Record<string, OpenCodeMcpServerConfig> {
+  const out: Record<string, OpenCodeMcpServerConfig> = {};
+  for (const server of servers) {
+    const t = server.transport;
+    if (t.type === "stdio") {
+      out[server.name] = {
+        type: "local",
+        command: [t.command, ...t.args],
+        ...(Object.keys(t.env).length > 0 ? { environment: t.env } : {}),
+        enabled: true,
+      };
+    } else {
+      out[server.name] = {
+        type: "remote",
+        url: t.url,
+        ...(Object.keys(t.headers).length > 0 ? { headers: t.headers } : {}),
+        enabled: true,
+      };
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// ACP (`mcpServers[]`). stdio has no `type` discriminator; http/sse do.
+// ---------------------------------------------------------------------------
+
+export interface AcpNamedValue {
+  name: string;
+  value: string;
+}
+
+export type AcpMcpServerConfig =
+  | { name: string; command: string; args: string[]; env: AcpNamedValue[] }
+  | { type: "http"; name: string; url: string; headers: AcpNamedValue[] }
+  | { type: "sse"; name: string; url: string; headers: AcpNamedValue[] };
+
+function toNamedValues(record: Record<string, string>): AcpNamedValue[] {
+  return Object.entries(record).map(([name, value]) => ({ name, value }));
+}
+
+export function buildAcpUserMcpServers(servers: readonly McpServer[]): AcpMcpServerConfig[] {
+  return servers.map((server): AcpMcpServerConfig => {
+    const t = server.transport;
+    if (t.type === "stdio") {
+      return { name: server.name, command: t.command, args: t.args, env: toNamedValues(t.env) };
+    }
+    return { type: t.type, name: server.name, url: t.url, headers: toNamedValues(t.headers) };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI (`-c mcp_servers.*` overrides + companion env for remote tokens).
+// ---------------------------------------------------------------------------
+
+function envTokenSegment(value: string): string {
+  return value
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/gu, "_")
+    .replace(/^_+|_+$/gu, "");
+}
+
+/** Env var name that carries the bearer token for a remote Codex MCP server. */
+export function codexMcpTokenEnvVar(server: Pick<McpServer, "id" | "name">): string {
+  const name = envTokenSegment(server.name) || "SERVER";
+  const id = envTokenSegment(server.id) || "ID";
+  return `LIGHTCODE_MCP_${name}_${id}_TOKEN`;
+}
+
+function tomlString(value: string): string {
+  // TOML basic strings share JSON's escaping for the characters we care about.
+  return JSON.stringify(value);
+}
+
+function tomlKeySegment(value: string): string {
+  return /^[A-Za-z0-9_-]+$/u.test(value) ? value : tomlString(value);
+}
+
+function tomlStringArray(values: readonly string[]): string {
+  return `[${values.map(tomlString).join(", ")}]`;
+}
+
+function tomlInlineTable(record: Record<string, string>): string {
+  const entries = Object.entries(record).map(
+    ([key, value]) => `${tomlString(key)} = ${tomlString(value)}`,
+  );
+  return `{ ${entries.join(", ")} }`;
+}
+
+function bearerToken(headers: Record<string, string>): string | undefined {
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "authorization") {
+      const match = /^Bearer\s+(.+)$/iu.exec(value.trim());
+      return match?.[1];
+    }
+  }
+  return undefined;
+}
+
+export interface CodexUserMcp {
+  args: string[];
+  env: Record<string, string>;
+}
+
+export function buildCodexUserMcp(servers: readonly McpServer[]): CodexUserMcp {
+  const args: string[] = [];
+  const env: Record<string, string> = {};
+  let rmcpEnabled = false;
+
+  for (const server of servers) {
+    const t = server.transport;
+    const key = `mcp_servers.${tomlKeySegment(server.name)}`;
+    if (t.type === "stdio") {
+      args.push("-c", `${key}.command=${tomlString(t.command)}`);
+      if (t.args.length > 0) args.push("-c", `${key}.args=${tomlStringArray(t.args)}`);
+      if (Object.keys(t.env).length > 0) args.push("-c", `${key}.env=${tomlInlineTable(t.env)}`);
+      continue;
+    }
+    // Remote (http/sse) — Codex speaks both via the rmcp client.
+    if (!rmcpEnabled) {
+      args.push("-c", `experimental_use_rmcp_client=true`);
+      rmcpEnabled = true;
+    }
+    args.push("-c", `${key}.url=${tomlString(t.url)}`);
+    const token = bearerToken(t.headers);
+    if (token) {
+      const envVar = codexMcpTokenEnvVar(server);
+      args.push("-c", `${key}.bearer_token_env_var=${tomlString(envVar)}`);
+      env[envVar] = token;
+    }
+  }
+
+  return { args, env };
+}

--- a/src/supervisor/runtime/cliHookPluginCoordinator.ts
+++ b/src/supervisor/runtime/cliHookPluginCoordinator.ts
@@ -11,6 +11,7 @@ import type {
   AgentHookPluginMutationResult,
   AgentHookPluginStatus,
   GetAgentHookPluginStatusesPayload,
+  McpServer,
   ProjectLocation,
 } from "@/shared/contracts";
 import {
@@ -189,6 +190,7 @@ export class CliHookPluginCoordinator {
     projectLocation?: ProjectLocation;
     browserMcpEnabled?: boolean;
     browserMcp?: BrowserMcpHttpConfig;
+    userMcpServers?: McpServer[];
   }): Promise<{ env: Record<string, string>; extraArgs: string[] } | undefined> {
     // The `disableCliHookPlugin` dev toggle is handled in the supervisor's
     // hook dispatcher (envelopes are dropped on receive). Install, launch
@@ -212,6 +214,8 @@ export class CliHookPluginCoordinator {
     const ctx = this.envContext(input.agentKind, input.projectLocation);
     if (input.browserMcpEnabled !== undefined) ctx.browserMcpEnabled = input.browserMcpEnabled;
     if (input.browserMcp) ctx.browserMcp = input.browserMcp;
+    if (input.userMcpServers && input.userMcpServers.length > 0)
+      ctx.userMcpServers = input.userMcpServers;
     const outcome = await this.ensureInstalledOrUpdated(adapter, slice, ctx);
     if (!outcome.ok) {
       return undefined;

--- a/src/supervisor/runtime/sessionTypes.ts
+++ b/src/supervisor/runtime/sessionTypes.ts
@@ -2,6 +2,7 @@ import type { IPty } from "node-pty";
 import type {
   AgentKind,
   AgentSlashCommand,
+  McpServer,
   ProjectLocation,
   PromptSegment,
   SessionRef,
@@ -46,6 +47,8 @@ export interface SessionRuntime {
   projectLocation: ProjectLocation;
   config: ThreadConfig;
   sessionRef?: SessionRef;
+  /** Lightcode-managed MCP servers resolved at launch; reused on reopen/restart. */
+  userMcpServers?: McpServer[];
   slashCommands?: AgentSlashCommand[];
   status: ThreadStatus;
   attention: ThreadAttention;

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -33,10 +33,13 @@ import {
   areAgentSlashCommandsEqual,
   isClaudeProfileKind,
   isThreadConfigEqual,
+  resolveMcpServersForAgent,
+  type McpServer,
 } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import { terminateProcessTree } from "@/shared/processTree";
 import {
+  BROWSER_MCP_SERVER_NAME,
   resolveBrowserMcpHttpConfigForLaunch,
   type BrowserMcpHttpConfig,
 } from "@/supervisor/agents/browserMcp";
@@ -1106,6 +1109,7 @@ export class ThreadSessionManager {
     projectLocation: ProjectLocation,
     config: ThreadConfig,
     browserMcp: BrowserMcpHttpConfig | undefined,
+    userMcpServers: McpServer[],
   ): Promise<{ env: Record<string, string>; extraArgs: string[] }> {
     const adapter = this.options.adapters.get(agentKind);
     const liveInputMode = adapter?.capabilities.liveInputMode ?? "terminal";
@@ -1128,6 +1132,7 @@ export class ThreadSessionManager {
         projectLocation,
         browserMcpEnabled: this.isBrowserMcpEnabledForLaunch(adapter, config),
         ...(browserMcp !== undefined ? { browserMcp } : {}),
+        ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
       });
       const merged = resolved ?? { env: {}, extraArgs: [] };
       const hookUrl = merged.env.LIGHTCODE_HOOK_URL;
@@ -1301,6 +1306,13 @@ export class ThreadSessionManager {
       payload.projectLocation,
       payload.config,
     );
+    const userMcpServers = resolveMcpServersForAgent(
+      payload.userMcpServers ?? [],
+      payload.agentKind,
+    ).filter(
+      (server) =>
+        !browserMcp || server.name.toLowerCase() !== BROWSER_MCP_SERVER_NAME.toLowerCase(),
+    );
     const structuredSession = await this.createStructuredSession(
       adapter,
       payload.threadId,
@@ -1308,6 +1320,7 @@ export class ThreadSessionManager {
       payload.projectLocation,
       payload.config,
       browserMcp,
+      userMcpServers,
       payload.sessionRef,
       requestedPresentation,
     );
@@ -1367,6 +1380,7 @@ export class ThreadSessionManager {
         config: payload.config,
         initialSize: payload.initialSize,
         launchPrompt: "",
+        ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
         structuredSession,
         ...(resolvedSessionRef ? { sessionRef: resolvedSessionRef } : {}),
         presentationMode: requestedPresentation,
@@ -1436,21 +1450,24 @@ export class ThreadSessionManager {
       adapter,
       structuredSession?.launchOptions,
     );
-    const launchOptionsWithBrowserMcp = this.launchOptionsWithBrowserMcp(launchOptions, browserMcp);
+    const launchOptionsResolved: AgentLaunchOptions = {
+      ...this.launchOptionsWithBrowserMcp(launchOptions, browserMcp),
+      ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
+    };
     const argv = payload.sessionRef
       ? adapter.buildResumeArgv(
           payload.projectLocation,
           payload.config,
           launchPrompt,
           payload.sessionRef,
-          launchOptionsWithBrowserMcp,
+          launchOptionsResolved,
         )
       : adapter.buildLaunchArgv(
           payload.projectLocation,
           payload.config,
           launchPrompt,
           payload.sessionRef,
-          launchOptionsWithBrowserMcp,
+          launchOptionsResolved,
         );
 
     // Append CLI hook plugin args (e.g. Claude `--settings <path>`); env vars
@@ -1466,6 +1483,7 @@ export class ThreadSessionManager {
       payload.projectLocation,
       payload.config,
       browserMcp,
+      userMcpServers,
     );
     if (cliHookExtras.extraArgs.length > 0) {
       argv.args = this.mergeCliHookExtraArgs(
@@ -1508,6 +1526,7 @@ export class ThreadSessionManager {
       config: payload.config,
       initialSize: payload.initialSize,
       launchPrompt,
+      ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
       command,
       ...(Object.keys(cliHookExtras.env).length > 0 ? { extraEnv: cliHookExtras.env } : {}),
       ...(keepStructuredSession ? { structuredSession } : {}),
@@ -1536,6 +1555,7 @@ export class ThreadSessionManager {
     projectLocation: ProjectLocation,
     config: ThreadConfig,
     browserMcp: BrowserMcpHttpConfig | undefined,
+    userMcpServers: McpServer[],
     sessionRef?: SessionRef,
     presentationMode?: import("@/shared/contracts").ThreadPresentationMode,
   ): Promise<StructuredSessionHandle | undefined> {
@@ -1549,6 +1569,7 @@ export class ThreadSessionManager {
         config,
         agentSettings: this.resolveAgentSettings(adapter),
         ...(browserMcp ? { browserMcp } : {}),
+        ...(userMcpServers.length > 0 ? { userMcpServers } : {}),
         ...(sessionRef ? { sessionRef } : {}),
         ...(presentationMode ? { presentationMode } : {}),
       });
@@ -1591,6 +1612,7 @@ export class ThreadSessionManager {
     extraEnv?: Record<string, string>;
     structuredSession?: StructuredSessionHandle;
     sessionRef?: SessionRef;
+    userMcpServers?: McpServer[];
     pendingLaunchPrompt?: string;
     pendingTerminalPreInputs?: string[][];
     pendingTerminalPrompt?: string;
@@ -1686,6 +1708,10 @@ export class ThreadSessionManager {
       attention: input.initialAttention ?? "none",
       canResumeWithConfig: input.sessionRef !== undefined,
       outputLength: 0,
+      // On restart/reopen the call sites don't re-resolve servers; fall back to
+      // the prior session (still in the map until we replace it below).
+      userMcpServers:
+        input.userMcpServers ?? this.sessions.get(input.threadId)?.userMcpServers ?? [],
       pendingLaunchPrompt: input.pendingLaunchPrompt,
       pendingTerminalPreInputs: input.pendingTerminalPreInputs,
       pendingTerminalPrompt: input.pendingTerminalPrompt,
@@ -1997,6 +2023,7 @@ export class ThreadSessionManager {
       session.projectLocation,
       config,
       browserMcp,
+      session.userMcpServers ?? [],
       session.sessionRef,
       session.presentationMode,
     );
@@ -2068,6 +2095,7 @@ export class ThreadSessionManager {
       session.projectLocation,
       config,
       browserMcp,
+      session.userMcpServers ?? [],
     );
     if (!this.isCurrentSession(session)) {
       await structuredSession?.dispose();
@@ -2169,6 +2197,7 @@ export class ThreadSessionManager {
         session.projectLocation,
         session.config,
         browserMcp,
+        session.userMcpServers ?? [],
       );
       if (!this.isCurrentSession(session)) {
         return;


### PR DESCRIPTION
## Summary

Adds a Lightcode-managed **MCP server manager**. A canonical `mcpServers` list (global settings + per-project, merged over global) is projected into each agent's native MCP config at launch, mirroring the existing browser-MCP path.

- **Contracts** — `mcpServer` Zod schema (stdio / http / sse) wired into shared contracts, project, and thread config.
- **Translators** — `supervisor/agents/userMcp` converts the canonical list into each agent's native format; integrated into the claude, codex, gemini, opencode, and ACP launch paths.
- **Detection** — read-only `detectMcpServers` surfaces MCP servers already configured on disk.
- **Marketplace** — bundled catalog (`shared/mcpCatalog`) plus renderer UI (`McpManager`, `McpMarketplace`, `McpServerEditorDialog`, detected panel) in both the global Settings overlay and per-project Settings overlay.

## Merge resolution

This branch merged the MCP feature into recent `master`. Six files had conflicts, all resolved by preserving both sides:

| File | Resolution |
|------|------------|
| `contracts/project.ts` | kept both `worktreeLocation` + `mcpServers` |
| `ipc/localHandlers.ts` | kept `writeKeybindingsFile`/`setKeybindings` + `detectMcpServers`/`getDetectedMcpServers` |
| `ipc/procedureMap.ts` | kept both `profile` + `mcp` procedures |
| `codex/argv.ts` | combined Windows-launch `binary` with merged `mcpEnv`/`hasMcpEnv` env |
| `ProjectSettingsOverlay/SettingsSidebar.tsx` | i18n label macros + `mcp` sidebar entry |
| `SettingsOverlay/SettingsSidebar.tsx` | refactored `sectionsAfterAgents.map()` with `mcp` entry (expanded + collapsed views) |

## Test plan

- [x] `pnpm typecheck` passes
- [x] pre-commit lint/format hooks pass
- [ ] Manual: add/edit MCP servers in global + project settings; confirm they launch into claude/codex/gemini/opencode

🤖 Generated with [Claude Code](https://claude.com/claude-code)