### PR TITLE
Fix staging counts and quoted git paths

### DIFF
--- a/src/renderer/state/gitRefresh.test.ts
+++ b/src/renderer/state/gitRefresh.test.ts
@@ -460,6 +460,138 @@ describe("watcher git status refresh", () => {
     expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(worktreeStatus);
   });
 
+  it("escalates a summary poll to a full refresh when a file was staged externally", async () => {
+    // Previously the file was unstaged/modified with real counts...
+    const previousWorktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      unstaged: [
+        { path: "src/changed.ts", status: "M", staged: false, insertions: 5, deletions: 1 },
+      ],
+      totalInsertions: 5,
+      totalDeletions: 1,
+    };
+    // A summary poll now reports it staged (an external `git add`) with 0/0 —
+    // no backfill key matches, so the counts can't be recovered from cache.
+    const summaryWorktreeStatus: GitStatusResult = {
+      ...status,
+      detail: "summary",
+      branch: "feature/wt",
+      staged: [{ path: "src/changed.ts", status: "M", staged: true, insertions: 0, deletions: 0 }],
+      unstaged: [],
+      totalInsertions: 0,
+      totalDeletions: 0,
+    };
+    // The follow-up full refresh recovers the real cumulative counts.
+    const fullWorktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      staged: [{ path: "src/changed.ts", status: "M", staged: true, insertions: 5, deletions: 1 }],
+      unstaged: [],
+      totalInsertions: 5,
+      totalDeletions: 1,
+    };
+    const getGitStatus = vi.fn<() => Promise<GitStatusResult>>().mockResolvedValue(status);
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+          detail?: "summary" | "full";
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockImplementation(async ({ detail }) => ({
+        statuses: {
+          "/repo-wt": detail === "full" ? fullWorktreeStatus : summaryWorktreeStatus,
+        },
+      }));
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: { platform: "darwin", getGitStatus, gitWorktreeStatusBatch },
+    });
+    useGitStore.getState().setWorktreeStatus("/repo-wt", previousWorktreeStatus);
+    useAppStore.setState({ threads: [worktreeThread] });
+
+    await refreshGitProject(project, "poll", "status");
+    // The escalation fires fire-and-forget after the poll resolves — flush it.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
+      projectLocation: location,
+      worktreePaths: ["/repo-wt"],
+      detail: "summary",
+    });
+    expect(gitWorktreeStatusBatch).toHaveBeenCalledWith({
+      projectLocation: location,
+      worktreePaths: ["/repo-wt"],
+      detail: "full",
+    });
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(fullWorktreeStatus);
+  });
+
+  it("retries summary-to-full escalation after a transient full refresh failure", async () => {
+    const previousWorktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      unstaged: [
+        { path: "src/changed.ts", status: "M", staged: false, insertions: 5, deletions: 1 },
+      ],
+      totalInsertions: 5,
+      totalDeletions: 1,
+    };
+    const summaryWorktreeStatus: GitStatusResult = {
+      ...status,
+      detail: "summary",
+      branch: "feature/wt",
+      staged: [{ path: "src/changed.ts", status: "M", staged: true, insertions: 0, deletions: 0 }],
+      unstaged: [],
+      totalInsertions: 0,
+      totalDeletions: 0,
+    };
+    const fullWorktreeStatus: GitStatusResult = {
+      ...status,
+      branch: "feature/wt",
+      staged: [{ path: "src/changed.ts", status: "M", staged: true, insertions: 5, deletions: 1 }],
+      unstaged: [],
+      totalInsertions: 5,
+      totalDeletions: 1,
+    };
+    const getGitStatus = vi.fn<() => Promise<GitStatusResult>>().mockResolvedValue(status);
+    let fullAttempts = 0;
+    const gitWorktreeStatusBatch = vi
+      .fn<
+        (payload: {
+          projectLocation: ProjectLocation;
+          worktreePaths: string[];
+          detail?: "summary" | "full";
+        }) => Promise<{ statuses: Record<string, GitStatusResult> }>
+      >()
+      .mockImplementation(async ({ detail }) => {
+        if (detail === "full") {
+          fullAttempts += 1;
+          if (fullAttempts === 1) throw new Error("bridge unavailable");
+          return { statuses: { "/repo-wt": fullWorktreeStatus } };
+        }
+        return { statuses: { "/repo-wt": summaryWorktreeStatus } };
+      });
+    Object.defineProperty(window, "lightcode", {
+      configurable: true,
+      value: { platform: "darwin", getGitStatus, gitWorktreeStatusBatch },
+    });
+    useGitStore.getState().setWorktreeStatus("/repo-wt", previousWorktreeStatus);
+    useAppStore.setState({ threads: [worktreeThread] });
+
+    await refreshGitProject(project, "poll", "status");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(summaryWorktreeStatus);
+
+    await refreshGitProject(project, "poll", "status");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fullAttempts).toBe(2);
+    expect(useGitStore.getState().worktreeStatuses["/repo-wt"]).toEqual(fullWorktreeStatus);
+  });
+
   it("preserves cached worktree diff stats during fetch refreshes", async () => {
     const cachedWorktreeStatus: GitStatusResult = {
       ...status,

--- a/src/renderer/state/gitRefresh.ts
+++ b/src/renderer/state/gitRefresh.ts
@@ -1,5 +1,6 @@
 import type {
   GitStatusDetail,
+  GitStatusResult,
   PrData,
   ProjectLocation,
   RemoteHostPlatform,
@@ -7,7 +8,7 @@ import type {
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
-import { useGitStore } from "@/renderer/state/gitStore";
+import { summaryBackfillMissed, useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchNamePrKey, buildBranchPrKey } from "@/renderer/state/gitSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
@@ -103,6 +104,80 @@ function getWorktreeStatusDetail(
 
 export function getWatcherRefreshMode(projectId: string): GitRefreshMode {
   return useGitStore.getState().statuses[projectId]?.isRepo === false ? "full" : "status";
+}
+
+/** Worktree paths with an in-flight summary→full escalation, so poll bursts don't stack requests. */
+const summaryFullEscalationInFlight = new Set<string>();
+const summaryFullEscalationPending = new Set<string>();
+
+/**
+ * A summary poll never carries real +/- counts — `mergeSummaryStatus` backfills
+ * them from the prior store snapshot. When a row can't be backfilled (it moved
+ * sections, changed status, or is brand new — e.g. an external `git add` in a
+ * terminal that the file watcher ignores), the counts stay 0/stale forever. This
+ * returns the worktree paths whose incoming summary status has such a miss,
+ * comparing against the CURRENT store snapshot (must be called BEFORE the summary
+ * status is merged in, or the miss becomes invisible).
+ */
+function findSummaryBackfillMisses(statuses: Record<string, GitStatusResult>): string[] {
+  const store = useGitStore.getState();
+  const missed: string[] = [];
+  for (const [worktreePath, status] of Object.entries(statuses)) {
+    if (summaryBackfillMissed(store.worktreeStatuses[worktreePath], status)) {
+      missed.push(worktreePath);
+    }
+  }
+  return missed;
+}
+
+/**
+ * Fetch a FULL worktree status for paths whose summary poll couldn't be
+ * backfilled and write the exact counts into the store. Fire-and-forget and
+ * deduped per path so overlapping poll cycles don't stack requests. This
+ * deliberately outlives the triggering refresh — `git add`/`reset` fire no
+ * watcher event, so this is the only path that reconciles externally-staged
+ * counts — and the store write is idempotent (`setWorktreeStatuses` dedupes), so
+ * it applies unconditionally rather than gating on the refresh token.
+ */
+function escalateSummaryToFull(location: ProjectLocation, worktreePaths: readonly string[]): void {
+  const paths = worktreePaths.filter((p) => !summaryFullEscalationInFlight.has(p));
+  if (paths.length === 0) return;
+  for (const p of paths) summaryFullEscalationInFlight.add(p);
+  void readBridge()
+    .gitWorktreeStatusBatch({
+      projectLocation: location,
+      worktreePaths: [...paths],
+      detail: "full",
+    })
+    .then((batch) => {
+      if (Object.keys(batch.statuses).length > 0) {
+        useGitStore.getState().setWorktreeStatuses(batch.statuses);
+        for (const p of Object.keys(batch.statuses)) summaryFullEscalationPending.delete(p);
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      for (const p of paths) summaryFullEscalationInFlight.delete(p);
+    });
+}
+
+/**
+ * Merge a batch of worktree summary statuses into the store, escalating any path
+ * whose counts couldn't be backfilled to a follow-up full refresh. The miss
+ * check runs against the pre-merge store state.
+ */
+function applyWorktreeStatusBatch(
+  location: ProjectLocation,
+  statuses: Record<string, GitStatusResult>,
+): void {
+  const missed = findSummaryBackfillMisses(statuses);
+  for (const p of missed) summaryFullEscalationPending.add(p);
+  for (const [p, status] of Object.entries(statuses)) {
+    if (status.detail !== "summary") summaryFullEscalationPending.delete(p);
+  }
+  useGitStore.getState().setWorktreeStatuses(statuses);
+  const stale = Object.keys(statuses).filter((p) => summaryFullEscalationPending.has(p));
+  if (stale.length > 0) escalateSummaryToFull(location, stale);
 }
 
 type ActiveGitProject = { id: string; location: ProjectLocation };
@@ -517,7 +592,7 @@ async function refreshProjectStatusOnly(
     .catch(() => undefined);
   if (!isActive() || !batch) return;
   if (Object.keys(batch.statuses).length > 0) {
-    useGitStore.getState().setWorktreeStatuses(batch.statuses);
+    applyWorktreeStatusBatch(project.location, batch.statuses);
   }
 }
 
@@ -637,7 +712,7 @@ export async function refreshGitProject(
                   .then((batch) => {
                     if (!isRefreshCurrent(project.id, refreshToken, isActive)) return;
                     if (Object.keys(batch.statuses).length > 0) {
-                      useGitStore.getState().setWorktreeStatuses(batch.statuses);
+                      applyWorktreeStatusBatch(project.location, batch.statuses);
                     }
                   })
                   .catch(() => undefined);

--- a/src/renderer/state/gitStore.test.ts
+++ b/src/renderer/state/gitStore.test.ts
@@ -6,7 +6,7 @@ import type {
   PrData,
   PrDetails,
 } from "@/shared/contracts";
-import { useGitStore } from "./gitStore";
+import { summaryBackfillMissed, useGitStore } from "./gitStore";
 
 const baseStatus: GitStatusResult = {
   isRepo: true,
@@ -208,7 +208,7 @@ describe("gitStore batch updates", () => {
     expect(status.totalDeletions).toBe(2);
   });
 
-  it("dedupes by path when staging an MM file (one entry, latest stats win)", () => {
+  it("sums stats when staging a file that already has a staged entry (MM)", () => {
     const stagedM = {
       path: "src/foo.ts",
       status: "M",
@@ -233,13 +233,34 @@ describe("gitStore batch updates", () => {
 
     const status = useGitStore.getState().statuses["p1"]!;
     expect(status.staged).toHaveLength(1);
+    // Git's HEAD→index diff is cumulative: 10+3 insertions, 2+1 deletions.
     expect(status.staged[0]).toMatchObject({
       path: "src/foo.ts",
       staged: true,
-      insertions: 3,
-      deletions: 1,
+      insertions: 13,
+      deletions: 3,
     });
     expect(status.unstaged).toHaveLength(0);
+  });
+
+  it("sums stats when unstaging a file that already has an unstaged entry", () => {
+    useGitStore.getState().setStatus("p1", {
+      ...baseStatus,
+      staged: [{ path: "src/foo.ts", status: "M", staged: true, insertions: 4, deletions: 1 }],
+      unstaged: [{ path: "src/foo.ts", status: "M", staged: false, insertions: 3, deletions: 2 }],
+    });
+
+    useGitStore.getState().optimisticUnstageFile("p1", "src/foo.ts", false);
+
+    const status = useGitStore.getState().statuses["p1"]!;
+    expect(status.staged).toHaveLength(0);
+    expect(status.unstaged).toHaveLength(1);
+    expect(status.unstaged[0]).toMatchObject({
+      path: "src/foo.ts",
+      staged: false,
+      insertions: 7,
+      deletions: 3,
+    });
   });
 
   it("moves staged conflict files out of the conflict list", () => {
@@ -261,7 +282,7 @@ describe("gitStore batch updates", () => {
     ]);
   });
 
-  it("dedupes by path when stage-all merges unstaged into already-staged entries", () => {
+  it("sums stats when stage-all merges unstaged into already-staged entries", () => {
     useGitStore.getState().setStatus("p1", {
       ...baseStatus,
       staged: [
@@ -279,30 +300,32 @@ describe("gitStore batch updates", () => {
     const status = useGitStore.getState().statuses["p1"]!;
     const byPath = new Map(status.staged.map((f) => [f.path, f]));
     expect(status.staged).toHaveLength(3);
-    expect(byPath.get("a.ts")).toMatchObject({ insertions: 2, deletions: 1, staged: true });
+    // a.ts already staged (5/0) + newly staged hunk (2/1) → cumulative 7/1.
+    expect(byPath.get("a.ts")).toMatchObject({ insertions: 7, deletions: 1, staged: true });
     expect(byPath.get("b.ts")).toMatchObject({ insertions: 50, deletions: 0, staged: true });
     expect(byPath.get("c.ts")).toMatchObject({ insertions: 7, status: "A", staged: true });
     expect(status.unstaged).toHaveLength(0);
   });
 
-  it("dedupes by path on repeated stage-all calls (no accumulation)", () => {
+  it("sums stats when unstage-all merges staged into already-unstaged entries", () => {
     useGitStore.getState().setStatus("p1", {
       ...baseStatus,
-      staged: [{ path: "a.ts", status: "M", staged: true, insertions: 5, deletions: 0 }],
-      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 1, deletions: 0 }],
+      staged: [
+        { path: "a.ts", status: "M", staged: true, insertions: 5, deletions: 1 },
+        { path: "b.ts", status: "M", staged: true, insertions: 8, deletions: 0 },
+      ],
+      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 2, deletions: 3 }],
     });
 
-    useGitStore.getState().optimisticStageAll("p1", false);
-    // Simulate a second click before the real status fetch lands by re-introducing an unstaged entry.
-    useGitStore.getState().setStatus("p1", {
-      ...useGitStore.getState().statuses["p1"]!,
-      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 2, deletions: 0 }],
-    });
-    useGitStore.getState().optimisticStageAll("p1", false);
+    useGitStore.getState().optimisticUnstageAll("p1", false);
 
     const status = useGitStore.getState().statuses["p1"]!;
-    expect(status.staged).toHaveLength(1);
-    expect(status.staged[0]).toMatchObject({ path: "a.ts", insertions: 2, staged: true });
+    const byPath = new Map(status.unstaged.map((f) => [f.path, f]));
+    expect(status.staged).toHaveLength(0);
+    expect(status.unstaged).toHaveLength(2);
+    // a.ts already unstaged (2/3) + unstaged staged hunk (5/1) → cumulative 7/4.
+    expect(byPath.get("a.ts")).toMatchObject({ insertions: 7, deletions: 4, staged: false });
+    expect(byPath.get("b.ts")).toMatchObject({ insertions: 8, deletions: 0, staged: false });
   });
 
   it("batches PR updates without rewriting equal entries", () => {
@@ -364,5 +387,61 @@ describe("gitStore batch updates", () => {
     const secondDetails = useGitStore.getState().prDetails;
     expect(secondDetails).not.toBe(firstDetails);
     expect(secondDetails["p1#42"]?.checks[0]?.conclusion).toBe("SUCCESS");
+  });
+});
+
+describe("summaryBackfillMissed", () => {
+  const summaryOf = (overrides: Partial<GitStatusResult>): GitStatusResult => ({
+    ...baseStatus,
+    detail: "summary",
+    ...overrides,
+  });
+
+  it("returns false for a non-summary incoming status", () => {
+    const incoming: GitStatusResult = {
+      ...baseStatus,
+      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 0, deletions: 0 }],
+    };
+    expect(summaryBackfillMissed(undefined, incoming)).toBe(false);
+  });
+
+  it("returns false when every summary row matches a previous entry", () => {
+    const previous: GitStatusResult = {
+      ...baseStatus,
+      staged: [{ path: "a.ts", status: "M", staged: true, insertions: 5, deletions: 1 }],
+      unstaged: [{ path: "b.ts", status: "M", staged: false, insertions: 2, deletions: 0 }],
+    };
+    const incoming = summaryOf({
+      staged: [{ path: "a.ts", status: "M", staged: true, insertions: 0, deletions: 0 }],
+      unstaged: [{ path: "b.ts", status: "M", staged: false, insertions: 0, deletions: 0 }],
+    });
+    expect(summaryBackfillMissed(previous, incoming)).toBe(false);
+  });
+
+  it("returns true when a file moved sections (external git add) — key no longer matches", () => {
+    // Previously unstaged/modified; an external `git add` now reports it staged.
+    const previous: GitStatusResult = {
+      ...baseStatus,
+      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 5, deletions: 1 }],
+    };
+    const incoming = summaryOf({
+      staged: [{ path: "a.ts", status: "M", staged: true, insertions: 0, deletions: 0 }],
+    });
+    expect(summaryBackfillMissed(previous, incoming)).toBe(true);
+  });
+
+  it("returns true when the previous snapshot is missing entirely", () => {
+    const incoming = summaryOf({
+      unstaged: [{ path: "a.ts", status: "M", staged: false, insertions: 0, deletions: 0 }],
+    });
+    expect(summaryBackfillMissed(undefined, incoming)).toBe(true);
+  });
+
+  it("treats a brand-new untracked row as a miss (full refresh fills its counts)", () => {
+    const previous: GitStatusResult = { ...baseStatus };
+    const incoming = summaryOf({
+      unstaged: [{ path: "new.ts", status: "?", staged: false, insertions: 0, deletions: 0 }],
+    });
+    expect(summaryBackfillMissed(previous, incoming)).toBe(true);
   });
 });

--- a/src/renderer/state/gitStore.ts
+++ b/src/renderer/state/gitStore.ts
@@ -78,11 +78,74 @@ function upsertByPath(list: readonly FileChange[], item: FileChange): FileChange
   return [...list.filter((f) => f.path !== item.path), item];
 }
 
-/** Bulk variant of upsertByPath — incoming entries win over any same-path entries in `list`. */
-function upsertManyByPath(list: readonly FileChange[], items: readonly FileChange[]): FileChange[] {
+/**
+ * Insert `item`, summing its +/- into any existing same-path entry (keeping that
+ * entry's position). When a file is staged, re-modified, then staged again, git's
+ * truth is the cumulative HEAD→index diff — so the optimistic move must add the
+ * new hunk's counts onto the already-staged counts rather than replace them.
+ * Summing is exact when edits don't overlap lines; the follow-up full refresh
+ * reconciles precisely regardless.
+ */
+function upsertSummingByPath(list: readonly FileChange[], item: FileChange): FileChange[] {
+  let matched = false;
+  const merged = list.map((f) => {
+    if (f.path !== item.path) return f;
+    matched = true;
+    return {
+      ...item,
+      insertions: f.insertions + item.insertions,
+      deletions: f.deletions + item.deletions,
+    };
+  });
+  return matched ? merged : [...merged, item];
+}
+
+/** Bulk variant of {@link upsertSummingByPath}. */
+function upsertManySummingByPath(
+  list: readonly FileChange[],
+  items: readonly FileChange[],
+): FileChange[] {
   if (items.length === 0) return [...list];
-  const incomingPaths = new Set(items.map((f) => f.path));
-  return [...list.filter((f) => !incomingPaths.has(f.path)), ...items];
+  let result: FileChange[] = [...list];
+  for (const item of items) {
+    result = upsertSummingByPath(result, item);
+  }
+  return result;
+}
+
+/** Key used to backfill summary-poll +/- counts from a prior store snapshot. */
+function summaryBackfillKey(file: FileChange): string {
+  return `${file.staged}\0${file.path}\0${file.oldPath ?? ""}\0${file.status}`;
+}
+
+/**
+ * True when an incoming summary status carries a file row that has no matching
+ * entry in the previous store snapshot — i.e. {@link mergeSummaryFiles} can't
+ * backfill its +/- counts because the row moved sections, changed status, or is
+ * brand new (e.g. an external `git add` in a terminal). Such a row would
+ * otherwise display 0/0 (or stale) forever, since summary polls never carry real
+ * counts and the file watcher ignores the `.git/index` write that produced it.
+ * Untracked ("?") rows count as a miss too: full refreshes fill their insertion
+ * counts, so a missed untracked row is also stale at 0. Callers escalate to a
+ * full refresh when this returns true.
+ */
+export function summaryBackfillMissed(
+  previous: GitStatusResult | undefined,
+  incoming: GitStatusResult,
+): boolean {
+  if (incoming.detail !== "summary") return false;
+  const previousKeys = new Set<string>();
+  if (previous) {
+    for (const file of previous.staged) previousKeys.add(summaryBackfillKey(file));
+    for (const file of previous.unstaged) previousKeys.add(summaryBackfillKey(file));
+  }
+  for (const file of incoming.staged) {
+    if (!previousKeys.has(summaryBackfillKey(file))) return true;
+  }
+  for (const file of incoming.unstaged) {
+    if (!previousKeys.has(summaryBackfillKey(file))) return true;
+  }
+  return false;
 }
 
 function removeByPath(list: readonly FileChange[], path: string): FileChange[] {
@@ -146,16 +209,9 @@ function mergeSummaryFiles(
   incoming: readonly FileChange[],
 ): FileChange[] {
   if (incoming.length === 0) return [];
-  const previousByKey = new Map(
-    previous.map((file) => [
-      `${file.staged}\0${file.path}\0${file.oldPath ?? ""}\0${file.status}`,
-      file,
-    ]),
-  );
+  const previousByKey = new Map(previous.map((file) => [summaryBackfillKey(file), file]));
   return incoming.map((file) => {
-    const previousFile = previousByKey.get(
-      `${file.staged}\0${file.path}\0${file.oldPath ?? ""}\0${file.status}`,
-    );
+    const previousFile = previousByKey.get(summaryBackfillKey(file));
     return previousFile
       ? { ...file, insertions: previousFile.insertions, deletions: previousFile.deletions }
       : file;
@@ -604,7 +660,7 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
           ...state[bucket],
           [key]: {
             ...status,
-            staged: upsertByPath(status.staged, moved),
+            staged: upsertSummingByPath(status.staged, moved),
             unstaged: removeByPath(status.unstaged, filePath),
           },
         },
@@ -625,7 +681,7 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
           [key]: {
             ...status,
             staged: removeByPath(status.staged, filePath),
-            unstaged: upsertByPath(status.unstaged, moved),
+            unstaged: upsertSummingByPath(status.unstaged, moved),
           },
         },
       };
@@ -646,7 +702,7 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
           ...state[bucket],
           [key]: {
             ...status,
-            staged: upsertManyByPath(status.staged, moved),
+            staged: upsertManySummingByPath(status.staged, moved),
             unstaged: [],
           },
         },
@@ -701,7 +757,7 @@ export const useGitStore = create<GitState & GitActions>()((set, get) => ({
           [key]: {
             ...status,
             staged: [],
-            unstaged: upsertManyByPath(status.unstaged, moved),
+            unstaged: upsertManySummingByPath(status.unstaged, moved),
           },
         },
       };

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictFileCard.tsx
@@ -15,6 +15,7 @@ import {
   getLang,
 } from "../../diffBuildClient";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
+import { reconcileStagingStatus } from "./reconcileStagingStatus";
 
 const LARGE_DIFF_THRESHOLD = 500;
 const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
@@ -117,7 +118,10 @@ export function ConflictFileCard(props: {
     useGitStore.getState().optimisticStageFile(storeKey, file.path, isWorktree);
     await readBridge()
       .gitStage({ projectLocation: project.location, filePath: file.path })
-      .catch(() => onRefresh());
+      .then(
+        () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+        () => onRefresh(),
+      );
   }
 
   return (

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/ConflictGroup.tsx
@@ -11,6 +11,7 @@ import { useLongPress } from "@/renderer/hooks/useLongPress";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 import { useGitTouch } from "../gitTouchContext";
 import { ConflictFileCard } from "./ConflictFileCard";
+import { reconcileStagingStatus } from "./reconcileStagingStatus";
 
 const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
 
@@ -53,7 +54,10 @@ export function ConflictGroup(props: {
     useGitStore.getState().optimisticStageFile(storeKey, path, isWorktree);
     await readBridge()
       .gitStage({ projectLocation: project.location, filePath: path })
-      .catch(() => onRefresh());
+      .then(
+        () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+        () => onRefresh(),
+      );
   }
 
   const sorted = files.toSorted(compareFilesByDirThenName);

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileGroup.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileGroup.tsx
@@ -12,6 +12,7 @@ import { StackedFileCard } from "../../GitStackedDiff";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 import { useGitTouch } from "../gitTouchContext";
 import { FileRow } from "./FileRow";
+import { reconcileStagingStatus } from "./reconcileStagingStatus";
 
 export function FileGroup(props: {
   title: string;
@@ -62,20 +63,26 @@ export function FileGroup(props: {
     useGitStore.getState().optimisticStageAll(storeKey, isWorktree);
     await readBridge()
       .gitStageAll({ projectLocation: project.location })
-      .catch((error: unknown) => {
-        toast.danger(friendlyError(error));
-        onRefresh();
-      });
+      .then(
+        () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+        (error: unknown) => {
+          toast.danger(friendlyError(error));
+          onRefresh();
+        },
+      );
   }
 
   async function handleUnstageAll() {
     useGitStore.getState().optimisticUnstageAll(storeKey, isWorktree);
     await readBridge()
       .gitUnstageAll({ projectLocation: project.location })
-      .catch((error: unknown) => {
-        toast.danger(friendlyError(error));
-        onRefresh();
-      });
+      .then(
+        () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+        (error: unknown) => {
+          toast.danger(friendlyError(error));
+          onRefresh();
+        },
+      );
   }
 
   async function handleRevertAll() {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/FileRow.tsx
@@ -19,6 +19,7 @@ import { openFileInEditor } from "@/renderer/utils/gitHelpers";
 import { useLongPress } from "@/renderer/hooks/useLongPress";
 import { useGitReviewRowPadX } from "../gitReviewPadXContext";
 import { useGitTouch } from "../gitTouchContext";
+import { reconcileStagingStatus } from "./reconcileStagingStatus";
 
 const COMPOSER_FILE_DRAG_TYPE = "application/lightcode-composer-file";
 
@@ -70,18 +71,24 @@ export function FileRow(props: {
       store.optimisticUnstageFile(storeKey, path, isWorktree);
       await readBridge()
         .gitUnstage({ projectLocation: project.location, filePath: path })
-        .catch((error: unknown) => {
-          toast.danger(friendlyError(error));
-          onRefresh();
-        });
+        .then(
+          () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+          (error: unknown) => {
+            toast.danger(friendlyError(error));
+            onRefresh();
+          },
+        );
     } else {
       store.optimisticStageFile(storeKey, path, isWorktree);
       await readBridge()
         .gitStage({ projectLocation: project.location, filePath: path })
-        .catch((error: unknown) => {
-          toast.danger(friendlyError(error));
-          onRefresh();
-        });
+        .then(
+          () => reconcileStagingStatus({ projectLocation: project.location, storeKey, isWorktree }),
+          (error: unknown) => {
+            toast.danger(friendlyError(error));
+            onRefresh();
+          },
+        );
     }
   }
 

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/reconcileStagingStatus.test.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/reconcileStagingStatus.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitStatusResult, ProjectLocation } from "@/shared/contracts";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { reconcileStagingStatus } from "./reconcileStagingStatus";
+
+const bridgeMock = vi.hoisted(() => ({
+  getGitStatus: vi.fn<() => Promise<GitStatusResult>>(),
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridgeMock,
+}));
+
+const baseStatus: GitStatusResult = {
+  isRepo: true,
+  branch: "main",
+  tracking: "origin/main",
+  hasRemote: true,
+  remoteInfo: null,
+  ahead: 0,
+  behind: 0,
+  staged: [],
+  unstaged: [],
+  totalInsertions: 0,
+  totalDeletions: 0,
+};
+
+const projectLocation: ProjectLocation = { kind: "posix", path: "/repo" };
+
+/** A promise whose resolution we control, to hold a fetch "in flight". */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let queued microtasks (awaits, `.then`) flush. */
+function flush(): Promise<void> {
+  return Promise.resolve().then(() => Promise.resolve());
+}
+
+const statusWithAhead = (ahead: number): GitStatusResult => ({ ...baseStatus, ahead });
+
+describe("reconcileStagingStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGitStore.setState({ statuses: {}, worktreeStatuses: {} });
+  });
+
+  it("fetches once and applies the status for a single call", async () => {
+    bridgeMock.getGitStatus.mockResolvedValueOnce(statusWithAhead(3));
+
+    await reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+
+    expect(bridgeMock.getGitStatus).toHaveBeenCalledTimes(1);
+    expect(useGitStore.getState().statuses["p1"]?.ahead).toBe(3);
+  });
+
+  it("coalesces rapid calls into an initial plus one trailing fetch", async () => {
+    const first = deferred<GitStatusResult>();
+    const second = deferred<GitStatusResult>();
+    bridgeMock.getGitStatus.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    // First call starts fetch #1 (kept pending); the next two only mark dirty.
+    const c1 = reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+    const c2 = reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+    const c3 = reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+    await flush();
+
+    // Only the initial fetch has been issued so far.
+    expect(bridgeMock.getGitStatus).toHaveBeenCalledTimes(1);
+
+    // Resolve fetch #1 → its result applies, then exactly one trailing fetch runs.
+    first.resolve(statusWithAhead(1));
+    await flush();
+    expect(bridgeMock.getGitStatus).toHaveBeenCalledTimes(2);
+
+    // Resolve the trailing fetch → its result is the final applied status.
+    second.resolve(statusWithAhead(2));
+    await Promise.all([c1, c2, c3]);
+
+    expect(bridgeMock.getGitStatus).toHaveBeenCalledTimes(2);
+    expect(useGitStore.getState().statuses["p1"]?.ahead).toBe(2);
+  });
+
+  it("swallows fetch errors, leaves the store untouched, and recovers on a later call", async () => {
+    useGitStore.getState().setStatus("p1", statusWithAhead(9));
+    bridgeMock.getGitStatus.mockRejectedValueOnce(new Error("bridge down"));
+
+    await reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+
+    // Errored fetch must not overwrite the existing store entry.
+    expect(useGitStore.getState().statuses["p1"]?.ahead).toBe(9);
+
+    // In-flight state was cleared, so a subsequent call fetches and applies again.
+    bridgeMock.getGitStatus.mockResolvedValueOnce(statusWithAhead(5));
+    await reconcileStagingStatus({ projectLocation, storeKey: "p1", isWorktree: false });
+
+    expect(bridgeMock.getGitStatus).toHaveBeenCalledTimes(2);
+    expect(useGitStore.getState().statuses["p1"]?.ahead).toBe(5);
+  });
+});

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/reconcileStagingStatus.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/reconcileStagingStatus.ts
@@ -1,0 +1,77 @@
+import type { ProjectLocation } from "@/shared/contracts";
+import { readBridge } from "@/renderer/bridge";
+import { useGitStore } from "@/renderer/state/gitStore";
+
+interface ReconcileState {
+  projectLocation: ProjectLocation;
+  isWorktree: boolean;
+  /** Set when a stage/unstage lands while a fetch is already in flight. */
+  dirty: boolean;
+}
+
+/**
+ * Per-storeKey coalescing state. An entry exists only while a fetch is in
+ * flight (or a trailing one is queued); it is deleted once the chain drains so
+ * the map cannot grow unbounded over the app's lifetime.
+ *
+ * `git add`/`reset` only touch `.git/index`, which the project watcher
+ * deliberately ignores — so no refresh follows a stage/unstage and the
+ * optimistic +/- counts would stick. We fetch a full status after each
+ * successful bridge call and write git's exact counts, but the user can toggle
+ * several files faster than the fetches resolve. On WSL each fetch is a bridge
+ * roundtrip, so firing one per click wastes N-1 roundtrips whose results are
+ * discarded anyway. Instead we coalesce: while a fetch runs, extra calls just
+ * mark the key dirty, and exactly one trailing fetch runs afterwards.
+ */
+const reconcileStates = new Map<string, ReconcileState>();
+
+/**
+ * Fetch a full git status after a successful stage/unstage and write it to the
+ * store, replacing the optimistic approximation with git's exact counts. Errors
+ * are swallowed (the cached optimistic state stays); callers keep their own
+ * `.catch → toast + onRefresh()` for the bridge call itself.
+ *
+ * Concurrent calls for the same `storeKey` are coalesced. A trailing fetch is
+ * always started *after* the last stage/unstage call marked the key dirty, so
+ * the final applied status can never predate the newest `git add`/`reset` — the
+ * in-flight fetch may have read the index before that write landed.
+ */
+export async function reconcileStagingStatus(params: {
+  projectLocation: ProjectLocation;
+  storeKey: string;
+  isWorktree: boolean;
+}): Promise<void> {
+  const { projectLocation, storeKey, isWorktree } = params;
+
+  const inFlight = reconcileStates.get(storeKey);
+  if (inFlight) {
+    // A fetch is already running for this key; the running fetch may have read
+    // the index before the toggle that triggered this call finished. Mark the
+    // key dirty to force exactly one trailing fetch, and refresh the params it
+    // will use.
+    inFlight.projectLocation = projectLocation;
+    inFlight.isWorktree = isWorktree;
+    inFlight.dirty = true;
+    return;
+  }
+
+  const state: ReconcileState = { projectLocation, isWorktree, dirty: false };
+  reconcileStates.set(storeKey, state);
+
+  // Loop until no newer toggle marked the key dirty while the last fetch ran.
+  // Between a fetch resolving and the `while` check there is no `await`, so no
+  // other call can slip in unnoticed.
+  do {
+    state.dirty = false;
+    const status = await readBridge()
+      .getGitStatus({ projectLocation: state.projectLocation })
+      .catch(() => undefined);
+    if (status) {
+      const store = useGitStore.getState();
+      if (state.isWorktree) store.setWorktreeStatus(storeKey, status);
+      else store.setStatus(storeKey, status);
+    }
+  } while (state.dirty);
+
+  reconcileStates.delete(storeKey);
+}

--- a/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitStackedDiff.tsx
@@ -27,6 +27,7 @@ import { handleKeyActivate } from "@/renderer/utils/a11y";
 import { openFileInEditor } from "@/renderer/utils/gitHelpers";
 import { ConfirmDialog } from "@/renderer/components/common/ConfirmDialog";
 import { useGitReviewRowPadX } from "./GitReviewSidebar/gitReviewPadXContext";
+import { reconcileStagingStatus } from "./GitReviewSidebar/parts/reconcileStagingStatus";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -165,11 +166,31 @@ export function StackedFileCard(props: {
     if (file.staged) {
       await readBridge()
         .gitUnstage({ projectLocation: project.location, filePath: file.path })
-        .catch(() => onRefresh());
+        .then(
+          () =>
+            storeKey
+              ? reconcileStagingStatus({
+                  projectLocation: project.location,
+                  storeKey,
+                  isWorktree: isWorktree ?? false,
+                })
+              : undefined,
+          () => onRefresh(),
+        );
     } else {
       await readBridge()
         .gitStage({ projectLocation: project.location, filePath: file.path })
-        .catch(() => onRefresh());
+        .then(
+          () =>
+            storeKey
+              ? reconcileStagingStatus({
+                  projectLocation: project.location,
+                  storeKey,
+                  isWorktree: isWorktree ?? false,
+                })
+              : undefined,
+          () => onRefresh(),
+        );
     }
   }
 

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -57,15 +57,25 @@ vi.mock("node:child_process", async () => {
 
 import { computeDefaultWorktreePath, GitService, parseRemoteUrl } from "./git";
 
+// Every git invocation is prefixed with `-c core.quotepath=false` (see
+// withQuotePathDisabled in git/exec.ts) so non-ASCII paths print as raw UTF-8.
+const GIT_QUOTEPATH_PREFIX = ["-c", "core.quotepath=false"];
+
+/** Strip the leading `-c core.quotepath=false` pair from a recorded arg array. */
+function gitSubcommandArgs(args: string[]): string[] {
+  return args[0] === "-c" && args[1] === "core.quotepath=false" ? args.slice(2) : args;
+}
+
 /** Helper to set up execFile mock for git commands. */
 function mockGitCommands(handler: (args: string[]) => { stdout?: string; error?: Error }) {
   execFileMock.mockImplementation(
     (
       _cmd: string,
-      args: string[],
+      rawArgs: string[],
       _opts: unknown,
       callback: (error: Error | null, result: { stdout: string; stderr: string }) => void,
     ) => {
+      const args = gitSubcommandArgs(rawArgs);
       const result = handler(args);
       if (result.error) {
         callback(result.error, { stdout: "", stderr: result.error.message });
@@ -215,8 +225,10 @@ describe("GitService.addWorktree", () => {
     const configCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "config" &&
-        (call[1] as string[]).includes("branch.lightcode/brave-heron.lightcodeSource"),
+        gitSubcommandArgs(call[1] as string[])[0] === "config" &&
+        gitSubcommandArgs(call[1] as string[]).includes(
+          "branch.lightcode/brave-heron.lightcodeSource",
+        ),
     );
     expect(configCall).toBeDefined();
     expect(configCall![1]).toContain("master");
@@ -247,7 +259,9 @@ describe("GitService.addWorktree", () => {
       "lightcode/silver-meadow-abcd",
     );
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(
       commands.some((c) =>
         c.includes(
@@ -262,8 +276,10 @@ describe("GitService.addWorktree", () => {
     const configCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "config" &&
-        (call[1] as string[]).includes("branch.lightcode/brave-heron.lightcodeSource"),
+        gitSubcommandArgs(call[1] as string[])[0] === "config" &&
+        gitSubcommandArgs(call[1] as string[]).includes(
+          "branch.lightcode/brave-heron.lightcodeSource",
+        ),
     );
     expect(configCall).toBeDefined();
     expect(configCall![1]).toContain("origin/lightcode/silver-meadow-abcd");
@@ -289,7 +305,9 @@ describe("GitService.addWorktree", () => {
       "main",
     );
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(
       commands.some(
         (c) => c.includes("worktree add -b lightcode/brave-heron") && c.endsWith("main"),
@@ -323,7 +341,7 @@ describe("GitService.addWorktree", () => {
     );
 
     const wtAdd = execFileMock.mock.calls
-      .map((c: unknown[]) => (c[1] as string[]).join(" "))
+      .map((c: unknown[]) => gitSubcommandArgs(c[1] as string[]).join(" "))
       .find((c) => c.startsWith("worktree add -b lightcode/brave-heron"));
     expect(wtAdd?.endsWith("upstream/feature/x")).toBe(true);
   });
@@ -354,7 +372,7 @@ describe("GitService.addWorktree", () => {
     );
 
     const wtAdd = execFileMock.mock.calls
-      .map((c: unknown[]) => (c[1] as string[]).join(" "))
+      .map((c: unknown[]) => gitSubcommandArgs(c[1] as string[]).join(" "))
       .find((c) => c.startsWith("worktree add -b lightcode/brave-heron"));
     expect(wtAdd?.endsWith("origin/feature/x")).toBe(true);
   });
@@ -377,7 +395,9 @@ describe("GitService.addWorktree", () => {
       "feature/x",
     );
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     const wtAdd = commands.find((c) => c.startsWith("worktree add -b lightcode/brave-heron"));
     expect(wtAdd?.endsWith("feature/x")).toBe(true);
     expect(commands.some((c) => c === "remote")).toBe(false);
@@ -416,6 +436,7 @@ describe("GitService.addWorktree", () => {
         expect.objectContaining({ linuxPath: "/home/demo/work/lightcode" }),
         expect.objectContaining({
           args: [
+            ...GIT_QUOTEPATH_PREFIX,
             "worktree",
             "add",
             expect.stringMatching(
@@ -472,7 +493,9 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
 
     expect(result.changesTransferred).toBe(true);
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(commands.some((c) => c.startsWith("stash push -u"))).toBe(true);
     expect(commands.some((c) => c.startsWith("worktree add -b feature/x"))).toBe(true);
     // Never relies on stash@{0}: apply/drop are pinned to the captured SHA.
@@ -483,7 +506,8 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
     const applyCwds = execFileMock.mock.calls
       .filter(
         (c: unknown[]) =>
-          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "stash apply --index stashsha",
+          Array.isArray(c[1]) &&
+          gitSubcommandArgs(c[1] as string[]).join(" ") === "stash apply --index stashsha",
       )
       .map((c: unknown[]) => (c[2] as { cwd?: string }).cwd);
     expect(applyCwds).toEqual([worktreePath]);
@@ -521,7 +545,9 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
 
     expect(result.changesTransferred).toBe(true);
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(commands).not.toContain("stash pop");
 
     // Copy semantics: the pinned stash is applied into BOTH the worktree and the
@@ -529,7 +555,8 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
     const applyCwds = execFileMock.mock.calls
       .filter(
         (c: unknown[]) =>
-          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "stash apply --index stashsha",
+          Array.isArray(c[1]) &&
+          gitSubcommandArgs(c[1] as string[]).join(" ") === "stash apply --index stashsha",
       )
       .map((c: unknown[]) => (c[2] as { cwd?: string }).cwd);
     expect(applyCwds).toContain(worktreePath);
@@ -568,7 +595,9 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
     // The source was already left clean by the stash push; a conflicting apply
     // keeps the work recoverable in the stash rather than dropping it.
     expect(result.changesTransferred).toBe(false);
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(commands.some((c) => c.startsWith("stash drop"))).toBe(false);
   });
 
@@ -590,7 +619,7 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
     );
 
     const stashCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[])[0] === "stash",
+      (c: unknown[]) => Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[])[0] === "stash",
     );
     expect(stashCall).toBeUndefined();
   });
@@ -616,7 +645,9 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
       true,
     );
 
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     // The worktree is still created, but the unrelated stash is never applied or
     // dropped — no data loss.
     expect(commands.some((c) => c.startsWith("worktree add -b feature/x"))).toBe(true);
@@ -638,7 +669,7 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
     const gitExec = vi.fn<
       (location: WslLocation, input: WslGitExecInput) => Promise<WslGitExecResult>
     >(async (_location, input) => {
-      const args = input.args;
+      const args = gitSubcommandArgs(input.args);
       if (args[0] === "status" && args[1] === "--porcelain") {
         return { ok: true, stdout: " M src/file.ts\n", stderr: "", exitCode: 0 };
       }
@@ -671,7 +702,7 @@ describe("GitService.addWorktree (transfer uncommitted changes)", () => {
       );
 
       const applyCalls = gitExec.mock.calls.filter(
-        ([, input]) => input.args.join(" ") === "stash apply --index stashsha",
+        ([, input]) => gitSubcommandArgs(input.args).join(" ") === "stash apply --index stashsha",
       );
       expect(applyCalls[0]?.[0]).toMatchObject({
         kind: "wsl",
@@ -706,7 +737,8 @@ describe("GitService.revert", () => {
     await new GitService().revert(location, "README.md");
 
     const checkoutCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("checkout"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("checkout"),
     );
     expect(checkoutCall).toBeDefined();
     expect(checkoutCall![1]).toContain("README.md");
@@ -721,7 +753,8 @@ describe("GitService.revert", () => {
     await new GitService().revert(location, "README.md");
 
     const cleanCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("clean"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("clean"),
     );
     expect(cleanCall).toBeDefined();
     expect(cleanCall![1]).toContain("README.md");
@@ -739,13 +772,15 @@ describe("GitService.revert", () => {
     await new GitService().revert(location, "docs/new-name.md");
 
     const cleanCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("clean"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("clean"),
     );
     expect(cleanCall).toBeDefined();
     expect(cleanCall![1]).toContain("docs/new-name.md");
 
     const checkoutCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("checkout"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("checkout"),
     );
     expect(checkoutCall).toBeDefined();
     expect(checkoutCall![1]).toContain("docs/old-name.md");
@@ -800,7 +835,7 @@ describe("GitService.commit", () => {
         expect.objectContaining({ linuxPath: "/home/demo/work/repo" }),
         expect.objectContaining({
           cwd: "/home/demo/work/repo",
-          args: ["commit", "-m", message],
+          args: [...GIT_QUOTEPATH_PREFIX, "commit", "-m", message],
           loginEnv: true,
           timeoutMs: expect.any(Number),
         }),
@@ -861,7 +896,7 @@ describe("GitService.init", () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
-      ["init"],
+      [...GIT_QUOTEPATH_PREFIX, "init"],
       expect.objectContaining({ cwd: location.path }),
       expect.any(Function),
     );
@@ -885,7 +920,7 @@ describe("GitService.addRemote", () => {
 
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
-      ["remote", "add", "origin", "https://github.com/demo/repo.git"],
+      [...GIT_QUOTEPATH_PREFIX, "remote", "add", "origin", "https://github.com/demo/repo.git"],
       expect.objectContaining({ cwd: location.path }),
       expect.any(Function),
     );
@@ -926,7 +961,7 @@ describe("GitService WSL bridge exec", () => {
         expect.objectContaining({ distro: "Ubuntu" }),
         expect.objectContaining({
           cwd: "/home/demo/work/repo",
-          args: ["log", "--oneline", "main..HEAD"],
+          args: [...GIT_QUOTEPATH_PREFIX, "log", "--oneline", "main..HEAD"],
           loginEnv: true,
         }),
       );
@@ -940,7 +975,7 @@ describe("GitService WSL bridge exec", () => {
     const gitExec = vi.fn<
       (location: WslLocation, input: WslGitExecInput) => Promise<WslGitExecResult>
     >(async (_location, input) => {
-      if (input.args[0] === "remote") {
+      if (gitSubcommandArgs(input.args)[0] === "remote") {
         return { ok: true, stdout: "origin\n", stderr: "", exitCode: 0 };
       }
       return { ok: true, stdout: "", stderr: "", exitCode: 0 };
@@ -963,12 +998,15 @@ describe("GitService WSL bridge exec", () => {
       expect(gitExec).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ distro: "Ubuntu" }),
-        expect.objectContaining({ args: ["remote"], loginEnv: true }),
+        expect.objectContaining({ args: [...GIT_QUOTEPATH_PREFIX, "remote"], loginEnv: true }),
       );
       expect(gitExec).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ distro: "Ubuntu" }),
-        expect.objectContaining({ args: ["fetch", "origin"], loginEnv: true }),
+        expect.objectContaining({
+          args: [...GIT_QUOTEPATH_PREFIX, "fetch", "origin"],
+          loginEnv: true,
+        }),
       );
       expect(execFileMock).not.toHaveBeenCalled();
     } finally {
@@ -996,7 +1034,7 @@ describe("GitService WSL bridge exec", () => {
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock).toHaveBeenCalledWith(
       "git",
-      ["remote"],
+      [...GIT_QUOTEPATH_PREFIX, "remote"],
       expect.objectContaining({ cwd: "C:\\Users\\demo\\work\\not-repo" }),
       expect.any(Function),
     );
@@ -1024,7 +1062,7 @@ describe("GitService WSL bridge exec", () => {
       expect(gitExec).toHaveBeenCalledTimes(1);
       expect(gitExec).toHaveBeenCalledWith(
         expect.objectContaining({ distro: "Ubuntu" }),
-        expect.objectContaining({ args: ["remote"], loginEnv: true }),
+        expect.objectContaining({ args: [...GIT_QUOTEPATH_PREFIX, "remote"], loginEnv: true }),
       );
       expect(execFileMock).not.toHaveBeenCalled();
     } finally {
@@ -1059,7 +1097,7 @@ describe("GitService WSL bridge exec", () => {
       expect(gitExec).toHaveBeenCalledTimes(1);
       expect(gitExec).toHaveBeenCalledWith(
         expect.objectContaining({ distro: "Ubuntu" }),
-        expect.objectContaining({ args: ["remote"], loginEnv: true }),
+        expect.objectContaining({ args: [...GIT_QUOTEPATH_PREFIX, "remote"], loginEnv: true }),
       );
       expect(execFileMock).not.toHaveBeenCalled();
     } finally {
@@ -1107,9 +1145,11 @@ describe("GitService.getDiff", () => {
     const result = await new GitService().getDiff(location, "src/file.ts", false);
 
     expect(result.diff).toBe(headDiff);
-    expect(execFileMock.mock.calls.some((call) => (call[1] as string[]).includes("HEAD"))).toBe(
-      true,
-    );
+    expect(
+      execFileMock.mock.calls.some((call) =>
+        gitSubcommandArgs(call[1] as string[]).includes("HEAD"),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -1264,7 +1304,7 @@ describe("GitService.getStatus", () => {
           commands: expect.arrayContaining([
             expect.objectContaining({
               cwd: "/home/demo/work/repo",
-              args: ["status", "--porcelain=v2", "-b"],
+              args: [...GIT_QUOTEPATH_PREFIX, "status", "--porcelain=v2", "-b"],
             }),
           ]),
         }),
@@ -1373,14 +1413,16 @@ describe("GitService.pullFromSource", () => {
 
     expect(result).toEqual({ merged: true, fastForward: true });
     const mergeCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("merge"),
     );
     expect(mergeCall![1]).toContain("--ff-only");
     expect(mergeCall![1]).toContain("origin/main");
     expect(
       execFileMock.mock.calls.some(
         (c: unknown[]) =>
-          Array.isArray(c[1]) && (c[1] as string[]).join(" ") === "fetch origin --prune",
+          Array.isArray(c[1]) &&
+          gitSubcommandArgs(c[1] as string[]).join(" ") === "fetch origin --prune",
       ),
     ).toBe(true);
   });
@@ -1396,7 +1438,8 @@ describe("GitService.pullFromSource", () => {
 
     expect(result).toEqual({ merged: true, fastForward: false });
     const mergeCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("merge"),
     );
     expect(mergeCall![1]).toContain("--no-ff");
   });
@@ -1411,7 +1454,7 @@ describe("GitService.pullFromSource", () => {
     await expect(new GitService().pullFromSource(location, "main")).rejects.toThrow("fetch failed");
     expect(
       execFileMock.mock.calls.some(
-        (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[])[0] === "merge",
+        (c: unknown[]) => Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[])[0] === "merge",
       ),
     ).toBe(false);
   });
@@ -1444,7 +1487,7 @@ describe("GitService.pullFromSource", () => {
     expect(result).toMatchObject({ merged: false, fastForward: false, needsStash: true });
     expect(
       execFileMock.mock.calls.some(
-        (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[])[0] === "merge",
+        (c: unknown[]) => Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[])[0] === "merge",
       ),
     ).toBe(false);
   });
@@ -1458,7 +1501,9 @@ describe("GitService.pullFromSource", () => {
     const result = await new GitService().pullFromSource(location, "main", true);
 
     expect(result).toEqual({ merged: true, fastForward: true });
-    const commands = execFileMock.mock.calls.map((c: unknown[]) => (c[1] as string[]).join(" "));
+    const commands = execFileMock.mock.calls.map((c: unknown[]) =>
+      gitSubcommandArgs(c[1] as string[]).join(" "),
+    );
     expect(commands).toContain("stash push -u -m Poracode: before pull from main");
     expect(commands).toContain("merge --ff-only origin/main");
     expect(commands).toContain("stash pop");
@@ -1512,7 +1557,8 @@ describe("GitService.mergeToSource (non-FF path)", () => {
     await new GitService().mergeToSource(repoLocation, worktreeLocation, "feature", "main");
 
     const mergeCalls = execFileMock.mock.calls.filter(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("merge"),
     );
     expect(mergeCalls.length).toBeGreaterThan(0);
     const mergeArgs = mergeCalls[0]![1] as string[];
@@ -1574,15 +1620,15 @@ describe("GitService.mergeToSource (source branch checked out elsewhere)", () =>
     const worktreeAddCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "worktree" &&
-        (call[1] as string[])[1] === "add",
+        gitSubcommandArgs(call[1] as string[])[0] === "worktree" &&
+        gitSubcommandArgs(call[1] as string[])[1] === "add",
     );
     expect(worktreeAddCall).toBeUndefined();
 
     const mergeCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "merge" &&
+        gitSubcommandArgs(call[1] as string[])[0] === "merge" &&
         (call[2] as { cwd?: string }).cwd === repoLocation.path,
     );
     expect(mergeCall).toBeDefined();
@@ -1620,7 +1666,8 @@ describe("GitService.mergeToSource (source branch checked out elsewhere)", () =>
     expect(result.error).toContain("has uncommitted changes");
 
     const mergeCall = execFileMock.mock.calls.find(
-      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[])[0] === "merge",
+      (call: unknown[]) =>
+        Array.isArray(call[1]) && gitSubcommandArgs(call[1] as string[])[0] === "merge",
     );
     expect(mergeCall).toBeUndefined();
   });
@@ -1676,14 +1723,17 @@ describe("GitService.getWorktreeSourceBranch", () => {
     const configCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "config" &&
-        (call[1] as string[])[1] !== "--get" &&
-        (call[1] as string[]).includes("branch.lightcode/brave-heron.lightcodeSource"),
+        gitSubcommandArgs(call[1] as string[])[0] === "config" &&
+        gitSubcommandArgs(call[1] as string[])[1] !== "--get" &&
+        gitSubcommandArgs(call[1] as string[]).includes(
+          "branch.lightcode/brave-heron.lightcodeSource",
+        ),
     );
     expect(configCall).toBeDefined();
     expect(configCall![1]).toContain("master");
     const revListCall = execFileMock.mock.calls.find(
-      (call: unknown[]) => Array.isArray(call[1]) && (call[1] as string[])[0] === "rev-list",
+      (call: unknown[]) =>
+        Array.isArray(call[1]) && gitSubcommandArgs(call[1] as string[])[0] === "rev-list",
     );
     expect(revListCall![1]).toContain("origin/master...lightcode/brave-heron");
   });
@@ -1712,8 +1762,8 @@ describe("GitService.push", () => {
     const pushCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "push" &&
-        (call[1] as string[]).includes("--set-upstream"),
+        gitSubcommandArgs(call[1] as string[])[0] === "push" &&
+        gitSubcommandArgs(call[1] as string[]).includes("--set-upstream"),
     );
     expect(pushCall).toBeDefined();
     expect(pushCall![1]).toEqual(
@@ -1748,10 +1798,16 @@ describe("GitService.removeWorktree", () => {
     const removeCall = execFileMock.mock.calls.find(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "worktree" &&
-        (call[1] as string[])[1] === "remove",
+        gitSubcommandArgs(call[1] as string[])[0] === "worktree" &&
+        gitSubcommandArgs(call[1] as string[])[1] === "remove",
     );
-    expect(removeCall?.[1]).toEqual(["worktree", "remove", "--force", "--force", worktreePath]);
+    expect(gitSubcommandArgs(removeCall?.[1] as string[])).toEqual([
+      "worktree",
+      "remove",
+      "--force",
+      "--force",
+      worktreePath,
+    ]);
   });
 
   it("does not prune worktrees from a sibling path with the same prefix", async () => {
@@ -1788,10 +1844,10 @@ describe("GitService.removeWorktree", () => {
     const removeCalls = execFileMock.mock.calls.filter(
       (call: unknown[]) =>
         Array.isArray(call[1]) &&
-        (call[1] as string[])[0] === "worktree" &&
-        (call[1] as string[])[1] === "remove",
+        gitSubcommandArgs(call[1] as string[])[0] === "worktree" &&
+        gitSubcommandArgs(call[1] as string[])[1] === "remove",
     );
-    expect(removeCalls.map((call) => call[1])).toEqual([
+    expect(removeCalls.map((call) => gitSubcommandArgs(call[1] as string[]))).toEqual([
       ["worktree", "remove", "--force", "--force", staleManagedPath],
     ]);
   });
@@ -1907,7 +1963,8 @@ describe("GitService.removeWorktree", () => {
     const gitExec = vi.fn<
       (location: WslLocation, input: WslGitExecInput) => Promise<WslGitExecResult>
     >(async (_location, input) => {
-      if (input.args[0] === "worktree" && input.args[1] === "remove") {
+      const args = gitSubcommandArgs(input.args);
+      if (args[0] === "worktree" && args[1] === "remove") {
         return {
           ok: false,
           stdout: "",
@@ -1915,7 +1972,7 @@ describe("GitService.removeWorktree", () => {
           exitCode: 1,
         };
       }
-      if (input.args[0] === "worktree" && input.args[1] === "list") {
+      if (args[0] === "worktree" && args[1] === "list") {
         return {
           ok: true,
           stdout: "worktree /home/demo/work/repo\nHEAD abc123\nbranch refs/heads/main\n\n",
@@ -1964,7 +2021,7 @@ describe("GitService.deleteBranch", () => {
 
     expect(forceDeleteAttempted).toBe(true);
     const softDeleteCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("-d"),
+      (c: unknown[]) => Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("-d"),
     );
     expect(softDeleteCall).toBeUndefined();
   });
@@ -1993,8 +2050,8 @@ describe("GitService.deleteBranch", () => {
     const pruneCall = execFileMock.mock.calls.find(
       (c: unknown[]) =>
         Array.isArray(c[1]) &&
-        (c[1] as string[])[0] === "worktree" &&
-        (c[1] as string[])[1] === "prune",
+        gitSubcommandArgs(c[1] as string[])[0] === "worktree" &&
+        gitSubcommandArgs(c[1] as string[])[1] === "prune",
     );
     expect(pruneCall).toBeDefined();
   });
@@ -2011,7 +2068,7 @@ describe("GitService.deleteBranch", () => {
       "not fully merged",
     );
     const forceDeleteCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("-D"),
+      (c: unknown[]) => Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("-D"),
     );
     expect(forceDeleteCall).toBeUndefined();
   });
@@ -2032,7 +2089,7 @@ describe("GitService.deleteRemoteBranch", () => {
 
     await new GitService().deleteRemoteBranch(location, "origin", "feature/x");
 
-    expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
+    expect(execFileMock.mock.calls.map((call) => gitSubcommandArgs(call[1] as string[]))).toEqual([
       ["push", "origin", "--delete", "feature/x"],
       ["update-ref", "-d", "refs/remotes/origin/feature/x"],
     ]);
@@ -2055,7 +2112,8 @@ describe("GitService.abortMerge", () => {
     await new GitService().abortMerge(location);
 
     const mergeCall = execFileMock.mock.calls.find(
-      (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes("merge"),
+      (c: unknown[]) =>
+        Array.isArray(c[1]) && gitSubcommandArgs(c[1] as string[]).includes("merge"),
     );
     expect(mergeCall).toBeDefined();
     expect(mergeCall![1]).toContain("--abort");

--- a/src/supervisor/git/exec.ts
+++ b/src/supervisor/git/exec.ts
@@ -28,6 +28,21 @@ export const GIT_HOOK_TIMEOUT = 300_000;
 // mid-delete leaves a half-removed husk that later removals refuse to touch.
 export const GIT_WORKTREE_REMOVE_TIMEOUT = 600_000;
 
+/**
+ * Force `core.quotepath=false` on every git invocation. With the default
+ * (`true`), git C-quotes non-ASCII bytes in porcelain/numstat output — e.g.
+ * `файл.txt` prints as `"\321\204\320\260\320\271\320\273.txt"` — which our
+ * parsers would then treat as the literal path, corrupting the git panel and
+ * every per-path operation. Passing it via `-c` overrides the user's config for
+ * this process only. The `-c` pair MUST precede the git subcommand.
+ */
+const QUOTEPATH_DISABLE_ARGS = ["-c", "core.quotepath=false"];
+
+/** Prepend the quotepath override in front of a git subcommand's args. */
+export function withQuotePathDisabled(args: string[]): string[] {
+  return [...QUOTEPATH_DISABLE_ARGS, ...args];
+}
+
 let wslGitBridgeClient: WslBridgeClient | undefined;
 
 export function setWslGitBridgeClient(client: WslBridgeClient | undefined): void {
@@ -51,9 +66,11 @@ export async function execGitBatchWslBridge(
     throw new Error(`WSL bridge unavailable for Git in distro "${location.distro}"`);
   }
   const result = await client.gitBatch(location, {
-    commands: commands.map((command) =>
-      command.loginEnv === undefined ? { ...command, loginEnv: true } : command,
-    ),
+    commands: commands.map((command) => ({
+      ...command,
+      args: withQuotePathDisabled(command.args),
+      ...(command.loginEnv === undefined ? { loginEnv: true } : {}),
+    })),
     timeoutMs,
   });
   return result.results;
@@ -94,7 +111,7 @@ export async function execGit(
     }
 
     const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0", ...(options?.env ?? {}) };
-    const { stdout } = await execFileAsync("git", args, {
+    const { stdout } = await execFileAsync("git", withQuotePathDisabled(args), {
       cwd: location.path,
       env,
       timeout,
@@ -125,7 +142,7 @@ async function execGitWslBridge(
   }
   return await client.gitExec(location, {
     cwd: location.linuxPath,
-    args,
+    args: withQuotePathDisabled(args),
     loginEnv: true,
     timeoutMs,
     ...(env ? { env } : {}),

--- a/src/supervisor/git/statusService.parser.test.ts
+++ b/src/supervisor/git/statusService.parser.test.ts
@@ -15,7 +15,13 @@ import {
   expandUntrackedEntries,
   parseDiffNumstat,
   parseStatusPorcelainV2,
+  unquoteGitPath,
 } from "./statusService";
+
+// git C-quotes non-ASCII bytes as octal-escaped UTF-8 wrapped in double quotes.
+// `файл.txt` → ф=\321\204 а=\320\260 й=\320\271 л=\320\273 then `.txt`.
+const QUOTED_CYRILLIC = '"\\321\\204\\320\\260\\320\\271\\320\\273.txt"';
+const DECODED_CYRILLIC = "файл.txt";
 
 describe("parseStatusPorcelainV2", () => {
   it("captures branch, upstream, ahead/behind from the header lines", () => {
@@ -120,6 +126,75 @@ describe("parseStatusPorcelainV2", () => {
     expect(ahead).toBe(0);
     expect(behind).toBe(0);
   });
+
+  it("decodes a C-quoted non-ASCII path back to real UTF-8", () => {
+    const output = [
+      "# branch.head main",
+      `1 M. N... 100644 100644 100644 aaa aaa ${QUOTED_CYRILLIC}`,
+    ].join("\n");
+    const { staged } = parseStatusPorcelainV2(output);
+    expect(staged[0]!.path).toBe(DECODED_CYRILLIC);
+  });
+
+  it("decodes a C-quoted path containing a literal double quote", () => {
+    // git still quotes double-quote/backslash/control chars even with
+    // core.quotepath=false: `a"b.txt` → `"a\"b.txt"`.
+    const output = [
+      "# branch.head main",
+      '1 M. N... 100644 100644 100644 aaa aaa "a\\"b.txt"',
+    ].join("\n");
+    const { staged } = parseStatusPorcelainV2(output);
+    expect(staged[0]!.path).toBe('a"b.txt');
+  });
+
+  it("decodes both the new and old quoted paths of a rename", () => {
+    const output = [
+      "# branch.head main",
+      `2 R. N... 100644 100644 100644 aaa aaa R100 ${QUOTED_CYRILLIC}\t"\\320\\261.txt"`,
+    ].join("\n");
+    const { staged } = parseStatusPorcelainV2(output);
+    expect(staged[0]!.path).toBe(DECODED_CYRILLIC);
+    expect(staged[0]!.oldPath).toBe("б.txt");
+  });
+
+  it("decodes a C-quoted `u ` conflict path", () => {
+    const output = [
+      "# branch.head main",
+      `u UU N... 100644 100644 100644 100644 aaa bbb ccc ${QUOTED_CYRILLIC}`,
+    ].join("\n");
+    const { conflictFiles } = parseStatusPorcelainV2(output);
+    expect(conflictFiles).toEqual([DECODED_CYRILLIC]);
+  });
+
+  it("leaves an unquoted (raw UTF-8) path untouched", () => {
+    const output = ["# branch.head main", `? ${DECODED_CYRILLIC}`].join("\n");
+    const { unstaged } = parseStatusPorcelainV2(output);
+    expect(unstaged[0]!.path).toBe(DECODED_CYRILLIC);
+  });
+});
+
+describe("unquoteGitPath", () => {
+  it("decodes multi-byte octal escapes as UTF-8 bytes, not code points", () => {
+    // `\321\204` are the two UTF-8 bytes of `ф`; decoding per-byte then reading
+    // the buffer as UTF-8 must reassemble the single code point.
+    expect(unquoteGitPath('"\\321\\204"')).toBe("ф");
+    expect(unquoteGitPath(QUOTED_CYRILLIC)).toBe(DECODED_CYRILLIC);
+  });
+
+  it("decodes the simple C escapes", () => {
+    expect(unquoteGitPath('"a\\tb"')).toBe("a\tb");
+    expect(unquoteGitPath('"a\\nb"')).toBe("a\nb");
+    expect(unquoteGitPath('"a\\"b.txt"')).toBe('a"b.txt');
+    expect(unquoteGitPath('"a\\\\b.txt"')).toBe("a\\b.txt");
+  });
+
+  it("returns unquoted input unchanged (raw UTF-8 or plain ASCII)", () => {
+    expect(unquoteGitPath("src/plain.ts")).toBe("src/plain.ts");
+    expect(unquoteGitPath(DECODED_CYRILLIC)).toBe(DECODED_CYRILLIC);
+    expect(unquoteGitPath("")).toBe("");
+    // A path only prefixed with a quote is not a fully-quoted blob.
+    expect(unquoteGitPath('"partial')).toBe('"partial');
+  });
 });
 
 describe("parseDiffNumstat", () => {
@@ -150,6 +225,53 @@ describe("parseDiffNumstat", () => {
 
   it("skips malformed lines that lack a path", () => {
     expect(parseDiffNumstat("3\t1")).toEqual([]);
+  });
+
+  it("resolves a brace rename with a common prefix to the new path", () => {
+    expect(parseDiffNumstat("1\t0\tsrc/{old.txt => new.txt}")).toEqual([
+      { path: "src/new.txt", insertions: 1, deletions: 0 },
+    ]);
+  });
+
+  it("resolves a brace rename with a common prefix AND suffix to the new path", () => {
+    expect(parseDiffNumstat("1\t0\tsrc/{a => b}/file.txt")).toEqual([
+      { path: "src/b/file.txt", insertions: 1, deletions: 0 },
+    ]);
+  });
+
+  it("resolves an empty-side brace rename to the new path", () => {
+    expect(parseDiffNumstat("2\t1\tdir/{ => sub}/file.txt")).toEqual([
+      { path: "dir/sub/file.txt", insertions: 2, deletions: 1 },
+    ]);
+    // Reverse (removal) side collapses the adjacent slashes back to the new path.
+    expect(parseDiffNumstat("2\t1\tdir/{sub => }/file.txt")).toEqual([
+      { path: "dir/file.txt", insertions: 2, deletions: 1 },
+    ]);
+  });
+
+  it("resolves a plain `old => new` rename (no common prefix) to the new path", () => {
+    expect(parseDiffNumstat("1\t0\tsrc/old.txt => deep/dir/new.txt")).toEqual([
+      { path: "deep/dir/new.txt", insertions: 1, deletions: 0 },
+    ]);
+  });
+
+  it("returns 0/0 for a binary rename line (`-\\t-\\t{old => new}`)", () => {
+    expect(parseDiffNumstat("-\t-\tsrc/{old.png => new.png}")).toEqual([
+      { path: "src/new.png", insertions: 0, deletions: 0 },
+    ]);
+  });
+
+  it("decodes a whole-field C-quoted non-ASCII path", () => {
+    expect(parseDiffNumstat(`3\t1\t${QUOTED_CYRILLIC}`)).toEqual([
+      { path: DECODED_CYRILLIC, insertions: 3, deletions: 1 },
+    ]);
+  });
+
+  it("decodes each independently-quoted side of a plain rename to the new path", () => {
+    // git quotes each side of a rename separately: `"old" => "new"`.
+    expect(parseDiffNumstat(`4\t2\t"\\320\\261.txt" => ${QUOTED_CYRILLIC}`)).toEqual([
+      { path: DECODED_CYRILLIC, insertions: 4, deletions: 2 },
+    ]);
   });
 });
 
@@ -225,6 +347,49 @@ describe("buildGitStatusResultFromOutputs", () => {
     expect(result.unstaged[0]!.deletions).toBe(0);
     expect(result.totalInsertions).toBe(7);
     expect(result.totalDeletions).toBe(1);
+  });
+
+  it("backfills rename numstat counts onto a porcelain-v2 rename entry", () => {
+    // Porcelain v2 carries the new path (`src/new.txt`); numstat emits the
+    // combined rename syntax, which must resolve to the same new path.
+    const result = buildGitStatusResultFromOutputs({
+      isRepo: true,
+      statusOutput: [
+        "# branch.head main",
+        "2 R. N... 100644 100644 100644 aaa aaa R83 src/new.txt\tsrc/old.txt",
+      ].join("\n"),
+      remoteOutput: "",
+      stagedNumstat: "4\t2\tsrc/{old.txt => new.txt}",
+      unstagedNumstat: "",
+    });
+    expect(result.staged).toHaveLength(1);
+    expect(result.staged[0]!.path).toBe("src/new.txt");
+    expect(result.staged[0]!.oldPath).toBe("src/old.txt");
+    expect(result.staged[0]!.insertions).toBe(4);
+    expect(result.staged[0]!.deletions).toBe(2);
+    expect(result.totalInsertions).toBe(4);
+    expect(result.totalDeletions).toBe(2);
+  });
+
+  it("merges numstat counts onto a porcelain entry when both paths are C-quoted", () => {
+    // End-to-end: the porcelain path and the numstat path both arrive C-quoted
+    // and must decode to the SAME real path so the count backfill matches.
+    const result = buildGitStatusResultFromOutputs({
+      isRepo: true,
+      statusOutput: [
+        "# branch.head main",
+        `1 .M N... 100644 100644 100644 aaa aaa ${QUOTED_CYRILLIC}`,
+      ].join("\n"),
+      remoteOutput: "",
+      stagedNumstat: "",
+      unstagedNumstat: `5\t2\t${QUOTED_CYRILLIC}`,
+    });
+    expect(result.unstaged).toHaveLength(1);
+    expect(result.unstaged[0]!.path).toBe(DECODED_CYRILLIC);
+    expect(result.unstaged[0]!.insertions).toBe(5);
+    expect(result.unstaged[0]!.deletions).toBe(2);
+    expect(result.totalInsertions).toBe(5);
+    expect(result.totalDeletions).toBe(2);
   });
 
   it("returns hasRemote=false when remoteOutput is empty", () => {

--- a/src/supervisor/git/statusService.ts
+++ b/src/supervisor/git/statusService.ts
@@ -37,6 +37,74 @@ interface DiffStatEntry {
   deletions: number;
 }
 
+/**
+ * Decode git's C-quoted path form. We force `core.quotepath=false` on every git
+ * invocation (see {@link withQuotePathDisabled}), so non-ASCII bytes come
+ * through raw — but git ALWAYS quotes a path that contains a double quote,
+ * backslash, or control character, regardless of that setting. When `raw` is
+ * such a quoted blob (starts and ends with `"`) strip the quotes and decode the
+ * C escapes; otherwise return it unchanged.
+ *
+ * Octal escapes (`\NNN`) are raw UTF-8 BYTES, not code points, so decoded bytes
+ * are accumulated into a Buffer and read back as UTF-8 once at the end — decoding
+ * each escape as a character would mojibake any multi-byte sequence.
+ */
+export function unquoteGitPath(raw: string): string {
+  if (raw.length < 2 || !raw.startsWith('"') || !raw.endsWith('"')) {
+    return raw;
+  }
+  const body = raw.slice(1, -1);
+  const bytes: number[] = [];
+  const pushUtf8 = (char: string): void => {
+    for (const b of Buffer.from(char, "utf-8")) bytes.push(b);
+  };
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i]!;
+    if (ch !== "\\") {
+      pushUtf8(ch);
+      continue;
+    }
+    const next = body[i + 1];
+    if (next === undefined) {
+      bytes.push(0x5c); // trailing backslash — keep literal
+      break;
+    }
+    if (next >= "0" && next <= "7") {
+      // Octal escape: up to 3 octal digits collapse to one byte.
+      let oct = "";
+      let j = i + 1;
+      while (j < body.length && oct.length < 3 && body[j]! >= "0" && body[j]! <= "7") {
+        oct += body[j]!;
+        j += 1;
+      }
+      bytes.push(parseInt(oct, 8) & 0xff);
+      i = j - 1;
+      continue;
+    }
+    switch (next) {
+      case "\\":
+        bytes.push(0x5c);
+        break;
+      case '"':
+        bytes.push(0x22);
+        break;
+      case "t":
+        bytes.push(0x09);
+        break;
+      case "n":
+        bytes.push(0x0a);
+        break;
+      case "r":
+        bytes.push(0x0d);
+        break;
+      default:
+        pushUtf8(next); // unknown escape — keep the escaped char literally
+    }
+    i += 1;
+  }
+  return Buffer.from(bytes).toString("utf-8");
+}
+
 function parseUntrackedPaths(output: string): string[] {
   return output
     .split("\0")
@@ -78,14 +146,14 @@ export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
     if (line.startsWith("u ")) {
       mergeInProgress = true;
       const parts = line.split(" ");
-      const path = toForwardSlash(parts.slice(10).join(" "));
+      const path = toForwardSlash(unquoteGitPath(parts.slice(10).join(" ")));
       conflictFiles.push(path);
       continue;
     }
 
     if (line.startsWith("? ")) {
       unstaged.push({
-        path: toForwardSlash(line.slice(2)),
+        path: toForwardSlash(unquoteGitPath(line.slice(2))),
         status: "?",
         staged: false,
         insertions: 0,
@@ -105,8 +173,8 @@ export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
     const indexStatus = xy[0]!;
     const worktreeStatus = xy[1]!;
 
-    const path = toForwardSlash(fields.slice(kind === "2" ? 9 : 8).join(" "));
-    const oldPath = kind === "2" ? toForwardSlash(parts[1] ?? "") : undefined;
+    const path = toForwardSlash(unquoteGitPath(fields.slice(kind === "2" ? 9 : 8).join(" ")));
+    const oldPath = kind === "2" ? toForwardSlash(unquoteGitPath(parts[1] ?? "")) : undefined;
 
     if (indexStatus !== ".") {
       staged.push({
@@ -142,14 +210,63 @@ export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
   };
 }
 
+/**
+ * `git diff --numstat` collapses a rename into the source/destination combined
+ * syntax in its path field. Resolve it to the NEW path so counts merge against
+ * the porcelain-v2 rename entries (which carry the new path):
+ *   - brace form: `src/{old => new}/file.txt` → `src/new/file.txt`
+ *   - empty side: `dir/{ => sub}/file.txt`   → `dir/sub/file.txt`
+ *   - plain form: `src/old.txt => deep/new.txt` → `deep/new.txt`
+ * A literal ` => ` inside a filename is vanishingly rare; the brace form is
+ * unambiguous, and the plain form is only applied when no braces are present.
+ *
+ * C-quoting is decoded per side, because git quotes each side of a rename
+ * independently (e.g. `"\321\204.txt" => "\320\261.txt"`) rather than the field
+ * as a whole. A non-rename field that is quoted as a whole (`"\321\204.txt"`)
+ * is decoded on the return path. The brace form with an embedded quote is rare;
+ * when git quotes the whole `prefix{old => new}suffix` field we decode it first
+ * so the braces are visible, then resolve.
+ */
+function resolveNumstatRenamePath(rawPath: string): string {
+  // Plain `old => new` rename with no braces: git quotes each side on its own,
+  // so split on the arrow and decode only the new side. Guarded by the absence
+  // of `{` so the brace form falls through to the dedicated handling below.
+  const plainArrow = rawPath.indexOf(" => ");
+  if (plainArrow !== -1 && rawPath.indexOf("{") === -1) {
+    return unquoteGitPath(rawPath.slice(plainArrow + " => ".length));
+  }
+  // Brace form (and whole-field-quoted non-renames): decode any whole-field
+  // quoting first so the `{`/`}`/`=>` structure is visible to the resolver.
+  const decoded = unquoteGitPath(rawPath);
+  const braceStart = decoded.indexOf("{");
+  if (braceStart !== -1) {
+    const braceEnd = decoded.indexOf("}", braceStart);
+    const arrow = decoded.indexOf(" => ", braceStart);
+    if (braceEnd !== -1 && arrow !== -1 && arrow < braceEnd) {
+      const prefix = decoded.slice(0, braceStart);
+      const suffix = decoded.slice(braceEnd + 1);
+      const newInner = decoded.slice(arrow + " => ".length, braceEnd);
+      // An empty side (`{ => sub}` / `{sub => }`) leaves the prefix/suffix
+      // slashes adjacent; collapse the resulting `//` back to a single `/`.
+      return `${prefix}${newInner}${suffix}`.replace(/\/{2,}/g, "/");
+    }
+  }
+  return decoded;
+}
+
 export function parseDiffNumstat(output: string): DiffStatEntry[] {
   const entries: DiffStatEntry[] = [];
   for (const line of output.trim().split(/\r?\n/)) {
     if (!line) continue;
-    const [insertionsRaw, deletionsRaw, path] = line.split("\t");
-    if (!path) continue;
+    // numstat has exactly two leading numeric fields; the path is the rest,
+    // rejoined so a tab inside a filename isn't truncated.
+    const parts = line.split("\t");
+    const insertionsRaw = parts[0];
+    const deletionsRaw = parts[1];
+    const rawPath = parts.slice(2).join("\t");
+    if (!rawPath) continue;
     entries.push({
-      path: toForwardSlash(path),
+      path: toForwardSlash(resolveNumstatRenamePath(rawPath)),
       insertions: Number.isNaN(Number(insertionsRaw ?? "0"))
         ? 0
         : parseInt(insertionsRaw ?? "0", 10),


### PR DESCRIPTION
- Bugfix: keep staged and unstaged file counts accurate when a file is staged, unstaged, or restaged from the Git review UI.
- Reconcile optimistic stage changes with a follow-up full status refresh so the sidebar reflects git’s real index state after each successful action.
- Preserve cumulative diff stats across repeated path updates in the renderer store, including summary-poll escalation when cached counts cannot be recovered.
- Make supervisor git status parsing handle `core.quotepath=false` and C-quoted paths so non-ASCII and quoted filenames stay readable and actionable.