### PR TITLE
Fix chat scrolling and collapsed row stability

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -83,8 +83,14 @@ function flushPendingRuntimeEvents(): void {
   if (pendingRuntimeEvents.size === 0) return;
   const store = useAppStore.getState();
   const threads = store.threads;
-  for (const [threadId, events] of pendingRuntimeEvents) {
-    store.applyRuntimeEvents(threadId, events);
+  const batches = [...pendingRuntimeEvents.entries()].map(([threadId, events]) => ({
+    threadId,
+    events,
+  }));
+  // One Zustand set for all concurrent streams — avoids N selector passes when
+  // several chats are working in the background / being switched between.
+  store.applyRuntimeEventBatches(batches);
+  for (const { threadId, events } of batches) {
     // Durable usage capture at the canonical layer (all providers normalized).
     // Thread metadata is resolved lazily inside, so pure-delta frames are free.
     recordRuntimeUsage(threadId, events, threads);

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -347,6 +347,83 @@ describe("ChatPane", () => {
     await waitFor(() => expect(metrics.getScrollTop()).toBe(80));
   });
 
+  it("does not re-stick when the scrollbar thumb is dragged away from the bottom", async () => {
+    // Regression: native scrollbar thumbs often never fire pointerdown on the
+    // scroller (Windows overlay scrollbars) — only scroll. Sticky used to
+    // require a prior intent flag to release, so ResizeObserver re-pins yanked
+    // the thumb back to the bottom mid-drag.
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Inspect output");
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const scrollElement = getScrollElement(container);
+    const contentElement = getContentElement(scrollElement);
+    const metrics = installScrollMetrics(scrollElement, {
+      scrollHeight: 200,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    act(() => {
+      metrics.setScrollTop(200);
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      // No pointerdown — mirrors a native thumb drag that only emits scroll.
+      metrics.setScrollTop(80);
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      metrics.setScrollHeight(300);
+      MockResizeObserver.notify(contentElement);
+    });
+
+    await waitFor(() => expect(metrics.getScrollTop()).toBe(80));
+  });
+
+  it("does not re-stick when the scrollbar thumb is dragged while content height grows", async () => {
+    // Working-thread regression: a thumb drag often coincides with streaming
+    // growth. Height growth must not be treated as a layout clamp that keeps
+    // sticky on — otherwise the next ResizeObserver re-pin yanks the thumb.
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Inspect output");
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const scrollElement = getScrollElement(container);
+    const contentElement = getContentElement(scrollElement);
+    const metrics = installScrollMetrics(scrollElement, {
+      scrollHeight: 200,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    act(() => {
+      metrics.setScrollTop(200);
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      // Thumb drag + live stream in the same scroll tick: height grew, scrollTop
+      // moved up, no pointerdown.
+      metrics.setScrollHeight(280);
+      metrics.setScrollTop(80);
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      metrics.setScrollHeight(360);
+      MockResizeObserver.notify(contentElement);
+    });
+
+    await waitFor(() => expect(metrics.getScrollTop()).toBe(80));
+  });
+
   it("does not snap back to the bottom after a tiny upward scroll within the bottom epsilon", async () => {
     // Regression: a wheel-up of only 1–3 px disables sticky in the wheel
     // handler, but the resulting scroll event arrives with `isAtBottom` still
@@ -474,6 +551,92 @@ describe("ChatPane", () => {
     });
 
     await waitFor(() => expect(metrics.getScrollTop()).toBe(300));
+  });
+
+  it("keeps sticky after a tool-collapse click whose height compensation moves scrollTop up", async () => {
+    // Regression: pointerdown on the disclosure used to arm user-scroll intent.
+    // Sticky row-height compensation then decreased scrollTop, and the scroll
+    // handler treated that as a user scroll-away — leaving the chat stranded
+    // above the bottom after collapsing a tool while pinned.
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Inspect output");
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const scrollElement = getScrollElement(container);
+    const contentElement = getContentElement(scrollElement);
+    const metrics = installScrollMetrics(scrollElement, {
+      scrollHeight: 320,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    act(() => {
+      metrics.setScrollTop(320);
+      fireEvent.scroll(scrollElement);
+    });
+
+    const toolButton = document.createElement("button");
+    toolButton.type = "button";
+    contentElement.append(toolButton);
+
+    act(() => {
+      fireEvent.pointerDown(toolButton);
+      metrics.setScrollHeight(220);
+      metrics.setScrollTop(80);
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      MockResizeObserver.notify(contentElement);
+    });
+
+    await waitFor(() => expect(metrics.getScrollTop()).toBe(220));
+    toolButton.remove();
+  });
+
+  it("keeps sticky after a tool-expand click whose content growth leaves scrollTop above the bottom", async () => {
+    // Same pointer-intent bug as collapse: expanding a tool grows scrollHeight
+    // while the click armed user-scroll intent. Without the control-click
+    // guard, sticky is released and the chat stays mid-transcript.
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Inspect output");
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const scrollElement = getScrollElement(container);
+    const contentElement = getContentElement(scrollElement);
+    const metrics = installScrollMetrics(scrollElement, {
+      scrollHeight: 220,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    act(() => {
+      metrics.setScrollTop(220);
+      fireEvent.scroll(scrollElement);
+    });
+
+    const toolButton = document.createElement("button");
+    toolButton.type = "button";
+    contentElement.append(toolButton);
+
+    act(() => {
+      fireEvent.pointerDown(toolButton);
+      metrics.setScrollHeight(420);
+      // Browser leaves scrollTop where it was; we are no longer at bottom until
+      // sticky re-pins.
+      fireEvent.scroll(scrollElement);
+    });
+
+    act(() => {
+      MockResizeObserver.notify(contentElement);
+    });
+
+    await waitFor(() => expect(metrics.getScrollTop()).toBe(420));
+    toolButton.remove();
   });
 
   it("re-pins after todo dock layout changes when the thread was already at the bottom", async () => {

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -27,6 +27,7 @@ import { ChatFindBar, type ScrollToIndex } from "@/renderer/components/find/Chat
 import { ChatPaneActionsContext, type ChatPaneActions } from "./chatPaneActionsContext";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
 import { selectVisibleThreadTimelineEntries, type ChatTimelineEntry } from "./chatPaneSelectors";
+import { shouldMarkUserScrollIntentFromPointerTarget } from "./chatScrollGeometry";
 import { normalizeChatProjectPath } from "./chatPathUtils";
 import { formatElapsed } from "./formatElapsed";
 import { MessageList, type CheckpointRevertActions } from "./parts/MessageList";
@@ -156,6 +157,11 @@ export function ChatPane(props: ChatPaneProps) {
           }),
       onContentHeightChange: () => scrollControlsRef.current?.onContentHeightChange(),
       isStickToBottom: () => scrollControlsRef.current?.isStickToBottom() ?? false,
+      hasRecentUserScrollIntent: () =>
+        scrollControlsRef.current?.hasRecentUserScrollIntent() ?? false,
+      noteProgrammaticScroll: (scrollTop) =>
+        scrollControlsRef.current?.noteProgrammaticScroll(scrollTop),
+      isThreadOpenSettling: () => scrollControlsRef.current?.isThreadOpenSettling() ?? false,
       registerVirtualScrollToBottom: (handler) => {
         virtualScrollToBottomRef.current = handler;
       },
@@ -300,8 +306,20 @@ export function ChatPane(props: ChatPaneProps) {
                 scrollControlsRef.current?.disableStickToBottom();
               }
             }}
-            onPointerDownCapture={() => {
+            onPointerDownCapture={(event) => {
+              // Only arm scroll-intent for real scroll gestures (scrollbar /
+              // empty-canvas drags). Tool expand/collapse clicks must not —
+              // sticky row-height compensation then looks like a user
+              // scroll-away and strands the transcript above the bottom.
+              if (!shouldMarkUserScrollIntentFromPointerTarget(event.target)) return;
               scrollControlsRef.current?.markUserScrollIntent();
+              // Unpin immediately — same as wheel-up. Native scrollbar thumbs
+              // are not DOM nodes and often overlay the content box (Windows
+              // overlay scrollbars), so gutter hit-testing is unreliable.
+              // Waiting for the first scroll event leaves sticky on long enough
+              // for row-measure ResizeObservers to re-pin and yank the thumb
+              // back to the bottom while the user is still dragging.
+              scrollControlsRef.current?.disableStickToBottom();
             }}
             onKeyDownCapture={(event) => {
               if (isScrollNavigationKey(event.key)) {

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+import { act } from "@testing-library/react";
+import { createRef, useRef } from "react";
+import { renderWithI18n } from "@/renderer/testUtils/i18n";
+import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
+
+vi.mock("@/renderer/state/appStore", () => ({
+  useAppStore: Object.assign(
+    (selector: (s: { chatScrollToBottomTokens: Record<string, number> }) => unknown) =>
+      selector({ chatScrollToBottomTokens: {} }),
+    {
+      subscribe: () => () => undefined,
+      getState: () => ({ chatScrollToBottomTokens: {} }),
+    },
+  ),
+}));
+
+vi.mock("@/renderer/state/panelResizeSignal", () => ({
+  isPanelResizing: () => false,
+  subscribePanelResize: () => () => undefined,
+}));
+
+function Harness(props: {
+  scrollEl: HTMLDivElement;
+  contentEl: HTMLDivElement;
+  controlsRef: React.RefObject<ChatScrollControlsHandle | null>;
+  virtualScrollToBottom: () => void;
+  initialScrollSettled?: boolean;
+}) {
+  const scrollRef = useRef(props.scrollEl);
+  const contentRef = useRef(props.contentEl);
+  const virtualScrollToBottomRef = useRef(props.virtualScrollToBottom);
+  return (
+    <ChatScrollControls
+      ref={props.controlsRef}
+      scrollRef={scrollRef}
+      contentRef={contentRef}
+      layoutChangeToken={null}
+      threadId="thread-1"
+      tailLoaderVisible={false}
+      initialScrollSettled={props.initialScrollSettled ?? true}
+      virtualScrollToBottomRef={virtualScrollToBottomRef}
+      onInitialScrollSettled={() => undefined}
+    />
+  );
+}
+
+describe("ChatScrollControls", () => {
+  it("skips scrollTop writes and virtualizer reconcile when already at bottom", () => {
+    const scrollEl = document.createElement("div");
+    const contentEl = document.createElement("div");
+    const scrollTopSetter = vi.fn<(value: number) => void>();
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: {
+        configurable: true,
+        get: () => 800,
+        set: scrollTopSetter,
+      },
+    });
+    const virtualScrollToBottom = vi.fn<() => void>();
+    const controlsRef = createRef<ChatScrollControlsHandle>();
+
+    renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        contentEl={contentEl}
+        controlsRef={controlsRef}
+        virtualScrollToBottom={virtualScrollToBottom}
+      />,
+    );
+
+    scrollTopSetter.mockClear();
+    virtualScrollToBottom.mockClear();
+
+    act(() => {
+      controlsRef.current?.onContentHeightChange();
+    });
+
+    expect(scrollTopSetter).not.toHaveBeenCalled();
+    expect(virtualScrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("reports thread-open settling until a user scroll-away ends the window", () => {
+    let scrollTop = 100;
+    const scrollEl = document.createElement("div");
+    const contentEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+    const controlsRef = createRef<ChatScrollControlsHandle>();
+
+    renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        contentEl={contentEl}
+        controlsRef={controlsRef}
+        virtualScrollToBottom={() => undefined}
+      />,
+    );
+
+    // The [threadId] open effect just armed the coalesce window.
+    expect(controlsRef.current?.isThreadOpenSettling()).toBe(true);
+
+    act(() => {
+      controlsRef.current?.disableStickToBottom();
+    });
+
+    // A scroll-away zeroes the window so consumers stop suppressing work.
+    expect(controlsRef.current?.isThreadOpenSettling()).toBe(false);
+  });
+
+  it("writes scrollTop when content grows past the bottom pin", () => {
+    let scrollTop = 100;
+    const scrollEl = document.createElement("div");
+    const contentEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => 1000 },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+    const virtualScrollToBottom = vi.fn<() => void>();
+    const controlsRef = createRef<ChatScrollControlsHandle>();
+
+    renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        contentEl={contentEl}
+        controlsRef={controlsRef}
+        virtualScrollToBottom={virtualScrollToBottom}
+      />,
+    );
+
+    act(() => {
+      controlsRef.current?.onContentHeightChange();
+    });
+
+    expect(scrollTop).toBe(1000);
+  });
+
+  it("re-pins when content grows after an open pin even if the at-bottom cache is warm", async () => {
+    // Regression: the open-storm at-bottom time cache used to short-circuit even
+    // when scrollHeight grew, so newly opened chats stayed mid-transcript.
+    let scrollHeight = 400;
+    let scrollTop = 200;
+    const scrollEl = document.createElement("div");
+    const contentEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+    const virtualScrollToBottom = vi.fn<() => void>();
+    const controlsRef = createRef<ChatScrollControlsHandle>();
+
+    renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        contentEl={contentEl}
+        controlsRef={controlsRef}
+        virtualScrollToBottom={virtualScrollToBottom}
+      />,
+    );
+
+    // Mount open path pins at the short estimated height (scrollTop -> 400).
+    expect(scrollTop).toBe(400);
+
+    // Virtualizer measures taller rows; leave scrollTop where the short pin left it.
+    scrollHeight = 1200;
+    scrollTop = 200;
+
+    // Open-storm layout sync is coalesced onto rAF — flush it.
+    act(() => {
+      controlsRef.current?.onContentHeightChange();
+    });
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    expect(scrollTop).toBe(1200);
+  });
+
+  it("re-pins when content shrinks while sticky (tool collapse)", async () => {
+    // Regression: collapsing a tool while at the bottom shrank scrollHeight;
+    // shouldSkip treated the transient geometry as still-at-bottom and skipped
+    // the pin write, leaving the transcript above the bottom.
+    let scrollHeight = 1000;
+    let scrollTop = 800;
+    const scrollEl = document.createElement("div");
+    const contentEl = document.createElement("div");
+    Object.defineProperties(scrollEl, {
+      scrollHeight: { configurable: true, get: () => scrollHeight },
+      clientHeight: { configurable: true, get: () => 200 },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+    const virtualScrollToBottom = vi.fn<() => void>();
+    const controlsRef = createRef<ChatScrollControlsHandle>();
+
+    renderWithI18n(
+      <Harness
+        scrollEl={scrollEl}
+        contentEl={contentEl}
+        controlsRef={controlsRef}
+        virtualScrollToBottom={virtualScrollToBottom}
+      />,
+    );
+
+    // Mount pins at bottom of the tall content.
+    expect(scrollTop).toBe(1000);
+
+    // Tool collapse: content shrinks; scrollTop left where it was (or partially
+    // compensated), so we are no longer at the new bottom without a pin write.
+    scrollHeight = 700;
+    scrollTop = 600;
+
+    act(() => {
+      controlsRef.current?.onContentHeightChange();
+    });
+    // Layout sync may still be coalesced inside the open-storm window.
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    expect(scrollTop).toBe(700);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -12,15 +12,39 @@ import { useLingui } from "@lingui/react/macro";
 import { ArrowDown } from "lucide-react";
 import { useAppStore } from "@/renderer/state/appStore";
 import { isPanelResizing, subscribePanelResize } from "@/renderer/state/panelResizeSignal";
-import { isElementAtBottom } from "./chatScrollGeometry";
+import {
+  BOTTOM_EPSILON_PX,
+  isElementAtBottom,
+  nextShowScrollDown,
+  shouldCoalesceLayoutSync,
+  shouldIgnoreProgrammaticPinScroll,
+  shouldReenableStickToBottom,
+  shouldReleaseStickToBottom,
+  shouldSkipScrollToBottomWrite,
+  shouldTrustCachedAtBottom,
+  nextAtBottomCacheUntil,
+  shouldRepinForContentGrowth,
+  THREAD_OPEN_COALESCE_MS,
+} from "./chatScrollGeometry";
 import { selectChatScrollAnchor, selectChatScrollAnchorForTimeline } from "./chatPaneSelectors";
 
 const USER_SCROLL_INTENT_MS = 750;
+/** Minimum at-bottom cache when no coalesce window is active. */
+const AT_BOTTOM_CACHE_MS = 16;
 
 export type ChatScrollControlsHandle = {
   disableStickToBottom(): void;
   isStickToBottom(): boolean;
   markUserScrollIntent(): void;
+  hasRecentUserScrollIntent(): boolean;
+  /** Mark the next scroll event matching this scrollTop as our own write. */
+  noteProgrammaticScroll(scrollTop: number): void;
+  /**
+   * True while the thread-open measurement storm is assumed to still be
+   * running. Single shared epoch — keyed to the thread opening (and ended
+   * early by a user scroll-away), not to any individual row's mount.
+   */
+  isThreadOpenSettling(): boolean;
   onContentHeightChange(): void;
 };
 
@@ -60,6 +84,13 @@ export const ChatScrollControls = forwardRef<
   const initialSettleRafRef = useRef<number | null>(null);
   const initialSettleSecondRafRef = useRef<number | null>(null);
   const userScrollIntentUntilRef = useRef(0);
+  const programmaticScrollTopRef = useRef<number | null>(null);
+  const programmaticScrollUntilRef = useRef(0);
+  const threadOpenCoalesceUntilRef = useRef(0);
+  const atBottomCachedUntilRef = useRef(0);
+  const lastPinnedScrollHeightRef = useRef(0);
+  const lastSeenScrollHeightRef = useRef(0);
+  const disableStickToBottomRef = useRef<() => void>(() => undefined);
   const [showScrollDown, setShowScrollDown] = useState(false);
 
   function syncBottomStateFromLayout() {
@@ -67,16 +98,27 @@ export const ChatScrollControls = forwardRef<
     if (!el) return;
     const isAtBottom = isElementAtBottom(el);
     if (isAtBottom) stickToBottomRef.current = true;
-    setShowScrollDown(!stickToBottomRef.current && !isAtBottom);
+    setShowScrollDown(nextShowScrollDown({ stickToBottom: stickToBottomRef.current, isAtBottom }));
   }
 
   function disableStickToBottom() {
     if (!stickToBottomRef.current) return;
     cancelScheduledInitialSettle();
+    cancelScheduledLayoutSync();
+    if (pinRafRef.current !== null) {
+      cancelAnimationFrame(pinRafRef.current);
+      pinRafRef.current = null;
+    }
+    // End the open-storm coalesce immediately so a first scroll-away is not
+    // still treated as a measurement settle that wants to re-pin / coalesce.
+    threadOpenCoalesceUntilRef.current = 0;
+    atBottomCachedUntilRef.current = 0;
+    lastPinnedScrollHeightRef.current = 0;
     stickToBottomRef.current = false;
     const el = scrollRef.current;
     setShowScrollDown(!el || !isElementAtBottom(el));
   }
+  disableStickToBottomRef.current = disableStickToBottom;
 
   function markUserScrollIntent() {
     userScrollIntentUntilRef.current = performance.now() + USER_SCROLL_INTENT_MS;
@@ -86,14 +128,114 @@ export const ChatScrollControls = forwardRef<
     return performance.now() <= userScrollIntentUntilRef.current;
   }
 
+  function noteProgrammaticScroll(scrollTop: number) {
+    // Cover the async scroll event that follows a scrollTop write. Match the
+    // written value so a later user thumb-drag (different scrollTop) is never
+    // mistaken for our pin/compensation write.
+    programmaticScrollTopRef.current = scrollTop;
+    programmaticScrollUntilRef.current = performance.now() + 48;
+  }
+
+  function consumeProgrammaticScroll(nextScrollTop: number): boolean {
+    if (performance.now() > programmaticScrollUntilRef.current) {
+      programmaticScrollTopRef.current = null;
+      return false;
+    }
+    const expected = programmaticScrollTopRef.current;
+    if (expected === null) return false;
+    if (Math.abs(nextScrollTop - expected) > BOTTOM_EPSILON_PX) return false;
+    programmaticScrollTopRef.current = null;
+    return true;
+  }
+
+  function writeScrollTop(el: HTMLElement, nextScrollTop: number) {
+    noteProgrammaticScroll(nextScrollTop);
+    el.scrollTop = nextScrollTop;
+  }
+
   function scrollToBottom(options: { reconcileVirtualizer?: boolean } = {}) {
     const el = scrollRef.current;
     if (!el) return;
+    // User is actively scrolling away (wheel / scrollbar / pointer drag).
+    // Never re-pin — ResizeObserver and streaming anchors must not fight the
+    // gesture. Intent alone used to leave sticky on until the first scroll
+    // event; this guard covers that race and any missed disable.
+    if (hasRecentUserScrollIntent() && !isElementAtBottom(el)) {
+      stickToBottomRef.current = false;
+      setShowScrollDown(true);
+      return;
+    }
+    const now = performance.now();
+    const scrollHeight = el.scrollHeight;
+    const reconcileVirtualizer = options.reconcileVirtualizer === true;
+    // Stick-to-bottom storms (thread switch / row measure) call this many times
+    // per frame. If we are already pinned at the same content height, skip
+    // scrollTop writes — they still fire scroll listeners and force style recalc.
+    // Never skip when reconcileVirtualizer is set: open/settle must drive the
+    // virtualizer to the last row. Never skip when scrollHeight grew either —
+    // otherwise chats open mid-transcript after rows measure taller.
+    if (
+      shouldTrustCachedAtBottom({
+        now,
+        cachedUntil: atBottomCachedUntilRef.current,
+        scrollHeight,
+        lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
+        reconcileVirtualizer,
+      })
+    ) {
+      stickToBottomRef.current = true;
+      setShowScrollDown(false);
+      return;
+    }
+    // During the open storm while sticky, only re-pin when scrollHeight grew.
+    if (
+      !reconcileVirtualizer &&
+      !shouldRepinForContentGrowth({
+        stickToBottom: stickToBottomRef.current,
+        now,
+        coalesceUntil: threadOpenCoalesceUntilRef.current,
+        scrollHeight,
+        lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
+      })
+    ) {
+      atBottomCachedUntilRef.current = nextAtBottomCacheUntil({
+        now,
+        frameCacheMs: AT_BOTTOM_CACHE_MS,
+        coalesceUntil: threadOpenCoalesceUntilRef.current,
+      });
+      stickToBottomRef.current = true;
+      setShowScrollDown(false);
+      return;
+    }
+    if (
+      !reconcileVirtualizer &&
+      shouldSkipScrollToBottomWrite({
+        scrollHeight,
+        scrollTop: el.scrollTop,
+        clientHeight: el.clientHeight,
+        lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
+      })
+    ) {
+      // Once pinned, trust that until the coalesce window ends — but only for
+      // this scrollHeight (see shouldTrustCachedAtBottom).
+      atBottomCachedUntilRef.current = nextAtBottomCacheUntil({
+        now,
+        frameCacheMs: AT_BOTTOM_CACHE_MS,
+        coalesceUntil: threadOpenCoalesceUntilRef.current,
+      });
+      lastPinnedScrollHeightRef.current = scrollHeight;
+      lastScrollTopRef.current = el.scrollTop;
+      stickToBottomRef.current = true;
+      setShowScrollDown(false);
+      return;
+    }
+    atBottomCachedUntilRef.current = 0;
     const virtualScrollToBottom = virtualScrollToBottomRef.current;
-    if (options.reconcileVirtualizer && virtualScrollToBottom) {
+    if (reconcileVirtualizer && virtualScrollToBottom) {
       virtualScrollToBottom();
     }
-    el.scrollTop = el.scrollHeight;
+    writeScrollTop(el, el.scrollHeight);
+    lastPinnedScrollHeightRef.current = el.scrollHeight;
     lastScrollTopRef.current = el.scrollTop;
     stickToBottomRef.current = true;
     setShowScrollDown(false);
@@ -123,6 +265,17 @@ export const ChatScrollControls = forwardRef<
   }
 
   const syncLayoutNowAndAfterPaint = useEffectEvent(() => {
+    const el = scrollRef.current;
+    const contentHeightChanged = !!el && el.scrollHeight !== lastPinnedScrollHeightRef.current;
+
+    // Height-driven sticky pins must run in this frame. Cancel any pending
+    // coalesce so an earlier open-storm schedule cannot defer the write.
+    if (contentHeightChanged && stickToBottomRef.current) {
+      cancelScheduledLayoutSync();
+      syncLayoutNow();
+      return;
+    }
+
     if (hasScheduledLayoutSync()) return;
     // During an active panel/divider drag the viewport changes every frame, and
     // both this scroller's ResizeObserver and MessageList's totalSize effect
@@ -130,7 +283,19 @@ export const ChatScrollControls = forwardRef<
     // read, no chained settle passes) so the content still reflows and stays
     // bottom-pinned live, but we do at most one forced reflow per frame instead
     // of stacking several. The drag-end reconcile below runs the full settle.
-    if (isPanelResizing()) {
+    //
+    // Same coalescing while the initial thread-open settle is still running, and
+    // for a short window after open while the virtualizer finishes measuring
+    // mounted rows — otherwise each ResizeObserver tick stacks sync
+    // scrollToBottom + two follow-up paints.
+    if (
+      shouldCoalesceLayoutSync({
+        isPanelResizing: isPanelResizing(),
+        initialScrollSettled,
+        now: performance.now(),
+        threadOpenCoalesceUntil: threadOpenCoalesceUntilRef.current,
+      })
+    ) {
       layoutSyncRafRef.current = requestAnimationFrame(() => {
         layoutSyncRafRef.current = null;
         syncLayoutNow();
@@ -176,21 +341,31 @@ export const ChatScrollControls = forwardRef<
     disableStickToBottom,
     isStickToBottom: () => stickToBottomRef.current,
     markUserScrollIntent,
+    hasRecentUserScrollIntent,
+    noteProgrammaticScroll,
+    isThreadOpenSettling: () => performance.now() < threadOpenCoalesceUntilRef.current,
     onContentHeightChange: syncLayoutNowAndAfterPaint,
   }));
 
   useLayoutEffect(() => {
+    threadOpenCoalesceUntilRef.current = performance.now() + THREAD_OPEN_COALESCE_MS;
+    atBottomCachedUntilRef.current = 0;
+    lastPinnedScrollHeightRef.current = 0;
+    lastSeenScrollHeightRef.current = scrollRef.current?.scrollHeight ?? 0;
     scrollToBottom({ reconcileVirtualizer: true });
     scheduleInitialScrollSettle();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- scroll reset is keyed to thread changes; the helper reads refs/state setters only.
   }, [threadId]);
 
   // Preserve the bottom pin when the surrounding thread layout changes, but
-  // keep the user's place if they already scrolled up.
+  // keep the user's place if they already scrolled up. Run synchronously —
+  // dock expand/collapse can shift scrollTop without changing scrollHeight,
+  // and open-storm coalesce would otherwise leave the view stranded for a frame.
   useLayoutEffect(() => {
     if (layoutChangeToken === initialLayoutChangeTokenRef.current) return;
     initialLayoutChangeTokenRef.current = layoutChangeToken;
-    syncLayoutNowAndAfterPaint();
+    cancelScheduledLayoutSync();
+    syncLayoutNow();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- effect is keyed to layout token changes; the helper reads refs/state setters only.
   }, [layoutChangeToken]);
 
@@ -204,6 +379,7 @@ export const ChatScrollControls = forwardRef<
     // eslint-disable-next-line react-hooks/exhaustive-deps -- helper reads refs/state setters only.
   }, [scrollToBottomToken]);
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- scroll listener is keyed to the scroller/thread; helpers close over refs.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -211,25 +387,59 @@ export const ChatScrollControls = forwardRef<
       const prevScrollTop = lastScrollTopRef.current;
       const nextScrollTop = el.scrollTop;
       lastScrollTopRef.current = nextScrollTop;
+      const nextScrollHeight = el.scrollHeight;
+      const scrollHeightShrunk = nextScrollHeight < lastSeenScrollHeightRef.current;
+      lastSeenScrollHeightRef.current = nextScrollHeight;
+      const isProgrammaticScroll = consumeProgrammaticScroll(nextScrollTop);
+      // Programmatic stick-to-bottom only moves down. Skip layout reads / button
+      // updates for those events — CDP profiles spent tens of ms here per switch.
+      if (
+        shouldIgnoreProgrammaticPinScroll({
+          stickToBottom: stickToBottomRef.current,
+          prevScrollTop,
+          nextScrollTop,
+        })
+      ) {
+        return;
+      }
       const isAtBottom = isElementAtBottom(el);
-      // Only release sticky when the user actually moves away from the bottom.
-      // Bare `!isAtBottom` here would race with virtualizer measurements that
-      // grow `scrollHeight` after a programmatic scroll lands — flipping sticky
-      // off in that one frame, then keeping the button stuck on because the
-      // corrective syncLayoutNow takes the non-sticky branch.
-      if (nextScrollTop < prevScrollTop && !isAtBottom && hasRecentUserScrollIntent()) {
-        cancelScheduledInitialSettle();
-        stickToBottomRef.current = false;
-      } else if (isAtBottom && (nextScrollTop >= prevScrollTop || !hasRecentUserScrollIntent())) {
+      // Release on upward scroll away from the bottom (native scrollbar thumb —
+      // often no pointerdown). Layout clamps that shrink scrollHeight and lower
+      // scrollTop keep sticky; height growth during a live stream must not block
+      // release. Our own scrollTop writes are tagged via noteProgrammaticScroll.
+      if (
+        shouldReleaseStickToBottom({
+          prevScrollTop,
+          nextScrollTop,
+          isAtBottom,
+          isProgrammaticScroll,
+          scrollHeightShrunk,
+        })
+      ) {
+        // Arm intent so ResizeObserver / streaming re-pins stay blocked for the
+        // rest of the thumb drag (which may never have set intent itself).
+        markUserScrollIntent();
+        disableStickToBottomRef.current();
+      } else if (
+        shouldReenableStickToBottom({
+          prevScrollTop,
+          nextScrollTop,
+          isAtBottom,
+          hasRecentUserScrollIntent: hasRecentUserScrollIntent(),
+        })
+      ) {
         // Don't re-enable sticky when the user is actively scrolling upward but
         // is still within `BOTTOM_EPSILON_PX` of the bottom — otherwise a tiny
         // wheel-up gets snapped back by the next streaming delta.
         stickToBottomRef.current = true;
       }
-      setShowScrollDown(!stickToBottomRef.current && !isAtBottom);
+      setShowScrollDown(
+        nextShowScrollDown({ stickToBottom: stickToBottomRef.current, isAtBottom }),
+      );
     };
 
     lastScrollTopRef.current = el.scrollTop;
+    lastSeenScrollHeightRef.current = el.scrollHeight;
     handleScroll();
     el.addEventListener("scroll", handleScroll, { passive: true });
     return () => el.removeEventListener("scroll", handleScroll);

--- a/src/renderer/components/thread/ChatPane/chatPaneActionsContext.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneActionsContext.ts
@@ -9,6 +9,16 @@ export type ChatPaneActions = {
   showProjectEntryInExplorer?: ((path: string) => void) | undefined;
   onContentHeightChange: () => void;
   isStickToBottom?: () => boolean;
+  /** True while the user is mid wheel / scrollbar / pointer scroll-away. */
+  hasRecentUserScrollIntent?: () => boolean;
+  /** Mark the next scroll event matching this scrollTop as our own write. */
+  noteProgrammaticScroll?: ((scrollTop: number) => void) | undefined;
+  /**
+   * True while the thread-open measurement storm is still settling. Shared
+   * epoch owned by the scroll controls — rows remount constantly under
+   * virtualization, so per-row mount clocks must not stand in for this.
+   */
+  isThreadOpenSettling?: () => boolean;
   registerVirtualScrollToBottom?: (handler: (() => void) | null) => void;
   projectLocation: ProjectLocation;
   /**

--- a/src/renderer/components/thread/ChatPane/chatScrollGeometry.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatScrollGeometry.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOTTOM_EPSILON_PX,
+  distanceFromBottom,
+  isElementAtBottom,
+  nextShowScrollDown,
+  shouldCoalesceLayoutSync,
+  shouldIgnoreProgrammaticPinScroll,
+  shouldMarkUserScrollIntentFromPointerTarget,
+  shouldReenableStickToBottom,
+  shouldReleaseStickToBottom,
+  shouldSkipScrollToBottomWrite,
+  shouldTrustCachedAtBottom,
+  nextAtBottomCacheUntil,
+  shouldRepinForContentGrowth,
+} from "./chatScrollGeometry";
+
+function scroller(partial: { scrollHeight: number; scrollTop: number; clientHeight: number }) {
+  return partial;
+}
+
+describe("chatScrollGeometry", () => {
+  it("treats within-epsilon distance as at bottom", () => {
+    // distance = scrollHeight - scrollTop - clientHeight = 1000 - 896 - 100 = 4
+    expect(
+      isElementAtBottom(scroller({ scrollHeight: 1000, scrollTop: 896, clientHeight: 100 })),
+    ).toBe(true);
+    expect(
+      distanceFromBottom(scroller({ scrollHeight: 1000, scrollTop: 896, clientHeight: 100 })),
+    ).toBe(4);
+    expect(BOTTOM_EPSILON_PX).toBe(4);
+  });
+
+  it("skips scrollTop writes when already pinned at the same content height", () => {
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 1000,
+        scrollTop: 900,
+        clientHeight: 100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 1000,
+        scrollTop: 800,
+        clientHeight: 100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 0,
+        scrollTop: 0,
+        clientHeight: 0,
+        lastPinnedScrollHeight: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip the pin write when content height shrinks (tool collapse)", () => {
+    // Sticky + collapse: scrollHeight drops while scrollTop may still look
+    // "at bottom" (or overscrolled). Skipping the write stranded the view.
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 800,
+        scrollTop: 700,
+        clientHeight: 100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 800,
+        scrollTop: 800,
+        clientHeight: 100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip the pin write when content height grows", () => {
+    expect(
+      shouldSkipScrollToBottomWrite({
+        scrollHeight: 1200,
+        scrollTop: 1100,
+        clientHeight: 100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores downward programmatic pin scrolls while sticky", () => {
+    expect(
+      shouldIgnoreProgrammaticPinScroll({
+        stickToBottom: true,
+        prevScrollTop: 100,
+        nextScrollTop: 120,
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnoreProgrammaticPinScroll({
+        stickToBottom: true,
+        prevScrollTop: 120,
+        nextScrollTop: 120,
+      }),
+    ).toBe(true);
+    expect(
+      shouldIgnoreProgrammaticPinScroll({
+        stickToBottom: true,
+        prevScrollTop: 120,
+        nextScrollTop: 100,
+      }),
+    ).toBe(false);
+    expect(
+      shouldIgnoreProgrammaticPinScroll({
+        stickToBottom: false,
+        prevScrollTop: 100,
+        nextScrollTop: 120,
+      }),
+    ).toBe(false);
+  });
+
+  it("releases sticky on upward scroll unless height shrunk or scroll is programmatic", () => {
+    // Native scrollbar thumbs often never fire pointerdown — only scroll — so
+    // release must not require a prior user-scroll-intent flag. Layout clamps
+    // that shrink scrollHeight and lower scrollTop must still keep sticky.
+    // Height growth (live stream) must not block a thumb-drag release.
+    expect(
+      shouldReleaseStickToBottom({
+        prevScrollTop: 200,
+        nextScrollTop: 150,
+        isAtBottom: false,
+        isProgrammaticScroll: false,
+        scrollHeightShrunk: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReleaseStickToBottom({
+        prevScrollTop: 200,
+        nextScrollTop: 150,
+        isAtBottom: false,
+        isProgrammaticScroll: true,
+        scrollHeightShrunk: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReleaseStickToBottom({
+        prevScrollTop: 200,
+        nextScrollTop: 150,
+        isAtBottom: false,
+        isProgrammaticScroll: false,
+        scrollHeightShrunk: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReleaseStickToBottom({
+        prevScrollTop: 200,
+        nextScrollTop: 150,
+        isAtBottom: true,
+        isProgrammaticScroll: false,
+        scrollHeightShrunk: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not arm scroll-intent for in-chat control clicks", () => {
+    const button = document.createElement("button");
+    const nested = document.createElement("span");
+    button.append(nested);
+    document.body.append(button);
+    expect(shouldMarkUserScrollIntentFromPointerTarget(button)).toBe(false);
+    expect(shouldMarkUserScrollIntentFromPointerTarget(nested)).toBe(false);
+
+    const link = document.createElement("a");
+    link.href = "#";
+    document.body.append(link);
+    expect(shouldMarkUserScrollIntentFromPointerTarget(link)).toBe(false);
+
+    const blank = document.createElement("div");
+    document.body.append(blank);
+    expect(shouldMarkUserScrollIntentFromPointerTarget(blank)).toBe(true);
+    expect(shouldMarkUserScrollIntentFromPointerTarget(null)).toBe(false);
+
+    button.remove();
+    link.remove();
+    blank.remove();
+  });
+
+  it("does not arm scroll-intent for ARIA-role controls (React Aria / HeroUI)", () => {
+    for (const role of [
+      "button",
+      "link",
+      "checkbox",
+      "radio",
+      "switch",
+      "option",
+      "tab",
+      "slider",
+      "menuitem",
+      "menuitemcheckbox",
+      "menuitemradio",
+    ]) {
+      const el = document.createElement("div");
+      el.setAttribute("role", role);
+      const nested = document.createElement("span");
+      el.append(nested);
+      document.body.append(el);
+      expect(shouldMarkUserScrollIntentFromPointerTarget(nested), `role=${role}`).toBe(false);
+      el.remove();
+    }
+  });
+
+  it("re-enables sticky at bottom unless the user is still scrolling up", () => {
+    expect(
+      shouldReenableStickToBottom({
+        prevScrollTop: 100,
+        nextScrollTop: 120,
+        isAtBottom: true,
+        hasRecentUserScrollIntent: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReenableStickToBottom({
+        prevScrollTop: 120,
+        nextScrollTop: 118,
+        isAtBottom: true,
+        hasRecentUserScrollIntent: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReenableStickToBottom({
+        prevScrollTop: 120,
+        nextScrollTop: 118,
+        isAtBottom: true,
+        hasRecentUserScrollIntent: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("shows the scroll-down button only when unpinned and not at bottom", () => {
+    expect(nextShowScrollDown({ stickToBottom: false, isAtBottom: false })).toBe(true);
+    expect(nextShowScrollDown({ stickToBottom: true, isAtBottom: false })).toBe(false);
+    expect(nextShowScrollDown({ stickToBottom: false, isAtBottom: true })).toBe(false);
+  });
+
+  it("trusts a recent at-bottom cache until its deadline when height is unchanged", () => {
+    expect(
+      shouldTrustCachedAtBottom({
+        now: 100,
+        cachedUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldTrustCachedAtBottom({
+        now: 400,
+        cachedUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTrustCachedAtBottom({
+        now: 100,
+        cachedUntil: 400,
+        scrollHeight: 1200,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTrustCachedAtBottom({
+        now: 100,
+        cachedUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+        reconcileVirtualizer: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("extends the at-bottom cache through the open coalesce window", () => {
+    expect(nextAtBottomCacheUntil({ now: 100, frameCacheMs: 16, coalesceUntil: 500 })).toBe(500);
+    expect(nextAtBottomCacheUntil({ now: 100, frameCacheMs: 16, coalesceUntil: 50 })).toBe(116);
+  });
+
+  it("only re-pins during open storm when scrollHeight grows", () => {
+    expect(
+      shouldRepinForContentGrowth({
+        stickToBottom: true,
+        now: 100,
+        coalesceUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRepinForContentGrowth({
+        stickToBottom: true,
+        now: 100,
+        coalesceUntil: 400,
+        scrollHeight: 1100,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRepinForContentGrowth({
+        stickToBottom: true,
+        now: 500,
+        coalesceUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRepinForContentGrowth({
+        stickToBottom: false,
+        now: 100,
+        coalesceUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+      }),
+    ).toBe(true);
+  });
+
+  it("coalesces layout sync during panel resize and thread-open storms", () => {
+    expect(
+      shouldCoalesceLayoutSync({
+        isPanelResizing: true,
+        initialScrollSettled: true,
+        now: 1000,
+        threadOpenCoalesceUntil: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCoalesceLayoutSync({
+        isPanelResizing: false,
+        initialScrollSettled: false,
+        now: 1000,
+        threadOpenCoalesceUntil: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCoalesceLayoutSync({
+        isPanelResizing: false,
+        initialScrollSettled: true,
+        now: 100,
+        threadOpenCoalesceUntil: 400,
+      }),
+    ).toBe(true);
+    expect(
+      shouldCoalesceLayoutSync({
+        isPanelResizing: false,
+        initialScrollSettled: true,
+        now: 500,
+        threadOpenCoalesceUntil: 400,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/chatScrollGeometry.ts
+++ b/src/renderer/components/thread/ChatPane/chatScrollGeometry.ts
@@ -1,5 +1,196 @@
 export const BOTTOM_EPSILON_PX = 4;
 
-export function isElementAtBottom(element: HTMLElement): boolean {
-  return element.scrollHeight - element.scrollTop - element.clientHeight <= BOTTOM_EPSILON_PX;
+/**
+ * How long after a thread opens the virtualizer row-measurement storm is
+ * assumed to still be running. Scroll controls coalesce layout syncs and user
+ * messages ignore ResizeObserver remeasures within this window.
+ */
+export const THREAD_OPEN_COALESCE_MS = 400;
+
+export function distanceFromBottom(element: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): number {
+  return element.scrollHeight - element.scrollTop - element.clientHeight;
+}
+
+export function isElementAtBottom(element: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): boolean {
+  return distanceFromBottom(element) <= BOTTOM_EPSILON_PX;
+}
+
+/**
+ * Stick-to-bottom storms call `scrollToBottom` many times per frame while the
+ * virtualizer measures rows. Writing `scrollTop` when already pinned still
+ * fires scroll listeners and forces style recalc — skip that write.
+ *
+ * Never skip when `scrollHeight` changed since the last pin: collapsing a tool
+ * (or any row resize) can leave a transient "at bottom" reading while the
+ * scroller is about to settle above the bottom. An explicit pin write is
+ * required to stay stuck.
+ */
+export function shouldSkipScrollToBottomWrite(input: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+  lastPinnedScrollHeight: number;
+}): boolean {
+  if (input.scrollHeight <= 0) return false;
+  if (input.scrollHeight !== input.lastPinnedScrollHeight) return false;
+  return isElementAtBottom(input);
+}
+
+/**
+ * During a thread-open measurement storm, trust a recent "already at bottom"
+ * result so we do not re-read scroll metrics on every ResizeObserver /
+ * totalSize callback — but only while `scrollHeight` is unchanged. If content
+ * grew (virtualizer measured taller rows), we must re-pin or the chat opens
+ * mid-transcript.
+ *
+ * Never trust the cache when `reconcileVirtualizer` is requested: the initial
+ * open settle path must still call the virtualizer's scrollToIndex.
+ */
+export function shouldTrustCachedAtBottom(input: {
+  now: number;
+  cachedUntil: number;
+  scrollHeight: number;
+  lastPinnedScrollHeight: number;
+  reconcileVirtualizer?: boolean;
+}): boolean {
+  if (input.reconcileVirtualizer) return false;
+  if (input.scrollHeight !== input.lastPinnedScrollHeight) return false;
+  return input.now < input.cachedUntil;
+}
+
+/**
+ * After confirming the scroller is already at bottom during a thread-open
+ * storm, keep trusting that result until the coalesce window ends (or at least
+ * one frame).
+ */
+export function nextAtBottomCacheUntil(input: {
+  now: number;
+  frameCacheMs: number;
+  coalesceUntil: number;
+}): number {
+  return Math.max(input.now + input.frameCacheMs, input.coalesceUntil);
+}
+
+/**
+ * While sticky during a thread-open storm, only re-pin when the scrollable
+ * content height changed. Re-reading distance-from-bottom on every callback is
+ * wasted when `scrollHeight` is unchanged; grow or shrink both require a pin
+ * (collapse must not leave the view stranded above the bottom).
+ */
+export function shouldRepinForContentGrowth(input: {
+  stickToBottom: boolean;
+  now: number;
+  coalesceUntil: number;
+  scrollHeight: number;
+  lastPinnedScrollHeight: number;
+}): boolean {
+  if (!input.stickToBottom) return true;
+  if (input.now >= input.coalesceUntil) return true;
+  return input.scrollHeight !== input.lastPinnedScrollHeight;
+}
+
+/**
+ * Programmatic pin scrolls only move downward (or stay). When sticky is on and
+ * scrollTop did not move up, the scroll listener can skip layout reads / button
+ * state updates — the pin path already owns bottom state.
+ */
+export function shouldIgnoreProgrammaticPinScroll(input: {
+  stickToBottom: boolean;
+  prevScrollTop: number;
+  nextScrollTop: number;
+}): boolean {
+  return input.stickToBottom && input.nextScrollTop >= input.prevScrollTop;
+}
+
+/**
+ * Release stick-to-bottom when the scroller moves up and is no longer at the
+ * bottom. Native scrollbar-thumb drags often never fire `pointerdown` on the
+ * scroller (Windows overlay scrollbars) — only `scroll` — so this must NOT
+ * require a prior user-scroll-intent flag.
+ *
+ * Layout clamps (content height shrinks and the browser lowers scrollTop) must
+ * not release sticky — those are filtered via `scrollHeightShrunk`. Height
+ * growth during a live stream must NOT block release: a thumb drag on a
+ * working thread often coincides with growing scrollHeight. Our own scrollTop
+ * writes are filtered via `isProgrammaticScroll`.
+ */
+export function shouldReleaseStickToBottom(input: {
+  prevScrollTop: number;
+  nextScrollTop: number;
+  isAtBottom: boolean;
+  isProgrammaticScroll: boolean;
+  scrollHeightShrunk: boolean;
+}): boolean {
+  if (input.isProgrammaticScroll) return false;
+  if (input.scrollHeightShrunk) return false;
+  return input.nextScrollTop < input.prevScrollTop && !input.isAtBottom;
+}
+
+/**
+ * `ChatPane` arms scroll-intent on pointerdown so scrollbar / touch drags can
+ * release stick-to-bottom. Clicks on in-chat controls (tool expand/collapse,
+ * links, inputs) must not arm that intent: sticky row-height compensation then
+ * moves `scrollTop` and the scroll handler would treat it as a user
+ * scroll-away, leaving the transcript stranded above the bottom while content
+ * grows or shrinks.
+ */
+export function shouldMarkUserScrollIntentFromPointerTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  // Includes the ARIA roles React Aria / HeroUI render for non-native controls
+  // (options, tabs, switches, sliders…) — a missed control here strands the
+  // transcript above the bottom when its click releases stick-to-bottom.
+  return (
+    target.closest(
+      "button, a, input, textarea, select, option, label, summary, [contenteditable='true'], " +
+        "[role='button'], [role='link'], [role='checkbox'], [role='radio'], [role='switch'], " +
+        "[role='option'], [role='tab'], [role='slider'], [role='menuitem'], " +
+        "[role='menuitemcheckbox'], [role='menuitemradio']",
+    ) === null
+  );
+}
+
+export function shouldReenableStickToBottom(input: {
+  prevScrollTop: number;
+  nextScrollTop: number;
+  isAtBottom: boolean;
+  hasRecentUserScrollIntent: boolean;
+}): boolean {
+  return (
+    input.isAtBottom &&
+    (input.nextScrollTop >= input.prevScrollTop || !input.hasRecentUserScrollIntent)
+  );
+}
+
+export function nextShowScrollDown(input: {
+  stickToBottom: boolean;
+  isAtBottom: boolean;
+}): boolean {
+  return !input.stickToBottom && !input.isAtBottom;
+}
+
+/**
+ * Collapse layout sync to a single rAF while the viewport is being resized or
+ * while a thread-open measurement storm is still settling. Otherwise each
+ * ResizeObserver tick stacks an immediate scrollToBottom plus two follow-up
+ * paints.
+ */
+export function shouldCoalesceLayoutSync(input: {
+  isPanelResizing: boolean;
+  initialScrollSettled: boolean;
+  now: number;
+  threadOpenCoalesceUntil: number;
+}): boolean {
+  return (
+    input.isPanelResizing ||
+    !input.initialScrollSettled ||
+    input.now < input.threadOpenCoalesceUntil
+  );
 }

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -236,7 +236,17 @@ describe("MessageList", () => {
     expect(scrollElement.scrollTop).toBe(160);
   });
 
-  it("compensates rows above the viewport during active upward scroll", () => {
+  it("compensates rows above the viewport when idle", () => {
+    const { scrollElement, shouldAdjust, commit } = renderCompensationList();
+
+    scrollElement.scrollTop = 120;
+    expect(shouldAdjust({ start: 0, size: 80 }, -40, idleVirtualizer)).toBe(false);
+
+    commit();
+    expect(scrollElement.scrollTop).toBe(80);
+  });
+
+  it("defers above-viewport compensation during active upward scroll until settle", () => {
     const { scrollElement, shouldAdjust, commit } = renderCompensationList();
 
     scrollElement.scrollTop = 120;
@@ -248,6 +258,11 @@ describe("MessageList", () => {
     ).toBe(false);
 
     commit();
+    // First scroll-back after opening mounts estimated rows; applying each
+    // measure delta mid-gesture fights the user. Buffer until settle.
+    expect(scrollElement.scrollTop).toBe(120);
+
+    scrollElement.dispatchEvent(new Event("scrollend"));
     expect(scrollElement.scrollTop).toBe(80);
   });
 
@@ -325,6 +340,62 @@ describe("MessageList", () => {
     expect(scrollElement.scrollTop).toBe(184);
   });
 
+  it("does not apply sticky measure compensation while the user has scroll intent", () => {
+    const actions = {
+      openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
+      revealProjectFolderInTree: vi.fn<(path: string) => void>(),
+      showProjectEntryInExplorer: vi.fn<(path: string) => void>(),
+      onContentHeightChange: vi.fn<() => void>(),
+      isStickToBottom: vi.fn<() => boolean>().mockReturnValue(true),
+      hasRecentUserScrollIntent: vi.fn<() => boolean>().mockReturnValue(true),
+      projectLocation: { kind: "windows" as const, path: "C:\\repo" },
+      projectRootNames: new Set<string>(),
+    };
+    const { scrollElement, shouldAdjust, commit } = renderCompensationList(actions);
+
+    expect(
+      shouldAdjust({ start: 96, size: 100 }, 40, {
+        isScrolling: true,
+        scrollDirection: "backward",
+      }),
+    ).toBe(false);
+
+    commit();
+    // Sticky + intent (scrollbar thumb drag) — do not yank scrollTop.
+    expect(scrollElement.scrollTop).toBe(160);
+  });
+
+  it("still applies above-viewport compensation while the user has scroll intent", () => {
+    // Regression: discarding ALL measure compensation during intent fixed sticky
+    // yank but made scroll-back jump — estimated rows above the viewport shrink
+    // with no scrollTop correction. Above-viewport deltas must still apply.
+    const noteProgrammaticScroll = vi.fn<(scrollTop: number) => void>();
+    const actions = {
+      openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
+      revealProjectFolderInTree: vi.fn<(path: string) => void>(),
+      showProjectEntryInExplorer: vi.fn<(path: string) => void>(),
+      onContentHeightChange: vi.fn<() => void>(),
+      isStickToBottom: vi.fn<() => boolean>().mockReturnValue(false),
+      hasRecentUserScrollIntent: vi.fn<() => boolean>().mockReturnValue(true),
+      noteProgrammaticScroll,
+      projectLocation: { kind: "windows" as const, path: "C:\\repo" },
+      projectRootNames: new Set<string>(),
+    };
+    const { scrollElement, shouldAdjust, commit } = renderCompensationList(actions);
+
+    scrollElement.scrollTop = 120;
+    expect(
+      shouldAdjust({ start: 0, size: 80 }, -40, {
+        isScrolling: true,
+        scrollDirection: "backward",
+      }),
+    ).toBe(false);
+
+    commit();
+    expect(scrollElement.scrollTop).toBe(80);
+    expect(noteProgrammaticScroll).toHaveBeenCalledWith(80);
+  });
+
   it("compensates streaming row height changes when bottom-sticky", () => {
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -345,34 +416,39 @@ describe("MessageList", () => {
 
   it("measures newly mounted rows synchronously so estimate corrections land pre-paint", () => {
     const scrollElement = document.createElement("div");
-    optionsMeasureElementMock.mockReturnValue(132);
+    const offsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "offsetHeight");
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return 132;
+      },
+    });
 
-    render(
-      <MessageList
-        threadId="thread-1"
-        entries={makeEntries(["item-1", "item-2", "item-3", "item-4"])}
-        scrollElement={scrollElement}
-      />,
-    );
+    try {
+      render(
+        <MessageList
+          threadId="thread-1"
+          entries={makeEntries(["item-1", "item-2", "item-3", "item-4"])}
+          scrollElement={scrollElement}
+        />,
+      );
 
-    expect(measureElementMock).toHaveBeenCalledWith(
-      document.querySelector("[data-item-id='item-2']"),
-    );
-    expect(measureElementMock).toHaveBeenCalledWith(
-      document.querySelector("[data-item-id='item-3']"),
-    );
-    expect(optionsMeasureElementMock).toHaveBeenCalledWith(
-      document.querySelector("[data-item-id='item-2']"),
-      undefined,
-      expect.any(Object),
-    );
-    expect(optionsMeasureElementMock).toHaveBeenCalledWith(
-      document.querySelector("[data-item-id='item-3']"),
-      undefined,
-      expect.any(Object),
-    );
-    expect(resizeItemMock).toHaveBeenCalledWith(1, 132);
-    expect(resizeItemMock).toHaveBeenCalledWith(2, 132);
+      expect(measureElementMock).toHaveBeenCalledWith(
+        document.querySelector("[data-item-id='item-2']"),
+      );
+      expect(measureElementMock).toHaveBeenCalledWith(
+        document.querySelector("[data-item-id='item-3']"),
+      );
+      // One forced resizeItem with a single offsetHeight read — not a second
+      // pass through options.measureElement (that used to double-measure).
+      expect(optionsMeasureElementMock).not.toHaveBeenCalled();
+      expect(resizeItemMock).toHaveBeenCalledWith(1, 132);
+      expect(resizeItemMock).toHaveBeenCalledWith(2, 132);
+    } finally {
+      if (offsetHeight) {
+        Object.defineProperty(HTMLElement.prototype, "offsetHeight", offsetHeight);
+      }
+    }
   });
 
   it("registers TanStack scrollToIndex as the bottom scroll handler", () => {

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -158,15 +158,26 @@ export function MessageList({
     virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, delta, instance) => {
       if (!scrollElement) return false;
       const isAboveViewport = item.start + item.size <= scrollElement.scrollTop;
-      if (parentActions?.isStickToBottom?.() || isAboveViewport) {
+      const stickToBottom = parentActions?.isStickToBottom?.() === true;
+      const hasIntent = parentActions?.hasRecentUserScrollIntent?.() === true;
+      // Sticky / in-viewport measure while the user is scrolling away must not
+      // write scrollTop — that yanks a thumb/wheel drag back toward the bottom.
+      // Above-viewport deltas are different: they keep the same pixels on screen
+      // when an estimated row mounts shorter/taller, so they must still apply
+      // (synchronously) or scroll-back jumps.
+      if (hasIntent && (stickToBottom || !isAboveViewport)) {
+        return false;
+      }
+      if (stickToBottom || isAboveViewport) {
         pendingScrollCompensationRef.current += delta;
-        // Only an above-viewport correction during an active upward (backward)
-        // momentum scroll needs to be deferred on iOS. The stick-to-bottom write
-        // lands at the bottom where there is no upward momentum to cancel, so it
-        // stays synchronous and keeps the streaming pin intact.
+        // Defer above-viewport corrections only for momentum coasts without a
+        // hard intent flag (iOS / trackpad). While intent is active we apply
+        // above-viewport deltas in the same frame as the measure. Sticky pin
+        // writes stay synchronous when there is no intent.
         if (
-          deferScrollCompensation &&
           isAboveViewport &&
+          !stickToBottom &&
+          !hasIntent &&
           instance?.isScrolling &&
           instance.scrollDirection === "backward"
         ) {
@@ -178,47 +189,65 @@ export function MessageList({
     return () => {
       virtualizer.shouldAdjustScrollPositionOnItemSizeChange = undefined;
     };
-  }, [deferScrollCompensation, parentActions, scrollElement, virtualizer]);
+  }, [parentActions, scrollElement, virtualizer]);
 
   // Intentionally dependency-free: runs after every commit, once row refs have
   // synchronously measured newly mounted rows, so the scroll correction lands
   // before the browser paints the row's real height.
   useLayoutEffect(() => {
     if (pendingScrollCompensationRef.current === 0 || !scrollElement) return;
-    // On iOS the buffered delta is held until the gesture settles (see the
-    // effect below) so the write never lands mid-momentum. Everywhere else it
-    // applies synchronously, in the same paint as the row-height change.
+    // Buffered deltas are held until the gesture settles (see the effect below)
+    // so the write never lands mid-momentum. Sticky / intent above-viewport
+    // corrections still apply synchronously, in the same paint as the measure.
     if (isCompensationDeferredRef.current) {
       // Arm the settle flush from the commit itself, not just from scroll
       // events — so a deferral set on the final scroll tick of a coast (where no
       // further scroll arrives to re-arm) is still flushed once activity idles,
-      // even on iOS versions without `scrollend`.
+      // even on platforms without `scrollend`.
       scheduleCompensationFlushRef.current?.();
       return;
     }
+    parentActions?.noteProgrammaticScroll?.(
+      scrollElement.scrollTop + pendingScrollCompensationRef.current,
+    );
     scrollElement.scrollTop += pendingScrollCompensationRef.current;
     pendingScrollCompensationRef.current = 0;
   });
 
-  // iOS only: apply the buffered scroll compensation in a single write once the
-  // momentum scroll has settled. A `scroll`-idle debounce covers both a short
-  // flick and a long inertial coast; `scrollend` (iOS 17+) gives a crisper
-  // signal; and a new `touchstart` (which itself cancels any in-flight momentum)
-  // bounds the visible drift to a single gesture. All three fire only when no
-  // inertial scroll is in flight, so the write cannot cancel momentum. On other
-  // platforms `deferScrollCompensation` is false and this attaches nothing.
+  // Apply buffered scroll compensation in a single write once an upward scroll
+  // has settled. A `scroll`-idle debounce covers both a short flick and a long
+  // inertial coast; `scrollend` gives a crisper signal when available. Sticky
+  // corrections never enter this path (they stay synchronous above).
   useLayoutEffect(() => {
-    if (!deferScrollCompensation || !scrollElement) return;
+    if (!scrollElement) return;
     const flushCompensation = () => {
       if (compensationFlushTimerRef.current !== null) {
         clearTimeout(compensationFlushTimerRef.current);
         compensationFlushTimerRef.current = null;
       }
-      isCompensationDeferredRef.current = false;
-      if (pendingScrollCompensationRef.current !== 0) {
-        scrollElement.scrollTop += pendingScrollCompensationRef.current;
-        pendingScrollCompensationRef.current = 0;
+      if (pendingScrollCompensationRef.current === 0) {
+        isCompensationDeferredRef.current = false;
+        return;
       }
+      // Intent still active — keep any leftover buffer and retry after settle.
+      // Do not discard: that used to jump scroll-back when estimate→measure
+      // shrinks landed above the viewport with no compensation.
+      if (parentActions?.hasRecentUserScrollIntent?.()) {
+        isCompensationDeferredRef.current = true;
+        if (compensationFlushTimerRef.current === null) {
+          compensationFlushTimerRef.current = window.setTimeout(
+            flushCompensation,
+            COMPENSATION_SETTLE_MS,
+          );
+        }
+        return;
+      }
+      isCompensationDeferredRef.current = false;
+      parentActions?.noteProgrammaticScroll?.(
+        scrollElement.scrollTop + pendingScrollCompensationRef.current,
+      );
+      scrollElement.scrollTop += pendingScrollCompensationRef.current;
+      pendingScrollCompensationRef.current = 0;
     };
     const scheduleFlush = () => {
       if (!isCompensationDeferredRef.current) return;
@@ -234,23 +263,32 @@ export function MessageList({
     scheduleCompensationFlushRef.current = scheduleFlush;
     scrollElement.addEventListener("scroll", scheduleFlush, { passive: true });
     scrollElement.addEventListener("scrollend", flushCompensation);
-    scrollElement.addEventListener("touchstart", flushCompensation, { passive: true });
+    if (deferScrollCompensation) {
+      // iOS: a new touchstart itself cancels any in-flight momentum — flush then
+      // so visible drift is bounded to a single gesture.
+      scrollElement.addEventListener("touchstart", flushCompensation, { passive: true });
+    }
     return () => {
       scheduleCompensationFlushRef.current = null;
       scrollElement.removeEventListener("scroll", scheduleFlush);
       scrollElement.removeEventListener("scrollend", flushCompensation);
-      scrollElement.removeEventListener("touchstart", flushCompensation);
+      if (deferScrollCompensation) {
+        scrollElement.removeEventListener("touchstart", flushCompensation);
+      }
       if (compensationFlushTimerRef.current !== null) {
         clearTimeout(compensationFlushTimerRef.current);
         compensationFlushTimerRef.current = null;
       }
       // Don't strand a buffered delta when the thread unmounts mid-flick.
       if (pendingScrollCompensationRef.current !== 0) {
+        parentActions?.noteProgrammaticScroll?.(
+          scrollElement.scrollTop + pendingScrollCompensationRef.current,
+        );
         scrollElement.scrollTop += pendingScrollCompensationRef.current;
         pendingScrollCompensationRef.current = 0;
       }
     };
-  }, [deferScrollCompensation, scrollElement]);
+  }, [deferScrollCompensation, parentActions, scrollElement]);
 
   useLayoutEffect(() => {
     const virtualSizeBox = virtualSizeBoxRef.current;
@@ -296,14 +334,12 @@ export function MessageList({
         // TanStack reads data-index during measurement; keep reused rows aligned.
         element.dataset.index = String(index);
       }
+      // Register with TanStack's ResizeObserver cache. measureElement skips
+      // resizeItem while isScrolling, so scroll-back still needs a forced sync
+      // size — but only one offsetHeight read (the old path measured twice).
       virtualizer.measureElement(element);
       if (!element) return;
-      // Measure newly mounted rows before paint so estimate corrections do not
-      // arrive from ResizeObserver a frame later and jump the scroll position.
-      virtualizer.resizeItem(
-        index,
-        virtualizer.options.measureElement(element, undefined, virtualizer),
-      );
+      virtualizer.resizeItem(index, element.offsetHeight);
     },
     [virtualizer],
   );

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChatItemAccordion } from "./ChatItemAccordion";
+
+vi.mock("../../chatPaneActionsContext", () => ({
+  useChatPaneActions: () => null,
+}));
+
+describe("ChatItemAccordion", () => {
+  it("does not force title overflow layout reads on mount", () => {
+    const { container } = render(
+      <ChatItemAccordion
+        icon={<span>i</span>}
+        title="a-very-long-tool-title-that-may-truncate"
+        hasBody={false}
+      />,
+    );
+    const code = container.querySelector("code");
+    expect(code).not.toBeNull();
+
+    const scrollWidth = vi.spyOn(code as HTMLElement, "scrollWidth", "get");
+    const clientWidth = vi.spyOn(code as HTMLElement, "clientWidth", "get");
+    scrollWidth.mockReturnValue(400);
+    clientWidth.mockReturnValue(100);
+
+    // Mount already completed; getters should not have been forced yet.
+    expect(scrollWidth).not.toHaveBeenCalled();
+    expect(clientWidth).not.toHaveBeenCalled();
+
+    fireEvent.pointerEnter(
+      screen.getByText("a-very-long-tool-title-that-may-truncate").closest("span")!,
+    );
+    expect(scrollWidth).toHaveBeenCalled();
+    expect(clientWidth).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
@@ -1,5 +1,5 @@
 import { Disclosure, Tooltip } from "@heroui/react";
-import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatFilePath } from "./ChatFilePath";
 import {
@@ -93,19 +93,16 @@ export function ChatItemAccordion({
   // mode — skip the overflow-tooltip dance.
   const usesPathDisplay = !!titleParts?.filePath;
 
-  useLayoutEffect(() => {
-    if (usesPathDisplay) {
-      setIsOverflowing(false);
-      return;
-    }
+  // Do not force layout (scrollWidth/clientWidth) for every tool row on mount.
+  // Thread switches mount ~overscan rows at once; CDP profiles spent ~140ms+ in
+  // that check. Tooltip overflow is only needed on hover/focus — measure then.
+  const measureTitleOverflow = () => {
+    if (usesPathDisplay) return;
     const el = titleParts ? pathRef.current : codeRef.current;
     if (!el) return;
-    const check = () => setIsOverflowing(el.scrollWidth > el.clientWidth + 1);
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [titleString, titleParts, usesPathDisplay]);
+    const next = el.scrollWidth > el.clientWidth + 1;
+    setIsOverflowing((prev) => (prev === next ? prev : next));
+  };
 
   const titleContent = titleParts ? (
     <code className={`${codeClass} flex items-baseline overflow-hidden`}>
@@ -130,7 +127,7 @@ export function ChatItemAccordion({
   );
 
   const titleNode = (
-    <span className="min-w-0">
+    <span className="min-w-0" onPointerEnter={measureTitleOverflow} onFocus={measureTitleOverflow}>
       <Tooltip delay={300} isDisabled={!isOverflowing || !titleString}>
         <Tooltip.Trigger className="block min-w-0 w-full">{titleContent}</Tooltip.Trigger>
         <Tooltip.Content placement="top" className="max-w-[80vw] break-all">

--- a/src/renderer/components/thread/ChatPane/parts/items/CommandExecution.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/CommandExecution.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import {
   Check,
   Eye,
@@ -18,12 +18,9 @@ import {
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { ChatItemAccordion } from "./ChatItemAccordion";
 import { CommandOutputViewport } from "./CommandOutputViewport";
-import {
-  commandIntentDisplay,
-  summarizeShellCommand,
-  type CommandIntentKind,
-} from "./commandSummary";
-import { extractAcpResultText, readAcpStringField } from "./acpToolPayload";
+import { getCommandExecutionCollapsedHeader } from "./collapsedHeaderCache";
+import { type CommandIntentKind } from "./commandSummary";
+import { extractAcpResultText } from "./acpToolPayload";
 
 interface CommandExecutionProps {
   item: RuntimeChatItem;
@@ -31,47 +28,31 @@ interface CommandExecutionProps {
 
 export const CommandExecution = memo(function CommandExecution({ item }: CommandExecutionProps) {
   const payload = getRuntimeItemPayload<CommandExecutionPayload>(item, "command_execution");
-  // ACP-sourced rows arrive without a streaming command_output; the actual
-  // command lives under `args.command` (codex-shape rows already have it on
-  // `payload.command`). Fall back so both shapes render the same title.
-  const command =
-    payload?.command && payload.command.length > 0
-      ? payload.command
-      : (readAcpStringField(payload, "command") ?? "");
-  const cwd = payload?.cwd?.trim() ?? readAcpStringField(payload, "cwd")?.trim() ?? undefined;
-  const isRunning = item.state !== "completed";
   const [isExpanded, setIsExpanded] = useState(false);
+  const header = payload ? getCommandExecutionCollapsedHeader(item, payload) : null;
+  const isRunning = item.state !== "completed";
   const status = resolveCommandStatus(
     isRunning,
-    payload?.exitCode,
-    payload?.durationMs,
-    payload?.status === "error",
+    header?.exitCode,
+    header?.durationMs,
+    header?.isPayloadError === true,
   );
-  const fullCommandLine = formatShellInvocation(cwd, command);
-  const displayCommandLine = fullCommandLine ? summarizeShellCommand(fullCommandLine) : "";
-  const display = commandIntentDisplay(fullCommandLine);
-  const Icon = iconForCommandIntent(display.kind);
+  const Icon = iconForCommandIntent(header?.display.kind ?? "command");
+  const displayCommandLine = header?.displayCommandLine ?? "";
+  const display = header?.display;
 
   const rawOutput = item.streams.command_output ?? "";
-  const plainOutput = useMemo(() => {
-    if (!isExpanded) return "";
-    return stripAnsiPreservingLayout(rawOutput);
-  }, [rawOutput, isExpanded]);
-
-  // ACP rows ship the full command output as a single result blob — surface it
-  // as the body when no streamed output exists.
+  // Body-only — skip ANSI strip while collapsed.
+  const plainOutput = isExpanded ? stripAnsiPreservingLayout(rawOutput) : "";
   const acpResultText = isExpanded && plainOutput.length === 0 ? extractAcpResultText(payload) : "";
+  const terminalBody = [
+    displayCommandLine ? `$ ${displayCommandLine}` : "$ (command)",
+    plainOutput.length > 0 ? plainOutput : acpResultText,
+  ]
+    .filter((p) => p.length > 0)
+    .join("\n\n");
 
-  const terminalBody = useMemo(
-    () =>
-      [
-        displayCommandLine ? `$ ${displayCommandLine}` : "$ (command)",
-        plainOutput.length > 0 ? plainOutput : acpResultText,
-      ]
-        .filter((p) => p.length > 0)
-        .join("\n\n"),
-    [displayCommandLine, plainOutput, acpResultText],
-  );
+  if (!payload || !header || !display) return null;
 
   return (
     <ChatItemAccordion
@@ -135,20 +116,4 @@ function resolveCommandStatus(
 function formatDuration(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(1)}s`;
-}
-
-function formatShellInvocation(cwd: string | undefined, command: string): string {
-  const cmd = command.trim();
-  if (!cmd) return "";
-  if (cwd && cwd.length > 0) {
-    const needsCd =
-      !cmd.toLowerCase().startsWith("cd ") &&
-      !/^(['"]).*\1\s+&&\s+/.test(cmd) &&
-      !/^\(\s*cd\s/.test(cmd);
-    if (needsCd) {
-      const escaped = cwd.includes(" ") ? JSON.stringify(cwd) : cwd;
-      return `cd ${escaped} && ${cmd}`;
-    }
-  }
-  return cmd;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
@@ -16,12 +16,13 @@ import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
 import {
   extractAcpAddedFileText,
   extractAcpArgsPart,
-  extractAcpDiffSummary,
   extractAcpDiffResultPart,
   extractAcpResultPart,
   readAcpContentEditTexts,
+  type DiffSummary,
   type ExtractedPart,
 } from "./acpToolPayload";
+import { getFileChangeCollapsedHeader } from "./collapsedHeaderCache";
 import { InlineDiffView } from "./InlineDiffView";
 import { detectLanguageFromPath } from "./languageDetect";
 import { FileContentPlaceholder, useReadAbsoluteFile } from "./useReadAbsoluteFile";
@@ -36,70 +37,61 @@ export const FileChange = memo(function FileChange({ item }: FileChangeProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const stream = item.streams.file_change_output;
   const hasStream = !!stream && stream.length > 0;
-  const isCreate = payload?.changeKind === "create";
-  const argContent = isCreate ? extractCreateContent(payload) : undefined;
-  const diffPart = !isCreate ? extractAcpDiffResultPart(payload) : undefined;
-  const diffText = diffPart?.text ? diffPart.text : undefined;
-  const contentEdit = readAcpContentEditTexts(payload);
+  const header = payload ? getFileChangeCollapsedHeader(item, payload) : null;
   const paneActions = useChatPaneActions();
 
   // Some SDKs (e.g. Claude `Write`) don't surface the new file contents on
   // `args.content`; fall back to an on-demand disk read when expanded.
   const fetchTarget =
-    isCreate &&
-    argContent === undefined &&
-    diffText === undefined &&
-    payload?.path &&
-    payload.path.length > 0 &&
+    header &&
+    header.changeKind === "create" &&
+    !header.hasArgContent &&
+    !header.hasDiffText &&
+    header.hasPath &&
     paneActions?.projectLocation
-      ? { path: payload.path, projectLocation: paneActions.projectLocation }
+      ? { path: header.path, projectLocation: paneActions.projectLocation }
       : null;
   const fetched = useReadAbsoluteFile(isExpanded ? fetchTarget : null);
 
-  const sections = useMemo<ToolCallSection[]>(() => {
-    if (!isExpanded || !payload) return [];
-    if (
-      hasStream ||
-      argContent !== undefined ||
-      diffText !== undefined ||
-      fetched.content !== undefined
-    )
-      return [];
-    const argsPart = extractAcpArgsPart(payload);
-    const resultPart = extractAcpResultPart(payload);
-    const path = payload.path;
-    return [
-      { label: "args", part: enrichLanguage(argsPart, path) },
-      { label: "result", part: resultPart },
-    ];
-  }, [isExpanded, payload, hasStream, argContent, diffText, fetched.content]);
-  if (!payload) return null;
-  const right = formatRightLabel(payload, t);
-  const fallbackTitle = readPayloadString(payload, "title") ?? readPayloadString(payload, "name");
+  if (!payload || !header) return null;
+
+  // Body-only extraction — collapsed remounts only need the cached header.
+  const argContent = isExpanded && header.hasArgContent ? extractCreateContent(payload) : undefined;
+  const diffText =
+    isExpanded && header.hasDiffText ? extractAcpDiffResultPart(payload)?.text : undefined;
+  const contentEdit = isExpanded ? readAcpContentEditTexts(payload) : undefined;
+  const sections: ToolCallSection[] =
+    isExpanded &&
+    !hasStream &&
+    !header.hasArgContent &&
+    !header.hasDiffText &&
+    fetched.content === undefined
+      ? [
+          { label: "args", part: enrichLanguage(extractAcpArgsPart(payload), payload.path) },
+          { label: "result", part: extractAcpResultPart(payload) },
+        ]
+      : [];
   const hasDetails =
     hasStream ||
-    argContent !== undefined ||
-    diffText !== undefined ||
+    header.hasArgContent ||
+    header.hasDiffText ||
     fetchTarget !== null ||
-    hasAuxFields(payload);
-  const kindVerb = formatKindVerb(payload.changeKind);
-  const hasPath = !!payload.path && payload.path.length > 0;
-  const showsFallback =
-    !hasPath && !!fallbackTitle && fallbackTitle.toLowerCase() !== kindVerb.toLowerCase();
-  const withPath = hasPath || showsFallback;
-  const kindLabel = localizeKindLabel(payload.changeKind, withPath, t);
+    header.hasAuxFields;
+  const right = formatRightLabel(header.payloadStatus, header.diffSummary, t);
   const titleNode = (
     <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
-      <span className="shrink-0 !text-[color:var(--muted)]">{kindLabel}</span>
-      {hasPath ? (
+      <span className="shrink-0 !text-[color:var(--muted)]">
+        {localizeKindLabel(header.changeKind, header.withPath, t)}
+      </span>
+      {header.hasPath ? (
         <ChatFilePath
           className="flex-1"
-          path={payload.path}
+          path={header.path}
           basenameClassName="!text-[color:var(--foreground)]"
           dirClassName="!text-[color:var(--muted)]"
         />
-      ) : showsFallback ? (
-        <span className="min-w-0 truncate !text-[color:var(--muted)]">{fallbackTitle}</span>
+      ) : header.showsFallback && header.fallbackTitle ? (
+        <span className="min-w-0 truncate !text-[color:var(--muted)]">{header.fallbackTitle}</span>
       ) : null}
     </span>
   );
@@ -146,12 +138,6 @@ function extractCreateContent(payload: unknown): string | undefined {
   if (!args || typeof args !== "object" || Array.isArray(args)) return undefined;
   const content = (args as Record<string, unknown>).content;
   return typeof content === "string" && content.length > 0 ? content : undefined;
-}
-
-function hasAuxFields(payload: unknown): boolean {
-  if (!payload || typeof payload !== "object") return false;
-  const p = payload as Record<string, unknown>;
-  return p.args !== undefined || p.result !== undefined;
 }
 
 function readPayloadString(payload: unknown, key: string): string | undefined {
@@ -221,9 +207,13 @@ export function formatDiffSummaryLabel(
   );
 }
 
-function formatRightLabel(payload: FileChangePayload, t: TranslateFn): ReactNode | undefined {
-  if (payload.status === "error") {
+function formatRightLabel(
+  payloadStatus: FileChangePayload["status"] | undefined,
+  diffSummary: DiffSummary | undefined,
+  t: TranslateFn,
+): ReactNode | undefined {
+  if (payloadStatus === "error") {
     return <CircleAlert className="size-3 text-danger" aria-label={t(msg`error`)} />;
   }
-  return formatDiffSummaryLabel(payload.diffSummary ?? extractAcpDiffSummary(payload));
+  return formatDiffSummaryLabel(diffSummary);
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, type ReactNode } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
@@ -16,14 +16,15 @@ import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
 import {
   extractAcpArgsPart,
   extractAcpDiffResultPart,
-  extractAcpDiffSummary,
   extractAcpResultPart,
   extractReadFileResultPart,
   readAcpContentEditTexts,
+  type DiffSummary,
 } from "./acpToolPayload";
+import { getToolCallCollapsedHeader } from "./collapsedHeaderCache";
 import { formatDiffSummaryLabel } from "./FileChange";
 import { InlineDiffView } from "./InlineDiffView";
-import { deriveToolDisplay, isSkillTool } from "./toolDisplay";
+import { isSkillTool } from "./toolDisplay";
 import { FileContentPlaceholder, useReadAbsoluteFile } from "./useReadAbsoluteFile";
 
 interface ToolCallProps {
@@ -35,51 +36,49 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
   const payload = item.payload as ToolCallPayload | undefined;
   const [isExpanded, setIsExpanded] = useState(false);
   const paneActions = useChatPaneActions();
-  const lazyReadPath = pickLazyReadPath(payload);
+  // Header cache is only meaningful for normal tool rows. Compaction / plan
+  // proposals short-circuit below — still call the hook with a null target so
+  // hook order stays stable across those branches.
+  const header =
+    payload?.name && !isContextCompactionToolCall(item) && !isPlanProposalToolCall(item)
+      ? getToolCallCollapsedHeader(item, payload)
+      : null;
   const fetchTarget =
-    lazyReadPath && paneActions?.projectLocation
-      ? { path: lazyReadPath, projectLocation: paneActions.projectLocation }
+    header?.lazyReadPath && paneActions?.projectLocation
+      ? { path: header.lazyReadPath, projectLocation: paneActions.projectLocation }
       : null;
   const fetched = useReadAbsoluteFile(isExpanded ? fetchTarget : null);
-  const readResultPart =
-    payload && isReadLikeToolPayload(payload) && !lazyReadPath
-      ? extractReadFileResultPart(payload)
-      : undefined;
-  const hasReadResult = !!readResultPart && readResultPart.text.length > 0;
-  const diffPart =
-    payload && isEditLikeToolPayload(payload) ? extractAcpDiffResultPart(payload) : undefined;
-  const diffText = diffPart?.text ? diffPart.text : undefined;
-  const contentEdit = readAcpContentEditTexts(payload);
-  const sections = useMemo<ToolCallSection[]>(() => {
-    if (!isExpanded || !payload) return [];
-    if (lazyReadPath || hasReadResult || diffText !== undefined) return [];
-    const isSkill = isSkillTool(payload);
-    return [
-      { label: "args", part: extractAcpArgsPart(payload) },
-      {
-        label: "result",
-        part: extractAcpResultPart(payload),
-        ...(isSkill ? { renderAsMarkdown: true } : {}),
-      },
-    ];
-  }, [isExpanded, payload, lazyReadPath, hasReadResult, diffText]);
+
   if (!payload?.name) return null;
   if (isContextCompactionToolCall(item)) return <ContextCompaction item={item} />;
   if (isPlanProposalToolCall(item)) return <PlanProposal item={item} />;
+  if (!header) return null;
+
+  // Body-only extraction — skipped while collapsed so remounts don't re-walk
+  // ACP result/diff blobs just to paint the header.
+  const readResultPart =
+    isExpanded && !header.lazyReadPath && header.hasReadResult
+      ? extractReadFileResultPart(payload)
+      : undefined;
+  const diffText =
+    isExpanded && header.hasDiffText ? extractAcpDiffResultPart(payload)?.text : undefined;
+  const contentEdit = isExpanded ? readAcpContentEditTexts(payload) : undefined;
+  const sections: ToolCallSection[] =
+    isExpanded && !header.lazyReadPath && !header.hasReadResult && !header.hasDiffText
+      ? [
+          { label: "args", part: extractAcpArgsPart(payload) },
+          {
+            label: "result",
+            part: extractAcpResultPart(payload),
+            ...(isSkillTool(payload) ? { renderAsMarkdown: true } : {}),
+          },
+        ]
+      : [];
   const hasDetails =
-    payload.args !== undefined ||
-    payload.result !== undefined ||
-    fetchTarget !== null ||
-    diffText !== undefined ||
-    hasReadResult;
-  const display = deriveToolDisplay(payload);
+    header.hasAuxDetails || fetchTarget !== null || header.hasDiffText || header.hasReadResult;
+  const display = header.display;
   const Icon = display.Icon;
-  const status = resolveToolStatus(
-    item,
-    payload,
-    diffText ? extractAcpDiffSummary(payload) : undefined,
-    t,
-  );
+  const status = resolveToolStatus(item, header.payloadStatus, header.diffSummary, t);
 
   return (
     <ChatItemAccordion
@@ -101,7 +100,7 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
         ) : (
           <FileContentPlaceholder state={fetched.state} reason={fetched.reason} />
         )
-      ) : readResultPart && hasReadResult ? (
+      ) : readResultPart && header.hasReadResult ? (
         <CommandOutputViewport text={readResultPart.text} language={readResultPart.language} />
       ) : diffText !== undefined ? (
         <InlineDiffView
@@ -116,19 +115,6 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
   );
 });
 
-/**
- * For ACP read tools that didn't carry the file content in the result (e.g.
- * Gemini's `read_file` only reports `locations[]`), pick a path so the
- * accordion body can lazy-fetch from disk with syntax highlighting. Returns
- * undefined when the result is already populated — those use the existing
- * read-file result extractor instead.
- */
-function pickLazyReadPath(payload: ToolCallPayload | undefined): string | undefined {
-  if (!payload || !isReadLikeToolPayload(payload)) return undefined;
-  if (payload.result !== undefined) return undefined;
-  return payload.locations?.find((location) => location.path.length > 0)?.path;
-}
-
 interface ToolStatusDisplay {
   rightLabel: ReactNode;
   rightLabelClassName: string;
@@ -136,18 +122,18 @@ interface ToolStatusDisplay {
 
 function resolveToolStatus(
   item: RuntimeChatItem,
-  payload: ToolCallPayload,
-  diffSummary: ReturnType<typeof extractAcpDiffSummary> | undefined,
+  payloadStatus: ToolCallPayload["status"] | undefined,
+  diffSummary: DiffSummary | undefined,
   t: TranslateFn,
 ): ToolStatusDisplay {
-  const isRunning = item.state !== "completed" || payload.status === "running";
+  const isRunning = item.state !== "completed" || payloadStatus === "running";
   if (isRunning) {
     return {
       rightLabel: <PixelLoader size="xxs" className="text-[color:var(--muted)]" />,
       rightLabelClassName: "!text-[color:var(--muted)]",
     };
   }
-  if (payload.status === "error") {
+  if (payloadStatus === "error") {
     return {
       rightLabel: <CircleAlert className="size-3 text-danger" aria-label={t(msg`error`)} />,
       rightLabelClassName: "text-danger",
@@ -160,30 +146,4 @@ function resolveToolStatus(
     };
   }
   return { rightLabel: null, rightLabelClassName: "!text-[color:var(--muted)]" };
-}
-
-function isReadLikeToolPayload(payload: ToolCallPayload): boolean {
-  if (payload.kind === "read") return true;
-  if (payload.name === "Read" || payload.name === "NotebookRead") return true;
-  const title = payload.title?.trim() || payload.name.trim();
-  return /^(?:view|read)(?:ing)?(?:\s|:|$)/i.test(title);
-}
-
-function isEditLikeToolPayload(payload: ToolCallPayload): boolean {
-  switch (payload.kind) {
-    case "edit":
-    case "delete":
-    case "move":
-      return true;
-  }
-  if (
-    ["Edit", "Write", "MultiEdit", "NotebookEdit", "Patch", "ApplyPatch", "apply_patch"].includes(
-      payload.name,
-    )
-  )
-    return true;
-  const title = payload.title?.trim() || payload.name.trim();
-  return /^(?:edit|editing|write|writing|patch|patching|create|creating|delete|deleting|remove|removing)(?:\s|:|$)/i.test(
-    title,
-  );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -25,15 +25,17 @@ import { chatPromptSurfaceClass } from "./chatMessageSurface";
 import { InlineFilePathChip } from "./InlineFilePathChip";
 import { ItemMarkdown } from "./ItemMarkdown";
 import { extractSelectorPayloads } from "./SelectorBadge";
+import {
+  hasUserMessageVisualOverflow,
+  shouldNotifyUserMessageHeightChange,
+  userMessageCollapsedHeightCache,
+} from "./userMessageOverflow";
 
 interface UserMessageProps {
   item: RuntimeChatItem;
   checkpointRevert: CheckpointRevertRequest | null;
 }
 
-const COLLAPSED_LINE_COUNT = 4;
-const FALLBACK_LINE_HEIGHT_RATIO = 1.375;
-const OVERFLOW_EPSILON_PX = 2;
 // The height clamp and the fade mask are deliberately separate. The clamp is
 // applied on the very first render — before overflow is measured — so the
 // virtualizer measures the 4-line collapsed height rather than the message's
@@ -83,10 +85,24 @@ export const UserMessage = memo(function UserMessage({ item, checkpointRevert }:
     // clamped-by-default, and this pass is what lifts that clamp. Relying on the
     // ref-equality short-circuit alone would leave a short message clamped
     // forever (its overflow value never differs from the initial state).
-    if (hasVisualOverflowRef.current !== nextHasVisualOverflow || !hasMeasuredRef.current) {
+    const wasFirstMeasure = !hasMeasuredRef.current;
+    const overflowChanged = hasVisualOverflowRef.current !== nextHasVisualOverflow;
+    if (overflowChanged || wasFirstMeasure) {
       hasVisualOverflowRef.current = nextHasVisualOverflow;
       setHasVisualOverflow(nextHasVisualOverflow);
-      actions?.onContentHeightChange();
+      // Notify scroll controls only when row height can change: overflow flips,
+      // or the first measure lifts the provisional 4-line clamp on a short
+      // message. First-measure + still-overflowing keeps the same clamp height
+      // (fade only), so skip the stick-to-bottom cascade on thread switch.
+      if (
+        shouldNotifyUserMessageHeightChange({
+          wasFirstMeasure,
+          overflowChanged,
+          nextHasVisualOverflow,
+        })
+      ) {
+        actions?.onContentHeightChange();
+      }
     }
     if (!hasMeasuredRef.current) {
       hasMeasuredRef.current = true;
@@ -96,17 +112,57 @@ export const UserMessage = memo(function UserMessage({ item, checkpointRevert }:
   });
 
   useLayoutEffect(() => {
-    syncVisualOverflow();
+    // Defer the forced layout read until after first paint. Thread switches
+    // mount many user rows; measuring in useLayoutEffect blocked first paint
+    // (~100ms in CDP). Double-rAF lands after the browser has painted the
+    // provisional clamp. Long pastes stay clamped so the virtualizer estimate
+    // does not inflate before this runs.
+    let cancelled = false;
+    let innerFrame: number | null = null;
+    const outerFrame = requestAnimationFrame(() => {
+      innerFrame = requestAnimationFrame(() => {
+        if (!cancelled) syncVisualOverflow();
+      });
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(outerFrame);
+      if (innerFrame !== null) cancelAnimationFrame(innerFrame);
+    };
   }, [text, attachments.length]);
+
+  const isThreadOpenSettling = useEffectEvent(() => actions?.isThreadOpenSettling?.() === true);
 
   useLayoutEffect(() => {
     const element = bodyRef.current;
     if (!element) return;
+    let frame: number | null = null;
+    // ResizeObserver always delivers an initial callback on observe(); the
+    // text/attachments effect above already scheduled syncVisualOverflow for
+    // that same layout, so skip it — on every mount, including virtualizer
+    // remounts mid-thread.
+    let sawInitialObservation = false;
     const observer = new ResizeObserver(() => {
-      syncVisualOverflow();
+      if (!sawInitialObservation) {
+        sawInitialObservation = true;
+        return;
+      }
+      // Skip RO-driven remeasures during the thread-open virtualizer storm.
+      // Read the shared epoch from scroll controls — rows remount constantly
+      // while scrolling, so a per-mount clock here would suppress genuine
+      // resizes on freshly remounted rows mid-thread.
+      if (isThreadOpenSettling()) return;
+      if (frame !== null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        syncVisualOverflow();
+      });
     });
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
   }, []);
 
   // On touch (the PWA) there is no hover to reveal the copy/revert strip, and
@@ -458,26 +514,26 @@ function buildUserPromptAttachments(content: CanonicalContentBlock[]): Attachmen
 }
 
 function measureUserMessageOverflow(element: HTMLElement): boolean {
-  const fullHeight = Math.max(element.scrollHeight, element.getBoundingClientRect().height);
-  return fullHeight - getCollapsedHeight(element) > OVERFLOW_EPSILON_PX;
-}
-
-function getCollapsedHeight(element: HTMLElement): number {
-  const style = window.getComputedStyle(element);
-  const fontSize = parseCssPx(style.fontSize) ?? 16;
-  const lineHeight = parseCssLineHeight(style.lineHeight, fontSize);
-  return lineHeight * COLLAPSED_LINE_COUNT;
-}
-
-function parseCssLineHeight(value: string, fontSize: number): number {
-  const parsed = Number.parseFloat(value);
-  if (!Number.isFinite(parsed)) return fontSize * FALLBACK_LINE_HEIGHT_RATIO;
-  if (value.trim().endsWith("px")) return parsed;
-  if (parsed <= 4) return parsed * fontSize;
-  return parsed;
-}
-
-function parseCssPx(value: string): number | null {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : null;
+  // Chat typography is shared across rows; resolve collapsed height once per
+  // session instead of getComputedStyle on every user message during switch.
+  const collapsedHeightPx = userMessageCollapsedHeightCache.getShared(() =>
+    window.getComputedStyle(element),
+  );
+  const scrollHeight = element.scrollHeight;
+  // Prefer scrollHeight; only pay for getBoundingClientRect when the scroll
+  // metric is still within epsilon of the collapsed height (ambiguous clamp).
+  if (
+    hasUserMessageVisualOverflow({
+      fullHeightPx: scrollHeight,
+      collapsedHeightPx,
+    })
+  ) {
+    return true;
+  }
+  const rectHeight = element.getBoundingClientRect().height;
+  if (rectHeight <= scrollHeight) return false;
+  return hasUserMessageVisualOverflow({
+    fullHeightPx: rectHeight,
+    collapsedHeightPx,
+  });
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.test.ts
@@ -324,6 +324,43 @@ describe("acpToolPayload", () => {
     });
   });
 
+  it("summarizes from a precomputed diff part instead of re-synthesizing", () => {
+    // Payload alone would summarize to {added:1,removed:1}; the hint winning
+    // proves the fallback used it rather than rebuilding the diff.
+    const payload = {
+      args: {
+        patchText: [
+          "*** Begin Patch",
+          "*** Update File: src/foo.ts",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+        ].join("\n"),
+      },
+    };
+    const precomputed = {
+      text: ["--- a/x.ts", "+++ b/x.ts", "@@ -1,1 +1,3 @@", "-a", "+b", "+c", "+d", ""].join("\n"),
+      language: "diff" as const,
+    };
+    expect(extractAcpDiffSummary(payload, precomputed)).toEqual({ added: 3, removed: 1 });
+  });
+
+  it("prefers content-edit stats over a precomputed diff part", () => {
+    const payload = {
+      path: "src/app.ts",
+      editOldText: "const oldValue = true;\n",
+      editNewText: "const oldValue = false;\n",
+    };
+    const precomputed = {
+      text: ["--- a/x.ts", "+++ b/x.ts", "@@ -1,0 +1,3 @@", "+one", "+two", "+three", ""].join(
+        "\n",
+      ),
+      language: "diff" as const,
+    };
+    expect(extractAcpDiffSummary(payload, precomputed)).toEqual({ added: 1, removed: 1 });
+  });
+
   it("synthesizes diffs and summaries from create content args", () => {
     const payload = {
       name: "Write",

--- a/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/acpToolPayload.ts
@@ -257,7 +257,15 @@ export function extractAcpPatchTargetPath(payload: unknown): string | undefined 
   return uniquePaths.size === 1 ? paths[0] : undefined;
 }
 
-export function extractAcpDiffSummary(payload: unknown): DiffSummary | undefined {
+/**
+ * Callers that already ran `extractAcpDiffResultPart` on the same payload can
+ * pass it as `precomputedDiffPart` to skip re-synthesizing the diff in the
+ * fallback branch; the higher-priority summary sources are still checked first.
+ */
+export function extractAcpDiffSummary(
+  payload: unknown,
+  precomputedDiffPart?: ExtractedPart,
+): DiffSummary | undefined {
   const contentEdit = readAcpContentEditTexts(payload);
   if (contentEdit) {
     const stats = countLineChangeStats(contentEdit.oldText, contentEdit.newText);
@@ -265,7 +273,7 @@ export function extractAcpDiffSummary(payload: unknown): DiffSummary | undefined
   }
   const changesSummary = summarizeStructuredFileChanges(payload);
   if (changesSummary) return changesSummary;
-  const diffPart = extractAcpDiffResultPart(payload);
+  const diffPart = precomputedDiffPart ?? extractAcpDiffResultPart(payload);
   return diffPart.text ? summarizeDiffText(diffPart.text) : undefined;
 }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/collapsedHeaderCache.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/collapsedHeaderCache.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallPayload } from "@/shared/contracts";
+import { i18n } from "@/renderer/i18n/i18n";
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import {
+  getCommandExecutionCollapsedHeader,
+  getFileChangeCollapsedHeader,
+  getToolCallCollapsedHeader,
+  hasCachedCommandHeader,
+  hasCachedFileChangeHeader,
+  hasCachedToolCallHeader,
+} from "./collapsedHeaderCache";
+
+vi.mock("./toolDisplay", async () => {
+  const actual = await vi.importActual<typeof import("./toolDisplay")>("./toolDisplay");
+  return {
+    ...actual,
+    deriveToolDisplay: vi.fn<typeof actual.deriveToolDisplay>(actual.deriveToolDisplay),
+  };
+});
+
+vi.mock("./acpToolPayload", async () => {
+  const actual = await vi.importActual<typeof import("./acpToolPayload")>("./acpToolPayload");
+  return {
+    ...actual,
+    extractAcpDiffResultPart: vi.fn<typeof actual.extractAcpDiffResultPart>(
+      actual.extractAcpDiffResultPart,
+    ),
+    extractAcpDiffSummary: vi.fn<typeof actual.extractAcpDiffSummary>(actual.extractAcpDiffSummary),
+  };
+});
+
+vi.mock("./commandSummary", async () => {
+  const actual = await vi.importActual<typeof import("./commandSummary")>("./commandSummary");
+  return {
+    ...actual,
+    summarizeShellCommand: vi.fn<typeof actual.summarizeShellCommand>(actual.summarizeShellCommand),
+    commandIntentDisplay: vi.fn<typeof actual.commandIntentDisplay>(actual.commandIntentDisplay),
+  };
+});
+
+import { deriveToolDisplay } from "./toolDisplay";
+import { extractAcpDiffResultPart, extractAcpDiffSummary } from "./acpToolPayload";
+import { commandIntentDisplay, summarizeShellCommand } from "./commandSummary";
+
+const deriveToolDisplayMock = vi.mocked(deriveToolDisplay);
+const extractAcpDiffResultPartMock = vi.mocked(extractAcpDiffResultPart);
+const extractAcpDiffSummaryMock = vi.mocked(extractAcpDiffSummary);
+const summarizeShellCommandMock = vi.mocked(summarizeShellCommand);
+const commandIntentDisplayMock = vi.mocked(commandIntentDisplay);
+
+function makeToolItem(
+  overrides: Partial<RuntimeChatItem> & { payload: ToolCallPayload },
+): RuntimeChatItem {
+  return {
+    id: "tool-1",
+    type: "tool_call",
+    state: "completed",
+    streams: {},
+    ...overrides,
+  };
+}
+
+describe("collapsedHeaderCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("computes a completed tool header once and reuses it on remount", () => {
+    const payload: ToolCallPayload = {
+      name: "Read",
+      kind: "read",
+      status: "success",
+      locations: [{ path: "src/foo.ts" }],
+    };
+    const item = makeToolItem({ payload });
+
+    const first = getToolCallCollapsedHeader(item, payload);
+    const second = getToolCallCollapsedHeader(item, payload);
+
+    expect(second).toBe(first);
+    expect(deriveToolDisplayMock).toHaveBeenCalledTimes(1);
+    expect(hasCachedToolCallHeader(item)).toBe(true);
+  });
+
+  it("does not populate the cache for running tool rows", () => {
+    const payload: ToolCallPayload = {
+      name: "Read",
+      kind: "read",
+      status: "running",
+      locations: [{ path: "src/foo.ts" }],
+    };
+    const item = makeToolItem({ state: "started", payload });
+
+    getToolCallCollapsedHeader(item, payload);
+    getToolCallCollapsedHeader(item, payload);
+
+    expect(hasCachedToolCallHeader(item)).toBe(false);
+    expect(deriveToolDisplayMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recomputes when the RuntimeChatItem object is replaced (late payload patch)", () => {
+    const payload: ToolCallPayload = {
+      name: "Edit",
+      kind: "edit",
+      status: "success",
+      result: { text: "--- a\n+++ b\n@@\n-a\n+b\n" },
+    };
+    const item1 = makeToolItem({ payload });
+    getToolCallCollapsedHeader(item1, payload);
+    expect(deriveToolDisplayMock).toHaveBeenCalledTimes(1);
+
+    // Reducer always spreads a new item object on item.updated / item.completed.
+    const item2 = { ...item1, payload: { ...payload, title: "Editing src/foo.ts" } };
+    getToolCallCollapsedHeader(item2, item2.payload as ToolCallPayload);
+
+    expect(deriveToolDisplayMock).toHaveBeenCalledTimes(2);
+    expect(hasCachedToolCallHeader(item1)).toBe(true);
+    expect(hasCachedToolCallHeader(item2)).toBe(true);
+  });
+
+  it("recomputes when the active locale changes", () => {
+    const payload: ToolCallPayload = {
+      name: "Read",
+      kind: "read",
+      status: "success",
+      locations: [{ path: "src/foo.ts" }],
+    };
+    const item = makeToolItem({ payload });
+    getToolCallCollapsedHeader(item, payload);
+    expect(deriveToolDisplayMock).toHaveBeenCalledTimes(1);
+
+    const prev = i18n.locale;
+    i18n.activate(prev === "en" ? "es" : "en");
+    try {
+      getToolCallCollapsedHeader(item, payload);
+      expect(deriveToolDisplayMock).toHaveBeenCalledTimes(2);
+    } finally {
+      i18n.activate(prev);
+    }
+  });
+
+  it("passes the synthesized diff part into the summary fallback", () => {
+    const payload: ToolCallPayload = {
+      name: "apply_patch",
+      kind: "edit",
+      status: "success",
+      args: {
+        patchText: [
+          "*** Begin Patch",
+          "*** Update File: src/foo.ts",
+          "@@",
+          "-old",
+          "+new",
+          "*** End Patch",
+        ].join("\n"),
+      },
+    };
+    const item = makeToolItem({ payload });
+
+    const header = getToolCallCollapsedHeader(item, payload);
+
+    expect(header.diffSummary).toEqual({ added: 1, removed: 1 });
+    // The already-synthesized diff part must ride along so the summary
+    // fallback does not rebuild the diff from the payload a second time.
+    expect(extractAcpDiffSummaryMock).toHaveBeenCalledWith(
+      payload,
+      expect.objectContaining({ language: "diff" }),
+    );
+  });
+
+  it("caches completed file-change headers across remounts", () => {
+    const payload = {
+      path: "src/foo.ts",
+      changeKind: "edit" as const,
+      status: "success" as const,
+      diffSummary: { added: 2, removed: 1 },
+    };
+    const item: RuntimeChatItem = {
+      id: "fc-1",
+      type: "file_change",
+      state: "completed",
+      streams: {},
+      payload,
+    };
+
+    getFileChangeCollapsedHeader(item, payload);
+    getFileChangeCollapsedHeader(item, payload);
+
+    expect(hasCachedFileChangeHeader(item)).toBe(true);
+    // First compute may call extractors; remount must not.
+    const callsAfterFirst = extractAcpDiffResultPartMock.mock.calls.length;
+    getFileChangeCollapsedHeader(item, payload);
+    expect(extractAcpDiffResultPartMock).toHaveBeenCalledTimes(callsAfterFirst);
+    expect(extractAcpDiffSummaryMock.mock.calls.length).toBeLessThanOrEqual(callsAfterFirst + 1);
+  });
+
+  it("caches completed command headers across remounts", () => {
+    const payload = {
+      command: "pnpm test",
+      cwd: "E:/repo",
+      exitCode: 0,
+      durationMs: 1200,
+      status: "success" as const,
+    };
+    const item: RuntimeChatItem = {
+      id: "cmd-1",
+      type: "command_execution",
+      state: "completed",
+      streams: {},
+      payload,
+    };
+
+    getCommandExecutionCollapsedHeader(item, payload);
+    getCommandExecutionCollapsedHeader(item, payload);
+
+    expect(hasCachedCommandHeader(item)).toBe(true);
+    expect(summarizeShellCommandMock).toHaveBeenCalledTimes(1);
+    expect(commandIntentDisplayMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/collapsedHeaderCache.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/collapsedHeaderCache.ts
@@ -1,0 +1,289 @@
+/**
+ * Remount-stable collapsed-header facts for completed chat tool rows.
+ *
+ * Virtualized scroll remounts rows constantly. React Compiler memo dies with
+ * the fiber, so expensive title/diff-summary derivation must live outside
+ * render — keyed on the `RuntimeChatItem` object reference. The reducer always
+ * replaces the item on mutation, so late payload patches miss the cache
+ * automatically. Locale is stored alongside the value so a language switch
+ * recomputes without a global clear.
+ *
+ * Cache plain data only — never JSX. `projectLocation`-derived fetch targets
+ * stay live in the component (cheap, not item-derived).
+ */
+
+import type {
+  CommandExecutionPayload,
+  FileChangePayload,
+  ToolCallPayload,
+} from "@/shared/contracts";
+import { i18n } from "@/renderer/i18n/i18n";
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import {
+  extractAcpAddedFileText,
+  extractAcpDiffResultPart,
+  extractAcpDiffSummary,
+  extractReadFileResultPart,
+  readAcpStringField,
+  type DiffSummary,
+} from "./acpToolPayload";
+import {
+  commandIntentDisplay,
+  summarizeShellCommand,
+  type CommandIntentDisplay,
+} from "./commandSummary";
+import { deriveToolDisplay, type ToolDisplay } from "./toolDisplay";
+
+type CacheEntry<T> = {
+  locale: string;
+  value: T;
+};
+
+const toolCallCache = new WeakMap<RuntimeChatItem, CacheEntry<ToolCallCollapsedHeader>>();
+const fileChangeCache = new WeakMap<RuntimeChatItem, CacheEntry<FileChangeCollapsedHeader>>();
+const commandCache = new WeakMap<RuntimeChatItem, CacheEntry<CommandExecutionCollapsedHeader>>();
+
+export type ToolCallCollapsedHeader = {
+  display: ToolDisplay;
+  lazyReadPath: string | undefined;
+  hasReadResult: boolean;
+  hasDiffText: boolean;
+  diffSummary: DiffSummary | undefined;
+  hasAuxDetails: boolean;
+  payloadStatus: ToolCallPayload["status"] | undefined;
+};
+
+export type FileChangeCollapsedHeader = {
+  changeKind: FileChangePayload["changeKind"];
+  path: string;
+  fallbackTitle: string | undefined;
+  hasPath: boolean;
+  showsFallback: boolean;
+  withPath: boolean;
+  hasArgContent: boolean;
+  hasDiffText: boolean;
+  hasAuxFields: boolean;
+  diffSummary: DiffSummary | undefined;
+  payloadStatus: FileChangePayload["status"] | undefined;
+};
+
+export type CommandExecutionCollapsedHeader = {
+  display: CommandIntentDisplay;
+  displayCommandLine: string;
+  fullCommandLine: string;
+  exitCode: number | undefined;
+  durationMs: number | undefined;
+  isPayloadError: boolean;
+};
+
+/**
+ * Remount-stable, locale-aware memo keyed on `RuntimeChatItem` identity. Only
+ * completed rows are cached — running rows still stream, and the reducer
+ * replaces the item object on every mutation so a late payload patch keys a
+ * fresh entry automatically.
+ */
+function getCachedHeader<T>(
+  cache: WeakMap<RuntimeChatItem, CacheEntry<T>>,
+  item: RuntimeChatItem,
+  compute: () => T,
+): T {
+  const locale = i18n.locale;
+  if (item.state === "completed") {
+    const cached = cache.get(item);
+    if (cached && cached.locale === locale) return cached.value;
+  }
+  const value = compute();
+  if (item.state === "completed") {
+    cache.set(item, { locale, value });
+  }
+  return value;
+}
+
+export function getToolCallCollapsedHeader(
+  item: RuntimeChatItem,
+  payload: ToolCallPayload,
+): ToolCallCollapsedHeader {
+  return getCachedHeader(toolCallCache, item, () => computeToolCallHeader(payload));
+}
+
+export function getFileChangeCollapsedHeader(
+  item: RuntimeChatItem,
+  payload: FileChangePayload,
+): FileChangeCollapsedHeader {
+  return getCachedHeader(fileChangeCache, item, () => computeFileChangeHeader(payload));
+}
+
+export function getCommandExecutionCollapsedHeader(
+  item: RuntimeChatItem,
+  payload: CommandExecutionPayload,
+): CommandExecutionCollapsedHeader {
+  return getCachedHeader(commandCache, item, () => computeCommandHeader(payload));
+}
+
+function computeToolCallHeader(payload: ToolCallPayload): ToolCallCollapsedHeader {
+  const lazyReadPath = pickLazyReadPath(payload);
+  const readResultPart =
+    isReadLikeToolPayload(payload) && !lazyReadPath
+      ? extractReadFileResultPart(payload)
+      : undefined;
+  const hasReadResult = !!readResultPart && readResultPart.text.length > 0;
+  const diffPart = isEditLikeToolPayload(payload) ? extractAcpDiffResultPart(payload) : undefined;
+  const hasDiffText = !!diffPart?.text;
+  return {
+    display: deriveToolDisplay(payload),
+    lazyReadPath,
+    hasReadResult,
+    hasDiffText,
+    // Reuse the already-synthesized diff so the fallback summary branch does
+    // not rebuild it from the payload a second time.
+    diffSummary: hasDiffText ? extractAcpDiffSummary(payload, diffPart) : undefined,
+    hasAuxDetails: payload.args !== undefined || payload.result !== undefined,
+    payloadStatus: payload.status,
+  };
+}
+
+function computeFileChangeHeader(payload: FileChangePayload): FileChangeCollapsedHeader {
+  const isCreate = payload.changeKind === "create";
+  const hasArgContent = isCreate ? extractCreateContentExists(payload) : false;
+  const diffPart = !isCreate ? extractAcpDiffResultPart(payload) : undefined;
+  const hasDiffText = !!diffPart?.text;
+  const fallbackTitle = readPayloadString(payload, "title") ?? readPayloadString(payload, "name");
+  const kindVerb = formatKindVerb(payload.changeKind);
+  const hasPath = !!payload.path && payload.path.length > 0;
+  const showsFallback =
+    !hasPath && !!fallbackTitle && fallbackTitle.toLowerCase() !== kindVerb.toLowerCase();
+  return {
+    changeKind: payload.changeKind,
+    path: payload.path,
+    fallbackTitle,
+    hasPath,
+    showsFallback,
+    withPath: hasPath || showsFallback,
+    hasArgContent,
+    hasDiffText,
+    hasAuxFields: hasAuxFields(payload),
+    diffSummary: payload.diffSummary ?? extractAcpDiffSummary(payload, diffPart),
+    payloadStatus: payload.status,
+  };
+}
+
+function computeCommandHeader(payload: CommandExecutionPayload): CommandExecutionCollapsedHeader {
+  const command =
+    payload.command && payload.command.length > 0
+      ? payload.command
+      : (readAcpStringField(payload, "command") ?? "");
+  const cwd = payload.cwd?.trim() ?? readAcpStringField(payload, "cwd")?.trim() ?? undefined;
+  const fullCommandLine = formatShellInvocation(cwd, command);
+  const displayCommandLine = fullCommandLine ? summarizeShellCommand(fullCommandLine) : "";
+  return {
+    display: commandIntentDisplay(fullCommandLine),
+    displayCommandLine,
+    fullCommandLine,
+    exitCode: payload.exitCode,
+    durationMs: payload.durationMs,
+    isPayloadError: payload.status === "error",
+  };
+}
+
+function pickLazyReadPath(payload: ToolCallPayload): string | undefined {
+  if (!isReadLikeToolPayload(payload)) return undefined;
+  if (payload.result !== undefined) return undefined;
+  return payload.locations?.find((location) => location.path.length > 0)?.path;
+}
+
+function isReadLikeToolPayload(payload: ToolCallPayload): boolean {
+  if (payload.kind === "read") return true;
+  if (payload.name === "Read" || payload.name === "NotebookRead") return true;
+  const title = payload.title?.trim() || payload.name.trim();
+  return /^(?:view|read)(?:ing)?(?:\s|:|$)/i.test(title);
+}
+
+function isEditLikeToolPayload(payload: ToolCallPayload): boolean {
+  switch (payload.kind) {
+    case "edit":
+    case "delete":
+    case "move":
+      return true;
+  }
+  if (
+    ["Edit", "Write", "MultiEdit", "NotebookEdit", "Patch", "ApplyPatch", "apply_patch"].includes(
+      payload.name,
+    )
+  ) {
+    return true;
+  }
+  const title = payload.title?.trim() || payload.name.trim();
+  return /^(?:edit|editing|write|writing|patch|patching|create|creating|delete|deleting|remove|removing)(?:\s|:|$)/i.test(
+    title,
+  );
+}
+
+function extractCreateContentExists(payload: FileChangePayload): boolean {
+  if (payload.path) {
+    if (extractAcpAddedFileText(payload, payload.path) !== undefined) return true;
+  }
+  const args = (payload as { args?: unknown }).args;
+  if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+  const content = (args as Record<string, unknown>).content;
+  return typeof content === "string" && content.length > 0;
+}
+
+function hasAuxFields(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+  const p = payload as Record<string, unknown>;
+  return p.args !== undefined || p.result !== undefined;
+}
+
+function readPayloadString(payload: unknown, key: string): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function formatKindVerb(kind: FileChangePayload["changeKind"]): string {
+  switch (kind) {
+    case "create":
+      return "Create";
+    case "delete":
+      return "Delete";
+    default:
+      return "Edit";
+  }
+}
+
+function formatShellInvocation(cwd: string | undefined, command: string): string {
+  const cmd = command.trim();
+  if (!cmd) return "";
+  if (cwd && cwd.length > 0) {
+    const needsCd =
+      !cmd.toLowerCase().startsWith("cd ") &&
+      !/^(['"]).*\1\s+&&\s+/.test(cmd) &&
+      !/^\(\s*cd\s/.test(cmd);
+    if (needsCd) {
+      const escaped = cwd.includes(" ") ? JSON.stringify(cwd) : cwd;
+      return `cd ${escaped} && ${cmd}`;
+    }
+  }
+  return cmd;
+}
+
+/** Test helper — peek whether an item is currently cached for the active locale. */
+function hasCachedHeader<T>(
+  cache: WeakMap<RuntimeChatItem, CacheEntry<T>>,
+  item: RuntimeChatItem,
+): boolean {
+  const cached = cache.get(item);
+  return !!cached && cached.locale === i18n.locale;
+}
+
+export function hasCachedToolCallHeader(item: RuntimeChatItem): boolean {
+  return hasCachedHeader(toolCallCache, item);
+}
+
+export function hasCachedFileChangeHeader(item: RuntimeChatItem): boolean {
+  return hasCachedHeader(fileChangeCache, item);
+}
+
+export function hasCachedCommandHeader(item: RuntimeChatItem): boolean {
+  return hasCachedHeader(commandCache, item);
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/userMessageOverflow.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/userMessageOverflow.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  collapsedHeightFromComputedStyle,
+  createCollapsedHeightCache,
+  hasUserMessageVisualOverflow,
+  parseCssLineHeight,
+  parseCssPx,
+  shouldNotifyUserMessageHeightChange,
+  USER_MESSAGE_COLLAPSED_LINE_COUNT,
+  USER_MESSAGE_OVERFLOW_EPSILON_PX,
+} from "./userMessageOverflow";
+
+describe("userMessageOverflow", () => {
+  it("notifies height change only when clamp height can change", () => {
+    expect(
+      shouldNotifyUserMessageHeightChange({
+        wasFirstMeasure: true,
+        overflowChanged: false,
+        nextHasVisualOverflow: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldNotifyUserMessageHeightChange({
+        wasFirstMeasure: true,
+        overflowChanged: false,
+        nextHasVisualOverflow: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotifyUserMessageHeightChange({
+        wasFirstMeasure: false,
+        overflowChanged: true,
+        nextHasVisualOverflow: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldNotifyUserMessageHeightChange({
+        wasFirstMeasure: false,
+        overflowChanged: false,
+        nextHasVisualOverflow: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("detects overflow past the collapsed height epsilon", () => {
+    expect(
+      hasUserMessageVisualOverflow({
+        fullHeightPx: 100,
+        collapsedHeightPx: 88,
+      }),
+    ).toBe(true);
+    expect(
+      hasUserMessageVisualOverflow({
+        fullHeightPx: 90,
+        collapsedHeightPx: 88,
+      }),
+    ).toBe(false);
+    expect(USER_MESSAGE_OVERFLOW_EPSILON_PX).toBe(2);
+  });
+
+  it("parses css lengths used for collapsed height", () => {
+    expect(parseCssPx("16px")).toBe(16);
+    expect(parseCssPx("not-a-number")).toBeNull();
+    expect(parseCssLineHeight("22px", 16)).toBe(22);
+    expect(parseCssLineHeight("1.375", 16)).toBe(22);
+    expect(parseCssLineHeight("normal", 16)).toBe(16 * 1.375);
+  });
+
+  it("computes and caches collapsed height from typography", () => {
+    const px = collapsedHeightFromComputedStyle({
+      fontSize: "16px",
+      lineHeight: "22px",
+    });
+    expect(px).toBe(22 * USER_MESSAGE_COLLAPSED_LINE_COUNT);
+
+    const cache = createCollapsedHeightCache();
+    const style = { fontSize: "16px", lineHeight: "22px" };
+    expect(cache.get(style)).toBe(px);
+    expect(cache.get(style)).toBe(px);
+    expect(cache.get({ fontSize: "14px", lineHeight: "20px" })).toBe(
+      20 * USER_MESSAGE_COLLAPSED_LINE_COUNT,
+    );
+  });
+
+  it("reuses shared collapsed height without re-reading style", () => {
+    const cache = createCollapsedHeightCache();
+    type StyleReader = () => { fontSize: string; lineHeight: string };
+    const readStyle = vi.fn<StyleReader>(() => ({
+      fontSize: "16px",
+      lineHeight: "22px",
+    }));
+    expect(cache.getShared(readStyle)).toBe(22 * USER_MESSAGE_COLLAPSED_LINE_COUNT);
+    expect(cache.getShared(readStyle)).toBe(22 * USER_MESSAGE_COLLAPSED_LINE_COUNT);
+    expect(readStyle).toHaveBeenCalledTimes(1);
+    cache.clear();
+    expect(cache.getShared(readStyle)).toBe(22 * USER_MESSAGE_COLLAPSED_LINE_COUNT);
+    expect(readStyle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/userMessageOverflow.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/userMessageOverflow.ts
@@ -1,0 +1,89 @@
+export const USER_MESSAGE_COLLAPSED_LINE_COUNT = 4;
+export const USER_MESSAGE_FALLBACK_LINE_HEIGHT_RATIO = 1.375;
+export const USER_MESSAGE_OVERFLOW_EPSILON_PX = 2;
+
+/**
+ * Whether the first overflow measurement should notify chat scroll controls.
+ *
+ * First-measure + still-overflowing keeps the provisional 4-line clamp height
+ * (only the fade mask is added), so stick-to-bottom does not need to run.
+ * Notify when overflow flips, or when the first measure lifts the clamp off a
+ * short message.
+ */
+export function shouldNotifyUserMessageHeightChange(input: {
+  wasFirstMeasure: boolean;
+  overflowChanged: boolean;
+  nextHasVisualOverflow: boolean;
+}): boolean {
+  return input.overflowChanged || (input.wasFirstMeasure && !input.nextHasVisualOverflow);
+}
+
+export function hasUserMessageVisualOverflow(input: {
+  fullHeightPx: number;
+  collapsedHeightPx: number;
+  epsilonPx?: number;
+}): boolean {
+  const epsilon = input.epsilonPx ?? USER_MESSAGE_OVERFLOW_EPSILON_PX;
+  return input.fullHeightPx - input.collapsedHeightPx > epsilon;
+}
+
+export function parseCssPx(value: string): number | null {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parseCssLineHeight(value: string, fontSize: number): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return fontSize * USER_MESSAGE_FALLBACK_LINE_HEIGHT_RATIO;
+  if (value.trim().endsWith("px")) return parsed;
+  if (parsed <= 4) return parsed * fontSize;
+  return parsed;
+}
+
+export function collapsedHeightFromComputedStyle(input: {
+  fontSize: string;
+  lineHeight: string;
+  lineCount?: number;
+}): number {
+  const fontSize = parseCssPx(input.fontSize) ?? 16;
+  const lineHeight = parseCssLineHeight(input.lineHeight, fontSize);
+  return lineHeight * (input.lineCount ?? USER_MESSAGE_COLLAPSED_LINE_COUNT);
+}
+
+/**
+ * Cache collapsed-height lookups across user-message rows that share the same
+ * chat typography. Thread switches measure many rows; getComputedStyle + parse
+ * on each was a CDP hotspot.
+ *
+ * `getShared` keeps the resolved px after the first successful read so later
+ * rows skip getComputedStyle entirely until `clear()` (e.g. chat font change).
+ */
+export function createCollapsedHeightCache() {
+  let cached: { fontSize: string; lineHeight: string; px: number } | null = null;
+  let sharedPx: number | null = null;
+  return {
+    get(style: { fontSize: string; lineHeight: string }): number {
+      if (cached && cached.fontSize === style.fontSize && cached.lineHeight === style.lineHeight) {
+        return cached.px;
+      }
+      const px = collapsedHeightFromComputedStyle(style);
+      cached = { fontSize: style.fontSize, lineHeight: style.lineHeight, px };
+      sharedPx = px;
+      return px;
+    },
+    getShared(readStyle: () => { fontSize: string; lineHeight: string }): number {
+      if (sharedPx !== null) return sharedPx;
+      return this.get(readStyle());
+    },
+    clear() {
+      cached = null;
+      sharedPx = null;
+    },
+  };
+}
+
+export const userMessageCollapsedHeightCache = createCollapsedHeightCache();
+
+export function clearUserMessageCollapsedHeightCache(): void {
+  userMessageCollapsedHeightCache.clear();
+}

--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -1,4 +1,4 @@
-import { type RefObject } from "react";
+import { useLayoutEffect, type RefObject } from "react";
 import { Trans } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -6,6 +6,7 @@ import { useThread } from "@/renderer/state/useThread";
 import { ChatPane } from "./ChatPane/ChatPane";
 import { ChatRuntimeDebugPanel } from "./ChatPane/ChatRuntimeDebugPanel";
 import { guiChatFontCssVars } from "./ChatPane/chatFontVars";
+import { clearUserMessageCollapsedHeightCache } from "./ChatPane/parts/items/userMessageOverflow";
 import type { TerminalPaneHandle } from "./TerminalPane";
 import { ThreadComposerSection } from "./ThreadComposerSection";
 import { ThreadTodoDock } from "./ThreadTodoDock";
@@ -38,6 +39,9 @@ export function GuiThreadContent(
   const { runtimeDebugOpen } = props;
   const thread = useThread(props.threadId) ?? props.fallbackThread;
   const guiChatFontSize = useSharedSettings((s) => s.guiChatFontSize);
+  useLayoutEffect(() => {
+    clearUserMessageCollapsedHeightCache();
+  }, [guiChatFontSize]);
   const ownDockState = useThreadDockState(thread.id);
   const dockState = props.dockState ?? ownDockState;
   const { todoDockState } = dockState;

--- a/src/renderer/components/thread/threadGoalState.ts
+++ b/src/renderer/components/thread/threadGoalState.ts
@@ -52,12 +52,10 @@ export function selectThreadGoalDockItem(
   state: AppStoreState,
   threadId: string,
 ): RuntimeChatItem | null {
-  return (
-    selectLatestThreadGoalCandidate(
-      state.runtimeItemIdsByThread[threadId],
-      state.runtimeItemsByIdByThread[threadId],
-    )?.item ?? null
-  );
+  // Reuse the dock-state cache so non-goal streaming deltas skip a full scan.
+  const dockState = selectThreadGoalDockState(state, threadId);
+  if (!dockState) return null;
+  return state.runtimeItemsByIdByThread[threadId]?.[dockState.sourceItemId] ?? null;
 }
 
 export function getThreadGoalDockStateFromThreadItems(

--- a/src/renderer/components/thread/threadTodoState.test.ts
+++ b/src/renderer/components/thread/threadTodoState.test.ts
@@ -3,11 +3,61 @@ import type { AppStoreState } from "@/renderer/state/appStore";
 import {
   areThreadTodoStepsEqual,
   getThreadTodoDockStateForItem,
+  selectThreadTodoDockItem,
   selectThreadTodoDockState,
 } from "./threadTodoState";
 import type { ThreadTodoDockState } from "./threadTodoState";
 
 describe("threadTodoState", () => {
+  it("returns a stable dock item across streaming deltas that do not change plans", () => {
+    const planItem = {
+      id: "plan-1",
+      type: "plan",
+      state: "updated",
+      payload: {
+        steps: [{ step: "Step one", status: "in_progress" }],
+      },
+      streams: {},
+    };
+    const state = {
+      runtimeItemIdsByThread: {
+        t1: ["plan-1", "assistant-1"],
+      },
+      runtimeItemsByIdByThread: {
+        t1: {
+          "plan-1": planItem,
+          "assistant-1": {
+            id: "assistant-1",
+            type: "assistant_message",
+            state: "running",
+            payload: {},
+            streams: { assistant_text: "hello" },
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+
+    const first = selectThreadTodoDockItem(state, "t1");
+    expect(first).toBe(planItem);
+
+    const itemsById = state.runtimeItemsByIdByThread.t1!;
+    const nextState = {
+      ...state,
+      runtimeItemsByIdByThread: {
+        t1: {
+          ...itemsById,
+          "assistant-1": {
+            ...itemsById["assistant-1"]!,
+            streams: { assistant_text: "hello world" },
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+
+    expect(selectThreadTodoDockItem(nextState, "t1")).toBe(planItem);
+    expect(selectThreadTodoDockState(nextState, "t1")).toBe(selectThreadTodoDockState(state, "t1"));
+  });
+
   it("selects the latest structured plan item and tracks the active step", () => {
     const state = {
       runtimeItemIdsByThread: {

--- a/src/renderer/components/thread/threadTodoState.ts
+++ b/src/renderer/components/thread/threadTodoState.ts
@@ -58,12 +58,11 @@ export function selectThreadTodoDockItem(
   state: AppStoreState,
   threadId: string,
 ): RuntimeChatItem | null {
-  return (
-    selectLatestThreadTodoDockCandidate(
-      state.runtimeItemIdsByThread[threadId],
-      state.runtimeItemsByIdByThread[threadId],
-    )?.item ?? null
-  );
+  // Reuse the dock-state cache so streaming deltas (which do not change plans)
+  // do not rescan every runtime item on each Zustand subscriber pass.
+  const dockState = selectThreadTodoDockState(state, threadId);
+  if (!dockState) return null;
+  return state.runtimeItemsByIdByThread[threadId]?.[dockState.sourceItemId] ?? null;
 }
 
 export function getThreadTodoDockStateFromThreadItems(

--- a/src/renderer/hooks/useScrollFade.test.tsx
+++ b/src/renderer/hooks/useScrollFade.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { act, render, renderHook } from "@testing-library/react";
 import { useScrollFade } from "./useScrollFade";
 
@@ -44,5 +44,31 @@ describe("useScrollFade", () => {
     act(() => result.current.setScrollContainer(null));
     expect(result.current.scrollEl).toBeNull();
     expect(result.current.scrollRef.current).toBeNull();
+  });
+
+  it("does not rewrite identical fade CSS vars on repeated scroll updates", async () => {
+    const { result } = renderHook(() => useScrollFade<HTMLDivElement>({ maxFadePx: 32 }));
+    const el = document.createElement("div");
+    Object.defineProperties(el, {
+      scrollTop: { configurable: true, get: () => 10, set: () => undefined },
+      scrollHeight: { configurable: true, get: () => 400 },
+      clientHeight: { configurable: true, get: () => 200 },
+    });
+    const setProperty = vi.spyOn(el.style, "setProperty");
+    act(() => result.current.setScrollContainer(el));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const writesAfterMount = setProperty.mock.calls.length;
+    expect(writesAfterMount).toBeGreaterThan(0);
+
+    el.dispatchEvent(new Event("scroll"));
+    el.dispatchEvent(new Event("scroll"));
+    el.dispatchEvent(new Event("scroll"));
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+    expect(setProperty.mock.calls.length).toBe(writesAfterMount);
   });
 });

--- a/src/renderer/hooks/useScrollFade.ts
+++ b/src/renderer/hooks/useScrollFade.ts
@@ -62,10 +62,23 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
     const el = scrollEl;
     if (!el) return;
 
+    let lastTopFade = Number.NaN;
+    let lastBottomFade = Number.NaN;
     const update = () => {
       const { scrollTop, scrollHeight, clientHeight } = el;
-      const topFade = Math.min(maxFadePx, scrollTop);
-      const bottomFade = Math.min(maxFadePx, Math.max(0, scrollHeight - scrollTop - clientHeight));
+      // Quantize to whole pixels so sub-pixel virtualizer churn does not keep
+      // rewriting identical-looking fade masks during thread-open measure.
+      const topFade = Math.min(maxFadePx, Math.round(scrollTop));
+      const bottomFade = Math.min(
+        maxFadePx,
+        Math.max(0, Math.round(scrollHeight - scrollTop - clientHeight)),
+      );
+      // Skip style writes when the mask sizes are unchanged. Thread switches
+      // fire many programmatic scrolls + ResizeObserver callbacks; rewriting
+      // identical CSS vars still costs style invalidation in the profile.
+      if (topFade === lastTopFade && bottomFade === lastBottomFade) return;
+      lastTopFade = topFade;
+      lastBottomFade = bottomFade;
       el.style.setProperty("--top-fade-size", `${topFade}px`);
       el.style.setProperty("--bottom-fade-size", `${bottomFade}px`);
     };
@@ -78,7 +91,10 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
     };
 
     update();
-    el.addEventListener("scroll", update, { passive: true });
+    // Coalesce scroll-driven updates with resize onto the same rAF. During
+    // stick-to-bottom thread opens, scrollTop is written many times per frame;
+    // a sync listener re-reads layout on each write.
+    el.addEventListener("scroll", scheduleUpdate, { passive: true });
 
     const observer = new ResizeObserver(scheduleUpdate);
     observer.observe(el);
@@ -86,7 +102,7 @@ export function useScrollFade<T extends HTMLElement = HTMLDivElement>(
     if (contentEl) observer.observe(contentEl);
 
     return () => {
-      el.removeEventListener("scroll", update);
+      el.removeEventListener("scroll", scheduleUpdate);
       observer.disconnect();
       if (resizeFrameRef.current !== null) {
         cancelAnimationFrame(resizeFrameRef.current);

--- a/src/renderer/state/remote/sync.ts
+++ b/src/renderer/state/remote/sync.ts
@@ -200,9 +200,11 @@ function flushPendingRuntimeEvents(): void {
   runtimeFlushHandle = null;
   if (pendingRuntimeEvents.size === 0) return;
   const store = useAppStore.getState();
-  for (const [threadId, events] of pendingRuntimeEvents) {
-    store.applyRuntimeEvents(threadId, events);
-  }
+  const batches = [...pendingRuntimeEvents.entries()].map(([threadId, events]) => ({
+    threadId,
+    events,
+  }));
+  store.applyRuntimeEventBatches(batches);
   pendingRuntimeEvents.clear();
 }
 

--- a/src/renderer/state/slices/runtimeEventReducer.ts
+++ b/src/renderer/state/slices/runtimeEventReducer.ts
@@ -25,6 +25,20 @@ export function applyRuntimeEventsToState(
   threadId: string,
   events: RuntimeEvent[],
 ): Partial<RuntimeEventState> {
+  return applyRuntimeEventBatchesToState(state, [{ threadId, events }]);
+}
+
+/**
+ * Apply runtime events for one or more threads in a single reducer pass so the
+ * rAF flush can commit concurrent streams with one Zustand `set()` instead of
+ * one per thread (each `set` re-runs every subscribed selector).
+ */
+export function applyRuntimeEventBatchesToState(
+  state: AppStoreState,
+  batches: ReadonlyArray<{ threadId: string; events: RuntimeEvent[] }>,
+): Partial<RuntimeEventState> {
+  if (batches.length === 0) return {};
+
   let nextState: RuntimeEventState = {
     runtimeItemIdsByThread: state.runtimeItemIdsByThread,
     runtimeItemsByIdByThread: state.runtimeItemsByIdByThread,
@@ -36,31 +50,44 @@ export function applyRuntimeEventsToState(
     threads: state.threads ?? [],
   };
   let changed = false;
-  let bumpStructural = false;
+  const structuralBumpThreadIds = new Set<string>();
+  const dirtyThreadIds = new Set<string>();
 
-  for (const event of coalesceRuntimeEvents(events)) {
-    const patch = applyRuntimeEventToRuntimeState(nextState, threadId, event);
-    if (Object.keys(patch).length === 0) continue;
-    nextState = { ...nextState, ...patch };
-    const reopenPatch = reopenGuiTurnForLiveRuntimeActivity(nextState, threadId, event);
-    if (Object.keys(reopenPatch).length > 0) {
-      nextState = { ...nextState, ...reopenPatch };
+  for (const batch of batches) {
+    if (batch.events.length === 0) continue;
+    const { threadId, events } = batch;
+    let batchChanged = false;
+    for (const event of coalesceRuntimeEvents(events)) {
+      const patch = applyRuntimeEventToRuntimeState(nextState, threadId, event);
+      if (Object.keys(patch).length === 0) continue;
+      nextState = { ...nextState, ...patch };
+      const reopenPatch = reopenGuiTurnForLiveRuntimeActivity(nextState, threadId, event);
+      if (Object.keys(reopenPatch).length > 0) {
+        nextState = { ...nextState, ...reopenPatch };
+      }
+      batchChanged = true;
+      if (eventAffectsStructuralVersion(event)) structuralBumpThreadIds.add(threadId);
     }
-    changed = true;
-    if (eventAffectsStructuralVersion(event)) bumpStructural = true;
+    if (batchChanged) {
+      changed = true;
+      dirtyThreadIds.add(threadId);
+    }
   }
 
   if (!changed) return {};
-  if (bumpStructural) {
-    nextState = {
-      ...nextState,
-      runtimeStructuralVersionByThread: {
-        ...nextState.runtimeStructuralVersionByThread,
-        [threadId]: (nextState.runtimeStructuralVersionByThread[threadId] ?? 0) + 1,
-      },
-    };
+  for (const threadId of dirtyThreadIds) {
+    markThreadRuntimeForPersistence(threadId);
   }
-  markThreadRuntimeForPersistence(threadId);
+  if (structuralBumpThreadIds.size > 0) {
+    let runtimeStructuralVersionByThread = nextState.runtimeStructuralVersionByThread;
+    for (const threadId of structuralBumpThreadIds) {
+      runtimeStructuralVersionByThread = {
+        ...runtimeStructuralVersionByThread,
+        [threadId]: (runtimeStructuralVersionByThread[threadId] ?? 0) + 1,
+      };
+    }
+    nextState = { ...nextState, runtimeStructuralVersionByThread };
+  }
   return {
     ...nextState,
   };
@@ -78,39 +105,41 @@ function reopenGuiTurnForLiveRuntimeActivity(
   // yet -> open !== false) still reopens, preserving the safety net.
   if (state.runtimeOpenTurnByThread[threadId] === false) return {};
   if (!isLiveAssistantActivity(state, threadId, event)) return {};
-  let changed = false;
-  let nextCompletedTurns = state.runtimeCompletedTurnsByThread;
-  const nowIso = new Date().toISOString();
-  const threads = state.threads.map((thread) => {
-    if (
-      thread.id !== threadId ||
-      thread.presentationMode !== "gui" ||
-      (thread.status !== "idle" && thread.status !== "finished")
-    ) {
-      return thread;
-    }
 
-    changed = true;
-    const activeTurnStartedAt = thread.lastTurnStartedAt ?? thread.updatedAt ?? nowIso;
-    const startedAt = parseTurnMs(thread.lastTurnStartedAt);
-    const endedAt = parseTurnMs(thread.lastTurnEndedAt);
-    if (startedAt !== null && endedAt !== null) {
-      nextCompletedTurns = removeCompletedTurnWindow(
-        nextCompletedTurns,
-        threadId,
-        startedAt,
-        endedAt,
-      );
-    }
-    return {
-      ...thread,
-      status: "working" as const,
-      attention: "working" as const,
-      activeTurnStartedAt,
-      lastTurnEndedAt: undefined,
-    };
-  });
-  if (!changed) return {};
+  // Fast path: already working (or not a reopen candidate). Streaming deltas
+  // hit this on every frame — avoid mapping the full threads array.
+  const threadIndex = state.threads.findIndex((thread) => thread.id === threadId);
+  if (threadIndex < 0) return {};
+  const thread = state.threads[threadIndex]!;
+  if (
+    thread.presentationMode !== "gui" ||
+    (thread.status !== "idle" && thread.status !== "finished")
+  ) {
+    return {};
+  }
+
+  const nowIso = new Date().toISOString();
+  const activeTurnStartedAt = thread.lastTurnStartedAt ?? thread.updatedAt ?? nowIso;
+  const startedAt = parseTurnMs(thread.lastTurnStartedAt);
+  const endedAt = parseTurnMs(thread.lastTurnEndedAt);
+  let nextCompletedTurns = state.runtimeCompletedTurnsByThread;
+  if (startedAt !== null && endedAt !== null) {
+    nextCompletedTurns = removeCompletedTurnWindow(
+      nextCompletedTurns,
+      threadId,
+      startedAt,
+      endedAt,
+    );
+  }
+
+  const threads = state.threads.slice();
+  threads[threadIndex] = {
+    ...thread,
+    status: "working" as const,
+    attention: "working" as const,
+    activeTurnStartedAt,
+    lastTurnEndedAt: undefined,
+  };
   return {
     threads,
     ...(nextCompletedTurns !== state.runtimeCompletedTurnsByThread

--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -630,4 +630,60 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     store.getState().hydrateThreadRuntimeItems("t1", [seeded]);
     expect(store.getState().runtimeItemsByIdByThread["t1"]?.["i1"]?.observedLive).toBeUndefined();
   });
+
+  it("applies concurrent thread batches in a single store update", () => {
+    apply("t1", {
+      type: "item.started",
+      threadId: "t1",
+      itemId: "a1",
+      itemType: "assistant_message",
+    });
+    apply("t2", {
+      type: "item.started",
+      threadId: "t2",
+      itemId: "b1",
+      itemType: "assistant_message",
+    });
+
+    let setCount = 0;
+    const unsub = store.subscribe(() => {
+      setCount += 1;
+    });
+
+    store.getState().applyRuntimeEventBatches([
+      {
+        threadId: "t1",
+        events: [
+          {
+            type: "content.delta",
+            threadId: "t1",
+            itemId: "a1",
+            stream: "assistant_text",
+            delta: "hello",
+          },
+        ],
+      },
+      {
+        threadId: "t2",
+        events: [
+          {
+            type: "content.delta",
+            threadId: "t2",
+            itemId: "b1",
+            stream: "assistant_text",
+            delta: "world",
+          },
+        ],
+      },
+    ]);
+    unsub();
+
+    expect(setCount).toBe(1);
+    expect(store.getState().runtimeItemsByIdByThread["t1"]?.["a1"]?.streams.assistant_text).toBe(
+      "hello",
+    );
+    expect(store.getState().runtimeItemsByIdByThread["t2"]?.["b1"]?.streams.assistant_text).toBe(
+      "world",
+    );
+  });
 });

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -12,7 +12,11 @@ import type {
 } from "@/shared/contracts";
 import { i18n } from "@/renderer/i18n/i18n";
 import type { SliceCreator } from "./shared";
-import { applyRuntimeEventsToState, mergeCompletedTurns } from "./runtimeEventReducer";
+import {
+  applyRuntimeEventsToState,
+  applyRuntimeEventBatchesToState,
+  mergeCompletedTurns,
+} from "./runtimeEventReducer";
 
 const STALE_SUB_AGENT_ERROR_MESSAGE = msg`Interrupted: agent session ended before completion.`;
 
@@ -121,6 +125,13 @@ export interface RuntimeEventSlice {
   fileCheckpointTurnsByThread: Record<string, Record<string, FileCheckpointTurn>>;
   applyRuntimeEvent(threadId: string, event: RuntimeEvent): void;
   applyRuntimeEvents(threadId: string, events: RuntimeEvent[]): void;
+  /**
+   * Apply runtime events for multiple threads in one Zustand `set()`. Used by
+   * the rAF flush when several chats stream concurrently.
+   */
+  applyRuntimeEventBatches(
+    batches: ReadonlyArray<{ threadId: string; events: RuntimeEvent[] }>,
+  ): void;
   clearThreadRuntimeEvents(threadId: string): void;
   /**
    * Force-terminate any still-running sub-agent tool_call items in a thread.
@@ -206,6 +217,9 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
 
   applyRuntimeEvents: (threadId, events) =>
     set((state) => applyRuntimeEventsToState(state, threadId, events)),
+
+  applyRuntimeEventBatches: (batches) =>
+    set((state) => applyRuntimeEventBatchesToState(state, batches)),
 
   clearThreadRuntimeEvents: (threadId) =>
     set((state) => {


### PR DESCRIPTION
Tickets: none

- Stabilize chat auto-scroll so dragging the scrollbar or scrolling away from bottom no longer re-sticks unexpectedly.
- Reduce layout churn in the chat pane by caching collapsed headers, user message overflow state, and scroll fade updates.
- Batch concurrent runtime event flushes into a single store update to cut selector churn when multiple threads stream at once.
- Add coverage for the new scroll, overflow, collapsed-header, and runtime batching behavior.