### PR TITLE
Add orchestrator subagent threading and Cursor task support

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import { app, BrowserWindow, Menu, nativeTheme, session as electronSession } fro
 import { resolveThemeMode } from "@/shared/themeMode";
 import { closeDatabase, dbGetProjects, dbGetThreads, initDatabase } from "./db";
 import { cleanupOrphanedAttachments, prepareLightcodeDataRoot } from "./lightcodeData";
+import { handleOrchestratorThreadCreated } from "./orchestratorThreadBridge";
 import { createLocalIpcHandlers, getRemoteAccessPairingInfo } from "./ipc/localHandlers";
 import { registerIpcHandlers } from "./ipc/registerHandlers";
 import { createSleepInhibitor } from "./sleepInhibitor";
@@ -384,6 +385,19 @@ if (!hasSingleInstanceLock) {
         captureMainException(error, tags);
       },
       onEvent: (event) => {
+        // Orchestrator create_thread requests are consumed here (DB upsert,
+        // renderer mirror, startThread call-back) and never fanned out.
+        if (event.type === "orchestrator-thread-created") {
+          void handleOrchestratorThreadCreated(event, {
+            startThread: (payload) => supervisorClient.call("startThread", payload),
+            sendThreadCommand: (command) => {
+              if (!mainWindow) return false;
+              mainWindow.webContents.send(IPC_EVENT_CHANNELS.remoteThreadCommand, command);
+              return true;
+            },
+          });
+          return;
+        }
         handleSupervisorEventForSleep(event);
         remoteAccessServer?.publishSupervisorEvent(event);
         pushCoordinator?.handleSupervisorEvent(event);

--- a/src/main/orchestratorThreadBridge.ts
+++ b/src/main/orchestratorThreadBridge.ts
@@ -1,0 +1,79 @@
+import type { RemoteThreadCommand, StartThreadPayload, Thread } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc";
+import { dbDeleteThread, dbGetThread, dbUpsertThread } from "./db";
+
+type OrchestratorThreadCreatedEvent = Extract<
+  SupervisorEvent,
+  { type: "orchestrator-thread-created" }
+>;
+
+export interface OrchestratorThreadBridgeDeps {
+  /** Launch the child session in the supervisor (main → supervisor request). */
+  startThread(payload: StartThreadPayload): Promise<unknown>;
+  /** Mirror a thread command to the renderer store; false when no window is up. */
+  sendThreadCommand(command: RemoteThreadCommand): boolean;
+}
+
+/**
+ * Main-process half of the subagents MCP orchestrator lane's `create_thread`.
+ * Mirrors the proven remote (mobile) start ordering exactly:
+ *
+ * 1. Resolve `projectId` from the PARENT thread's DB row (the supervisor
+ *    doesn't know project ids) and complete the child `Thread` record.
+ * 2. `dbUpsertThread` — persist the row first, so the thread survives even if
+ *    a later step fails mid-flight.
+ * 3. Mirror to the renderer (`remoteThreadCommand` "start" with
+ *    `launchRuntime: false` — the launch happens below, not in the renderer —
+ *    and `focus: false` so orchestrator fan-out doesn't steal the user's view).
+ * 4. `startThread` back into the supervisor. On failure the fresh row is
+ *    deleted and the renderer told to drop it; the supervisor-side
+ *    `create_thread` call then times out and surfaces a tool error.
+ */
+export async function handleOrchestratorThreadCreated(
+  event: OrchestratorThreadCreatedEvent,
+  deps: OrchestratorThreadBridgeDeps,
+): Promise<void> {
+  const parent = dbGetThread(event.parentThreadId);
+  if (!parent) {
+    console.warn(
+      `[main] orchestrator create_thread: parent thread ${event.parentThreadId} not found in DB; dropping child ${event.thread.id}`,
+    );
+    return;
+  }
+
+  const thread: Thread = { ...event.thread, projectId: parent.projectId };
+  const existing = dbGetThread(thread.id) != null;
+  // New rows sort to the top via a descending timestamp (same convention as
+  // the remote-access server's sortOrderForThread).
+  dbUpsertThread(thread, -Date.now());
+
+  deps.sendThreadCommand({
+    kind: "start",
+    threadId: thread.id,
+    projectId: thread.projectId,
+    agentKind: thread.agentKind,
+    config: thread.config,
+    prompt: event.start.prompt,
+    // Forward the title only when the orchestrator gave a custom one (e.g. a
+    // ticket key) — a forwarded title is authoritative and disables AI title
+    // generation in the renderer; a prompt-derived title still gets one.
+    ...(event.hasCustomTitle ? { title: thread.title } : {}),
+    presentationMode: "gui",
+    ...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {}),
+    ...(thread.worktreeBranch ? { worktreeBranch: thread.worktreeBranch } : {}),
+    ...(event.isNewWorktree ? { isNewWorktree: true } : {}),
+    launchRuntime: false,
+    focus: false,
+    parentThreadId: event.parentThreadId,
+  });
+
+  try {
+    await deps.startThread(event.start);
+  } catch (error) {
+    console.warn(`[main] orchestrator child thread ${thread.id} failed to launch:`, error);
+    if (!existing) {
+      dbDeleteThread(thread.id);
+      deps.sendThreadCommand({ kind: "delete", threadId: thread.id });
+    }
+  }
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -272,9 +272,12 @@ const mainWindowCleanups: Array<() => void> = isBrowserExtractWindow
             ...(command.agentInstanceId ? { agentInstanceId: command.agentInstanceId } : {}),
             config: command.config,
             prompt: titlePrompt,
+            ...(command.title ? { title: command.title } : {}),
             ...(command.presentationMode ? { presentationMode: command.presentationMode } : {}),
             ...(command.worktreePath ? { worktreePath: command.worktreePath } : {}),
             ...(command.worktreeBranch ? { worktreeBranch: command.worktreeBranch } : {}),
+            ...(command.focus === false ? { focus: false } : {}),
+            ...(command.parentThreadId ? { parentThreadId: command.parentThreadId } : {}),
           });
           if (command.launchRuntime !== false) {
             store.queueThreadLaunch(thread.id, command.prompt, command.segments);
@@ -285,7 +288,11 @@ const mainWindowCleanups: Array<() => void> = isBrowserExtractWindow
             agentStatuses,
             wslAgentStatuses,
           );
-          generateTitleAsync(thread.id, project.location, projectAgentStatuses, titlePrompt);
+          // An explicit title (e.g. an orchestrator-provided ticket key) is
+          // authoritative — don't let AI title generation overwrite it.
+          if (!command.title) {
+            generateTitleAsync(thread.id, project.location, projectAgentStatuses, titlePrompt);
+          }
           if (command.worktreePath) {
             void primeWorktreeGitState(project, command.worktreePath);
             if (command.isNewWorktree) {

--- a/src/renderer/components/common/BranchSelector/BranchSelector.tsx
+++ b/src/renderer/components/common/BranchSelector/BranchSelector.tsx
@@ -19,7 +19,7 @@ import { ResponsiveMenuSurface } from "../ResponsiveMenuSurface";
 import { useBranchList } from "./parts/useBranchList";
 import { BranchListBox, type OpenPrReviewArgs } from "./parts/BranchListBox";
 import { BranchFooterActions } from "./parts/BranchFooterActions";
-import { generateWorktreeBranch } from "./parts/generateWorktreeBranch";
+import { generateWorktreeBranch } from "@/shared/worktreeBranch";
 import type { BranchSelection } from "./parts/types";
 
 export type { BranchSelection };
@@ -462,4 +462,4 @@ export function BranchSelector(props: BranchSelectorProps) {
   );
 }
 
-export { generateWorktreeBranch } from "./parts/generateWorktreeBranch";
+export { generateWorktreeBranch } from "@/shared/worktreeBranch";

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -51,12 +51,18 @@ export interface ThreadSlice {
     agentInstanceId?: AgentInstanceId;
     config: ThreadConfig;
     prompt: string;
+    /** Explicit title; defaults to a prompt-derived one when omitted. */
+    title?: string;
     worktreePath?: string;
     worktreeBranch?: string;
     groupId?: string;
     groupName?: string;
     replacePaneId?: string;
     presentationMode?: ThreadPresentationMode;
+    /** `false` adds the row without switching the active view to it (orchestrator-created children). */
+    focus?: boolean;
+    /** Orchestrator thread that created this one (metadata only). */
+    parentThreadId?: string;
   }) => Thread;
   deleteThread: (threadId: string) => void;
   renameThread: (threadId: string, title: string) => void;
@@ -233,18 +239,21 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
     agentInstanceId,
     config,
     prompt,
+    title,
     worktreePath,
     worktreeBranch,
     groupId,
     groupName,
     replacePaneId: replacePaneIdParam,
     presentationMode,
