### PR TITLE
Support Cursor ACP task subagent extensions

### DIFF
--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -1738,15 +1738,17 @@ describe("RemoteAccessServer", () => {
       body: JSON.stringify({ kind: "add-existing", path: "/repo/new-app" }),
     });
     expect(commandResponse.status).toBe(200);
+    // The server derives the location kind from the host platform.
+    const locationKind = process.platform === "win32" ? "windows" : "posix";
     await expect(commandResponse.json()).resolves.toMatchObject({
       project: {
         name: "new-app",
-        location: { kind: "posix", path: "/repo/new-app" },
+        location: { kind: locationKind, path: "/repo/new-app" },
       },
       projects: [
         {
           name: "new-app",
-          location: { kind: "posix", path: "/repo/new-app" },
+          location: { kind: locationKind, path: "/repo/new-app" },
         },
       ],
     });
@@ -1761,7 +1763,7 @@ describe("RemoteAccessServer", () => {
         projects: [
           {
             name: "new-app",
-            location: { kind: "posix", path: "/repo/new-app" },
+            location: { kind: locationKind, path: "/repo/new-app" },
           },
         ],
       },

--- a/src/main/remote/auth.test.ts
+++ b/src/main/remote/auth.test.ts
@@ -102,16 +102,20 @@ describe("RemoteAuthStore", () => {
     expect(store.revokeAccessSession(session!.id)).toBe(false);
   });
 
-  it("writes persisted access sessions with owner-only permissions", () => {
-    const baseDir = mkdtempSync(join(tmpdir(), "lc-remote-auth-"));
-    try {
-      writeRemoteAccessSessions(baseDir, []);
+  // POSIX-only: Windows does not honor the 0o600 mode bits (stat reports 0o666).
+  it.skipIf(process.platform === "win32")(
+    "writes persisted access sessions with owner-only permissions",
+    () => {
+      const baseDir = mkdtempSync(join(tmpdir(), "lc-remote-auth-"));
+      try {
+        writeRemoteAccessSessions(baseDir, []);
 
-      expect(statSync(remoteAuthFilePath(baseDir)).mode & 0o777).toBe(0o600);
-    } finally {
-      rmSync(baseDir, { recursive: true, force: true });
-    }
-  });
+        expect(statSync(remoteAuthFilePath(baseDir)).mode & 0o777).toBe(0o600);
+      } finally {
+        rmSync(baseDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("parses bearer authorization schemes case-insensitively", () => {
     expect(parseBearerAuthorizationHeader("Bearer lc_access_token")).toBe("lc_access_token");

--- a/src/supervisor/agents/acp/canonicalMapping.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.ts
@@ -973,6 +973,7 @@ function isAcpSubAgentToolCall(toolCall: {
   kind?: string | null;
   rawInput?: unknown;
 }): boolean {
+  if (readStringField(toolCall.rawInput, "_toolName") === "task") return true;
   if (readStringField(toolCall.rawInput, "agent_type")) return true;
   if (readStringField(toolCall.rawInput, "subagent_type")) return true;
   return (

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -122,6 +122,7 @@ function makeConfigSyncSession(
   const session = Object.create(AcpStructuredSession.prototype) as Record<string, unknown>;
   session["child"] = { killed: true };
   session["connection"] = connection;
+  session["acpToolCallIdToItemId"] = new Map();
   session["sessionId"] = "session-1";
   session["threadId"] = "thread-1";
   session["projectLocation"] = { kind: "windows", path: "C:\\repo" };

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -444,6 +444,11 @@ export interface AcpStructuredSessionOptions {
    * provider-agnostic.
    */
   sessionUpdateTransform?: (notification: SessionNotification) => SessionNotification;
+  /**
+   * Vendor ACP extension notifications (e.g. Cursor `cursor/task`) that are
+   * not surfaced as standard `session/update` messages.
+   */
+  extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
 }
@@ -456,6 +461,9 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
   private sessionUpdateTransform?: (notification: SessionNotification) => SessionNotification;
 
+  private extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
+
+  private readonly acpToolCallIdToItemId = new Map<string, string>();
   private readonly child: ChildProcess;
   private readonly connection: ClientSideConnection;
   private readonly cwd: string;
@@ -546,6 +554,9 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     }
     if (options?.sessionUpdateTransform) {
       this.sessionUpdateTransform = options.sessionUpdateTransform;
+    }
+    if (options?.extensionNotificationHandler) {
+      this.extensionNotificationHandler = options.extensionNotificationHandler;
     }
     this.browserMcp = options?.browserMcp;
     this.subagentMcp = options?.subagentMcp;
@@ -830,6 +841,10 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         extNotification(method: string, params: Record<string, unknown>) {
           session.handleExtNotification(method, params);
           return Promise.resolve();
+        },
+        extMethod(method: string, params: Record<string, unknown>) {
+          session.handleExtNotification(method, params);
+          return Promise.resolve({});
         },
       }),
       stream,
@@ -1128,6 +1143,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       // belonged to this turn are no longer reachable. Drop them so the cache
       // can't grow across a long-lived session.
       this.releasedAcpTerminalOutput.clear();
+      this.clearAcpToolCallItemIdMap();
     }
   }
 
@@ -1581,6 +1597,47 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       this.handleSessionUpdate(params as unknown as SessionNotification);
       return;
     }
+    if (
+      this.extensionNotificationHandler &&
+      !this.isReplayingHistory &&
+      Date.now() >= (this.replayHistoryUntil || 0)
+    ) {
+      const events = this.extensionNotificationHandler(method, params, {
+        threadId: this.threadId,
+        resolveToolCallItemId: (toolCallId) => this.acpToolCallIdToItemId.get(toolCallId),
+      });
+      if (events.length > 0) {
+        this.emitRuntimeEvents(events);
+      }
+    }
+  }
+
+  private rememberAcpToolCallItemId(
+    notification: SessionNotification,
+    events: RuntimeEvent[],
+  ): void {
+    const update = notification.update;
+    if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
+      return;
+    }
+    const toolCallId = (update as { toolCallId?: unknown }).toolCallId;
+    if (typeof toolCallId !== "string" || toolCallId.length === 0) return;
+
+    const fromMapper = this.mapperState?.toolCallItems.get(toolCallId)?.itemId;
+    if (fromMapper) {
+      this.acpToolCallIdToItemId.set(toolCallId, fromMapper);
+      return;
+    }
+
+    for (const event of events) {
+      if (event.type !== "item.started" || event.itemType !== "tool_call") continue;
+      this.acpToolCallIdToItemId.set(toolCallId, event.itemId);
+      return;
+    }
+  }
+
+  private clearAcpToolCallItemIdMap(): void {
+    this.acpToolCallIdToItemId.clear();
   }
 
   /**
@@ -1612,6 +1669,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     // avoid duplicating every message in the chat pane.
     if (!this.isReplayingHistory && Date.now() >= (this.replayHistoryUntil || 0)) {
       const events = mapAcpSessionUpdate(params, this.ensureMapperState());
+      this.rememberAcpToolCallItemId(params, events);
       if (events.length > 0) {
         this.recordAgentSurfacedError(events);
         this.emitRuntimeEvents(events);
@@ -1853,6 +1911,9 @@ export function createAcpStructuredSession(
       : {}),
     ...(input.acpSessionUpdateTransform
       ? { sessionUpdateTransform: input.acpSessionUpdateTransform }
+      : {}),
+    ...(input.acpExtensionNotificationHandler
+      ? { extensionNotificationHandler: input.acpExtensionNotificationHandler }
       : {}),
     ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
     ...(input.subagentMcp !== undefined ? { subagentMcp: input.subagentMcp } : {}),

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -142,11 +142,25 @@ export interface CreateStructuredSessionInput {
    * the shared mapper must remain provider-agnostic.
    */
   acpSessionUpdateTransform?: AcpSessionUpdateTransform;
+  /**
+   * Handle vendor ACP extension notifications (e.g. Cursor's `cursor/task`)
+   * that carry metadata absent from the standard `session/update` stream.
+   */
+  acpExtensionNotificationHandler?: AcpExtensionNotificationHandler;
 }
 
 export type AcpSessionUpdateTransform = (
   notification: import("@agentclientprotocol/sdk").SessionNotification,
 ) => import("@agentclientprotocol/sdk").SessionNotification;
+
+export type AcpExtensionNotificationHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  ctx: {
+    threadId: string;
+    resolveToolCallItemId: (toolCallId: string) => string | undefined;
+  },
+) => import("@/shared/contracts").RuntimeEvent[];
 
 export interface AgentArgvSpec {
   binary: string;

--- a/src/supervisor/agents/cursor/acpExtension.ts
+++ b/src/supervisor/agents/cursor/acpExtension.ts
@@ -1,0 +1,19 @@
+import type { AcpExtensionNotificationHandler } from "../base/types";
+import {
+  isCursorTaskExtension,
+  mapCursorTaskExtension,
+  parseCursorTaskExtensionParams,
+} from "./acpTaskExtension";
+
+export const handleCursorAcpExtensionNotification: AcpExtensionNotificationHandler = (
+  method,
+  params,
+  ctx,
+) => {
+  if (!isCursorTaskExtension(method)) return [];
+  const parsed = parseCursorTaskExtensionParams(params);
+  if (!parsed) return [];
+  const parentItemId = ctx.resolveToolCallItemId(parsed.toolCallId);
+  if (!parentItemId) return [];
+  return mapCursorTaskExtension(ctx.threadId, parentItemId, parsed);
+};

--- a/src/supervisor/agents/cursor/acpSubagent.integration.test.ts
+++ b/src/supervisor/agents/cursor/acpSubagent.integration.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { createAcpMapperState, mapAcpSessionUpdate } from "../acp/canonicalMapping";
+import { handleCursorAcpExtensionNotification } from "./acpExtension";
+
+describe("Cursor ACP subagent end-to-end mapping", () => {
+  it("maps tool_call + cursor/task extension into subagent row + child thread", () => {
+    const threadId = "thread-probe";
+    const state = createAcpMapperState(threadId);
+    const toolCallId = "toolu_01Gz2XKWCQXLbKsWqND9L7FQ";
+
+    const started = mapAcpSessionUpdate(
+      {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId,
+          title: "Task: Subagent task",
+          kind: "other",
+          status: "in_progress",
+          rawInput: { _toolName: "task" },
+        },
+      },
+      state,
+    );
+    const parentItemId = (started[0] as { itemId: string }).itemId;
+    expect((started[0] as { payload: Record<string, unknown> }).payload.isSubAgent).toBe(true);
+
+    mapAcpSessionUpdate(
+      {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId,
+          status: "completed",
+          rawOutput: { durationMs: 28426, isBackground: false },
+        },
+      },
+      state,
+    );
+
+    const extensionEvents = handleCursorAcpExtensionNotification(
+      "cursor/task",
+      {
+        toolCallId,
+        description: "Count words in hello.txt",
+        prompt: "Read hello.txt and count the words in it.",
+        model: "composer-2.5-fast",
+        durationMs: 28426,
+        subagentType: { custom: { explore: {} } },
+      },
+      {
+        threadId,
+        resolveToolCallItemId: () => parentItemId,
+      },
+    );
+
+    expect(extensionEvents[0]).toMatchObject({
+      type: "item.updated",
+      itemId: parentItemId,
+      payload: {
+        isSubAgent: true,
+        name: "Task: Count words in hello.txt",
+        args: {
+          _toolName: "task",
+          description: "Count words in hello.txt",
+          prompt: "Read hello.txt and count the words in it.",
+          subagent_type: "explore",
+        },
+        progress: {
+          model: "composer-2.5-fast",
+          durationMs: 28426,
+        },
+      },
+    });
+
+    const childStarted = extensionEvents.find(
+      (event) => event.type === "item.started" && event.itemType === "assistant_message",
+    );
+    expect(childStarted).toMatchObject({ parentItemId });
+  });
+});

