### PR TITLE
Fix Grok 0.2 session and effort handling

### DIFF
--- a/src/renderer/components/providers/grok/index.tsx
+++ b/src/renderer/components/providers/grok/index.tsx
@@ -16,8 +16,10 @@ registerProviderLabel("grok", "Grok Build");
 
 // Grok has two models, both covered by the subscription (no per-token cost), so
 // pick by fit: `grok-composer-2.5-fast` is Grok's own default — fast, ideal for
-// the lightweight title/commit one-shots; the heavier agentic `grok-build` stays
-// for the conflict resolver, which is a real code-editing session.
+// the lightweight title/commit one-shots; the frontier `grok-4.5` takes the
+// conflict resolver, which is a real code-editing session. (The old `grok-build`
+// model id was retired upstream — the 0.2.x catalog is grok-4.5 +
+// grok-composer-2.5-fast.)
 registerCommitGenDefaults("grok", {
   label: "Grok",
   hint: "Composer 2.5 Fast",
@@ -34,15 +36,16 @@ registerTitleGenDefaults("grok", {
 
 registerConflictResolverDefaults("grok", {
   label: "Grok",
-  hint: "Build",
-  model: "grok-build",
+  hint: "Grok 4.5",
+  model: "grok-4.5",
   effort: "",
 });
 
 // Composer surface for Grok: a single Default ↔ Bypass Approvals toggle.
-// Plan mode and effort are intentionally absent — neither is driveable from
-// launch flags on Grok 0.1.218. See `supervisor/agents/grok/detection.ts`
-// and `supervisor/agents/grok/argv.ts` for the rationale.
+// Plan mode is intentionally absent — it is not driveable from launch flags
+// (re-verified on grok 0.2.93). Effort needs no control here: the shared
+// model picker reads `capabilities.modelEfforts` filled by the ACP probe.
+// See `supervisor/agents/grok/detection.ts` and `supervisor/agents/grok/argv.ts`.
 registerComposerControls("grok", ({ capabilities, config, isDisabled, onConfigChange }) => {
   if (!capabilities.approvalPolicies?.length) return [];
   const bypassPolicy = capabilities.bypassPermissions?.approvalPolicy ?? "bypassPermissions";

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -409,16 +409,38 @@ describe("agent command builders", () => {
 
   it("builds a Grok one-shot command via the headless `grok -p` path", () => {
     expect(
-      createGrokAdapter().buildOneShotCommand?.("grok-build", undefined, "Summarize this diff"),
+      createGrokAdapter().buildOneShotCommand?.(
+        "grok-composer-2.5-fast",
+        undefined,
+        "Summarize this diff",
+      ),
     ).toEqual({
       command: "grok",
-      args: ["-p", "Summarize this diff", "-m", "grok-build", "--always-approve"],
+      args: ["-p", "Summarize this diff", "-m", "grok-composer-2.5-fast", "--always-approve"],
+      stdin: "",
+    });
+  });
+
+  it("forwards effort to Grok one-shots as --reasoning-effort", () => {
+    expect(
+      createGrokAdapter().buildOneShotCommand?.("grok-4.5", "low", "Summarize this diff"),
+    ).toEqual({
+      command: "grok",
+      args: [
+        "-p",
+        "Summarize this diff",
+        "-m",
+        "grok-4.5",
+        "--reasoning-effort",
+        "low",
+        "--always-approve",
+      ],
       stdin: "",
     });
   });
 
   it("returns undefined for a Grok one-shot when no prompt is supplied", () => {
-    expect(createGrokAdapter().buildOneShotCommand?.("grok-build", undefined, undefined)).toBe(
+    expect(createGrokAdapter().buildOneShotCommand?.("grok-4.5", undefined, undefined)).toBe(
       undefined,
     );
   });

--- a/src/supervisor/agents/grok/argv.test.ts
+++ b/src/supervisor/agents/grok/argv.test.ts
@@ -6,11 +6,19 @@ describe("buildGrokArgs (TUI/PTY)", () => {
     expect(buildGrokArgs({ mode: "agent" } as any, "", undefined)).toEqual([]);
   });
 
-  it("passes -r <id> when the session id is known", () => {
-    expect(buildGrokArgs({ mode: "agent" } as any, "", "abc-123")).toEqual(["-r", "abc-123"]);
+  it("passes -r <id> when resuming a materialized session", () => {
+    expect(
+      buildGrokArgs({ mode: "agent" } as any, "", { kind: "resume", sessionId: "abc-123" }),
+    ).toEqual(["-r", "abc-123"]);
   });
 
-  it("never emits -c, --no-plan, --permission-mode, or --effort", () => {
+  it("passes -s <id> when pre-assigning a new session id", () => {
+    expect(
+      buildGrokArgs({ mode: "agent" } as any, "", { kind: "new", sessionId: "abc-123" }),
+    ).toEqual(["-s", "abc-123"]);
+  });
+
+  it("never emits -c, --no-plan, or --permission-mode", () => {
     const cases: Array<Partial<{ mode: string; approvalPolicy: string; effort: string }>> = [
       { mode: "agent" },
       { mode: "plan" },
@@ -22,9 +30,20 @@ describe("buildGrokArgs (TUI/PTY)", () => {
       expect(args).not.toContain("-c");
       expect(args).not.toContain("--no-plan");
       expect(args).not.toContain("--permission-mode");
-      expect(args).not.toContain("--effort");
-      expect(args).not.toContain("--reasoning-effort");
     }
+  });
+
+  it("forwards config.effort as --reasoning-effort", () => {
+    expect(buildGrokArgs({ mode: "agent", effort: "low" } as any, "", undefined)).toEqual([
+      "--reasoning-effort",
+      "low",
+    ]);
+  });
+
+  it("omits --reasoning-effort when effort is unset", () => {
+    expect(buildGrokArgs({ mode: "agent" } as any, "", undefined)).not.toContain(
+      "--reasoning-effort",
+    );
   });
 
   it("adds --always-approve when approval policy bypasses permissions", () => {
@@ -48,9 +67,32 @@ describe("buildGrokArgs (TUI/PTY)", () => {
   });
 
   it("passes -m <model> when set", () => {
-    expect(buildGrokArgs({ mode: "agent", model: "grok-build" } as any, "", undefined)).toEqual([
+    expect(buildGrokArgs({ mode: "agent", model: "grok-4.5" } as any, "", undefined)).toEqual([
       "-m",
-      "grok-build",
+      "grok-4.5",
+    ]);
+  });
+
+  it("combines session, model, effort, and bypass flags", () => {
+    expect(
+      buildGrokArgs(
+        {
+          mode: "agent",
+          model: "grok-4.5",
+          effort: "high",
+          approvalPolicy: "bypassPermissions",
+        } as any,
+        "",
+        { kind: "new", sessionId: "abc-123" },
+      ),
+    ).toEqual([
+      "-s",
+      "abc-123",
+      "-m",
+      "grok-4.5",
+      "--reasoning-effort",
+      "high",
+      "--always-approve",
     ]);
   });
 });
@@ -60,7 +102,7 @@ describe("buildGrokAcpArgs (`grok agent stdio` prefix)", () => {
     expect(buildGrokAcpArgs({} as any)).toEqual([]);
   });
 
-  it("never emits --permission-mode, --no-plan, --effort, or --reasoning-effort", () => {
+  it("never emits --permission-mode or --no-plan", () => {
     const args = buildGrokAcpArgs({
       mode: "plan",
       approvalPolicy: "bypassPermissions",
@@ -68,8 +110,10 @@ describe("buildGrokAcpArgs (`grok agent stdio` prefix)", () => {
     } as any);
     expect(args).not.toContain("--permission-mode");
     expect(args).not.toContain("--no-plan");
-    expect(args).not.toContain("--effort");
-    expect(args).not.toContain("--reasoning-effort");
+  });
+
+  it("forwards config.effort as --reasoning-effort", () => {
+    expect(buildGrokAcpArgs({ effort: "medium" } as any)).toEqual(["--reasoning-effort", "medium"]);
   });
 
   it("adds --always-approve when approval policy bypasses permissions", () => {
@@ -79,6 +123,6 @@ describe("buildGrokAcpArgs (`grok agent stdio` prefix)", () => {
   });
 
   it("passes -m <model> when set", () => {
-    expect(buildGrokAcpArgs({ model: "grok-build" } as any)).toEqual(["-m", "grok-build"]);
+    expect(buildGrokAcpArgs({ model: "grok-4.5" } as any)).toEqual(["-m", "grok-4.5"]);
   });
 });

--- a/src/supervisor/agents/grok/argv.ts
+++ b/src/supervisor/agents/grok/argv.ts
@@ -2,28 +2,55 @@ import type { ThreadConfig } from "@/shared/contracts";
 
 /**
  * Flag references — verified against `grok --help`, `grok agent --help`, and
- * the Grok docs on grok 0.1.218:
+ * live PTY/ACP probes on grok 0.2.93 (2026-07-09):
  *   https://docs.x.ai/build/cli/headless-scripting
  *   https://docs.x.ai/build/modes-and-commands
  *
  * Constraints we encode here:
- *   • `--permission-mode <MODE>` is documented as headless-only — the TUI
- *     silently ignores it and `grok agent stdio` accepts it without effect
- *     (verified live: a session created with `--permission-mode plan`
- *     reports "normal mode" when asked). We don't pass it. The only
- *     approval control Grok honors at launch is `--always-approve`
+ *   • `-s, --session-id <UUID>` names a **new** session (it must not exist
+ *     yet — reusing an existing id fails with "Session ID … is already in
+ *     use", exit 1). Verified live: the TUI boots straight into the composer
+ *     and normally writes ~/.grok/sessions/<cwd>/<uuid>/ within ~1s of boot;
+ *     creation is deferred only in edge cases (welcome/resume menu, launch
+ *     killed at startup). This replaced the pre-0.2.x ACP mint handshake as
+ *     the way to know a session ID before spawning the PTY.
+ *   • `-r, --resume <SESSION_ID>` resumes an existing session. Bare `-r` is
+ *     still skipped — grok exits 1 when no prior session exists for the cwd
+ *     — and `-c/--continue` is still never used (by user request we
+ *     standardise on explicit ids).
+ *   • `--reasoning-effort <EFFORT>` is honored at TUI launch since 0.2.x
+ *     (verified live: the composer footer shows "Grok 4.5 (low)" and the
+ *     session's summary.json records `reasoning_effort`). Models that don't
+ *     advertise `supportsReasoningEffort` (grok-composer-2.5-fast) simply
+ *     ignore it, so we forward `config.effort` whenever it is set.
+ *   • `--permission-mode <MODE>` is STILL silently ignored at launch on both
+ *     surfaces (verified live on 0.2.93: booting the TUI with
+ *     `--permission-mode plan` shows no "· plan" footer chip while Shift+Tab
+ *     does, and an ACP session created with it reports kind "build"). The
+ *     only approval control Grok honors at launch remains `--always-approve`
  *     (alias `--yolo`).
  *   • `--no-plan` is a hard restriction — passing it disables plan tooling
- *     entirely. Poracode never sets it; plan mode is entered when the
- *     model calls `enter_plan_mode` and the user approves
- *     (`~/.grok/docs/user-guide/19-plan-mode.md`).
- *   • `--effort` / `--reasoning-effort` are not surfaced in the Grok
- *     composer (the CLI flag is headless-only and ACP doesn't advertise
- *     effort either), so we don't emit them.
- *   • Grok ACP (`session/new`) does not advertise `modes` / `configOptions`
- *     for permission modes, so even on ACP we drive bypass via the CLI
- *     flag rather than `setSessionMode`.
+ *     entirely. Poracode never sets it; plan mode is entered in the TUI
+ *     (Shift+Tab or the model calling `enter_plan_mode`).
+ *   • Grok ACP (`session/new`) still does not advertise `modes` / standard
+ *     `configOptions`. Model + effort state ride vendor `_meta` extensions
+ *     (`modelState`, `x.ai/sessionConfig`), live model switching works via
+ *     the unstable `session/set_model` (the shared ACP session's fallback),
+ *     and `session/set_config_option` returns method-not-found — so effort
+ *     changes only apply at (re)spawn via `--reasoning-effort`.
  */
+
+/**
+ * Which session flag to emit for a PTY launch:
+ *   • `resume` → `-r <id>` — the session has materialized on disk.
+ *   • `new`    → `-s <id>` — pre-assign the UUID for a fresh session (also
+ *     used to re-assign a known id whose session never materialized — e.g.
+ *     the previous launch died at startup — since `-s` requires a
+ *     non-existent session).
+ */
+export type GrokSessionArg =
+  | { kind: "resume"; sessionId: string }
+  | { kind: "new"; sessionId: string };
 
 function isBypassApproval(config: ThreadConfig): boolean {
   switch (config.approvalPolicy) {
@@ -39,51 +66,44 @@ function isBypassApproval(config: ThreadConfig): boolean {
   }
 }
 
+function pushSharedFlags(args: string[], config: ThreadConfig): void {
+  if (config.model) {
+    args.push("-m", config.model);
+  }
+  if (config.effort) {
+    args.push("--reasoning-effort", config.effort);
+  }
+  if (isBypassApproval(config)) {
+    args.push("--always-approve");
+  }
+}
+
 /**
  * Argv for `grok` (TUI / PTY).
- *
- * Resume semantics (per `grok --help`):
- *   `-r, --resume [<SESSION_ID>]`  Resume by ID, or the most recent if omitted.
- *
- * We pass `-r <id>` when we already know the session ID (typically minted via
- * ACP just before launch). We never use `-c, --continue` — by user request,
- * we standardise on `-r`. Bare `-r` is also skipped because Grok exits 1 when
- * no prior session exists for the cwd.
  */
 export function buildGrokArgs(
   config: ThreadConfig,
   _prompt: string,
-  resumeSessionId?: string,
+  session?: GrokSessionArg,
 ): string[] {
   const args: string[] = [];
 
-  if (resumeSessionId) {
-    args.push("-r", resumeSessionId);
+  if (session?.kind === "resume") {
+    args.push("-r", session.sessionId);
+  } else if (session?.kind === "new") {
+    args.push("-s", session.sessionId);
   }
 
-  if (config.model) {
-    args.push("-m", config.model);
-  }
-
-  if (isBypassApproval(config)) {
-    args.push("--always-approve");
-  }
+  pushSharedFlags(args, config);
 
   return args;
 }
 
 /**
- * Argv prefix for `grok [FLAGS] agent stdio` (ACP / GUI tab and mint helper).
+ * Argv prefix for `grok [FLAGS] agent stdio` (ACP / GUI tab).
  */
 export function buildGrokAcpArgs(config: ThreadConfig): string[] {
   const args: string[] = [];
-
-  if (config.model) {
-    args.push("-m", config.model);
-  }
-  if (isBypassApproval(config)) {
-    args.push("--always-approve");
-  }
-
+  pushSharedFlags(args, config);
   return args;
 }

--- a/src/supervisor/agents/grok/detection.test.ts
+++ b/src/supervisor/agents/grok/detection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildGrokProviderMetadata, mapGrokEffortCapabilities } from "./detection";
+
+// Model `_meta` shapes as returned live by `grok agent stdio` 0.2.93
+// (initialize/_meta.modelState and session/new `models.availableModels[]._meta`).
+const GROK_45_META = {
+  totalContextTokens: 500_000,
+  agentType: "grok-build-plan",
+  supportsReasoningEffort: true,
+  reasoningEffort: "high",
+  reasoningEfforts: [
+    { id: "high", value: "high", label: "High Effort", default: true },
+    { id: "medium", value: "medium", label: "Medium Effort", default: false },
+    { id: "low", value: "low", label: "Low Effort", default: false },
+  ],
+};
+
+const COMPOSER_META = {
+  totalContextTokens: 200_000,
+  agentType: "cursor",
+};
+
+describe("mapGrokEffortCapabilities", () => {
+  it("derives ascending effort tiers and the advertised default", () => {
+    const caps = mapGrokEffortCapabilities({
+      "grok-4.5": GROK_45_META,
+      "grok-composer-2.5-fast": COMPOSER_META,
+    });
+    expect(caps.efforts).toEqual(["low", "medium", "high"]);
+    expect(caps.defaultEffort).toBe("high");
+  });
+
+  it("gives models without tiers an explicit empty list so the picker hides effort", () => {
+    const caps = mapGrokEffortCapabilities({
+      "grok-4.5": GROK_45_META,
+      "grok-composer-2.5-fast": COMPOSER_META,
+    });
+    expect(caps.modelEfforts).toEqual({
+      "grok-4.5": ["low", "medium", "high"],
+      "grok-composer-2.5-fast": [],
+    });
+  });
+
+  it("keeps unknown tier ids after the known ones in their original order", () => {
+    const caps = mapGrokEffortCapabilities({
+      m: {
+        reasoningEfforts: [
+          { id: "turbo", default: false },
+          { id: "low", default: true },
+          { id: "hyper", default: false },
+        ],
+      },
+    });
+    expect(caps.modelEfforts["m"]).toEqual(["low", "turbo", "hyper"]);
+    expect(caps.defaultEffort).toBe("low");
+  });
+
+  it("returns empty capabilities when metadata is missing or malformed", () => {
+    expect(mapGrokEffortCapabilities(undefined)).toEqual({ efforts: [], modelEfforts: {} });
+    expect(mapGrokEffortCapabilities({ m: { reasoningEfforts: "nope" as unknown } })).toEqual({
+      efforts: [],
+      modelEfforts: { m: [] },
+    });
+  });
+});
+
+describe("buildGrokProviderMetadata", () => {
+  it("maps the 0.2.x authenticate _meta fields, including team_name → organization", () => {
+    expect(
+      buildGrokProviderMetadata({
+        email: "dev@example.com",
+        auth_mode: "Oidc",
+        subscription_tier: "X Premium+",
+        team_name: "Acme",
+        team_id: "t-1",
+        is_zdr: false,
+      }),
+    ).toEqual({
+      authenticatedAs: "dev@example.com",
+      organization: "Acme",
+      plan: "X Premium+",
+      authMethod: "OIDC",
+    });
+  });
+
+  it("omits organization when team_name is null (personal accounts)", () => {
+    expect(buildGrokProviderMetadata({ email: "dev@example.com", team_name: null })).toEqual({
+      authenticatedAs: "dev@example.com",
+    });
+  });
+});

--- a/src/supervisor/agents/grok/detection.ts
+++ b/src/supervisor/agents/grok/detection.ts
@@ -19,22 +19,25 @@ import { buildContextSizeCapabilities } from "../contextWindowLabel";
 import { getAgentProbeCwd, resolveProbeSpawnCwd } from "../probeCwd";
 
 // Approval policies surfaced to Poracode. Grok only honors `--always-approve`
-// (bypass) at launch — `--permission-mode <MODE>` is headless-only and is
-// silently ignored by both the TUI and `grok agent stdio`. We therefore
-// expose a single Default ↔ Bypass Approvals toggle in the composer.
+// (bypass) at launch — `--permission-mode <MODE>` is silently ignored by both
+// the TUI and `grok agent stdio` (re-verified live on 0.2.93; see argv.ts).
+// We therefore expose a single Default ↔ Bypass Approvals toggle in the
+// composer.
 const GROK_APPROVAL_POLICIES = [
   { id: "default", label: "Default" },
   { id: "bypassPermissions", label: "Bypass Approvals" },
 ] as const;
 
-// Plan mode and effort are intentionally omitted from the composer surface:
-//   • Plan mode cannot be force-activated at launch on either Grok surface —
-//     `--permission-mode plan` is silently ignored. The model has to call
-//     `enter_plan_mode` itself (`~/.grok/docs/user-guide/19-plan-mode.md`),
-//     so a Plan/Work toggle would falsely imply we drive it.
-//   • Effort selection (`--effort` / `--reasoning-effort`) is headless-only
-//     for the CLI and not advertised by ACP either, so surfacing it would
-//     be misleading.
+// Plan mode is intentionally omitted from the composer surface: it cannot be
+// force-activated at launch on either Grok surface — `--permission-mode plan`
+// is silently ignored (verified live on 0.2.93). Plan mode is entered in the
+// TUI via Shift+Tab or by the model calling `enter_plan_mode`, so a Plan/Work
+// toggle would falsely imply we drive it.
+//
+// Effort IS surfaced since grok 0.2.x: `--reasoning-effort` is honored at
+// launch and the ACP handshake advertises per-model tiers in the models'
+// `_meta.reasoningEfforts` — the capabilities probe fills `efforts` /
+// `modelEfforts` / `defaultEffort` from it (see mapGrokEffortCapabilities).
 export const grokDefaultCapabilities: AgentCapability = {
   models: [],
   efforts: [],
@@ -75,15 +78,21 @@ async function probeCapabilities(
     authenticateMethodIds: ["cached_token"],
   });
 
-  // Extract context window from model _meta (grok reports totalContextTokens)
+  // Extract context windows from model _meta (grok reports totalContextTokens
+  // per model, e.g. 500k for grok-4.5 and 200k for grok-composer-2.5-fast).
   let contextCaps: Pick<AgentCapability, "contextSizes" | "modelContextSizes"> = {};
   if (probe?.modelMetadata) {
-    const meta = probe.modelMetadata["grok-build"] ?? Object.values(probe.modelMetadata)[0];
-    const tokens = (meta as { totalContextTokens?: unknown })?.totalContextTokens;
-    if (typeof tokens === "number" && tokens > 0) {
-      contextCaps = buildContextSizeCapabilities(new Map([["grok-build", tokens]]));
+    const sizes = new Map<string, number>();
+    for (const [modelId, meta] of Object.entries(probe.modelMetadata)) {
+      const tokens = (meta as { totalContextTokens?: unknown }).totalContextTokens;
+      if (typeof tokens === "number" && tokens > 0) sizes.set(modelId, tokens);
+    }
+    if (sizes.size > 0) {
+      contextCaps = buildContextSizeCapabilities(sizes);
     }
   }
+
+  const effortCaps = mapGrokEffortCapabilities(probe?.modelMetadata);
 
   const dedupedAuth = probe?.authMethods?.length
     ? dedupeAcpAuthMethods(probe.authMethods)
@@ -94,6 +103,13 @@ async function probeCapabilities(
   return {
     ...grokDefaultCapabilities,
     ...(probe?.models?.length ? { models: probe.models } : {}),
+    // Grok advertises effort tiers in model `_meta`, not standard ACP
+    // configOptions — derive them ourselves, but let the generic probe win
+    // if Grok ever adds a `thought_level` config option.
+    ...(effortCaps.efforts.length
+      ? { efforts: effortCaps.efforts, modelEfforts: effortCaps.modelEfforts }
+      : {}),
+    ...(effortCaps.defaultEffort ? { defaultEffort: effortCaps.defaultEffort } : {}),
     ...(probe?.efforts?.length ? { efforts: probe.efforts } : {}),
     ...(probe?.defaultEffort ? { defaultEffort: probe.defaultEffort } : {}),
     ...(probe?.modelEfforts ? { modelEfforts: probe.modelEfforts } : {}),
@@ -113,8 +129,60 @@ async function probeCapabilities(
 }
 
 /**
+ * Poracode-canonical effort ordering (ascending). Grok advertises its tiers
+ * descending (high → low); the pickers across providers list ascending.
+ * Unknown tier ids sort after the known ones, keeping their original order.
+ */
+const GROK_EFFORT_RANK: Record<string, number> = {
+  minimal: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  xhigh: 4,
+};
+
+type GrokReasoningEffortMeta = { id?: unknown; default?: unknown };
+
+/**
+ * Derive effort capabilities from the per-model `_meta.reasoningEfforts` the
+ * grok 0.2.x ACP handshake advertises (verified live on 0.2.93: grok-4.5
+ * exposes high/medium/low with high as default; grok-composer-2.5-fast
+ * advertises none). Models without tiers get an explicit empty list so the
+ * shared model picker hides the effort dropdown for them.
+ */
+export function mapGrokEffortCapabilities(
+  modelMetadata: Record<string, Record<string, unknown>> | undefined,
+): { efforts: string[]; modelEfforts: Record<string, string[]>; defaultEffort?: string } {
+  const modelEfforts: Record<string, string[]> = {};
+  let efforts: string[] = [];
+  let defaultEffort: string | undefined;
+
+  for (const [modelId, meta] of Object.entries(modelMetadata ?? {})) {
+    const raw = (meta as { reasoningEfforts?: unknown }).reasoningEfforts;
+    const entries = Array.isArray(raw) ? (raw as GrokReasoningEffortMeta[]) : [];
+    const ids = entries.flatMap((entry) => (typeof entry?.id === "string" ? [entry.id] : []));
+    const sorted = ids
+      .map((id, index) => ({ id, index }))
+      .sort(
+        (a, b) =>
+          (GROK_EFFORT_RANK[a.id] ?? 99 + a.index) - (GROK_EFFORT_RANK[b.id] ?? 99 + b.index),
+      ) // unknown ids sort after known tiers, keeping their original order
+      .map((entry) => entry.id);
+    modelEfforts[modelId] = sorted;
+    if (sorted.length > efforts.length) efforts = sorted;
+    if (!defaultEffort) {
+      const def = entries.find((entry) => entry?.default === true);
+      if (def && typeof def.id === "string") defaultEffort = def.id;
+    }
+  }
+
+  return { efforts, modelEfforts, ...(defaultEffort ? { defaultEffort } : {}) };
+}
+
+/**
  * Grok's ACP `authenticate` response (with the `cached_token` method) returns
- * identity fields in `_meta` — `email`, `auth_mode`, `subscription_tier`. See
+ * identity fields in `_meta` — `email`, `auth_mode`, `subscription_tier`, and
+ * since 0.2.x also team fields (`team_name`). See
  * https://docs.x.ai/build/cli/headless-scripting#acp. Translate them into the
  * shared `AgentProviderMetadata` shape so the settings UI shows the signed-in
  * email / plan instead of a generic "Signed in" line.
@@ -130,6 +198,7 @@ export function buildGrokProviderMetadata(
   const authMode = pick("auth_mode");
   return compactAgentProviderMetadata({
     ...(pick("email") ? { authenticatedAs: pick("email") } : {}),
+    ...(pick("team_name") ? { organization: pick("team_name") } : {}),
     ...(pick("subscription_tier") ? { plan: pick("subscription_tier") } : {}),
     ...(authMode ? { authMethod: formatGrokAuthMode(authMode) } : {}),
   });

--- a/src/supervisor/agents/grok/grok.test.ts
+++ b/src/supervisor/agents/grok/grok.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import type { OscNotification, OscTitle } from "@/shared/osc";
+import { createKnownSessionRef } from "../base";
 import { grokDetectionSpec } from "./detection";
 import { createGrokAdapter } from "./index";
 
@@ -11,7 +16,8 @@ function oscNotify(body: string, code: 9 | 99 | 777 = 9): OscNotification {
   return { code, title: "", body, payload: undefined };
 }
 
-// Observed live from `grok 0.1.218` PTY capture (idle → user prompt → response):
+// Observed live from grok PTY captures (0.1.218, re-verified on 0.2.93 —
+// idle title is still plain "grok"):
 //   OSC 0 "grok"                       (idle, frequent)
 //   OSC 0 "⠴ - Waiting - grok"         (working, braille frames ⠴ / ⠦)
 //   OSC 9 "4;0;0"                      (iTerm2 progress: clear → idle)
@@ -109,6 +115,84 @@ describe("grokDetectionSpec", () => {
         : grokDetectionSpec.loginCommand;
 
     expect(loginCommand).toBe("grok login");
+  });
+});
+
+describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", () => {
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  const SESSION_ID = "11111111-2222-4333-8444-555555555555";
+  const config = { model: "grok-4.5", mode: "agent" } as ThreadConfig;
+  let grokHome: string;
+  let projectDir: string;
+  let location: ProjectLocation;
+  let previousGrokHome: string | undefined;
+
+  beforeEach(() => {
+    grokHome = mkdtempSync(join(tmpdir(), "grok-home-"));
+    projectDir = join(tmpdir(), "grok-proj");
+    previousGrokHome = process.env["GROK_HOME"];
+    process.env["GROK_HOME"] = grokHome;
+    location = { kind: "windows", path: projectDir } as ProjectLocation;
+  });
+
+  afterEach(() => {
+    if (previousGrokHome === undefined) delete process.env["GROK_HOME"];
+    else process.env["GROK_HOME"] = previousGrokHome;
+    rmSync(grokHome, { recursive: true, force: true });
+  });
+
+  it("pre-assigns a fresh UUID with -s and returns it as the session ref", () => {
+    const adapter = createGrokAdapter();
+    const result = adapter.buildLaunchArgv(location, config, "", undefined, {});
+    expect(result.args[0]).toBe("-s");
+    expect(result.args[1]).toMatch(UUID_RE);
+    expect(result.sessionRef?.providerSessionId).toBe(result.args[1]);
+  });
+
+  it("resumes a known id with -r when the session dir has materialized", () => {
+    mkdirSync(join(grokHome, "sessions", encodeURIComponent(projectDir), SESSION_ID), {
+      recursive: true,
+    });
+    const adapter = createGrokAdapter();
+    const result = adapter.buildLaunchArgv(
+      location,
+      config,
+      "",
+      createKnownSessionRef(SESSION_ID),
+      {},
+    );
+    expect(result.args.slice(0, 2)).toEqual(["-r", SESSION_ID]);
+    expect(result.sessionRef?.providerSessionId).toBe(SESSION_ID);
+  });
+
+  it("re-assigns a known id with -s when the session never materialized", () => {
+    const adapter = createGrokAdapter();
+    const result = adapter.buildLaunchArgv(
+      location,
+      config,
+      "",
+      createKnownSessionRef(SESSION_ID),
+      {},
+    );
+    expect(result.args.slice(0, 2)).toEqual(["-s", SESSION_ID]);
+    expect(result.sessionRef?.providerSessionId).toBe(SESSION_ID);
+  });
+
+  it("buildResumeArgv applies the same materialization fallback", () => {
+    const adapter = createGrokAdapter();
+    const fresh = adapter.buildResumeArgv(location, config, "", createKnownSessionRef(SESSION_ID));
+    expect(fresh.args.slice(0, 2)).toEqual(["-s", SESSION_ID]);
+
+    mkdirSync(join(grokHome, "sessions", encodeURIComponent(projectDir), SESSION_ID), {
+      recursive: true,
+    });
+    const materialized = adapter.buildResumeArgv(
+      location,
+      config,
+      "",
+      createKnownSessionRef(SESSION_ID),
+    );
+    expect(materialized.args.slice(0, 2)).toEqual(["-r", SESSION_ID]);
   });
 });
 

--- a/src/supervisor/agents/grok/index.ts
+++ b/src/supervisor/agents/grok/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { PromptSegment } from "@/shared/contracts";
 import { createAcpStructuredSession } from "../acp";
 import {
@@ -23,7 +24,7 @@ import {
 import {
   makeGrokDiscoverSessionRef,
   makeGrokWatchSessionRef,
-  mintGrokSessionIdViaAcpSync,
+  resolveGrokSessionArg,
   snapshotGrokPreSpawnSessions,
 } from "./sessionFiles";
 
@@ -95,35 +96,41 @@ export function createGrokAdapter(): AgentAdapter {
     buildLaunchArgv(location, config, prompt, sessionRef, _launchOptions) {
       const cwd = location.kind === "wsl" ? location.linuxPath : location.path;
       // Snapshot existing session dirs so discoverSessionRef can identify the
-      // new UUID Grok creates if minting fails and the PTY ends up creating
-      // its own session.
+      // new UUID Grok creates if the pre-assigned `-s` id is ever ignored and
+      // the PTY ends up creating its own session.
       snapshotGrokPreSpawnSessions(location, cwd);
 
-      // Resolve a session ID before spawning the PTY: prefer one we already
-      // know (resume), otherwise mint one via a short-lived `grok agent stdio`
-      // handshake so the TUI loads directly into the chat composer. Without
-      // an ID Grok renders its welcome menu in cwds with prior sessions —
-      // that breaks `isReadyForInitialPrompt` and the initial prompt never
-      // gets delivered.
-      let resumeId = sessionRef?.providerSessionId;
-      if (!resumeId) {
-        resumeId = mintGrokSessionIdViaAcpSync(location, 2600, buildGrokAcpArgs(config));
-      }
+      // Resolve the session ID before spawning the PTY: resume a known one
+      // with `-r`, otherwise pre-assign a fresh UUID with `-s` (grok 0.2.93,
+      // works on native and WSL alike). Grok normally materializes the
+      // session dir within ~1s of boot; a known id whose dir never appeared
+      // (launch died at startup) is re-assigned via `-s`
+      // (see resolveGrokSessionArg).
+      const known = sessionRef?.providerSessionId;
+      const sessionId = known ?? randomUUID();
+      const sessionArg = known
+        ? resolveGrokSessionArg(location, cwd, known)
+        : ({ kind: "new", sessionId } as const);
 
-      const args = buildGrokArgs(config, prompt, resumeId);
-      // Returning the minted/resumed id as sessionRef lets the runtime skip
-      // post-spawn discovery on the happy path (mirrors gemini/cursor).
-      // discoverSessionRef stays wired up as the fallback for mint failures
-      // in fresh cwds where Grok creates its own session.
+      const args = buildGrokArgs(config, prompt, sessionArg);
+      // Returning the id as sessionRef lets the runtime skip post-spawn
+      // discovery on the happy path (mirrors gemini/cursor).
+      // discoverSessionRef stays wired up as the fallback.
       return {
         binary: "grok",
         args,
-        ...(resumeId ? { sessionRef: createKnownSessionRef(resumeId) } : {}),
+        sessionRef: createKnownSessionRef(sessionId),
       };
     },
 
-    buildResumeArgv(_location, config, prompt, sessionRef) {
-      const args = buildGrokArgs(config, prompt, sessionRef?.providerSessionId);
+    buildResumeArgv(location, config, prompt, sessionRef) {
+      const cwd = location.kind === "wsl" ? location.linuxPath : location.path;
+      const known = sessionRef?.providerSessionId;
+      const args = buildGrokArgs(
+        config,
+        prompt,
+        known ? resolveGrokSessionArg(location, cwd, known) : undefined,
+      );
       return { binary: "grok", args };
     },
 
@@ -173,6 +180,9 @@ export function createGrokAdapter(): AgentAdapter {
       const t = text.toLowerCase();
       if (t.includes("grok build")) return true;
       if (/type @|mention files|\/ commands/i.test(text)) return true;
+      // 0.2.x composer footer ("Shift+Tab:mode") — present on both the
+      // welcome screen and resumed sessions (verified live on 0.2.93).
+      if (t.includes("shift+tab")) return true;
       return false;
     },
 
@@ -196,13 +206,14 @@ export function createGrokAdapter(): AgentAdapter {
     // One-shot (title / commit) generation reuses Grok's documented headless
     // path: `grok -p <prompt>`. `--always-approve` keeps the non-interactive run
     // from blocking on a tool-approval prompt it cannot answer (mirrors the
-    // launch/ACP bypass in argv.ts). Effort is intentionally not passed: it's
-    // headless-only and Grok does not surface effort tiers (see detection.ts).
-    defaultOneShotModel: "grok-build",
-    buildOneShotCommand(model, _effort, prompt) {
+    // launch/ACP bypass in argv.ts). The default is Grok's own default model —
+    // fast and subscription-covered, ideal for lightweight one-shots.
+    defaultOneShotModel: "grok-composer-2.5-fast",
+    buildOneShotCommand(model, effort, prompt) {
       if (!prompt) return undefined;
       const args = ["-p", prompt];
       if (model) args.push("-m", model);
+      if (effort) args.push("--reasoning-effort", effort);
       args.push("--always-approve");
       return { command: "grok", args, stdin: "" };
     },

--- a/src/supervisor/agents/grok/sessionFiles.test.ts
+++ b/src/supervisor/agents/grok/sessionFiles.test.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+import { grokSessionDirMaterialized, resolveGrokSessionArg } from "./sessionFiles";
+
+const SESSION_ID = "11111111-2222-4333-8444-555555555555";
+
+describe("grok session materialization (native)", () => {
+  let grokHome: string;
+  let projectDir: string;
+  let location: ProjectLocation;
+  let previousGrokHome: string | undefined;
+
+  beforeEach(() => {
+    grokHome = mkdtempSync(join(tmpdir(), "grok-home-"));
+    projectDir = join(tmpdir(), "grok-proj");
+    previousGrokHome = process.env["GROK_HOME"];
+    process.env["GROK_HOME"] = grokHome;
+    location = { kind: "windows", path: projectDir } as ProjectLocation;
+  });
+
+  afterEach(() => {
+    if (previousGrokHome === undefined) delete process.env["GROK_HOME"];
+    else process.env["GROK_HOME"] = previousGrokHome;
+    rmSync(grokHome, { recursive: true, force: true });
+  });
+
+  it("reports false for a session id that never materialized", () => {
+    expect(grokSessionDirMaterialized(location, projectDir, SESSION_ID)).toBe(false);
+  });
+
+  it("reports true once grok wrote the session dir", () => {
+    mkdirSync(join(grokHome, "sessions", encodeURIComponent(projectDir), SESSION_ID), {
+      recursive: true,
+    });
+    expect(grokSessionDirMaterialized(location, projectDir, SESSION_ID)).toBe(true);
+  });
+
+  it("resolveGrokSessionArg re-assigns unmaterialized ids with -s and resumes real ones with -r", () => {
+    expect(resolveGrokSessionArg(location, projectDir, SESSION_ID)).toEqual({
+      kind: "new",
+      sessionId: SESSION_ID,
+    });
+    mkdirSync(join(grokHome, "sessions", encodeURIComponent(projectDir), SESSION_ID), {
+      recursive: true,
+    });
+    expect(resolveGrokSessionArg(location, projectDir, SESSION_ID)).toEqual({
+      kind: "resume",
+      sessionId: SESSION_ID,
+    });
+  });
+});

--- a/src/supervisor/agents/grok/sessionFiles.ts
+++ b/src/supervisor/agents/grok/sessionFiles.ts
@@ -1,7 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { Worker } from "node:worker_threads";
 import type { ProjectLocation, SessionRef } from "@/shared/contracts";
 import {
   createKnownSessionRef,
@@ -11,9 +10,16 @@ import {
   statSessionPaths,
   watchSessionPaths,
 } from "../base";
-import { resolveAgentBinaryPath } from "../binaryResolver";
+import type { GrokSessionArg } from "./argv";
 
-const GROK_SESSIONS_ROOT = join(homedir(), ".grok", "sessions");
+// Honor the same GROK_HOME override the CLI (and grokCredentials.ts) support.
+function getNativeGrokSessionsRoot(): string {
+  const grokHome = process.env["GROK_HOME"];
+  return join(
+    grokHome && grokHome.trim().length > 0 ? grokHome : join(homedir(), ".grok"),
+    "sessions",
+  );
+}
 
 // Module-level snapshot captured right before we spawn a PTY for a fresh Grok launch.
 // This lets discoverSessionRef reliably identify the *new* session dir that Grok
@@ -32,7 +38,7 @@ function getGrokCwdSessionsDir(location: ProjectLocation, cwd: string): string |
     if (!home) return null;
     return `${home}/.grok/sessions/${encodeCwdKey(cwd)}`;
   }
-  return join(GROK_SESSIONS_ROOT, encodeCwdKey(cwd));
+  return join(getNativeGrokSessionsRoot(), encodeCwdKey(cwd));
 }
 
 async function getGrokCwdSessionsDirAsync(
@@ -49,7 +55,7 @@ function getGrokSessionsRoot(location: ProjectLocation): string | null {
     const home = getCachedWslHomeDirectory(location.distro);
     return home ? `${home}/.grok/sessions` : null;
   }
-  return GROK_SESSIONS_ROOT;
+  return getNativeGrokSessionsRoot();
 }
 
 /**
@@ -85,6 +91,59 @@ export function snapshotGrokPreSpawnSessions(location: ProjectLocation, cwd: str
 
 function isUuid(s: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}
+
+/**
+ * True when the session directory for <cwd>/<sessionId> exists on disk.
+ *
+ * grok 0.2.93 normally writes the session dir within ~1s of TUI boot
+ * (verified live), but a UUID we pre-assigned with `-s` can still be missing
+ * when the launch died at startup (spawn failure, immediate kill) or the TUI
+ * deferred to its welcome/resume menu. Callers use this to decide between
+ * `-r <id>` (resume a real session) and `-s <id>` (re-assign the same id —
+ * `-s` requires the session to not exist and exits 1 on a collision, so the
+ * choice must reflect live disk state, never a timing assumption).
+ *
+ * Returns `undefined` when the check is unavailable (WSL distro home not
+ * cached / UNC bridge unreachable); callers should then default to resume.
+ */
+export function grokSessionDirMaterialized(
+  location: ProjectLocation,
+  cwd: string,
+  sessionId: string,
+): boolean | undefined {
+  if (location.kind === "wsl") {
+    const home = getCachedWslHomeDirectory(location.distro);
+    if (!home) return undefined;
+    const linuxPath = `${home}/.grok/sessions/${encodeCwdKey(cwd)}/${sessionId}`;
+    const uncPath = `\\\\wsl.localhost\\${location.distro}${linuxPath.replaceAll("/", "\\")}`;
+    try {
+      return existsSync(uncPath);
+    } catch {
+      return undefined;
+    }
+  }
+  const dir = getGrokCwdSessionsDir(location, cwd);
+  if (!dir) return undefined;
+  return existsSync(join(dir, sessionId));
+}
+
+/**
+ * Map a known provider session id to the right PTY session flag: `-r` when
+ * the session has materialized, `-s` (re-assign) when it never did. When the
+ * materialization check is unavailable we default to resume — wrongly
+ * re-assigning an existing id makes grok exit 1, while wrongly resuming a
+ * missing one is the same failure mode we had before `-s` existed.
+ */
+export function resolveGrokSessionArg(
+  location: ProjectLocation,
+  cwd: string,
+  knownSessionId: string,
+): GrokSessionArg {
+  const materialized = grokSessionDirMaterialized(location, cwd, knownSessionId);
+  return materialized === false
+    ? { kind: "new", sessionId: knownSessionId }
+    : { kind: "resume", sessionId: knownSessionId };
 }
 
 /**
@@ -146,7 +205,7 @@ export function resolveGrokSessionsWatchPaths(location: ProjectLocation, cwd: st
     return [dir ?? undefined, root ?? undefined].filter((p): p is string => Boolean(p));
   }
   if (dir && existsSync(dir)) return [dir];
-  return [GROK_SESSIONS_ROOT];
+  return [getNativeGrokSessionsRoot()];
 }
 
 export function makeGrokWatchSessionRef() {
@@ -158,125 +217,4 @@ export function makeGrokWatchSessionRef() {
     const label = `grok:${location.kind === "wsl" ? "wsl:" + location.distro : location.kind}`;
     return watchSessionPaths(location, paths, onChanged, label);
   };
-}
-
-/**
- * Worker payload: spawn `grok [flags] agent stdio`, drive `initialize` →
- * `authenticate` → `session/new`, write the returned UUID into the shared
- * buffer, then notify the parent. Runs inside a `worker_threads.Worker` so
- * that `mintGrokSessionIdViaAcpSync` can block via `Atomics.wait` without
- * changing the synchronous `AgentLauncher` interface.
- *
- * NOTE: `spawnSync` is unusable here because Grok 0.1.218 closes the ACP
- * connection as soon as stdin EOFs — usually before it has processed the
- * `session/new` request. We need to keep stdin open until id:3 lands.
- */
-const MINT_WORKER_SCRIPT = `
-const { workerData } = require("worker_threads");
-const { spawn } = require("child_process");
-const { sab, binary, args, cwd } = workerData;
-const signalView = new Int32Array(sab, 0, 1);
-const idView = new Uint8Array(sab, 4, 64);
-
-let resolved = false;
-function finish(sessionId) {
-  if (resolved) return;
-  resolved = true;
-  if (sessionId) {
-    const buf = Buffer.from(sessionId, "utf8");
-    for (let i = 0; i < buf.length && i < 64; i++) idView[i] = buf[i];
-  }
-  Atomics.store(signalView, 0, 1);
-  Atomics.notify(signalView, 0);
-  try { p.kill(); } catch {}
-}
-
-const p = spawn(binary, [...args, "agent", "stdio"], { cwd, stdio: ["pipe","pipe","pipe"], windowsHide: true });
-// Stdin EOF on terminate is the documented Grok-exit signal, but kill the
-// child explicitly too so a future Grok build that keeps the connection open
-// on EOF cannot orphan the process.
-process.on("exit", () => { try { p.kill(); } catch {} });
-let buf = "";
-p.stdout.on("data", (chunk) => {
-  buf += chunk.toString("utf8");
-  let nl;
-  while ((nl = buf.indexOf("\\n")) >= 0) {
-    const line = buf.slice(0, nl).trim();
-    buf = buf.slice(nl + 1);
-    if (!line) continue;
-    try {
-      const msg = JSON.parse(line);
-      if (msg.id === 3 && msg.result && typeof msg.result.sessionId === "string") {
-        finish(msg.result.sessionId);
-        return;
-      }
-    } catch { /* skip non-JSON noise */ }
-  }
-});
-p.on("error", () => finish());
-p.on("close", () => finish());
-
-const reqs = [
-  { jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: 1, clientInfo: { name: "lightcode-grok-mint", version: "1" }, clientCapabilities: { auth: { terminal: true } } } },
-  { jsonrpc: "2.0", id: 2, method: "authenticate", params: { methodId: "cached_token" } },
-  { jsonrpc: "2.0", id: 3, method: "session/new", params: { cwd, mcpServers: [] } },
-];
-for (const r of reqs) p.stdin.write(JSON.stringify(r) + "\\n");
-`;
-
-/**
- * Synchronously mint a Grok session ID by spinning up `grok agent stdio` long
- * enough to drive `initialize` → `authenticate` → `session/new`. The returned
- * UUID is then used with the PTY `-r <id>` flag so the TUI loads that session
- * directly instead of rendering the welcome menu (which would otherwise
- * suppress our initial-prompt delivery path).
- *
- * `extraLaunchArgs` should be the output of `buildGrokAcpArgs(config)` so the
- * minted session is born with the right model / effort / permission-mode /
- * always-approve state already recorded in `summary.json`.
- *
- * Returns `undefined` on any failure (timeout, auth error, JSON parse, etc.).
- * Callers must treat undefined as "no minted ID" and proceed without `-r`.
- *
- * WSL is skipped — minting would require routing the ACP child through
- * `wsl.exe`, which is out of scope here.
- */
-export function mintGrokSessionIdViaAcpSync(
-  location: ProjectLocation,
-  timeoutMs = 4500,
-  extraLaunchArgs: string[] = [],
-): string | undefined {
-  if (location.kind === "wsl") return undefined;
-
-  // Use the absolute path resolved during detection. Packaged Electron apps
-  // start with a minimal PATH that may exclude Homebrew/asdf/etc., so a bare
-  // "grok" in the worker's spawn would fail even though detection found the
-  // binary. Mirrors how createCursorChatSync passes resolveAgentBinaryPath().
-  const binary = resolveAgentBinaryPath(location, "grok") ?? "grok";
-
-  // 4 bytes for the Atomics signal (Int32), 64 bytes for the UUID payload.
-  const sab = new SharedArrayBuffer(4 + 64);
-  const signalView = new Int32Array(sab, 0, 1);
-  const idView = new Uint8Array(sab, 4, 64);
-
-  const worker = new Worker(MINT_WORKER_SCRIPT, {
-    eval: true,
-    workerData: { sab, binary, args: extraLaunchArgs, cwd: location.path },
-  });
-  worker.on("error", () => {
-    Atomics.store(signalView, 0, 1);
-    Atomics.notify(signalView, 0);
-  });
-
-  Atomics.wait(signalView, 0, 0, timeoutMs);
-
-  const terminator = idView.indexOf(0);
-  const length = terminator >= 0 ? terminator : idView.length;
-  const sessionId = length > 0 ? Buffer.from(idView.slice(0, length)).toString("utf8") : undefined;
-
-  // Best-effort cleanup. terminate() is async; we don't await because the
-  // worker is fully self-contained and its child has been signalled to die.
-  worker.terminate();
-
-  return sessionId && isUuid(sessionId) ? sessionId : undefined;
 }


### PR DESCRIPTION
- Tickets: none
- Update Grok launch and resume flow for the 0.2.x CLI, using `-s` for new session IDs and `-r` for real resumes.
- Switch the Grok conflict resolver to `grok-4.5` and forward reasoning effort settings where the model supports them.
- Align session-file detection with `GROK_HOME` and add coverage for native session materialization and session-arg resolution.
- Refresh adapter tests to cover the new command-line behavior and remove assumptions tied to the retired `grok-build` model ID.