+    focus,
+    parentThreadId,
   }) => {
     const now = new Date().toISOString();
     const thread: Thread = {
       id: threadId ?? crypto.randomUUID(),
       projectId,
-      title: makeThreadTitle(prompt),
+      title: title ?? makeThreadTitle(prompt),
       agentKind,
       ...(agentInstanceId ? { agentInstanceId } : {}),
       config,
@@ -260,6 +269,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       ...(worktreeBranch ? { worktreeBranch } : {}),
       ...(groupId ? { groupId } : {}),
       ...(groupName ? { groupName } : {}),
+      ...(parentThreadId ? { parentThreadId } : {}),
       createdAt: now,
       updatedAt: now,
       activeTurnStartedAt: now,
@@ -267,7 +277,11 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
 
     set((state) => {
       let nextView: AppView;
-      if (replacePaneIdParam && state.view.kind === "thread") {
+      if (focus === false) {
+        // Add the row without stealing the user's current view (a fan-out of
+        // orchestrator-created threads must not flip the active pane).
+        nextView = state.view;
+      } else if (replacePaneIdParam && state.view.kind === "thread") {
         const idx = state.view.panes.indexOf(replacePaneIdParam);
         if (idx !== -1) {
           nextView = replacePaneInView(state.view, replacePaneIdParam, thread.id);

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -51,6 +51,12 @@ export const threadSchema = z.object({
   /** Latest error reason from the runtime, present when `status === "error"`. */
   errorMessage: z.string().optional(),
   slashCommands: z.array(agentSlashCommandSchema).optional(),
+  /**
+   * Id of the orchestrator thread that created this thread via the subagents
+   * MCP `create_thread` tool. Pure metadata for now (no renderer UI keys on
+   * it); absent for user-created threads.
+   */
+  parentThreadId: z.string().min(1).optional(),
 });
 export type Thread = z.infer<typeof threadSchema>;
 
@@ -174,6 +180,12 @@ export const remoteThreadCommandSchema = z.discriminatedUnion("kind", [
     agentInstanceId: agentInstanceIdSchema.optional(),
     config: threadConfigSchema,
     prompt: z.string(),
+    /**
+     * Explicit thread title (e.g. an orchestrator-provided ticket key). When
+     * present the renderer uses it verbatim and skips AI title generation;
+     * otherwise the title is derived from the prompt.
+     */
+    title: z.string().min(1).optional(),
     segments: z.array(promptSegmentSchema).optional(),
     presentationMode: threadPresentationModeSchema.optional(),
     worktreePath: z.string().min(1).optional(),
@@ -186,6 +198,18 @@ export const remoteThreadCommandSchema = z.discriminatedUnion("kind", [
      * row without launching the same session again.
      */
     launchRuntime: z.boolean().optional(),
+    /**
+     * Desktop-renderer hint. `false` mirrors the thread row without switching
+     * the active view to it — used by orchestrator-created child threads so a
+     * fan-out of `create_thread` calls doesn't steal the user's focus.
+     * Omitted/`true` keeps the existing focus-switch behavior.
+     */
+    focus: z.boolean().optional(),
+    /**
+     * Id of the orchestrator thread that created this thread (see
+     * {@link threadSchema}'s `parentThreadId`).
+     */
+    parentThreadId: z.string().min(1).optional(),
   }),
   z.object({ kind: z.literal("rename"), threadId: z.string().min(1), title: z.string().min(1) }),
   z.object({ kind: z.literal("set-done"), threadId: z.string().min(1), done: z.boolean() }),

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -5,6 +5,8 @@ import type {
   AgentStatus,
   PendingSteerState,
   RuntimeEvent,
+  StartThreadPayload,
+  Thread,
   ThreadAttention,
   ThreadConfig,
   ThreadStatus,
@@ -57,6 +59,32 @@ export type SupervisorEvent =
       pending: PendingSteerState | null;
     }
   | { type: "thread-exited"; threadId: string; exitCode: number | null }
+  /**
+   * Emitted by the supervisor's orchestrator lane (subagents MCP
+   * `create_thread`) when an agent thread asks for a first-class child thread.
+   * The main process owns the rest of the flow, mirroring the remote-start
+   * path: it resolves `projectId` from the parent's DB row, upserts the child
+   * row, mirrors it to the renderer (`remoteThreadCommand` "start" with
+   * `launchRuntime: false`), then calls the supervisor's `startThread` with
+   * `start`. This event is consumed in main and never forwarded to the
+   * renderer or remote clients.
+   */
+  | {
+      type: "orchestrator-thread-created";
+      parentThreadId: string;
+      /** Child thread row, complete except `projectId` (main fills it from the parent's row). */
+      thread: Omit<Thread, "projectId">;
+      /** Ready-to-send supervisor `startThread` payload for the child. */
+      start: StartThreadPayload;
+      /** True when `create_thread` just created the child's git worktree. */
+      isNewWorktree?: boolean;
+      /**
+       * True when the caller supplied an explicit title (vs. a prompt-derived
+       * one). Main forwards the title to the renderer only in this case, so a
+       * custom title stays authoritative and suppresses AI title generation.
+       */
+      hasCustomTitle?: boolean;
+    }
   | {
       type: "thread-osc-notification";
       threadId: string;

--- a/src/shared/worktreeBranch.ts
+++ b/src/shared/worktreeBranch.ts
@@ -1,3 +1,11 @@
+/**
+ * Random worktree branch-name generator (`lightcode/<adjective>-<noun>-<8hex>`).
+ * Lives in `src/shared` because both the renderer (BranchSelector "new branch"
+ * action) and the supervisor (orchestrator `create_thread` MCP tool) mint
+ * branches with the same scheme. Uses the Web Crypto global, available in both
+ * the renderer and Node >= 20 without imports.
+ */
+
 const ADJECTIVES = [
   "awesome",
   "brave",

--- a/src/supervisor/runtime.ts
+++ b/src/supervisor/runtime.ts
@@ -222,6 +222,7 @@ import { UsageService } from "./runtime/usageService";
 import { type SessionRuntime, type ShellSessionRuntime } from "./runtime/sessionTypes";
 import { ThreadSessionManager, writeSubmittedPrompt } from "./runtime/threadSessionManager";
 import { CliHookPluginCoordinator } from "./runtime/cliHookPluginCoordinator";
+import { OrchestratorThreadManager } from "./subagentMcp/OrchestratorThreadManager";
 import { SubagentMcpIngress } from "./subagentMcp/SubagentMcpIngress";
 import { SubagentRunManager } from "./subagentMcp/SubagentRunManager";
 import { buildSpawnableAgents } from "./subagentMcp/toolRegistry";
@@ -257,6 +258,7 @@ export class SupervisorRuntime {
   private readonly cliHookPluginCoordinator: CliHookPluginCoordinator;
   private readonly subagentMcpIngress: SubagentMcpIngress;
   private readonly subagentRunManager: SubagentRunManager;
+  private readonly orchestratorThreadManager: OrchestratorThreadManager;
   private wslHookBridge: WslBridgeServer | undefined;
   private extractionAbortControllers = new Map<string, AbortController>();
 
@@ -431,8 +433,64 @@ export class SupervisorRuntime {
           this.threadSessionManager.appendSubagentRuntimeEvent(parentThreadId, event),
       },
     });
+    // Orchestrator lane of the subagents MCP: creates first-class child
+    // threads. Creation is main-orchestrated — the manager emits an
+    // `orchestrator-thread-created` supervisor event; main upserts the DB row,
+    // mirrors it to the renderer, and calls startThread back into this
+    // process. Host closures resolve the thread session manager lazily, same
+    // as the run manager above.
+    this.orchestratorThreadManager = new OrchestratorThreadManager({
+      adapters: this.adapters,
+      emit: (event) => this.emit(event),
+      host: {
+        getParentContext: (threadId) =>
+          this.threadSessionManager.getSubagentParentContext(threadId),
+        getThreadState: (threadId) =>
+          this.threadSessionManager.getOrchestratorThreadState(threadId),
+        readThreadHistory: (threadId) => this.threadSessionManager.readThreadHistory(threadId),
+        sendThreadInput: (payload) => this.threadSessionManager.sendThreadInput(payload),
+        interruptThread: (threadId) => this.threadSessionManager.interruptThread({ threadId }),
+        // Tear down the child's runtime session to free a cap slot. Reuses the
+        // same closeThread that removes the session from the TSM map (which is
+        // what makes getOrchestratorThreadState — and thus the live-child count
+        // — drop the child). The persisted thread row + worktree remain.
+        closeThread: (threadId) => this.threadSessionManager.closeThread({ threadId }),
+      },
+      // Same worktree pipeline the renderer-driven `gitAddWorktree` procedure
+      // uses, with placement resolved from global settings (per-project
+      // overrides live in the renderer DB and aren't visible here).
+      createWorktree: async ({ location, branch, baseBranch }) => {
+        const placement = resolveWorktreePlacement(
+          this.sharedSettingsCache.read(),
+          undefined,
+          location,
+        );
+        const result = await this.gitService.addWorktree(
+          location,
+          undefined,
+          branch,
+          true,
+          baseBranch,
+          undefined,
+          false,
+          false,
+          {
+            ...(placement.root ? { root: placement.root } : {}),
+            ...(placement.omitRepoDir ? { omitRepoDir: true } : {}),
+          },
+        );
+        return { path: result.path };
+      },
+      // Roll back a worktree created by a create_thread call that then failed to
+      // launch (force removal + branch delete), so a ticket-keyed retry isn't
+      // poisoned by a leftover branch.
+      removeWorktree: async ({ location, path }) => {
+        await this.gitService.removeWorktree(location, path, true, true);
+      },
+    });
     this.subagentMcpIngress = new SubagentMcpIngress({
       runManager: this.subagentRunManager,
+      orchestrator: this.orchestratorThreadManager,
       getSpawnableAgents: async () => {
         const { windows } = await this.agentStatusService.getAgentStatuses({ wslDistros: [] });
         return buildSpawnableAgents(this.adapters, windows);
@@ -450,7 +508,12 @@ export class SupervisorRuntime {
     });
 
     this.threadSessionManager = new ThreadSessionManager({
-      emit,
+      // Tap the outbound stream so the orchestrator lane can track child
+      // thread-state transitions (wait_for_thread) without polling.
+      emit: (event) => {
+        this.orchestratorThreadManager.observeSupervisorEvent(event);
+        emit(event);
+      },
       isDev: this.isDev,
       logsDir: this.logsDir,
       settingsPath: this.settingsPath,

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -51,6 +51,7 @@ import {
   type AgentLaunchOptions,
   type CommandSpec,
   type StructuredSessionHandle,
+  type ThreadHistory,
   createKnownSessionRef,
   defaultFormatPromptSegments,
   getRefreshedWindowsPath,
@@ -245,6 +246,39 @@ export class ThreadSessionManager {
   appendSubagentRuntimeEvent(parentThreadId: string, event: RuntimeEvent): void {
     if (!this.sessions.has(parentThreadId)) return;
     this.enqueueRuntimeEvent(parentThreadId, event);
+  }
+
+  /**
+   * Orchestrator host hook: a thread's live runtime state plus whether its
+   * session supports non-interrupting steer. `undefined` once the session is
+   * gone. Consumed by the subagents MCP orchestrator lane.
+   */
+  getOrchestratorThreadState(threadId: string):
+    | {
+        status: import("@/shared/contracts").ThreadStatus;
+        attention: import("@/shared/contracts").ThreadAttention;
+        config: ThreadConfig;
+        supportsSteer: boolean;
+      }
+    | undefined {
+    const session = this.sessions.get(threadId);
+    if (!session) return undefined;
+    return {
+      status: session.status,
+      attention: session.attention,
+      config: session.config,
+      supportsSteer: Boolean(session.structuredSession?.steerTurn),
+    };
+  }
+
+  /**
+   * Orchestrator host hook: read a thread's provider transcript when its
+   * session's adapter supports `readThread`; `undefined` otherwise.
+   */
+  async readThreadHistory(threadId: string): Promise<ThreadHistory | undefined> {
+    const session = this.sessions.get(threadId);
+    if (!session?.structuredSession?.readThread) return undefined;
+    return await session.structuredSession.readThread();
   }
 
   /**

--- a/src/supervisor/subagentMcp/OrchestratorThreadManager.test.ts
+++ b/src/supervisor/subagentMcp/OrchestratorThreadManager.test.ts
@@ -1,0 +1,658 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectLocation, SendThreadInputPayload, ThreadConfig } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc/events";
+import type { AgentAdapter, ThreadHistory } from "@/supervisor/agents/base";
+import {
+  MAX_CONCURRENT_CHILD_THREADS_PER_PARENT,
+  OrchestratorThreadError,
+  OrchestratorThreadManager,
+} from "./OrchestratorThreadManager";
+import type { OrchestratorThreadState } from "./OrchestratorThreadManager";
+
+const PARENT = "parent-thread";
+const PROJECT: ProjectLocation = { kind: "posix", path: "/tmp/project" };
+
+type CreatedEvent = Extract<SupervisorEvent, { type: "orchestrator-thread-created" }>;
+
+interface Harness {
+  manager: OrchestratorThreadManager;
+  emitted: SupervisorEvent[];
+  states: Map<string, OrchestratorThreadState>;
+  sent: SendThreadInputPayload[];
+  interrupted: string[];
+  closed: string[];
+  worktrees: Array<{ location: ProjectLocation; branch: string; baseBranch?: string }>;
+  removedWorktrees: Array<{ location: ProjectLocation; path: string }>;
+  setHistory(history: ThreadHistory | undefined): void;
+  lastCreated(): CreatedEvent;
+}
+
+function makeState(overrides: Partial<OrchestratorThreadState> = {}): OrchestratorThreadState {
+  return {
+    status: "launching",
+    attention: "none",
+    config: { model: "gpt-5.5" },
+    supportsSteer: false,
+    ...overrides,
+  };
+}
+
+function makeHarness(options?: {
+  /** Simulate main launching the child as soon as the create event is emitted. */
+  autoLaunch?: boolean;
+  parentConfig?: ThreadConfig;
+  launchTimeoutMs?: number;
+  /** Simulate the create handoff (emit → main) hard-failing after the worktree exists. */
+  failEmit?: boolean;
+  /** Simulate git failing to create the worktree (e.g. branch collision). */
+  createWorktreeError?: Error;
+}): Harness {
+  const emitted: SupervisorEvent[] = [];
+  const states = new Map<string, OrchestratorThreadState>();
+  const sent: SendThreadInputPayload[] = [];
+  const interrupted: string[] = [];
+  const closed: string[] = [];
+  const worktrees: Array<{ location: ProjectLocation; branch: string; baseBranch?: string }> = [];
+  const removedWorktrees: Array<{ location: ProjectLocation; path: string }> = [];
+  let history: ThreadHistory | undefined;
+
+  const structured = {
+    kind: "codex",
+    label: "Codex",
+    capabilities: { models: [{ id: "gpt-5.5", label: "GPT-5.5" }], efforts: ["low", "high"] },
+    createStructuredSession: async () => ({}),
+  } as unknown as AgentAdapter;
+  const oneShot = {
+    kind: "commandcode",
+    label: "Command Code",
+    capabilities: { models: [{ id: "cc-1", label: "CC One" }], efforts: [] },
+    buildSubagentOneShotCommand: () => ({ command: "x", args: [] }),
+  } as unknown as AgentAdapter;
+
+  const parentConfig: ThreadConfig = options?.parentConfig ?? {
+    model: "parent-model",
+    approvalPolicy: "never",
+    sandboxMode: "workspace-write",
+    subagentMcp: true,
+    browserMcp: true,
+  };
+
+  const manager = new OrchestratorThreadManager({
+    adapters: new Map([
+      ["codex" as never, structured],
+      ["commandcode" as never, oneShot],
+    ]),
+    ...(options?.launchTimeoutMs !== undefined ? { launchTimeoutMs: options.launchTimeoutMs } : {}),
+    emit: (event) => {
+      emitted.push(event);
+      if (event.type === "orchestrator-thread-created" && options?.failEmit) {
+        throw new Error("main bridge unavailable");
+      }
+      if (options?.autoLaunch !== false && event.type === "orchestrator-thread-created") {
+        // Simulate main's round-trip: the session appears in the TSM.
+        states.set(event.thread.id, makeState());
+      }
+    },
+    host: {
+      getParentContext: (threadId) =>
+        threadId === PARENT ? { projectLocation: PROJECT, config: parentConfig } : undefined,
+      getThreadState: (threadId) => states.get(threadId),
+      readThreadHistory: async () => history,
+      sendThreadInput: async (payload) => {
+        sent.push(payload);
+      },
+      interruptThread: async (threadId) => {
+        interrupted.push(threadId);
+      },
+      closeThread: async (threadId) => {
+        // Mirror the real host: closing removes the session from the TSM map,
+        // which is what frees the child's cap slot (getThreadState → undefined).
+        closed.push(threadId);
+        states.delete(threadId);
+      },
+    },
+    createWorktree: async ({ location, branch, baseBranch }) => {
+      if (options?.createWorktreeError) throw options.createWorktreeError;
+      worktrees.push({ location, branch, ...(baseBranch ? { baseBranch } : {}) });
+      return { path: `/tmp/worktrees/${branch}` };
+    },
+    removeWorktree: async ({ location, path }) => {
+      removedWorktrees.push({ location, path });
+    },
+  });
+
+  return {
+    manager,
+    emitted,
+    states,
+    sent,
+    interrupted,
+    closed,
+    worktrees,
+    removedWorktrees,
+    setHistory: (next) => {
+      history = next;
+    },
+    lastCreated: () => {
+      const event = [...emitted]
+        .reverse()
+        .find((entry): entry is CreatedEvent => entry.type === "orchestrator-thread-created");
+      if (!event) throw new Error("no orchestrator-thread-created event emitted");
+      return event;
+    },
+  };
+}
+
+async function createChild(
+  h: Harness,
+  request: Partial<Parameters<OrchestratorThreadManager["createThread"]>[1]> = {},
+): Promise<string> {
+  const { threadId } = await h.manager.createThread(PARENT, {
+    agent: "codex",
+    prompt: "do the ticket",
+    ...request,
+  });
+  return threadId;
+}
+
+describe("OrchestratorThreadManager.createThread", () => {
+  it("emits a complete thread row + start payload and resolves once the session appears", async () => {
+    const h = makeHarness();
+    const result = await h.manager.createThread(PARENT, { agent: "codex", prompt: "fix bug #1" });
+
+    const event = h.lastCreated();
+    expect(event.parentThreadId).toBe(PARENT);
+    expect(event.thread.id).toBe(result.threadId);
+    expect(event.thread.title).toBe("fix bug #1");
+    expect(event.thread.agentKind).toBe("codex");
+    expect(event.thread.status).toBe("launching");
+    expect(event.thread.presentationMode).toBe("gui");
+    expect(event.thread.parentThreadId).toBe(PARENT);
+    expect(event.start.threadId).toBe(result.threadId);
+    expect(event.start.prompt).toBe("fix bug #1");
+    expect(event.start.presentationMode).toBe("gui");
+    expect(event.start.projectLocation).toEqual(PROJECT);
+    expect(result.title).toBe("fix bug #1");
+    expect(result.worktreePath).toBeUndefined();
+  });
+
+  it("strips subagentMcp/browserMcp from the child config and inherits posture", async () => {
+    const h = makeHarness();
+    await createChild(h, { effort: "high" });
+    const { start, thread } = h.lastCreated();
+    for (const config of [start.config, thread.config]) {
+      expect(config).not.toHaveProperty("subagentMcp");
+      expect(config).not.toHaveProperty("browserMcp");
+      expect(config.model).toBe("gpt-5.5");
+      expect(config.effort).toBe("high");
+      expect(config.approvalPolicy).toBe("never");
+      expect(config.sandboxMode).toBe("workspace-write");
+    }
+  });
+
+  it("creates a worktree with a generated lightcode/ branch and launches inside it", async () => {
+    const h = makeHarness();
+    const result = await createChild(h, { worktree: true });
+    expect(h.worktrees).toHaveLength(1);
+    const branch = h.worktrees[0]!.branch;
+    expect(branch).toMatch(/^lightcode\/[a-z]+-[a-z]+-[0-9a-f]{8}$/);
+    const event = h.lastCreated();
+    expect(event.isNewWorktree).toBe(true);
+    expect(event.thread.worktreePath).toBe(`/tmp/worktrees/${branch}`);
+    expect(event.thread.worktreeBranch).toBe(branch);
+    expect(event.start.projectLocation).toEqual({
+      kind: "posix",
+      path: `/tmp/worktrees/${branch}`,
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("uses the custom branch + base_branch when given (branch implies worktree)", async () => {
+    const h = makeHarness();
+    await createChild(h, { branch: "feature/PROJ-42", baseBranch: "develop" });
+    expect(h.worktrees).toEqual([
+      { location: PROJECT, branch: "feature/PROJ-42", baseBranch: "develop" },
+    ]);
+  });
+
+  it("rejects unknown agents, one-shot-only agents, and empty prompts", async () => {
+    const h = makeHarness();
+    await expect(h.manager.createThread(PARENT, { agent: "nope", prompt: "x" })).rejects.toThrow(
+      OrchestratorThreadError,
+    );
+    await expect(
+      h.manager.createThread(PARENT, { agent: "commandcode", prompt: "x" }),
+    ).rejects.toThrow(/one-shot/);
+    await expect(h.manager.createThread(PARENT, { agent: "codex", prompt: "  " })).rejects.toThrow(
+      OrchestratorThreadError,
+    );
+  });
+
+  it("rejects when the parent thread is gone", async () => {
+    const h = makeHarness();
+    await expect(
+      h.manager.createThread("other-parent", { agent: "codex", prompt: "x" }),
+    ).rejects.toThrow(/no longer active/);
+  });
+
+  it("enforces the live-children cap, and close_thread frees a slot", async () => {
+    const h = makeHarness();
+    const ids: string[] = [];
+    for (let i = 0; i < MAX_CONCURRENT_CHILD_THREADS_PER_PARENT; i++) {
+      ids.push(await createChild(h));
+    }
+    await expect(createChild(h)).rejects.toThrow(/live child thread/);
+    // close_thread tears down a child's session, which frees its slot.
+    await h.manager.closeThread(PARENT, ids[0]!);
+    expect(h.closed).toEqual([ids[0]]);
+    await expect(createChild(h)).resolves.toBeDefined();
+  });
+
+  it("resolves when the session appears only after a thread-state wake", async () => {
+    const h = makeHarness({ autoLaunch: false });
+    const pending = h.manager.createThread(PARENT, { agent: "codex", prompt: "x" });
+    const event = h.lastCreated();
+    // First wake without a live session: the create must keep pending.
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: event.thread.id,
+      status: "launching",
+      attention: "none",
+      canResumeWithConfig: false,
+    });
+    h.states.set(event.thread.id, makeState());
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: event.thread.id,
+      status: "working",
+      attention: "working",
+      canResumeWithConfig: false,
+    });
+    await expect(pending).resolves.toBeDefined();
+  });
+
+  it("keeps the child + its worktree when launch is not yet confirmed (may still be starting)", async () => {
+    const h = makeHarness({ autoLaunch: false, launchTimeoutMs: 25 });
+    await expect(
+      h.manager.createThread(PARENT, { agent: "codex", prompt: "x", worktree: true }),
+    ).rejects.toThrow(/has not confirmed launch/);
+    // The record is KEPT so list_threads can surface it if it appears late, and
+    // the worktree is preserved — the caller must not recreate it blindly.
+    expect(h.manager.listThreads(PARENT)).toHaveLength(1);
+    expect(h.removedWorktrees).toEqual([]);
+  });
+
+  it("rolls back the worktree and forgets the child when the create handoff hard-fails", async () => {
+    const h = makeHarness({ failEmit: true });
+    await expect(
+      h.manager.createThread(PARENT, { agent: "codex", prompt: "x", worktree: true }),
+    ).rejects.toThrow(/main bridge unavailable/);
+    // A hard pre-session failure removes the worktree WE created and forgets the child.
+    expect(h.manager.listThreads(PARENT)).toEqual([]);
+    expect(h.removedWorktrees).toHaveLength(1);
+  });
+
+  it("turns a branch collision into actionable guidance and creates no child", async () => {
+    const h = makeHarness({
+      createWorktreeError: new Error("fatal: a branch named 'PROJ-1' already exists"),
+    });
+    await expect(
+      h.manager.createThread(PARENT, { agent: "codex", prompt: "x", branch: "PROJ-1" }),
+    ).rejects.toThrow(/already exists|different `branch`/);
+    expect(h.manager.listThreads(PARENT)).toEqual([]);
+  });
+});
+
+describe("OrchestratorThreadManager registry scoping", () => {
+  it("scopes list_threads to the parent's own children", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    expect(h.manager.listThreads(PARENT).map((t) => t.threadId)).toEqual([childId]);
+    expect(h.manager.listThreads("other-parent")).toEqual([]);
+  });
+
+  it("rejects access to another parent's child across all tools", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    expect(() => h.manager.getThread("intruder", childId)).toThrow(/Unknown thread_id/);
+    await expect(h.manager.readThread("intruder", childId, 20)).rejects.toThrow(
+      /Unknown thread_id/,
+    );
+    await expect(h.manager.sendToThread("intruder", childId, "hi", false)).rejects.toThrow(
+      /Unknown thread_id/,
+    );
+    await expect(h.manager.waitForThreads("intruder", [childId], 10)).rejects.toThrow(
+      /Unknown thread_id/,
+    );
+    await expect(h.manager.interruptThread("intruder", childId)).rejects.toThrow(
+      /Unknown thread_id/,
+    );
+  });
+
+  it("reports live status and worktree metadata in summaries", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h, { branch: "feature/x" });
+    h.states.set(childId, makeState({ status: "working", attention: "working" }));
+    const [summary] = h.manager.listThreads(PARENT);
+    expect(summary).toMatchObject({
+      threadId: childId,
+      agent: "codex",
+      status: "working",
+      attention: "working",
+      branch: "feature/x",
+      worktreePath: "/tmp/worktrees/feature/x",
+    });
+  });
+
+  it("reports inactive once the session is gone", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.delete(childId);
+    expect(h.manager.getThread(PARENT, childId).status).toBe("inactive");
+  });
+});
+
+describe("OrchestratorThreadManager.waitForThreads", () => {
+  it("returns immediately when a thread is already settled", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "idle" }));
+    const result = await h.manager.waitForThreads(PARENT, [childId], 60_000);
+    expect(result).toEqual({
+      statuses: { [childId]: { status: "idle", attention: "none" } },
+      settled: [childId],
+      timedOut: false,
+    });
+  });
+
+  it("times out while all listed threads stay busy", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "working" }));
+    const result = await h.manager.waitForThreads(PARENT, [childId], 30);
+    expect(result.timedOut).toBe(true);
+    expect(result.settled).toEqual([]);
+    expect(result.statuses[childId]!.status).toBe("working");
+  });
+
+  it("wakes when ANY listed thread settles via a thread-state event", async () => {
+    const h = makeHarness();
+    const a = await createChild(h);
+    const b = await createChild(h);
+    h.states.set(a, makeState({ status: "working" }));
+    h.states.set(b, makeState({ status: "working" }));
+
+    const pending = h.manager.waitForThreads(PARENT, [a, b], 10_000);
+    h.states.set(b, makeState({ status: "needs_approval", attention: "needs_approval" }));
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: b,
+      status: "needs_approval",
+      attention: "needs_approval",
+      canResumeWithConfig: false,
+    });
+    const result = await pending;
+    expect(result.timedOut).toBe(false);
+    expect(result.settled).toEqual([b]);
+    expect(result.statuses).toEqual({
+      [a]: { status: "working", attention: "none" },
+      [b]: { status: "needs_approval", attention: "needs_approval" },
+    });
+  });
+
+  it("validates the 1..8 thread_ids bound", async () => {
+    const h = makeHarness();
+    await expect(h.manager.waitForThreads(PARENT, [], 10)).rejects.toThrow(/between 1 and 8/);
+  });
+});
+
+describe("OrchestratorThreadManager.sendToThread", () => {
+  it("starts a new turn when the child is idle", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "idle", config: { model: "child-model" } }));
+    const result = await h.manager.sendToThread(PARENT, childId, "next step", false);
+    expect(result.delivery).toBe("started_turn");
+    expect(h.sent).toEqual([
+      { threadId: childId, prompt: "next step", config: { model: "child-model" } },
+    ]);
+  });
+
+  it("steers when working and the session supports steer", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "working", supportsSteer: true }));
+    const result = await h.manager.sendToThread(PARENT, childId, "also do X", false);
+    expect(result.delivery).toBe("steered");
+    expect(h.sent).toHaveLength(1);
+  });
+
+  it("errors when working without steer support and interrupt=false", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "working", supportsSteer: false }));
+    await expect(h.manager.sendToThread(PARENT, childId, "msg", false)).rejects.toThrow(
+      /does not support steering/,
+    );
+    expect(h.sent).toEqual([]);
+  });
+
+  it("interrupts then sends when interrupt=true", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "working", supportsSteer: false }));
+    const pending = h.manager.sendToThread(PARENT, childId, "stop and pivot", true);
+    // Simulate the interrupt landing: the thread leaves `working`.
+    h.states.set(childId, makeState({ status: "idle" }));
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: childId,
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: false,
+    });
+    const result = await pending;
+    expect(result.delivery).toBe("interrupted_and_sent");
+    expect(h.interrupted).toEqual([childId]);
+    expect(h.sent).toHaveLength(1);
+  });
+
+  it("errors when the child session is gone", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.delete(childId);
+    await expect(h.manager.sendToThread(PARENT, childId, "msg", false)).rejects.toThrow(
+      /not running/,
+    );
+  });
+});
+
+describe("OrchestratorThreadManager.readThread", () => {
+  it("returns the transcript tail with truncated bodies", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    const long = "x".repeat(10_000);
+    h.setHistory({
+      providerSessionId: "session-1",
+      messages: [
+        { messageId: "m1", role: "user", parts: [{ type: "text", text: "hello" }], info: {} },
+        { messageId: "m2", role: "assistant", parts: [{ type: "text", text: long }], info: {} },
+      ],
+    });
+    const result = await h.manager.readThread(PARENT, childId, 20);
+    if (result.source !== "native") throw new Error("expected native transcript");
+    expect(result.messageCount).toBe(2);
+    expect(result.messages[0]).toEqual({ role: "user", text: "hello" });
+    expect(result.messages[1]!.text.length).toBeLessThan(5_000);
+    expect(result.messages[1]!.text).toContain("[truncated]");
+  });
+
+  it("slices to the requested tail, clamped to 1..100", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.setHistory({
+      providerSessionId: "session-1",
+      messages: Array.from({ length: 5 }, (_, i) => ({
+        messageId: `m${i}`,
+        role: "assistant" as const,
+        parts: [`message ${i}`],
+        info: {},
+      })),
+    });
+    const result = await h.manager.readThread(PARENT, childId, 2);
+    if (result.source !== "native") throw new Error("expected native transcript");
+    expect(result.messages.map((m) => m.text)).toEqual(["message 3", "message 4"]);
+  });
+
+  it("serves the buffered transcript when the adapter lacks native readThread", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.setHistory(undefined);
+    // Feed a couple of runtime items so the structured buffer is non-empty.
+    h.manager.observeSupervisorEvent({
+      type: "thread-runtime-events",
+      threadId: childId,
+      events: [
+        {
+          type: "item.completed",
+          threadId: childId,
+          itemId: "a1",
+          payload: { content: [{ kind: "text", text: "did the thing" }] },
+        },
+      ],
+    });
+    const result = await h.manager.readThread(PARENT, childId, 20);
+    if (result.source !== "buffer") throw new Error("expected buffered transcript");
+    expect(result.entries.at(-1)).toEqual({ kind: "assistant", text: "did the thing" });
+  });
+
+  it("returns a note when nothing has been recorded and there is no native transcript", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.setHistory(undefined);
+    const result = await h.manager.readThread(PARENT, childId, 20);
+    expect(result.source).toBe("note");
+  });
+});
+
+describe("OrchestratorThreadManager.interruptThread + output tail", () => {
+  it("interrupts an owned live child", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    await h.manager.interruptThread(PARENT, childId);
+    expect(h.interrupted).toEqual([childId]);
+  });
+
+  it("errors when interrupting a closed child", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.delete(childId);
+    await expect(h.manager.interruptThread(PARENT, childId)).rejects.toThrow(/not running/);
+  });
+
+  it("keeps a bounded assistant-output tail from runtime events", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.manager.observeSupervisorEvent({
+      type: "thread-runtime-events",
+      threadId: childId,
+      events: [
+        {
+          type: "content.delta",
+          threadId: childId,
+          itemId: "m",
+          stream: "assistant_text",
+          delta: "working on it: ",
+        },
+        {
+          type: "content.delta",
+          threadId: childId,
+          itemId: "m",
+          stream: "assistant_text",
+          delta: "a".repeat(5_000),
+        },
+      ],
+    });
+    const summary = h.manager.getThread(PARENT, childId);
+    expect(summary.recentOutput).toBeDefined();
+    expect(summary.recentOutput!.length).toBeLessThanOrEqual(2_000);
+    expect(summary.recentOutput!.endsWith("a")).toBe(true);
+  });
+});
+
+describe("OrchestratorThreadManager failure reason + final result", () => {
+  it("captures the failure reason from thread-state and clears it when work resumes", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "error", attention: "error" }));
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: childId,
+      status: "error",
+      attention: "error",
+      canResumeWithConfig: false,
+      errorMessage: "provider auth failed",
+    });
+    expect(h.manager.getThread(PARENT, childId).error).toBe("provider auth failed");
+
+    // A fresh turn clears the stale reason so it doesn't linger.
+    h.states.set(childId, makeState({ status: "working", attention: "working" }));
+    h.manager.observeSupervisorEvent({
+      type: "thread-state",
+      threadId: childId,
+      status: "working",
+      attention: "working",
+      canResumeWithConfig: false,
+    });
+    expect(h.manager.getThread(PARENT, childId).error).toBeUndefined();
+  });
+
+  it("captures a durable final_result that survives close_thread", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.manager.observeSupervisorEvent({
+      type: "thread-runtime-events",
+      threadId: childId,
+      events: [
+        {
+          type: "content.delta",
+          threadId: childId,
+          itemId: "m",
+          stream: "assistant_text",
+          delta: "Ticket done: shipped the fix.",
+        },
+        { type: "turn.completed", threadId: childId, turnId: "t1", state: "completed" },
+      ],
+    });
+    await h.manager.closeThread(PARENT, childId);
+    const summary = h.manager.getThread(PARENT, childId);
+    // Session is gone, but the collected result remains for the orchestrator.
+    expect(summary.status).toBe("inactive");
+    expect(summary.finalResult).toBe("Ticket done: shipped the fix.");
+  });
+});
+
+describe("OrchestratorThreadManager.sendToThread approval handling", () => {
+  it("refuses to send into a needs_approval child but answers a needs_reply", async () => {
+    const h = makeHarness();
+    const childId = await createChild(h);
+    h.states.set(childId, makeState({ status: "needs_approval", attention: "needs_approval" }));
+    await expect(h.manager.sendToThread(PARENT, childId, "approved", false)).rejects.toThrow(
+      /approval/,
+    );
+    expect(h.sent).toEqual([]);
+
+    // needs_reply is a question to the caller → answering starts a turn.
+    h.states.set(
+      childId,
+      makeState({
+        status: "needs_reply",
+        attention: "needs_reply",
+        config: { model: "child-model" },
+      }),
+    );
+    const result = await h.manager.sendToThread(PARENT, childId, "use option B", false);
+    expect(result.delivery).toBe("started_turn");
+    expect(h.sent).toHaveLength(1);
+  });
+});

