### PR TITLE
Bugfix: Discard replaced draft content on project switch

### DIFF
--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -4,9 +4,11 @@ import type { Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 import {
   deleteThread,
+  openNewThread,
   openThread,
   reopenStoredThread,
   switchToAdjacentThread,
@@ -66,6 +68,56 @@ describe("threadActions", () => {
       tabActivity: {},
     });
     useWorktreeDeleteStore.setState({ dialog: null });
+    useSharedSettings.setState({
+      homeScopeEnabled: false,
+      newThreadMode: "page",
+    });
+  });
+
+  it("discards the replaced draft when starting a sidebar draft for another project", () => {
+    const firstProject = useAppStore.getState().addProject({ kind: "posix", path: "/repo-a" });
+    const secondProject = useAppStore.getState().addProject({ kind: "posix", path: "/repo-b" });
+    useAppStore.setState((state) => ({
+      ...state,
+      view: { kind: "draft", projectId: firstProject.id },
+      draftContents: {
+        [firstProject.id]: {
+          segments: [{ kind: "text", content: "old draft" }],
+          attachments: [],
+        },
+      },
+      draftContentDiscardRequests: {},
+    }));
+
+    openNewThread(secondProject.id);
+
+    expect(useAppStore.getState().view).toEqual({
+      kind: "draft",
+      projectId: secondProject.id,
+    });
+    expect(useAppStore.getState().draftContents[firstProject.id]).toBeUndefined();
+    expect(useAppStore.getState().consumeDraftContentDiscard(firstProject.id)).toBe(true);
+  });
+
+  it("keeps visible draft panes when starting a sidebar draft as a panel", () => {
+    useSharedSettings.setState({ newThreadMode: "panel" });
+    const firstProject = useAppStore.getState().addProject({ kind: "posix", path: "/repo-a" });
+    const secondProject = useAppStore.getState().addProject({ kind: "posix", path: "/repo-b" });
+    const thread = makeThread({ id: "thread-visible", projectId: firstProject.id });
+    const draftPaneId = `draft:${firstProject.id}`;
+    useAppStore.setState((state) => ({
+      ...state,
+      threads: [thread],
+      view: { kind: "thread", panes: [thread.id, draftPaneId] },
+      draftContentDiscardRequests: {},
+    }));
+
+    openNewThread(secondProject.id);
+
+    const view = useAppStore.getState().view;
+    expect(view.kind).toBe("thread");
+    expect(view.kind === "thread" && view.panes).toContain(draftPaneId);
+    expect(useAppStore.getState().draftContentDiscardRequests[firstProject.id]).toBeUndefined();
   });
 
   it("hydrates a persisted GUI thread before opening the pane", async () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -1,7 +1,7 @@
 import { startTransition } from "react";
 import type { Thread } from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
-import { isDraftPaneId } from "@/shared/paneId";
+import { isDraftPaneId, parseDraftProjectId } from "@/shared/paneId";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
@@ -21,6 +21,22 @@ import { getCurrentProjectId } from "./currentProject";
 import { performWorktreeRemoval } from "./worktreeActions";
 
 let openThreadRequestId = 0;
+
+function discardReplacedDraftContents(targetProjectId: string): void {
+  const store = useAppStore.getState();
+  const view = store.view;
+  if (view.kind === "draft") {
+    if (view.projectId !== targetProjectId) store.discardDraftContent(view.projectId);
+    return;
+  }
+  if (view.kind !== "thread") return;
+  for (const paneId of view.panes) {
+    const draftProjectId = parseDraftProjectId(paneId);
+    if (draftProjectId && draftProjectId !== targetProjectId) {
+      store.discardDraftContent(draftProjectId);
+    }
+  }
+}
 
 export function openNewThread(projectId?: string): void {
   openThreadRequestId += 1;
@@ -42,6 +58,7 @@ export function openNewThread(projectId?: string): void {
     if (mode === "panel" && view.kind === "thread" && view.panes.length > 0) {
       useAppStore.getState().openDraftSideBySide(targetProjectId);
     } else {
+      discardReplacedDraftContents(targetProjectId);
       useAppStore.getState().openDraft(targetProjectId);
     }
   });
@@ -73,6 +90,7 @@ export function openNewThreadInWorktree(input: {
     if (mode === "panel" && view.kind === "thread" && view.panes.length > 0) {
       useAppStore.getState().openDraftSideBySide(input.projectId);
     } else {
+      discardReplacedDraftContents(input.projectId);
       useAppStore.getState().openDraft(input.projectId);
     }
   });

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -45,6 +45,7 @@ export function ProjectSwitchMenu(props: {
   );
   const openDraft = useAppStore((state) => state.openDraft);
   const replacePaneId = useAppStore((state) => state.replacePaneId);
+  const discardDraftContent = useAppStore((state) => state.discardDraftContent);
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -60,6 +61,7 @@ export function ProjectSwitchMenu(props: {
 
   function handleSelect(nextProjectId: string) {
     if (nextProjectId === currentProjectId) return;
+    discardDraftContent(currentProjectId);
     startTransition(() => {
       if (paneId) {
         replacePaneId(paneId, makeDraftPaneId(nextProjectId));

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -527,6 +527,7 @@ export function ThreadDraftComposerArea(props: {
     const pid = props.project.id;
     return () => {
       if (submittedRef.current) return;
+      if (useAppStore.getState().consumeDraftContentDiscard(pid)) return;
       const content = { segments: latestSegmentsRef.current, attachments: attachmentsRef.current };
       if (isDraftContentNonEmpty(content)) {
         saveDraftContent(pid, content);

--- a/src/renderer/components/thread/ThreadSlashCommands.test.tsx
+++ b/src/renderer/components/thread/ThreadSlashCommands.test.tsx
@@ -162,6 +162,7 @@ describe("ThreadSlashCommands", () => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
     useAppStore.getState().clearDraftContent(draftProject.id);
+    useAppStore.setState({ draftContentDiscardRequests: {} });
     useSharedSettings.setState({ collapseTerminalComposer: false });
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
@@ -553,5 +554,66 @@ describe("ThreadSlashCommands", () => {
     expect(onStart).not.toHaveBeenCalled();
     expect(screen.queryByText("Commands")).not.toBeInTheDocument();
     expect(editor.textContent).toBe("/review ");
+  });
+
+  it("saves draft composer content on ordinary unmount", () => {
+    const { unmount } = render(
+      <AppProvider>
+        <ThreadDraftComposerArea
+          project={draftProject}
+          selectedAgent={makeAgentStatus()}
+          controls={[]}
+          config={{ model: "gemini-2.5-pro" }}
+          compact={false}
+          paneCount={1}
+          gitBranch={undefined}
+          worktreeMode={false}
+          supportsModePicker={false}
+          presentationMode="terminal"
+          onConfigChange={() => {}}
+          onWorktreeModeChange={() => {}}
+          onSwitchBranch={() => {}}
+          onRememberPresentationMode={() => {}}
+          onStart={() => {}}
+        />
+      </AppProvider>,
+    );
+
+    typeSlashQuery(screen.getByRole("textbox"), "ordinary draft");
+    unmount();
+
+    expect(useAppStore.getState().draftContents[draftProject.id]).toMatchObject({
+      segments: [{ kind: "text", content: "ordinary draft" }],
+    });
+  });
+
+  it("discards draft composer content when project switching requests it", () => {
+    const { unmount } = render(
+      <AppProvider>
+        <ThreadDraftComposerArea
+          project={draftProject}
+          selectedAgent={makeAgentStatus()}
+          controls={[]}
+          config={{ model: "gemini-2.5-pro" }}
+          compact={false}
+          paneCount={1}
+          gitBranch={undefined}
+          worktreeMode={false}
+          supportsModePicker={false}
+          presentationMode="terminal"
+          onConfigChange={() => {}}
+          onWorktreeModeChange={() => {}}
+          onSwitchBranch={() => {}}
+          onRememberPresentationMode={() => {}}
+          onStart={() => {}}
+        />
+      </AppProvider>,
+    );
+
+    typeSlashQuery(screen.getByRole("textbox"), "discarded draft");
+    useAppStore.getState().discardDraftContent(draftProject.id);
+    unmount();
+
+    expect(useAppStore.getState().draftContents[draftProject.id]).toBeUndefined();
   });
 });

--- a/src/renderer/state/slices/draftSlice.ts
+++ b/src/renderer/state/slices/draftSlice.ts
@@ -26,8 +26,11 @@ export interface DraftSlice {
   threadDraftContents: Record<string, DraftContent>;
   pendingDraftWorktreeSelections: Record<string, PendingDraftWorktreeSelection>;
   pendingComposerSeeds: Record<string, PendingComposerSeed>;
+  draftContentDiscardRequests: Record<string, true>;
   saveDraftContent: (projectId: string, content: DraftContent) => void;
   clearDraftContent: (projectId: string) => void;
+  discardDraftContent: (projectId: string) => void;
+  consumeDraftContentDiscard: (projectId: string) => boolean;
   saveThreadDraftContent: (threadId: string, content: DraftContent) => void;
   clearThreadDraftContent: (threadId: string) => void;
   setPendingDraftWorktreeSelection: (
@@ -44,6 +47,7 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
   threadDraftContents: {},
   pendingDraftWorktreeSelections: {},
   pendingComposerSeeds: {},
+  draftContentDiscardRequests: {},
   saveDraftContent: (projectId, content) =>
     set((state) => ({
       draftContents: { ...state.draftContents, [projectId]: content },
@@ -54,6 +58,27 @@ export const createDraftSlice: SliceCreator<DraftSlice> = (set) => ({
       const { [projectId]: _, ...rest } = state.draftContents;
       return { draftContents: rest };
     }),
+  discardDraftContent: (projectId) =>
+    set((state) => {
+      const { [projectId]: _draft, ...draftContents } = state.draftContents;
+      return {
+        draftContents,
+        draftContentDiscardRequests: {
+          ...state.draftContentDiscardRequests,
+          [projectId]: true,
+        },
+      };
+    }),
+  consumeDraftContentDiscard: (projectId) => {
+    let shouldDiscard = false;
+    set((state) => {
+      if (!(projectId in state.draftContentDiscardRequests)) return {};
+      shouldDiscard = true;
+      const { [projectId]: _, ...rest } = state.draftContentDiscardRequests;
+      return { draftContentDiscardRequests: rest };
+    });
+    return shouldDiscard;
+  },
   saveThreadDraftContent: (threadId, content) =>
     set((state) => ({
       threadDraftContents: { ...state.threadDraftContents, [threadId]: content },

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -285,6 +285,7 @@ export function AppContent() {
     return (
       <div className="h-full">
         <DraftViewContent
+          key={draftProject.id}
           project={draftProject}
           lastDraftConfig={draftLastDraftConfig}
           onStart={(input) => handleDraftStart(draftProject, input)}


### PR DESCRIPTION
- Prevent stale draft content from surviving when a user switches projects and opens a new draft.
- Preserve visible draft panes in panel mode while still clearing replaced composer state in sidebar mode.
- Make draft composer unmount behavior respect explicit discard requests so normal saves still work.
- Add coverage for project-switch flows, draft unmount persistence, and discard-triggered cleanup.