### PR TITLE
Add Fast-mode support indicators to the Codex model menu

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject,
 } from "react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Check, ChevronDown, Search, Star } from "lucide-react";
+import { Check, ChevronDown, Search, Star, Zap } from "lucide-react";
 import { Tooltip } from "@heroui/react";
 import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
 import { ResponsiveMenuSurface, useResponsiveMenu } from "../ResponsiveMenuSurface";
@@ -791,6 +791,13 @@ function WindowedProviderModelList(props: {
               const content = (
                 <span className="flex min-w-0 flex-1 items-center gap-1.5">
                   <span className="min-w-0 truncate">{name}</span>
+                  {item.supportsFast ? (
+                    <Zap
+                      role="img"
+                      aria-label={t`Supports Fast mode`}
+                      className="size-3 shrink-0 text-muted/60"
+                    />
+                  ) : null}
                   {mutedHint ? (
                     <span className="shrink-0 text-[10px] leading-none text-muted/60">
                       · {mutedHint}

--- a/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
@@ -155,6 +155,17 @@ function joinHints(...hints: Array<string | undefined>): string | undefined {
   return parts.length > 0 ? parts.join(" · ") : undefined;
 }
 
+/**
+ * The model supports fast mode AND the account can actually use it. Mirrors
+ * `supportsUsableFastMode` in the thread helpers, inlined here to keep the
+ * `common/` menu free of a dependency on `components/thread`. Derived from the
+ * same capability object at row-build time, so it can never go stale against
+ * the per-capability `ModelEntry` cache.
+ */
+function supportsFastModel(capability: AgentCapability, modelId: string): boolean {
+  return (capability.fastModels?.includes(modelId) ?? false) && !capability.fastDisabledReason;
+}
+
 function modelHintProps(model: {
   modelDescription?: string;
   contextDescription?: string;
@@ -442,6 +453,10 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
         ...modelHintProps(m),
         ...(m.tooltipDescription ? { tooltipDescription: m.tooltipDescription } : {}),
         showProviderIcon: true,
+        ...(visibleProvider &&
+        supportsFastModel(visibleProvider.provider.capabilities, m.ref.modelId)
+          ? { supportsFast: true }
+          : {}),
         isFavorite: favoriteStateSet.has(refKey(m.ref)),
       });
     }
@@ -509,6 +524,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
           ...modelHintProps(m),
           ...(m.tooltipDescription ? { tooltipDescription: m.tooltipDescription } : {}),
           showProviderIcon: true,
+          ...(supportsFastModel(cap, m.id) ? { supportsFast: true } : {}),
           isFavorite: favoriteStateSet.has(`${provider.kind}:${m.id}`),
         });
       }
@@ -543,6 +559,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
         ...(provider.icon ? { providerIcon: provider.icon } : {}),
         ...modelHintProps(m),
         ...(m.tooltipDescription ? { tooltipDescription: m.tooltipDescription } : {}),
+        ...(supportsFastModel(cap, m.id) ? { supportsFast: true } : {}),
         isFavorite: favoriteStateSet.has(`${provider.kind}:${m.id}`),
       });
     }
@@ -574,6 +591,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
           ...(provider.icon ? { providerIcon: provider.icon } : {}),
           ...modelHintProps(m),
           ...(m.tooltipDescription ? { tooltipDescription: m.tooltipDescription } : {}),
+          ...(supportsFastModel(cap, m.id) ? { supportsFast: true } : {}),
           isFavorite: favoriteStateSet.has(`${provider.kind}:${m.id}`),
         });
       }

--- a/src/renderer/components/common/ProviderModelMenu/parts/modelShortcutLabel.test.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/modelShortcutLabel.test.ts
@@ -45,6 +45,74 @@ describe("formatShortcutModelLabel", () => {
   });
 });
 
