### PR TITLE
Show unsent draft markers in the sidebar

### DIFF
--- a/src/renderer/components/common/SidebarButton.tsx
+++ b/src/renderer/components/common/SidebarButton.tsx
@@ -128,8 +128,11 @@ export function SidebarButton(props: {
       isOpen={isTooltipOpen}
       onOpenChange={(open) => {
         if (open) {
+          // Labels may truncate on the wrapper itself or on a nested `.truncate`
+          // element (e.g. a title inside a flex row with trailing markers).
           const el = labelRef.current;
-          if (el && el.scrollWidth > el.clientWidth) {
+          const measured = el?.querySelector<HTMLElement>(".truncate") ?? el;
+          if (measured && measured.scrollWidth > measured.clientWidth) {
             setIsTooltipOpen(true);
           }
         } else {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -26,6 +26,7 @@ import { useBrowserAttachInbox } from "@/renderer/state/browserAttachInbox";
 import { useComposerUiStore } from "@/renderer/state/composerUiStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { useThread } from "@/renderer/state/useThread";
 import { selectActiveSubAgentParentItemIds } from "./ChatPane/chatPaneSelectors";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
@@ -429,10 +430,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps -- reading the latest refs at unmount is the point: they mirror the live composer state
       if (submittedRef.current) return;
-      const segments = latestSegmentsRef.current;
-      const atts = attachmentsRef.current;
-      if (segments.length > 0 || atts.length > 0) {
-        saveThreadDraftContent(tid, { segments, attachments: atts });
+      const content = { segments: latestSegmentsRef.current, attachments: attachmentsRef.current };
+      if (isDraftContentNonEmpty(content)) {
+        saveThreadDraftContent(tid, content);
       } else {
         clearThreadDraftContent(tid);
       }

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -40,6 +40,7 @@ import {
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { ThreadCommandPanel } from "./ThreadCommandPanel";
 import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
 import { ThreadAuthRequiredDock } from "./ThreadAuthRequiredDock";
@@ -499,10 +500,9 @@ export function ThreadDraftComposerArea(props: {
     const pid = props.project.id;
     return () => {
       if (submittedRef.current) return;
-      const segments = latestSegmentsRef.current;
-      const atts = attachmentsRef.current;
-      if (segments.length > 0 || atts.length > 0) {
-        saveDraftContent(pid, { segments, attachments: atts });
+      const content = { segments: latestSegmentsRef.current, attachments: attachmentsRef.current };
+      if (isDraftContentNonEmpty(content)) {
+        saveDraftContent(pid, content);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup-only effect keyed on project

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -5,6 +5,7 @@ import { getProjectAgentStatuses } from "@/shared/agentStatus";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { createArrayKeyedMap } from "@/renderer/state/derivations";
+import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -255,4 +256,12 @@ export function useThreadPendingLaunch(threadId: string): {
 /** Whether a persisted draft exists for this project. */
 export function useHasDraft(projectId: string): boolean {
   return useAppStore((s) => projectId in s.draftContents);
+}
+
+/** Whether an already-launched thread has unsent composer content saved for it. */
+export function useThreadHasDraft(threadId: string): boolean {
+  return useAppStore((s) => {
+    const draft = s.threadDraftContents[threadId];
+    return !!draft && isDraftContentNonEmpty(draft);
+  });
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3353,6 +3353,10 @@ msgstr "Handle"
 msgid "Hard Reload"
 msgstr "Hart neu laden"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Hat einen ungesendeten Entwurf"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4329,8 +4333,8 @@ msgid "New thread — {projectName}"
 msgstr "Neuer Thread — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Neuer Thread (Entwurf)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Neuer Thread (Entwurf)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3313,6 +3313,10 @@ msgstr "Handle"
 msgid "Hard Reload"
 msgstr "Hard Reload"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Has unsent draft"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4283,8 +4287,8 @@ msgid "New thread — {projectName}"
 msgstr "New thread — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "New thread (draft)"
+#~ msgid "New thread (draft)"
+#~ msgstr "New thread (draft)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3345,6 +3345,10 @@ msgstr "Identificador"
 msgid "Hard Reload"
 msgstr "Recarga forzada"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Tiene un borrador sin enviar"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4323,8 +4327,8 @@ msgid "New thread — {projectName}"
 msgstr "Nuevo hilo — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Nuevo hilo (borrador)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Nuevo hilo (borrador)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3355,6 +3355,10 @@ msgstr "Identifiant"
 msgid "Hard Reload"
 msgstr "Rechargement forcé"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Contient un brouillon non envoyé"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4331,8 +4335,8 @@ msgid "New thread — {projectName}"
 msgstr "Nouveau fil de discussion — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Nouveau fil de discussion (brouillon)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Nouveau fil de discussion (brouillon)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3286,6 +3286,10 @@ msgstr "ハンドル"
 msgid "Hard Reload"
 msgstr "ハードリロード"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "未送信の下書きがあります"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4248,8 +4252,8 @@ msgid "New thread — {projectName}"
 msgstr "新しいスレッド —{projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "新しいスレッド（草案）"
+#~ msgid "New thread (draft)"
+#~ msgstr "新しいスレッド（草案）"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3283,6 +3283,10 @@ msgstr "핸들"
 msgid "Hard Reload"
 msgstr "강제 새로고침"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "보내지 않은 초안이 있습니다"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4246,8 +4250,8 @@ msgid "New thread — {projectName}"
 msgstr "새 스레드 — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "새 스레드(초안)"
+#~ msgid "New thread (draft)"
+#~ msgstr "새 스레드(초안)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3346,6 +3346,10 @@ msgstr "Identyfikator"
 msgid "Hard Reload"
 msgstr "Twarde przeładowanie"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Zawiera niewysłaną wersję roboczą"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4320,8 +4324,8 @@ msgid "New thread — {projectName}"
 msgstr "Nowy wątek — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Nowy wątek (wersja robocza)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Nowy wątek (wersja robocza)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3342,6 +3342,10 @@ msgstr "Identificador"
 msgid "Hard Reload"
 msgstr "Recarregar forçado"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Há um rascunho não enviado"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4318,8 +4322,8 @@ msgid "New thread — {projectName}"
 msgstr "Novo tópico —{projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Novo tópico (rascunho)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Novo tópico (rascunho)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3345,6 +3345,10 @@ msgstr "Никнейм"
 msgid "Hard Reload"
 msgstr "Жёсткая перезагрузка"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Есть неотправленный черновик"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4320,8 +4324,8 @@ msgid "New thread — {projectName}"
 msgstr "Новый тред — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Новый тред (черновик)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Новый тред (черновик)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3339,6 +3339,10 @@ msgstr "Kullanıcı adı"
 msgid "Hard Reload"
 msgstr "Sert Yeniden Yükleme"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Gönderilmemiş taslak var"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4315,8 +4319,8 @@ msgid "New thread — {projectName}"
 msgstr "Yeni konu — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Yeni konu (taslak)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Yeni konu (taslak)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3344,6 +3344,10 @@ msgstr "Нік"
 msgid "Hard Reload"
 msgstr "Жорстке перезавантаження"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Є невідправлена чернетка"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4319,8 +4323,8 @@ msgid "New thread — {projectName}"
 msgstr "Новий тред — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Новий тред (чернетка)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Новий тред (чернетка)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3326,6 +3326,10 @@ msgstr "Handle"
 msgid "Hard Reload"
 msgstr "Tải lại cứng"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "Có bản nháp chưa gửi"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4301,8 +4305,8 @@ msgid "New thread — {projectName}"
 msgstr "Luồng mới — {projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "Luồng mới (bản nháp)"
+#~ msgid "New thread (draft)"
+#~ msgstr "Luồng mới (bản nháp)"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3275,6 +3275,10 @@ msgstr "用户名"
 msgid "Hard Reload"
 msgstr "硬重载"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+msgid "Has unsent draft"
+msgstr "有未发送的草稿"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/ThreadSettings.tsx
 msgid "Hidden resumable threads are swept every 5 minutes and unloaded after "
@@ -4235,8 +4239,8 @@ msgid "New thread — {projectName}"
 msgstr "新线程 —{projectName}"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
-msgid "New thread (draft)"
-msgstr "新线程（草稿）"
+#~ msgid "New thread (draft)"
+#~ msgstr "新线程（草稿）"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
 msgid "New thread from this to-do"

--- a/src/renderer/state/slices/types.ts
+++ b/src/renderer/state/slices/types.ts
@@ -7,6 +7,11 @@ export interface DraftContent {
   attachments: Attachment[];
 }
 
+/** Canonical "draft is worth keeping/showing" test — keep all save/indicator sites on this. */
+export function isDraftContentNonEmpty(content: DraftContent): boolean {
+  return content.segments.length > 0 || content.attachments.length > 0;
+}
+
 export interface PendingDraftWorktreeSelection {
   branch: string;
   baseBranch: string;

--- a/src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/DraftIndicator.tsx
@@ -1,0 +1,13 @@
+import { useLingui } from "@lingui/react/macro";
+
+/** Shared unsent-draft marker: a small accent dot rendered right after a sidebar row title. */
+export function DraftIndicator() {
+  const { t } = useLingui();
+  return (
+    <span
+      role="img"
+      aria-label={t`Has unsent draft`}
+      className="size-1 shrink-0 rounded-full bg-accent"
+    />
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -4,6 +4,7 @@ import { useDraggable } from "@dnd-kit/react";
 import { useLingui } from "@lingui/react/macro";
 import { ContextMenu, SidebarButton } from "@/renderer/components/common";
 import type { DragSourceData } from "@/renderer/dnd";
+import { DraftIndicator } from "./DraftIndicator";
 
 export function NewThreadButton(props: {
   projectId: string;
@@ -45,13 +46,15 @@ export function NewThreadButton(props: {
         liveText
         ref={newThreadRef}
         icon={<Plus className="size-4" />}
-        label={props.hasDraft ? t`New thread (draft)` : t`New thread`}
+        label={
+          <span className="flex items-center gap-1.5">
+            <span className="min-w-0 truncate">{t`New thread`}</span>
+            {props.hasDraft && <DraftIndicator />}
+          </span>
+        }
         isActive={props.isActive}
         isDraggingAnything={props.isDraggingAnything}
         onPress={props.onPress}
-        suffix={
-          props.hasDraft ? <span className="size-1.5 shrink-0 rounded-full bg-accent" /> : undefined
-        }
       />
     </ContextMenu>
   );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -10,9 +10,10 @@ type MockContextMenuItem = {
   disabledReason?: string;
 };
 
-const { sortableRefMock, contextMenuItemsMock } = vi.hoisted(() => ({
+const { sortableRefMock, contextMenuItemsMock, useThreadHasDraftMock } = vi.hoisted(() => ({
   sortableRefMock: vi.fn<(element: HTMLElement | null) => void>(),
   contextMenuItemsMock: vi.fn<(items: MockContextMenuItem[]) => void>(),
+  useThreadHasDraftMock: vi.fn<(threadId: string) => boolean>(),
 }));
 
 vi.mock("@dnd-kit/react/sortable", () => ({
@@ -41,6 +42,7 @@ vi.mock("@/renderer/hooks/uiSelectors", () => ({
   useCurrentThreadIdsCount: () => 1,
   useProjectAgentStatuses: () => [],
   useIsCurrentThread: () => false,
+  useThreadHasDraft: (threadId: string) => useThreadHasDraftMock(threadId),
 }));
 
 vi.mock("@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions", () => ({
@@ -112,6 +114,42 @@ describe("SortableThreadItem", () => {
   beforeEach(() => {
     sortableRefMock.mockClear();
     contextMenuItemsMock.mockClear();
+    useThreadHasDraftMock.mockReset();
+    useThreadHasDraftMock.mockReturnValue(false);
+  });
+
+  it("shows the draft dot after the title when the thread has an unsent draft", () => {
+    useThreadHasDraftMock.mockReturnValue(true);
+
+    const { getByLabelText } = render(
+      <SortableThreadItem
+        thread={makeThread()}
+        threadIndex={1}
+        project={project}
+        showWorktreeBadge={false}
+        editingThreadId={null}
+        setEditingThreadId={vi.fn<(id: string | null) => void>()}
+        group="project-entries:project-1"
+      />,
+    );
+
+    expect(getByLabelText("Has unsent draft")).toBeInTheDocument();
+  });
+
+  it("hides the draft dot when the thread has no draft", () => {
+    const { queryByLabelText } = render(
+      <SortableThreadItem
+        thread={makeThread()}
+        threadIndex={1}
+        project={project}
+        showWorktreeBadge={false}
+        editingThreadId={null}
+        setEditingThreadId={vi.fn<(id: string | null) => void>()}
+        group="project-entries:project-1"
+      />,
+    );
+
+    expect(queryByLabelText("Has unsent draft")).not.toBeInTheDocument();
   });
 
   it("registers the row element as the sortable element", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -23,12 +23,14 @@ import { readBridge } from "@/renderer/bridge";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions";
 import { gitMenuIcons } from "@/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons";
+import { DraftIndicator } from "../DraftIndicator";
 import { InlineRenameInput } from "../InlineRenameInput";
 import { ThreadItemSuffix } from "./parts/ThreadItemSuffix";
 import {
   useCurrentThreadIdsCount,
   useIsCurrentThread,
   useProjectAgentStatuses,
+  useThreadHasDraft,
 } from "@/renderer/hooks/uiSelectors";
 import { useThreadHasLiveWorkflow } from "@/renderer/state/threadLiveWorkflowStore";
 import { openGitReview } from "@/renderer/actions/panelActions";
@@ -75,6 +77,7 @@ export function SortableThreadItem(props: {
   } = props;
   const { t } = useLingui();
   const isCurrentThread = useIsCurrentThread(thread.id);
+  const hasDraft = useThreadHasDraft(thread.id);
   const currentThreadCount = useCurrentThreadIdsCount();
   const projectAgents = useProjectAgentStatuses(project.location);
   const worktreeGitItems = useWorktreeGitItems(
@@ -313,10 +316,17 @@ export function SortableThreadItem(props: {
                 }}
                 onCancel={() => props.setEditingThreadId(null)}
               />
-            ) : thread.done ? (
-              <span className="opacity-50 line-through">{thread.title}</span>
             ) : (
-              thread.title
+              <span className="flex items-center gap-1.5">
+                <span className="min-w-0 truncate">
+                  {thread.done ? (
+                    <span className="opacity-50 line-through">{thread.title}</span>
+                  ) : (
+                    thread.title
+                  )}
+                </span>
+                {hasDraft && <DraftIndicator />}
+              </span>
             )
           }
           tooltip={editingThreadId === thread.id ? undefined : thread.title}


### PR DESCRIPTION
- Feature: surface unsent draft state in sidebar thread rows and the new-thread entry with a subtle indicator, so draft presence is visible at a glance.
- Normalize draft detection around a shared non-empty draft check, keeping sidebar indicators and composer state aligned.
- Improve sidebar tooltip behavior for truncated labels that include trailing markers.
- Add and localize the new draft indicator copy across all supported languages.