### PR TITLE
Fix Cursor API dollar reconciliation

### DIFF
--- a/packages/agents-usage/src/collectors/cursor.test.ts
+++ b/packages/agents-usage/src/collectors/cursor.test.ts
@@ -51,7 +51,7 @@ describe("parseCursorUsage", () => {
           limit: 25000, // cents
           totalPercentUsed: 49,
           autoPercentUsed: 34,
-          apiPercentUsed: 100,
+          apiPercentUsed: 37.4, // agrees with 9347/25000 → dollars pass through
         },
         onDemand: { used: 0, limit: 0, enabled: false },
       },
@@ -68,10 +68,61 @@ describe("parseCursorUsage", () => {
     expect(auto.usedPercent).toBe(34);
     expect(auto.resetsAt).toBe(1_719_600_000_000);
     const api = snap.windows.find((w) => w.id === "cursor-api")!;
-    expect(api.usedPercent).toBe(100);
+    expect(api.usedPercent).toBeCloseTo(37.4);
     expect(api.used).toBeCloseTo(93.47);
     expect(api.limit).toBeCloseTo(250);
     expect(api.resetsAt).toBe(1_719_600_000_000);
+  });
+
+  it("treats breakdown.total as real spend and derives the allowance from the percent", () => {
+    // Live payload shape: used/limit/remaining clamp at the included $20 while
+    // breakdown.total carries the real spend ($20 included + $8.75 bonus
+    // consumed = $28.75). The authoritative 55.07% then implies a ~$52.21
+    // allowance (28.75 / 0.5507), keeping the dollars consistent with the bar.
+    const body = {
+      membershipType: "pro",
+      individualUsage: {
+        plan: {
+          used: 2000,
+          limit: 2000,
+          remaining: 0,
+          breakdown: { included: 2000, bonus: 875, total: 2875 },
+          autoPercentUsed: 2.65,
+          apiPercentUsed: 55.07,
+        },
+      },
+    };
+    const snap = parseCursorUsage(body, {}, NOW);
+    const api = snap.windows.find((w) => w.id === "cursor-api")!;
+    expect(api.usedPercent).toBeCloseTo(55.07);
+    expect(api.used).toBeCloseTo(28.75);
+    expect(api.limit).toBeCloseTo(52.21, 1);
+  });
+
+  it("derives the allowance when the clamped dollars disagree with the percent (no breakdown)", () => {
+    // Older payloads without a breakdown: used/limit cap at the plan price
+    // ($20/$20) while the percent says 44% consumed → allowance ≈ $45.45.
+    const body = {
+      membershipType: "pro",
+      individualUsage: {
+        plan: { used: 2000, limit: 2000, autoPercentUsed: 3, apiPercentUsed: 44 },
+      },
+    };
+    const snap = parseCursorUsage(body, {}, NOW);
+    const api = snap.windows.find((w) => w.id === "cursor-api")!;
+    expect(api.usedPercent).toBe(44);
+    expect(api.used).toBeCloseTo(20);
+    expect(api.limit).toBeCloseTo(45.45, 1);
+  });
+
+  it("keeps the vendor limit when the dollars already agree with the percent", () => {
+    const body = {
+      individualUsage: { plan: { used: 9347, limit: 25000, apiPercentUsed: 37.39 } },
+    };
+    const snap = parseCursorUsage(body, {}, NOW);
+    const api = snap.windows.find((w) => w.id === "cursor-api")!;
+    expect(api.used).toBeCloseTo(93.47);
+    expect(api.limit).toBeCloseTo(250);
   });
 
   it("adds an on-demand window only when enabled", () => {

--- a/packages/agents-usage/src/collectors/cursor.ts
+++ b/packages/agents-usage/src/collectors/cursor.ts
@@ -10,9 +10,11 @@ import type { UsageSnapshot, UsageWindow } from "../types";
  * involvement.
  *
  * Schema (per codexbar) of GET /api/usage-summary → individualUsage.plan:
- *   { used (cents), limit (cents), totalPercentUsed, autoPercentUsed,
- *     apiPercentUsed }  + billingCycleEnd + membershipType. Surfaced as a
- *   Auto and API breakdown windows. The dollar allowance belongs to API usage.
+ *   { used (cents), limit (cents), breakdown { included, bonus, total },
+ *     totalPercentUsed, autoPercentUsed, apiPercentUsed } + billingCycleEnd +
+ *   membershipType. Surfaced as Auto and API breakdown windows. The dollar
+ *   allowance belongs to API usage; see `apiDollars` for how the clamped
+ *   dollar fields are reconciled with the authoritative percents.
  */
 
 export const CURSOR_USAGE_ENDPOINT = "https://cursor.com/api/usage-summary";
@@ -20,6 +22,8 @@ export const CURSOR_USAGE_ENDPOINT = "https://cursor.com/api/usage-summary";
 interface CursorPlanUsage {
   used?: number;
   limit?: number;
+  /** Cents: `included` is the nominal plan allowance; `total` adds any bonus credit. */
+  breakdown?: { included?: number; bonus?: number; total?: number };
   totalPercentUsed?: number;
   autoPercentUsed?: number;
   apiPercentUsed?: number;
@@ -58,6 +62,48 @@ function clampPercent(value: number | undefined): number | undefined {
   return Math.min(100, Math.max(0, value));
 }
 
+/**
+ * Cursor's plan dollar fields need reconciliation (verified against the live
+ * payload and CodexBar's Cursor probe, which scrapes the same endpoint):
+ *
+ * - `used`/`limit`/`remaining` clamp at the nominal plan price (e.g. $20/$20
+ *   while the percent says 55%), so they understate real spend.
+ * - `breakdown.total` is the total credits *consumed* (included + bonus spend),
+ *   not the allowance — treating it as the limit was CodexBar regression #240.
+ *   Prefer it as the real spend when it exceeds the clamped `used`.
+ * - `apiPercentUsed` is the authoritative consumed fraction (it's what
+ *   Cursor's own dashboard messages report). When the dollar pair disagrees
+ *   with it, keep the spend and derive the allowance as `spend / percent` so
+ *   the dollar text always matches the bar (e.g. $28.75 / $52.21 at 55%,
+ *   instead of a clamped, full-looking $20 / $20).
+ */
+function apiDollars(plan: CursorPlanUsage, percent: number): { used?: number; limit?: number } {
+  const reportedUsed = centsToUsd(plan.used);
+  const reportedLimit = centsToUsd(plan.limit);
+  const breakdownTotal = centsToUsd(plan.breakdown?.total);
+  const spend =
+    breakdownTotal !== undefined && breakdownTotal > (reportedUsed ?? 0)
+      ? breakdownTotal
+      : reportedUsed;
+
+  if (spend === undefined) {
+    return reportedLimit !== undefined && reportedLimit > 0 ? { limit: reportedLimit } : {};
+  }
+  if (spend > 0 && percent > 0) {
+    const impliedPercent =
+      reportedLimit !== undefined && reportedLimit > 0 ? (spend / reportedLimit) * 100 : undefined;
+    // 1-point tolerance so ordinary rounding drift in the reported percent
+    // doesn't override a limit the spend already agrees with.
+    if (impliedPercent === undefined || Math.abs(impliedPercent - percent) > 1) {
+      return { used: spend, limit: spend / (percent / 100) };
+    }
+  }
+  return {
+    used: spend,
+    ...(reportedLimit !== undefined && reportedLimit > 0 ? { limit: reportedLimit } : {}),
+  };
+}
+
 /** billingCycleEnd may be unix seconds/ms (as a string) or ISO-8601. */
 function toResetMs(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -94,16 +140,13 @@ export function parseCursorUsage(
 
   const apiPercent = clampPercent(plan.apiPercentUsed);
   if (apiPercent !== undefined) {
-    const used = centsToUsd(plan.used);
-    const limit = centsToUsd(plan.limit);
     windows.push({
       id: "cursor-api",
       label: "API",
       usedPercent: apiPercent,
       unit: "percent",
       currency: "USD",
-      ...(used !== undefined ? { used } : {}),
-      ...(limit !== undefined && limit > 0 ? { limit } : {}),
+      ...apiDollars(plan, apiPercent),
       ...withReset,
     });
   }


### PR DESCRIPTION
- Bugfix: reconcile Cursor API spend with authoritative usage percent.
- Treat Cursor breakdown totals as real consumed spend, not allowance.
- Derive API allowance when Cursor dollar fields are clamped or disagree with percent.
- Add Cursor usage tests for breakdown, clamped, and already-consistent payloads.