+describe("buildProviderModelItems fast-mode flag", () => {
+  const baseCaps = {
+    efforts: [],
+    modelEfforts: {},
+    modes: ["agent" as const],
+    approvalPolicies: [],
+    sandboxModes: [],
+    supportsResume: true,
+    supportsDirectInput: true,
+    liveInputMode: "terminal" as const,
+    presentationMode: "terminal" as const,
+    settingDefs: [],
+  };
+
+  function makeCodexProvider(
+    extra: Partial<ProviderModelMenuProvider["capabilities"]>,
+  ): ProviderModelMenuProvider {
+    return {
+      kind: "codex",
+      label: "Codex",
+      capabilities: {
+        ...baseCaps,
+        models: [
+          { id: "gpt-5.5", label: "GPT-5.5" },
+          { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+        ],
+        ...extra,
+      },
+    } satisfies ProviderModelMenuProvider;
+  }
+
+  it("sets supportsFast only on models listed in fastModels", () => {
+    const items = buildProviderModelItems({
+      providers: [makeCodexProvider({ fastModels: ["gpt-5.5"] })],
+      search: "",
+    });
+    const rows = items.filter((item) => item.type === "model");
+    const fastRow = rows.find((row) => row.modelId === "gpt-5.5");
+    const otherRow = rows.find((row) => row.modelId === "gpt-5.4-mini");
+    expect(fastRow?.supportsFast).toBe(true);
+    expect(otherRow?.supportsFast).toBeUndefined();
+  });
+
+  it("suppresses supportsFast when fastDisabledReason is set", () => {
+    const items = buildProviderModelItems({
+      providers: [
+        makeCodexProvider({ fastModels: ["gpt-5.5"], fastDisabledReason: "Disabled by org" }),
+      ],
+      search: "",
+    });
+    const fastRow = items.find((item) => item.type === "model" && item.modelId === "gpt-5.5");
+    expect(fastRow?.type === "model" ? fastRow.supportsFast : undefined).toBeUndefined();
+  });
+
+  it("carries supportsFast onto aggregated favorites rows", () => {
+    const items = buildProviderModelItems({
+      providers: [
+        makeCodexProvider({ fastModels: ["gpt-5.5"] }),
+        { kind: "cursor", label: "Cursor", capabilities: { ...baseCaps, models: [] } },
+      ],
+      search: "",
+      favorites: [{ agentKind: "codex", modelId: "gpt-5.5" }],
+    });
+    const favoriteRow = items.find((item) => item.type === "model" && item.id.startsWith("fav:"));
+    expect(favoriteRow?.type === "model" ? favoriteRow.supportsFast : undefined).toBe(true);
+  });
+});
+
 describe("buildProviderModelItems shortcut labels", () => {
   const codexProvider = {
     kind: "codex",

--- a/src/renderer/components/common/ProviderModelMenu/parts/types.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/types.ts
@@ -45,6 +45,8 @@ export interface ProviderModelRow {
   tooltipDescription?: string;
   /** When true, show the provider icon in the row right rail. */
   showProviderIcon?: boolean;
+  /** When true, this model supports a usable fast mode (drives the fast-mode hint glyph). */
+  supportsFast?: boolean;
   /** When true, the row's persisted favorite state is true (drives the star icon). */
   isFavorite: boolean;
   /** When true, omit the star button — used for read-only contexts (none today). */

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Der Support-Modus wird angezeigt, sobald die Sitzung verbunden ist."
 msgid "Support:"
 msgstr "Unterstützung:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Unterstützt Schnellmodus"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Notizen und Aufgaben tauschen"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Support mode appears once the session connects."
 msgid "Support:"
 msgstr "Support:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Supports Fast mode"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Swap notes and to-dos"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -6809,6 +6809,10 @@ msgstr "El modo de soporte aparece cuando la sesión se conecta."
 msgid "Support:"
 msgstr "Soporte:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Compatible con el modo rápido"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Intercambiar notas y tareas pendientes"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -6808,6 +6808,10 @@ msgstr "Le mode support apparaît une fois la session connectée."
 msgid "Support:"
 msgstr "Prise en charge :"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Compatible avec le mode rapide"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Basculer entre les notes et les tâches"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -6807,6 +6807,10 @@ msgstr "セッションが接続されると、サポート モードが表示�
 msgid "Support:"
 msgstr "サポート:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "高速モードに対応"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "メモやToDoを交換する"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -6809,6 +6809,10 @@ msgstr "세션이 연결되면 지원 모드가 나타납니다."
 msgid "Support:"
 msgstr "지원:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "고속 모드 지원"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "메모와 할 일 바꾸기"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Tryb wsparcia pojawi się po nawiązaniu połączenia sesji."
 msgid "Support:"
 msgstr "Wsparcie:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Obsługuje tryb szybki"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Zamień notatki i zadania"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -6809,6 +6809,10 @@ msgstr "O modo de suporte aparece quando a sessão é conectada."
 msgid "Support:"
 msgstr "Suporte:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Compatível com o modo rápido"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Alternar entre notas e tarefas"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Режим поддержки появляется после подкл
 msgid "Support:"
 msgstr "Поддержка:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Поддерживает быстрый режим"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Поменять местами заметки и задачи"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Oturum bağlandığında destek modu görünür."
 msgid "Support:"
 msgstr "Destek:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Hızlı modu destekler"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Notları ve yapılacak işleri değiştir"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Режим підтримки з'являється після підк�
 msgid "Support:"
 msgstr "Підтримка:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Підтримує швидкий режим"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Поміняти місцями нотатки та завдання"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -6809,6 +6809,10 @@ msgstr "Chế độ hỗ trợ xuất hiện khi phiên kết nối."
 msgid "Support:"
 msgstr "Hỗ trợ:"
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "Hỗ trợ chế độ nhanh"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "Hoán đổi ghi chú và việc cần làm"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -6808,6 +6808,10 @@ msgstr "会话连接后就会出现支持模式。"
 msgid "Support:"
 msgstr "支持："
 
+#: src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+msgid "Supports Fast mode"
+msgstr "支持快速模式"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesPanel.tsx
 msgid "Swap notes and to-dos"
 msgstr "切换笔记和待办事项"

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -1375,4 +1375,104 @@ describe("mapCodexModels", () => {
       efforts: ["low", "medium", "high"],
     });
   });
+
+  it("advertises Fast only for models whose additionalSpeedTiers include 'fast'", () => {
+    const result = mapCodexModels([
+      {
+        id: "gpt-5.5",
+        model: "gpt-5.5",
+        displayName: "gpt-5.5",
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        additionalSpeedTiers: ["fast"],
+        serviceTiers: [{ id: "priority" }],
+      },
+      {
+        id: "gpt-5.4",
+        model: "gpt-5.4",
+        displayName: "gpt-5.4",
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        additionalSpeedTiers: ["fast"],
+        serviceTiers: [{ id: "priority" }],
+      },
+      {
+        id: "gpt-5.4-mini",
+        model: "gpt-5.4-mini",
+        displayName: "gpt-5.4-mini",
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        additionalSpeedTiers: [],
+        serviceTiers: [],
+      },
+      {
+        id: "gpt-5.3-codex-spark",
+        model: "gpt-5.3-codex-spark",
+        displayName: "gpt-5.3-codex-spark",
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        additionalSpeedTiers: [],
+        serviceTiers: [],
+      },
+    ]);
+    expect(result.fastModels).toEqual(["gpt-5.5", "gpt-5.4"]);
+  });
+
+  it("treats every visible model as fast-capable when the CLI omits tier fields", () => {
+    const result = mapCodexModels([
+      {
+        id: "gpt-5.4",
+        model: "gpt-5.4",
+        displayName: "gpt-5.4",
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+      },
+      {
+        id: "gpt-5.4-mini",
+        model: "gpt-5.4-mini",
+        displayName: "gpt-5.4-mini",
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+      },
+    ]);
+    expect(result.fastModels).toEqual(["gpt-5.4", "gpt-5.4-mini"]);
+  });
+
+  it("falls back to serviceTiers presence when additionalSpeedTiers is missing", () => {
+    const result = mapCodexModels([
+      {
+        id: "gpt-5.5",
+        model: "gpt-5.5",
+        displayName: "gpt-5.5",
+        hidden: false,
+        isDefault: true,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        serviceTiers: [{ id: "priority" }],
+      },
+      {
+        id: "gpt-5.4-mini",
+        model: "gpt-5.4-mini",
+        displayName: "gpt-5.4-mini",
+        hidden: false,
+        isDefault: false,
+        defaultReasoningEffort: "medium",
+        supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        serviceTiers: [],
+      },
+    ]);
+    expect(result.fastModels).toEqual(["gpt-5.5"]);
+  });
 });

--- a/src/supervisor/agents/codex/detection.ts
+++ b/src/supervisor/agents/codex/detection.ts
@@ -219,9 +219,10 @@ export function probeResultToCapabilityPartial(probe: CodexProbeResult): Partial
     ...(probe.approvalPolicies?.length ? { approvalPolicies: probe.approvalPolicies } : {}),
     ...(probe.sandboxModes?.length ? { sandboxModes: probe.sandboxModes } : {}),
     ...(probe.slashCommands?.length ? { slashCommands: probe.slashCommands } : {}),
-    // All Codex models accept the `service_tier="fast"` config knob (per
-    // openai/codex config schema), so every probed model can opt into Fast.
-    ...(probe.models?.length ? { fastModels: probe.models.map((m) => m.id) } : {}),
+    // Only models whose `model/list` entry advertises the Fast/priority service
+    // tier can opt into Fast — the probe filters these from per-model tier data
+    // (with a legacy fallback to all models when the CLI omits the fields).
+    ...(probe.fastModels?.length ? { fastModels: probe.fastModels } : {}),
   };
 }
 