--- a/src/supervisor/agents/cursor/acpTaskExtension.test.ts
+++ b/src/supervisor/agents/cursor/acpTaskExtension.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { createAcpMapperState, mapAcpSessionUpdate } from "../acp/canonicalMapping";
+import {
+  isCursorTaskExtension,
+  mapCursorTaskExtension,
+  parseCursorTaskExtensionParams,
+} from "./acpTaskExtension";
+
+describe("parseCursorTaskExtensionParams", () => {
+  it("parses cursor/task wire payload", () => {
+    expect(
+      parseCursorTaskExtensionParams({
+        toolCallId: "toolu_abc",
+        description: "Count words in hello.txt",
+        prompt: "Read hello.txt and count words.",
+        model: "composer-2.5-fast",
+        durationMs: 28426,
+        subagentType: { custom: { explore: {} } },
+      }),
+    ).toMatchObject({
+      toolCallId: "toolu_abc",
+      description: "Count words in hello.txt",
+      prompt: "Read hello.txt and count words.",
+      model: "composer-2.5-fast",
+      durationMs: 28426,
+    });
+  });
+});
+
+describe("mapCursorTaskExtension", () => {
+  it("marks the parent tool as a subagent and opens a child prompt thread", () => {
+    const events = mapCursorTaskExtension("thread-1", "tool-parent", {
+      toolCallId: "toolu_abc",
+      description: "Count words in hello.txt",
+      prompt: "Read hello.txt and count words.",
+      model: "composer-2.5-fast",
+      durationMs: 1200,
+      subagentType: { explore: {} },
+    });
+
+    expect(events[0]).toMatchObject({
+      type: "item.updated",
+      threadId: "thread-1",
+      itemId: "tool-parent",
+      payload: {
+        isSubAgent: true,
+        name: "Task: Count words in hello.txt",
+        args: {
+          _toolName: "task",
+          description: "Count words in hello.txt",
+          prompt: "Read hello.txt and count words.",
+          subagent_type: "explore",
+        },
+        progress: {
+          model: "composer-2.5-fast",
+          durationMs: 1200,
+          description: "Count words in hello.txt",
+        },
+      },
+    });
+
+    const childStarted = events.find(
+      (event) => event.type === "item.started" && event.itemType === "assistant_message",
+    );
+    expect(childStarted).toMatchObject({
+      parentItemId: "tool-parent",
+    });
+    expect(
+      events.some(
+        (event) =>
+          event.type === "content.delta" &&
+          event.stream === "assistant_text" &&
+          event.delta === "Read hello.txt and count words.",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isCursorTaskExtension", () => {
+  it("matches cursor/task only", () => {
+    expect(isCursorTaskExtension("cursor/task")).toBe(true);
+    expect(isCursorTaskExtension("cursor/update_todos")).toBe(false);
+  });
+});
+
+describe("Cursor task tool_call ACP mapping", () => {
+  it("treats Cursor `_toolName: task` tool calls as subagents", () => {
+    const state = createAcpMapperState("thread-cursor");
+    const events = mapAcpSessionUpdate(
+      {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "toolu_task",
+          title: "Task: Subagent task",
+          kind: "other",
+          status: "in_progress",
+          rawInput: { _toolName: "task" },
+        },
+      },
+      state,
+    );
+
+    expect(events[0]).toMatchObject({
+      type: "item.started",
+      itemType: "tool_call",
+      payload: { isSubAgent: true },
+    });
+  });
+});

--- a/src/supervisor/agents/cursor/acpTaskExtension.ts
+++ b/src/supervisor/agents/cursor/acpTaskExtension.ts
@@ -1,0 +1,155 @@
+/**
+ * Cursor ACP `cursor/task` extension → canonical RuntimeEvent mapper.
+ *
+ * Cursor's ACP server emits near-empty `tool_call` payloads for subagent tasks
+ * (`rawInput: { _toolName: "task" }`) and delivers the real metadata only after
+ * the task completes via a vendor `cursor/task` extension notification. Without
+ * this bridge the chat renders a generic tool accordion instead of a sub-agent
+ * row with an openable overlay thread.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { RuntimeEvent } from "@/shared/contracts";
+
+export interface CursorTaskExtensionParams {
+  toolCallId: string;
+  description?: unknown;
+  prompt?: unknown;
+  model?: unknown;
+  agentId?: unknown;
+  durationMs?: unknown;
+  subagentType?: unknown;
+}
+
+export function isCursorTaskExtension(method: string): boolean {
+  return method === "cursor/task";
+}
+
+export function parseCursorTaskExtensionParams(
+  params: Record<string, unknown>,
+): CursorTaskExtensionParams | undefined {
+  const toolCallId = readString(params.toolCallId);
+  if (!toolCallId) return undefined;
+  return {
+    toolCallId,
+    description: params.description,
+    prompt: params.prompt,
+    model: params.model,
+    agentId: params.agentId,
+    durationMs: params.durationMs,
+    subagentType: params.subagentType,
+  };
+}
+
+export function mapCursorTaskExtension(
+  threadId: string,
+  parentItemId: string,
+  params: CursorTaskExtensionParams,
+): RuntimeEvent[] {
+  const description = readString(params.description);
+  const prompt = readString(params.prompt);
+  const model = readString(params.model);
+  const subagentType = readCursorSubagentType(params.subagentType);
+  const durationMs = readNonNegativeInteger(params.durationMs);
+
+  const args: Record<string, unknown> = {
+    _toolName: "task",
+    ...(description ? { description, name: description } : {}),
+    ...(prompt ? { prompt } : {}),
+    ...(subagentType ? { subagent_type: subagentType } : {}),
+  };
+
+  const progress: Record<string, unknown> = {};
+  if (model) progress.model = model;
+  if (durationMs !== undefined) progress.durationMs = durationMs;
+  if (description) progress.description = description;
+
+  const title = description ? `Task: ${description}` : "Task: Subagent task";
+  const events: RuntimeEvent[] = [
+    {
+      type: "item.updated",
+      threadId,
+      itemId: parentItemId,
+      payload: {
+        isSubAgent: true,
+        name: title,
+        title,
+        args,
+        ...(Object.keys(progress).length > 0 ? { progress } : {}),
+      },
+    },
+  ];
+
+  if (prompt) {
+    const childId = `cursor-subagent-${randomUUID()}`;
+    events.push(
+      {
+        type: "item.started",
+        threadId,
+        itemId: childId,
+        itemType: "assistant_message",
+        parentItemId,
+      },
+      {
+        type: "content.delta",
+        threadId,
+        itemId: childId,
+        stream: "assistant_text",
+        delta: prompt,
+      },
+      { type: "item.completed", threadId, itemId: childId },
+    );
+    events.push({
+      type: "item.updated",
+      threadId,
+      itemId: parentItemId,
+      payload: {
+        isSubAgent: true,
+        status: "running",
+        progress: {
+          ...(Object.keys(progress).length > 0 ? progress : {}),
+          stepCount: 1,
+        },
+      },
+    });
+  }
+
+  return events;
+}
+
+function readCursorSubagentType(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 && trimmed !== "unspecified" ? trimmed : undefined;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of [
+    "explore",
+    "computer_use",
+    "browser_use",
+    "shell",
+    "video_review",
+    "vm_setup_helper",
+  ]) {
+    if (key in record) return key;
+  }
+  const custom = record.custom;
+  if (custom && typeof custom === "object" && !Array.isArray(custom)) {
+    for (const key of Object.keys(custom as Record<string, unknown>)) {
+      if (key !== "unspecified") return key;
+    }
+  }
+  return undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.trunc(value));
+}

--- a/src/supervisor/agents/cursor/acpTransform.task.test.ts
+++ b/src/supervisor/agents/cursor/acpTransform.task.test.ts
@@ -1,0 +1,44 @@
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { transformCursorAcpSessionUpdate } from "./acpTransform";
+
+function toolCall(overrides: Record<string, unknown>): SessionNotification {
+  return {
+    sessionId: "ses-1",
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: "tc-task",
+      status: "pending",
+      ...overrides,
+    },
+  } as unknown as SessionNotification;
+}
+
+describe("transformCursorAcpSessionUpdate — task tools", () => {
+  it("enriches Cursor task tool_call rawInput from the title description", () => {
+    const input = toolCall({
+      kind: "other",
+      title: "Task: Count words in hello.txt",
+      rawInput: { _toolName: "task" },
+    });
+    const rawInput = (transformCursorAcpSessionUpdate(input).update as { rawInput?: unknown })
+      .rawInput as Record<string, unknown>;
+    expect(rawInput).toMatchObject({
+      _toolName: "task",
+      description: "Count words in hello.txt",
+      name: "Count words in hello.txt",
+      prompt: "Count words in hello.txt",
+    });
+  });
+
+  it("leaves generic Subagent task titles untouched until cursor/task arrives", () => {
+    const input = toolCall({
+      kind: "other",
+      title: "Task: Subagent task",
+      rawInput: { _toolName: "task" },
+    });
+    expect(transformCursorAcpSessionUpdate(input).update).toMatchObject({
+      rawInput: { _toolName: "task" },
+    });
+  });
+});

--- a/src/supervisor/agents/cursor/acpTransform.ts
+++ b/src/supervisor/agents/cursor/acpTransform.ts
@@ -34,15 +34,47 @@ export function transformCursorAcpSessionUpdate(
   if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
     return notification;
   }
-  const rawOutput = (update as { rawOutput?: unknown }).rawOutput;
-  if (!isPlainRecord(rawOutput)) return notification;
-  const kind = readString((update as { kind?: unknown }).kind)?.toLowerCase();
+  const enriched = enrichCursorTaskToolCall(update);
+  const rawOutput = (enriched as { rawOutput?: unknown }).rawOutput;
+  if (!isPlainRecord(rawOutput)) {
+    return enriched === update ? notification : { ...notification, update: enriched };
+  }
+  const kind = readString((enriched as { kind?: unknown }).kind)?.toLowerCase();
   const replacement = formatRawOutput(kind, rawOutput);
-  if (replacement === undefined) return notification;
+  if (replacement === undefined) {
+    return enriched === update ? notification : { ...notification, update: enriched };
+  }
   return {
     ...notification,
-    update: { ...update, rawOutput: replacement },
+    update: { ...enriched, rawOutput: replacement } as SessionNotification["update"],
   };
+}
+
+function enrichCursorTaskToolCall(
+  update: SessionNotification["update"],
+): SessionNotification["update"] {
+  const toolUpdate = update as {
+    rawInput?: unknown;
+    title?: unknown;
+  };
+  const rawInput = toolUpdate.rawInput;
+  if (!isPlainRecord(rawInput) || rawInput._toolName !== "task") return update;
+  const title = readString(toolUpdate.title);
+  const fromTitle = title?.replace(/^Task:\s*/i, "").trim();
+  const description =
+    readString(rawInput.description) ??
+    (fromTitle && fromTitle.toLowerCase() !== "subagent task" ? fromTitle : undefined);
+  if (!description && readString(rawInput.prompt)) return update;
+  if (!description) return update;
+  return {
+    ...update,
+    rawInput: {
+      ...rawInput,
+      description,
+      name: readString(rawInput.name) ?? description,
+      ...(readString(rawInput.prompt) ? {} : { prompt: description }),
+    },
+  } as SessionNotification["update"];
 }
 
 function formatRawOutput(

--- a/src/supervisor/agents/cursor/index.ts
+++ b/src/supervisor/agents/cursor/index.ts
@@ -14,6 +14,7 @@ import {
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { resolveInstallNodePath, warnIfPluginManifestMissing } from "../plugin/installerBase";
 import { transformCursorAcpSessionUpdate } from "./acpTransform";
+import { handleCursorAcpExtensionNotification } from "./acpExtension";
 import { buildCursorArgs } from "./argv";
 import {
   cursorDefaultCapabilities,
@@ -130,6 +131,7 @@ export function createCursorAdapter(): AgentAdapter {
         ...input,
         loadSessionErrorRewriter: rewriteCursorLoadSessionError,
         acpSessionUpdateTransform: transformCursorAcpSessionUpdate,
+        acpExtensionNotificationHandler: handleCursorAcpExtensionNotification,
       });
     },
     async buildAcpAuthCommand(ctx?: AgentEnvContext) {

--- a/src/supervisor/agents/gemini/plugin/install.test.ts
+++ b/src/supervisor/agents/gemini/plugin/install.test.ts
@@ -156,7 +156,7 @@ describe("syncGeminiSubagentMcpSettings", () => {
       subagents: {
         httpUrl: subagentCfg.url,
         headers: subagentCfg.headers,
-        timeout: 30_000,
+        timeout: 300_000,
       },
     });
 
@@ -180,7 +180,7 @@ describe("syncGeminiSubagentMcpSettings", () => {
       subagents: {
         httpUrl: subagentCfg.url,
         headers: subagentCfg.headers,
-        timeout: 30_000,
+        timeout: 300_000,
       },
       browser: {
         httpUrl: browserCfg.url,
@@ -195,7 +195,7 @@ describe("syncGeminiSubagentMcpSettings", () => {
       subagents: {
         httpUrl: subagentCfg.url,
         headers: subagentCfg.headers,
-        timeout: 30_000,
+        timeout: 300_000,
       },
     });
   });


### PR DESCRIPTION
- Add Feature support for Cursor `cursor/task` ACP extensions.
- Map Cursor task metadata into subagent rows and child prompt threads.
- Preserve task identity by recognizing `_toolName: task` ACP tool calls.
- Cover ACP extension plumbing, Cursor transforms, and subagent mapping with tests.