### PR TITLE
Bugfix: preserve Claude subagents during structured steering

### DIFF
--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -98,6 +98,20 @@ export interface StructuredSessionHandle {
     segments?: PromptSegment[],
     options?: StartTurnOptions,
   ): Promise<void>;
+  /**
+   * Steer the in-flight turn: enqueue a new user message onto the running
+   * turn WITHOUT interrupting it (no subagents killed, no error result). The
+   * message either steers the current turn or is answered in the next one.
+   * Providers that expose this let the runtime skip the interrupt-drain steer
+   * path. When no turn is in flight, implementations fall back to `startTurn`
+   * semantics so turn accounting stays correct.
+   */
+  steerTurn?(
+    prompt: string,
+    config: ThreadConfig,
+    segments?: PromptSegment[],
+    options?: StartTurnOptions,
+  ): Promise<void>;
   interruptTurn?(): Promise<void>;
   resolveServerRequest?(requestId: ThreadServerRequestId, response: unknown): Promise<void>;
   readThread?(): Promise<ThreadHistory>;

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1562,7 +1562,7 @@ describe("sdkCanonicalMapping — tool use", () => {
 });
 
 describe("sdkCanonicalMapping — sub-agents", () => {
-  it("tags item.started events with parentItemId when parent_tool_use_id is set", () => {
+  it("drops sub-agent stream_event partials (parent_tool_use_id set)", () => {
     const state = createClaudeMapperState("thread-1");
     const events = mapClaudeSdkMessage(
       streamEventWithParent(
@@ -1571,15 +1571,122 @@ describe("sdkCanonicalMapping — sub-agents", () => {
       ),
       state,
     );
-    expect(events).toEqual([
+    expect(events).toEqual([]);
+  });
+
+  it("sub-agent partials do not corrupt the main-thread stream lane", () => {
+    const state = createClaudeMapperState("thread-1");
+    // Main thread opens a streaming text block at index 0.
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      state,
+    );
+    const mainItem = state.assistantTextItems.get(0);
+    expect(mainItem).toBeDefined();
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "main-thread answer" },
+      }),
+      state,
+    );
+
+    // A sub-agent message_start at the same index must NOT clear the main lane,
+    // and a sub-agent delta must NOT append to the main item.
+    const subAgentEvents = [
+      mapClaudeSdkMessage(
+        streamEventWithParent(
+          { type: "message_start", message: { id: "sub-msg" } },
+          "toolu_parent",
+        ),
+        state,
+      ),
+      mapClaudeSdkMessage(
+        streamEventWithParent(
+          {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "SUBAGENT" },
+          },
+          "toolu_parent",
+        ),
+        state,
+      ),
+    ].flat();
+    expect(subAgentEvents).toEqual([]);
+    // Main lane still points at the same live item.
+    expect(state.assistantTextItems.get(0)).toBe(mainItem);
+
+    // Main thread continues streaming onto its own item, uncorrupted.
+    const more = mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "!" },
+      }),
+      state,
+    );
+    expect(more).toEqual([
       {
-        type: "item.started",
+        type: "content.delta",
         threadId: "thread-1",
-        itemId: expect.stringMatching(/^asst-/),
-        itemType: "assistant_message",
-        parentItemId: "toolu_parent",
+        itemId: mainItem!.itemId,
+        stream: "assistant_text",
+        delta: "!",
       },
     ]);
