### PR TITLE
Fix persisted runtime snapshots dropping transient errors

### DIFF
--- a/src/renderer/state/chatRuntimePersister.test.ts
+++ b/src/renderer/state/chatRuntimePersister.test.ts
@@ -173,6 +173,20 @@ describe("prepareRuntimeSnapshotForPersistence", () => {
     expect(ids.some((id) => id.startsWith("tool-call-summary:"))).toBe(false);
   });
 
+  it("drops error items so stale errors do not resurface on reopen", () => {
+    const snapshot = prepareRuntimeSnapshotForPersistence(
+      [
+        makeItem({ id: "user-1", type: "user_message" }),
+        makeItem({ id: "assistant-1", type: "assistant_message" }),
+        makeItem({ id: "err-1", type: "error", payload: { message: "boom" } }),
+      ],
+      [makeTurn("err-1")],
+    );
+
+    expect(snapshot.items.map((item) => item.id)).toEqual(["user-1", "assistant-1"]);
+    expect(snapshot.turns[0]?.anchorItemId).toBe("assistant-1");
+  });
+
   it("keeps dropped-anchor markers attached to the previous surviving row", () => {
     const snapshot = prepareRuntimeSnapshotForPersistence(
       [

--- a/src/renderer/state/chatRuntimePersister.ts
+++ b/src/renderer/state/chatRuntimePersister.ts
@@ -248,7 +248,12 @@ function compactRuntimeItemsForPersistence(
   let idx = 0;
   while (idx < items.length) {
     const item = items[idx]!;
-    if (isEmptyCompletedReasoning(item)) {
+    // Error items are session-transient: they describe a failure of the run
+    // that produced them, so persisting them would resurface stale errors in
+    // the composer dock every time the thread is reopened. Dropping them here
+    // covers both the save path and hydration (which re-runs this compactor),
+    // so errors already sitting in older databases are cleaned up on load too.
+    if (item.type === "error" || isEmptyCompletedReasoning(item)) {
       // If a turn marker was anchored to a row we drop on save, keep it
       // attached to the previous surviving row so it renders in the same gap.
       anchorRemap.set(item.id, lastPersistedItemId);


### PR DESCRIPTION
- Tickets: none
- Stop error items from being saved into runtime snapshots so stale run failures do not reappear when a thread is reopened.
- Preserve turn anchoring when error rows are removed, keeping surrounding timeline gaps stable after compaction.
- Add a regression test covering reopen behavior and the updated anchor remapping.