### PR TITLE
Fix chat row hover affordance

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -283,7 +283,9 @@ function ToolCallInline({ item }: { item: RuntimeChatItem }) {
       }}
     >
       <Disclosure.Heading>
-        <Disclosure.Trigger className="flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left transition-colors hover:bg-[var(--row-hover)]">
+        <Disclosure.Trigger
+          className={`flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left ${chatRowHoverClass}`}
+        >
           <Icon className="size-3 shrink-0 text-[color:var(--muted)]" />
           <InlineRowTitle
             title={row.title}

--- a/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
@@ -23,8 +23,11 @@ export const chatRowShellClass = "w-full pl-4";
 export const chatRowClass =
   "flex w-fit max-w-full min-w-0 items-center rounded-lg px-2 py-1 text-left";
 
-// Hover affordance for rows that expand a body on click.
-export const chatRowHoverClass = "transition-colors hover:bg-[var(--row-hover)]";
+// Hover affordance for rows that expand a body on click. Matches the
+// Thinking/Thought toggle: the row's muted text lights up to foreground
+// (all row content is colored via `var(--muted)`) instead of a background
+// tint.
+export const chatRowHoverClass = "transition-colors hover:[--muted:var(--foreground)]";
 
 // Hairline rule above an expanded row's body. Callers append the top padding
 // (`pt-1` dense, `pt-2.5` roomier).


### PR DESCRIPTION
- Bugfix for chat pane rows with expandable bodies, aligning hover treatment across tool-call groups and related rows.
- Switch the hover affordance from a background tint to a muted-text-to-foreground transition so the whole row reads consistently.
- Update the shared chat row hover class and apply it to the tool call disclosure trigger to keep interactive rows visually matched.