+  });
+
+  it("renders a forwarded sub-agent assistant text message as a complete child item", () => {
+    const state = createClaudeMapperState("thread-1");
+    // Register the parent tool so tagParent can bump its step counter.
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_parent",
+          name: "Agent",
+          input: { description: "Investigate", subagent_type: "general-purpose" },
+        },
+      }),
+      state,
+    );
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "assistant",
+        session_id: "claude-session",
+        uuid: "msg-sub-text",
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          id: "msg-sub-text",
+          role: "assistant",
+          content: [{ type: "text", text: "sub-agent thinking out loud" }],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    expect(events).toMatchObject([
+      {
+        type: "item.started",
+        itemType: "assistant_message",
+        parentItemId: "toolu_parent",
+        itemId: expect.stringMatching(/^asst-/),
+      },
+      { type: "content.delta", stream: "assistant_text", delta: "sub-agent thinking out loud" },
+      { type: "item.completed" },
+      { type: "item.updated", itemId: "toolu_parent", payload: { progress: { stepCount: 1 } } },
+    ]);
+    // The main lane's per-index text map is untouched by the sub-agent flush.
+    expect(state.assistantTextItems.size).toBe(0);
   });
 
   it("does not set parentItemId on top-level messages (parent_tool_use_id null)", () => {
@@ -1877,6 +1984,398 @@ describe("sdkCanonicalMapping — task progress", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("sdkCanonicalMapping — background sub-agents", () => {
+  function startAgentTool(
+    state: ReturnType<typeof createClaudeMapperState>,
+    toolUseId: string,
+    name = "Agent",
+  ): void {
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: toolUseId,
+          name,
+          input: { description: "Investigate", subagent_type: "general-purpose" },
+        },
+      }),
+      state,
+    );
+  }
+
+  function taskStarted(toolUseId: string, subagentType: string | undefined): SDKMessage {
+    return {
+      type: "system",
+      subtype: "task_started",
+      session_id: "claude-session",
+      task_id: "task-A",
+      tool_use_id: toolUseId,
+      description: "Investigate",
+      ...(subagentType ? { subagent_type: subagentType } : {}),
+    } as unknown as SDKMessage;
+  }
+
+  function launchToolResult(toolUseId: string): SDKMessage {
+    return {
+      type: "user",
+      session_id: "claude-session",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUseId,
+            content: "Async agent launched successfully. It is running in the background.",
+          },
+        ],
+      },
+    } as unknown as SDKMessage;
+  }
+
+  it("keeps the Agent parent running after its launch tool_result when a subagent task is live", () => {
+    const state = createClaudeMapperState("thread-1");
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+
+    const events = mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+    expect(events).toEqual([
+      {
+        type: "item.updated",
+        threadId: "thread-1",
+        itemId: "toolu_parent",
+        payload: expect.objectContaining({ name: "Agent", status: "running", isSubAgent: true }),
+      },
+    ]);
+    // Parent item survives — not deleted, not completed.
+    expect(state.toolItemsById.has("toolu_parent")).toBe(true);
+  });
+
+  it("marks the Agent parent as a sub-agent tool via isSubAgent payload", () => {
+    const state = createClaudeMapperState("thread-1");
+    const started = mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "toolu_parent", name: "Agent", input: {} },
+      }),
+      state,
+    );
+    expect(started).toMatchObject([
+      { type: "item.started", payload: { name: "Agent", isSubAgent: true } },
+    ]);
+  });
+
+  it("does not keep-alive a background Bash task_started without subagent_type", () => {
+    const state = createClaudeMapperState("thread-1");
+    // Bash tool opens at index 0.
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_bash",
+          name: "Bash",
+          input: { command: "ls" },
+        },
+      }),
+      state,
+    );
+    mapClaudeSdkMessage(taskStarted("toolu_bash", undefined), state);
+    expect(state.activeSubAgentToolToTask?.has("toolu_bash") ?? false).toBe(false);
+
+    // Its tool_result completes it normally.
+    const events = mapClaudeSdkMessage(
+      {
+        type: "user",
+        session_id: "claude-session",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_bash", content: "file.txt" }],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(events.some((e) => e.type === "item.completed" && e.itemId === "toolu_bash")).toBe(true);
+    expect(state.toolItemsById.has("toolu_bash")).toBe(false);
+  });
+
+  it("maps task_updated patch onto the live parent without closing it", () => {
+    const state = createClaudeMapperState("thread-1");
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_updated",
+        session_id: "claude-session",
+        task_id: "task-A",
+        patch: { status: "completed", end_time: 1_783_066_726_333 },
+      } as unknown as SDKMessage,
+      state,
+    );
+    // Terminal patch status alone does NOT close the parent — wait for
+    // task_notification. No descriptive fields → no-op update here.
+    expect(events).toEqual([]);
+    expect(state.toolItemsById.has("toolu_parent")).toBe(true);
+  });
+
+  it("closes the parent on task_notification completed and cleans the registry", () => {
+    const state = createClaudeMapperState("thread-1");
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_parent",
+        status: "completed",
+        summary: "Investigation complete",
+        usage: { total_tokens: 4_200, tool_uses: 3, duration_ms: 1_500 },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(events).toMatchObject([
+      {
+        type: "item.updated",
+        itemId: "toolu_parent",
+        payload: { status: "success", progress: { summary: "Investigation complete" } },
+      },
+      { type: "item.completed", itemId: "toolu_parent", payload: { status: "success" } },
+    ]);
+    expect(state.toolItemsById.has("toolu_parent")).toBe(false);
+    expect(state.activeSubAgentTaskToTool?.has("task-A") ?? false).toBe(false);
+    expect(state.activeSubAgentToolToTask?.has("toolu_parent") ?? false).toBe(false);
+  });
+
+  it("closes the parent as error on task_notification stopped (interrupt)", () => {
+    const state = createClaudeMapperState("thread-1");
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_parent",
+        status: "stopped",
+        summary: "Stopped by user",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(events).toMatchObject([
+      { type: "item.updated", itemId: "toolu_parent", payload: { status: "error" } },
+      { type: "item.completed", itemId: "toolu_parent", payload: { status: "error" } },
+    ]);
+    expect(state.toolItemsById.has("toolu_parent")).toBe(false);
+  });
+
+  it("registers a keep-alive when task_started omits subagent_type but the tool is Agent-like", () => {
+    const state = createClaudeMapperState("thread-1");
+    startAgentTool(state, "toolu_parent");
+    // task_started arrives without subagent_type, but the tool is classified
+    // sub-agent-like → still registers.
+    mapClaudeSdkMessage(taskStarted("toolu_parent", undefined), state);
+    expect(state.activeSubAgentToolToTask?.has("toolu_parent") ?? false).toBe(true);
+  });
+
+  it("keeps the live parent and its child tools alive across the main turn's result", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-1", "launch subagent", undefined);
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    // A forwarded child tool_use from the running subagent.
+    mapClaudeSdkMessage(
+      {
+        type: "assistant",
+        session_id: "claude-session",
+        uuid: "sub-msg-tool",
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          id: "sub-msg-tool",
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_child", name: "Read", input: { file_path: "a" } },
+          ],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    // Main turn ends while the subagent still runs. The parent and child must
+    // NOT be completed/evicted here.
+    const resultEvents = mapClaudeSdkMessage(
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "claude-session",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(
+      resultEvents.some(
+        (e) =>
+          e.type === "item.completed" &&
+          (e.itemId === "toolu_parent" || e.itemId === "toolu_child"),
+      ),
+    ).toBe(false);
+    expect(state.toolItemsById.has("toolu_parent")).toBe(true);
+    expect(state.toolItemsById.has("toolu_child")).toBe(true);
+
+    // The child's own forwarded tool_result still completes it.
+    const childResult = mapClaudeSdkMessage(
+      {
+        type: "user",
+        session_id: "claude-session",
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_child", content: "file body" }],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(childResult.some((e) => e.type === "item.completed" && e.itemId === "toolu_child")).toBe(
+      true,
+    );
+
+    // The authoritative task_notification finally closes the parent.
+    const close = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_parent",
+        status: "completed",
+        summary: "Done",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(close.some((e) => e.type === "item.completed" && e.itemId === "toolu_parent")).toBe(
+      true,
+    );
+    expect(state.toolItemsById.has("toolu_parent")).toBe(false);
+  });
+
+  it("keeps the live parent across a new user turn started while the subagent runs", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-1", "launch subagent", undefined);
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    // Main turn ends; thread goes idle while the task still runs.
+    mapClaudeSdkMessage(
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "claude-session",
+        usage: { input_tokens: 1, output_tokens: 1 },
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    // The user submits another message during the idle window. The new-turn
+    // reset must not evict the live parent — the later task_notification
+    // still needs to find and close it.
+    startClaudeTurn(state, "turn-2", "unrelated follow-up", undefined);
+    expect(state.toolItemsById.has("toolu_parent")).toBe(true);
+
+    const close = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_parent",
+        status: "completed",
+        summary: "Done",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(close.some((e) => e.type === "item.completed" && e.itemId === "toolu_parent")).toBe(
+      true,
+    );
+    expect(state.toolItemsById.has("toolu_parent")).toBe(false);
+  });
+
+  it("flushes a dangling child of a stopped subagent instead of leaving it running", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-1", "launch subagent", undefined);
+    startAgentTool(state, "toolu_parent");
+    mapClaudeSdkMessage(taskStarted("toolu_parent", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_parent"), state);
+
+    // Forwarded child tool_use whose tool_result will never arrive (the
+    // subagent gets killed mid-execution).
+    mapClaudeSdkMessage(
+      {
+        type: "assistant",
+        session_id: "claude-session",
+        uuid: "sub-msg-tool",
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          id: "sub-msg-tool",
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_child", name: "Read", input: { file_path: "a" } },
+          ],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    // Interrupt: the subagent's task_notification "stopped" closes the parent
+    // and unregisters the task, leaving the child dangling.
+    mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_parent",
+        status: "stopped",
+        summary: "Stopped by user",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(state.toolItemsById.has("toolu_child")).toBe(true);
+
+    // The interrupt's result closes open items; with no live subagent left the
+    // dangling child must be completed, not silently dropped.
+    const resultEvents = mapClaudeSdkMessage(
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "claude-session",
+        is_error: true,
+        errors: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(
+      resultEvents.some((e) => e.type === "item.completed" && e.itemId === "toolu_child"),
+    ).toBe(true);
+    expect(state.toolItemsById.has("toolu_child")).toBe(false);
   });
 });
 

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -92,7 +92,16 @@ export function startClaudeTurn(
   state.assistantTextItems.clear();
   state.reasoningItems.clear();
   state.toolItemsByIndex.clear();
-  state.toolItemsById.clear();
+  // Background subagents keep running across user turns: their live parent
+  // tool_call (and forwarded children) must survive this reset so the later
+  // `task_notification` can still find and close them — a blanket clear would
+  // strand the parent pill on "running" forever. `toolItemsByIndex` is
+  // per-message scratch (cleared on every message_start), so clearing it fully
+  // is safe.
+  for (const [id, tool] of [...state.toolItemsById]) {
+    if (isLiveSubAgentScopedTool(state, tool)) continue;
+    state.toolItemsById.delete(id);
+  }
   delete state.currentAssistantMessageId;
   delete state.currentCompactionItemId;
   state.streamedAssistantMessageIds.clear();
@@ -219,21 +228,44 @@ export function closeClaudeOpenItems(
   for (const item of state.reasoningItems.values()) {
     completeTextItem(state, item, "reasoning_text", events);
   }
-  for (const tool of state.toolItemsByIndex.values()) {
+  // Background subagents run past the main turn's `result`; their parent tool
+  // and any in-flight child tools must survive this close so a later
+  // `task_notification` / child tool_result can complete them. Once no subagent
+  // is live, nothing more is coming, so any dangling child rows are flushed.
+  for (const [index, tool] of [...state.toolItemsByIndex]) {
+    if (isLiveSubAgentScopedTool(state, tool)) continue;
     // Plan-aggregated tools never emitted item.started; their lifecycle is
     // owned by the aggregator's plan item, which persists across turns.
-    if (tool.planAggregatorRole) continue;
-    events.push({
-      type: "item.completed",
-      threadId: state.threadId,
-      itemId: tool.itemId,
-      payload: toolPayload(tool, "success"),
-    });
+    if (!tool.planAggregatorRole) {
+      events.push({
+        type: "item.completed",
+        threadId: state.threadId,
+        itemId: tool.itemId,
+        payload: toolPayload(tool, "success"),
+      });
+    }
+    state.toolItemsByIndex.delete(index);
+  }
+  for (const [id, tool] of [...state.toolItemsById]) {
+    if (isLiveSubAgentScopedTool(state, tool)) continue;
+    // A dangling sub-agent child whose subagent already closed will never get
+    // its tool_result; flush it with a completion (like the open main-thread
+    // tools above) so it doesn't stay "running" in the overlay forever. Tools
+    // completed by the index loop above are never in the child set, so this
+    // cannot double-complete.
+    if (!tool.planAggregatorRole && state.subAgentChildToolItemIds?.has(id)) {
+      events.push({
+        type: "item.completed",
+        threadId: state.threadId,
+        itemId: tool.itemId,
+        payload: toolPayload(tool, "success"),
+      });
+    }
+    state.toolItemsById.delete(id);
+    state.subAgentChildToolItemIds?.delete(id);
   }
   state.assistantTextItems.clear();
   state.reasoningItems.clear();
-  state.toolItemsByIndex.clear();
-  state.toolItemsById.clear();
   if (options?.closePlan && state.planAggregator) {
     events.push(...closePlanAggregator(state.planAggregator));
   }
@@ -242,16 +274,40 @@ export function closeClaudeOpenItems(
 
 const ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
 
-function classifyToolItemType(toolName: string): CanonicalItemType {
+/**
+ * Whether a tool name launches a sub-agent (Claude `Agent`/`Task`, workflow
+ * orchestration, or any *subagent* variant). Single source of truth shared by
+ * `classifyToolItemType`, `syncSubAgentModelProgress`, the `isSubAgent` payload
+ * flag, and the background-subagent keep-alive registry so they never drift.
+ */
+function isSubAgentToolName(toolName: string): boolean {
   const name = toolName.toLowerCase();
-  if (name === "todowrite" || name.includes("todo")) return "plan";
-  if (
+  return (
     name === "task" ||
     name === "workflow" ||
     name === "agent" ||
     name.includes("subagent") ||
     name.includes("sub-agent")
-  ) {
+  );
+}
+
+/**
+ * Whether a tool item belongs to a still-running background subagent — either
+ * the launching Agent/Task parent itself or a forwarded child tool inside it.
+ * Such items must survive turn-boundary map resets (`closeClaudeOpenItems`,
+ * `startClaudeTurn`) so the eventual `task_notification` / forwarded
+ * tool_result can complete them.
+ */
+function isLiveSubAgentScopedTool(state: ClaudeMapperState, tool: ToolItemState): boolean {
+  const liveParents = state.activeSubAgentToolToTask;
+  if (!liveParents || liveParents.size === 0) return false;
+  return liveParents.has(tool.itemId) || state.subAgentChildToolItemIds?.has(tool.itemId) === true;
+}
+
+function classifyToolItemType(toolName: string): CanonicalItemType {
+  const name = toolName.toLowerCase();
+  if (name === "todowrite" || name.includes("todo")) return "plan";
+  if (isSubAgentToolName(name)) {
     return "tool_call";
   }
   if (
@@ -484,7 +540,7 @@ function startToolItem(
 }
 
 function syncSubAgentModelProgress(tool: ToolItemState): void {
-  if (tool.toolName !== "Task") return;
+  if (!isSubAgentToolName(tool.toolName)) return;
   const model = readStringField(tool.input, "model");
   if (!model) return;
   tool.progress = { ...tool.progress, model };
@@ -825,7 +881,7 @@ function toolPayload(
     ...(images && images.length > 0 ? { images } : {}),
     status,
     ...(tool.progress ? { progress: tool.progress } : {}),
-    ...(tool.toolName === "Workflow" ? { isSubAgent: true } : {}),
+    ...(isSubAgentToolName(tool.toolName) ? { isSubAgent: true } : {}),
   };
 }
 
@@ -1007,34 +1063,27 @@ function extractText(value: unknown): string {
   return extractText(obj.content);
 }
 
-/**
- * Absorb a `task_started` / `task_progress` / `task_notification` system
- * message into the parent Task tool_call's progress field. Lets a collapsed
- * sub-agent row show its current step without expanding to read the children.
- */
-function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
-  const events: RuntimeEvent[] = [];
-  const obj = message as {
-    task_id?: unknown;
-    tool_use_id?: unknown;
-    description?: unknown;
-    last_tool_name?: unknown;
-    summary?: unknown;
-    usage?: unknown;
-  };
-  const usage =
-    obj.usage && typeof obj.usage === "object"
-      ? (obj.usage as { total_tokens?: number; tool_uses?: number; duration_ms?: number })
-      : undefined;
-  const goalUsage = emitActiveGoalTaskUsageUpdate(state, obj, usage);
-  if (goalUsage) events.push(goalUsage);
+interface TaskLifecycleMessage {
+  task_id?: unknown;
+  tool_use_id?: unknown;
+  description?: unknown;
+  last_tool_name?: unknown;
+  summary?: unknown;
+  usage?: unknown;
+}
 
-  const toolUseId = typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined;
-  if (!toolUseId) return events;
-  const tool = state.toolItemsById.get(toolUseId);
-  if (!tool) return events;
-  syncSubAgentModelProgress(tool);
+type TaskUsage = { total_tokens?: number; tool_uses?: number; duration_ms?: number };
 
+function readTaskUsage(obj: { usage?: unknown }): TaskUsage | undefined {
+  return obj.usage && typeof obj.usage === "object" ? (obj.usage as TaskUsage) : undefined;
+}
+
+/** Merge a task lifecycle message's descriptive/usage fields onto a tool's progress. */
+function mergeTaskProgress(
+  tool: ToolItemState,
+  obj: TaskLifecycleMessage,
+  usage: TaskUsage | undefined,
+): ToolCallProgress {
   const next: ToolCallProgress = {
     ...tool.progress,
     ...(typeof obj.description === "string" && obj.description.length > 0
@@ -1051,6 +1100,28 @@ function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): Runt
   if (typeof usage?.tool_uses === "number") {
     next.stepCount = Math.max(next.stepCount ?? 0, usage.tool_uses);
   }
+  return next;
+}
+
+/**
+ * Absorb a `task_started` / `task_progress` / `task_notification` system
+ * message into the parent Task tool_call's progress field. Lets a collapsed
+ * sub-agent row show its current step without expanding to read the children.
+ */
+function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const obj = message as TaskLifecycleMessage;
+  const usage = readTaskUsage(obj);
+  const goalUsage = emitActiveGoalTaskUsageUpdate(state, obj, usage);
+  if (goalUsage) events.push(goalUsage);
+
+  const toolUseId = typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined;
+  if (!toolUseId) return events;
+  const tool = state.toolItemsById.get(toolUseId);
+  if (!tool) return events;
+  syncSubAgentModelProgress(tool);
+
+  const next = mergeTaskProgress(tool, obj, usage);
   if (Object.keys(next).length === 0) return events;
   tool.progress = next;
   events.push({
@@ -1059,6 +1130,126 @@ function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState): Runt
     itemId: tool.itemId,
     payload: toolPayload(tool, "running"),
   });
+  return events;
+}
+
+function unregisterSubAgentTask(state: ClaudeMapperState, taskId: string, toolUseId: string): void {
+  state.activeSubAgentTaskToTool?.delete(taskId);
+  state.activeSubAgentToolToTask?.delete(toolUseId);
+}
+
+/**
+ * Record a live background subagent task so later lifecycle events can find the
+ * parent tool item and keep it "running" past its launch tool_result. Only
+ * genuine subagent launches register: a `task_started` WITHOUT `subagent_type`
+ * (a plain background Bash task) whose tool is not a subagent-like tool is
+ * ignored so it still completes normally when its tool_result arrives.
+ */
+function registerSubAgentTaskIfNeeded(message: SDKMessage, state: ClaudeMapperState): void {
+  const obj = message as { task_id?: unknown; tool_use_id?: unknown; subagent_type?: unknown };
+  const taskId =
+    typeof obj.task_id === "string" && obj.task_id.length > 0 ? obj.task_id : undefined;
+  const toolUseId =
+    typeof obj.tool_use_id === "string" && obj.tool_use_id.length > 0 ? obj.tool_use_id : undefined;
+  if (!taskId || !toolUseId) return;
+  const hasSubagentType = typeof obj.subagent_type === "string" && obj.subagent_type.length > 0;
+  const tool = state.toolItemsById.get(toolUseId);
+  const toolIsSubAgent = tool ? isSubAgentToolName(tool.toolName) : false;
+  if (!hasSubagentType && !toolIsSubAgent) return;
+  (state.activeSubAgentTaskToTool ??= new Map<string, string>()).set(taskId, toolUseId);
+  (state.activeSubAgentToolToTask ??= new Map<string, string>()).set(toolUseId, taskId);
+}
+
+/**
+ * `task_updated` carries a `patch` but no `tool_use_id`. For a tracked subagent
+ * task, fold the patch's descriptive fields onto the parent tool's progress so
+ * the collapsed pill reflects the latest state. Terminal patch statuses are NOT
+ * closed here — the authoritative `task_notification` (which carries the summary)
+ * owns the close.
+ */
+function applyTaskUpdated(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
+  const obj = message as { task_id?: unknown; patch?: unknown };
+  const taskId = typeof obj.task_id === "string" ? obj.task_id : undefined;
+  if (!taskId) return [];
+  const toolUseId = state.activeSubAgentTaskToTool?.get(taskId);
+  if (!toolUseId) return [];
+  const tool = state.toolItemsById.get(toolUseId);
+  if (!tool) return [];
+  const patch =
+    obj.patch && typeof obj.patch === "object" ? (obj.patch as Record<string, unknown>) : undefined;
+  if (!patch) return [];
+  const description =
+    typeof patch.description === "string" && patch.description.length > 0
+      ? patch.description
+      : undefined;
+  const error = typeof patch.error === "string" && patch.error.length > 0 ? patch.error : undefined;
+  if (!description && !error) return [];
+  tool.progress = {
+    ...tool.progress,
+    ...(description ? { description } : {}),
+    ...(error ? { summary: error } : {}),
+  };
+  return [
+    {
+      type: "item.updated",
+      threadId: state.threadId,
+      itemId: tool.itemId,
+      payload: toolPayload(tool, "running"),
+    },
+  ];
+}
+
+/**
+ * `task_notification` is the authoritative close for a background task. For a
+ * tracked subagent, emit the final `item.updated` (+ `item.completed`) on the
+ * parent tool and clean up the registry. For everything else (plain background
+ * Bash), fall back to the progress-attach behavior — the tool's own tool_result
+ * still owns its completion.
+ */
+function applyTaskNotification(message: SDKMessage, state: ClaudeMapperState): RuntimeEvent[] {
+  const obj = message as TaskLifecycleMessage & { status?: unknown };
+  const taskId = typeof obj.task_id === "string" ? obj.task_id : undefined;
+  const registeredToolUseId = taskId ? state.activeSubAgentTaskToTool?.get(taskId) : undefined;
+  if (!taskId || !registeredToolUseId) {
+    return applyTaskLifecycle(message, state);
+  }
+
+  const events: RuntimeEvent[] = [];
+  const usage = readTaskUsage(obj);
+  const goalUsage = emitActiveGoalTaskUsageUpdate(state, obj, usage);
+  if (goalUsage) events.push(goalUsage);
+
+  const tool = state.toolItemsById.get(registeredToolUseId);
+  if (!tool) {
+    unregisterSubAgentTask(state, taskId, registeredToolUseId);
+    return events;
+  }
+
+  syncSubAgentModelProgress(tool);
+  tool.progress = mergeTaskProgress(tool, obj, usage);
+  const status: "success" | "error" = obj.status === "completed" ? "success" : "error";
+  const summary =
+    typeof obj.summary === "string" && obj.summary.length > 0 ? obj.summary : undefined;
+  events.push({
+    type: "item.updated",
+    threadId: state.threadId,
+    itemId: tool.itemId,
+    payload:
+      status === "error"
+        ? toolPayload(tool, "error", summary ? { message: summary } : undefined)
+        : toolPayload(tool, "success", summary),
+  });
+  events.push({
+    type: "item.completed",
+    threadId: state.threadId,
+    itemId: tool.itemId,
+    payload: toolPayload(tool, status),
+  });
+  state.toolItemsById.delete(registeredToolUseId);
+  for (const [idx, value] of state.toolItemsByIndex) {
+    if (value.itemId === registeredToolUseId) state.toolItemsByIndex.delete(idx);
+  }
+  unregisterSubAgentTask(state, taskId, registeredToolUseId);
   return events;
 }
 
@@ -1185,7 +1376,7 @@ function mapPermissionDenied(message: SDKMessage, state: ClaudeMapperState): Run
   return events;
 }
 
-function readParentToolUseId(message: SDKMessage): string | undefined {
+export function readParentToolUseId(message: SDKMessage): string | undefined {
   const value = (message as { parent_tool_use_id?: unknown }).parent_tool_use_id;
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
@@ -1505,6 +1696,90 @@ function readPositiveInteger(value: unknown): number | undefined {
   return parsed !== undefined && parsed > 0 ? parsed : undefined;
 }
 
+/**
+ * Render a sub-agent's forwarded whole `assistant` message as self-contained,
+ * already-complete child items. Unlike the main-thread path this never reads or
+ * writes `assistantTextItems` / `reasoningItems` / `toolItemsByIndex` (the
+ * shared per-index lanes), so a sub-agent block at index 0 can't clobber the
+ * main thread's live stream. Tool calls ARE recorded in `toolItemsById` (keyed
+ * by their globally-unique tool_use id) so the sub-agent's own tool_result can
+ * complete them. The outer `tagParent` stamps `parentItemId` on the emitted
+ * `item.started` events and bumps the parent sub-agent's step counter.
+ */
+function flushSubAgentAssistantMessage(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const content = (message as { message?: { content?: unknown } }).message?.content;
+  if (!Array.isArray(content)) return events;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const obj = block as Record<string, unknown>;
+    if (obj.type === "text" && typeof obj.text === "string" && obj.text.length > 0) {
+      const itemId = newItemId("asst");
+      events.push({
+        type: "item.started",
+        threadId: state.threadId,
+        itemId,
+        itemType: "assistant_message",
+      });
+      events.push({
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "assistant_text",
+        delta: obj.text,
+      });
+      events.push({ type: "item.completed", threadId: state.threadId, itemId });
+      continue;
+    }
+    if (obj.type === "thinking") {
+      const text = extractText(obj);
+      if (text.length === 0) continue;
+      const itemId = newItemId("reason");
+      events.push({
+        type: "item.started",
+        threadId: state.threadId,
+        itemId,
+        itemType: "reasoning",
+      });
+      events.push({
+        type: "content.delta",
+        threadId: state.threadId,
+        itemId,
+        stream: "reasoning_text",
+        delta: text,
+      });
+      events.push({ type: "item.completed", threadId: state.threadId, itemId });
+      continue;
+    }
+    if (obj.type === "tool_use" || obj.type === "server_tool_use" || obj.type === "mcp_tool_use") {
+      const toolName = typeof obj.name === "string" ? obj.name : "Tool";
+      if (toolName === ASK_USER_QUESTION_TOOL_NAME) continue;
+      const input =
+        obj.input && typeof obj.input === "object" && !Array.isArray(obj.input)
+          ? (obj.input as Record<string, unknown>)
+          : {};
+      const itemId = typeof obj.id === "string" ? obj.id : newItemId("tool");
+      const tool = createToolItemState({ itemId, toolName, input });
+      // Plan-aggregator tools inside a sub-agent would pollute the main plan
+      // item; skip them (their result is dropped too — they're child-scoped).
+      if (tool.planAggregatorRole) continue;
+      if (!state.toolItemsById.has(itemId)) state.toolItemsById.set(itemId, tool);
+      (state.subAgentChildToolItemIds ??= new Set<string>()).add(itemId);
+      events.push({
+        type: "item.started",
+        threadId: state.threadId,
+        itemId: tool.itemId,
+        itemType: tool.itemType,
+        payload: toolPayload(tool, "running"),
+      });
+    }
+  }
+  return events;
+}
+
 function mapClaudeSdkMessageInner(
   message: SDKMessage,
   state: ClaudeMapperState,
@@ -1512,6 +1787,13 @@ function mapClaudeSdkMessageInner(
 ): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
   if (message.type === "stream_event") {
+    // Sub-agent partial streams (parent_tool_use_id set) interleave with the
+    // main-thread stream but share the same per-block-index lane maps. Their
+    // `message_start` would clear the main lane mid-stream and their deltas
+    // would append to main-thread items at the same index. Drop them — the
+    // sub-agent's forwarded whole assistant/user messages render its child
+    // items (see flushSubAgentAssistantMessage), so nothing is lost.
+    if (readParentToolUseId(message)) return events;
     const event = message.event as unknown as Record<string, unknown>;
     const type = event.type;
     const index = typeof event.index === "number" ? event.index : 0;
@@ -1657,6 +1939,13 @@ function mapClaudeSdkMessageInner(
   }
 
   if (message.type === "assistant") {
+    // Sub-agent (parent-attributed) whole messages must not touch the shared
+    // main-lane per-index maps — index 0 of a sub-agent message would collide
+    // with the main thread's streaming block at index 0. Emit self-contained,
+    // already-complete child items instead (tagParent attaches parentItemId).
+    if (readParentToolUseId(message)) {
+      return flushSubAgentAssistantMessage(message, state);
+    }
     const messageId = readClaudeAssistantMessageId(message.message);
     const skipTextSnapshot = messageId ? state.streamedAssistantMessageIds.has(messageId) : false;
     const content = (message.message as { content?: unknown }).content;
@@ -1741,6 +2030,19 @@ function mapClaudeSdkMessageInner(
         }
         continue;
       }
+      // A background subagent's launch tool_result ("Async agent launched…")
+      // arrives immediately while the subagent keeps running. Keep the parent
+      // tool_call alive (running) instead of completing/deleting it — the
+      // authoritative `task_notification` closes it later (applyTaskNotification).
+      if (state.activeSubAgentToolToTask?.has(toolUseId)) {
+        events.push({
+          type: "item.updated",
+          threadId: state.threadId,
+          itemId: tool.itemId,
+          payload: toolPayload(tool, "running"),
+        });
+        continue;
+      }
       const isError = obj.is_error === true;
       if (tool.itemType === "file_change" && !isError) {
         const metadata = fileChangeMetadataFromToolResult(
@@ -1775,6 +2077,7 @@ function mapClaudeSdkMessageInner(
       });
       events.push({ type: "item.completed", threadId: state.threadId, itemId: tool.itemId });
       state.toolItemsById.delete(toolUseId);
+      state.subAgentChildToolItemIds?.delete(toolUseId);
       for (const [idx, value] of state.toolItemsByIndex) {
         if (value.itemId === toolUseId) state.toolItemsByIndex.delete(idx);
       }
@@ -1802,13 +2105,24 @@ function mapClaudeSdkMessageInner(
     return events;
   }
 
-  if (
-    message.type === "system" &&
-    (message.subtype === "task_started" ||
-      message.subtype === "task_progress" ||
-      message.subtype === "task_notification")
-  ) {
+  if (message.type === "system" && message.subtype === "task_started") {
+    registerSubAgentTaskIfNeeded(message, state);
     events.push(...applyTaskLifecycle(message, state));
+    return events;
+  }
+
+  if (message.type === "system" && message.subtype === "task_progress") {
+    events.push(...applyTaskLifecycle(message, state));
+    return events;
+  }
+
+  if (message.type === "system" && message.subtype === "task_updated") {
+    events.push(...applyTaskUpdated(message, state));
+    return events;
+  }
+
+  if (message.type === "system" && message.subtype === "task_notification") {
+    events.push(...applyTaskNotification(message, state));
     return events;
   }
 

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -65,6 +65,24 @@ export interface ClaudeMapperState {
   activeGoalLiveApiTokensUsed?: number;
   activeGoalTaskTokensByKey?: Map<string, number>;
   planAggregator?: PlanAggregatorState;
+  /**
+   * Live background subagent tasks, keyed by the SDK `task_id`, mapping to the
+   * launching Agent/Task tool_use id. Populated on `task_started` that carries
+   * a `subagent_type` (or whose tool maps to a subagent-like tool). Lets a
+   * `task_updated` (which carries no `tool_use_id`) find the parent item, and
+   * keeps the parent tool_call alive after its launch tool_result arrives until
+   * the authoritative `task_notification` closes it.
+   */
+  activeSubAgentTaskToTool?: Map<string, string>;
+  /** Reverse of {@link activeSubAgentTaskToTool}: tool_use id → task_id. */
+  activeSubAgentToolToTask?: Map<string, string>;
+  /**
+   * tool_use ids of tools launched INSIDE a running subagent (forwarded child
+   * messages). Tracked so the main turn's `result` close doesn't evict them
+   * before their own (also-forwarded) tool_result arrives to complete them —
+   * background subagent activity continues after the main turn's result.
+   */
+  subAgentChildToolItemIds?: Set<string>;
 }
 
 export function createClaudeMapperState(threadId: string): ClaudeMapperState {

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -193,12 +193,38 @@ function sdkAssistantMessage(sessionId: string, uuid: string, text: string): SDK
   } as unknown as SDKMessage;
 }
 
+function sdkAssistantMessageWithParent(
+  sessionId: string,
+  uuid: string,
+  text: string,
+  parentToolUseId: string,
+): SDKMessage {
+  return {
+    type: "assistant",
+    uuid,
+    session_id: sessionId,
+    parent_tool_use_id: parentToolUseId,
+    message: {
+      id: uuid,
+      role: "assistant",
+      content: [{ type: "text", text }],
+    },
+  } as unknown as SDKMessage;
+}
+
 function sdkSuccessResult(sessionId: string): SDKMessage {
   return {
     type: "result",
     subtype: "success",
     session_id: sessionId,
   } as unknown as SDKMessage;
+}
+
+function promptQueueForLatestQuery(): AsyncIterator<{ message: { content: unknown } }> {
+  const queryArg = mockSdk.query.mock.calls.at(-1)?.[0] as {
+    prompt: AsyncIterable<{ message: { content: unknown } }>;
+  };
+  return queryArg.prompt[Symbol.asyncIterator]();
 }
 
 describe("ClaudeSdkSession", () => {
@@ -591,6 +617,120 @@ describe("ClaudeSdkSession", () => {
     expect(runtimeEvents.filter((e) => e.type === "turn.completed").length).toBe(
       turnCompletesAfterFirst + 1,
     );
+
+    await session.dispose();
+  });
+
+  it("does not open a resumed turn on sub-agent chatter after idle", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const runtimeEvents: RuntimeEvent[] = [];
+    const updates: StructuredSessionUpdate[] = [];
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-subagent-idle",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+      onUpdate: (update) => updates.push(update),
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    const openedSessionId = await session.openThread(config);
+    await session.startTurn("launch a background subagent", config);
+    await flushAsyncWork();
+    fake.emitMessage(sdkAssistantMessage(openedSessionId, "assistant-uuid-1", "launched"));
+    fake.emitMessage(sdkSuccessResult(openedSessionId));
+    await flushAsyncWork();
+    expect(updates.at(-1)).toMatchObject({ status: "idle" });
+
+    const turnStartsAfterIdle = runtimeEvents.filter((e) => e.type === "turn.started").length;
+
+    // Sub-agent output keeps arriving AFTER the main result — must NOT reopen a turn.
+    fake.emitMessage(
+      sdkAssistantMessageWithParent(openedSessionId, "sub-uuid-1", "subagent working", "toolu_p"),
+    );
+    await flushAsyncWork();
+
+    expect(updates.at(-1)).toMatchObject({ status: "idle" });
+    expect(runtimeEvents.filter((e) => e.type === "turn.started").length).toBe(turnStartsAfterIdle);
+
+    await session.dispose();
+  });
+
+  it("steerTurn enqueues onto the running turn without interrupting or reopening", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const runtimeEvents: RuntimeEvent[] = [];
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-steer",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    await session.openThread(config);
+    await session.startTurn("first", config);
+    await flushAsyncWork();
+    const queue = promptQueueForLatestQuery();
+    expect((await queue.next()).value?.message.content).toBe("first");
+
+    const turnStartsBeforeSteer = runtimeEvents.filter((e) => e.type === "turn.started").length;
+    runtimeEvents.length = 0;
+
+    await session.steerTurn!("steer this", config);
+
+    // No interrupt, no new turn.started; an optimistic user_message item is painted.
+    expect(fake.runtime.interrupt).not.toHaveBeenCalled();
+    expect(runtimeEvents.filter((e) => e.type === "turn.started").length).toBe(0);
+    expect(turnStartsBeforeSteer).toBe(1);
+    expect(
+      runtimeEvents.filter((e) => e.type === "item.started" && e.itemType === "user_message")
+        .length,
+    ).toBe(1);
+    // The steer message was pushed onto the SDK input queue.
+    expect((await queue.next()).value?.message.content).toBe("steer this");
+
+    await session.dispose();
+  });
+
+  it("steerTurn falls back to startTurn semantics when no turn is in flight", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const runtimeEvents: RuntimeEvent[] = [];
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-steer-idle",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: (event) => runtimeEvents.push(event),
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    const openedSessionId = await session.openThread(config);
+    await session.startTurn("first", config);
+    await flushAsyncWork();
+    fake.emitMessage(sdkAssistantMessage(openedSessionId, "assistant-uuid-1", "done"));
+    fake.emitMessage(sdkSuccessResult(openedSessionId));
+    await flushAsyncWork();
+    runtimeEvents.length = 0;
+
+    // Raced idle: steer opens a fresh turn just like startTurn.
+    await session.steerTurn!("second", config);
+    expect(runtimeEvents.filter((e) => e.type === "turn.started").length).toBe(1);
 
     await session.dispose();
   });

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -55,6 +55,7 @@ import { CLAUDE_DEFAULT_APPROVAL_POLICY } from "./detection";
 import {
   ACCEPT_SUGGESTION_OPTION_PREFIX,
   buildClaudeQuestionAnswerEvents,
+  buildPromptContentBlocks,
   closeClaudeOpenItems,
   createClaudeMapperState,
   emitActiveGoalTokenUpdate,
@@ -67,6 +68,7 @@ import {
   nonDiagnosticErrors,
   parseClaudeQuestions,
   readClaudeApiUsageSpendTokens,
+  readParentToolUseId,
   startClaudeTurn,
   type ClaudeMapperState,
   type ClaudeQuestion,
@@ -581,6 +583,44 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     await this.syncUltracodeFlag(query);
     await this.syncFastMode(query);
 
+    const message = await buildSdkUserMessage(prompt, segments);
+    this.promptQueue.push(message);
+  }
+
+  /**
+   * Steer the running turn by streaming a new user message into the SDK's input
+   * queue WITHOUT interrupting — the probed-safe steering mechanism: the running
+   * turn continues, background subagents are unaffected, and the message steers
+   * the current turn or is answered in the next one. No `turn.started` is
+   * emitted mid-turn (the message joins the open turn); if no turn is in flight
+   * (raced idle) we fall back to `startTurn` so turn accounting stays correct.
+   */
+  async steerTurn(
+    prompt: string,
+    config: ThreadConfig,
+    segments?: PromptSegment[],
+    options?: StartTurnOptions,
+  ): Promise<void> {
+    if (this.disposed) return;
+    if (!this.currentTurnInFlight) {
+      await this.startTurn(prompt, config, segments, options);
+      return;
+    }
+    this.currentConfig = config;
+    // Optimistic user_message item only (no turn.started) so the chat paints the
+    // steer immediately; mirrors the emission startClaudeTurn performs.
+    const userItemId = options?.userMessageItemId ?? `user-${randomUUID()}`;
+    this.emitRuntimeEvents([
+      {
+        type: "item.started",
+        threadId: this.input.threadId,
+        itemId: userItemId,
+        itemType: "user_message",
+        payload: { content: buildPromptContentBlocks(prompt, segments) },
+      },
+      { type: "item.completed", threadId: this.input.threadId, itemId: userItemId },
+    ]);
+    await this.requireQuery();
     const message = await buildSdkUserMessage(prompt, segments);
     this.promptQueue.push(message);
   }
@@ -1154,7 +1194,9 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       this.emitUpdate(mapped);
     }
 
-    if (message.type === "assistant") {
+    if (message.type === "assistant" && !readParentToolUseId(message)) {
+      // Only main-thread assistant uuids are valid resume anchors; a sub-agent
+      // uuid (parent_tool_use_id set) must never become a rollback resume point.
       this.currentTurnAssistantUuid = message.uuid;
     }
 
@@ -1276,12 +1318,14 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
  * Whether an SDK message represents the model starting to produce fresh
  * assistant output. A streamed message opens with a `message_start` stream
  * event; non-streaming transports deliver a whole `assistant` message instead.
- * Sub-agent (`Task`) output also arrives as assistant messages, but only while
- * a turn is already in flight, so callers gate on `currentTurnInFlight` to
- * exclude it. Used to detect a wakeup/background resume that bypassed
- * `startTurn`.
+ * Sub-agent output also arrives as assistant messages / stream events, but it
+ * carries a `parent_tool_use_id` and keeps arriving AFTER the main turn's
+ * `result` — it must never open a resumed turn (that would flip the thread back
+ * to working on background subagent chatter). Exclude anything parent-attributed
+ * here. Used to detect a wakeup/background resume that bypassed `startTurn`.
  */
 function isResumedAssistantActivity(message: SDKMessage): boolean {
+  if (readParentToolUseId(message)) return false;
   if (message.type === "assistant") return true;
   if (message.type === "stream_event") {
     return message.event.type === "message_start";

--- a/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
@@ -272,3 +272,98 @@ describe("ThreadSessionManager structured stale-interrupt watchdog", () => {
     expect(events).toEqual([]);
   });
 });
+
+describe("ThreadSessionManager steer capability", () => {
+  function steerableSession(withSteer: boolean): StructuredSessionHandle & {
+    startTurn: ReturnType<typeof vi.fn>;
+    steerTurn?: ReturnType<typeof vi.fn>;
+  } {
+    const startTurn = vi.fn<NonNullable<StructuredSessionHandle["startTurn"]>>(
+      async () => undefined,
+    );
+    const steerTurn = vi.fn<NonNullable<StructuredSessionHandle["steerTurn"]>>(
+      async () => undefined,
+    );
+    return createStructuredSession({
+      startTurn,
+      ...(withSteer ? { steerTurn } : {}),
+    }) as StructuredSessionHandle & {
+      startTurn: typeof startTurn;
+      steerTurn?: typeof steerTurn;
+    };
+  }
+
+  it("submit-while-working uses steerTurn without interrupting when available", async () => {
+    const structuredSession = steerableSession(true);
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.sendThreadInput({
+      threadId: THREAD_ID,
+      prompt: "steer me",
+      config: { model: `${AGENT_KIND}/model` },
+    });
+
+    expect(structuredSession.steerTurn).toHaveBeenCalledTimes(1);
+    expect(structuredSession.steerTurn).toHaveBeenCalledWith(
+      "steer me",
+      { model: `${AGENT_KIND}/model` },
+      undefined,
+      undefined,
+    );
+    expect(structuredSession.interruptTurn).not.toHaveBeenCalled();
+    expect(structuredSession.startTurn).not.toHaveBeenCalled();
+  });
+
+  it("submit-while-working falls back to interrupt-drain when steerTurn is absent", async () => {
+    const structuredSession = steerableSession(false);
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.sendThreadInput({
+      threadId: THREAD_ID,
+      prompt: "steer me",
+      config: { model: `${AGENT_KIND}/model` },
+    });
+
+    expect(structuredSession.interruptTurn).toHaveBeenCalledTimes(1);
+    expect(structuredSession.startTurn).not.toHaveBeenCalled();
+  });
+
+  it("setPendingSteer uses steerTurn without interrupting when available", async () => {
+    const structuredSession = steerableSession(true);
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.setPendingSteer({
+      threadId: THREAD_ID,
+      prompt: "steer via slot",
+      config: { model: `${AGENT_KIND}/model` },
+    });
+
+    expect(structuredSession.steerTurn).toHaveBeenCalledTimes(1);
+    expect(structuredSession.interruptTurn).not.toHaveBeenCalled();
+  });
+
+  it("setPendingSteer falls back to interrupt-drain when steerTurn is absent", async () => {
+    const structuredSession = steerableSession(false);
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await manager.setPendingSteer({
+      threadId: THREAD_ID,
+      prompt: "steer via slot",
+      config: { model: `${AGENT_KIND}/model` },
+    });
+
+    expect(structuredSession.interruptTurn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -369,6 +369,13 @@ export class ThreadSessionManager {
       // any `sendThreadInput` that lands here while working is treated as a
       // steer (replace-latest) for backwards compatibility.
       if (session.presentationMode === "gui" && session.status === "working") {
+        // Capability-based: sessions that support non-interrupting steer enqueue
+        // the message onto the running turn (subagents survive); others fall
+        // back to the interrupt-drain pending-steer path.
+        if (session.structuredSession.steerTurn) {
+          this.steerStructuredTurn(session, turn);
+          return;
+        }
         this.stagePendingSteer(session, turn);
         this.fireSteerInterrupt(session);
         return;
@@ -771,6 +778,12 @@ export class ThreadSessionManager {
       config: payload.config,
       ...(effectiveSegments ? { segments: effectiveSegments } : {}),
     };
+    // Capability-based: non-interrupting steer enqueues onto the running turn
+    // (subagents survive, no watchdog); others use the interrupt-drain path.
+    if (session.structuredSession.steerTurn) {
+      this.steerStructuredTurn(session, turn);
+      return;
+    }
     this.stagePendingSteer(session, turn);
     if (session.status === "working") {
       this.fireSteerInterrupt(session);
@@ -813,6 +826,36 @@ export class ThreadSessionManager {
       optimisticItemId ? { userMessageItemId: optimisticItemId } : undefined,
     );
     void startTurn.catch((error) => {
+      if (this.sessions.get(session.threadId)?.instanceId !== session.instanceId) {
+        return;
+      }
+      this.failStructuredSession(session, error);
+    });
+  }
+
+  /**
+   * Steer an in-flight turn via the session's `steerTurn` capability: enqueue
+   * the user message onto the running turn without interrupting it (no
+   * subagents killed, no error result, no pending-steer/watchdog dance). The
+   * session emits its own optimistic user_message item, so pass the renderer's
+   * id through when present to keep it deduped. Providers without `steerTurn`
+   * never reach here — callers keep the interrupt-drain path for them.
+   */
+  private steerStructuredTurn(session: SessionRuntime, turn: QueuedStructuredTurn): void {
+    const steerTurn = session.structuredSession?.steerTurn;
+    if (!steerTurn) return;
+    const optimisticItemId =
+      session.presentationMode === "gui" && turn.prompt.length > 0
+        ? turn.userMessageItemId
+        : undefined;
+    const steer = steerTurn.call(
+      session.structuredSession,
+      turn.prompt,
+      turn.config,
+      turn.segments,
+      optimisticItemId ? { userMessageItemId: optimisticItemId } : undefined,
+    );
+    void steer.catch((error) => {
       if (this.sessions.get(session.threadId)?.instanceId !== session.instanceId) {
         return;
       }


### PR DESCRIPTION
- Fix structured Claude sessions so background subagents keep running when a turn is steered instead of being interrupted or reset.
- Add a non-interrupting `steerTurn` capability and teach the thread session manager to use it when available, with fallback to the existing interrupt-drain path.
- Prevent sub-agent stream events from corrupting the main assistant stream and keep late sub-agent activity from reopening completed turns.
- Expand coverage around Claude stream mapping, session lifecycle, and stale-interrupt behavior to lock in the new subagent handling.