### PR TITLE
Bugfix: Sync Claude model changes before steer turns

### DIFF
--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -704,6 +704,39 @@ describe("ClaudeSdkSession", () => {
     await session.dispose();
   });
 
+  it("steerTurn applies a changed model so a next-turn steer uses the new one", async () => {
+    const fake = createFakeQuery();
+    mockSdk.query.mockReturnValue(fake.runtime);
+    const session = await ClaudeSdkSession.create({
+      threadId: "thread-claude-steer-model",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+    session.setListener({
+      onRuntimeEvent: () => {},
+      onUpdate: () => {},
+      onError: () => {},
+      onClose: () => {},
+    });
+
+    await session.openThread(config);
+    await session.startTurn("first", config);
+    await flushAsyncWork();
+    fake.setModel.mockClear();
+
+    // setModel never affects the in-flight turn, but the steer message may
+    // start the NEXT turn, so the model change must be applied before pushing.
+    await session.steerTurn!("steer this", { model: "opus" });
+    expect(fake.setModel).toHaveBeenCalledWith("opus");
+
+    // Unchanged model on a later steer must not re-send the control request.
+    await session.steerTurn!("again", { model: "opus" });
+    expect(fake.setModel).toHaveBeenCalledTimes(1);
+
+    await session.dispose();
+  });
+
   it("steerTurn falls back to startTurn semantics when no turn is in flight", async () => {
     const fake = createFakeQuery();
     mockSdk.query.mockReturnValue(fake.runtime);

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -237,15 +237,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.startGoalTracking();
 
     const query = await this.requireQuery();
-    const model = applyClaudeContextSuffix(config.model, config.contextSize);
-    if (model !== this.appliedModel) {
-      try {
-        await query.setModel(model);
-        this.appliedModel = model;
-      } catch {
-        // Older SDK transports can reject live model updates; the launch model still applies.
-      }
-    }
+    await this.syncModel(query, config);
     const permissionMode = permissionModeForConfig(config);
     if (permissionMode !== this.appliedPermissionMode || config.mode === "plan") {
       try {
@@ -296,9 +288,29 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       },
       { type: "item.completed", threadId: this.input.threadId, itemId: userItemId },
     ]);
-    await this.requireQuery();
+    const query = await this.requireQuery();
+    // The SDK never hot-swaps a running turn, but if the steer message ends up
+    // starting the NEXT turn (current turn settles before consuming it), the
+    // model change must already be applied — no startTurn runs for that message.
+    await this.syncModel(query, config);
     const message = await buildSdkUserMessage(prompt, segments);
     this.promptQueue.push(message);
+  }
+
+  /**
+   * Apply the configured model via a live control request when it differs from
+   * the last applied one. setModel takes effect at the next turn boundary; it
+   * never affects an in-flight turn.
+   */
+  private async syncModel(runtime: Query, config: ThreadConfig): Promise<void> {
+    const model = applyClaudeContextSuffix(config.model, config.contextSize);
+    if (model === this.appliedModel) return;
+    try {
+      await runtime.setModel(model);
+      this.appliedModel = model;
+    } catch {
+      // Older SDK transports can reject live model updates; the launch model still applies.
+    }
   }
 
   /**


### PR DESCRIPTION
- Tickets: none
- Ensure Claude steer messages apply any model change before the next turn starts, so the queued turn uses the intended model.
- Preserve the existing behavior for in-flight turns and avoid re-sending unchanged model updates.
- Add coverage for the steer path to lock in the next-turn model sync behavior.