### PR TITLE
Fix sidebar manual group collapse defaults

### DIFF
--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -135,6 +135,7 @@ export function switchToAdjacentThread(current: Thread, direction: "next" | "pre
     projectThreads,
     sortMode: usePanelStore.getState().threadSortMode,
     collapsedWorktrees: {},
+    expandAllGroups: true,
     visibleLimit: Number.MAX_SAFE_INTEGER,
   }).flatMap((row) => (row.kind === "thread" ? [row.thread.id] : []));
 

--- a/src/renderer/state/sidebarUiStore.ts
+++ b/src/renderer/state/sidebarUiStore.ts
@@ -1,7 +1,10 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { captureProductEvent } from "@/renderer/analytics/posthog";
-import { SIDEBAR_THREAD_LIST_PAGE_SIZE } from "@/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows";
+import {
+  isSidebarGroupCollapsed,
+  SIDEBAR_THREAD_LIST_PAGE_SIZE,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows";
 
 /**
  * Legacy hand-rolled key, read once as the initial seed so existing installs
@@ -70,13 +73,13 @@ export const useSidebarUiStore = create<SidebarUiState>()(
         }),
       setWorktreeCollapsed: (key, collapsed) =>
         set((state) => {
-          if ((state.collapsedWorktrees[key] ?? false) === collapsed) return {};
+          if (isSidebarGroupCollapsed(state.collapsedWorktrees, key) === collapsed) return {};
           captureProductEvent("ui.worktree_group_toggled", { collapsed });
           return { collapsedWorktrees: { ...state.collapsedWorktrees, [key]: collapsed } };
         }),
       toggleWorktreeCollapsed: (key) =>
         set((state) => {
-          const collapsed = !(state.collapsedWorktrees[key] ?? false);
+          const collapsed = !isSidebarGroupCollapsed(state.collapsedWorktrees, key);
           captureProductEvent("ui.worktree_group_toggled", { collapsed });
           return {
             collapsedWorktrees: {
@@ -118,5 +121,5 @@ export function useThreadListLimit(projectId: string): number {
 }
 
 export function useIsWorktreeCollapsed(key: string): boolean {
-  return useSidebarUiStore((s) => s.collapsedWorktrees[key] ?? false);
+  return useSidebarUiStore((s) => isSidebarGroupCollapsed(s.collapsedWorktrees, key));
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
@@ -44,6 +44,18 @@ export const SIDEBAR_THREAD_LIST_PAGE_SIZE = 10;
 
 const EMPTY_THREAD_ID_SET: ReadonlySet<string> = new Set();
 
+/**
+ * Collapse state for both group kinds lives in one map: worktree groups are
+ * keyed by worktree path and start collapsed on launch; manual thread groups
+ * are keyed `group:<groupId>` and start expanded.
+ */
+export function isSidebarGroupCollapsed(
+  collapsedWorktrees: Record<string, boolean>,
+  key: string,
+): boolean {
+  return collapsedWorktrees[key] ?? !key.startsWith("group:");
+}
+
 /** Pinned or attention-needing threads are never hidden behind "See more". */
 function threadIsProtected(thread: Thread, liveWorkflowThreadIds: ReadonlySet<string>): boolean {
   return (
@@ -89,7 +101,7 @@ function pushEntryRows(
     projectId: string;
     dndGroup: string;
     dndDisabled: boolean;
-    collapsedWorktrees: Record<string, boolean>;
+    isCollapsed: (key: string) => boolean;
     nextUngroupedIndex: () => number;
   },
 ) {
@@ -117,7 +129,7 @@ function pushEntryRows(
       sortableGroup: input.dndGroup,
       sortDisabled: input.dndDisabled,
     });
-    if (!(input.collapsedWorktrees[entry.group.worktreePath] ?? false)) {
+    if (!input.isCollapsed(entry.group.worktreePath)) {
       entry.group.threads.forEach((thread, threadIndex) => {
         rows.push({
           kind: "thread",
@@ -139,7 +151,7 @@ function pushEntryRows(
     key: `group:${groupKey}`,
     entry,
   });
-  if (!(input.collapsedWorktrees[`group:${groupKey}`] ?? false)) {
+  if (!input.isCollapsed(`group:${groupKey}`)) {
     entry.group.threads.forEach((thread, threadIndex) => {
       rows.push({
         kind: "thread",
@@ -159,6 +171,8 @@ export function buildSidebarProjectRows(input: {
   projectThreads: Thread[];
   sortMode: ThreadSortMode;
   collapsedWorktrees: Record<string, boolean>;
+  /** Treat every group as expanded regardless of collapse state (keyboard navigation). */
+  expandAllGroups?: boolean;
   /** Max list items shown before "See more"; protected items are always kept. */
   visibleLimit: number;
   /** Threads with a live background workflow — kept visible like working ones. */
@@ -167,6 +181,8 @@ export function buildSidebarProjectRows(input: {
   const rows: SidebarRow[] = [];
   const dndGroup = `project-entries:${input.projectId}`;
   const liveWorkflowThreadIds = input.liveWorkflowThreadIds ?? EMPTY_THREAD_ID_SET;
+  const isCollapsed = (key: string) =>
+    input.expandAllGroups ? false : isSidebarGroupCollapsed(input.collapsedWorktrees, key);
 
   if (input.sortMode === "manual") {
     const orderedThreads = [...input.projectThreads].sort(
@@ -218,20 +234,14 @@ export function buildSidebarProjectRows(input: {
         projectId: input.projectId,
         dndGroup,
         dndDisabled: true,
-        collapsedWorktrees: input.collapsedWorktrees,
+        isCollapsed,
         nextUngroupedIndex,
       });
       const isLast = i === list.length - 1;
       if (isLast) return;
-      if (
-        entry.kind === "worktree-group" &&
-        !(input.collapsedWorktrees[entry.group.worktreePath] ?? false)
-      ) {
+      if (entry.kind === "worktree-group" && !isCollapsed(entry.group.worktreePath)) {
         rows.push({ kind: "divider", key: `wt-divider:${entry.group.worktreePath}` });
-      } else if (
-        entry.kind === "thread-group" &&
-        !(input.collapsedWorktrees[`group:${entry.group.groupId}`] ?? false)
-      ) {
+      } else if (entry.kind === "thread-group" && !isCollapsed(`group:${entry.group.groupId}`)) {
         rows.push({ kind: "divider", key: `group-divider:${entry.group.groupId}` });
       }
     });


### PR DESCRIPTION
- Bugfix: keep manual thread groups expanded by default while preserving collapsed worktree groups.
- Apply consistent sidebar collapse behavior across toggles, selectors, and row building.
- Keep adjacent-thread navigation able to reach threads inside collapsed groups.