--- a/src/supervisor/subagentMcp/OrchestratorThreadManager.ts
+++ b/src/supervisor/subagentMcp/OrchestratorThreadManager.ts
@@ -1,0 +1,832 @@
+import { randomUUID } from "node:crypto";
+import type {
+  AgentKind,
+  ProjectLocation,
+  RuntimeEvent,
+  SendThreadInputPayload,
+  StartThreadPayload,
+  Thread,
+  ThreadAttention,
+  ThreadConfig,
+  ThreadStatus,
+} from "@/shared/contracts";
+import { DEFAULT_TERMINAL_SIZE } from "@/shared/contracts";
+import type { SupervisorEvent } from "@/shared/ipc/events";
+import { makeThreadTitle } from "@/shared/threadTitle";
+import { buildWorktreeLocation } from "@/shared/worktree";
+import { generateWorktreeBranch } from "@/shared/worktreeBranch";
+import type { AgentAdapter, ThreadHistory } from "@/supervisor/agents/base";
+import { ChildTranscriptBuffer } from "./childTranscriptBuffer";
+import type { TranscriptEntry } from "./childTranscriptBuffer";
+import { truncate } from "./toolResult";
+import { buildInheritedChildConfig, resolveSubagentExecution } from "./types";
+
+/**
+ * Max live (session-active) orchestrator child threads per parent. Higher than
+ * the ephemeral subagent cap (4) because the motivating use case is an
+ * orchestrator working a batch of tickets, one worktree-backed thread each.
+ */
+export const MAX_CONCURRENT_CHILD_THREADS_PER_PARENT = 8;
+
+/** How long `create_thread` waits for the main process to launch the child. */
+export const CHILD_THREAD_LAUNCH_TIMEOUT_MS = 30_000;
+
+/** Rolling per-child assistant-output tail kept for `get_thread`. */
+const ASSISTANT_TAIL_MAX_CHARS = 2_000;
+
+/** Per-message body cap for `read_thread` so transcripts can't blow up the caller's context. */
+const MESSAGE_TEXT_MAX_CHARS = 4_000;
+
+/**
+ * Cap on the durable `finalResult` snapshot captured at turn end. Generous
+ * (unlike the rolling tail) so a child's concluding answer survives intact for
+ * the orchestrator to collect — even after the child's session is closed.
+ */
+const FINAL_RESULT_MAX_CHARS = 16_000;
+
+/** Statuses `wait_for_thread` treats as settled (turn finished or needs the caller). */
+const SETTLED_STATUSES: ReadonlySet<ThreadStatus> = new Set([
+  "idle",
+  "finished",
+  "needs_approval",
+  "needs_reply",
+  "error",
+  "inactive",
+]);
+
+/** A synchronous validation/orchestration failure surfaced as an MCP tool error. */
+export class OrchestratorThreadError extends Error {}
+
+/** Live-session view of a child thread, resolved from the thread session manager. */
+export interface OrchestratorThreadState {
+  status: ThreadStatus;
+  attention: ThreadAttention;
+  config: ThreadConfig;
+  /** Whether the session supports non-interrupting steer while working. */
+  supportsSteer: boolean;
+}
+
+/**
+ * Host surface the orchestrator manager needs from the supervisor's thread
+ * session manager. Kept minimal (thin hooks only) so the TSM stays lean.
+ */
+export interface OrchestratorThreadHost {
+  /** Resolve a live parent thread's project location + config for child inheritance. */
+  getParentContext(
+    threadId: string,
+  ): { projectLocation: ProjectLocation; config: ThreadConfig } | undefined;
+  /** Live runtime state of a thread; `undefined` once its session is gone. */
+  getThreadState(threadId: string): OrchestratorThreadState | undefined;
+  /** Provider transcript when the session's adapter supports `readThread`. */
+  readThreadHistory(threadId: string): Promise<ThreadHistory | undefined>;
+  /** Start/steer a turn on a live thread (routes through the TSM's normal input path). */
+  sendThreadInput(payload: SendThreadInputPayload): Promise<void>;
+  /** Interrupt a live thread's current turn (the thread stays addressable). */
+  interruptThread(threadId: string): Promise<void>;
+  /**
+   * Close a child's runtime session (frees its capacity slot). The persisted
+   * thread row + its git worktree remain — this does not delete the child's work.
+   */
+  closeThread(threadId: string): Promise<void>;
+}
+
+export interface OrchestratorThreadManagerDeps {
+  adapters: Map<AgentKind, AgentAdapter>;
+  host: OrchestratorThreadHost;
+  /** Supervisor event channel — carries `orchestrator-thread-created` to main. */
+  emit(event: SupervisorEvent): void;
+  /** Create a git worktree (new branch) in the parent's repo; returns its path. */
+  createWorktree(input: {
+    location: ProjectLocation;
+    branch: string;
+    baseBranch?: string;
+  }): Promise<{ path: string }>;
+  /**
+   * Remove a git worktree (force + delete branch) — used only to roll back a
+   * worktree created by a `create_thread` call that then failed to launch.
+   */
+  removeWorktree(input: { location: ProjectLocation; path: string }): Promise<void>;
+  /** Test hook: overrides {@link CHILD_THREAD_LAUNCH_TIMEOUT_MS}. */
+  launchTimeoutMs?: number;
+}
+
+/** Arguments accepted by the `create_thread` tool. */
+export interface CreateChildThreadRequest {
+  agent: string;
+  prompt: string;
+  title?: string;
+  model?: string;
+  effort?: string;
+  worktree?: boolean;
+  branch?: string;
+  baseBranch?: string;
+}
+
+export interface CreateChildThreadResult {
+  threadId: string;
+  title: string;
+  worktreePath?: string;
+  branch?: string;
+}
+
+export interface ChildThreadSummary {
+  threadId: string;
+  title: string;
+  agent: string;
+  status: ThreadStatus;
+  attention: ThreadAttention;
+  createdAt: string;
+  worktreePath?: string;
+  branch?: string;
+  /** Latest failure reason from the child's `thread-state` (cleared while it works). */
+  error?: string;
+  /** When the child's current turn started (progress signal). */
+  turnStartedAt?: string;
+}
+
+/** Per-thread settled-state bits returned by `wait_for_thread`. */
+export interface ThreadStatusBits {
+  status: ThreadStatus;
+  attention: ThreadAttention;
+  error?: string;
+}
+
+interface ChildThreadRecord {
+  threadId: string;
+  parentThreadId: string;
+  agent: string;
+  title: string;
+  worktreePath?: string;
+  branch?: string;
+  lastStatus: ThreadStatus;
+  lastAttention: ThreadAttention;
+  /** Latest failure reason from `thread-state` (cleared when the child works again). */
+  lastError: string | undefined;
+  /** Durable snapshot of the child's concluding assistant message (survives close). */
+  finalResult: string | undefined;
+  /** ISO timestamp the child was created. */
+  createdAt: string;
+  /** ISO timestamp the child's current/last turn began (set on → working). */
+  turnStartedAt: string | undefined;
+  /** Compact structured transcript for `read_thread` (works without native readThread). */
+  transcript: ChildTranscriptBuffer;
+}
+
+interface StatusWaiter {
+  threadIds: ReadonlySet<string>;
+  wake(): void;
+}
+
+/** Internal marker so `createThread` can distinguish a launch timeout from a hard failure. */
+class LaunchTimeoutError extends OrchestratorThreadError {}
+
+/**
+ * Orchestrator lane of the subagents MCP: lets a parent thread create and
+ * manage REAL first-class app threads (persisted rows, sidebar-visible,
+ * optionally worktree-backed), as opposed to the ephemeral in-memory runs
+ * owned by {@link SubagentRunManager}.
+ *
+ * Thread creation is main-orchestrated: this manager emits an
+ * `orchestrator-thread-created` supervisor event carrying the child row + a
+ * ready `startThread` payload; the main process resolves the projectId from
+ * the parent's DB row, upserts the child, mirrors it to the renderer, and
+ * calls back into the supervisor's `startThread` — the exact ordering the
+ * proven remote (mobile) start path uses. `create_thread` then resolves once
+ * the child's session appears in the thread session manager.
+ *
+ * The parent→children registry is in-memory only: if the supervisor restarts,
+ * the parent's session (and its MCP connection) is gone too. Child threads
+ * themselves are durable app threads and survive independently.
+ */
+export class OrchestratorThreadManager {
+  private readonly children = new Map<string, ChildThreadRecord>();
+  private readonly waiters = new Set<StatusWaiter>();
+
+  constructor(private readonly deps: OrchestratorThreadManagerDeps) {}
+
+  /** Agent kinds eligible for `create_thread` (full structured/GUI sessions). */
+  private structuredAgentKinds(): string[] {
+    const kinds: string[] = [];
+    for (const [kind, adapter] of this.deps.adapters) {
+      if (resolveSubagentExecution(adapter) === "structured") kinds.push(kind);
+    }
+    return kinds;
+  }
+
+  /**
+   * Create a first-class child thread (optionally in a fresh git worktree) and
+   * initiate its launch. Resolves once the child's session is live in the
+   * thread session manager; does NOT wait for the child's first turn to finish.
+   */
+  async createThread(
+    parentThreadId: string,
+    request: CreateChildThreadRequest,
+  ): Promise<CreateChildThreadResult> {
+    const prompt = request.prompt?.trim();
+    if (!prompt) throw new OrchestratorThreadError("prompt is required");
+    const adapter = this.deps.adapters.get(request.agent as AgentKind);
+    if (!adapter) {
+      throw new OrchestratorThreadError(
+        `Unknown agent: ${request.agent}. Call list_agents for the available agents.`,
+      );
+    }
+    if (resolveSubagentExecution(adapter) !== "structured") {
+      throw new OrchestratorThreadError(
+        `Agent ${request.agent} only supports one-shot subagent runs and cannot host a full thread. ` +
+          `Agents eligible for create_thread: ${this.structuredAgentKinds().join(", ") || "none"}.`,
+      );
+    }
+    const parent = this.deps.host.getParentContext(parentThreadId);
+    if (!parent) throw new OrchestratorThreadError("Parent thread is no longer active");
+    const live = this.liveChildCount(parentThreadId);
+    if (live >= MAX_CONCURRENT_CHILD_THREADS_PER_PARENT) {
+      throw new OrchestratorThreadError(
+        `You already have ${live} live child thread(s) — the max is ${MAX_CONCURRENT_CHILD_THREADS_PER_PARENT}. ` +
+          "A finished child keeps holding its slot until you free it: call close_thread on a completed thread " +
+          "(check list_threads / wait_for_thread for which are done) to make room, then retry create_thread. " +
+          "Waiting does not free a slot — only close_thread (or the child's session ending) does.",
+      );
+    }
+
+    const model = request.model ?? adapter.capabilities.models[0]?.id;
+    if (!model) {
+      throw new OrchestratorThreadError(`Agent ${request.agent} has no available models`);
+    }
+
+    // A custom branch/base_branch implies the caller wants a worktree.
+    let worktreePath: string | undefined;
+    let branch: string | undefined;
+    if (request.worktree || request.branch || request.baseBranch) {
+      branch = request.branch?.trim() || generateWorktreeBranch();
+      const baseBranch = request.baseBranch?.trim();
+      try {
+        const created = await this.deps.createWorktree({
+          location: parent.projectLocation,
+          branch,
+          ...(baseBranch ? { baseBranch } : {}),
+        });
+        worktreePath = created.path;
+      } catch (error) {
+        // No child thread exists yet — turn the raw git failure into actionable
+        // guidance (branch collisions poison ticket-keyed retries otherwise).
+        throw describeWorktreeFailure(error, branch);
+      }
+    }
+
+    const threadId = randomUUID();
+    const customTitle = request.title?.trim();
+    const title = customTitle || makeThreadTitle(prompt) || "New thread";
+    // Child inherits the parent's approval/sandbox posture but never carries
+    // subagentMcp/browserMcp — depth limit 1: children can't spawn grandchildren.
+    const childConfig = buildInheritedChildConfig(parent.config, {
+      model,
+      ...(request.effort ? { effort: request.effort } : {}),
+    });
+    const childLocation = worktreePath
+      ? buildWorktreeLocation(parent.projectLocation, worktreePath)
+      : parent.projectLocation;
+
+    const now = new Date().toISOString();
+    const thread: Omit<Thread, "projectId"> = {
+      id: threadId,
+      title,
+      agentKind: request.agent as AgentKind,
+      config: childConfig,
+      status: "launching",
+      attention: "none",
+      canResumeWithConfig: false,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "gui",
+      threadStatusSource: "server",
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(branch ? { worktreeBranch: branch } : {}),
+      parentThreadId,
+      createdAt: now,
+      updatedAt: now,
+      activeTurnStartedAt: now,
+    };
+    const start: StartThreadPayload = {
+      threadId,
+      projectLocation: childLocation,
+      agentKind: request.agent as AgentKind,
+      config: childConfig,
+      prompt,
+      initialSize: DEFAULT_TERMINAL_SIZE,
+      presentationMode: "gui",
+    };
+
+    const record: ChildThreadRecord = {
+      threadId,
+      parentThreadId,
+      agent: request.agent,
+      title,
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(branch ? { branch } : {}),
+      lastStatus: "launching",
+      lastAttention: "none",
+      lastError: undefined,
+      finalResult: undefined,
+      createdAt: now,
+      turnStartedAt: undefined,
+      transcript: new ChildTranscriptBuffer(),
+    };
+    this.children.set(threadId, record);
+
+    // Hard failure in the create/launch handoff (emit throws) → no session can
+    // appear: roll back the worktree WE created this call and forget the record.
+    try {
+      this.deps.emit({
+        type: "orchestrator-thread-created",
+        parentThreadId,
+        thread,
+        start,
+        ...(worktreePath ? { isNewWorktree: true } : {}),
+        ...(customTitle ? { hasCustomTitle: true } : {}),
+      });
+    } catch (error) {
+      await this.cleanupFailedLaunch(
+        threadId,
+        worktreePath ? { location: parent.projectLocation, path: worktreePath } : undefined,
+      );
+      throw error;
+    }
+
+    try {
+      await this.waitForLaunch(
+        threadId,
+        this.deps.launchTimeoutMs ?? CHILD_THREAD_LAUNCH_TIMEOUT_MS,
+      );
+    } catch (error) {
+      if (error instanceof LaunchTimeoutError) {
+        // The child may still come up (main can finish startThread after we stop
+        // waiting). KEEP the record so list_threads can surface it if it appears,
+        // and KEEP the worktree. A never-launched record can't wedge the cap:
+        // liveChildCount is gated on getThreadState, undefined until a session exists.
+        throw new OrchestratorThreadError(
+          `Child thread ${threadId} has not confirmed launch yet — it may still be starting in the app. ` +
+            "Do NOT recreate it blindly: check list_threads first (it appears there once/if it launches) " +
+            "so you don't create a duplicate." +
+            (branch ? ` Its worktree (branch "${branch}") is preserved.` : ""),
+        );
+      }
+      // Any other failure before a session exists → treat as a hard failure.
+      await this.cleanupFailedLaunch(
+        threadId,
+        worktreePath ? { location: parent.projectLocation, path: worktreePath } : undefined,
+      );
+      throw error;
+    }
+
+    return {
+      threadId,
+      title,
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(branch ? { branch } : {}),
+    };
+  }
+
+  /** Forget a failed child and roll back the worktree this call created (best effort). */
+  private async cleanupFailedLaunch(
+    threadId: string,
+    worktree: { location: ProjectLocation; path: string } | undefined,
+  ): Promise<void> {
+    this.children.delete(threadId);
+    if (!worktree) return;
+    try {
+      await this.deps.removeWorktree(worktree);
+    } catch (cleanupError) {
+      // Never mask the original failure with a cleanup error.
+      console.warn(
+        `[orchestrator] failed to remove worktree ${worktree.path} after a failed launch:`,
+        cleanupError,
+      );
+    }
+  }
+
+  /**
+   * Close a finished child's runtime session to free a capacity slot. The
+   * persisted thread row + its worktree stay in the app for the human, and the
+   * record is retained so post-close get_thread/read_thread still return the
+   * captured final result.
+   */
+  async closeThread(parentThreadId: string, threadId: string): Promise<void> {
+    this.requireChild(parentThreadId, threadId);
+    await this.deps.host.closeThread(threadId);
+  }
+
+  /** Children of `parentThreadId` with their current status. */
+  listThreads(parentThreadId: string): ChildThreadSummary[] {
+    const out: ChildThreadSummary[] = [];
+    for (const record of this.children.values()) {
+      if (record.parentThreadId !== parentThreadId) continue;
+      out.push(this.summarize(record));
+    }
+    return out;
+  }
+
+  /** Status + attention + recent output tail + durable final result for one owned child. */
+  getThread(
+    parentThreadId: string,
+    threadId: string,
+  ): ChildThreadSummary & { recentOutput?: string; finalResult?: string } {
+    const record = this.requireChild(parentThreadId, threadId);
+    // Derive the recent-output tail lazily from the transcript's last assistant
+    // message (a cold read) instead of maintaining a second per-token accumulator.
+    const tail = record.transcript.lastAssistantMessage().slice(-ASSISTANT_TAIL_MAX_CHARS).trim();
+    const finalResult = record.finalResult?.trim();
+    return {
+      ...this.summarize(record),
+      ...(tail ? { recentOutput: tail } : {}),
+      ...(finalResult ? { finalResult } : {}),
+    };
+  }
+
+  /**
+   * Transcript tail for an owned child. Prefers the session's native
+   * `readThread` (highest fidelity, e.g. opencode) while it's live; otherwise
+   * serves the buffered structured transcript built from the child's runtime
+   * events — so Claude/Codex/ACP children (and closed sessions) still return
+   * something useful. Falls back to a graceful note only when nothing is buffered.
+   * Message/entry bodies are truncated so the result can't blow up the caller's context.
+   */
+  async readThread(
+    parentThreadId: string,
+    threadId: string,
+    lastMessages: number,
+  ): Promise<
+    | { status: ThreadStatus; source: "note"; note: string }
+    | {
+        status: ThreadStatus;
+        source: "native";
+        messageCount: number;
+        messages: Array<{ role: "user" | "assistant"; text: string }>;
+      }
+    | {
+        status: ThreadStatus;
+        source: "buffer";
+        entryCount: number;
+        entries: TranscriptEntry[];
+      }
+  > {
+    const record = this.requireChild(parentThreadId, threadId);
+    const status = this.currentStatus(record);
+    const count = Math.min(Math.max(Math.trunc(lastMessages) || 20, 1), 100);
+    const history = this.deps.host.getThreadState(threadId)
+      ? await this.deps.host.readThreadHistory(threadId)
+      : undefined;
+    if (history) {
+      const messages = history.messages.slice(-count).map((message) => ({
+        role: message.role,
+        text: truncate(renderHistoryParts(message.parts), MESSAGE_TEXT_MAX_CHARS),
+      }));
+      return { status, source: "native", messageCount: history.messages.length, messages };
+    }
+    const entries = record.transcript.snapshot(count);
+    if (entries.length > 0) {
+      return { status, source: "buffer", entryCount: record.transcript.size, entries };
+    }
+    return {
+      status,
+      source: "note",
+      note:
+        "No transcript is available yet for this thread (it has produced no recorded messages, tool calls, or errors). " +
+        "Use get_thread for its status and recent output.",
+    };
+  }
+
+  /**
+   * Deliver a message to an owned child: start a turn when it's settled, steer
+   * when it's working and the session supports steering, or interrupt-then-send
+   * when `interrupt` is set. Errors when the child is busy and can't be steered.
+   */
+  async sendToThread(
+    parentThreadId: string,
+    threadId: string,
+    message: string,
+    interrupt: boolean,
+  ): Promise<{ delivery: "started_turn" | "steered" | "interrupted_and_sent" }> {
+    this.requireChild(parentThreadId, threadId);
+    const prompt = message.trim();
+    if (!prompt) throw new OrchestratorThreadError("message is required");
+    const state = this.deps.host.getThreadState(threadId);
+    if (!state) {
+      throw new OrchestratorThreadError(
+        `Thread ${threadId} is not running (its session was closed in the app), so it cannot receive input.`,
+      );
+    }
+    if (state.status === "needs_approval") {
+      // A tool-permission prompt is pending; this tool has no requestId to
+      // resolve it. Sending here would silently start a NEW turn (false success)
+      // rather than approving the tool. `needs_reply` is different (a question) —
+      // that falls through to the normal start-a-turn path below.
+      throw new OrchestratorThreadError(
+        `Thread ${threadId} is blocked waiting for a tool-permission approval that send_to_thread cannot resolve. ` +
+          "A human must approve/deny it in the app UI, or the child should have been created under a more " +
+          "autonomous approval policy (children inherit the parent's approval posture). This is not a message prompt.",
+      );
+    }
+    const payload: SendThreadInputPayload = { threadId, prompt, config: state.config };
+    const busy = state.status === "working" || state.status === "launching";
+    if (busy && interrupt) {
+      await this.deps.host.interruptThread(threadId);
+      await this.waitWhileWorking(threadId, 5_000);
+      await this.deps.host.sendThreadInput(payload);
+      return { delivery: "interrupted_and_sent" };
+    }
+    if (busy) {
+      if (state.status === "working" && state.supportsSteer) {
+        await this.deps.host.sendThreadInput(payload);
+        return { delivery: "steered" };
+      }
+      throw new OrchestratorThreadError(
+        `Thread ${threadId} is ${state.status} and does not support steering. ` +
+          "Retry with interrupt=true, or wait_for_thread first.",
+      );
+    }
+    await this.deps.host.sendThreadInput(payload);
+    return { delivery: "started_turn" };
+  }
+
+  /**
+   * Block until ANY listed child settles (idle | finished | needs_approval |
+   * needs_reply | error, or its session is gone) or the timeout elapses.
+   * Returns immediately when one is already settled. Event-driven (woken by
+   * `thread-state` supervisor events), no tight polling.
+   */
+  async waitForThreads(
+    parentThreadId: string,
+    threadIds: string[],
+    timeoutMs: number,
+  ): Promise<{
+    statuses: Record<string, ThreadStatusBits>;
+    settled: string[];
+    timedOut: boolean;
+  }> {
+    if (threadIds.length < 1 || threadIds.length > 8) {
+      throw new OrchestratorThreadError("thread_ids must list between 1 and 8 threads");
+    }
+    const records = threadIds.map((id) => this.requireChild(parentThreadId, id));
+    const settledResult = await this.waitUntil(threadIds, timeoutMs, () => {
+      const snap = this.snapshotStatuses(records);
+      return snap.settled.length > 0 ? snap : undefined;
+    });
+    if (settledResult) return { ...settledResult, timedOut: false };
+    return { ...this.snapshotStatuses(records), timedOut: true };
+  }
+
+  /** Current status/settled snapshot for a set of child records. */
+  private snapshotStatuses(records: ChildThreadRecord[]): {
+    statuses: Record<string, ThreadStatusBits>;
+    settled: string[];
+  } {
+    const statuses: Record<string, ThreadStatusBits> = {};
+    const settled: string[] = [];
+    for (const record of records) {
+      const bits = this.statusBits(record);
+      statuses[record.threadId] = bits;
+      if (SETTLED_STATUSES.has(bits.status)) settled.push(record.threadId);
+    }
+    return { statuses, settled };
+  }
+
+  /** Interrupt an owned child's current turn; the thread stays addressable. */
+  async interruptThread(parentThreadId: string, threadId: string): Promise<void> {
+    this.requireChild(parentThreadId, threadId);
+    if (!this.deps.host.getThreadState(threadId)) {
+      throw new OrchestratorThreadError(
+        `Thread ${threadId} is not running (its session was closed in the app).`,
+      );
+    }
+    await this.deps.host.interruptThread(threadId);
+  }
+
+  /**
+   * Tap on the supervisor's outbound event stream (wired in the runtime's
+   * `emit` plumbing): tracks child status transitions, wakes waiters, and keeps
+   * a bounded assistant-output tail per child. Cheap no-op for non-child events.
+   */
+  observeSupervisorEvent(event: SupervisorEvent): void {
+    switch (event.type) {
+      case "thread-state": {
+        const record = this.children.get(event.threadId);
+        if (record) {
+          const wasWorking = record.lastStatus === "working";
+          record.lastStatus = event.status;
+          record.lastAttention = event.attention;
+          if (event.status === "working" || event.status === "launching") {
+            // A fresh turn started — stale failure reasons no longer apply.
+            record.lastError = undefined;
+            if (event.status === "working" && !wasWorking) {
+              record.turnStartedAt = new Date().toISOString();
+            }
+          } else {
+            if (event.errorMessage) record.lastError = event.errorMessage;
+            // Fallback capture of the final result if no turn.completed was seen.
+            if (event.status === "idle" || event.status === "finished") {
+              this.captureFinalResult(record);
+            }
+          }
+        }
+        // Common case is zero waiters (no orchestrator wait in flight) — skip
+        // the loop entirely. wake() only deletes the current waiter, which is
+        // safe to do while iterating a Set directly (no defensive copy needed).
+        if (this.waiters.size > 0) {
+          for (const waiter of this.waiters) {
+            if (waiter.threadIds.has(event.threadId)) waiter.wake();
+          }
+        }
+        return;
+      }
+      case "thread-runtime-event":
+        this.trackRuntimeEvents(event.threadId, [event.event]);
+        return;
+      case "thread-runtime-events":
+        this.trackRuntimeEvents(event.threadId, event.events);
+        return;
+      case "thread-runtime-events-multi":
+        for (const batch of event.batches) this.trackRuntimeEvents(batch.threadId, batch.events);
+        return;
+      default:
+        return;
+    }
+  }
+
+  private trackRuntimeEvents(threadId: string, events: ReadonlyArray<RuntimeEvent>): void {
+    const record = this.children.get(threadId);
+    if (!record) return;
+    for (const event of events) {
+      record.transcript.ingest(event);
+      if (event.type === "turn.completed") this.captureFinalResult(record);
+    }
+  }
+
+  /** Snapshot the child's concluding assistant message as a durable final result. */
+  private captureFinalResult(record: ChildThreadRecord): void {
+    const text = record.transcript.lastAssistantMessage().trim();
+    if (text) record.finalResult = truncate(text, FINAL_RESULT_MAX_CHARS);
+  }
+
+  private summarize(record: ChildThreadRecord): ChildThreadSummary {
+    const live = this.deps.host.getThreadState(record.threadId);
+    return {
+      threadId: record.threadId,
+      title: record.title,
+      agent: record.agent,
+      status: live?.status ?? "inactive",
+      attention: live?.attention ?? record.lastAttention,
+      createdAt: record.createdAt,
+      ...(record.worktreePath ? { worktreePath: record.worktreePath } : {}),
+      ...(record.branch ? { branch: record.branch } : {}),
+      ...(record.lastError ? { error: record.lastError } : {}),
+      ...(record.turnStartedAt ? { turnStartedAt: record.turnStartedAt } : {}),
+    };
+  }
+
+  /** Status + attention + failure reason bits used by `wait_for_thread` (subset of the summary). */
+  private statusBits(record: ChildThreadRecord): ThreadStatusBits {
+    const { status, attention, error } = this.summarize(record);
+    return { status, attention, ...(error ? { error } : {}) };
+  }
+
+  /** Live session status, or `inactive` once the child's session is gone. */
+  private currentStatus(record: ChildThreadRecord): ThreadStatus {
+    return this.deps.host.getThreadState(record.threadId)?.status ?? "inactive";
+  }
+
+  private liveChildCount(parentThreadId: string): number {
+    let count = 0;
+    for (const record of this.children.values()) {
+      if (record.parentThreadId !== parentThreadId) continue;
+      if (this.deps.host.getThreadState(record.threadId)) count += 1;
+    }
+    return count;
+  }
+
+  private requireChild(parentThreadId: string, threadId: string): ChildThreadRecord {
+    const record = this.children.get(threadId);
+    if (!record || record.parentThreadId !== parentThreadId) {
+      throw new OrchestratorThreadError(
+        `Unknown thread_id: ${threadId}. Only threads you created via create_thread are addressable (see list_threads).`,
+      );
+    }
+    return record;
+  }
+
+  /**
+   * Resolve once the child's session appears in the thread session manager
+   * (the launch loops back through main → supervisor `startThread`). Woken by
+   * the child's first `thread-state` event, with a coarse 500ms re-check as a
+   * safety net; throws with diagnostics on timeout.
+   */
+  private async waitForLaunch(threadId: string, timeoutMs: number): Promise<void> {
+    // 500ms re-check caps the wait between event wakes as a safety net for the
+    // race where the session appears before a waiter is registered.
+    const launched = await this.waitUntil(
+      [threadId],
+      timeoutMs,
+      () => (this.deps.host.getThreadState(threadId) ? true : undefined),
+      500,
+    );
+    if (!launched) {
+      throw new LaunchTimeoutError(
+        `Child thread did not confirm launch within ${Math.round(timeoutMs / 1000)}s. ` +
+          "The desktop app may be slow or unavailable, or the parent thread's project could not be resolved.",
+      );
+    }
+  }
+
+  /** Best-effort wait for a thread to leave `working` (used after an interrupt). */
+  private async waitWhileWorking(threadId: string, timeoutMs: number): Promise<void> {
+    await this.waitUntil([threadId], timeoutMs, () => {
+      const state = this.deps.host.getThreadState(threadId);
+      return !state || state.status !== "working" ? true : undefined;
+    });
+  }
+
+  /**
+   * Event-driven wait: re-evaluate `poll` on each `thread-state` wake for the
+   * given ids (plus an optional `maxChunkMs` re-check cap) until it returns a
+   * value, or the deadline elapses. Returns the polled value, or `undefined` on
+   * timeout. Shared loop scaffolding for the wait_for/launch/while-working paths.
+   */
+  private async waitUntil<T>(
+    threadIds: string[],
+    timeoutMs: number,
+    poll: () => T | undefined,
+    maxChunkMs = Number.POSITIVE_INFINITY,
+  ): Promise<T | undefined> {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+    for (;;) {
+      const value = poll();
+      if (value !== undefined) return value;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return undefined;
+      await this.waitForWake(threadIds, Math.min(maxChunkMs, remaining));
+    }
+  }
+
+  /** Sleep until a `thread-state` event lands for one of `threadIds`, or `timeoutMs`. */
+  private waitForWake(threadIds: string[], timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const waiter: StatusWaiter = {
+        threadIds: new Set(threadIds),
+        wake: () => {
+          if (timer) clearTimeout(timer);
+          this.waiters.delete(waiter);
+          resolve();
+        },
+      };
+      this.waiters.add(waiter);
+      timer = setTimeout(() => waiter.wake(), Math.max(0, timeoutMs));
+    });
+  }
+}
+
+/**
+ * Turn a raw `createWorktree` git failure into actionable guidance. Branch
+ * collisions are the common trap: ticket-keyed branch names permanently poison
+ * retries, so name the branch and tell the model how to recover.
+ */
+function describeWorktreeFailure(error: unknown, branch: string): OrchestratorThreadError {
+  const message = error instanceof Error ? error.message : String(error);
+  const collision =
+    /already exists|already checked out|already used by worktree|cannot lock ref|not a valid branch name|fatal: a branch named/i.test(
+      message,
+    );
+  if (collision) {
+    return new OrchestratorThreadError(
+      `Could not create a worktree for branch "${branch}" — it likely already exists ` +
+        "(often from a previous thread for the same ticket). Retry create_thread with a different `branch` name, " +
+        "or close/clean up the earlier thread that owns this branch first. " +
+        `Underlying git error: ${message}`,
+    );
+  }
+  return new OrchestratorThreadError(
+    `Could not create a worktree for branch "${branch}": ${message}. ` +
+      "Retry create_thread with a different `branch` name.",
+  );
+}
+
+/** Best-effort plain-text projection of provider-shaped history parts. */
+function renderHistoryParts(parts: ReadonlyArray<unknown>): string {
+  const chunks: string[] = [];
+  for (const part of parts) {
+    if (typeof part === "string") {
+      if (part.trim()) chunks.push(part);
+      continue;
+    }
+    if (part && typeof part === "object") {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string" && text.trim()) {
+        chunks.push(text);
+        continue;
+      }
+      const summary = JSON.stringify(part);
+      if (summary && summary !== "{}") chunks.push(truncate(summary, 500));
+    }
+  }
+  return chunks.join("\n");
+}