--- a/src/supervisor/agents/codex/probe.ts
+++ b/src/supervisor/agents/codex/probe.ts
@@ -28,6 +28,12 @@ interface CodexModelEntry {
   isDefault: boolean;
   defaultReasoningEffort: string;
   supportedReasoningEfforts: Array<{ reasoningEffort: string; description: string }>;
+  // Fast/priority service-tier signals (Codex CLI 0.143.0+). Loosely typed —
+  // older CLIs omit both fields, so treat the payload defensively. `["fast"]`
+  // marks a model that honors `service_tier="fast"`; the `serviceTiers` list
+  // carries the matching tier descriptor (e.g. the "priority"/Fast tier).
+  additionalSpeedTiers?: string[];
+  serviceTiers?: Array<{ id: string }>;
 }
 
 /** Raw requirements from `configRequirements/read`. */
@@ -41,6 +47,8 @@ export interface CodexProbeResult {
   efforts?: string[];
   defaultEffort?: string;
   modelEfforts?: Record<string, string[]>;
+  /** Visible model ids that support the Fast/priority service tier. */
+  fastModels?: string[];
   approvalPolicies?: Array<{ id: string; label: string }>;
   sandboxModes?: Array<{ id: string; label: string }>;
   slashCommands?: AgentSlashCommand[];
@@ -123,9 +131,23 @@ export function humanizeCodexModelName(id: string, displayName: string): string 
     .join(" ");
 }
 
