### PR TITLE
Add Claude Sonnet 5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.21.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
     "@chenglou/pretext": "^0.0.6",
     "@dnd-kit/abstract": "^0.4.0",
     "@dnd-kit/collision": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^0.21.1
         version: 0.21.1(zod@4.4.2)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.170
-        version: 0.3.170(@anthropic-ai/sdk@0.93.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.2))(zod@4.4.2)
+        specifier: ^0.3.197
+        version: 0.3.197(@anthropic-ai/sdk@0.93.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.2))(zod@4.4.2)
       '@chenglou/pretext':
         specifier: ^0.0.6
         version: 0.0.6
@@ -404,52 +404,52 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170':
-    resolution: {integrity: sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
+    resolution: {integrity: sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.170':
-    resolution: {integrity: sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
+    resolution: {integrity: sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.170':
-    resolution: {integrity: sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
+    resolution: {integrity: sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.170':
-    resolution: {integrity: sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
+    resolution: {integrity: sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.170':
-    resolution: {integrity: sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
+    resolution: {integrity: sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.170':
-    resolution: {integrity: sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
+    resolution: {integrity: sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.170':
-    resolution: {integrity: sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
+    resolution: {integrity: sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.170':
-    resolution: {integrity: sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
+    resolution: {integrity: sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.170':
-    resolution: {integrity: sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.197':
+    resolution: {integrity: sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -6791,44 +6791,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.170':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.170(@anthropic-ai/sdk@0.93.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.2))(zod@4.4.2)':
+  '@anthropic-ai/claude-agent-sdk@0.3.197(@anthropic-ai/sdk@0.93.0(zod@4.4.2))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.2))(zod@4.4.2)':
     dependencies:
       '@anthropic-ai/sdk': 0.93.0(zod@4.4.2)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.2)
       zod: 4.4.2
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.170
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.170
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.197
 
   '@anthropic-ai/sdk@0.93.0(zod@4.4.2)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,15 +50,15 @@ nodeLinker: hoisted
 
 minimumReleaseAgeExclude:
   - electron@41.7.0
-  - "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.170"
-  - "@anthropic-ai/claude-agent-sdk@0.3.170"
+  - "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197"
+  - "@anthropic-ai/claude-agent-sdk@0.3.197"
   # Already present in the lockfile when the supply-chain guard was added.
   - "react@19.2.7"
   - "react-dom@19.2.7"

--- a/src/supervisor/agents/claude/claude.test.ts
+++ b/src/supervisor/agents/claude/claude.test.ts
@@ -155,6 +155,23 @@ describe("claudeCapabilities", () => {
   it("lists Opus 4.8 first so it is the default for new threads while Fable 5 is disabled", () => {
     expect(claudeCapabilities.models[0]).toEqual({ id: "claude-opus-4-8", label: "Opus 4.8" });
   });
+
+  it("surfaces Sonnet 5 with frontier effort tiers", () => {
+    expect(claudeCapabilities.models).toContainEqual({
+      id: "claude-sonnet-5",
+      label: "Sonnet 5",
+    });
+    expect(claudeCapabilities.modelEfforts["claude-sonnet-5"]).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xHigh",
+      "max",
+      "ultracode",
+    ]);
+    expect(claudeCapabilities.modelContextSizes?.["claude-sonnet-5"]).toEqual(["1m"]);
+    expect(claudeCapabilities.modelContextSizes?.sonnet).toEqual(["200k", "1m"]);
+  });
 });
 
 describe("createClaudeAdapter buildAcpLogoutCommand", () => {
@@ -260,12 +277,14 @@ describe("createClaudeProfileAdapter", () => {
       displayName: "GLM",
       config: {
         configDir: "~/.lightcode/claude-profiles/glm",
-        models: [{ id: "sonnet", label: "Sonnet (custom)" }],
+        models: [{ id: "claude-sonnet-5", label: "Sonnet (custom)" }],
       },
     });
 
-    const sonnetEntries = adapter.capabilities.models.filter((model) => model.id === "sonnet");
-    expect(sonnetEntries).toEqual([{ id: "sonnet", label: "Sonnet" }]);
+    const sonnetEntries = adapter.capabilities.models.filter(
+      (model) => model.id === "claude-sonnet-5",
+    );
+    expect(sonnetEntries).toEqual([{ id: "claude-sonnet-5", label: "Sonnet 5" }]);
   });
 
   it("does not duplicate repeated configured model ids", () => {

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -31,6 +31,7 @@ const PREMIUM_EFFORT_TIERS: string[] = [...CLAUDE_EFFORT_TIERS];
  * (the leftover keyed entries are inert without a matching `models` row).
  */
 const FABLE_5_ENABLED = false;
+const SONNET_5_MODEL_ID = "claude-sonnet-5";
 
 export const claudeCapabilities: AgentCapability = {
   models: [
@@ -38,7 +39,7 @@ export const claudeCapabilities: AgentCapability = {
     { id: "claude-opus-4-8", label: "Opus 4.8" },
     { id: "claude-opus-4-7", label: "Opus 4.7" },
     { id: "claude-opus-4-6", label: "Opus 4.6" },
-    { id: "sonnet", label: "Sonnet" },
+    { id: SONNET_5_MODEL_ID, label: "Sonnet 5" },
     { id: "haiku", label: "Haiku" },
   ],
   efforts: PREMIUM_EFFORT_TIERS,
@@ -48,21 +49,25 @@ export const claudeCapabilities: AgentCapability = {
     "claude-opus-4-8": PREMIUM_EFFORT_TIERS,
     "claude-opus-4-7": PREMIUM_EFFORT_TIERS,
     "claude-opus-4-6": ["low", "medium", "high", "max"],
+    [SONNET_5_MODEL_ID]: PREMIUM_EFFORT_TIERS,
     haiku: [],
-    sonnet: ["low", "medium", "high", "max"],
   },
   contextSizes: [
     { id: "200k", label: "200k" },
     { id: "1m", label: "1M" },
   ],
-  // Order matters: the first entry is the per-model default. Opus tiers default
-  // to 1M (the long-context build users select these for); Sonnet defaults to
-  // 200k because the 1M tier is billed per-token at premium rates.
+  // Order matters: the first entry is the per-model default. Frontier models
+  // default to 1M (the long-context build users select these for).
   modelContextSizes: {
     "claude-fable-5": ["1m"],
     "claude-opus-4-8": ["1m", "200k"],
     "claude-opus-4-7": ["1m", "200k"],
     "claude-opus-4-6": ["1m", "200k"],
+    [SONNET_5_MODEL_ID]: ["1m"],
+    // Legacy `sonnet` alias — dropped from the picker (replaced by Sonnet 5) but
+    // still used by commit-gen defaults and pre-rename threads, so keep it
+    // context-managed (200k default) for backward compatibility. Its presence
+    // here is what keeps it in CLAUDE_CONTEXT_MANAGED_MODEL_IDS below.
     sonnet: ["200k", "1m"],
   },
   defaultContextSize: "200k",

--- a/src/supervisor/agents/claude/probe.test.ts
+++ b/src/supervisor/agents/claude/probe.test.ts
@@ -110,35 +110,46 @@ afterEach(() => {
 });
 
 describe("claudeCapabilitiesFromCliVersion", () => {
-  it("hides Fable 5, Opus 4.7, and Opus 4.8 when CLI is below 2.1.111", () => {
+  it("hides Fable 5, Opus 4.7, Opus 4.8, and Sonnet 5 when CLI is below 2.1.111", () => {
     const p = claudeCapabilitiesFromCliVersion("2.1.110");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-fable-5");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-opus-4-7");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-opus-4-8");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-sonnet-5");
     expect(p?.modelContextSizes && "claude-fable-5" in p.modelContextSizes).toBe(false);
     expect(p?.modelEfforts && "claude-opus-4-7" in p.modelEfforts).toBe(false);
     expect(p?.models?.map((m) => m.id)).toContain("claude-opus-4-6");
   });
 
-  it("hides Fable 5 and Opus 4.8 when CLI supports Opus 4.7 but not Opus 4.8", () => {
+  it("hides Fable 5, Opus 4.8, and Sonnet 5 when CLI supports Opus 4.7 but not Opus 4.8", () => {
     const p = claudeCapabilitiesFromCliVersion("2.1.153");
     expect(p?.models?.map((m) => m.id)).toContain("claude-opus-4-7");
     expect(p?.models?.map((m) => m.id)).toContain("claude-opus-4-6");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-fable-5");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-opus-4-8");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-sonnet-5");
   });
 
-  it("hides only Fable 5 when CLI supports Opus 4.8 but not Fable 5", () => {
+  it("hides Fable 5 and Sonnet 5 when CLI supports Opus 4.8 but not Fable 5", () => {
     const p = claudeCapabilitiesFromCliVersion("2.1.169");
     expect(p?.models?.map((m) => m.id)).toContain("claude-opus-4-8");
     expect(p?.models?.map((m) => m.id)).toContain("claude-opus-4-7");
     expect(p?.models?.map((m) => m.id)).not.toContain("claude-fable-5");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-sonnet-5");
     expect(p?.modelEfforts && "claude-fable-5" in p.modelEfforts).toBe(false);
     expect(p?.modelContextSizes && "claude-fable-5" in p.modelContextSizes).toBe(false);
   });
 
-  it("returns undefined when CLI supports Fable 5", () => {
-    expect(claudeCapabilitiesFromCliVersion("2.1.170")).toBeUndefined();
+  it("hides only Sonnet 5 when CLI supports Fable 5 but not Sonnet 5", () => {
+    const p = claudeCapabilitiesFromCliVersion("2.1.196");
+    expect(p?.models?.map((m) => m.id)).toContain("claude-fable-5");
+    expect(p?.models?.map((m) => m.id)).not.toContain("claude-sonnet-5");
+    expect(p?.modelEfforts && "claude-sonnet-5" in p.modelEfforts).toBe(false);
+    expect(p?.modelContextSizes && "claude-sonnet-5" in p.modelContextSizes).toBe(false);
+  });
+
+  it("returns undefined when CLI supports Sonnet 5", () => {
+    expect(claudeCapabilitiesFromCliVersion("2.1.197")).toBeUndefined();
     expect(claudeCapabilitiesFromCliVersion("3.0.0")).toBeUndefined();
   });
 

--- a/src/supervisor/agents/claude/probe.ts
+++ b/src/supervisor/agents/claude/probe.ts
@@ -28,9 +28,11 @@ export function claudeTerminalAuthMethod(env?: Record<string, string>): AgentTer
 const MIN_CLAUDE_OPUS_47_CLI = [2, 1, 111] as const;
 const MIN_CLAUDE_OPUS_48_CLI = [2, 1, 154] as const;
 const MIN_CLAUDE_FABLE_5_CLI = [2, 1, 170] as const;
+const MIN_CLAUDE_SONNET_5_CLI = [2, 1, 197] as const;
 const OPUS_48_MODEL_ID = "claude-opus-4-8";
 const OPUS_47_MODEL_ID = "claude-opus-4-7";
 const FABLE_5_MODEL_ID = "claude-fable-5";
+const SONNET_5_MODEL_ID = "claude-sonnet-5";
 
 const CLAUDE_SEMVER_RE = /(\d+)\.(\d+)\.(\d+)/;
 
@@ -40,7 +42,7 @@ const BUILTIN_MODELS: AgentCapability["models"] = [
   { id: OPUS_48_MODEL_ID, label: "Opus 4.8" },
   { id: OPUS_47_MODEL_ID, label: "Opus 4.7" },
   { id: "claude-opus-4-6", label: "Opus 4.6" },
-  { id: "sonnet", label: "Sonnet" },
+  { id: SONNET_5_MODEL_ID, label: "Sonnet 5" },
   { id: "haiku", label: "Haiku" },
 ];
 
@@ -52,8 +54,8 @@ const BUILTIN_MODEL_EFFORTS: AgentCapability["modelEfforts"] = {
   [OPUS_48_MODEL_ID]: PREMIUM_EFFORT_TIERS,
   [OPUS_47_MODEL_ID]: PREMIUM_EFFORT_TIERS,
   "claude-opus-4-6": ["low", "medium", "high", "max"],
+  [SONNET_5_MODEL_ID]: PREMIUM_EFFORT_TIERS,
   haiku: [],
-  sonnet: ["low", "medium", "high", "max"],
 };
 
 const BUILTIN_MODEL_CONTEXT_SIZES: NonNullable<AgentCapability["modelContextSizes"]> = {
@@ -61,6 +63,8 @@ const BUILTIN_MODEL_CONTEXT_SIZES: NonNullable<AgentCapability["modelContextSize
   [OPUS_48_MODEL_ID]: ["1m", "200k"],
   [OPUS_47_MODEL_ID]: ["1m", "200k"],
   "claude-opus-4-6": ["1m", "200k"],
+  [SONNET_5_MODEL_ID]: ["1m"],
+  // Legacy `sonnet` alias retained for backward compatibility — see detection.ts.
   sonnet: ["200k", "1m"],
 };
 
@@ -92,6 +96,7 @@ export function claudeCapabilitiesFromCliVersion(
 
   const hiddenModelIds = new Set<string>();
   if (!semverGte(triplet, MIN_CLAUDE_FABLE_5_CLI)) hiddenModelIds.add(FABLE_5_MODEL_ID);
+  if (!semverGte(triplet, MIN_CLAUDE_SONNET_5_CLI)) hiddenModelIds.add(SONNET_5_MODEL_ID);
   if (!semverGte(triplet, MIN_CLAUDE_OPUS_48_CLI)) hiddenModelIds.add(OPUS_48_MODEL_ID);
   if (!semverGte(triplet, MIN_CLAUDE_OPUS_47_CLI)) hiddenModelIds.add(OPUS_47_MODEL_ID);
   if (hiddenModelIds.size === 0) return undefined;


### PR DESCRIPTION
- Add Sonnet 5 to Claude capabilities with frontier effort tiers and 1M context support.
- Gate Sonnet 5 availability on Claude CLI 2.1.197 so older CLIs hide unsupported models.
- Update Claude Agent SDK dependency and release-age exclusions to 0.3.197.
- Cover Sonnet 5 defaults, profile model de-duplication, and CLI probing with tests.