### PR TITLE
Show resolved Claude subagent models in progress

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.test.ts
@@ -33,4 +33,9 @@ describe("subAgentProgressMeta", () => {
     expect(formatSubAgentModelLabel("gemini-2.5-pro")).toBe("Gemini 2.5 Pro");
     expect(formatSubAgentModelLabel("claude-opus-4-8")).toBe("Opus 4.8");
   });
+
+  it("strips the date suffix from Claude release ids reported by child assistant messages", () => {
+    expect(formatSubAgentModelLabel("claude-opus-4-8-20250915")).toBe("Opus 4.8");
+    expect(formatSubAgentModelLabel("claude-haiku-4-5-20251001")).toBe("Haiku 4.5");
+  });
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/subAgentProgressMeta.tsx
@@ -100,7 +100,9 @@ function formatKnownModelId(modelId: string): string | undefined {
   const claudeShort = /^(opus|sonnet|haiku)$/i.exec(modelId);
   if (claudeShort) return capitalizeSegment(claudeShort[1]!);
 
-  const claudeRelease = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)$/i.exec(modelId);
+  // Optional trailing -YYYYMMDD: assistant messages report the dated release
+  // id (e.g. claude-opus-4-8-20250915); the pill shows just "Opus 4.8".
+  const claudeRelease = /^claude-(opus|sonnet|haiku)-(\d+)-(\d+)(?:-\d{8})?$/i.exec(modelId);
   if (claudeRelease) {
     return `${capitalizeSegment(claudeRelease[1]!)} ${claudeRelease[2]}.${claudeRelease[3]}`;
   }

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -1689,6 +1689,95 @@ describe("sdkCanonicalMapping — sub-agents", () => {
     expect(state.assistantTextItems.size).toBe(0);
   });
 
+  it("folds the child assistant message model onto the parent Task progress", () => {
+    const state = createClaudeMapperState("thread-1");
+    // Task input has no `model` — the agent definition supplies it, so only
+    // the child assistant messages reveal which model actually runs.
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_parent",
+          name: "Task",
+          input: { description: "Investigate", subagent_type: "Explore" },
+        },
+      }),
+      state,
+    );
+
+    const childMessage = (id: string): SDKMessage =>
+      ({
+        type: "assistant",
+        session_id: "claude-session",
+        uuid: id,
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          id,
+          role: "assistant",
+          model: "claude-haiku-4-5-20251001",
+          content: [{ type: "text", text: "looking around" }],
+        },
+      }) as unknown as SDKMessage;
+
+    const events = mapClaudeSdkMessage(childMessage("msg-sub-1"), state);
+    expect(events[0]).toMatchObject({
+      type: "item.updated",
+      itemId: "toolu_parent",
+      payload: {
+        name: "Task",
+        status: "running",
+        progress: { model: "claude-haiku-4-5-20251001" },
+      },
+    });
+
+    // Later child messages don't re-emit a leading model update (only the
+    // usual tagParent step-counter bump follows the child items).
+    const repeat = mapClaudeSdkMessage(childMessage("msg-sub-2"), state);
+    expect(repeat[0]).toMatchObject({ type: "item.started", itemType: "assistant_message" });
+    expect(state.toolItemsById.get("toolu_parent")?.progress?.model).toBe(
+      "claude-haiku-4-5-20251001",
+    );
+  });
+
+  it("keeps an explicit Task input model over the child assistant message model", () => {
+    const state = createClaudeMapperState("thread-1");
+    mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "toolu_parent",
+          name: "Task",
+          input: { description: "Investigate", subagent_type: "Explore", model: "opus" },
+        },
+      }),
+      state,
+    );
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "assistant",
+        session_id: "claude-session",
+        uuid: "msg-sub-1",
+        parent_tool_use_id: "toolu_parent",
+        message: {
+          id: "msg-sub-1",
+          role: "assistant",
+          model: "claude-opus-4-8-20250915",
+          content: [{ type: "text", text: "looking around" }],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+
+    // No leading model update — the input model already populated progress.
+    expect(events[0]).toMatchObject({ type: "item.started", itemType: "assistant_message" });
+    expect(state.toolItemsById.get("toolu_parent")?.progress?.model).toBe("opus");
+  });
+
   it("does not set parentItemId on top-level messages (parent_tool_use_id null)", () => {
     const state = createClaudeMapperState("thread-1");
     const events = mapClaudeSdkMessage(

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -1710,7 +1710,7 @@ function flushSubAgentAssistantMessage(
   message: SDKMessage,
   state: ClaudeMapperState,
 ): RuntimeEvent[] {
-  const events: RuntimeEvent[] = [];
+  const events: RuntimeEvent[] = [...syncSubAgentModelFromChildAssistant(message, state)];
   const content = (message as { message?: { content?: unknown } }).message?.content;
   if (!Array.isArray(content)) return events;
   for (const block of content) {
@@ -1778,6 +1778,38 @@ function flushSubAgentAssistantMessage(
     }
   }
   return events;
+}
+
+/**
+ * A Task/Agent launch usually omits `model` from its input — the agent
+ * definition behind `subagent_type` supplies it — so the collapsed pill can't
+ * tell the user which model the subagent runs on. The forwarded child
+ * assistant messages carry the resolved model id; fold the first observed one
+ * onto the parent tool's progress (an explicit `model` input keeps
+ * precedence) so the row shows `Model · tokens` like MCP subagent tiles.
+ */
+function syncSubAgentModelFromChildAssistant(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+): RuntimeEvent[] {
+  const parentToolUseId = readParentToolUseId(message);
+  if (!parentToolUseId) return [];
+  const tool = state.toolItemsById.get(parentToolUseId);
+  if (!tool || !isSubAgentToolName(tool.toolName)) return [];
+  if (tool.progress?.model) return [];
+  const inner = (message as { message?: unknown }).message;
+  if (!inner || typeof inner !== "object") return [];
+  const model = readStringField(inner as Record<string, unknown>, "model");
+  if (!model) return [];
+  tool.progress = { ...tool.progress, model };
+  return [
+    {
+      type: "item.updated",
+      threadId: state.threadId,
+      itemId: tool.itemId,
+      payload: toolPayload(tool, "running"),
+    },
+  ];
 }
 
 function mapClaudeSdkMessageInner(


### PR DESCRIPTION
- Bugfix: display the resolved Claude subagent model on Task progress when launch input omits it.
- Preserve explicit Task input models over child assistant model data.
- Format dated Claude release IDs without the trailing date in progress pills.
- Cover the mapping and label formatting behavior with focused tests.