--- a/src/supervisor/subagentMcp/SubagentMcpIngress.test.ts
+++ b/src/supervisor/subagentMcp/SubagentMcpIngress.test.ts
@@ -1,8 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { OrchestratorThreadManager } from "./OrchestratorThreadManager";
 import { SubagentMcpIngress } from "./SubagentMcpIngress";
 import type { SubagentRunManager } from "./SubagentRunManager";
 import { SUBAGENT_MCP_INSTRUCTIONS_BASE } from "./toolRegistry";
 import type { SpawnableAgent } from "./types";
+
+/** Inert orchestrator lane — these tests only exercise the ephemeral-run tools. */
+function makeInertOrchestrator(): OrchestratorThreadManager {
+  return new OrchestratorThreadManager({
+    adapters: new Map(),
+    emit: () => {},
+    host: {
+      getParentContext: () => undefined,
+      getThreadState: () => undefined,
+      readThreadHistory: async () => undefined,
+      sendThreadInput: async () => {},
+      interruptThread: async () => {},
+      closeThread: async () => {},
+    },
+    createWorktree: async () => ({ path: "/unused" }),
+    removeWorktree: async () => {},
+  });
+}
 
 const AGENTS: SpawnableAgent[] = [
   {
@@ -43,6 +62,7 @@ describe("SubagentMcpIngress", () => {
     spawned = rm.spawned;
     ingress = new SubagentMcpIngress({
       runManager: rm.runManager,
+      orchestrator: makeInertOrchestrator(),
       getSpawnableAgents: async () => AGENTS,
       getRoutingGuide: () => "PREFER codex for search.",
     });
@@ -91,11 +111,19 @@ describe("SubagentMcpIngress", () => {
     const names = (body.result.tools as Array<{ name: string }>).map((t) => t.name).sort();
     expect(names).toEqual([
       "cancel",
+      "close_thread",
+      "create_thread",
       "get_status",
+      "get_thread",
+      "interrupt_thread",
       "list_agents",
+      "list_threads",
+      "read_thread",
       "run_agent",
+      "send_to_thread",
       "spawn_agent",
       "wait_for_agent",
+      "wait_for_thread",
     ]);
   });
 

--- a/src/supervisor/subagentMcp/SubagentMcpIngress.ts
+++ b/src/supervisor/subagentMcp/SubagentMcpIngress.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { randomBytes, randomUUID } from "node:crypto";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
+import type { OrchestratorThreadManager } from "./OrchestratorThreadManager";
 import type { SubagentRunManager } from "./SubagentRunManager";
 import { buildSubagentInstructions, dispatchTool, isKnownToolName, TOOLS } from "./toolRegistry";
 import type { SpawnableAgent } from "./types";
@@ -12,6 +13,8 @@ export interface SubagentMcpIngressInfo {
 
 export interface SubagentMcpIngressDeps {
   runManager: SubagentRunManager;
+  /** Orchestrator lane: create/manage first-class child threads. */
+  orchestrator: OrchestratorThreadManager;
   /** Catalog of installed + authenticated agents the caller may spawn. */
   getSpawnableAgents: () => Promise<SpawnableAgent[]>;
   /** Optional user-provided routing guide appended to the MCP instructions (phase 3). */
@@ -284,6 +287,7 @@ export class SubagentMcpIngress {
         const result = await dispatchTool(name, args, {
           parentThreadId: threadId,
           runManager: this.deps.runManager,
+          orchestrator: this.deps.orchestrator,
           listSpawnableAgents: this.deps.getSpawnableAgents,
         });
         return { jsonrpc: "2.0", id, result };

--- a/src/supervisor/subagentMcp/SubagentRunManager.ts
+++ b/src/supervisor/subagentMcp/SubagentRunManager.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/shared/contracts";
 import type { AgentAdapter, StructuredSessionHandle } from "@/supervisor/agents/base";
 import { runOneShotChild, type OneShotChildHandle } from "./oneShotChild";
-import { resolveSubagentExecution } from "./types";
+import { buildInheritedChildConfig, resolveSubagentExecution } from "./types";
 import type {
   SpawnAgentRequest,
   SubagentRunHost,
@@ -156,15 +156,10 @@ export class SubagentRunManager {
     const runId = randomBytes(6).toString("hex");
     const childThreadId = `${parentThreadId}::sub::${runId}`;
 
-    // Child config inherits the parent's approval/sandbox posture but never
-    // carries subagentMcp/browserMcp — the recursion guard: children can't
-    // spawn grandchildren.
-    const childConfig: ThreadConfig = {
+    const childConfig = buildInheritedChildConfig(parent.config, {
       model,
       ...(request.effort ? { effort: request.effort } : {}),
-      ...(parent.config.approvalPolicy ? { approvalPolicy: parent.config.approvalPolicy } : {}),
-      ...(parent.config.sandboxMode ? { sandboxMode: parent.config.sandboxMode } : {}),
-    };
+    });
 
     let resolveSettled!: () => void;
     const settledPromise = new Promise<void>((resolve) => {

--- a/src/supervisor/subagentMcp/childTranscriptBuffer.ts
+++ b/src/supervisor/subagentMcp/childTranscriptBuffer.ts
@@ -1,0 +1,248 @@
+import type { RuntimeEvent } from "@/shared/contracts";
+import { truncate } from "./toolResult";
+
+/** Max finalized entries retained for `read_thread`'s buffered transcript. */
+const MAX_ENTRIES = 200;
+/** Total-character budget across retained entries (evicts oldest past this). */
+const MAX_TOTAL_CHARS = 64_000;
+/** Per-entry body cap so one huge message can't dominate the buffer. */
+const PER_ENTRY_MAX_CHARS = 4_000;
+/** Per-tool summary cap (command/path/query lines). */
+const TOOL_SUMMARY_MAX_CHARS = 500;
+/** Cap on the live "last assistant message" accumulator (feeds finalResult). */
+const LIVE_ASSISTANT_MAX_CHARS = 20_000;
+
+/** Item types whose completion is recorded as a compact tool row. */
+const TOOL_TYPES: ReadonlySet<string> = new Set([
+  "tool_call",
+  "mcp_tool_call",
+  "dynamic_tool_call",
+  "image_view",
+  "command_execution",
+  "file_change",
+  "web_search",
+]);
+
+/**
+ * One finalized row of the compact structured transcript. Provider-agnostic —
+ * derived from canonical runtime events, never provider-native payloads.
+ */
+export type TranscriptEntry =
+  | { kind: "assistant"; text: string }
+  | { kind: "user"; text: string }
+  | { kind: "tool"; name: string; status?: string; summary?: string }
+  | { kind: "error"; message: string }
+  | { kind: "turn_end"; state: string };
+
+interface OpenItem {
+  type: string;
+  text: string;
+  name?: string;
+  status?: string;
+  summary?: string;
+}
+
+/**
+ * Per-child ring buffer of a compact, structured transcript built from the
+ * canonical runtime-event stream. Serves `read_thread` for agents whose adapter
+ * has no native `readThread` (Claude/Codex/ACP) and after the session closes,
+ * and tracks the concluding assistant message so the manager can snapshot a
+ * durable final result on turn completion.
+ *
+ * Bounded by both entry count and total characters so it can't grow without
+ * limit for a long-running child.
+ */
+export class ChildTranscriptBuffer {
+  private readonly entries: TranscriptEntry[] = [];
+  private totalChars = 0;
+  private readonly open = new Map<string, OpenItem>();
+  private liveAssistantItemId: string | undefined;
+  private liveAssistantText = "";
+
+  /** Fold one canonical runtime event into the buffer. Ignores unrelated kinds. */
+  ingest(event: RuntimeEvent): void {
+    switch (event.type) {
+      case "item.started": {
+        const item: OpenItem = { type: event.itemType, text: extractContentText(event.payload) };
+        if (TOOL_TYPES.has(event.itemType)) mergeToolMeta(item, event.itemType, event.payload);
+        this.open.set(event.itemId, item);
+        if (event.itemType === "assistant_message" && item.text) {
+          this.setAssistant(event.itemId, item.text);
+        }
+        return;
+      }
+      case "item.updated": {
+        const item = this.open.get(event.itemId);
+        if (!item) return;
+        this.applyPayload(event.itemId, item, event.payload);
+        return;
+      }
+      case "item.completed": {
+        const item = this.open.get(event.itemId) ?? { type: "assistant_message", text: "" };
+        this.applyPayload(event.itemId, item, event.payload);
+        this.finalize(item);
+        this.open.delete(event.itemId);
+        return;
+      }
+      case "content.delta": {
+        if (event.stream !== "assistant_text") return;
+        const item = this.open.get(event.itemId) ?? { type: "assistant_message", text: "" };
+        item.type = "assistant_message";
+        item.text = capTail(item.text + event.delta, LIVE_ASSISTANT_MAX_CHARS);
+        this.open.set(event.itemId, item);
+        this.appendAssistantDelta(event.itemId, event.delta);
+        return;
+      }
+      case "error": {
+        const message = event.message.trim();
+        if (message) this.push({ kind: "error", message: truncate(message, PER_ENTRY_MAX_CHARS) });
+        return;
+      }
+      case "turn.completed": {
+        for (const item of this.open.values()) this.finalize(item);
+        this.open.clear();
+        if (event.state !== "completed") this.push({ kind: "turn_end", state: event.state });
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  /** Text of the most recent assistant message (the concluding message of the last turn). */
+  lastAssistantMessage(): string {
+    return this.liveAssistantText;
+  }
+
+  /** Oldest→newest slice of the finalized transcript, capped to `limit` entries. */
+  snapshot(limit: number): TranscriptEntry[] {
+    const n = Math.min(Math.max(Math.trunc(limit) || 1, 1), MAX_ENTRIES);
+    return this.entries.slice(-n);
+  }
+
+  /** Number of finalized entries currently retained. */
+  get size(): number {
+    return this.entries.length;
+  }
+
+  /** Fold an item.updated/completed payload into an open item (text, tool meta, assistant tracking). */
+  private applyPayload(itemId: string, item: OpenItem, payload: unknown): void {
+    const text = extractContentText(payload);
+    if (text) item.text = text;
+    if (TOOL_TYPES.has(item.type)) mergeToolMeta(item, item.type, payload);
+    if (item.type === "assistant_message" && text) this.setAssistant(itemId, text);
+  }
+
+  private setAssistant(itemId: string, text: string): void {
+    this.liveAssistantItemId = itemId;
+    this.liveAssistantText = capTail(text, LIVE_ASSISTANT_MAX_CHARS);
+  }
+
+  private appendAssistantDelta(itemId: string, delta: string): void {
+    if (itemId !== this.liveAssistantItemId) {
+      this.liveAssistantItemId = itemId;
+      this.liveAssistantText = delta;
+    } else {
+      this.liveAssistantText += delta;
+    }
+    this.liveAssistantText = capTail(this.liveAssistantText, LIVE_ASSISTANT_MAX_CHARS);
+  }
+
+  private finalize(item: OpenItem): void {
+    const text = item.text.trim();
+    if (item.type === "assistant_message") {
+      if (text) this.push({ kind: "assistant", text: truncate(text, PER_ENTRY_MAX_CHARS) });
+      return;
+    }
+    if (item.type === "user_message") {
+      if (text) this.push({ kind: "user", text: truncate(text, PER_ENTRY_MAX_CHARS) });
+      return;
+    }
+    if (item.type === "error") {
+      if (text) this.push({ kind: "error", message: truncate(text, PER_ENTRY_MAX_CHARS) });
+      return;
+    }
+    if (TOOL_TYPES.has(item.type)) {
+      this.push({
+        kind: "tool",
+        name: item.name ?? item.type,
+        ...(item.status ? { status: item.status } : {}),
+        ...(item.summary ? { summary: truncate(item.summary, TOOL_SUMMARY_MAX_CHARS) } : {}),
+      });
+    }
+  }
+
+  private push(entry: TranscriptEntry): void {
+    this.entries.push(entry);
+    this.totalChars += entryChars(entry);
+    while (
+      this.entries.length > 0 &&
+      (this.entries.length > MAX_ENTRIES || this.totalChars > MAX_TOTAL_CHARS)
+    ) {
+      const removed = this.entries.shift();
+      if (!removed) break;
+      this.totalChars -= entryChars(removed);
+    }
+  }
+}
+
+function entryChars(entry: TranscriptEntry): number {
+  switch (entry.kind) {
+    case "assistant":
+    case "user":
+      return entry.text.length;
+    case "error":
+      return entry.message.length;
+    case "tool":
+      return (entry.name.length + (entry.summary?.length ?? 0)) | 0;
+    case "turn_end":
+      return entry.state.length;
+  }
+}
+
+function mergeToolMeta(item: OpenItem, type: string, payload: unknown): void {
+  const p = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const status = typeof p.status === "string" ? p.status : undefined;
+  if (status) item.status = status;
+  if (type === "command_execution") {
+    item.name = "command";
+    if (typeof p.command === "string" && p.command) item.summary = p.command;
+    return;
+  }
+  if (type === "file_change") {
+    item.name = "file_change";
+    const path = typeof p.path === "string" ? p.path : undefined;
+    const changeKind = typeof p.changeKind === "string" ? p.changeKind : undefined;
+    if (path) item.summary = changeKind ? `${changeKind} ${path}` : path;
+    return;
+  }
+  if (type === "web_search") {
+    item.name = "web_search";
+    if (typeof p.query === "string" && p.query) item.summary = p.query;
+    return;
+  }
+  const name = typeof p.name === "string" && p.name ? p.name : undefined;
+  const title = typeof p.title === "string" && p.title ? p.title : undefined;
+  if (name) item.name = name;
+  else if (title) item.name = title;
+  if (title && title !== item.name) item.summary = title;
+}
+
+/** Join canonical text content blocks (`{ kind: "text", text }`) into a plain string. */
+function extractContentText(payload: unknown): string {
+  if (!payload || typeof payload !== "object") return "";
+  const content = (payload as { content?: unknown }).content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (block && typeof block === "object" && (block as { kind?: unknown }).kind === "text") {
+      const text = (block as { text?: unknown }).text;
+      if (typeof text === "string" && text) parts.push(text);
+    }
+  }
+  return parts.join("");
+}
+
+function capTail(text: string, maxChars: number): string {
+  return text.length > maxChars ? text.slice(-maxChars) : text;
+}

--- a/src/supervisor/subagentMcp/orchestratorTools.ts
+++ b/src/supervisor/subagentMcp/orchestratorTools.ts
@@ -1,0 +1,296 @@
+import { OrchestratorThreadError } from "./OrchestratorThreadManager";
+import type {
+  ChildThreadSummary,
+  CreateChildThreadRequest,
+  OrchestratorThreadManager,
+} from "./OrchestratorThreadManager";
+import { errorResult, jsonResult, parseWaitTimeoutMs } from "./toolResult";
+import type { McpToolResult, ToolSpec } from "./types";
+
+/**
+ * Orchestrator-lane tool catalog: create/manage REAL first-class app threads
+ * (persisted, sidebar-visible, optionally worktree-backed), as opposed to the
+ * ephemeral spawn_agent/run_agent lane. Dispatched by the shared tool registry.
+ */
+export const ORCHESTRATOR_TOOLS: ToolSpec[] = [
+  {
+    name: "create_thread",
+    description:
+      "Create a REAL app thread (visible to the user in the sidebar) running the given agent, optionally in its own fresh git worktree, and start it on the prompt. Returns as soon as the thread is launched — it keeps working in the background; monitor it with wait_for_thread / get_thread. Use this lane for long-lived parallel work items (e.g. one ticket per thread); use spawn_agent/run_agent for quick ephemeral helpers instead. Caps & rules: at most 8 LIVE child threads per parent — a slot frees only via close_thread or the child's session ending (a finished-but-not-closed child still holds its slot). Passing `branch` or `base_branch` implies `worktree: true`. The child INHERITS this thread's approval policy + sandbox mode (you cannot override them per call), so it runs as autonomously — or as gated — as you do. On close_thread the sidebar thread row + its worktree remain for the human (closing frees the slot, it does NOT delete work).",
+    inputSchema: {
+      type: "object",
+      required: ["agent", "prompt"],
+      properties: {
+        agent: {
+          type: "string",
+          description: "Agent kind from list_agents (structured-execution agents only).",
+        },
+        prompt: { type: "string", description: "Self-contained task for the new thread." },
+        title: {
+          type: "string",
+          description: "Optional thread title shown in the sidebar. Defaults from the prompt.",
+        },
+        model: {
+          type: "string",
+          description: "Model value from list_agents. Omit for the agent default.",
+        },
+        effort: { type: "string", description: "Optional effort/reasoning level." },
+        worktree: {
+          type: "boolean",
+          description:
+            "Create a dedicated git worktree (new branch) for this thread so its changes stay isolated. Default false.",
+        },
+        branch: {
+          type: "string",
+          description:
+            "Custom branch name for the worktree (implies worktree=true). Auto-generated when omitted.",
+        },
+        base_branch: {
+          type: "string",
+          description:
+            "Branch/ref to fork the worktree from (implies worktree=true). Defaults to the current HEAD.",
+        },
+      },
+    },
+  },
+  {
+    name: "list_threads",
+    description:
+      "List the threads you created via create_thread, with their current status and attention state.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "get_thread",
+    description:
+      "Check one of your created threads without blocking: current status, attention, error reason (when it failed), created_at / turn_started_at timestamps, a short tail of recent assistant output, and — once a turn has finished — its durable final_result (the concluding answer, kept even after close_thread). Cheap first step when a thread reports error/needs_reply: read the error + recent output here before escalating to read_thread.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id"],
+      properties: { thread_id: { type: "string" } },
+    },
+  },
+  {
+    name: "read_thread",
+    description:
+      "Read the tail of a created thread's transcript (last N entries, bodies truncated). Prefers the agent's native transcript when the session is live; otherwise returns a compact structured transcript (assistant/user text, tool calls, errors) reconstructed from the thread's events — so it works for every agent and even after close_thread. The user can watch the thread live in the app, so avoid polling this aggressively; use get_thread for a quick status/error check first.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id"],
+      properties: {
+        thread_id: { type: "string" },
+        last_messages: {
+          type: "number",
+          description: "How many trailing messages to return (default 20, max 100).",
+        },
+      },
+    },
+  },
+  {
+    name: "send_to_thread",
+    description:
+      "Send a message to a created thread. Starts a new turn on a settled thread, answers a thread that is waiting on your reply (needs_reply), or steers a working thread when the agent supports it; with interrupt=true, interrupts the current turn first and then sends. It does NOT resolve needs_approval tool-permission prompts (a human must approve those in the app) and errors if the thread is stuck there. Errors when the thread is busy and cannot be steered.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id", "message"],
+      properties: {
+        thread_id: { type: "string" },
+        message: { type: "string", description: "Message to deliver to the thread." },
+        interrupt: {
+          type: "boolean",
+          description: "Interrupt the thread's current turn before sending. Default false.",
+        },
+      },
+    },
+  },
+  {
+    name: "wait_for_thread",
+    description:
+      "Block until ANY of the listed created threads settles (idle | finished | needs_approval | needs_reply | error | inactive) or the timeout elapses. Returns `statuses` (per thread: status, attention, and error when it failed), `settled` (the ids that are settled — i.e. which threads woke you), and `timed_out`. Returns immediately when one is already settled; call again with the still-running ids to keep waiting. Waiting does NOT free a create_thread slot — close_thread does.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_ids"],
+      properties: {
+        thread_ids: {
+          type: "array",
+          items: { type: "string" },
+          minItems: 1,
+          maxItems: 8,
+          description: "Thread ids from create_thread (1-8).",
+        },
+        timeout_s: {
+          type: "number",
+          description:
+            "Max seconds to wait (default 120, capped at 240). On timeout, call wait_for_thread again to keep waiting.",
+        },
+      },
+    },
+  },
+  {
+    name: "interrupt_thread",
+    description:
+      "Interrupt a created thread's current turn. The thread stays alive and addressable (send_to_thread can start a new turn).",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id"],
+      properties: { thread_id: { type: "string" } },
+    },
+  },
+  {
+    name: "close_thread",
+    description:
+      "Close a finished child thread's runtime session to FREE ITS CAPACITY SLOT so you can create_thread again (you can have at most 8 live children per parent, and a finished-but-not-closed child keeps holding its slot). Do this once you've collected a thread's result (get_thread returns its final_result even after close). The sidebar thread row and its git worktree REMAIN for the human — this frees the slot, it does not delete the work. Mirrors closing a background worker when its task is done.",
+    inputSchema: {
+      type: "object",
+      required: ["thread_id"],
+      properties: { thread_id: { type: "string" } },
+    },
+  },
+];
+
+const ORCHESTRATOR_TOOL_NAMES = new Set(ORCHESTRATOR_TOOLS.map((tool) => tool.name));
+
+export function isOrchestratorToolName(name: string): boolean {
+  return ORCHESTRATOR_TOOL_NAMES.has(name);
+}
+
+export interface OrchestratorToolContext {
+  parentThreadId: string;
+  orchestrator: OrchestratorThreadManager;
+}
+
+function parseCreateThreadRequest(args: Record<string, unknown>): CreateChildThreadRequest {
+  const agent = typeof args.agent === "string" ? args.agent : "";
+  const prompt = typeof args.prompt === "string" ? args.prompt : "";
+  if (!agent) throw new OrchestratorThreadError("agent is required");
+  if (!prompt.trim()) throw new OrchestratorThreadError("prompt is required");
+  return {
+    agent,
+    prompt,
+    ...(typeof args.title === "string" ? { title: args.title } : {}),
+    ...(typeof args.model === "string" ? { model: args.model } : {}),
+    ...(typeof args.effort === "string" ? { effort: args.effort } : {}),
+    ...(args.worktree === true ? { worktree: true } : {}),
+    ...(typeof args.branch === "string" && args.branch.trim() ? { branch: args.branch } : {}),
+    ...(typeof args.base_branch === "string" && args.base_branch.trim()
+      ? { baseBranch: args.base_branch }
+      : {}),
+  };
+}
+
+function requireThreadId(args: Record<string, unknown>): string {
+  const threadId = typeof args.thread_id === "string" ? args.thread_id : "";
+  if (!threadId) throw new OrchestratorThreadError("thread_id is required");
+  return threadId;
+}
+
+/**
+ * Dispatch an orchestrator-lane tools/call. Mirrors the base registry's
+ * contract: never throws — validation failures return isError results.
+ */
+export async function dispatchOrchestratorTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: OrchestratorToolContext,
+): Promise<McpToolResult> {
+  try {
+    switch (name) {
+      case "create_thread": {
+        const request = parseCreateThreadRequest(args);
+        const created = await ctx.orchestrator.createThread(ctx.parentThreadId, request);
+        return jsonResult({
+          thread_id: created.threadId,
+          title: created.title,
+          ...(created.worktreePath ? { worktree_path: created.worktreePath } : {}),
+          ...(created.branch ? { branch: created.branch } : {}),
+        });
+      }
+      case "list_threads":
+        return jsonResult(ctx.orchestrator.listThreads(ctx.parentThreadId).map(toWireSummary));
+      case "get_thread": {
+        const summary = ctx.orchestrator.getThread(ctx.parentThreadId, requireThreadId(args));
+        return jsonResult({
+          ...toWireSummary(summary),
+          ...(summary.recentOutput ? { recent_output: summary.recentOutput } : {}),
+          ...(summary.finalResult ? { final_result: summary.finalResult } : {}),
+        });
+      }
+      case "read_thread": {
+        const lastMessages =
+          typeof args.last_messages === "number" && Number.isFinite(args.last_messages)
+            ? args.last_messages
+            : 20;
+        const result = await ctx.orchestrator.readThread(
+          ctx.parentThreadId,
+          requireThreadId(args),
+          lastMessages,
+        );
+        if (result.source === "native") {
+          return jsonResult({
+            status: result.status,
+            source: "native",
+            message_count: result.messageCount,
+            messages: result.messages,
+          });
+        }
+        if (result.source === "buffer") {
+          return jsonResult({
+            status: result.status,
+            source: "buffer",
+            entry_count: result.entryCount,
+            entries: result.entries,
+          });
+        }
+        return jsonResult({ status: result.status, source: "note", note: result.note });
+      }
+      case "send_to_thread": {
+        const message = typeof args.message === "string" ? args.message : "";
+        if (!message.trim()) return errorResult("message is required");
+        const { delivery } = await ctx.orchestrator.sendToThread(
+          ctx.parentThreadId,
+          requireThreadId(args),
+          message,
+          args.interrupt === true,
+        );
+        return jsonResult({ ok: true, delivery });
+      }
+      case "wait_for_thread": {
+        const threadIds = Array.isArray(args.thread_ids)
+          ? args.thread_ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+          : [];
+        const { statuses, settled, timedOut } = await ctx.orchestrator.waitForThreads(
+          ctx.parentThreadId,
+          threadIds,
+          parseWaitTimeoutMs(args.timeout_s),
+        );
+        return jsonResult({ statuses, settled, timed_out: timedOut });
+      }
+      case "interrupt_thread": {
+        await ctx.orchestrator.interruptThread(ctx.parentThreadId, requireThreadId(args));
+        return jsonResult({ ok: true });
+      }
+      case "close_thread": {
+        await ctx.orchestrator.closeThread(ctx.parentThreadId, requireThreadId(args));
+        return jsonResult({ ok: true });
+      }
+      default:
+        return errorResult(`Unknown tool: ${name}`);
+    }
+  } catch (error) {
+    return errorResult(error instanceof Error ? error.message : String(error));
+  }
+}
+
+function toWireSummary(summary: ChildThreadSummary): Record<string, unknown> {
+  return {
+    thread_id: summary.threadId,
+    title: summary.title,
+    agent: summary.agent,
+    status: summary.status,
+    attention: summary.attention,
+    created_at: summary.createdAt,
+    ...(summary.worktreePath ? { worktree_path: summary.worktreePath } : {}),
+    ...(summary.branch ? { branch: summary.branch } : {}),
+    ...(summary.error ? { error: summary.error } : {}),
+    ...(summary.turnStartedAt ? { turn_started_at: summary.turnStartedAt } : {}),
+  };
+}

--- a/src/supervisor/subagentMcp/toolRegistry.test.ts
+++ b/src/supervisor/subagentMcp/toolRegistry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { AgentKind, AgentStatus } from "@/shared/contracts";
 import type { AgentAdapter } from "@/supervisor/agents/base";
-import { buildSpawnableAgents, classifyModelTier } from "./toolRegistry";
+import type { OrchestratorThreadManager } from "./OrchestratorThreadManager";
+import type { SubagentRunManager } from "./SubagentRunManager";
+import { buildSpawnableAgents, classifyModelTier, dispatchTool, TOOLS } from "./toolRegistry";
+import type { SubagentToolContext } from "./toolRegistry";
 
 describe("classifyModelTier", () => {
   it.each([
@@ -100,5 +103,188 @@ describe("buildSpawnableAgents", () => {
       ["claude" as AgentKind, {} as unknown as AgentAdapter],
     ]);
     expect(buildSpawnableAgents(adapters, [makeStatus()])).toEqual([]);
+  });
+});
+
+const ORCHESTRATOR_TOOL_NAMES = [
+  "create_thread",
+  "list_threads",
+  "get_thread",
+  "read_thread",
+  "send_to_thread",
+  "wait_for_thread",
+  "interrupt_thread",
+  "close_thread",
+] as const;
+
+function makeToolContext(orchestrator: Partial<OrchestratorThreadManager>): {
+  ctx: SubagentToolContext;
+} {
+  return {
+    ctx: {
+      parentThreadId: "parent-1",
+      runManager: {} as unknown as SubagentRunManager,
+      orchestrator: orchestrator as unknown as OrchestratorThreadManager,
+      listSpawnableAgents: async () => [],
+    },
+  };
+}
+
+function resultText(result: { content: Array<{ text: string }> }): string {
+  return result.content[0]?.text ?? "";
+}
+
+describe("orchestrator tool registration", () => {
+  it("registers all orchestrator tools alongside the existing run tools", () => {
+    const names = new Set(TOOLS.map((tool) => tool.name));
+    for (const name of ORCHESTRATOR_TOOL_NAMES) expect(names.has(name)).toBe(true);
+    for (const name of [
+      "list_agents",
+      "spawn_agent",
+      "wait_for_agent",
+      "run_agent",
+      "get_status",
+      "cancel",
+    ]) {
+      expect(names.has(name)).toBe(true);
+    }
+  });
+
+  it("declares required fields on the new tool schemas", () => {
+    const byName = new Map(TOOLS.map((tool) => [tool.name, tool]));
+    expect(byName.get("create_thread")!.inputSchema).toMatchObject({
+      required: ["agent", "prompt"],
+    });
+    expect(byName.get("get_thread")!.inputSchema).toMatchObject({ required: ["thread_id"] });
+    expect(byName.get("read_thread")!.inputSchema).toMatchObject({ required: ["thread_id"] });
+    expect(byName.get("send_to_thread")!.inputSchema).toMatchObject({
+      required: ["thread_id", "message"],
+    });
+    expect(byName.get("wait_for_thread")!.inputSchema).toMatchObject({
+      required: ["thread_ids"],
+    });
+    expect(byName.get("interrupt_thread")!.inputSchema).toMatchObject({
+      required: ["thread_id"],
+    });
+  });
+});
+
+describe("orchestrator tool dispatch", () => {
+  it("routes create_thread to the manager and returns snake_case fields", async () => {
+    const calls: Array<{ parent: string; request: unknown }> = [];
+    const { ctx } = makeToolContext({
+      createThread: async (parent: string, request: unknown) => {
+        calls.push({ parent, request });
+        return {
+          threadId: "child-1",
+          title: "Ticket",
+          worktreePath: "/tmp/wt/x",
+          branch: "lightcode/x",
+        };
+      },
+    } as Partial<OrchestratorThreadManager>);
+    const result = await dispatchTool(
+      "create_thread",
+      { agent: "codex", prompt: "do it", worktree: true },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(resultText(result))).toEqual({
+      thread_id: "child-1",
+      title: "Ticket",
+      worktree_path: "/tmp/wt/x",
+      branch: "lightcode/x",
+    });
+    expect(calls).toEqual([
+      { parent: "parent-1", request: { agent: "codex", prompt: "do it", worktree: true } },
+    ]);
+  });
+
+  it("returns tool errors (not throws) for missing required arguments", async () => {
+    const { ctx } = makeToolContext({});
+    for (const [name, args] of [
+      ["create_thread", { prompt: "x" }],
+      ["create_thread", { agent: "codex" }],
+      ["get_thread", {}],
+      ["read_thread", {}],
+      ["send_to_thread", { thread_id: "t" }],
+      ["interrupt_thread", {}],
+    ] as const) {
+      const result = await dispatchTool(name, args as Record<string, unknown>, ctx);
+      expect(result.isError).toBe(true);
+    }
+  });
+
+  it("maps wait_for_thread args (id filtering + timeout clamp) onto the manager", async () => {
+    const calls: Array<{ ids: string[]; timeoutMs: number }> = [];
+    const { ctx } = makeToolContext({
+      waitForThreads: async (_parent: string, ids: string[], timeoutMs: number) => {
+        calls.push({ ids, timeoutMs });
+        return {
+          statuses: { a: { status: "idle" as const, attention: "none" as const } },
+          settled: ["a"],
+          timedOut: false,
+        };
+      },
+    } as Partial<OrchestratorThreadManager>);
+    const result = await dispatchTool(
+      "wait_for_thread",
+      { thread_ids: ["a", 42, "", "b"], timeout_s: 9_999 },
+      ctx,
+    );
+    expect(JSON.parse(resultText(result))).toEqual({
+      statuses: { a: { status: "idle", attention: "none" } },
+      settled: ["a"],
+      timed_out: false,
+    });
+    expect(calls).toEqual([{ ids: ["a", "b"], timeoutMs: 240_000 }]);
+  });
+
+  it("surfaces manager errors as MCP tool errors", async () => {
+    const { ctx } = makeToolContext({
+      getThread: () => {
+        throw new Error("Unknown thread_id: nope");
+      },
+    } as Partial<OrchestratorThreadManager>);
+    const result = await dispatchTool("get_thread", { thread_id: "nope" }, ctx);
+    expect(result.isError).toBe(true);
+    expect(resultText(result)).toContain("Unknown thread_id");
+  });
+
+  it("routes send_to_thread and interrupt_thread with the caller's parent id", async () => {
+    const sends: unknown[] = [];
+    const interrupts: unknown[] = [];
+    const { ctx } = makeToolContext({
+      sendToThread: async (...args: unknown[]) => {
+        sends.push(args);
+        return { delivery: "steered" as const };
+      },
+      interruptThread: async (...args: unknown[]) => {
+        interrupts.push(args);
+      },
+    } as Partial<OrchestratorThreadManager>);
+    const sendResult = await dispatchTool(
+      "send_to_thread",
+      { thread_id: "child-1", message: "hi", interrupt: true },
+      ctx,
+    );
+    expect(JSON.parse(resultText(sendResult))).toEqual({ ok: true, delivery: "steered" });
+    expect(sends).toEqual([["parent-1", "child-1", "hi", true]]);
+
+    const interruptResult = await dispatchTool("interrupt_thread", { thread_id: "child-1" }, ctx);
+    expect(JSON.parse(resultText(interruptResult))).toEqual({ ok: true });
+    expect(interrupts).toEqual([["parent-1", "child-1"]]);
+  });
+
+  it("routes close_thread with the caller's parent id", async () => {
+    const closes: unknown[] = [];
+    const { ctx } = makeToolContext({
+      closeThread: async (...args: unknown[]) => {
+        closes.push(args);
+      },
+    } as Partial<OrchestratorThreadManager>);
+    const result = await dispatchTool("close_thread", { thread_id: "child-1" }, ctx);
+    expect(JSON.parse(resultText(result))).toEqual({ ok: true });
+    expect(closes).toEqual([["parent-1", "child-1"]]);
   });
 });

--- a/src/supervisor/subagentMcp/toolRegistry.ts
+++ b/src/supervisor/subagentMcp/toolRegistry.ts
@@ -1,17 +1,24 @@
 import type { AgentKind, AgentStatus } from "@/shared/contracts";
 import type { AgentAdapter } from "@/supervisor/agents/base";
+import type { OrchestratorThreadManager } from "./OrchestratorThreadManager";
 import {
-  DEFAULT_WAIT_TIMEOUT_MS,
-  MAX_WAIT_TIMEOUT_MS,
-  SubagentSpawnError,
-} from "./SubagentRunManager";
+  dispatchOrchestratorTool,
+  isOrchestratorToolName,
+  ORCHESTRATOR_TOOLS,
+} from "./orchestratorTools";
+import { SubagentSpawnError } from "./SubagentRunManager";
 import type { SubagentRunManager } from "./SubagentRunManager";
+import { errorResult, jsonResult, parseWaitTimeoutMs, TIMEOUT_S_DESCRIPTION } from "./toolResult";
 import { resolveSubagentExecution } from "./types";
-import type { McpToolResult, ModelTier, SpawnableAgent, SpawnAgentRequest } from "./types";
+import type {
+  McpToolResult,
+  ModelTier,
+  SpawnableAgent,
+  SpawnAgentRequest,
+  ToolSpec,
+} from "./types";
 
-/** Shared `timeout_s` schema description for `wait_for_agent` and `run_agent`. */
-const TIMEOUT_S_DESCRIPTION =
-  'Max seconds to wait (capped at 240). On timeout, status is "running" — call wait_for_agent again to keep waiting.';
+export type { ToolSpec } from "./types";
 
 const FAST_CHEAP_KEYWORDS = ["haiku", "mini", "nano", "lite", "flash", "small", "spark", "fast"];
 const MAX_CAPABILITY_KEYWORDS = ["opus", "fable", "pro", "max", "ultra", "big"];
@@ -36,20 +43,18 @@ export function classifyModelTier(modelId: string, modelLabel: string): ModelTie
   return "balanced";
 }
 
-export interface ToolSpec {
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-}
-
 /** Base routing guidance always included in the MCP `initialize` instructions. */
 export const SUBAGENT_MCP_INSTRUCTIONS_BASE = [
   "Use the subagents MCP server to delegate work to the other AI agents connected to this Lightcode session.",
   "Call list_agents first to see which agents and models are available.",
+  "There are two delegation lanes.",
+  "Lightweight subagent runs (spawn_agent, run_agent, wait_for_agent, get_status, cancel): quick, ephemeral helpers whose output streams into your own thread and disappears afterwards — best for search, summarization, bulk edits, and one-off checks.",
+  "Full threads (create_thread, list_threads, get_thread, read_thread, send_to_thread, wait_for_thread, interrupt_thread): long-lived first-class app threads the user sees in the sidebar, each optionally in its own git worktree — best for parallel work items (e.g. one ticket or feature per thread) that need isolation, review, or follow-up conversation.",
   "Routing: prefer fast/cheap agents+models for search, bulk edits, and summarization; reserve the strongest agents for implementation and review.",
-  "Run independent tasks concurrently as parallel spawn_agent calls, then collect them with wait_for_agent.",
+  "Run independent tasks concurrently as parallel spawn_agent or create_thread calls, then collect them with wait_for_agent / wait_for_thread.",
   "Use run_agent for a single blocking delegation; use spawn_agent + wait_for_agent for long tasks or fan-out.",
-  "Give each subagent a self-contained prompt — it does not share your conversation context.",
+  "Give each subagent or child thread a self-contained prompt — it does not share your conversation context.",
+  "The human can watch child threads live in the app UI, so do not poll read_thread/get_thread aggressively; rely on wait_for_thread and read transcripts only when you need the details.",
 ].join(" ");
 
 export function buildSubagentInstructions(routingGuide?: string): string {
@@ -57,7 +62,7 @@ export function buildSubagentInstructions(routingGuide?: string): string {
   return guide ? `${SUBAGENT_MCP_INSTRUCTIONS_BASE}\n\n${guide}` : SUBAGENT_MCP_INSTRUCTIONS_BASE;
 }
 
-export const TOOLS: ToolSpec[] = [
+const BASE_TOOLS: ToolSpec[] = [
   {
     name: "list_agents",
     description:
@@ -143,6 +148,9 @@ export const TOOLS: ToolSpec[] = [
   },
 ];
 
+/** Full catalog: ephemeral subagent runs + the orchestrator thread lane. */
+export const TOOLS: ToolSpec[] = [...BASE_TOOLS, ...ORCHESTRATOR_TOOLS];
+
 export const TOOL_NAMES = new Set(TOOLS.map((t) => t.name));
 
 export function isKnownToolName(name: string): boolean {
@@ -194,15 +202,8 @@ export function buildSpawnableAgents(
 export interface SubagentToolContext {
   parentThreadId: string;
   runManager: SubagentRunManager;
+  orchestrator: OrchestratorThreadManager;
   listSpawnableAgents: () => Promise<SpawnableAgent[]>;
-}
-
-function jsonResult(value: unknown): McpToolResult {
-  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
-}
-
-function errorResult(message: string): McpToolResult {
-  return { content: [{ type: "text", text: message }], isError: true };
 }
 
 function parseSpawnRequest(args: Record<string, unknown>): SpawnAgentRequest {
@@ -217,15 +218,6 @@ function parseSpawnRequest(args: Record<string, unknown>): SpawnAgentRequest {
     ...(typeof args.effort === "string" ? { effort: args.effort } : {}),
     ...(typeof args.name === "string" ? { name: args.name } : {}),
   };
-}
-
-/** Caller-supplied `timeout_s` → ms, clamped to [0, {@link MAX_WAIT_TIMEOUT_MS}]. */
-function parseWaitTimeoutMs(value: unknown): number {
-  const requestedMs =
-    typeof value === "number" && Number.isFinite(value)
-      ? Math.max(0, value * 1000)
-      : DEFAULT_WAIT_TIMEOUT_MS;
-  return Math.min(requestedMs, MAX_WAIT_TIMEOUT_MS);
 }
 
 /** Dispatch a tools/call. Never throws — validation failures return isError results. */
@@ -267,6 +259,12 @@ export async function dispatchTool(
         return jsonResult({ ok: true });
       }
       default:
+        if (isOrchestratorToolName(name)) {
+          return await dispatchOrchestratorTool(name, args, {
+            parentThreadId: ctx.parentThreadId,
+            orchestrator: ctx.orchestrator,
+          });
+        }
         return errorResult(`Unknown tool: ${name}`);
     }
   } catch (error) {

--- a/src/supervisor/subagentMcp/toolResult.ts
+++ b/src/supervisor/subagentMcp/toolResult.ts
@@ -1,0 +1,29 @@
+import { DEFAULT_WAIT_TIMEOUT_MS, MAX_WAIT_TIMEOUT_MS } from "./SubagentRunManager";
+import type { McpToolResult } from "./types";
+
+/** Shared `timeout_s` schema description for the blocking wait tools. */
+export const TIMEOUT_S_DESCRIPTION =
+  'Max seconds to wait (capped at 240). On timeout, status is "running" — call wait_for_agent again to keep waiting.';
+
+export function jsonResult(value: unknown): McpToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+export function errorResult(message: string): McpToolResult {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
+/** Cap `text` at `maxChars`, appending an ellipsis marker when truncated. */
+export function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}… [truncated]`;
+}
+
+/** Caller-supplied `timeout_s` → ms, clamped to [0, {@link MAX_WAIT_TIMEOUT_MS}]. */
+export function parseWaitTimeoutMs(value: unknown): number {
+  const requestedMs =
+    typeof value === "number" && Number.isFinite(value)
+      ? Math.max(0, value * 1000)
+      : DEFAULT_WAIT_TIMEOUT_MS;
+  return Math.min(requestedMs, MAX_WAIT_TIMEOUT_MS);
+}

--- a/src/supervisor/subagentMcp/types.ts
+++ b/src/supervisor/subagentMcp/types.ts
@@ -47,6 +47,24 @@ export function resolveSubagentExecution(adapter: {
   return undefined;
 }
 
+/**
+ * Build a child thread config that inherits the parent's approval/sandbox
+ * posture but NEVER carries `subagentMcp`/`browserMcp` — the recursion guard so
+ * children can't spawn grandchildren. Shared by both subagent lanes (ephemeral
+ * runs and orchestrator threads) so the inherited posture can't drift between them.
+ */
+export function buildInheritedChildConfig(
+  parentConfig: ThreadConfig,
+  child: { model: string; effort?: string },
+): ThreadConfig {
+  return {
+    model: child.model,
+    ...(child.effort ? { effort: child.effort } : {}),
+    ...(parentConfig.approvalPolicy ? { approvalPolicy: parentConfig.approvalPolicy } : {}),
+    ...(parentConfig.sandboxMode ? { sandboxMode: parentConfig.sandboxMode } : {}),
+  };
+}
+
 export interface SpawnableAgent {
   kind: string;
   label: string;
@@ -93,4 +111,11 @@ export interface McpTextContent {
 export interface McpToolResult {
   content: McpTextContent[];
   isError?: boolean;
+}
+
+/** An MCP tool catalog entry (name + description + JSON input schema). */
+export interface ToolSpec {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
 }

--- a/tests/integration/opencode-subagent-mcp.integration.test.ts
+++ b/tests/integration/opencode-subagent-mcp.integration.test.ts
@@ -10,6 +10,7 @@ import {
   resolveOpenCodeSessionDirectory,
   shutdownSpawnedOpenCodeServers,
 } from "@/supervisor/agents/opencode/sdkClient";
+import { OrchestratorThreadManager } from "@/supervisor/subagentMcp/OrchestratorThreadManager";
 import { SubagentMcpIngress } from "@/supervisor/subagentMcp/SubagentMcpIngress";
 import { SubagentRunManager } from "@/supervisor/subagentMcp/SubagentRunManager";
 import type { SpawnableAgent } from "@/supervisor/subagentMcp/types";
@@ -73,6 +74,20 @@ describe("opencode hosts subagents MCP (live)", () => {
 
     ingress = new SubagentMcpIngress({
       runManager,
+      orchestrator: new OrchestratorThreadManager({
+        adapters: new Map(),
+        emit: () => {},
+        host: {
+          getParentContext: () => undefined,
+          getThreadState: () => undefined,
+          readThreadHistory: async () => undefined,
+          sendThreadInput: async () => {},
+          interruptThread: async () => {},
+          closeThread: async () => {},
+        },
+        createWorktree: async () => ({ path: "/unused" }),
+        removeWorktree: async () => {},
+      }),
       getSpawnableAgents: async () => spawnable,
       getRoutingGuide: () => "Prefer opencode/big-pickle for everything in this test.",
     });

--- a/tests/integration/subagent-mcp.integration.test.ts
+++ b/tests/integration/subagent-mcp.integration.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { AgentKind, ProjectLocation, RuntimeEvent } from "@/shared/contracts";
 import type { AgentAdapter } from "@/supervisor/agents/base";
 import { createAgentRegistry } from "@/supervisor/agents/registry";
+import { OrchestratorThreadManager } from "@/supervisor/subagentMcp/OrchestratorThreadManager";
 import { SubagentMcpIngress } from "@/supervisor/subagentMcp/SubagentMcpIngress";
 import { SubagentRunManager } from "@/supervisor/subagentMcp/SubagentRunManager";
 import type { SpawnableAgent } from "@/supervisor/subagentMcp/types";
@@ -69,6 +70,20 @@ describe("subagents MCP (live)", () => {
 
     ingress = new SubagentMcpIngress({
       runManager,
+      orchestrator: new OrchestratorThreadManager({
+        adapters: new Map(),
+        emit: () => {},
+        host: {
+          getParentContext: () => undefined,
+          getThreadState: () => undefined,
+          readThreadHistory: async () => undefined,
+          sendThreadInput: async () => {},
+          interruptThread: async () => {},
+          closeThread: async () => {},
+        },
+        createWorktree: async () => ({ path: "/unused" }),
+        removeWorktree: async () => {},
+      }),
       getSpawnableAgents: async () => spawnable,
       getRoutingGuide: () => ROUTING_GUIDE,
     });


### PR DESCRIPTION
- Tickets: none found
- Add first-class orchestrator thread support for subagent MCP, including child-thread lifecycle, transcript buffering, tool routing, and runtime IPC integration.
- Extend Cursor ACP handling so task/subagent extensions are normalized into canonical runtime events and shown consistently in progress UI.
- Tighten thread/title handling in the renderer and shared contracts, including explicit thread titles and shared worktree branch generation.
- Improve diff and usage handling with safer large-line diff behavior, cleaner tool edit rendering, updated Cursor usage parsing, and WSL Browser MCP upstream resolution.