+/**
+ * Whether a single model entry advertises the Fast/priority service tier.
+ *
+ * Prefer the explicit `additionalSpeedTiers` list when present; only fall
+ * back to `serviceTiers` (non-empty ⇒ a tier like "priority"/Fast exists)
+ * when `additionalSpeedTiers` is absent.
+ */
+function codexModelSupportsFast(entry: CodexModelEntry): boolean {
+  if (entry.additionalSpeedTiers !== undefined) {
+    return Array.isArray(entry.additionalSpeedTiers) && entry.additionalSpeedTiers.includes("fast");
+  }
+  return Array.isArray(entry.serviceTiers) && entry.serviceTiers.length > 0;
+}
+
 export function mapCodexModels(
   models: CodexModelEntry[],
-): Pick<CodexProbeResult, "models" | "efforts" | "defaultEffort" | "modelEfforts"> {
+): Pick<CodexProbeResult, "models" | "efforts" | "defaultEffort" | "modelEfforts" | "fastModels"> {
   const visible = models.filter((m) => !m.hidden);
   if (visible.length === 0) return {};
 
@@ -176,11 +198,24 @@ export function mapCodexModels(
     }
   }
 
+  // Fast-mode capability. When the payload reports tier data on any visible
+  // model, advertise Fast only for the models that actually support it.
+  // Older Codex CLIs omit both tier fields entirely — in that case keep the
+  // prior behavior and treat every visible model as fast-capable so the Fast
+  // toggle isn't silently dropped after a downgrade.
+  const reportsTierData = visible.some(
+    (m) => m.additionalSpeedTiers !== undefined || m.serviceTiers !== undefined,
+  );
+  const fastModels = reportsTierData
+    ? visible.filter((m) => codexModelSupportsFast(m)).map((m) => m.id)
+    : visible.map((m) => m.id);
+
   return {
     models: mapped,
     efforts: sortedEfforts,
     defaultEffort,
     ...(Object.keys(modelEfforts).length > 0 ? { modelEfforts } : {}),
+    ...(fastModels.length > 0 ? { fastModels } : {}),
   };
 }
 


### PR DESCRIPTION
- Feature + refactor: surface which Codex models can actually use Fast mode, so users can pick supported models with less guesswork.
- Update Codex probing and capability mapping to derive Fast eligibility from model tier metadata instead of assuming every model supports it.
- Show a Fast-mode hint in the provider model menu, with localized copy across all supported languages.
- Cover the new detection and menu behavior with targeted tests.