### PR TITLE
Add computer-use MCP for desktop control across providers

### DIFF
--- a/src/main/browser/BrowserMcpIngress.ts
+++ b/src/main/browser/BrowserMcpIngress.ts
@@ -1,60 +1,44 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { randomBytes, randomUUID } from "node:crypto";
-import { decodeThreadIdentity, type McpThreadIdentity } from "@/shared/browserMcpThread";
-import { isLocalhostOrigin, readBoundedNodeRequestBody, writeJsonResponse } from "@/shared/http";
+import type { McpThreadIdentity } from "@/shared/browserMcpThread";
 import type { BrowserPanelManager } from "./BrowserPanelManager";
+import {
+  StreamableHttpMcpIngress,
+  type StreamableHttpMcpIngressInfo,
+} from "../mcp/StreamableHttpMcpIngress";
 import {
   BROWSER_MCP_INSTRUCTIONS,
   TOOLS,
   dispatchTool,
   formatToolResult,
   isKnownToolName,
-  type McpToolResult,
   type ToolContext,
 } from "./mcp/toolRegistry";
 
-export interface BrowserMcpIngressInfo {
-  url: string;
-  token: string;
-  port: number;
-}
-
-const MAX_BODY = 1024 * 1024;
-const MCP_PROTOCOL_VERSION = "2025-03-26";
-
-interface JsonRpcRequest {
-  jsonrpc: "2.0";
-  id?: number | string | null;
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcResponseOk {
-  jsonrpc: "2.0";
-  id: number | string | null;
-  result: unknown;
-}
-
-interface JsonRpcResponseErr {
-  jsonrpc: "2.0";
-  id: number | string | null;
-  error: { code: number; message: string; data?: unknown };
-}
-
-type JsonRpcResponse = JsonRpcResponseOk | JsonRpcResponseErr;
+export type BrowserMcpIngressInfo = StreamableHttpMcpIngressInfo;
 
 /**
  * Single in-process MCP server. Speaks Streamable-HTTP MCP at `POST /mcp`
  * (JSON-RPC body, single JSON response). All five agent providers connect
- * here by URL — no per-thread Node child process.
+ * here by URL — no per-thread Node child process. The transport is shared
+ * with the computer-use ingress via {@link StreamableHttpMcpIngress}.
  */
 export class BrowserMcpIngress {
-  private server: Server | null = null;
-  private token = randomBytes(32).toString("hex");
-  private info: BrowserMcpIngressInfo | null = null;
   private allowEval = false;
   private allowDataAccess = false;
   private getManager: (() => BrowserPanelManager | null) | null = null;
+  private readonly ingress = new StreamableHttpMcpIngress<ToolContext>({
+    serverInfo: { name: "browser", version: "2.0.0" },
+    instructions: BROWSER_MCP_INSTRUCTIONS,
+    tools: TOOLS,
+    isKnownToolName,
+    // Agent tool calls no longer force the browser panel open — the tab's
+    // <webview> stays alive off-screen (see BrowserHost "background" mode),
+    // so the agent works headless without stealing the user's UI. Hence no
+    // onBeforeToolCall reveal hook.
+    buildContext: (identity) => this.buildContext(identity),
+    contextUnavailableMessage: "browser panel not ready",
+    dispatchTool,
+    formatToolResult,
+  });
 
   setManagerAccessor(getter: () => BrowserPanelManager | null): void {
     this.getManager = getter;
@@ -68,36 +52,16 @@ export class BrowserMcpIngress {
     this.allowDataAccess = allow;
   }
 
-  async start(): Promise<BrowserMcpIngressInfo> {
-    if (this.info) return this.info;
-    return await new Promise<BrowserMcpIngressInfo>((resolve, reject) => {
-      const server = createServer((req, res) => this.handle(req, res));
-      server.on("error", reject);
-      // Bind 0.0.0.0 so WSL agents can reach the host via gateway IP. Access
-      // is guarded by a 256-bit bearer token regenerated per app launch; the
-      // URL is only ever passed to immediate child processes via env vars.
-      server.listen(0, "0.0.0.0", () => {
-        const addr = server.address();
-        const port = typeof addr === "object" && addr ? addr.port : 0;
-        this.server = server;
-        this.info = { url: `http://127.0.0.1:${port}`, token: this.token, port };
-        resolve(this.info);
-      });
-    });
+  start(): Promise<BrowserMcpIngressInfo> {
+    return this.ingress.start();
   }
 
   getInfo(): BrowserMcpIngressInfo | null {
-    return this.info;
+    return this.ingress.getInfo();
   }
 
   dispose(): void {
-    try {
-      this.server?.closeAllConnections?.();
-    } catch {}
-    try {
-      this.server?.close();
-    } catch {}
-    this.server = null;
+    this.ingress.dispose();
   }
 
   private buildContext(identity: McpThreadIdentity): ToolContext | null {
@@ -111,216 +75,4 @@ export class BrowserMcpIngress {
       ...(identity.title ? { threadTitle: identity.title } : {}),
     };
   }
-
-  private async readBody(req: IncomingMessage): Promise<string> {
-    const body = await readBoundedNodeRequestBody(req, MAX_BODY, () => new Error("body too large"));
-    return body.toString("utf8");
-  }
-
-  private sendJson(res: ServerResponse, status: number, body: unknown): void {
-    writeJsonResponse(res, status, body, { cacheControl: "no-store" });
-  }
-
-  private checkAuth(req: IncomingMessage): boolean {
-    const auth = req.headers.authorization;
-    if (auth && auth.startsWith("Bearer ") && auth.slice(7).trim() === this.token) {
-      return true;
-    }
-    // Some MCP clients pass the token in a custom header.
-    const xToken = req.headers["x-lightcode-token"];
-    if (typeof xToken === "string" && xToken === this.token) return true;
-    return false;
-  }
-
-  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    try {
-      if (!req.url) {
-        this.sendJson(res, 404, { error: "not found" });
-        return;
-      }
-      const path = new URL(req.url, "http://x").pathname;
-
-      // CORS preflight — restrict to localhost origins so remote web pages
-      // cannot issue cross-origin requests to the MCP ingress.
-      if (req.method === "OPTIONS") {
-        const origin = req.headers.origin;
-        if (typeof origin === "string" && isLocalhostOrigin(origin)) {
-          res.setHeader("Access-Control-Allow-Origin", origin);
-          res.setHeader(
-            "Access-Control-Allow-Headers",
-            "Authorization, X-Lightcode-Token, Content-Type, Mcp-Session-Id",
-          );
-          res.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
-        }
-        res.statusCode = 204;
-        res.end();
-        return;
-      }
-
-      if (!this.checkAuth(req)) {
-        this.sendJson(res, 401, { error: "unauthorized" });
-        return;
-      }
-
-      if (path === "/mcp" || path === "/mcp/") {
-        if (req.method === "GET") {
-          // MCP Streamable HTTP allows GET to open an SSE stream. We don't
-          // push server-initiated events; return 405 with Allow header.
-          res.statusCode = 405;
-          res.setHeader("Allow", "POST");
-          res.end();
-          return;
-        }
-        if (req.method !== "POST") {
-          this.sendJson(res, 405, { error: "method not allowed" });
-          return;
-        }
-        await this.handleMcp(req, res);
-        return;
-      }
-
-      this.sendJson(res, 404, { error: "not found" });
-    } catch (err) {
-      this.sendJson(res, 500, { error: (err as Error).message ?? "internal" });
-    }
-  }
-
-  private async handleMcp(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const identity = decodeThreadIdentity(req.url);
-    const raw = await this.readBody(req);
-    let body: unknown;
-    try {
-      body = raw ? JSON.parse(raw) : {};
-    } catch {
-      this.sendJson(res, 400, {
-        jsonrpc: "2.0",
-        id: null,
-        error: { code: -32700, message: "Parse error" },
-      });
-      return;
-    }
-
-    // Mcp-Session-Id: stateless server, but echo a session id so clients
-    // that key off of it have one.
-    let sessionId = req.headers["mcp-session-id"];
-    if (Array.isArray(sessionId)) sessionId = sessionId[0];
-    if (typeof sessionId !== "string" || !sessionId) {
-      sessionId = randomUUID();
-    }
-    res.setHeader("Mcp-Session-Id", sessionId);
-
-    // Streamable HTTP allows a single response or a batch. Match the input.
-    if (Array.isArray(body)) {
-      const out: JsonRpcResponse[] = [];
-      for (const m of body) {
-        const reply = await this.handleSingle(m, identity);
-        if (reply) out.push(reply);
-      }
-      this.sendJson(res, 200, out);
-      return;
-    }
-    const reply = await this.handleSingle(body, identity);
-    if (!reply) {
-      // notification — no response
-      res.statusCode = 202;
-      res.end();
-      return;
-    }
-    this.sendJson(res, 200, reply);
-  }
-
-  private async handleSingle(
-    message: unknown,
-    identity: McpThreadIdentity,
-  ): Promise<JsonRpcResponse | null> {
-    if (!isJsonRpcRequest(message)) return null;
-    const { id = null, method, params } = message;
-    try {
-      if (method === "initialize") {
-        return {
-          jsonrpc: "2.0",
-          id,
-          result: {
-            protocolVersion: MCP_PROTOCOL_VERSION,
-            capabilities: { tools: {} },
-            serverInfo: { name: "browser", version: "2.0.0" },
-            instructions: BROWSER_MCP_INSTRUCTIONS,
-          },
-        };
-      }
-      if (method === "notifications/initialized" || method === "initialized") {
-        return null;
-      }
-      if (method === "ping") {
-        return { jsonrpc: "2.0", id, result: {} };
-      }
-      if (method === "tools/list") {
-        return { jsonrpc: "2.0", id, result: { tools: TOOLS } };
-      }
-      if (method === "tools/call") {
-        const p = (params ?? {}) as { name?: string; arguments?: Record<string, unknown> };
-        const name = String(p.name ?? "");
-        const args = (p.arguments ?? {}) as Record<string, unknown>;
-        if (!isKnownToolName(name)) {
-          return {
-            jsonrpc: "2.0",
-            id,
-            result: {
-              isError: true,
-              content: [{ type: "text", text: `Unknown tool: ${name}` }],
-            },
-          };
-        }
-        const ctx = this.buildContext(identity);
-        if (!ctx) {
-          return {
-            jsonrpc: "2.0",
-            id,
-            result: {
-              isError: true,
-              content: [{ type: "text", text: "browser panel not ready" }],
-            },
-          };
-        }
-        // Agent tool calls no longer force the browser panel open — the tab's
-        // <webview> stays alive off-screen (see BrowserHost "background" mode),
-        // so the agent works headless without stealing the user's UI.
-        let raw: unknown;
-        try {
-          raw = await dispatchTool(name, args, ctx);
-        } catch (err) {
-          return {
-            jsonrpc: "2.0",
-            id,
-            result: {
-              isError: true,
-              content: [{ type: "text", text: (err as Error).message ?? String(err) }],
-            },
-          };
-        }
-        const result: McpToolResult = formatToolResult(name, raw);
-        return { jsonrpc: "2.0", id, result };
-      }
-      return {
-        jsonrpc: "2.0",
-        id,
-        error: { code: -32601, message: `Method not found: ${method}` },
-      };
-    } catch (err) {
-      return {
-        jsonrpc: "2.0",
-        id,
-        error: { code: -32000, message: (err as Error).message ?? "internal" },
-      };
-    }
-  }
-}
-
-function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { jsonrpc?: unknown }).jsonrpc === "2.0" &&
-    typeof (value as { method?: unknown }).method === "string"
-  );
 }

--- a/src/main/computer-use/ComputerUseDesktopOverlay.test.ts
+++ b/src/main/computer-use/ComputerUseDesktopOverlay.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => {
+  class BrowserWindow {
+    static instances: BrowserWindow[] = [];
+    readonly options: Record<string, unknown>;
+    readonly handlers = new Map<string, () => void>();
+    destroyed = false;
+    visible = false;
+    setAlwaysOnTop = vi.fn<(flag: boolean, level: string) => void>();
+    setBounds = vi.fn<(bounds: unknown) => void>();
+    setIgnoreMouseEvents = vi.fn<(ignore: boolean) => void>();
+    setVisibleOnAllWorkspaces = vi.fn<(visible: boolean, options?: unknown) => void>();
+    showInactive = vi.fn<() => void>(() => {
+      this.visible = true;
+    });
+    hide = vi.fn<() => void>(() => {
+      this.visible = false;
+    });
+    destroy = vi.fn<() => void>(() => {
+      this.destroyed = true;
+      this.handlers.get("closed")?.();
+    });
+    loadURL = vi.fn<(url: string) => Promise<void>>(async () => undefined);
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      BrowserWindow.instances.push(this);
+    }
+
+    isDestroyed() {
+      return this.destroyed;
+    }
+
+    isVisible() {
+      return this.visible;
+    }
+
+    on(event: string, handler: () => void): void {
+      this.handlers.set(event, handler);
+    }
+  }
+
+  const shortcuts = new Map<string, () => void>();
+  return {
+    BrowserWindow,
+    globalShortcut: {
+      register: vi.fn<(accelerator: string, handler: () => void) => boolean>(
+        (accelerator, handler) => {
+          shortcuts.set(accelerator, handler);
+          return true;
+        },
+      ),
+      unregister: vi.fn<(accelerator: string) => boolean>((accelerator) =>
+        shortcuts.delete(accelerator),
+      ),
+    },
+    screen: {
+      getAllDisplays: vi.fn<() => Array<{ id: number; bounds: Record<string, number> }>>(() => [
+        { id: 1, bounds: { x: 0, y: 0, width: 1920, height: 1080 } },
+        { id: 2, bounds: { x: 1920, y: 0, width: 1280, height: 1024 } },
+      ]),
+    },
+    shortcuts,
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: electronMock.BrowserWindow,
+  globalShortcut: electronMock.globalShortcut,
+  screen: electronMock.screen,
+}));
+
+import {
+  COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS,
+  ComputerUseDesktopOverlay,
+} from "./ComputerUseDesktopOverlay";
+
+describe("ComputerUseDesktopOverlay", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    electronMock.BrowserWindow.instances.length = 0;
+    electronMock.shortcuts.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("covers every display with a transparent click-through border during control", async () => {
+    const overlay = new ComputerUseDesktopOverlay({
+      onExit: vi.fn<(threadIds: string[]) => void>(),
+    });
+
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    await Promise.resolve();
+
+    expect(electronMock.BrowserWindow.instances).toHaveLength(2);
+    for (const window of electronMock.BrowserWindow.instances) {
+      expect(window.options).toMatchObject({ transparent: true, focusable: false, frame: false });
+      expect(window.setIgnoreMouseEvents).toHaveBeenCalledWith(true);
+      expect(window.setAlwaysOnTop).toHaveBeenCalledWith(true, "screen-saver");
+      expect(window.showInactive).toHaveBeenCalled();
+      const overlayHtml = decodeURIComponent(window.loadURL.mock.calls[0]![0].split(",", 2)[1]!);
+      expect(overlayHtml).toContain("inset 0 0 0 3px");
+      expect(overlayHtml).toContain("Poracode using your computer | Esc to Exit");
+      expect(overlayHtml).not.toContain("<button");
+    }
+    expect(electronMock.globalShortcut.register).toHaveBeenCalledWith(
+      "Escape",
+      expect.any(Function),
+    );
+
+    overlay.dispose();
+  });
+
+  it("keeps the border visible briefly across a burst of interactive actions", async () => {
+    const overlay = new ComputerUseDesktopOverlay({
+      onExit: vi.fn<(threadIds: string[]) => void>(),
+    });
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    await Promise.resolve();
+    const windows = [...electronMock.BrowserWindow.instances];
+
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: false });
+    vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS - 1);
+    expect(windows.every((window) => window.visible)).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(windows.every((window) => !window.visible)).toBe(true);
+
+    overlay.dispose();
+  });
+
+  it("interrupts active threads when Escape returns control to the user", async () => {
+    const onExit = vi.fn<(threadIds: string[]) => void>();
+    const overlay = new ComputerUseDesktopOverlay({ onExit });
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    await Promise.resolve();
+
+    electronMock.shortcuts.get("Escape")?.();
+
+    expect(onExit).toHaveBeenCalledWith(["thread-1"]);
+    expect(electronMock.BrowserWindow.instances.every((window) => !window.visible)).toBe(true);
+    expect(electronMock.globalShortcut.unregister).toHaveBeenCalledWith("Escape");
+
+    overlay.dispose();
+  });
+
+  it("does not intercept Escape while the agent is sending a keypress", async () => {
+    const overlay = new ComputerUseDesktopOverlay({
+      onExit: vi.fn<(threadIds: string[]) => void>(),
+    });
+    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: true });
+    await Promise.resolve();
+
+    expect(electronMock.shortcuts.has("Escape")).toBe(false);
+
+    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: false });
+    expect(electronMock.shortcuts.has("Escape")).toBe(true);
+
+    overlay.dispose();
+  });
+
+  it("stays active until overlapping interactive calls have both finished", async () => {
+    const overlay = new ComputerUseDesktopOverlay({
+      onExit: vi.fn<(threadIds: string[]) => void>(),
+    });
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: true });
+    await Promise.resolve();
+    const windows = [...electronMock.BrowserWindow.instances];
+
+    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: false });
+    vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS);
+    expect(windows.every((window) => window.visible)).toBe(true);
+    expect(electronMock.shortcuts.has("Escape")).toBe(false);
+
+    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: false });
+    expect(electronMock.shortcuts.has("Escape")).toBe(true);
+    vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS);
+    expect(windows.every((window) => !window.visible)).toBe(true);
+
+    overlay.dispose();
+  });
+});

--- a/src/main/computer-use/ComputerUseDesktopOverlay.ts
+++ b/src/main/computer-use/ComputerUseDesktopOverlay.ts
@@ -1,0 +1,207 @@
+import { BrowserWindow, globalShortcut, screen, type Display } from "electron";
+import type { ComputerUseActivityEvent } from "./ComputerUseMcpIngress";
+import { isKeyChordToolName } from "./mcp/toolRegistry";
+
+export const COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS = 500;
+
+const ESCAPE_ACCELERATOR = "Escape";
+const OVERLAY_HTML = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="color-scheme" content="dark">
+    <title>Computer Use Overlay</title>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
+      body {
+        background: rgba(8, 12, 20, 0.08);
+        box-shadow:
+          inset 0 0 0 3px rgba(92, 167, 255, 0.95),
+          inset 0 0 24px rgba(92, 167, 255, 0.2);
+      }
+      .badge {
+        position: fixed;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 8px 14px;
+        border: 1px solid rgba(92, 167, 255, 0.7);
+        border-top: 0;
+        border-radius: 0 0 12px 12px;
+        background: rgba(8, 12, 20, 0.92);
+        color: #f7f9fc;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+        font: 600 13px/1.2 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="badge">Poracode using your computer | Esc to Exit</div>
+  </body>
+</html>`;
+const OVERLAY_URL = `data:text/html;charset=utf-8,${encodeURIComponent(OVERLAY_HTML)}`;
+
+interface OverlayWindow {
+  loaded: boolean;
+  window: BrowserWindow;
+}
+
+export interface ComputerUseDesktopOverlayOptions {
+  onExit(threadIds: string[]): void;
+}
+
+export class ComputerUseDesktopOverlay {
+  private readonly activeThreads = new Set<string>();
+  private readonly activeCalls = new Map<string, number>();
+  private escapeSuppressedCalls = 0;
+  private readonly releaseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly windows = new Map<number, OverlayWindow>();
+  private escapeRegistered = false;
+  private visible = false;
+  private disposed = false;
+
+  constructor(private readonly options: ComputerUseDesktopOverlayOptions) {}
+
+  setActivity(event: ComputerUseActivityEvent): void {
+    if (this.disposed) return;
+    const releaseTimer = this.releaseTimers.get(event.threadId);
+    if (releaseTimer) {
+      clearTimeout(releaseTimer);
+      this.releaseTimers.delete(event.threadId);
+    }
+
+    if (event.active) {
+      this.activeCalls.set(event.threadId, (this.activeCalls.get(event.threadId) ?? 0) + 1);
+      this.activeThreads.add(event.threadId);
+      if (isKeyChordToolName(event.toolName)) this.escapeSuppressedCalls += 1;
+      this.show();
+      this.syncEscapeShortcut();
+      return;
+    }
+
+    const activeCalls = Math.max(0, (this.activeCalls.get(event.threadId) ?? 1) - 1);
+    if (activeCalls > 0) this.activeCalls.set(event.threadId, activeCalls);
+    else this.activeCalls.delete(event.threadId);
+    if (isKeyChordToolName(event.toolName)) {
+      this.escapeSuppressedCalls = Math.max(0, this.escapeSuppressedCalls - 1);
+    }
+    this.syncEscapeShortcut();
+    if (!this.activeThreads.has(event.threadId) || activeCalls > 0) return;
+    this.releaseTimers.set(
+      event.threadId,
+      setTimeout(() => {
+        this.releaseTimers.delete(event.threadId);
+        this.activeThreads.delete(event.threadId);
+        if (this.activeThreads.size === 0) this.hide();
+      }, COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS),
+    );
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.clearActivity();
+    for (const overlay of this.windows.values()) {
+      if (!overlay.window.isDestroyed()) overlay.window.destroy();
+    }
+    this.windows.clear();
+  }
+
+  private show(): void {
+    if (this.visible) return;
+    this.visible = true;
+    const displays = screen.getAllDisplays();
+    this.removeMissingDisplays(displays);
+    for (const display of displays) {
+      const overlay = this.windows.get(display.id) ?? this.createWindow(display);
+      overlay.window.setBounds(display.bounds);
+      if (overlay.loaded && !overlay.window.isVisible()) overlay.window.showInactive();
+    }
+  }
+
+  private createWindow(display: Display): OverlayWindow {
+    const window = new BrowserWindow({
+      ...display.bounds,
+      transparent: true,
+      backgroundColor: "#00000000",
+      frame: false,
+      focusable: false,
+      fullscreenable: false,
+      hasShadow: false,
+      maximizable: false,
+      minimizable: false,
+      movable: false,
+      resizable: false,
+      skipTaskbar: true,
+      show: false,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    const overlay: OverlayWindow = { loaded: false, window };
+    this.windows.set(display.id, overlay);
+    window.setAlwaysOnTop(true, "screen-saver");
+    window.setIgnoreMouseEvents(true);
+    window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    window.on("closed", () => {
+      if (this.windows.get(display.id)?.window === window) this.windows.delete(display.id);
+    });
+    void window.loadURL(OVERLAY_URL).then(() => {
+      overlay.loaded = true;
+      if (!this.disposed && this.activeThreads.size > 0 && !window.isDestroyed()) {
+        window.showInactive();
+      }
+    });
+    return overlay;
+  }
+
+  private removeMissingDisplays(displays: Display[]): void {
+    const displayIds = new Set(displays.map((display) => display.id));
+    for (const [displayId, overlay] of this.windows) {
+      if (displayIds.has(displayId)) continue;
+      this.windows.delete(displayId);
+      if (!overlay.window.isDestroyed()) overlay.window.destroy();
+    }
+  }
+
+  private hide(): void {
+    this.visible = false;
+    this.unregisterEscape();
+    for (const overlay of this.windows.values()) {
+      if (!overlay.window.isDestroyed()) overlay.window.hide();
+    }
+  }
+
+  private syncEscapeShortcut(): void {
+    const shouldRegister = this.activeThreads.size > 0 && this.escapeSuppressedCalls === 0;
+    if (shouldRegister === this.escapeRegistered) return;
+    if (!shouldRegister) {
+      this.unregisterEscape();
+      return;
+    }
+    this.escapeRegistered = globalShortcut.register(ESCAPE_ACCELERATOR, () => {
+      const threadIds = [...this.activeThreads];
+      this.clearActivity();
+      this.options.onExit(threadIds);
+    });
+  }
+
+  private unregisterEscape(): void {
+    if (!this.escapeRegistered) return;
+    globalShortcut.unregister(ESCAPE_ACCELERATOR);
+    this.escapeRegistered = false;
+  }
+
+  private clearActivity(): void {
+    for (const releaseTimer of this.releaseTimers.values()) clearTimeout(releaseTimer);
+    this.releaseTimers.clear();
+    this.activeThreads.clear();
+    this.activeCalls.clear();
+    this.escapeSuppressedCalls = 0;
+    this.hide();
+  }
+}

--- a/src/main/computer-use/ComputerUseMcpIngress.test.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.test.ts
@@ -1,7 +1,47 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { ComputerUseMcpIngress } from "./ComputerUseMcpIngress";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ComputerUseMcpIngress, type ComputerUseMcpIngressOptions } from "./ComputerUseMcpIngress";
+import type { ComputerUseDriver, ComputerUseInteractiveResult } from "./mcp/types";
 
 let ingress: ComputerUseMcpIngress | null = null;
+
+function createDriver(overrides: Partial<ComputerUseDriver> = {}): ComputerUseDriver {
+  return {
+    activateWindow: vi.fn<ComputerUseDriver["activateWindow"]>(),
+    click: vi.fn<ComputerUseDriver["click"]>(),
+    dispose: vi.fn<ComputerUseDriver["dispose"]>(),
+    drag: vi.fn<ComputerUseDriver["drag"]>(),
+    getWindow: vi.fn<ComputerUseDriver["getWindow"]>(),
+    getWindowState: vi.fn<ComputerUseDriver["getWindowState"]>(),
+    launchApp: vi.fn<ComputerUseDriver["launchApp"]>(),
+    listApps: vi.fn<ComputerUseDriver["listApps"]>(),
+    listWindows: vi.fn<ComputerUseDriver["listWindows"]>().mockResolvedValue([]),
+    pressKey: vi.fn<ComputerUseDriver["pressKey"]>(),
+    scroll: vi.fn<ComputerUseDriver["scroll"]>(),
+    typeText: vi.fn<ComputerUseDriver["typeText"]>(),
+    ...overrides,
+  };
+}
+
+function callTool(
+  info: { url: string; token: string },
+  name: string,
+  args: Record<string, unknown>,
+  threadId = "thread-1",
+): Promise<Response> {
+  return fetch(`${info.url}/mcp?thread=${encodeURIComponent(threadId)}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${info.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+}
 
 afterEach(() => {
   ingress?.dispose();
@@ -60,5 +100,70 @@ describe("ComputerUseMcpIngress", () => {
     });
     const body = (await authorized.json()) as { result: { tools: Array<{ name: string }> } };
     expect(body.result.tools.map((tool) => tool.name)).toContain("get_window_state");
+  });
+
+  it("emits thread activity only while an interactive tool is running", async () => {
+    let resolveClick: ((result: ComputerUseInteractiveResult) => void) | undefined;
+    const clickResult = new Promise<ComputerUseInteractiveResult>((resolve) => {
+      resolveClick = resolve;
+    });
+    const onActivity = vi.fn<NonNullable<ComputerUseMcpIngressOptions["onActivity"]>>();
+    ingress = new ComputerUseMcpIngress({
+      driver: createDriver({
+        click: vi.fn<ComputerUseDriver["click"]>(() => clickResult),
+      }),
+      onActivity,
+    });
+    const info = await ingress.start();
+
+    const response = callTool(info, "click", {
+      window: { app: "calc", id: 1 },
+      x: 10,
+      y: 20,
+    });
+    await vi.waitFor(() => {
+      expect(onActivity).toHaveBeenCalledWith({
+        threadId: "thread-1",
+        toolName: "click",
+        active: true,
+      });
+    });
+    expect(onActivity).toHaveBeenCalledTimes(1);
+
+    resolveClick?.({ ok: true, mode: "interactive" });
+    expect((await response).status).toBe(200);
+    expect(onActivity.mock.calls.map(([event]) => event.active)).toEqual([true, false]);
+  });
+
+  it("does not emit takeover activity for passive tools", async () => {
+    const onActivity = vi.fn<NonNullable<ComputerUseMcpIngressOptions["onActivity"]>>();
+    ingress = new ComputerUseMcpIngress({ driver: createDriver(), onActivity });
+    const info = await ingress.start();
+
+    expect((await callTool(info, "list_windows", {})).status).toBe(200);
+    expect(onActivity).not.toHaveBeenCalled();
+  });
+
+  it("cancels active driver actions on emergency exit", () => {
+    const driver = createDriver();
+    ingress = new ComputerUseMcpIngress({ driver });
+
+    ingress.interruptActiveActions();
+
+    expect(driver.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("normalizes interactive tool aliases in activity events", async () => {
+    const onActivity = vi.fn<NonNullable<ComputerUseMcpIngressOptions["onActivity"]>>();
+    ingress = new ComputerUseMcpIngress({ driver: createDriver(), onActivity });
+    const info = await ingress.start();
+
+    expect(
+      (await callTool(info, "key", { window: { app: "calc", id: 1 }, key: "Escape" })).status,
+    ).toBe(200);
+    expect(onActivity.mock.calls.map(([event]) => event.toolName)).toEqual([
+      "press_key",
+      "press_key",
+    ]);
   });
 });

--- a/src/main/computer-use/ComputerUseMcpIngress.test.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ComputerUseMcpIngress } from "./ComputerUseMcpIngress";
+
+let ingress: ComputerUseMcpIngress | null = null;
+
+afterEach(() => {
+  ingress?.dispose();
+  ingress = null;
+});
+
+describe("ComputerUseMcpIngress", () => {
+  it("advertises computer_use instructions and tools on initialize", async () => {
+    ingress = new ComputerUseMcpIngress();
+    const info = await ingress.start();
+
+    const response = await fetch(`${info.url}/mcp`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${info.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
+    });
+
+    const body = (await response.json()) as {
+      result: {
+        serverInfo: { name: string };
+        instructions: string;
+      };
+    };
+
+    expect(body.result.serverInfo.name).toBe("computer_use");
+    expect(body.result.instructions).toContain("computer_use.api");
+    expect(body.result.instructions).toContain("switch to interactive mode");
+  });
+
+  it("requires bearer auth before listing tools", async () => {
+    ingress = new ComputerUseMcpIngress();
+    const info = await ingress.start();
+
+    const unauthorized = await fetch(`${info.url}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(unauthorized.status).toBe(401);
+
+    const authorized = await fetch(`${info.url}/mcp`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${info.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+    });
+    const body = (await authorized.json()) as { result: { tools: Array<{ name: string }> } };
+    expect(body.result.tools.map((tool) => tool.name)).toContain("get_window_state");
+  });
+});

--- a/src/main/computer-use/ComputerUseMcpIngress.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.ts
@@ -1,4 +1,6 @@
+import type { McpThreadIdentity } from "@/shared/browserMcpThread";
 import { createComputerUseDriver } from "./drivers";
+import type { ComputerUseDriver } from "./mcp/types";
 import {
   StreamableHttpMcpIngress,
   type StreamableHttpMcpIngressInfo,
@@ -8,27 +10,45 @@ import {
   TOOLS,
   dispatchTool,
   formatToolResult,
+  isInteractiveToolName,
   isKnownToolName,
+  normalizeToolName,
   type ToolContext,
 } from "./mcp/toolRegistry";
 
 export type ComputerUseMcpIngressInfo = StreamableHttpMcpIngressInfo;
 
+export interface ComputerUseActivityEvent {
+  threadId: string;
+  active: boolean;
+  toolName: string;
+}
+
+export interface ComputerUseMcpIngressOptions {
+  driver?: ComputerUseDriver;
+  onActivity?: (event: ComputerUseActivityEvent) => void;
+}
+
 export class ComputerUseMcpIngress {
-  private readonly driver = createComputerUseDriver();
-  private readonly ingress = new StreamableHttpMcpIngress<ToolContext>({
-    // Computer-use drives the host's real mouse/keyboard/windows, so the ingress
-    // must never be reachable off the machine — bind loopback only (unlike the
-    // browser ingress, which binds 0.0.0.0 for WSL reachability).
-    bindHost: "127.0.0.1",
-    serverInfo: { name: "computer_use", version: "0.1.0" },
-    instructions: COMPUTER_USE_MCP_INSTRUCTIONS,
-    tools: TOOLS,
-    isKnownToolName,
-    buildContext: () => this.buildContext(),
-    dispatchTool,
-    formatToolResult,
-  });
+  private readonly driver: ComputerUseDriver;
+  private readonly ingress: StreamableHttpMcpIngress<ToolContext>;
+
+  constructor(private readonly options: ComputerUseMcpIngressOptions = {}) {
+    this.driver = options.driver ?? createComputerUseDriver();
+    this.ingress = new StreamableHttpMcpIngress<ToolContext>({
+      // Computer-use drives the host's real mouse/keyboard/windows, so the ingress
+      // must never be reachable off the machine — bind loopback only (unlike the
+      // browser ingress, which binds 0.0.0.0 for WSL reachability).
+      bindHost: "127.0.0.1",
+      serverInfo: { name: "computer_use", version: "0.1.0" },
+      instructions: COMPUTER_USE_MCP_INSTRUCTIONS,
+      tools: TOOLS,
+      isKnownToolName,
+      buildContext: (identity) => this.buildContext(identity),
+      dispatchTool: (name, args, ctx) => this.dispatch(name, args, ctx),
+      formatToolResult,
+    });
+  }
 
   start(): Promise<ComputerUseMcpIngressInfo> {
     return this.ingress.start();
@@ -38,14 +58,38 @@ export class ComputerUseMcpIngress {
     return this.ingress.getInfo();
   }
 
+  interruptActiveActions(): void {
+    this.driver.dispose();
+  }
+
   dispose(): void {
     this.ingress.dispose();
     // Release the driver's long-lived resources (e.g. the Windows persistent
     // PowerShell host) so the child process doesn't leak on app teardown.
-    this.driver.dispose?.();
+    this.driver.dispose();
   }
 
-  private buildContext(): ToolContext {
-    return { driver: this.driver };
+  private buildContext(identity: McpThreadIdentity): ToolContext {
+    return {
+      driver: this.driver,
+      ...(identity.threadId ? { threadId: identity.threadId } : {}),
+    };
+  }
+
+  private async dispatch(
+    name: string,
+    args: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<unknown> {
+    if (!ctx.threadId || !isInteractiveToolName(name)) {
+      return await dispatchTool(name, args, ctx);
+    }
+    const event = { threadId: ctx.threadId, toolName: normalizeToolName(name) };
+    this.options.onActivity?.({ ...event, active: true });
+    try {
+      return await dispatchTool(name, args, ctx);
+    } finally {
+      this.options.onActivity?.({ ...event, active: false });
+    }
   }
 }

--- a/src/main/computer-use/ComputerUseMcpIngress.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.ts
@@ -40,6 +40,9 @@ export class ComputerUseMcpIngress {
 
   dispose(): void {
     this.ingress.dispose();
+    // Release the driver's long-lived resources (e.g. the Windows persistent
+    // PowerShell host) so the child process doesn't leak on app teardown.
+    this.driver.dispose?.();
   }
 
   private buildContext(): ToolContext {

--- a/src/main/computer-use/ComputerUseMcpIngress.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.ts
@@ -1,0 +1,48 @@
+import { createComputerUseDriver } from "./drivers";
+import {
+  StreamableHttpMcpIngress,
+  type StreamableHttpMcpIngressInfo,
+} from "../mcp/StreamableHttpMcpIngress";
+import {
+  COMPUTER_USE_MCP_INSTRUCTIONS,
+  TOOLS,
+  dispatchTool,
+  formatToolResult,
+  isKnownToolName,
+  type ToolContext,
+} from "./mcp/toolRegistry";
+
+export type ComputerUseMcpIngressInfo = StreamableHttpMcpIngressInfo;
+
+export class ComputerUseMcpIngress {
+  private readonly driver = createComputerUseDriver();
+  private readonly ingress = new StreamableHttpMcpIngress<ToolContext>({
+    // Computer-use drives the host's real mouse/keyboard/windows, so the ingress
+    // must never be reachable off the machine — bind loopback only (unlike the
+    // browser ingress, which binds 0.0.0.0 for WSL reachability).
+    bindHost: "127.0.0.1",
+    serverInfo: { name: "computer_use", version: "0.1.0" },
+    instructions: COMPUTER_USE_MCP_INSTRUCTIONS,
+    tools: TOOLS,
+    isKnownToolName,
+    buildContext: () => this.buildContext(),
+    dispatchTool,
+    formatToolResult,
+  });
+
+  start(): Promise<ComputerUseMcpIngressInfo> {
+    return this.ingress.start();
+  }
+
+  getInfo(): ComputerUseMcpIngressInfo | null {
+    return this.ingress.getInfo();
+  }
+
+  dispose(): void {
+    this.ingress.dispose();
+  }
+
+  private buildContext(): ToolContext {
+    return { driver: this.driver };
+  }
+}

--- a/src/main/computer-use/drivers/common.ts
+++ b/src/main/computer-use/drivers/common.ts
@@ -1,5 +1,8 @@
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { ComputerUseWindow } from "../mcp/types";
+
+const execFileAsync = promisify(execFile);
 
 export function readRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
@@ -50,67 +53,18 @@ export function runProcess(
   command: string,
   args: string[],
   options?: {
-    input?: string;
     timeoutMs?: number;
     maxBufferBytes?: number;
   },
 ): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    });
-    const maxBufferBytes = options?.maxBufferBytes ?? 12 * 1024 * 1024;
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    let stdoutBytes = 0;
-    let stderrBytes = 0;
-    let settled = false;
-    const timer =
-      options?.timeoutMs && options.timeoutMs > 0
-        ? setTimeout(() => {
-            if (settled) return;
-            settled = true;
-            child.kill();
-            reject(new Error(`${command} timed out after ${options.timeoutMs}ms`));
-          }, options.timeoutMs)
-        : undefined;
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdoutBytes += chunk.length;
-      if (stdoutBytes > maxBufferBytes) {
-        child.kill();
-        return;
-      }
-      stdout.push(chunk);
-    });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderrBytes += chunk.length;
-      if (stderrBytes <= maxBufferBytes) stderr.push(chunk);
-    });
-    child.on("error", (error) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      reject(error);
-    });
-    child.on("close", (code) => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      const out = Buffer.concat(stdout).toString("utf8");
-      const err = Buffer.concat(stderr).toString("utf8");
-      if (stdoutBytes > maxBufferBytes) {
-        reject(new Error(`${command} output exceeded ${maxBufferBytes} bytes`));
-        return;
-      }
-      if (code !== 0) {
-        reject(new Error(err.trim() || `${command} exited with code ${code}`));
-        return;
-      }
-      resolve({ stdout: out, stderr: err });
-    });
-    if (options?.input) child.stdin.end(options.input);
-    else child.stdin.end();
+  // Native execFile enforces timeout/maxBuffer and appends stderr to the
+  // thrown error's message ("Command failed: <cmd>\n<stderr>"), so failures
+  // still surface the process's own diagnostics.
+  return execFileAsync(command, args, {
+    windowsHide: true,
+    maxBuffer: options?.maxBufferBytes ?? 12 * 1024 * 1024,
+    ...(options?.timeoutMs !== undefined && options.timeoutMs > 0
+      ? { timeout: options.timeoutMs }
+      : {}),
   });
 }

--- a/src/main/computer-use/drivers/common.ts
+++ b/src/main/computer-use/drivers/common.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import type { ComputerUseWindow } from "../mcp/types";
+
+export function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+export function readWindow(value: unknown): ComputerUseWindow {
+  const obj = readRecord(value);
+  const id = Number(obj.id);
+  const app = typeof obj.app === "string" ? obj.app : "";
+  if (!Number.isFinite(id) || !app) {
+    throw new Error("window with app and id is required");
+  }
+  return {
+    app,
+    id,
+    ...(typeof obj.title === "string" ? { title: obj.title } : {}),
+    ...(typeof obj.x === "number" ? { x: obj.x } : {}),
+    ...(typeof obj.y === "number" ? { y: obj.y } : {}),
+    ...(typeof obj.width === "number" ? { width: obj.width } : {}),
+    ...(typeof obj.height === "number" ? { height: obj.height } : {}),
+  };
+}
+
+export function readNumber(value: unknown, name: string): number {
+  const next = Number(value);
+  if (!Number.isFinite(next)) throw new Error(`${name} is required`);
+  return next;
+}
+
+export function readString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} is required`);
+  return value;
+}
+
+export function runProcess(
+  command: string,
+  args: string[],
+  options?: {
+    input?: string;
+    timeoutMs?: number;
+    maxBufferBytes?: number;
+  },
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const maxBufferBytes = options?.maxBufferBytes ?? 12 * 1024 * 1024;
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let settled = false;
+    const timer =
+      options?.timeoutMs && options.timeoutMs > 0
+        ? setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            child.kill();
+            reject(new Error(`${command} timed out after ${options.timeoutMs}ms`));
+          }, options.timeoutMs)
+        : undefined;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes > maxBufferBytes) {
+        child.kill();
+        return;
+      }
+      stdout.push(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes <= maxBufferBytes) stderr.push(chunk);
+    });
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      const out = Buffer.concat(stdout).toString("utf8");
+      const err = Buffer.concat(stderr).toString("utf8");
+      if (stdoutBytes > maxBufferBytes) {
+        reject(new Error(`${command} output exceeded ${maxBufferBytes} bytes`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(err.trim() || `${command} exited with code ${code}`));
+        return;
+      }
+      resolve({ stdout: out, stderr: err });
+    });
+    if (options?.input) child.stdin.end(options.input);
+    else child.stdin.end();
+  });
+}

--- a/src/main/computer-use/drivers/common.ts
+++ b/src/main/computer-use/drivers/common.ts
@@ -24,9 +24,21 @@ export function readWindow(value: unknown): ComputerUseWindow {
 }
 
 export function readNumber(value: unknown, name: string): number {
-  const next = Number(value);
-  if (!Number.isFinite(next)) throw new Error(`${name} is required`);
-  return next;
+  // Number("")/Number(null)/Number("  ")/Number(true) all coerce to a finite
+  // number, so a missing coordinate would silently become 0 (a top-left click).
+  // Require a real number or a strictly-numeric string before coercing.
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error(`${name} is required`);
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) throw new Error(`${name} is required`);
+    const next = Number(trimmed);
+    if (!Number.isFinite(next)) throw new Error(`${name} is required`);
+    return next;
+  }
+  throw new Error(`${name} is required`);
 }
 
 export function readString(value: unknown, name: string): string {

--- a/src/main/computer-use/drivers/index.ts
+++ b/src/main/computer-use/drivers/index.ts
@@ -1,0 +1,67 @@
+import type { ComputerUseDriver } from "../mcp/types";
+import { MacComputerUseDriver } from "./macos";
+import { WindowsComputerUseDriver } from "./windows";
+
+class UnsupportedComputerUseDriver implements ComputerUseDriver {
+  private unavailable(): never {
+    throw new Error("Computer Use is only available on macOS and Windows.");
+  }
+
+  listApps(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  listWindows(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  getWindow(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  getWindowState(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  activateWindow(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  click(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  typeText(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  pressKey(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  scroll(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  drag(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  launchApp(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  setValue(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+
+  performSecondaryAction(): Promise<never> {
+    return Promise.reject(this.unavailable());
+  }
+}
+
+export function createComputerUseDriver(): ComputerUseDriver {
+  if (process.platform === "win32") return new WindowsComputerUseDriver();
+  if (process.platform === "darwin") return new MacComputerUseDriver();
+  return new UnsupportedComputerUseDriver();
+}

--- a/src/main/computer-use/drivers/index.ts
+++ b/src/main/computer-use/drivers/index.ts
@@ -3,8 +3,8 @@ import { MacComputerUseDriver } from "./macos";
 import { WindowsComputerUseDriver } from "./windows";
 
 class UnsupportedComputerUseDriver implements ComputerUseDriver {
-  private unavailable(): never {
-    throw new Error("Computer Use is only available on macOS and Windows.");
+  private unavailable(): Promise<never> {
+    return Promise.reject(new Error("Computer Use is only available on macOS and Windows."));
   }
 
   dispose(): void {
@@ -12,55 +12,47 @@ class UnsupportedComputerUseDriver implements ComputerUseDriver {
   }
 
   listApps(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   listWindows(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   getWindow(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   getWindowState(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   activateWindow(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   click(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   typeText(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   pressKey(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   scroll(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   drag(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 
   launchApp(): Promise<never> {
-    return Promise.reject(this.unavailable());
-  }
-
-  setValue(): Promise<never> {
-    return Promise.reject(this.unavailable());
-  }
-
-  performSecondaryAction(): Promise<never> {
-    return Promise.reject(this.unavailable());
+    return this.unavailable();
   }
 }
 

--- a/src/main/computer-use/drivers/index.ts
+++ b/src/main/computer-use/drivers/index.ts
@@ -7,6 +7,10 @@ class UnsupportedComputerUseDriver implements ComputerUseDriver {
     throw new Error("Computer Use is only available on macOS and Windows.");
   }
 
+  dispose(): void {
+    // No long-lived resources to release.
+  }
+
   listApps(): Promise<never> {
     return Promise.reject(this.unavailable());
   }

--- a/src/main/computer-use/drivers/macos.ts
+++ b/src/main/computer-use/drivers/macos.ts
@@ -169,6 +169,10 @@ end tell
 }
 
 export class MacComputerUseDriver implements ComputerUseDriver {
+  dispose(): void {
+    // macOS spawns a fresh osascript per call, so there is nothing to release.
+  }
+
   async listApps(): Promise<ComputerUseApp[]> {
     const windows = await listMacWindows();
     const groups = new Map<string, ComputerUseWindow[]>();
@@ -200,8 +204,10 @@ export class MacComputerUseDriver implements ComputerUseDriver {
   }
 
   async getWindowState(input: {
+    format?: "jpeg" | "png";
     include_screenshot?: boolean;
     include_text?: boolean;
+    max_dimension?: number;
     window: ComputerUseWindow;
   }): Promise<ComputerUseWindowState> {
     const window = await this.getWindow(input.window);
@@ -210,6 +216,14 @@ export class MacComputerUseDriver implements ComputerUseDriver {
       "macOS window listing and screenshots are passive. Input actions switch to interactive mode and activate the target app.",
       "macOS captures the visible screen region; occluded windows and locked screens may require the user to reveal or unlock the desktop.",
     ];
+    if (
+      input.max_dimension !== undefined ||
+      (input.format !== undefined && input.format !== "png")
+    ) {
+      notes.push(
+        "macOS screenshots are always full-resolution PNG; max_dimension and format are not applied on this platform yet.",
+      );
+    }
     if (input.include_screenshot !== false) {
       const captureDir = join(tmpdir(), "lightcode-computer-use");
       await mkdir(captureDir, { recursive: true });

--- a/src/main/computer-use/drivers/macos.ts
+++ b/src/main/computer-use/drivers/macos.ts
@@ -9,6 +9,19 @@ import type {
 } from "../mcp/types";
 import { readNumber, runProcess } from "./common";
 
+// Reads the pixel dimensions encoded in a PNG's IHDR chunk (width at byte 16,
+// height at byte 20, both big-endian uint32). Returns null for non-PNG or
+// truncated buffers.
+function readPngPixelSize(bytes: Buffer): { width: number; height: number } | null {
+  const PNG_SIGNATURE = "\x89PNG\r\n\x1a\n";
+  if (bytes.length < 24) return null;
+  if (bytes.toString("latin1", 0, 8) !== PNG_SIGNATURE) return null;
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
 function hashWindowId(input: string): number {
   let hash = 2166136261;
   for (let i = 0; i < input.length; i += 1) {
@@ -29,10 +42,16 @@ function normalizeWindows(value: unknown): ComputerUseWindow[] {
     const y = typeof obj.y === "number" ? obj.y : 0;
     const width = typeof obj.width === "number" ? obj.width : 0;
     const height = typeof obj.height === "number" ? obj.height : 0;
+    // Per-process identity, captured in listMacWindows (unix pid + the window's
+    // ordinal within that process). We hash on these instead of geometry so the
+    // id stays stable when the user moves or resizes the window. Geometry below
+    // is reported for display/coordinate math only.
+    const pid = typeof obj.pid === "number" ? obj.pid : 0;
+    const index = typeof obj.index === "number" ? obj.index : 0;
     if (!app || width <= 0 || height <= 0) continue;
     windows.push({
       app,
-      id: hashWindowId(`${app}\n${title ?? ""}\n${x},${y},${width},${height}`),
+      id: hashWindowId(`${app}\n${pid}\n${index}`),
       ...(title ? { title } : {}),
       x,
       y,
@@ -58,7 +77,11 @@ const windows = [];
 for (const process of app.applicationProcesses()) {
   if (!process.visible()) continue;
   const appName = process.name();
-  for (const window of process.windows()) {
+  let pid = 0;
+  try { pid = Number(process.unixId()) || 0; } catch {}
+  const procWindows = process.windows();
+  for (let index = 0; index < procWindows.length; index += 1) {
+    const window = procWindows[index];
     let position = [0, 0];
     let size = [0, 0];
     try { position = window.position(); } catch {}
@@ -67,6 +90,8 @@ for (const process of app.applicationProcesses()) {
     try { title = window.name(); } catch {}
     windows.push({
       app: appName,
+      pid,
+      index,
       title,
       x: Number(position[0]) || 0,
       y: Number(position[1]) || 0,
@@ -206,12 +231,26 @@ export class MacComputerUseDriver implements ComputerUseDriver {
           },
         );
         const bytes = await readFile(path);
+        // window.width/height are in POINTS, but `screencapture` encodes the
+        // native pixel resolution (e.g. 2x on Retina). Report the PNG's actual
+        // pixel dimensions so the model's pixel measurements are correct, and,
+        // when they differ from the point size, tell it the scale factor it must
+        // divide by — click/scroll/drag coordinates are interpreted in POINTS.
+        const pixelSize = readPngPixelSize(bytes);
+        const shotWidth = pixelSize?.width ?? width;
+        const shotHeight = pixelSize?.height ?? height;
+        if (pixelSize && pixelSize.width > width) {
+          const scale = Math.round((pixelSize.width / width) * 100) / 100;
+          notes.push(
+            `Screenshot is HiDPI/Retina: it is ${pixelSize.width}x${pixelSize.height} pixels for a ${width}x${height}-point window (scale ${scale}x). Click/scroll/drag coordinates are in POINTS — divide screenshot pixel coordinates by ${scale} before sending them.`,
+          );
+        }
         screenshots.push({
           id: "window",
           mimeType: "image/png",
           data: bytes.toString("base64"),
-          width,
-          height,
+          width: shotWidth,
+          height: shotHeight,
           originX: x,
           originY: y,
           zIndex: 0,
@@ -219,6 +258,11 @@ export class MacComputerUseDriver implements ComputerUseDriver {
       } finally {
         await rm(path, { force: true });
       }
+    }
+    if (input.include_text === true) {
+      notes.push(
+        "The accessibility tree is a placeholder (window title and app name only); detailed macOS accessibility text is not extracted yet. Do not rely on it for element targeting — use the screenshot and coordinate input.",
+      );
     }
     return {
       window,
@@ -254,10 +298,23 @@ export class MacComputerUseDriver implements ComputerUseDriver {
     const x = readNumber(window.x, "window.x") + readNumber(input.x, "x");
     const y = readNumber(window.y, "window.y") + readNumber(input.y, "y");
     const count = Math.max(1, Math.trunc(input.click_count ?? 1));
+    // System Events exposes distinct `click` / `right click` verbs but has no
+    // middle-button verb; throw rather than silently left-clicking.
+    const button = (input.mouse_button ?? "left").trim().toLowerCase();
+    let verb: "click" | "right click";
+    if (button === "right" || button === "r") {
+      verb = "right click";
+    } else if (button === "middle" || button === "m") {
+      throw new Error(
+        "middle-button click is not supported on macOS via System Events; use mouse_button 'left' or 'right'.",
+      );
+    } else {
+      verb = "click";
+    }
     await runAppleScript(`
 tell application "System Events"
-  click at {${x}, ${y}}
-  ${count > 1 ? `click at {${x}, ${y}}` : ""}
+  ${verb} at {${x}, ${y}}
+  ${count > 1 ? `${verb} at {${x}, ${y}}` : ""}
 end tell
 `);
     return { ok: true, mode: "interactive" };
@@ -311,11 +368,28 @@ end tell
   }): Promise<{ ok: true; mode: "interactive" }> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
-    const direction = input.scrollY >= 0 ? "down" : "up";
-    const steps = Math.max(1, Math.min(20, Math.round(Math.abs(input.scrollY) / 120)));
+    // NOTE (needs live-mac verification): System Events has no verb to move the
+    // pointer, so we cannot target the (x,y) point the way the Windows driver
+    // does with SetCursorPos; the scroll lands on whatever is under the current
+    // pointer / key focus in the activated app. The `scroll <direction> <n>`
+    // command itself is not documented for System Events and may be unreliable
+    // on some macOS versions. We now honor BOTH axes (previously scrollX was
+    // dropped): vertical via up/down, horizontal via left/right.
+    const commands: string[] = [];
+    if (input.scrollY !== 0) {
+      const vDir = input.scrollY >= 0 ? "down" : "up";
+      const vSteps = Math.max(1, Math.min(20, Math.round(Math.abs(input.scrollY) / 120)));
+      commands.push(`scroll ${vDir} ${vSteps}`);
+    }
+    if (input.scrollX !== 0) {
+      const hDir = input.scrollX >= 0 ? "right" : "left";
+      const hSteps = Math.max(1, Math.min(20, Math.round(Math.abs(input.scrollX) / 120)));
+      commands.push(`scroll ${hDir} ${hSteps}`);
+    }
+    if (commands.length === 0) return { ok: true, mode: "interactive" };
     await runAppleScript(`
 tell application "System Events"
-  scroll ${direction} ${steps}
+  ${commands.join("\n  ")}
 end tell
 `);
     return { ok: true, mode: "interactive" };

--- a/src/main/computer-use/drivers/macos.ts
+++ b/src/main/computer-use/drivers/macos.ts
@@ -1,0 +1,365 @@
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ComputerUseApp,
+  ComputerUseDriver,
+  ComputerUseWindow,
+  ComputerUseWindowState,
+} from "../mcp/types";
+import { readNumber, runProcess } from "./common";
+
+function hashWindowId(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function normalizeWindows(value: unknown): ComputerUseWindow[] {
+  const items = Array.isArray(value) ? value : value ? [value] : [];
+  const windows: ComputerUseWindow[] = [];
+  for (const item of items) {
+    const obj = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
+    const app = typeof obj.app === "string" ? obj.app : "";
+    const title = typeof obj.title === "string" ? obj.title : undefined;
+    const x = typeof obj.x === "number" ? obj.x : 0;
+    const y = typeof obj.y === "number" ? obj.y : 0;
+    const width = typeof obj.width === "number" ? obj.width : 0;
+    const height = typeof obj.height === "number" ? obj.height : 0;
+    if (!app || width <= 0 || height <= 0) continue;
+    windows.push({
+      app,
+      id: hashWindowId(`${app}\n${title ?? ""}\n${x},${y},${width},${height}`),
+      ...(title ? { title } : {}),
+      x,
+      y,
+      width,
+      height,
+    });
+  }
+  return windows;
+}
+
+async function osascript<T>(script: string): Promise<T> {
+  const { stdout } = await runProcess("/usr/bin/osascript", ["-l", "JavaScript", "-e", script], {
+    timeoutMs: 15_000,
+  });
+  return JSON.parse(stdout.trim()) as T;
+}
+
+async function listMacWindows(): Promise<ComputerUseWindow[]> {
+  const raw = await osascript<unknown>(`
+ObjC.import("stdlib");
+const app = Application("System Events");
+const windows = [];
+for (const process of app.applicationProcesses()) {
+  if (!process.visible()) continue;
+  const appName = process.name();
+  for (const window of process.windows()) {
+    let position = [0, 0];
+    let size = [0, 0];
+    try { position = window.position(); } catch {}
+    try { size = window.size(); } catch {}
+    let title = "";
+    try { title = window.name(); } catch {}
+    windows.push({
+      app: appName,
+      title,
+      x: Number(position[0]) || 0,
+      y: Number(position[1]) || 0,
+      width: Number(size[0]) || 0,
+      height: Number(size[1]) || 0,
+    });
+  }
+}
+JSON.stringify(windows);
+`);
+  return normalizeWindows(raw);
+}
+
+function keyCodeForToken(token: string): number | undefined {
+  const t = token.trim().toLowerCase();
+  const map: Record<string, number> = {
+    return: 36,
+    enter: 36,
+    tab: 48,
+    escape: 53,
+    esc: 53,
+    delete: 51,
+    backspace: 51,
+    left: 123,
+    arrowleft: 123,
+    right: 124,
+    arrowright: 124,
+    down: 125,
+    arrowdown: 125,
+    up: 126,
+    arrowup: 126,
+    home: 115,
+    end: 119,
+    pageup: 116,
+    page_up: 116,
+    pagedown: 121,
+    page_down: 121,
+    space: 49,
+  };
+  if (map[t] !== undefined) return map[t];
+  const fKey = /^f([1-9]|1[0-9]|2[0])$/.exec(t);
+  if (fKey) {
+    const codes = [
+      122, 120, 99, 118, 96, 97, 98, 100, 101, 109, 103, 111, 105, 107, 113, 106, 64, 79, 80, 90,
+    ];
+    return codes[Number(fKey[1]) - 1];
+  }
+  return undefined;
+}
+
+function modifierForToken(token: string): string | undefined {
+  const t = token.trim().toLowerCase();
+  if (t === "control" || t === "ctrl" || t === "control_l" || t === "control_r")
+    return "control down";
+  if (t === "shift" || t === "shift_l" || t === "shift_r") return "shift down";
+  if (t === "alt" || t === "option" || t === "alt_l" || t === "alt_r") return "option down";
+  if (t === "command" || t === "cmd" || t === "meta") return "command down";
+  return undefined;
+}
+
+function quoteAppleScript(value: string): string {
+  return JSON.stringify(value);
+}
+
+async function runAppleScript(script: string): Promise<void> {
+  await runProcess("/usr/bin/osascript", ["-e", script], { timeoutMs: 10_000 });
+}
+
+async function activateApp(app: string): Promise<void> {
+  await runAppleScript(`
+tell application "System Events"
+  set frontmost of first application process whose name is ${quoteAppleScript(app)} to true
+end tell
+`);
+}
+
+export class MacComputerUseDriver implements ComputerUseDriver {
+  async listApps(): Promise<ComputerUseApp[]> {
+    const windows = await listMacWindows();
+    const groups = new Map<string, ComputerUseWindow[]>();
+    for (const window of windows) {
+      const prev = groups.get(window.app) ?? [];
+      prev.push(window);
+      groups.set(window.app, prev);
+    }
+    return [...groups.entries()].map(([id, appWindows]) => ({
+      id,
+      displayName: id,
+      isRunning: true,
+      windows: appWindows,
+    }));
+  }
+
+  listWindows(): Promise<ComputerUseWindow[]> {
+    return listMacWindows();
+  }
+
+  async getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow> {
+    const windows = await listMacWindows();
+    const window = windows.find(
+      (candidate) =>
+        candidate.id === input.id && (input.app === undefined || candidate.app === input.app),
+    );
+    if (!window) throw new Error("Window is no longer available.");
+    return window;
+  }
+
+  async getWindowState(input: {
+    include_screenshot?: boolean;
+    include_text?: boolean;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseWindowState> {
+    const window = await this.getWindow(input.window);
+    const screenshots: ComputerUseWindowState["screenshots"] = [];
+    const notes = [
+      "macOS window listing and screenshots are passive. Input actions switch to interactive mode and activate the target app.",
+      "macOS captures the visible screen region; occluded windows and locked screens may require the user to reveal or unlock the desktop.",
+    ];
+    if (input.include_screenshot !== false) {
+      const captureDir = join(tmpdir(), "lightcode-computer-use");
+      await mkdir(captureDir, { recursive: true });
+      const path = join(
+        captureDir,
+        `capture-${Date.now()}-${Math.random().toString(16).slice(2)}.png`,
+      );
+      try {
+        const x = readNumber(window.x, "window.x");
+        const y = readNumber(window.y, "window.y");
+        const width = Math.max(1, readNumber(window.width, "window.width"));
+        const height = Math.max(1, readNumber(window.height, "window.height"));
+        await runProcess(
+          "/usr/sbin/screencapture",
+          ["-x", "-R", `${x},${y},${width},${height}`, path],
+          {
+            timeoutMs: 10_000,
+            maxBufferBytes: 1024 * 1024,
+          },
+        );
+        const bytes = await readFile(path);
+        screenshots.push({
+          id: "window",
+          mimeType: "image/png",
+          data: bytes.toString("base64"),
+          width,
+          height,
+          originX: x,
+          originY: y,
+          zIndex: 0,
+        });
+      } finally {
+        await rm(path, { force: true });
+      }
+    }
+    return {
+      window,
+      accessibility:
+        input.include_text === true
+          ? {
+              tree: `Window: "${window.title ?? ""}", App: ${window.app}`,
+            }
+          : null,
+      screenshots,
+      mode: "passive",
+      notes,
+    };
+  }
+
+  async activateWindow(input: {
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async click(input: {
+    click_count?: number;
+    mouse_button?: string;
+    window: ComputerUseWindow;
+    x?: number;
+    y?: number;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    const x = readNumber(window.x, "window.x") + readNumber(input.x, "x");
+    const y = readNumber(window.y, "window.y") + readNumber(input.y, "y");
+    const count = Math.max(1, Math.trunc(input.click_count ?? 1));
+    await runAppleScript(`
+tell application "System Events"
+  click at {${x}, ${y}}
+  ${count > 1 ? `click at {${x}, ${y}}` : ""}
+end tell
+`);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    await runAppleScript(`
+tell application "System Events"
+  keystroke ${quoteAppleScript(input.text)}
+end tell
+`);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    const tokens = input.key
+      .split("+")
+      .map((token) => token.trim())
+      .filter(Boolean);
+    const modifiers = tokens
+      .map(modifierForToken)
+      .filter((token): token is string => Boolean(token));
+    const keyToken = tokens.find((token) => !modifierForToken(token));
+    if (!keyToken) throw new Error("key is required");
+    const using = modifiers.length ? ` using {${modifiers.join(", ")}}` : "";
+    const keyCode = keyCodeForToken(keyToken);
+    await runAppleScript(`
+tell application "System Events"
+  ${keyCode === undefined ? `keystroke ${quoteAppleScript(keyToken)}${using}` : `key code ${keyCode}${using}`}
+end tell
+`);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async scroll(input: {
+    scrollX: number;
+    scrollY: number;
+    window: ComputerUseWindow;
+    x: number;
+    y: number;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    const direction = input.scrollY >= 0 ? "down" : "up";
+    const steps = Math.max(1, Math.min(20, Math.round(Math.abs(input.scrollY) / 120)));
+    await runAppleScript(`
+tell application "System Events"
+  scroll ${direction} ${steps}
+end tell
+`);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async drag(input: {
+    from_x: number;
+    from_y: number;
+    to_x: number;
+    to_y: number;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    const window = await this.getWindow(input.window);
+    await activateApp(window.app);
+    const fromX = readNumber(window.x, "window.x") + input.from_x;
+    const fromY = readNumber(window.y, "window.y") + input.from_y;
+    const toX = readNumber(window.x, "window.x") + input.to_x;
+    const toY = readNumber(window.y, "window.y") + input.to_y;
+    await runAppleScript(`
+tell application "System Events"
+  drag from {${fromX}, ${fromY}} to {${toX}, ${toY}}
+end tell
+`);
+    return { ok: true, mode: "interactive" };
+  }
+
+  async launchApp(input: { app: string }): Promise<{ ok: true }> {
+    if (input.app.startsWith("/") || input.app.endsWith(".app")) {
+      await runProcess("/usr/bin/open", [input.app], { timeoutMs: 10_000 });
+    } else {
+      await runProcess("/usr/bin/open", ["-a", input.app], { timeoutMs: 10_000 });
+    }
+    return { ok: true };
+  }
+
+  setValue(): Promise<{ ok: true; mode: "interactive" }> {
+    throw new Error(
+      "set_value is not supported yet; click or focus the target field, then use type_text.",
+    );
+  }
+
+  performSecondaryAction(): Promise<{ ok: true; mode: "interactive" }> {
+    throw new Error(
+      "perform_secondary_action is not supported yet; use keyboard navigation or coordinate input.",
+    );
+  }
+}

--- a/src/main/computer-use/drivers/macos.ts
+++ b/src/main/computer-use/drivers/macos.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type {
   ComputerUseApp,
   ComputerUseDriver,
+  ComputerUseInteractiveResult,
   ComputerUseWindow,
   ComputerUseWindowState,
 } from "../mcp/types";
@@ -69,14 +70,21 @@ async function osascript<T>(script: string): Promise<T> {
   return JSON.parse(stdout.trim()) as T;
 }
 
-async function listMacWindows(): Promise<ComputerUseWindow[]> {
+// `appFilter` (exact process-name match, same resolution the unfiltered path
+// uses) lets interactive actions skip enumerating every visible process's
+// windows — System Events window queries are Apple Events round-trips and are
+// by far the slowest part of each action. list_windows/list_apps pass no
+// filter and keep the full enumeration.
+async function listMacWindows(appFilter?: string): Promise<ComputerUseWindow[]> {
   const raw = await osascript<unknown>(`
 ObjC.import("stdlib");
 const app = Application("System Events");
+const appFilter = ${JSON.stringify(appFilter ?? null)};
 const windows = [];
 for (const process of app.applicationProcesses()) {
   if (!process.visible()) continue;
   const appName = process.name();
+  if (appFilter !== null && appName !== appFilter) continue;
   let pid = 0;
   try { pid = Number(process.unixId()) || 0; } catch {}
   const procWindows = process.windows();
@@ -194,7 +202,7 @@ export class MacComputerUseDriver implements ComputerUseDriver {
   }
 
   async getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow> {
-    const windows = await listMacWindows();
+    const windows = await listMacWindows(input.app);
     const window = windows.find(
       (candidate) =>
         candidate.id === input.id && (input.app === undefined || candidate.app === input.app),
@@ -216,21 +224,17 @@ export class MacComputerUseDriver implements ComputerUseDriver {
       "macOS window listing and screenshots are passive. Input actions switch to interactive mode and activate the target app.",
       "macOS captures the visible screen region; occluded windows and locked screens may require the user to reveal or unlock the desktop.",
     ];
-    if (
-      input.max_dimension !== undefined ||
-      (input.format !== undefined && input.format !== "png")
-    ) {
-      notes.push(
-        "macOS screenshots are always full-resolution PNG; max_dimension and format are not applied on this platform yet.",
-      );
-    }
     if (input.include_screenshot !== false) {
       const captureDir = join(tmpdir(), "lightcode-computer-use");
       await mkdir(captureDir, { recursive: true });
-      const path = join(
-        captureDir,
-        `capture-${Date.now()}-${Math.random().toString(16).slice(2)}.png`,
-      );
+      // Mirror the Windows driver's defaults: downscale to 1280px max and
+      // encode JPEG (quality 75) so passive captures don't bill multi-MB
+      // Retina PNGs as image tokens on every get_window_state.
+      const maxDimension = input.max_dimension ?? 1280;
+      const format = input.format ?? "jpeg";
+      const token = `capture-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const capturePath = join(captureDir, `${token}.png`);
+      const encodedPath = join(captureDir, `${token}-out.${format === "jpeg" ? "jpg" : "png"}`);
       try {
         const x = readNumber(window.x, "window.x");
         const y = readNumber(window.y, "window.y");
@@ -238,30 +242,55 @@ export class MacComputerUseDriver implements ComputerUseDriver {
         const height = Math.max(1, readNumber(window.height, "window.height"));
         await runProcess(
           "/usr/sbin/screencapture",
-          ["-x", "-R", `${x},${y},${width},${height}`, path],
+          ["-x", "-R", `${x},${y},${width},${height}`, capturePath],
           {
             timeoutMs: 10_000,
             maxBufferBytes: 1024 * 1024,
           },
         );
-        const bytes = await readFile(path);
         // window.width/height are in POINTS, but `screencapture` encodes the
-        // native pixel resolution (e.g. 2x on Retina). Report the PNG's actual
-        // pixel dimensions so the model's pixel measurements are correct, and,
-        // when they differ from the point size, tell it the scale factor it must
-        // divide by — click/scroll/drag coordinates are interpreted in POINTS.
+        // native pixel resolution (e.g. 2x on Retina). Read the PNG's actual
+        // pixel dimensions, then post-process with `sips` (ships with macOS)
+        // to apply max_dimension/format before base64-encoding.
+        let bytes = await readFile(capturePath);
         const pixelSize = readPngPixelSize(bytes);
-        const shotWidth = pixelSize?.width ?? width;
-        const shotHeight = pixelSize?.height ?? height;
-        if (pixelSize && pixelSize.width > width) {
-          const scale = Math.round((pixelSize.width / width) * 100) / 100;
+        let shotWidth = pixelSize?.width ?? width;
+        let shotHeight = pixelSize?.height ?? height;
+        let mimeType = "image/png";
+        const needsResample = maxDimension > 0 && Math.max(shotWidth, shotHeight) > maxDimension;
+        const needsJpeg = format === "jpeg";
+        if (needsResample || needsJpeg) {
+          const sipsArgs: string[] = [];
+          if (needsResample) sipsArgs.push("--resampleHeightWidthMax", String(maxDimension));
+          if (needsJpeg) sipsArgs.push("-s", "format", "jpeg", "-s", "formatOptions", "75");
+          sipsArgs.push(capturePath, "--out", encodedPath);
+          await runProcess("/usr/bin/sips", sipsArgs, { timeoutMs: 10_000 });
+          // Ask sips for the dimensions it actually encoded so the reported
+          // size matches the payload exactly (its rounding may differ by 1px).
+          const { stdout } = await runProcess(
+            "/usr/bin/sips",
+            ["-g", "pixelWidth", "-g", "pixelHeight", encodedPath],
+            { timeoutMs: 10_000 },
+          );
+          const encodedWidth = /pixelWidth:\s*(\d+)/.exec(stdout);
+          const encodedHeight = /pixelHeight:\s*(\d+)/.exec(stdout);
+          if (encodedWidth) shotWidth = Number(encodedWidth[1]);
+          if (encodedHeight) shotHeight = Number(encodedHeight[1]);
+          bytes = await readFile(encodedPath);
+          if (needsJpeg) mimeType = "image/jpeg";
+        }
+        // Click/scroll/drag coordinates are interpreted in POINTS. When the
+        // encoded pixel size differs from the point size (Retina capture,
+        // downscaling, or both), tell the model the factor to divide by.
+        const scale = Math.round((shotWidth / width) * 100) / 100;
+        if (scale !== 1) {
           notes.push(
-            `Screenshot is HiDPI/Retina: it is ${pixelSize.width}x${pixelSize.height} pixels for a ${width}x${height}-point window (scale ${scale}x). Click/scroll/drag coordinates are in POINTS — divide screenshot pixel coordinates by ${scale} before sending them.`,
+            `Screenshot is ${shotWidth}x${shotHeight} pixels for a ${width}x${height}-point window (scale ${scale}x). Click/scroll/drag coordinates are in POINTS — divide screenshot pixel coordinates by ${scale} before sending them.`,
           );
         }
         screenshots.push({
           id: "window",
-          mimeType: "image/png",
+          mimeType,
           data: bytes.toString("base64"),
           width: shotWidth,
           height: shotHeight,
@@ -270,7 +299,8 @@ export class MacComputerUseDriver implements ComputerUseDriver {
           zIndex: 0,
         });
       } finally {
-        await rm(path, { force: true });
+        await rm(capturePath, { force: true });
+        await rm(encodedPath, { force: true });
       }
     }
     if (input.include_text === true) {
@@ -294,7 +324,7 @@ export class MacComputerUseDriver implements ComputerUseDriver {
 
   async activateWindow(input: {
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     return { ok: true, mode: "interactive" };
@@ -306,7 +336,7 @@ export class MacComputerUseDriver implements ComputerUseDriver {
     window: ComputerUseWindow;
     x?: number;
     y?: number;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     const x = readNumber(window.x, "window.x") + readNumber(input.x, "x");
@@ -334,10 +364,10 @@ end tell
     return { ok: true, mode: "interactive" };
   }
 
-  async typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }> {
+  async typeText(input: {
+    text: string;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     await runAppleScript(`
@@ -348,10 +378,10 @@ end tell
     return { ok: true, mode: "interactive" };
   }
 
-  async pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }> {
+  async pressKey(input: {
+    key: string;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     const tokens = input.key
@@ -379,7 +409,7 @@ end tell
     window: ComputerUseWindow;
     x: number;
     y: number;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     // NOTE (needs live-mac verification): System Events has no verb to move the
@@ -415,7 +445,7 @@ end tell
     to_x: number;
     to_y: number;
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     const window = await this.getWindow(input.window);
     await activateApp(window.app);
     const fromX = readNumber(window.x, "window.x") + input.from_x;
@@ -437,17 +467,5 @@ end tell
       await runProcess("/usr/bin/open", ["-a", input.app], { timeoutMs: 10_000 });
     }
     return { ok: true };
-  }
-
-  setValue(): Promise<{ ok: true; mode: "interactive" }> {
-    throw new Error(
-      "set_value is not supported yet; click or focus the target field, then use type_text.",
-    );
-  }
-
-  performSecondaryAction(): Promise<{ ok: true; mode: "interactive" }> {
-    throw new Error(
-      "perform_secondary_action is not supported yet; use keyboard navigation or coordinate input.",
-    );
   }
 }

--- a/src/main/computer-use/drivers/windows.test.ts
+++ b/src/main/computer-use/drivers/windows.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateWindowsLaunchAppInput } from "./windows";
+
+describe("validateWindowsLaunchAppInput", () => {
+  it("allows app aliases, drive paths, and shell AppsFolder targets", () => {
+    expect(() => validateWindowsLaunchAppInput("calc")).not.toThrow();
+    expect(() =>
+      validateWindowsLaunchAppInput(String.raw`C:\Windows\System32\notepad.exe`),
+    ).not.toThrow();
+    expect(() =>
+      validateWindowsLaunchAppInput(
+        String.raw`shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App`,
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects URL/protocol handlers and UNC paths", () => {
+    expect(() => validateWindowsLaunchAppInput("ms-settings:privacy")).toThrow(
+      "URL schemes are not allowed",
+    );
+    expect(() => validateWindowsLaunchAppInput("mailto:test@example.com")).toThrow(
+      "URL schemes are not allowed",
+    );
+    expect(() => validateWindowsLaunchAppInput("https://example.com")).toThrow(
+      "URL schemes are not allowed",
+    );
+    expect(() => validateWindowsLaunchAppInput(String.raw`\\server\share\tool.exe`)).toThrow(
+      "UNC paths are not allowed",
+    );
+    expect(() => validateWindowsLaunchAppInput(String.raw`.\tool.exe`)).toThrow(
+      "Relative paths are not allowed",
+    );
+  });
+});

--- a/src/main/computer-use/drivers/windows.ts
+++ b/src/main/computer-use/drivers/windows.ts
@@ -1,0 +1,554 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type {
+  ComputerUseApp,
+  ComputerUseDriver,
+  ComputerUseWindow,
+  ComputerUseWindowState,
+} from "../mcp/types";
+import { runProcess } from "./common";
+
+const WINDOWS_HELPER = String.raw`
+$ErrorActionPreference = 'Stop'
+$raw = [Console]::In.ReadToEnd()
+$request = if ($raw.Trim().Length -gt 0) { $raw | ConvertFrom-Json } else { @{} }
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class LightcodeComputerUseNative {
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT {
+    public int Left;
+    public int Top;
+    public int Right;
+    public int Bottom;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct INPUT {
+    public int type;
+    public InputUnion U;
+  }
+
+  [StructLayout(LayoutKind.Explicit)]
+  public struct InputUnion {
+    [FieldOffset(0)] public MOUSEINPUT mi;
+    [FieldOffset(0)] public KEYBDINPUT ki;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct MOUSEINPUT {
+    public int dx;
+    public int dy;
+    public uint mouseData;
+    public uint dwFlags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  [StructLayout(LayoutKind.Sequential)]
+  public struct KEYBDINPUT {
+    public ushort wVk;
+    public ushort wScan;
+    public uint dwFlags;
+    public uint time;
+    public IntPtr dwExtraInfo;
+  }
+
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr hWnd, IntPtr hdcBlt, uint nFlags);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+  [DllImport("user32.dll")] public static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extraInfo);
+  [DllImport("user32.dll")] public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+  [DllImport("user32.dll")] public static extern short VkKeyScan(char ch);
+
+  public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+  public const uint MOUSEEVENTF_LEFTUP = 0x0004;
+  public const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+  public const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+  public const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020;
+  public const uint MOUSEEVENTF_MIDDLEUP = 0x0040;
+  public const uint MOUSEEVENTF_WHEEL = 0x0800;
+  public const uint MOUSEEVENTF_HWHEEL = 0x01000;
+  public const uint KEYEVENTF_KEYUP = 0x0002;
+  public const uint KEYEVENTF_UNICODE = 0x0004;
+
+  public static List<IntPtr> Windows() {
+    var windows = new List<IntPtr>();
+    EnumWindows((hWnd, lParam) => {
+      windows.Add(hWnd);
+      return true;
+    }, IntPtr.Zero);
+    return windows;
+  }
+
+  public static void SendUnicodeText(string text) {
+    if (String.IsNullOrEmpty(text)) return;
+    var inputs = new INPUT[text.Length * 2];
+    for (var i = 0; i < text.Length; i++) {
+      inputs[i * 2].type = 1;
+      inputs[i * 2].U.ki.wScan = text[i];
+      inputs[i * 2].U.ki.dwFlags = KEYEVENTF_UNICODE;
+      inputs[i * 2 + 1].type = 1;
+      inputs[i * 2 + 1].U.ki.wScan = text[i];
+      inputs[i * 2 + 1].U.ki.dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP;
+    }
+    SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+  }
+
+  public static void Key(ushort vk, bool up) {
+    var input = new INPUT[1];
+    input[0].type = 1;
+    input[0].U.ki.wVk = vk;
+    input[0].U.ki.dwFlags = up ? KEYEVENTF_KEYUP : 0;
+    SendInput(1, input, Marshal.SizeOf(typeof(INPUT)));
+  }
+}
+"@
+
+function Get-WindowObject([IntPtr]$hWnd) {
+  if (-not [LightcodeComputerUseNative]::IsWindow($hWnd)) { return $null }
+  if (-not [LightcodeComputerUseNative]::IsWindowVisible($hWnd)) { return $null }
+  $titleBuilder = [Text.StringBuilder]::new(512)
+  [void][LightcodeComputerUseNative]::GetWindowText($hWnd, $titleBuilder, $titleBuilder.Capacity)
+  $title = $titleBuilder.ToString()
+  if ($title.Trim().Length -eq 0) { return $null }
+  $procId = [uint32]0
+  [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$procId)
+  try { $process = Get-Process -Id ([int]$procId) -ErrorAction Stop } catch { $process = $null }
+  $rect = New-Object LightcodeComputerUseNative+RECT
+  [void][LightcodeComputerUseNative]::GetWindowRect($hWnd, [ref]$rect)
+  $width = [Math]::Max(0, $rect.Right - $rect.Left)
+  $height = [Math]::Max(0, $rect.Bottom - $rect.Top)
+  $app = if ($process -and $process.Path) { $process.Path } elseif ($process) { $process.ProcessName } else { "unknown" }
+  $displayName = if ($process) { $process.ProcessName } else { $app }
+  [pscustomobject]@{
+    app = $app
+    displayName = $displayName
+    id = [int64]$hWnd
+    title = $title
+    x = $rect.Left
+    y = $rect.Top
+    width = $width
+    height = $height
+  }
+}
+
+function Get-WindowList {
+  $items = New-Object System.Collections.Generic.List[object]
+  foreach ($hWnd in [LightcodeComputerUseNative]::Windows()) {
+    $window = Get-WindowObject $hWnd
+    if ($null -ne $window -and $window.width -gt 0 -and $window.height -gt 0) {
+      $items.Add($window)
+    }
+  }
+  $items
+}
+
+function Require-Window($req) {
+  $hWnd = [IntPtr]([int64]$req.id)
+  $window = Get-WindowObject $hWnd
+  if ($null -eq $window) { throw "Window is no longer available." }
+  if ($req.app -and $window.app -ne [string]$req.app) {
+    throw "Window app no longer matches the requested app."
+  }
+  $window
+}
+
+function Activate-Window($window) {
+  $hWnd = [IntPtr]([int64]$window.id)
+  [void][LightcodeComputerUseNative]::ShowWindow($hWnd, 9)
+  Start-Sleep -Milliseconds 40
+  if (-not [LightcodeComputerUseNative]::SetForegroundWindow($hWnd)) {
+    throw "Unable to activate window. The desktop may be locked or another secure surface may be active."
+  }
+  Start-Sleep -Milliseconds 40
+}
+
+function Capture-Window($window) {
+  $hWnd = [IntPtr]([int64]$window.id)
+  $width = [Math]::Max(1, [int]$window.width)
+  $height = [Math]::Max(1, [int]$window.height)
+  $bitmap = New-Object Drawing.Bitmap($width, $height)
+  $graphics = [Drawing.Graphics]::FromImage($bitmap)
+  $usedFallback = $false
+  try {
+    $hdc = $graphics.GetHdc()
+    try {
+      $ok = [LightcodeComputerUseNative]::PrintWindow($hWnd, $hdc, 2)
+    } finally {
+      $graphics.ReleaseHdc($hdc)
+    }
+    if (-not $ok) {
+      $usedFallback = $true
+      $graphics.CopyFromScreen([int]$window.x, [int]$window.y, 0, 0, [Drawing.Size]::new($width, $height))
+    }
+    $stream = New-Object IO.MemoryStream
+    try {
+      $bitmap.Save($stream, [Drawing.Imaging.ImageFormat]::Png)
+      [pscustomobject]@{
+        id = "window"
+        mimeType = "image/png"
+        data = [Convert]::ToBase64String($stream.ToArray())
+        width = $width
+        height = $height
+        originX = [int]$window.x
+        originY = [int]$window.y
+        zIndex = 0
+        fallback = $usedFallback
+      }
+    } finally {
+      $stream.Dispose()
+    }
+  } finally {
+    $graphics.Dispose()
+    $bitmap.Dispose()
+  }
+}
+
+function Resolve-Key($token) {
+  $t = ([string]$token).Trim().ToLowerInvariant()
+  switch ($t) {
+    "control" { return 0x11 }
+    "ctrl" { return 0x11 }
+    "control_l" { return 0x11 }
+    "control_r" { return 0x11 }
+    "shift" { return 0x10 }
+    "shift_l" { return 0x10 }
+    "shift_r" { return 0x10 }
+    "alt" { return 0x12 }
+    "alt_l" { return 0x12 }
+    "alt_r" { return 0x12 }
+    "return" { return 0x0D }
+    "enter" { return 0x0D }
+    "tab" { return 0x09 }
+    "escape" { return 0x1B }
+    "esc" { return 0x1B }
+    "space" { return 0x20 }
+    "backspace" { return 0x08 }
+    "delete" { return 0x2E }
+    "left" { return 0x25 }
+    "arrowleft" { return 0x25 }
+    "up" { return 0x26 }
+    "arrowup" { return 0x26 }
+    "right" { return 0x27 }
+    "arrowright" { return 0x27 }
+    "down" { return 0x28 }
+    "arrowdown" { return 0x28 }
+    "home" { return 0x24 }
+    "end" { return 0x23 }
+    "page_up" { return 0x21 }
+    "pageup" { return 0x21 }
+    "page_down" { return 0x22 }
+    "pagedown" { return 0x22 }
+    "period" { return 0xBE }
+    "comma" { return 0xBC }
+    "slash" { return 0xBF }
+    "minus" { return 0xBD }
+    "plus" { return 0xBB }
+    "equal" { return 0xBB }
+  }
+  if ($t -match '^f([1-9]|1[0-9]|2[0-4])$') { return 0x70 + [int]$Matches[1] - 1 }
+  if ($t -match '^kp_([0-9])$' -or $t -match '^numpad_([0-9])$') { return 0x60 + [int]$Matches[1] }
+  if ($t.Length -eq 1) {
+    $vk = [LightcodeComputerUseNative]::VkKeyScan([char]$t[0])
+    if ($vk -eq -1) { throw "Unsupported key: $token" }
+    return ($vk -band 0xff)
+  }
+  throw "Unsupported key: $token"
+}
+
+function Press-Chord($key) {
+  $tokens = ([string]$key) -split '\+' | ForEach-Object { $_.Trim() } | Where-Object { $_.Length -gt 0 }
+  if ($tokens.Count -eq 0) { throw "key is required" }
+  $vks = @($tokens | ForEach-Object { [uint16](Resolve-Key $_) })
+  foreach ($vk in $vks) { [LightcodeComputerUseNative]::Key($vk, $false) }
+  [Array]::Reverse($vks)
+  foreach ($vk in $vks) { [LightcodeComputerUseNative]::Key($vk, $true) }
+}
+
+function Mouse-Click($button, $count) {
+  $down = [LightcodeComputerUseNative]::MOUSEEVENTF_LEFTDOWN
+  $up = [LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP
+  $b = ([string]$button).ToLowerInvariant()
+  if ($b -eq "right" -or $b -eq "r") {
+    $down = [LightcodeComputerUseNative]::MOUSEEVENTF_RIGHTDOWN
+    $up = [LightcodeComputerUseNative]::MOUSEEVENTF_RIGHTUP
+  } elseif ($b -eq "middle" -or $b -eq "m") {
+    $down = [LightcodeComputerUseNative]::MOUSEEVENTF_MIDDLEDOWN
+    $up = [LightcodeComputerUseNative]::MOUSEEVENTF_MIDDLEUP
+  }
+  for ($i = 0; $i -lt [Math]::Max(1, [int]$count); $i++) {
+    [LightcodeComputerUseNative]::mouse_event($down, 0, 0, 0, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 20
+    [LightcodeComputerUseNative]::mouse_event($up, 0, 0, 0, [UIntPtr]::Zero)
+  }
+}
+
+switch ([string]$request.action) {
+  "list_windows" {
+    $result = @(Get-WindowList | ForEach-Object {
+      [pscustomobject]@{ app = $_.app; id = $_.id; title = $_.title; x = $_.x; y = $_.y; width = $_.width; height = $_.height }
+    })
+  }
+  "list_apps" {
+    $groups = Get-WindowList | Group-Object app
+    $result = @($groups | ForEach-Object {
+      $first = $_.Group[0]
+      [pscustomobject]@{
+        id = $_.Name
+        displayName = $first.displayName
+        isRunning = $true
+        windows = @($_.Group | ForEach-Object {
+          [pscustomobject]@{ app = $_.app; id = $_.id; title = $_.title; x = $_.x; y = $_.y; width = $_.width; height = $_.height }
+        })
+      }
+    })
+  }
+  "get_window" {
+    $window = Require-Window $request.input
+    $result = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+  }
+  "get_window_state" {
+    $window = Require-Window $request.input.window
+    $screenshots = @()
+    $notes = @("Window listing and screenshots are passive. Input actions switch to interactive mode and activate the target window.")
+    if ($request.input.include_screenshot -ne $false) {
+      $capture = Capture-Window $window
+      if ($capture.fallback) { $notes += "Passive PrintWindow capture was unavailable; used visible screen-region capture." }
+      $screenshots = @([pscustomobject]@{
+        id = $capture.id
+        mimeType = $capture.mimeType
+        data = $capture.data
+        width = $capture.width
+        height = $capture.height
+        originX = $capture.originX
+        originY = $capture.originY
+        zIndex = $capture.zIndex
+      })
+    }
+    $accessibility = $null
+    if ($request.input.include_text -eq $true) {
+      $accessibility = [pscustomobject]@{
+        tree = 'Window: "' + $window.title + '", App: ' + $window.app
+      }
+      $notes += "Detailed UI Automation text is not available in this Lightcode helper yet."
+    }
+    $result = [pscustomobject]@{
+      window = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+      accessibility = $accessibility
+      screenshots = $screenshots
+      mode = "passive"
+      notes = $notes
+    }
+  }
+  "activate_window" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "click" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    $x = [int]$request.input.x
+    $y = [int]$request.input.y
+    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + $x, [int]$window.y + $y)
+    Mouse-Click $request.input.mouse_button $request.input.click_count
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "type_text" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    [LightcodeComputerUseNative]::SendUnicodeText([string]$request.input.text)
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "press_key" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    Press-Chord $request.input.key
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "scroll" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.x, [int]$window.y + [int]$request.input.y)
+    if ([int]$request.input.scrollY -ne 0) {
+      [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_WHEEL, 0, 0, [uint32](-1 * [int]$request.input.scrollY), [UIntPtr]::Zero)
+    }
+    if ([int]$request.input.scrollX -ne 0) {
+      [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_HWHEEL, 0, 0, [uint32]([int]$request.input.scrollX), [UIntPtr]::Zero)
+    }
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "drag" {
+    $window = Require-Window $request.input.window
+    Activate-Window $window
+    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.from_x, [int]$window.y + [int]$request.input.from_y)
+    [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTDOWN, 0, 0, 0, [UIntPtr]::Zero)
+    Start-Sleep -Milliseconds 40
+    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.to_x, [int]$window.y + [int]$request.input.to_y)
+    Start-Sleep -Milliseconds 40
+    [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero)
+    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+  }
+  "launch_app" {
+    Start-Process -FilePath ([string]$request.input.app)
+    $result = [pscustomobject]@{ ok = $true }
+  }
+  "set_value" {
+    throw "set_value is not supported yet; click or focus the target field, then use type_text."
+  }
+  "perform_secondary_action" {
+    throw "perform_secondary_action is not supported yet; use keyboard navigation or coordinate input."
+  }
+  default {
+    throw "Unknown action: $($request.action)"
+  }
+}
+
+$result | ConvertTo-Json -Depth 32 -Compress
+`;
+
+// The helper is too large to pass via `-EncodedCommand` (base64 of the
+// UTF-16LE script exceeds the ~32k Windows command-line limit and spawn fails
+// with ENAMETOOLONG). Stage it to a temp `.ps1` once per process and run it
+// with `-File`, leaving stdin free for the JSON request payload.
+let cachedHelperPath: string | null = null;
+
+function ensureWindowsHelperScript(): string {
+  if (cachedHelperPath) return cachedHelperPath;
+  const dir = join(tmpdir(), "lightcode-computer-use");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "windows-helper.ps1");
+  writeFileSync(path, WINDOWS_HELPER, "utf8");
+  cachedHelperPath = path;
+  return path;
+}
+
+async function runWindowsComputerUse<T>(action: string, input?: unknown): Promise<T> {
+  const scriptPath = ensureWindowsHelperScript();
+  const { stdout } = await runProcess(
+    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+    {
+      input: JSON.stringify({ action, input: input ?? {} }),
+      timeoutMs: 20_000,
+      maxBufferBytes: 24 * 1024 * 1024,
+    },
+  );
+  return JSON.parse(stdout.trim()) as T;
+}
+
+function normalizeArray<T>(value: T | T[] | null | undefined): T[] {
+  if (Array.isArray(value)) return value;
+  return value == null ? [] : [value];
+}
+
+export class WindowsComputerUseDriver implements ComputerUseDriver {
+  async listApps(): Promise<ComputerUseApp[]> {
+    return normalizeArray(
+      await runWindowsComputerUse<ComputerUseApp | ComputerUseApp[]>("list_apps"),
+    );
+  }
+
+  async listWindows(): Promise<ComputerUseWindow[]> {
+    return normalizeArray(
+      await runWindowsComputerUse<ComputerUseWindow | ComputerUseWindow[]>("list_windows"),
+    );
+  }
+
+  getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow> {
+    return runWindowsComputerUse("get_window", input);
+  }
+
+  getWindowState(input: {
+    include_screenshot?: boolean;
+    include_text?: boolean;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseWindowState> {
+    return runWindowsComputerUse("get_window_state", input);
+  }
+
+  activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("activate_window", input);
+  }
+
+  click(input: {
+    click_count?: number;
+    mouse_button?: string;
+    window: ComputerUseWindow;
+    x?: number;
+    y?: number;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("click", input);
+  }
+
+  typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }> {
+    return runWindowsComputerUse("type_text", input);
+  }
+
+  pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }> {
+    return runWindowsComputerUse("press_key", input);
+  }
+
+  scroll(input: {
+    scrollX: number;
+    scrollY: number;
+    window: ComputerUseWindow;
+    x: number;
+    y: number;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("scroll", input);
+  }
+
+  drag(input: {
+    from_x: number;
+    from_y: number;
+    to_x: number;
+    to_y: number;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("drag", input);
+  }
+
+  launchApp(input: { app: string }): Promise<{ ok: true }> {
+    return runWindowsComputerUse("launch_app", input);
+  }
+
+  setValue(input: {
+    element_index: number;
+    value: string;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("set_value", input);
+  }
+
+  performSecondaryAction(input: {
+    action: string;
+    element_index: number;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }> {
+    return runWindowsComputerUse("perform_secondary_action", input);
+  }
+}

--- a/src/main/computer-use/drivers/windows.ts
+++ b/src/main/computer-use/drivers/windows.ts
@@ -1,3 +1,4 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,12 +8,16 @@ import type {
   ComputerUseWindow,
   ComputerUseWindowState,
 } from "../mcp/types";
-import { runProcess } from "./common";
 
 const WINDOWS_HELPER = String.raw`
 $ErrorActionPreference = 'Stop'
-$raw = [Console]::In.ReadToEnd()
-$request = if ($raw.Trim().Length -gt 0) { $raw | ConvertFrom-Json } else { @{} }
+# Long-lived host: compile the native shim ONCE, then serve newline-delimited
+# JSON requests over stdin/stdout. Force UTF-8 on stdout so response strings
+# (titles, notes, emoji) survive; the Node side ASCII-escapes every request so
+# the stdin code page is irrelevant. Warnings go to stderr to keep stdout pure
+# NDJSON.
+try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false) } catch {}
+$WarningPreference = 'SilentlyContinue'
 
 Add-Type -AssemblyName System.Drawing
 Add-Type -TypeDefinition @"
@@ -245,13 +250,14 @@ function Activate-Window($window) {
   return $fresh
 }
 
-function Capture-Window($window) {
+function Capture-Window($window, $maxDimension, $format) {
   $hWnd = [IntPtr]([int64]$window.id)
-  $width = [Math]::Max(1, [int]$window.width)
-  $height = [Math]::Max(1, [int]$window.height)
-  $bitmap = New-Object Drawing.Bitmap($width, $height)
+  $srcWidth = [Math]::Max(1, [int]$window.width)
+  $srcHeight = [Math]::Max(1, [int]$window.height)
+  $bitmap = New-Object Drawing.Bitmap($srcWidth, $srcHeight)
   $graphics = [Drawing.Graphics]::FromImage($bitmap)
   $usedFallback = $false
+  $scaledBitmap = $null
   try {
     $hdc = $graphics.GetHdc()
     try {
@@ -261,26 +267,70 @@ function Capture-Window($window) {
     }
     if (-not $ok) {
       $usedFallback = $true
-      $graphics.CopyFromScreen([int]$window.x, [int]$window.y, 0, 0, [Drawing.Size]::new($width, $height))
+      $graphics.CopyFromScreen([int]$window.x, [int]$window.y, 0, 0, [Drawing.Size]::new($srcWidth, $srcHeight))
+    }
+    # Downscale (preserving aspect) so passive captures don't bill multi-MB PNGs
+    # as image tokens on every get_window_state. Report the ACTUAL encoded pixel
+    # size below so click coordinates can be mapped back to window points.
+    $scale = 1.0
+    $maxDim = [int]$maxDimension
+    if ($maxDim -gt 0) {
+      $largest = [Math]::Max($srcWidth, $srcHeight)
+      if ($largest -gt $maxDim) { $scale = [double]$maxDim / [double]$largest }
+    }
+    $encWidth = [Math]::Max(1, [int][Math]::Round($srcWidth * $scale))
+    $encHeight = [Math]::Max(1, [int][Math]::Round($srcHeight * $scale))
+    $encodeBitmap = $bitmap
+    if ($encWidth -ne $srcWidth -or $encHeight -ne $srcHeight) {
+      $scaledBitmap = New-Object Drawing.Bitmap($encWidth, $encHeight)
+      $sg = [Drawing.Graphics]::FromImage($scaledBitmap)
+      try {
+        $sg.InterpolationMode = [Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+        $sg.PixelOffsetMode = [Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+        $sg.DrawImage($bitmap, 0, 0, $encWidth, $encHeight)
+      } finally {
+        $sg.Dispose()
+      }
+      $encodeBitmap = $scaledBitmap
     }
     $stream = New-Object IO.MemoryStream
     try {
-      $bitmap.Save($stream, [Drawing.Imaging.ImageFormat]::Png)
+      $fmt = ([string]$format).ToLowerInvariant()
+      if ($fmt -eq "png") {
+        $encodeBitmap.Save($stream, [Drawing.Imaging.ImageFormat]::Png)
+        $mime = "image/png"
+      } else {
+        # JPEG (default) at quality 75 for passive captures. WebP has no
+        # .NET Framework encoder, so JPEG is the smallest widely-supported option.
+        $jpegCodec = [Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.FormatID -eq [Drawing.Imaging.ImageFormat]::Jpeg.Guid } | Select-Object -First 1
+        $encoderParams = [Drawing.Imaging.EncoderParameters]::new(1)
+        $encoderParams.Param[0] = [Drawing.Imaging.EncoderParameter]::new([Drawing.Imaging.Encoder]::Quality, [int64]75)
+        try {
+          $encodeBitmap.Save($stream, $jpegCodec, $encoderParams)
+        } finally {
+          $encoderParams.Dispose()
+        }
+        $mime = "image/jpeg"
+      }
       [pscustomobject]@{
         id = "window"
-        mimeType = "image/png"
+        mimeType = $mime
         data = [Convert]::ToBase64String($stream.ToArray())
-        width = $width
-        height = $height
+        width = $encWidth
+        height = $encHeight
         originX = [int]$window.x
         originY = [int]$window.y
         zIndex = 0
         fallback = $usedFallback
+        scale = $scale
+        sourceWidth = $srcWidth
+        sourceHeight = $srcHeight
       }
     } finally {
       $stream.Dispose()
     }
   } finally {
+    if ($null -ne $scaledBitmap) { $scaledBitmap.Dispose() }
     $graphics.Dispose()
     $bitmap.Dispose()
   }
@@ -407,6 +457,8 @@ function Mouse-Click($button, $count) {
   }
 }
 
+function Invoke-ComputerUseAction($request) {
+$result = $null
 switch ([string]$request.action) {
   "list_windows" {
     $result = @(Get-WindowList | ForEach-Object {
@@ -436,8 +488,13 @@ switch ([string]$request.action) {
     $screenshots = @()
     $notes = @("Window listing and screenshots are passive. Input actions switch to interactive mode and activate the target window.")
     if ($request.input.include_screenshot -ne $false) {
-      $capture = Capture-Window $window
+      $maxDimension = if ($null -ne $request.input.max_dimension) { [int]$request.input.max_dimension } else { 1280 }
+      $format = if ($request.input.format) { [string]$request.input.format } else { "jpeg" }
+      $capture = Capture-Window $window $maxDimension $format
       if ($capture.fallback) { $notes += "Passive PrintWindow capture was unavailable; used visible screen-region capture." }
+      if ($capture.scale -ne 1.0) {
+        $notes += "Screenshot was downscaled to $($capture.width)x$($capture.height) px (scale $($capture.scale)) from the $($capture.sourceWidth)x$($capture.sourceHeight) window to shrink the payload. To convert a coordinate you read from this screenshot into the window-relative coordinate for click/scroll/drag, DIVIDE it by $($capture.scale) (both x and y)."
+      }
       $screenshots = @([pscustomobject]@{
         id = $capture.id
         mimeType = $capture.mimeType
@@ -571,8 +628,25 @@ switch ([string]$request.action) {
     throw "Unknown action: $($request.action)"
   }
 }
+return $result
+}
 
-$result | ConvertTo-Json -Depth 32 -Compress
+# Serve one JSON request per stdin line; emit exactly one JSON response line per
+# request. Any throw inside an action becomes an { ok = $false; error } response
+# so a single failing action never tears down the long-lived host.
+while ($null -ne ($line = [Console]::In.ReadLine())) {
+  if ($line.Trim().Length -eq 0) { continue }
+  $reqId = $null
+  try {
+    $request = $line | ConvertFrom-Json
+    $reqId = $request.id
+    $result = Invoke-ComputerUseAction $request
+    $response = [pscustomobject]@{ id = $reqId; ok = $true; result = $result }
+  } catch {
+    $response = [pscustomobject]@{ id = $reqId; ok = $false; error = [string]$_.Exception.Message }
+  }
+  [Console]::Out.WriteLine(($response | ConvertTo-Json -Depth 32 -Compress))
+}
 `;
 
 // The helper is too large to pass via `-EncodedCommand` (base64 of the
@@ -591,18 +665,186 @@ function ensureWindowsHelperScript(): string {
   return path;
 }
 
-async function runWindowsComputerUse<T>(action: string, input?: unknown): Promise<T> {
-  const scriptPath = ensureWindowsHelperScript();
-  const { stdout } = await runProcess(
-    "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
-    {
-      input: JSON.stringify({ action, input: input ?? {} }),
-      timeoutMs: 20_000,
-      maxBufferBytes: 24 * 1024 * 1024,
-    },
-  );
-  return JSON.parse(stdout.trim()) as T;
+const POWERSHELL_PATH = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+const REQUEST_TIMEOUT_MS = 20_000;
+// Responses can be multi-MB (screenshots). Cap the accumulated stdout so a
+// runaway/garbage child can't grow the buffer without bound; on overflow we
+// recycle the child.
+const MAX_STDOUT_BUFFER_BYTES = 64 * 1024 * 1024;
+
+interface PendingRequest {
+  reject: (error: Error) => void;
+  resolve: (value: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+// Escape every non-ASCII UTF-16 code unit so each request line is pure ASCII on
+// the wire. PowerShell's ConvertFrom-Json rebuilds the original string (incl.
+// emoji surrogate pairs) from the \uXXXX escapes, so correct Unicode input
+// (type_text) never depends on the child's stdin code page.
+function toAsciiRequestLine(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  let out = "";
+  for (let i = 0; i < json.length; i += 1) {
+    const code = json.charCodeAt(i);
+    out += code > 0x7f ? `\\u${code.toString(16).padStart(4, "0")}` : json[i];
+  }
+  return `${out}\n`;
+}
+
+// Long-lived PowerShell host. The helper compiles its native shim once and then
+// serves newline-delimited JSON requests, eliminating the ~300ms Add-Type
+// recompile + ~112ms process spawn that the old one-shot model paid per action.
+// Requests are serialized over a single stdin/stdout pipe (SendInput is a global
+// machine action, so serializing shared-driver calls is also semantically
+// correct). Each request carries a monotonic id so responses are matched even
+// though the child processes them one at a time.
+class PersistentPowerShellHost {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private stderrTail = "";
+  private stdoutBuffer = "";
+
+  request<T>(action: string, input?: unknown): Promise<T> {
+    const child = this.ensureChild();
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        this.pending.delete(id);
+        pending.reject(
+          new Error(`computer-use action "${action}" timed out after ${REQUEST_TIMEOUT_MS}ms`),
+        );
+        // A hung native call poisons the shared pipe for every queued request,
+        // so recycle the child; the next request lazily respawns a clean host.
+        this.teardown(new Error("computer-use host was recycled after a timed-out action"), true);
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve: resolve as (value: unknown) => void, reject, timer });
+      child.stdin.write(toAsciiRequestLine({ id, action, input: input ?? {} }), (error) => {
+        if (!error) return;
+        const pending = this.pending.get(id);
+        if (!pending) return;
+        this.pending.delete(id);
+        clearTimeout(pending.timer);
+        pending.reject(error);
+      });
+    });
+  }
+
+  dispose(): void {
+    this.teardown(new Error("computer-use host disposed"), true);
+  }
+
+  private ensureChild(): ChildProcessWithoutNullStreams {
+    if (this.child) return this.child;
+    const scriptPath = ensureWindowsHelperScript();
+    const child = spawn(
+      POWERSHELL_PATH,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        scriptPath,
+      ],
+      { windowsHide: true },
+    ) as ChildProcessWithoutNullStreams;
+    this.child = child;
+    this.stdoutBuffer = "";
+    this.stderrTail = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      if (this.child !== child) return;
+      this.onStdout(chunk);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      this.stderrTail = (this.stderrTail + chunk).slice(-4096);
+    });
+    child.on("error", (error: Error) => {
+      if (this.child !== child) return;
+      this.teardown(new Error(`computer-use host failed: ${error.message}`), false);
+    });
+    child.on("exit", (code, signal) => {
+      if (this.child !== child) return;
+      const detail = this.stderrTail.trim();
+      this.teardown(
+        new Error(
+          `computer-use host exited unexpectedly (code=${code ?? "null"}, signal=${signal ?? "null"})${detail ? `: ${detail}` : ""}`,
+        ),
+        false,
+      );
+    });
+    return child;
+  }
+
+  private onStdout(chunk: string): void {
+    this.stdoutBuffer += chunk;
+    if (this.stdoutBuffer.length > MAX_STDOUT_BUFFER_BYTES) {
+      this.teardown(new Error("computer-use host response exceeded the buffer limit"), true);
+      return;
+    }
+    let newlineIndex = this.stdoutBuffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = this.stdoutBuffer.slice(0, newlineIndex);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      // PowerShell writes CRLF; trim strips the trailing \r. base64 payloads
+      // contain no newlines, so each response is exactly one line.
+      this.dispatchLine(line.trim());
+      newlineIndex = this.stdoutBuffer.indexOf("\n");
+    }
+  }
+
+  private dispatchLine(line: string): void {
+    if (!line) return;
+    let message: { error?: unknown; id?: unknown; ok?: unknown; result?: unknown };
+    try {
+      message = JSON.parse(line) as typeof message;
+    } catch {
+      // Non-JSON noise on stdout — ignore rather than corrupt a pending request.
+      return;
+    }
+    if (typeof message.id !== "number") return;
+    const pending = this.pending.get(message.id);
+    if (!pending) return;
+    this.pending.delete(message.id);
+    clearTimeout(pending.timer);
+    if (message.ok) {
+      pending.resolve(message.result);
+    } else {
+      pending.reject(
+        new Error(typeof message.error === "string" ? message.error : "computer-use action failed"),
+      );
+    }
+  }
+
+  private teardown(error: Error, kill: boolean): void {
+    const child = this.child;
+    this.child = null;
+    this.stdoutBuffer = "";
+    this.stderrTail = "";
+    const pendings = [...this.pending.values()];
+    this.pending.clear();
+    for (const pending of pendings) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    if (!child) return;
+    child.stdout.removeAllListeners();
+    child.stderr.removeAllListeners();
+    child.removeAllListeners();
+    if (kill) {
+      try {
+        child.kill();
+      } catch {
+        // The child may already be gone; nothing to clean up.
+      }
+    }
+  }
 }
 
 function normalizeArray<T>(value: T | T[] | null | undefined): T[] {
@@ -611,32 +853,38 @@ function normalizeArray<T>(value: T | T[] | null | undefined): T[] {
 }
 
 export class WindowsComputerUseDriver implements ComputerUseDriver {
+  private readonly host = new PersistentPowerShellHost();
+
+  dispose(): void {
+    this.host.dispose();
+  }
+
   async listApps(): Promise<ComputerUseApp[]> {
-    return normalizeArray(
-      await runWindowsComputerUse<ComputerUseApp | ComputerUseApp[]>("list_apps"),
-    );
+    return normalizeArray(await this.host.request<ComputerUseApp | ComputerUseApp[]>("list_apps"));
   }
 
   async listWindows(): Promise<ComputerUseWindow[]> {
     return normalizeArray(
-      await runWindowsComputerUse<ComputerUseWindow | ComputerUseWindow[]>("list_windows"),
+      await this.host.request<ComputerUseWindow | ComputerUseWindow[]>("list_windows"),
     );
   }
 
   getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow> {
-    return runWindowsComputerUse("get_window", input);
+    return this.host.request("get_window", input);
   }
 
   getWindowState(input: {
+    format?: "jpeg" | "png";
     include_screenshot?: boolean;
     include_text?: boolean;
+    max_dimension?: number;
     window: ComputerUseWindow;
   }): Promise<ComputerUseWindowState> {
-    return runWindowsComputerUse("get_window_state", input);
+    return this.host.request("get_window_state", input);
   }
 
   activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("activate_window", input);
+    return this.host.request("activate_window", input);
   }
 
   click(input: {
@@ -646,21 +894,21 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     x?: number;
     y?: number;
   }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("click", input);
+    return this.host.request("click", input);
   }
 
   typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
     ok: true;
     mode: "interactive";
   }> {
-    return runWindowsComputerUse("type_text", input);
+    return this.host.request("type_text", input);
   }
 
   pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
     ok: true;
     mode: "interactive";
   }> {
-    return runWindowsComputerUse("press_key", input);
+    return this.host.request("press_key", input);
   }
 
   scroll(input: {
@@ -670,7 +918,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     x: number;
     y: number;
   }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("scroll", input);
+    return this.host.request("scroll", input);
   }
 
   drag(input: {
@@ -680,7 +928,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     to_y: number;
     window: ComputerUseWindow;
   }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("drag", input);
+    return this.host.request("drag", input);
   }
 
   launchApp(input: { app: string }): Promise<{
@@ -688,7 +936,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     window?: ComputerUseWindow | null;
     note?: string;
   }> {
-    return runWindowsComputerUse("launch_app", input);
+    return this.host.request("launch_app", input);
   }
 
   setValue(input: {
@@ -696,7 +944,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     value: string;
     window: ComputerUseWindow;
   }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("set_value", input);
+    return this.host.request("set_value", input);
   }
 
   performSecondaryAction(input: {
@@ -704,6 +952,6 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     element_index: number;
     window: ComputerUseWindow;
   }): Promise<{ ok: true; mode: "interactive" }> {
-    return runWindowsComputerUse("perform_secondary_action", input);
+    return this.host.request("perform_secondary_action", input);
   }
 }

--- a/src/main/computer-use/drivers/windows.ts
+++ b/src/main/computer-use/drivers/windows.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type {
   ComputerUseApp,
   ComputerUseDriver,
+  ComputerUseInteractiveResult,
   ComputerUseWindow,
   ComputerUseWindowState,
 } from "../mcp/types";
@@ -158,16 +159,45 @@ try { [void][LightcodeComputerUseNative]::SetProcessDpiAwarenessContext([IntPtr]
 
 $ASFW_ANY = [uint32]"0xFFFFFFFF"
 
-function Get-WindowObject([IntPtr]$hWnd) {
+# App-specific launch heuristics, consumed generically by the launch_app handler.
+# names:        leaf tokens (lowercase) that select this alias
+# tokenPattern: matched against the AUMID token of a shell:AppsFolder target to
+#               derive a friendly leaf name
+# leaf:         the friendly leaf name used when tokenPattern matches
+# targets:      extra Start-Process targets tried when the primary target yields
+#               no window (e.g. calc.exe redirects to the Store Calculator)
+# hints:        extra title / process-name hints for detecting the redirected window
+$launchAliases = @(
+  @{
+    names = @('calc', 'calculator')
+    tokenPattern = 'Calculator'
+    leaf = 'Calculator'
+    targets = @('shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App', 'calculator:')
+    hints = @('Calculator', 'CalculatorApp')
+  },
+  @{
+    names = @('notepad')
+    tokenPattern = 'Notepad'
+    leaf = 'Notepad'
+    targets = @()
+    hints = @('Notepad')
+  }
+)
+
+function Get-WindowObject([IntPtr]$hWnd, [switch]$AllowHidden, [hashtable]$ProcessMap) {
   if (-not [LightcodeComputerUseNative]::IsWindow($hWnd)) { return $null }
-  if (-not [LightcodeComputerUseNative]::IsWindowVisible($hWnd)) { return $null }
+  if (-not $AllowHidden -and -not [LightcodeComputerUseNative]::IsWindowVisible($hWnd)) { return $null }
   $titleBuilder = [Text.StringBuilder]::new(512)
   [void][LightcodeComputerUseNative]::GetWindowText($hWnd, $titleBuilder, $titleBuilder.Capacity)
   $title = $titleBuilder.ToString()
   if ($title.Trim().Length -eq 0) { return $null }
   $procId = [uint32]0
   [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$procId)
-  try { $process = Get-Process -Id ([int]$procId) -ErrorAction Stop } catch { $process = $null }
+  if ($null -ne $ProcessMap) {
+    $process = $ProcessMap[[int]$procId]
+  } else {
+    try { $process = Get-Process -Id ([int]$procId) -ErrorAction Stop } catch { $process = $null }
+  }
   $rect = New-Object LightcodeComputerUseNative+RECT
   [void][LightcodeComputerUseNative]::GetWindowRect($hWnd, [ref]$rect)
   $width = [Math]::Max(0, $rect.Right - $rect.Left)
@@ -186,10 +216,19 @@ function Get-WindowObject([IntPtr]$hWnd) {
   }
 }
 
+# Project a window record into the wire shape shared by every action response.
+# Field names and order are the serialized JSON contract — keep them stable.
+function Select-Window($w) {
+  [pscustomobject]@{ app = $w.app; id = $w.id; title = $w.title; x = $w.x; y = $w.y; width = $w.width; height = $w.height }
+}
+
 function Get-WindowList {
+  # Snapshot processes once per listing instead of one Get-Process -Id per window.
+  $processMap = @{}
+  foreach ($proc in (Get-Process)) { $processMap[[int]$proc.Id] = $proc }
   $items = New-Object System.Collections.Generic.List[object]
   foreach ($hWnd in [LightcodeComputerUseNative]::Windows()) {
-    $window = Get-WindowObject $hWnd
+    $window = Get-WindowObject $hWnd -ProcessMap $processMap
     if ($null -ne $window -and $window.width -gt 0 -and $window.height -gt 0) {
       $items.Add($window)
     }
@@ -197,18 +236,109 @@ function Get-WindowList {
   $items
 }
 
+function Window-MatchesApp($candidate, [string]$wantedApp) {
+  if (-not $wantedApp) { return $true }
+  if ([string]::Equals([string]$candidate.app, $wantedApp, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+  $wantedLeaf = [IO.Path]::GetFileNameWithoutExtension($wantedApp)
+  if (-not $wantedLeaf) { return $false }
+  if ([string]::Equals($candidate.displayName, $wantedLeaf, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+  if ($candidate.app -and [IO.Path]::GetFileNameWithoutExtension([string]$candidate.app) -ieq $wantedLeaf) { return $true }
+  return $false
+}
+
+function Recover-Window($req) {
+  $wantedApp = if ($req.app) { [string]$req.app } else { $null }
+  $wantedTitle = if ($req.title) { [string]$req.title } else { $null }
+  for ($recover = 0; $recover -lt 8; $recover++) {
+    $matches = New-Object System.Collections.Generic.List[object]
+    foreach ($candidate in (Get-WindowList)) {
+      if (-not (Window-MatchesApp $candidate $wantedApp)) { continue }
+      $matches.Add($candidate)
+    }
+    if ($matches.Count -gt 0) {
+      # Prefer exact-title matches when possible, then choose foreground/largest
+      # within that pool. WinUI apps can expose duplicate localized titles.
+      $pool = $matches
+      if ($wantedTitle) {
+        $titleMatches = New-Object System.Collections.Generic.List[object]
+        foreach ($candidate in $matches) {
+          if ([string]::Equals([string]$candidate.title, $wantedTitle, [StringComparison]::OrdinalIgnoreCase)) {
+            $titleMatches.Add($candidate)
+          }
+        }
+        if ($titleMatches.Count -gt 0) { $pool = $titleMatches }
+      }
+      $fg = [LightcodeComputerUseNative]::GetForegroundWindow()
+      foreach ($candidate in $pool) {
+        if ([IntPtr]([int64]$candidate.id) -eq $fg) { return $candidate }
+      }
+      $best = $null
+      $bestArea = -1
+      foreach ($candidate in $pool) {
+        $area = [int]$candidate.width * [int]$candidate.height
+        if ($area -gt $bestArea) { $best = $candidate; $bestArea = $area }
+      }
+      return $best
+    }
+    Start-Sleep -Milliseconds 100
+  }
+  return $null
+}
+
 function Require-Window($req) {
   $hWnd = [IntPtr]([int64]$req.id)
-  $window = Get-WindowObject $hWnd
-  if ($null -eq $window) { throw "Window is no longer available." }
-  if ($req.app -and $window.app -ne [string]$req.app) {
-    throw "Window app no longer matches the requested app."
+  # Exact id: allow temporarily-hidden windows (WinUI tab shells often flip
+  # visibility during activation) so we can still activate/recover them.
+  $window = Get-WindowObject $hWnd -AllowHidden
+  if ($null -ne $window) {
+    if ($req.app -and -not (Window-MatchesApp $window ([string]$req.app))) {
+      throw "Window app no longer matches the requested app."
+    }
+    return $window
   }
-  $window
+  $recovered = Recover-Window $req
+  if ($null -ne $recovered) { return $recovered }
+  throw "Window is no longer available. Call list_windows or get_window for a fresh id and retry."
+}
+
+function Try-SetForeground([IntPtr]$hWnd) {
+  [void][LightcodeComputerUseNative]::AllowSetForegroundWindow($ASFW_ANY)
+  $fg = [LightcodeComputerUseNative]::GetForegroundWindow()
+  $fgPid = [uint32]0
+  $fgThread = [LightcodeComputerUseNative]::GetWindowThreadProcessId($fg, [ref]$fgPid)
+  $cur = [LightcodeComputerUseNative]::GetCurrentThreadId()
+  $attached = $false
+  if ($fgThread -ne $cur) { $attached = [LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $true) }
+  try {
+    [void][LightcodeComputerUseNative]::BringWindowToTop($hWnd)
+    [void][LightcodeComputerUseNative]::SetForegroundWindow($hWnd)
+  } finally {
+    if ($attached) { [void][LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $false) }
+  }
+}
+
+function Find-WindowByProcessId([uint32]$targetPid, [int64]$preferId) {
+  $fallback = $null
+  $fg = [LightcodeComputerUseNative]::GetForegroundWindow()
+  foreach ($candidateHwnd in [LightcodeComputerUseNative]::Windows()) {
+    $wPid = [uint32]0
+    [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($candidateHwnd, [ref]$wPid)
+    if ($wPid -ne $targetPid) { continue }
+    $candidate = Get-WindowObject $candidateHwnd -AllowHidden
+    if ($null -eq $candidate -or $candidate.width -le 0 -or $candidate.height -le 0) { continue }
+    if ([int64]$candidate.id -eq $preferId) { return $candidate }
+    if ($candidateHwnd -eq $fg) { return $candidate }
+    if ($null -eq $fallback -and [LightcodeComputerUseNative]::IsWindowVisible($candidateHwnd)) {
+      $fallback = $candidate
+    }
+  }
+  return $fallback
 }
 
 function Activate-Window($window) {
   $hWnd = [IntPtr]([int64]$window.id)
+  $ownerPid = [uint32]0
+  [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$ownerPid)
   # SW_RESTORE (9) un-maximizes a maximized window, which would move/resize it
   # AFTER the agent's screenshot and break coordinate math. Only restore when the
   # window is actually minimized; otherwise SW_SHOW (5) leaves geometry untouched.
@@ -219,34 +349,70 @@ function Activate-Window($window) {
     [void][LightcodeComputerUseNative]::ShowWindow($hWnd, 5)
   }
   $activated = $false
+  $usedAlt = $false
   for ($attempt = 0; $attempt -lt 3; $attempt++) {
-    if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
-    [void][LightcodeComputerUseNative]::AllowSetForegroundWindow($ASFW_ANY)
-    # An alt-key nudge releases the foreground lock so SetForegroundWindow is honored.
-    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 0, [UIntPtr]::Zero)
-    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 2, [UIntPtr]::Zero)
-    $fg = [LightcodeComputerUseNative]::GetForegroundWindow()
-    $fgPid = [uint32]0
-    $fgThread = [LightcodeComputerUseNative]::GetWindowThreadProcessId($fg, [ref]$fgPid)
-    $cur = [LightcodeComputerUseNative]::GetCurrentThreadId()
-    $attached = $false
-    if ($fgThread -ne $cur) { $attached = [LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $true) }
-    try {
-      [void][LightcodeComputerUseNative]::BringWindowToTop($hWnd)
-      [void][LightcodeComputerUseNative]::SetForegroundWindow($hWnd)
-    } finally {
-      if ($attached) { [void][LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $false) }
+    # Some WinUI/Store apps destroy the HWND mid-activation and recreate it.
+    # Re-resolve by owning PID before each attempt so we don't chase a dead handle.
+    if (-not [LightcodeComputerUseNative]::IsWindow($hWnd)) {
+      $replacement = Find-WindowByProcessId $ownerPid ([int64]$window.id)
+      if ($null -eq $replacement) { break }
+      $hWnd = [IntPtr]([int64]$replacement.id)
+      $window = $replacement
     }
+    if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
+    # Prefer AttachThreadInput alone. The Alt nudge releases the foreground lock
+    # but leaves many apps (WinUI / Store Notepad) in menu mode so type_text is
+    # swallowed by the menu bar — only use it as a fallback.
+    Try-SetForeground $hWnd
     Start-Sleep -Milliseconds 60
     if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
+    $usedAlt = $true
+    # KEYEVENTF_EXTENDEDKEY (1) matches the documented Alt unlock sequence.
+    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 1, [UIntPtr]::Zero)
+    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 3, [UIntPtr]::Zero)
+    Try-SetForeground $hWnd
+    Start-Sleep -Milliseconds 60
+    if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
+  }
+  # Final HWND recovery: activation may have succeeded on a replacement window
+  # that became foreground under the same process.
+  if (-not [LightcodeComputerUseNative]::IsWindow($hWnd) -or -not $activated) {
+    $replacement = Find-WindowByProcessId $ownerPid ([int64]$window.id)
+    if ($null -ne $replacement) {
+      $hWnd = [IntPtr]([int64]$replacement.id)
+      $window = $replacement
+      if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) {
+        $activated = $true
+      } elseif (-not $activated) {
+        Try-SetForeground $hWnd
+        Start-Sleep -Milliseconds 60
+        if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true }
+      }
+    }
   }
   if (-not $activated) {
     throw "Focus did not reach the target window. The desktop may be locked or another secure surface may be active."
   }
+  if ($usedAlt) {
+    # Dismiss menu mode left by the Alt nudge so subsequent typing lands in the
+    # document/control instead of the File menu accelerator.
+    [LightcodeComputerUseNative]::Key(0x1B, $false)
+    [LightcodeComputerUseNative]::Key(0x1B, $true)
+    Start-Sleep -Milliseconds 40
+  }
   # Re-capture the window rect AFTER activation: show/restore may have changed the
-  # window geometry, so return the fresh object for coordinate math.
-  $fresh = Get-WindowObject $hWnd
-  if ($null -eq $fresh) { return $window }
+  # window geometry. AllowHidden covers WinUI shells that briefly flip visibility
+  # while becoming foreground; if the original HWND is gone, recover by PID/FG.
+  $fresh = $null
+  if ([LightcodeComputerUseNative]::IsWindow($hWnd)) {
+    $fresh = Get-WindowObject $hWnd -AllowHidden
+  }
+  if ($null -eq $fresh) {
+    $fresh = Find-WindowByProcessId $ownerPid ([int64]$window.id)
+  }
+  if ($null -eq $fresh) {
+    throw "Window is no longer available (destroyed during activation). Call list_windows or get_window for a fresh id and retry."
+  }
   return $fresh
 }
 
@@ -462,7 +628,7 @@ $result = $null
 switch ([string]$request.action) {
   "list_windows" {
     $result = @(Get-WindowList | ForEach-Object {
-      [pscustomobject]@{ app = $_.app; id = $_.id; title = $_.title; x = $_.x; y = $_.y; width = $_.width; height = $_.height }
+      Select-Window $_
     })
   }
   "list_apps" {
@@ -474,19 +640,19 @@ switch ([string]$request.action) {
         displayName = $first.displayName
         isRunning = $true
         windows = @($_.Group | ForEach-Object {
-          [pscustomobject]@{ app = $_.app; id = $_.id; title = $_.title; x = $_.x; y = $_.y; width = $_.width; height = $_.height }
+          Select-Window $_
         })
       }
     })
   }
   "get_window" {
     $window = Require-Window $request.input
-    $result = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+    $result = Select-Window $window
   }
   "get_window_state" {
     $window = Require-Window $request.input.window
     $screenshots = @()
-    $notes = @("Window listing and screenshots are passive. Input actions switch to interactive mode and activate the target window.")
+    $notes = @("Window listing and screenshots are passive and do not steal focus. Input actions switch to interactive mode, bring the target window to the foreground, and take exclusive control of the mouse/keyboard.")
     if ($request.input.include_screenshot -ne $false) {
       $maxDimension = if ($null -ne $request.input.max_dimension) { [int]$request.input.max_dimension } else { 1280 }
       $format = if ($request.input.format) { [string]$request.input.format } else { "jpeg" }
@@ -514,7 +680,7 @@ switch ([string]$request.action) {
       $notes += "Detailed UI Automation text is not available in this Lightcode helper yet."
     }
     $result = [pscustomobject]@{
-      window = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+      window = Select-Window $window
       accessibility = $accessibility
       screenshots = $screenshots
       mode = "passive"
@@ -524,7 +690,11 @@ switch ([string]$request.action) {
   "activate_window" {
     $window = Require-Window $request.input.window
     $window = Activate-Window $window
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "click" {
     $window = Require-Window $request.input.window
@@ -533,19 +703,31 @@ switch ([string]$request.action) {
     $y = [int]$request.input.y
     [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + $x, [int]$window.y + $y)
     Mouse-Click $request.input.mouse_button $request.input.click_count
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "type_text" {
     $window = Require-Window $request.input.window
     $window = Activate-Window $window
     [LightcodeComputerUseNative]::SendUnicodeText([string]$request.input.text)
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "press_key" {
     $window = Require-Window $request.input.window
     $window = Activate-Window $window
     Press-Chord $request.input.key
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "scroll" {
     $window = Require-Window $request.input.window
@@ -557,7 +739,11 @@ switch ([string]$request.action) {
     if ([int]$request.input.scrollX -ne 0) {
       [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_HWHEEL, 0, 0, [uint32]([int]$request.input.scrollX), [UIntPtr]::Zero)
     }
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "drag" {
     $window = Require-Window $request.input.window
@@ -578,51 +764,124 @@ switch ([string]$request.action) {
         try { [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero) } catch {}
       }
     }
-    $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
+    $result = [pscustomobject]@{
+      ok = $true
+      mode = "interactive"
+      window = Select-Window $window
+    }
   }
   "launch_app" {
     $app = [string]$request.input.app
     if ($app.Trim().Length -eq 0) { throw "app is required" }
     # Defense-in-depth: refuse UNC paths and URL schemes so launch_app can't pull
-    # a remote payload or hand off to a protocol handler.
+    # a remote payload or hand off to a protocol handler. shell:AppsFolder is an
+    # explicit allow-listed exception for Store/UWP aliases (calc, etc.); drive
+    # paths such as C:\Windows\System32\notepad.exe are still allowed.
+    # Mirrored in validateWindowsLaunchAppInput on the Node side — keep in sync.
     if ($app -match '^\\\\') { throw "UNC paths are not allowed for launch_app." }
-    if ($app -match '^[A-Za-z][A-Za-z0-9+.\-]*://') { throw "URL schemes are not allowed for launch_app." }
-    $proc = Start-Process -FilePath $app -PassThru
-    $window = $null
-    if ($proc -and $proc.Id) {
-      $targetPid = [uint32]$proc.Id
-      # Start-Process returns before the window exists; poll (bounded ~4s) for a
-      # visible, titled top-level window owned by the new process.
-      $deadline = (Get-Date).AddSeconds(4)
-      while ((Get-Date) -lt $deadline -and $null -eq $window) {
-        foreach ($hWnd in [LightcodeComputerUseNative]::Windows()) {
-          $wPid = [uint32]0
-          [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$wPid)
-          if ($wPid -eq $targetPid) {
-            $candidate = Get-WindowObject $hWnd
-            if ($null -ne $candidate -and $candidate.width -gt 0 -and $candidate.height -gt 0) {
-              $window = $candidate
-              break
-            }
-          }
-        }
-        if ($null -eq $window) { Start-Sleep -Milliseconds 150 }
+    $isShellAppsFolder = $app -match '(?i)^shell:AppsFolder\\'
+    $isDrivePath = $app -match '^[A-Za-z]:[\\/]'
+    if (-not $isShellAppsFolder -and -not $isDrivePath -and $app -match '^[A-Za-z][A-Za-z0-9+.\-]*:') {
+      throw "URL schemes are not allowed for launch_app."
+    }
+    if (-not $isShellAppsFolder -and -not $isDrivePath -and $app -match '[\\/]') {
+      throw "Relative paths are not allowed for launch_app."
+    }
+    # Snapshot existing windows so we can detect a newly appeared one when the
+    # launched stub process exits / redirects (e.g. System32\notepad.exe → Store
+    # Notepad, or calc.exe → CalculatorApp under a different PID/path).
+    $beforeIds = New-Object 'System.Collections.Generic.HashSet[int64]'
+    foreach ($existing in (Get-WindowList)) { [void]$beforeIds.Add([int64]$existing.id) }
+    $leaf = if ($isShellAppsFolder) {
+      # shell:AppsFolder\Microsoft.WindowsCalculator_8wekyb3d8bbwe!App → Calculator
+      $token = ($app -split '\\')[-1]
+      $aliasLeaf = $null
+      foreach ($alias in $launchAliases) {
+        if ($token -match $alias.tokenPattern) { $aliasLeaf = $alias.leaf; break }
+      }
+      if ($aliasLeaf) { $aliasLeaf } else { ($token -split '[_.!]')[0] }
+    } else {
+      [IO.Path]::GetFileNameWithoutExtension($app)
+    }
+    # Extra launch targets and title / process-name hints for aliases where
+    # Start-Process alone often fails to resolve to a window (Store redirects,
+    # e.g. calc → CalculatorApp). Declared once in $launchAliases at the top.
+    $launchTargets = New-Object System.Collections.Generic.List[string]
+    $launchTargets.Add($app)
+    $titleHints = New-Object System.Collections.Generic.List[string]
+    if ($leaf) {
+      $titleHints.Add($leaf)
+      foreach ($alias in $launchAliases) {
+        if ($alias.names -notcontains $leaf.ToLowerInvariant()) { continue }
+        foreach ($aliasTarget in $alias.targets) { $launchTargets.Add($aliasTarget) }
+        foreach ($aliasHint in $alias.hints) { $titleHints.Add($aliasHint) }
+        break
       }
     }
+
+    function Find-LaunchedWindow([uint32]$targetPid) {
+      foreach ($hWnd in [LightcodeComputerUseNative]::Windows()) {
+        # Cheap pre-filter: resolve pid + newness from the handle alone and skip
+        # windows that can never match before building the full window object.
+        $wPid = [uint32]0
+        [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$wPid)
+        $isNew = -not $beforeIds.Contains([int64]$hWnd)
+        $pidMatch = ($targetPid -ne 0 -and $wPid -eq $targetPid)
+        if (-not $isNew -and -not $pidMatch) { continue }
+        $candidate = Get-WindowObject $hWnd
+        if ($null -eq $candidate -or $candidate.width -le 0 -or $candidate.height -le 0) { continue }
+        $hintMatch = $false
+        if ($isNew) {
+          foreach ($hint in $titleHints) {
+            if (
+              ($candidate.title -and $candidate.title -match [regex]::Escape($hint)) -or
+              ($candidate.displayName -and [string]::Equals($candidate.displayName, $hint, [StringComparison]::OrdinalIgnoreCase)) -or
+              ($candidate.app -and [IO.Path]::GetFileNameWithoutExtension([string]$candidate.app) -ieq $hint)
+            ) { $hintMatch = $true; break }
+          }
+        }
+        if ($pidMatch -or $hintMatch) { return $candidate }
+      }
+      return $null
+    }
+
+    $window = $null
+    $anyLaunchAttempted = $false
+    foreach ($target in $launchTargets) {
+      $proc = $null
+      try {
+        $isShellOrProtocol = (
+          $target -match '(?i)^shell:AppsFolder\\' -or
+          $target -match '^[A-Za-z][A-Za-z0-9+.\-]*:'
+        ) -and ($target -notmatch '^[A-Za-z]:\\')
+        if ($isShellOrProtocol) {
+          Start-Process -FilePath $target -ErrorAction Stop | Out-Null
+        } else {
+          $proc = Start-Process -FilePath $target -PassThru -ErrorAction Stop
+        }
+        $anyLaunchAttempted = $true
+      } catch {
+        continue
+      }
+      $targetPid = if ($proc -and $proc.Id) { [uint32]$proc.Id } else { [uint32]0 }
+      # Per-target poll (~3s). If the stub starts but no window appears (common for
+      # calc.exe → Store Calculator), fall through to the next alias.
+      $deadline = (Get-Date).AddSeconds(3)
+      while ((Get-Date) -lt $deadline -and $null -eq $window) {
+        $window = Find-LaunchedWindow $targetPid
+        if ($null -eq $window) { Start-Sleep -Milliseconds 150 }
+      }
+      if ($null -ne $window) { break }
+    }
+    if (-not $anyLaunchAttempted) { throw "Unable to launch app: $app" }
     if ($null -ne $window) {
       $result = [pscustomobject]@{
         ok = $true
-        window = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+        window = Select-Window $window
       }
     } else {
-      $result = [pscustomobject]@{ ok = $true; window = $null; note = "App launched but no window became available within the timeout." }
+      $result = [pscustomobject]@{ ok = $true; window = $null; note = "App launched but no window became available within the timeout. Call list_windows to find it." }
     }
-  }
-  "set_value" {
-    throw "set_value is not supported yet; click or focus the target field, then use type_text."
-  }
-  "perform_secondary_action" {
-    throw "perform_secondary_action is not supported yet; use keyboard navigation or coordinate input."
   }
   default {
     throw "Unknown action: $($request.action)"
@@ -847,6 +1106,21 @@ class PersistentPowerShellHost {
   }
 }
 
+// Defense-in-depth: mirrored in the PowerShell helper's launch_app validation
+// across the process boundary — keep both sides in sync.
+export function validateWindowsLaunchAppInput(app: string): void {
+  if (app.trim().length === 0) throw new Error("app is required");
+  if (/^\\\\/.test(app)) throw new Error("UNC paths are not allowed for launch_app.");
+  const isShellAppsFolder = /^shell:AppsFolder\\/i.test(app);
+  const isDrivePath = /^[A-Za-z]:[\\/]/.test(app);
+  if (!isShellAppsFolder && !isDrivePath && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(app)) {
+    throw new Error("URL schemes are not allowed for launch_app.");
+  }
+  if (!isShellAppsFolder && !isDrivePath && /[\\/]/.test(app)) {
+    throw new Error("Relative paths are not allowed for launch_app.");
+  }
+}
+
 function normalizeArray<T>(value: T | T[] | null | undefined): T[] {
   if (Array.isArray(value)) return value;
   return value == null ? [] : [value];
@@ -883,7 +1157,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     return this.host.request("get_window_state", input);
   }
 
-  activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }> {
+  activateWindow(input: { window: ComputerUseWindow }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("activate_window", input);
   }
 
@@ -893,21 +1167,21 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     window: ComputerUseWindow;
     x?: number;
     y?: number;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("click", input);
   }
 
-  typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }> {
+  typeText(input: {
+    text: string;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("type_text", input);
   }
 
-  pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }> {
+  pressKey(input: {
+    key: string;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("press_key", input);
   }
 
@@ -917,7 +1191,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     window: ComputerUseWindow;
     x: number;
     y: number;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("scroll", input);
   }
 
@@ -927,7 +1201,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     to_x: number;
     to_y: number;
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }> {
+  }): Promise<ComputerUseInteractiveResult> {
     return this.host.request("drag", input);
   }
 
@@ -936,22 +1210,7 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     window?: ComputerUseWindow | null;
     note?: string;
   }> {
+    validateWindowsLaunchAppInput(input.app);
     return this.host.request("launch_app", input);
-  }
-
-  setValue(input: {
-    element_index: number;
-    value: string;
-    window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }> {
-    return this.host.request("set_value", input);
-  }
-
-  performSecondaryAction(input: {
-    action: string;
-    element_index: number;
-    window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }> {
-    return this.host.request("perform_secondary_action", input);
   }
 }

--- a/src/main/computer-use/drivers/windows.ts
+++ b/src/main/computer-use/drivers/windows.ts
@@ -76,6 +76,14 @@ public static class LightcodeComputerUseNative {
   [DllImport("user32.dll")] public static extern void mouse_event(uint flags, uint dx, uint dy, uint data, UIntPtr extraInfo);
   [DllImport("user32.dll")] public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
   [DllImport("user32.dll")] public static extern short VkKeyScan(char ch);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+  [DllImport("user32.dll")] public static extern bool BringWindowToTop(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+  [DllImport("user32.dll")] public static extern bool AllowSetForegroundWindow(uint dwProcessId);
+  [DllImport("user32.dll")] public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, UIntPtr dwExtraInfo);
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr value);
+  [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
 
   public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
   public const uint MOUSEEVENTF_LEFTUP = 0x0004;
@@ -97,18 +105,36 @@ public static class LightcodeComputerUseNative {
     return windows;
   }
 
+  private static INPUT UnicodeInput(char unit, bool up) {
+    var input = new INPUT();
+    input.type = 1;
+    input.U.ki.wScan = unit;
+    input.U.ki.dwFlags = KEYEVENTF_UNICODE | (up ? KEYEVENTF_KEYUP : 0);
+    return input;
+  }
+
   public static void SendUnicodeText(string text) {
     if (String.IsNullOrEmpty(text)) return;
-    var inputs = new INPUT[text.Length * 2];
-    for (var i = 0; i < text.Length; i++) {
-      inputs[i * 2].type = 1;
-      inputs[i * 2].U.ki.wScan = text[i];
-      inputs[i * 2].U.ki.dwFlags = KEYEVENTF_UNICODE;
-      inputs[i * 2 + 1].type = 1;
-      inputs[i * 2 + 1].U.ki.wScan = text[i];
-      inputs[i * 2 + 1].U.ki.dwFlags = KEYEVENTF_UNICODE | KEYEVENTF_KEYUP;
+    var inputs = new List<INPUT>(text.Length * 2);
+    var i = 0;
+    while (i < text.Length) {
+      var c = text[i];
+      if (Char.IsHighSurrogate(c) && i + 1 < text.Length && Char.IsLowSurrogate(text[i + 1])) {
+        // Keep a surrogate pair together: both code units down, then both up.
+        var lo = text[i + 1];
+        inputs.Add(UnicodeInput(c, false));
+        inputs.Add(UnicodeInput(lo, false));
+        inputs.Add(UnicodeInput(c, true));
+        inputs.Add(UnicodeInput(lo, true));
+        i += 2;
+      } else {
+        inputs.Add(UnicodeInput(c, false));
+        inputs.Add(UnicodeInput(c, true));
+        i += 1;
+      }
     }
-    SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
+    var arr = inputs.ToArray();
+    if (arr.Length > 0) SendInput((uint)arr.Length, arr, Marshal.SizeOf(typeof(INPUT)));
   }
 
   public static void Key(ushort vk, bool up) {
@@ -120,6 +146,12 @@ public static class LightcodeComputerUseNative {
   }
 }
 "@
+
+# Make GetWindowRect / capture / SetCursorPos share physical pixels on scaled
+# displays. PER_MONITOR_AWARE_V2 = -4. Guard for pre-1703 hosts that lack the API.
+try { [void][LightcodeComputerUseNative]::SetProcessDpiAwarenessContext([IntPtr](-4)) } catch {}
+
+$ASFW_ANY = [uint32]"0xFFFFFFFF"
 
 function Get-WindowObject([IntPtr]$hWnd) {
   if (-not [LightcodeComputerUseNative]::IsWindow($hWnd)) { return $null }
@@ -172,12 +204,45 @@ function Require-Window($req) {
 
 function Activate-Window($window) {
   $hWnd = [IntPtr]([int64]$window.id)
-  [void][LightcodeComputerUseNative]::ShowWindow($hWnd, 9)
-  Start-Sleep -Milliseconds 40
-  if (-not [LightcodeComputerUseNative]::SetForegroundWindow($hWnd)) {
-    throw "Unable to activate window. The desktop may be locked or another secure surface may be active."
+  # SW_RESTORE (9) un-maximizes a maximized window, which would move/resize it
+  # AFTER the agent's screenshot and break coordinate math. Only restore when the
+  # window is actually minimized; otherwise SW_SHOW (5) leaves geometry untouched.
+  if ([LightcodeComputerUseNative]::IsIconic($hWnd)) {
+    [void][LightcodeComputerUseNative]::ShowWindow($hWnd, 9)
+    Start-Sleep -Milliseconds 40
+  } else {
+    [void][LightcodeComputerUseNative]::ShowWindow($hWnd, 5)
   }
-  Start-Sleep -Milliseconds 40
+  $activated = $false
+  for ($attempt = 0; $attempt -lt 3; $attempt++) {
+    if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
+    [void][LightcodeComputerUseNative]::AllowSetForegroundWindow($ASFW_ANY)
+    # An alt-key nudge releases the foreground lock so SetForegroundWindow is honored.
+    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 0, [UIntPtr]::Zero)
+    [LightcodeComputerUseNative]::keybd_event(0x12, 0, 2, [UIntPtr]::Zero)
+    $fg = [LightcodeComputerUseNative]::GetForegroundWindow()
+    $fgPid = [uint32]0
+    $fgThread = [LightcodeComputerUseNative]::GetWindowThreadProcessId($fg, [ref]$fgPid)
+    $cur = [LightcodeComputerUseNative]::GetCurrentThreadId()
+    $attached = $false
+    if ($fgThread -ne $cur) { $attached = [LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $true) }
+    try {
+      [void][LightcodeComputerUseNative]::BringWindowToTop($hWnd)
+      [void][LightcodeComputerUseNative]::SetForegroundWindow($hWnd)
+    } finally {
+      if ($attached) { [void][LightcodeComputerUseNative]::AttachThreadInput($fgThread, $cur, $false) }
+    }
+    Start-Sleep -Milliseconds 60
+    if ([LightcodeComputerUseNative]::GetForegroundWindow() -eq $hWnd) { $activated = $true; break }
+  }
+  if (-not $activated) {
+    throw "Focus did not reach the target window. The desktop may be locked or another secure surface may be active."
+  }
+  # Re-capture the window rect AFTER activation: show/restore may have changed the
+  # window geometry, so return the fresh object for coordinate math.
+  $fresh = Get-WindowObject $hWnd
+  if ($null -eq $fresh) { return $window }
+  return $fresh
 }
 
 function Capture-Window($window) {
@@ -222,7 +287,8 @@ function Capture-Window($window) {
 }
 
 function Resolve-Key($token) {
-  $t = ([string]$token).Trim().ToLowerInvariant()
+  $raw = ([string]$token).Trim()
+  $t = $raw.ToLowerInvariant()
   switch ($t) {
     "control" { return 0x11 }
     "ctrl" { return 0x11 }
@@ -234,6 +300,10 @@ function Resolve-Key($token) {
     "alt" { return 0x12 }
     "alt_l" { return 0x12 }
     "alt_r" { return 0x12 }
+    "win" { return 0x5B }
+    "super" { return 0x5B }
+    "meta" { return 0x5B }
+    "cmd" { return 0x5B }
     "return" { return 0x0D }
     "enter" { return 0x0D }
     "tab" { return 0x09 }
@@ -242,6 +312,9 @@ function Resolve-Key($token) {
     "space" { return 0x20 }
     "backspace" { return 0x08 }
     "delete" { return 0x2E }
+    "insert" { return 0x2D }
+    "ins" { return 0x2D }
+    "capslock" { return 0x14 }
     "left" { return 0x25 }
     "arrowleft" { return 0x25 }
     "up" { return 0x26 }
@@ -265,21 +338,55 @@ function Resolve-Key($token) {
   }
   if ($t -match '^f([1-9]|1[0-9]|2[0-4])$') { return 0x70 + [int]$Matches[1] - 1 }
   if ($t -match '^kp_([0-9])$' -or $t -match '^numpad_([0-9])$') { return 0x60 + [int]$Matches[1] }
-  if ($t.Length -eq 1) {
-    $vk = [LightcodeComputerUseNative]::VkKeyScan([char]$t[0])
+  if ($raw.Length -eq 1) {
+    # Return the FULL VkKeyScan result, keeping the shift/ctrl/alt flags in the
+    # high byte so Press-Chord can reproduce them (e.g. '!' => shift+1, 'A' => shift+a).
+    $vk = [LightcodeComputerUseNative]::VkKeyScan([char]$raw[0])
     if ($vk -eq -1) { throw "Unsupported key: $token" }
-    return ($vk -band 0xff)
+    return [int]$vk
   }
   throw "Unsupported key: $token"
 }
 
 function Press-Chord($key) {
-  $tokens = ([string]$key) -split '\+' | ForEach-Object { $_.Trim() } | Where-Object { $_.Length -gt 0 }
+  $rawKey = ([string]$key).Trim()
+  if ($rawKey.Length -eq 0) { throw "key is required" }
+  # Splitting on '+' would drop a standalone or trailing literal '+' (e.g. "+"
+  # or "ctrl++"); special-case it so the plus key is still emitted.
+  if ($rawKey -eq '+') {
+    $tokens = @('+')
+  } else {
+    $tokens = @($rawKey -split '\+' | ForEach-Object { $_.Trim() } | Where-Object { $_.Length -gt 0 })
+    if ($rawKey.EndsWith('+')) { $tokens += '+' }
+  }
   if ($tokens.Count -eq 0) { throw "key is required" }
-  $vks = @($tokens | ForEach-Object { [uint16](Resolve-Key $_) })
-  foreach ($vk in $vks) { [LightcodeComputerUseNative]::Key($vk, $false) }
-  [Array]::Reverse($vks)
-  foreach ($vk in $vks) { [LightcodeComputerUseNative]::Key($vk, $true) }
+  $modVks = New-Object System.Collections.Generic.List[uint16]
+  $baseVks = New-Object System.Collections.Generic.List[uint16]
+  foreach ($tok in $tokens) {
+    $val = [int](Resolve-Key $tok)
+    $vk = [uint16]($val -band 0xff)
+    $mods = ($val -shr 8) -band 0xff
+    if (($mods -band 1) -and (-not $modVks.Contains([uint16]0x10))) { $modVks.Add([uint16]0x10) }
+    if (($mods -band 2) -and (-not $modVks.Contains([uint16]0x11))) { $modVks.Add([uint16]0x11) }
+    if (($mods -band 4) -and (-not $modVks.Contains([uint16]0x12))) { $modVks.Add([uint16]0x12) }
+    $baseVks.Add($vk)
+  }
+  $pressed = New-Object System.Collections.Generic.List[uint16]
+  try {
+    foreach ($vk in $modVks) { [LightcodeComputerUseNative]::Key($vk, $false); $pressed.Add($vk) }
+    foreach ($vk in $baseVks) { [LightcodeComputerUseNative]::Key($vk, $false); $pressed.Add($vk) }
+    for ($i = $baseVks.Count - 1; $i -ge 0; $i--) {
+      [LightcodeComputerUseNative]::Key($baseVks[$i], $true); [void]$pressed.Remove($baseVks[$i])
+    }
+    for ($i = $modVks.Count - 1; $i -ge 0; $i--) {
+      [LightcodeComputerUseNative]::Key($modVks[$i], $true); [void]$pressed.Remove($modVks[$i])
+    }
+  } finally {
+    # Never leave a key physically down system-wide if we threw mid-sequence.
+    for ($i = $pressed.Count - 1; $i -ge 0; $i--) {
+      try { [LightcodeComputerUseNative]::Key($pressed[$i], $true) } catch {}
+    }
+  }
 }
 
 function Mouse-Click($button, $count) {
@@ -359,12 +466,12 @@ switch ([string]$request.action) {
   }
   "activate_window" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
+    $window = Activate-Window $window
     $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
   }
   "click" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
+    $window = Activate-Window $window
     $x = [int]$request.input.x
     $y = [int]$request.input.y
     [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + $x, [int]$window.y + $y)
@@ -373,19 +480,19 @@ switch ([string]$request.action) {
   }
   "type_text" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
+    $window = Activate-Window $window
     [LightcodeComputerUseNative]::SendUnicodeText([string]$request.input.text)
     $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
   }
   "press_key" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
+    $window = Activate-Window $window
     Press-Chord $request.input.key
     $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
   }
   "scroll" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
+    $window = Activate-Window $window
     [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.x, [int]$window.y + [int]$request.input.y)
     if ([int]$request.input.scrollY -ne 0) {
       [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_WHEEL, 0, 0, [uint32](-1 * [int]$request.input.scrollY), [UIntPtr]::Zero)
@@ -397,18 +504,62 @@ switch ([string]$request.action) {
   }
   "drag" {
     $window = Require-Window $request.input.window
-    Activate-Window $window
-    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.from_x, [int]$window.y + [int]$request.input.from_y)
-    [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTDOWN, 0, 0, 0, [UIntPtr]::Zero)
-    Start-Sleep -Milliseconds 40
-    [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.to_x, [int]$window.y + [int]$request.input.to_y)
-    Start-Sleep -Milliseconds 40
-    [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero)
+    $window = Activate-Window $window
+    $downSent = $false
+    try {
+      [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.from_x, [int]$window.y + [int]$request.input.from_y)
+      [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTDOWN, 0, 0, 0, [UIntPtr]::Zero)
+      $downSent = $true
+      Start-Sleep -Milliseconds 40
+      [void][LightcodeComputerUseNative]::SetCursorPos([int]$window.x + [int]$request.input.to_x, [int]$window.y + [int]$request.input.to_y)
+      Start-Sleep -Milliseconds 40
+      [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero)
+      $downSent = $false
+    } finally {
+      # Never leave the mouse button physically down if we threw mid-drag.
+      if ($downSent) {
+        try { [LightcodeComputerUseNative]::mouse_event([LightcodeComputerUseNative]::MOUSEEVENTF_LEFTUP, 0, 0, 0, [UIntPtr]::Zero) } catch {}
+      }
+    }
     $result = [pscustomobject]@{ ok = $true; mode = "interactive" }
   }
   "launch_app" {
-    Start-Process -FilePath ([string]$request.input.app)
-    $result = [pscustomobject]@{ ok = $true }
+    $app = [string]$request.input.app
+    if ($app.Trim().Length -eq 0) { throw "app is required" }
+    # Defense-in-depth: refuse UNC paths and URL schemes so launch_app can't pull
+    # a remote payload or hand off to a protocol handler.
+    if ($app -match '^\\\\') { throw "UNC paths are not allowed for launch_app." }
+    if ($app -match '^[A-Za-z][A-Za-z0-9+.\-]*://') { throw "URL schemes are not allowed for launch_app." }
+    $proc = Start-Process -FilePath $app -PassThru
+    $window = $null
+    if ($proc -and $proc.Id) {
+      $targetPid = [uint32]$proc.Id
+      # Start-Process returns before the window exists; poll (bounded ~4s) for a
+      # visible, titled top-level window owned by the new process.
+      $deadline = (Get-Date).AddSeconds(4)
+      while ((Get-Date) -lt $deadline -and $null -eq $window) {
+        foreach ($hWnd in [LightcodeComputerUseNative]::Windows()) {
+          $wPid = [uint32]0
+          [void][LightcodeComputerUseNative]::GetWindowThreadProcessId($hWnd, [ref]$wPid)
+          if ($wPid -eq $targetPid) {
+            $candidate = Get-WindowObject $hWnd
+            if ($null -ne $candidate -and $candidate.width -gt 0 -and $candidate.height -gt 0) {
+              $window = $candidate
+              break
+            }
+          }
+        }
+        if ($null -eq $window) { Start-Sleep -Milliseconds 150 }
+      }
+    }
+    if ($null -ne $window) {
+      $result = [pscustomobject]@{
+        ok = $true
+        window = [pscustomobject]@{ app = $window.app; id = $window.id; title = $window.title; x = $window.x; y = $window.y; width = $window.width; height = $window.height }
+      }
+    } else {
+      $result = [pscustomobject]@{ ok = $true; window = $null; note = "App launched but no window became available within the timeout." }
+    }
   }
   "set_value" {
     throw "set_value is not supported yet; click or focus the target field, then use type_text."
@@ -532,7 +683,11 @@ export class WindowsComputerUseDriver implements ComputerUseDriver {
     return runWindowsComputerUse("drag", input);
   }
 
-  launchApp(input: { app: string }): Promise<{ ok: true }> {
+  launchApp(input: { app: string }): Promise<{
+    ok: true;
+    window?: ComputerUseWindow | null;
+    note?: string;
+  }> {
     return runWindowsComputerUse("launch_app", input);
   }
 

--- a/src/main/computer-use/index.ts
+++ b/src/main/computer-use/index.ts
@@ -1,1 +1,6 @@
-export { ComputerUseMcpIngress, type ComputerUseMcpIngressInfo } from "./ComputerUseMcpIngress";
+export {
+  ComputerUseMcpIngress,
+  type ComputerUseActivityEvent,
+  type ComputerUseMcpIngressInfo,
+} from "./ComputerUseMcpIngress";
+export { ComputerUseDesktopOverlay } from "./ComputerUseDesktopOverlay";

--- a/src/main/computer-use/index.ts
+++ b/src/main/computer-use/index.ts
@@ -1,0 +1,1 @@
+export { ComputerUseMcpIngress, type ComputerUseMcpIngressInfo } from "./ComputerUseMcpIngress";

--- a/src/main/computer-use/mcp/toolRegistry.test.ts
+++ b/src/main/computer-use/mcp/toolRegistry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ComputerUseDriver } from "./types";
+import { dispatchTool, isInteractiveToolName, TOOLS } from "./toolRegistry";
+
+function createDriver(overrides: Partial<ComputerUseDriver> = {}): ComputerUseDriver {
+  const driver: ComputerUseDriver = {
+    activateWindow: vi.fn<ComputerUseDriver["activateWindow"]>(),
+    click: vi.fn<ComputerUseDriver["click"]>(),
+    dispose: vi.fn<ComputerUseDriver["dispose"]>(),
+    drag: vi.fn<ComputerUseDriver["drag"]>(),
+    getWindow: vi.fn<ComputerUseDriver["getWindow"]>(),
+    getWindowState: vi.fn<ComputerUseDriver["getWindowState"]>(),
+    launchApp: vi.fn<ComputerUseDriver["launchApp"]>(),
+    listApps: vi.fn<ComputerUseDriver["listApps"]>(),
+    listWindows: vi.fn<ComputerUseDriver["listWindows"]>(),
+    pressKey: vi.fn<ComputerUseDriver["pressKey"]>(),
+    scroll: vi.fn<ComputerUseDriver["scroll"]>(),
+    typeText: vi.fn<ComputerUseDriver["typeText"]>(),
+    ...overrides,
+  };
+  return driver;
+}
+
+describe("computer-use toolRegistry", () => {
+  it("does not advertise unsupported accessibility action tools", () => {
+    expect(TOOLS.map((tool) => tool.name)).not.toContain("set_value");
+    expect(TOOLS.map((tool) => tool.name)).not.toContain("perform_secondary_action");
+  });
+
+  it("distinguishes takeover tools from passive inspection", () => {
+    expect(isInteractiveToolName("click")).toBe(true);
+    expect(isInteractiveToolName("type")).toBe(true);
+    expect(isInteractiveToolName("get_window_state")).toBe(false);
+    expect(isInteractiveToolName("list_windows")).toBe(false);
+  });
+
+  it("preserves the refreshed window returned by interactive driver actions", async () => {
+    const inputWindow = { app: "calc", id: 1 };
+    const refreshedWindow = { app: "calc", id: 2, title: "Calculator" };
+    const driver = createDriver({
+      click: vi.fn<ComputerUseDriver["click"]>().mockResolvedValue({
+        ok: true,
+        mode: "interactive",
+        window: refreshedWindow,
+      }),
+    });
+
+    await expect(
+      dispatchTool("click", { window: inputWindow, x: 10, y: 20 }, { driver }),
+    ).resolves.toEqual({
+      ok: true,
+      mode: "interactive",
+      window: refreshedWindow,
+    });
+    expect(driver.click).toHaveBeenCalledWith({ window: inputWindow, x: 10, y: 20 });
+  });
+
+  it("rejects malformed click options instead of silently left-clicking", async () => {
+    const driver = createDriver();
+    const window = { app: "calc", id: 1 };
+
+    await expect(
+      dispatchTool("click", { window, x: 10, y: 20, mouse_button: "primary" }, { driver }),
+    ).rejects.toThrow("mouse_button must be left, right, or middle");
+    await expect(
+      dispatchTool("click", { window, x: 10, y: 20, click_count: 100 }, { driver }),
+    ).rejects.toThrow("click_count must be 1 or 2");
+    expect(driver.click).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/computer-use/mcp/toolRegistry.ts
+++ b/src/main/computer-use/mcp/toolRegistry.ts
@@ -26,7 +26,7 @@ const WINDOW_SCHEMA = {
 };
 
 export const COMPUTER_USE_MCP_INSTRUCTIONS =
-  "Use the computer_use MCP server to inspect and control native macOS or Windows apps. Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. list/get/screenshot operations are passive where the OS allows it; click, drag, scroll, type_text, press_key, set_value, perform_secondary_action, activate_window, and launch_app switch to interactive mode and may activate the target app. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
+  "Use the computer_use MCP server to inspect and control native macOS or Windows apps. Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. list/get/screenshot operations are passive where the OS allows it; click, drag, scroll, type_text, press_key, activate_window, and launch_app switch to interactive mode and may activate the target app. Coordinates (x/y) are window-relative with the origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the most recent get_window_state screenshot for that window; if the window may have moved or resized, call get_window_state again before sending coordinates. If a tool reports that the window is no longer available (windows are re-identified after they move/resize), call computer_use.list_windows or computer_use.get_window to obtain a fresh window id and retry. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
 
 export const TOOLS: ToolSpec[] = [
   {
@@ -57,10 +57,10 @@ export const TOOLS: ToolSpec[] = [
   {
     name: "get_window",
     description:
-      "Refresh a window object returned by list_apps, list_windows, or get_window_state.",
+      "Refresh a window object returned by list_apps, list_windows, or get_window_state. Use this to obtain a fresh window id (with current geometry) whenever a tool reports that the window is no longer available.",
     inputSchema: {
       type: "object",
-      required: ["id"],
+      required: ["app", "id"],
       properties: { app: { type: "string" }, id: { type: "number" } },
     },
   },
@@ -90,7 +90,7 @@ export const TOOLS: ToolSpec[] = [
   {
     name: "click",
     description:
-      "Click window-relative coordinates from the latest screenshot. This is interactive.",
+      "Click window-relative coordinates. x/y have their origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the get_window_state screenshot. Coordinates must come from the most recent get_window_state screenshot for this window; if the window may have moved, call get_window_state again first. If this reports the window is no longer available, call list_windows or get_window for a fresh id and retry. This is interactive.",
     inputSchema: {
       type: "object",
       required: ["window", "x", "y"],
@@ -125,7 +125,8 @@ export const TOOLS: ToolSpec[] = [
   },
   {
     name: "scroll",
-    description: "Scroll from window-relative coordinates. This is interactive.",
+    description:
+      "Scroll from window-relative coordinates. x/y have their origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the get_window_state screenshot. Coordinates must come from the most recent get_window_state screenshot for this window; if the window may have moved, call get_window_state again first. If this reports the window is no longer available, call list_windows or get_window for a fresh id and retry. This is interactive.",
     inputSchema: {
       type: "object",
       required: ["window", "x", "y", "scrollX", "scrollY"],
@@ -140,7 +141,8 @@ export const TOOLS: ToolSpec[] = [
   },
   {
     name: "drag",
-    description: "Drag between window-relative coordinates. This is interactive.",
+    description:
+      "Drag between window-relative coordinates. from_x/from_y and to_x/to_y have their origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the get_window_state screenshot. Coordinates must come from the most recent get_window_state screenshot for this window; if the window may have moved, call get_window_state again first. If this reports the window is no longer available, call list_windows or get_window for a fresh id and retry. This is interactive.",
     inputSchema: {
       type: "object",
       required: ["window", "from_x", "from_y", "to_x", "to_y"],
@@ -153,38 +155,13 @@ export const TOOLS: ToolSpec[] = [
       },
     },
   },
-  {
-    name: "set_value",
-    description:
-      "Set the value of an editable element by accessibility element_index when supported. This is interactive.",
-    inputSchema: {
-      type: "object",
-      required: ["window", "element_index", "value"],
-      properties: {
-        window: WINDOW_SCHEMA,
-        element_index: { type: "number" },
-        value: { type: "string" },
-      },
-    },
-  },
-  {
-    name: "perform_secondary_action",
-    description:
-      "Invoke a secondary accessibility action by element_index when supported. This is interactive.",
-    inputSchema: {
-      type: "object",
-      required: ["window", "element_index", "action"],
-      properties: {
-        window: WINDOW_SCHEMA,
-        element_index: { type: "number" },
-        action: { type: "string" },
-      },
-    },
-  },
 ];
 
 export const TOOL_NAMES = new Set(TOOLS.map((tool) => tool.name));
 
+// Lenience map: these short aliases are NOT advertised via tools/list and are
+// not discoverable through MCP. They only rescue a model that guesses a common
+// short name (e.g. "screenshot") before, or instead of, reading tools/list.
 const TOOL_ALIASES = new Map([
   ["apps", "list_apps"],
   ["windows", "list_windows"],
@@ -275,18 +252,6 @@ export async function dispatchTool(
         from_y: readNumber(args.from_y, "from_y"),
         to_x: readNumber(args.to_x, "to_x"),
         to_y: readNumber(args.to_y, "to_y"),
-      });
-    case "set_value":
-      return await ctx.driver.setValue({
-        window: readWindow(args.window),
-        element_index: readNumber(args.element_index, "element_index"),
-        value: readString(args.value, "value"),
-      });
-    case "perform_secondary_action":
-      return await ctx.driver.performSecondaryAction({
-        window: readWindow(args.window),
-        element_index: readNumber(args.element_index, "element_index"),
-        action: readString(args.action, "action"),
       });
     default:
       throw new Error(`unknown tool: ${name}`);

--- a/src/main/computer-use/mcp/toolRegistry.ts
+++ b/src/main/computer-use/mcp/toolRegistry.ts
@@ -67,7 +67,7 @@ export const TOOLS: ToolSpec[] = [
   {
     name: "get_window_state",
     description:
-      "Capture a point-in-time passive window screenshot and optional accessibility text.",
+      "Capture a point-in-time passive window screenshot and optional accessibility text. By default the screenshot is a JPEG downscaled so its largest side is at most max_dimension (1280) px to keep the payload small; if it was downscaled, the notes report the scale factor you must divide screenshot pixel coordinates by to get window-relative click coordinates. Pass format:'png' and/or a larger max_dimension for a pixel-exact capture.",
     inputSchema: {
       type: "object",
       required: ["window"],
@@ -75,6 +75,8 @@ export const TOOLS: ToolSpec[] = [
         window: WINDOW_SCHEMA,
         include_screenshot: { type: "boolean" },
         include_text: { type: "boolean" },
+        max_dimension: { type: "number" },
+        format: { type: "string", enum: ["png", "jpeg"] },
       },
     },
   },
@@ -214,6 +216,12 @@ export async function dispatchTool(
           : {}),
         ...(typeof payload.include_text === "boolean"
           ? { include_text: payload.include_text }
+          : {}),
+        ...(typeof payload.max_dimension === "number" && Number.isFinite(payload.max_dimension)
+          ? { max_dimension: payload.max_dimension }
+          : {}),
+        ...(payload.format === "png" || payload.format === "jpeg"
+          ? { format: payload.format }
           : {}),
       });
     }

--- a/src/main/computer-use/mcp/toolRegistry.ts
+++ b/src/main/computer-use/mcp/toolRegistry.ts
@@ -1,8 +1,9 @@
 import type { ComputerUseDriver, ComputerUseScreenshot, ComputerUseWindowState } from "./types";
-import { readNumber, readRecord, readString, readWindow } from "../drivers/common";
+import { readNumber, readString, readWindow } from "../drivers/common";
 
 export interface ToolContext {
   driver: ComputerUseDriver;
+  threadId?: string;
 }
 
 export interface ToolSpec {
@@ -26,7 +27,7 @@ const WINDOW_SCHEMA = {
 };
 
 export const COMPUTER_USE_MCP_INSTRUCTIONS =
-  "Use the computer_use MCP server to inspect and control native macOS or Windows apps. Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. list/get/screenshot operations are passive where the OS allows it; click, drag, scroll, type_text, press_key, activate_window, and launch_app switch to interactive mode and may activate the target app. Coordinates (x/y) are window-relative with the origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the most recent get_window_state screenshot for that window; if the window may have moved or resized, call get_window_state again before sending coordinates. If a tool reports that the window is no longer available (windows are re-identified after they move/resize), call computer_use.list_windows or computer_use.get_window to obtain a fresh window id and retry. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
+  "Use the computer_use MCP server to inspect and control native macOS or Windows apps on the host desktop (including when the user is driving from a paired phone/remote client — agents still run on that desktop). Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. Prefer ordinary Win32 desktop apps when you have a choice — some Store/WinUI apps recreate window handles during activation, so always prefer the `window` object returned by interactive tools (or re-call list_windows/get_window) before the next click/type. list/get/screenshot operations are passive and do not steal focus; click, drag, scroll, type_text, press_key, activate_window, and launch_app switch to interactive mode, bring the target app to the FOREGROUND, and take exclusive control of the real mouse/keyboard — nobody should use the host machine while interactive computer-use is running. Coordinates (x/y) are window-relative with the origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the most recent get_window_state screenshot for that window; if the window may have moved or resized, call get_window_state again before sending coordinates. If a tool reports that the window is no longer available (windows are re-identified after they move/resize), call computer_use.list_windows or computer_use.get_window to obtain a fresh window id and retry. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
 
 export const TOOLS: ToolSpec[] = [
   {
@@ -100,7 +101,7 @@ export const TOOLS: ToolSpec[] = [
         window: WINDOW_SCHEMA,
         x: { type: "number" },
         y: { type: "number" },
-        click_count: { type: "number" },
+        click_count: { type: "integer", minimum: 1, maximum: 2 },
         mouse_button: { type: "string", enum: ["left", "right", "middle", "l", "r", "m"] },
       },
     },
@@ -161,6 +162,16 @@ export const TOOLS: ToolSpec[] = [
 
 export const TOOL_NAMES = new Set(TOOLS.map((tool) => tool.name));
 
+const INTERACTIVE_TOOL_NAMES = new Set([
+  "activate_window",
+  "click",
+  "press_key",
+  "type_text",
+  "scroll",
+  "drag",
+  "launch_app",
+]);
+
 // Lenience map: these short aliases are NOT advertised via tools/list and are
 // not discoverable through MCP. They only rescue a model that guesses a common
 // short name (e.g. "screenshot") before, or instead of, reading tools/list.
@@ -178,6 +189,36 @@ export function normalizeToolName(name: string): string {
 
 export function isKnownToolName(name: string): boolean {
   return TOOL_NAMES.has(normalizeToolName(name));
+}
+
+export function isInteractiveToolName(name: string): boolean {
+  return INTERACTIVE_TOOL_NAMES.has(normalizeToolName(name));
+}
+
+// Tools that can synthesize arbitrary key chords (including Escape). While one
+// is in flight, the desktop overlay must not intercept Escape globally.
+// type_text is deliberately excluded: it types literal text and cannot emit Escape.
+const KEY_CHORD_TOOL_NAMES = new Set(["press_key"]);
+
+export function isKeyChordToolName(name: string): boolean {
+  return KEY_CHORD_TOOL_NAMES.has(normalizeToolName(name));
+}
+
+function readClickCount(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const count = readNumber(value, "click_count");
+  if (!Number.isInteger(count) || count < 1 || count > 2) {
+    throw new Error("click_count must be 1 or 2");
+  }
+  return count;
+}
+
+function readMouseButton(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !["left", "right", "middle", "l", "r", "m"].includes(value)) {
+    throw new Error("mouse_button must be left, right, or middle");
+  }
+  return value;
 }
 
 export async function dispatchTool(
@@ -207,34 +248,31 @@ export async function dispatchTool(
         ...(typeof args.app === "string" ? { app: args.app } : {}),
         id: readNumber(args.id, "id"),
       });
-    case "get_window_state": {
-      const payload = readRecord(args);
+    case "get_window_state":
       return await ctx.driver.getWindowState({
-        window: readWindow(payload.window),
-        ...(typeof payload.include_screenshot === "boolean"
-          ? { include_screenshot: payload.include_screenshot }
+        window: readWindow(args.window),
+        ...(typeof args.include_screenshot === "boolean"
+          ? { include_screenshot: args.include_screenshot }
           : {}),
-        ...(typeof payload.include_text === "boolean"
-          ? { include_text: payload.include_text }
+        ...(typeof args.include_text === "boolean" ? { include_text: args.include_text } : {}),
+        ...(typeof args.max_dimension === "number" && Number.isFinite(args.max_dimension)
+          ? { max_dimension: args.max_dimension }
           : {}),
-        ...(typeof payload.max_dimension === "number" && Number.isFinite(payload.max_dimension)
-          ? { max_dimension: payload.max_dimension }
-          : {}),
-        ...(payload.format === "png" || payload.format === "jpeg"
-          ? { format: payload.format }
-          : {}),
+        ...(args.format === "png" || args.format === "jpeg" ? { format: args.format } : {}),
       });
-    }
     case "activate_window":
       return await ctx.driver.activateWindow({ window: readWindow(args.window) });
-    case "click":
+    case "click": {
+      const clickCount = readClickCount(args.click_count);
+      const mouseButton = readMouseButton(args.mouse_button);
       return await ctx.driver.click({
         window: readWindow(args.window),
         x: readNumber(args.x, "x"),
         y: readNumber(args.y, "y"),
-        ...(typeof args.click_count === "number" ? { click_count: args.click_count } : {}),
-        ...(typeof args.mouse_button === "string" ? { mouse_button: args.mouse_button } : {}),
+        ...(clickCount !== undefined ? { click_count: clickCount } : {}),
+        ...(mouseButton !== undefined ? { mouse_button: mouseButton } : {}),
       });
+    }
     case "press_key":
       return await ctx.driver.pressKey({
         window: readWindow(args.window),

--- a/src/main/computer-use/mcp/toolRegistry.ts
+++ b/src/main/computer-use/mcp/toolRegistry.ts
@@ -1,0 +1,336 @@
+import type { ComputerUseDriver, ComputerUseScreenshot, ComputerUseWindowState } from "./types";
+import { readNumber, readRecord, readString, readWindow } from "../drivers/common";
+
+export interface ToolContext {
+  driver: ComputerUseDriver;
+}
+
+export interface ToolSpec {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+const WINDOW_SCHEMA = {
+  type: "object",
+  required: ["app", "id"],
+  properties: {
+    app: { type: "string" },
+    id: { type: "number" },
+    title: { type: "string" },
+    x: { type: "number" },
+    y: { type: "number" },
+    width: { type: "number" },
+    height: { type: "number" },
+  },
+};
+
+export const COMPUTER_USE_MCP_INSTRUCTIONS =
+  "Use the computer_use MCP server to inspect and control native macOS or Windows apps. Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. list/get/screenshot operations are passive where the OS allows it; click, drag, scroll, type_text, press_key, set_value, perform_secondary_action, activate_window, and launch_app switch to interactive mode and may activate the target app. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
+
+export const TOOLS: ToolSpec[] = [
+  {
+    name: "api",
+    description:
+      "Return the complete Computer Use API and guidance. Call first when controlling a native app.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "list_apps",
+    description: "List discoverable apps and their currently targetable windows.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "list_windows",
+    description: "List currently targetable windows.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "launch_app",
+    description: "Launch an app by a list_apps id, app name, or explicit executable/app path.",
+    inputSchema: {
+      type: "object",
+      required: ["app"],
+      properties: { app: { type: "string" } },
+    },
+  },
+  {
+    name: "get_window",
+    description:
+      "Refresh a window object returned by list_apps, list_windows, or get_window_state.",
+    inputSchema: {
+      type: "object",
+      required: ["id"],
+      properties: { app: { type: "string" }, id: { type: "number" } },
+    },
+  },
+  {
+    name: "get_window_state",
+    description:
+      "Capture a point-in-time passive window screenshot and optional accessibility text.",
+    inputSchema: {
+      type: "object",
+      required: ["window"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        include_screenshot: { type: "boolean" },
+        include_text: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "activate_window",
+    description: "Bring a returned window to the foreground. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window"],
+      properties: { window: WINDOW_SCHEMA },
+    },
+  },
+  {
+    name: "click",
+    description:
+      "Click window-relative coordinates from the latest screenshot. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "x", "y"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        x: { type: "number" },
+        y: { type: "number" },
+        click_count: { type: "number" },
+        mouse_button: { type: "string", enum: ["left", "right", "middle", "l", "r", "m"] },
+      },
+    },
+  },
+  {
+    name: "press_key",
+    description:
+      "Press a key or + separated chord such as Return, Escape, Control_L+a, or KP_0. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "key"],
+      properties: { window: WINDOW_SCHEMA, key: { type: "string" } },
+    },
+  },
+  {
+    name: "type_text",
+    description:
+      "Type literal text into the focused control in a returned window. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "text"],
+      properties: { window: WINDOW_SCHEMA, text: { type: "string" } },
+    },
+  },
+  {
+    name: "scroll",
+    description: "Scroll from window-relative coordinates. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "x", "y", "scrollX", "scrollY"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        x: { type: "number" },
+        y: { type: "number" },
+        scrollX: { type: "number" },
+        scrollY: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "drag",
+    description: "Drag between window-relative coordinates. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "from_x", "from_y", "to_x", "to_y"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        from_x: { type: "number" },
+        from_y: { type: "number" },
+        to_x: { type: "number" },
+        to_y: { type: "number" },
+      },
+    },
+  },
+  {
+    name: "set_value",
+    description:
+      "Set the value of an editable element by accessibility element_index when supported. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "element_index", "value"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        element_index: { type: "number" },
+        value: { type: "string" },
+      },
+    },
+  },
+  {
+    name: "perform_secondary_action",
+    description:
+      "Invoke a secondary accessibility action by element_index when supported. This is interactive.",
+    inputSchema: {
+      type: "object",
+      required: ["window", "element_index", "action"],
+      properties: {
+        window: WINDOW_SCHEMA,
+        element_index: { type: "number" },
+        action: { type: "string" },
+      },
+    },
+  },
+];
+
+export const TOOL_NAMES = new Set(TOOLS.map((tool) => tool.name));
+
+const TOOL_ALIASES = new Map([
+  ["apps", "list_apps"],
+  ["windows", "list_windows"],
+  ["screenshot", "get_window_state"],
+  ["key", "press_key"],
+  ["type", "type_text"],
+]);
+
+export function normalizeToolName(name: string): string {
+  return TOOL_ALIASES.get(name) ?? name;
+}
+
+export function isKnownToolName(name: string): boolean {
+  return TOOL_NAMES.has(normalizeToolName(name));
+}
+
+export async function dispatchTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: ToolContext,
+): Promise<unknown> {
+  const tool = normalizeToolName(name);
+  switch (tool) {
+    case "api":
+      return {
+        instructions: COMPUTER_USE_MCP_INSTRUCTIONS,
+        platform: process.platform,
+        tools: TOOLS.map((entry) => ({
+          name: `computer_use.${entry.name}`,
+          description: entry.description,
+        })),
+      };
+    case "list_apps":
+      return await ctx.driver.listApps();
+    case "list_windows":
+      return await ctx.driver.listWindows();
+    case "launch_app":
+      return await ctx.driver.launchApp({ app: readString(args.app, "app") });
+    case "get_window":
+      return await ctx.driver.getWindow({
+        ...(typeof args.app === "string" ? { app: args.app } : {}),
+        id: readNumber(args.id, "id"),
+      });
+    case "get_window_state": {
+      const payload = readRecord(args);
+      return await ctx.driver.getWindowState({
+        window: readWindow(payload.window),
+        ...(typeof payload.include_screenshot === "boolean"
+          ? { include_screenshot: payload.include_screenshot }
+          : {}),
+        ...(typeof payload.include_text === "boolean"
+          ? { include_text: payload.include_text }
+          : {}),
+      });
+    }
+    case "activate_window":
+      return await ctx.driver.activateWindow({ window: readWindow(args.window) });
+    case "click":
+      return await ctx.driver.click({
+        window: readWindow(args.window),
+        x: readNumber(args.x, "x"),
+        y: readNumber(args.y, "y"),
+        ...(typeof args.click_count === "number" ? { click_count: args.click_count } : {}),
+        ...(typeof args.mouse_button === "string" ? { mouse_button: args.mouse_button } : {}),
+      });
+    case "press_key":
+      return await ctx.driver.pressKey({
+        window: readWindow(args.window),
+        key: readString(args.key, "key"),
+      });
+    case "type_text":
+      return await ctx.driver.typeText({
+        window: readWindow(args.window),
+        text: readString(args.text, "text"),
+      });
+    case "scroll":
+      return await ctx.driver.scroll({
+        window: readWindow(args.window),
+        x: readNumber(args.x, "x"),
+        y: readNumber(args.y, "y"),
+        scrollX: readNumber(args.scrollX, "scrollX"),
+        scrollY: readNumber(args.scrollY, "scrollY"),
+      });
+    case "drag":
+      return await ctx.driver.drag({
+        window: readWindow(args.window),
+        from_x: readNumber(args.from_x, "from_x"),
+        from_y: readNumber(args.from_y, "from_y"),
+        to_x: readNumber(args.to_x, "to_x"),
+        to_y: readNumber(args.to_y, "to_y"),
+      });
+    case "set_value":
+      return await ctx.driver.setValue({
+        window: readWindow(args.window),
+        element_index: readNumber(args.element_index, "element_index"),
+        value: readString(args.value, "value"),
+      });
+    case "perform_secondary_action":
+      return await ctx.driver.performSecondaryAction({
+        window: readWindow(args.window),
+        element_index: readNumber(args.element_index, "element_index"),
+        action: readString(args.action, "action"),
+      });
+    default:
+      throw new Error(`unknown tool: ${name}`);
+  }
+}
+
+export interface McpContent {
+  type: "text" | "image";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export interface McpToolResult {
+  content: McpContent[];
+  isError?: boolean;
+}
+
+function screenshotMetadata(
+  screenshot: ComputerUseScreenshot,
+): Omit<ComputerUseScreenshot, "data"> {
+  const { data: _data, ...metadata } = screenshot;
+  return metadata;
+}
+
+export function formatToolResult(name: string, result: unknown): McpToolResult {
+  if (normalizeToolName(name) === "get_window_state" && result && typeof result === "object") {
+    const state = result as ComputerUseWindowState;
+    const metadata = {
+      ...state,
+      screenshots: state.screenshots.map(screenshotMetadata),
+    };
+    return {
+      content: [
+        { type: "text", text: JSON.stringify(metadata, null, 2) },
+        ...state.screenshots.map((screenshot) => ({
+          type: "image" as const,
+          data: screenshot.data,
+          mimeType: screenshot.mimeType,
+        })),
+      ],
+    };
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+  };
+}

--- a/src/main/computer-use/mcp/types.ts
+++ b/src/main/computer-use/mcp/types.ts
@@ -18,10 +18,10 @@ export interface ComputerUseApp {
 }
 
 export interface ComputerUseAccessibilityState {
-  document_text?: string;
-  focused_element?: string;
-  selected_elements?: string[];
-  selected_text?: string;
+  // Only `tree` is populated today, and it holds a placeholder string (window
+  // title + app name) — no driver yet extracts a real accessibility tree.
+  // Callers must not rely on this for element targeting. See the
+  // "accessibility tree is a placeholder" note emitted by get_window_state.
   tree: string;
 }
 
@@ -66,7 +66,11 @@ export interface ComputerUseDriver {
     include_text?: boolean;
     window: ComputerUseWindow;
   }): Promise<ComputerUseWindowState>;
-  launchApp(input: { app: string }): Promise<{ ok: true }>;
+  launchApp(input: { app: string }): Promise<{
+    ok: true;
+    window?: ComputerUseWindow | null;
+    note?: string;
+  }>;
   listApps(): Promise<ComputerUseApp[]>;
   listWindows(): Promise<ComputerUseWindow[]>;
   performSecondaryAction(input: {

--- a/src/main/computer-use/mcp/types.ts
+++ b/src/main/computer-use/mcp/types.ts
@@ -44,8 +44,14 @@ export interface ComputerUseWindowState {
   window: ComputerUseWindow;
 }
 
+export interface ComputerUseInteractiveResult {
+  ok: true;
+  mode: "interactive";
+  window?: ComputerUseWindow;
+}
+
 export interface ComputerUseDriver {
-  activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }>;
+  activateWindow(input: { window: ComputerUseWindow }): Promise<ComputerUseInteractiveResult>;
   // Release any long-lived resources (e.g. the Windows persistent PowerShell
   // host). No-op for drivers that spawn a fresh process per call.
   dispose(): void;
@@ -55,14 +61,14 @@ export interface ComputerUseDriver {
     window: ComputerUseWindow;
     x?: number;
     y?: number;
-  }): Promise<{ ok: true; mode: "interactive" }>;
+  }): Promise<ComputerUseInteractiveResult>;
   drag(input: {
     from_x: number;
     from_y: number;
     to_x: number;
     to_y: number;
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }>;
+  }): Promise<ComputerUseInteractiveResult>;
   getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow>;
   getWindowState(input: {
     format?: "jpeg" | "png";
@@ -78,29 +84,19 @@ export interface ComputerUseDriver {
   }>;
   listApps(): Promise<ComputerUseApp[]>;
   listWindows(): Promise<ComputerUseWindow[]>;
-  performSecondaryAction(input: {
-    action: string;
-    element_index: number;
+  pressKey(input: {
+    key: string;
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }>;
-  pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }>;
+  }): Promise<ComputerUseInteractiveResult>;
   scroll(input: {
     scrollX: number;
     scrollY: number;
     window: ComputerUseWindow;
     x: number;
     y: number;
-  }): Promise<{ ok: true; mode: "interactive" }>;
-  setValue(input: {
-    element_index: number;
-    value: string;
+  }): Promise<ComputerUseInteractiveResult>;
+  typeText(input: {
+    text: string;
     window: ComputerUseWindow;
-  }): Promise<{ ok: true; mode: "interactive" }>;
-  typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
-    ok: true;
-    mode: "interactive";
-  }>;
+  }): Promise<ComputerUseInteractiveResult>;
 }

--- a/src/main/computer-use/mcp/types.ts
+++ b/src/main/computer-use/mcp/types.ts
@@ -46,6 +46,9 @@ export interface ComputerUseWindowState {
 
 export interface ComputerUseDriver {
   activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }>;
+  // Release any long-lived resources (e.g. the Windows persistent PowerShell
+  // host). No-op for drivers that spawn a fresh process per call.
+  dispose(): void;
   click(input: {
     click_count?: number;
     mouse_button?: string;
@@ -62,8 +65,10 @@ export interface ComputerUseDriver {
   }): Promise<{ ok: true; mode: "interactive" }>;
   getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow>;
   getWindowState(input: {
+    format?: "jpeg" | "png";
     include_screenshot?: boolean;
     include_text?: boolean;
+    max_dimension?: number;
     window: ComputerUseWindow;
   }): Promise<ComputerUseWindowState>;
   launchApp(input: { app: string }): Promise<{

--- a/src/main/computer-use/mcp/types.ts
+++ b/src/main/computer-use/mcp/types.ts
@@ -1,0 +1,97 @@
+export interface ComputerUseWindow {
+  app: string;
+  id: number;
+  title?: string;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface ComputerUseApp {
+  displayName?: string;
+  id: string;
+  isRunning?: boolean;
+  lastUsedDate?: string;
+  useCount?: number;
+  windows: ComputerUseWindow[];
+}
+
+export interface ComputerUseAccessibilityState {
+  document_text?: string;
+  focused_element?: string;
+  selected_elements?: string[];
+  selected_text?: string;
+  tree: string;
+}
+
+export interface ComputerUseScreenshot {
+  data: string;
+  height?: number;
+  id: string;
+  mimeType: string;
+  originX?: number;
+  originY?: number;
+  width?: number;
+  zIndex: number;
+}
+
+export interface ComputerUseWindowState {
+  accessibility: ComputerUseAccessibilityState | null;
+  mode: "passive" | "interactive";
+  notes?: string[];
+  screenshots: ComputerUseScreenshot[];
+  window: ComputerUseWindow;
+}
+
+export interface ComputerUseDriver {
+  activateWindow(input: { window: ComputerUseWindow }): Promise<{ ok: true; mode: "interactive" }>;
+  click(input: {
+    click_count?: number;
+    mouse_button?: string;
+    window: ComputerUseWindow;
+    x?: number;
+    y?: number;
+  }): Promise<{ ok: true; mode: "interactive" }>;
+  drag(input: {
+    from_x: number;
+    from_y: number;
+    to_x: number;
+    to_y: number;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }>;
+  getWindow(input: { app?: string; id: number }): Promise<ComputerUseWindow>;
+  getWindowState(input: {
+    include_screenshot?: boolean;
+    include_text?: boolean;
+    window: ComputerUseWindow;
+  }): Promise<ComputerUseWindowState>;
+  launchApp(input: { app: string }): Promise<{ ok: true }>;
+  listApps(): Promise<ComputerUseApp[]>;
+  listWindows(): Promise<ComputerUseWindow[]>;
+  performSecondaryAction(input: {
+    action: string;
+    element_index: number;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }>;
+  pressKey(input: { key: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }>;
+  scroll(input: {
+    scrollX: number;
+    scrollY: number;
+    window: ComputerUseWindow;
+    x: number;
+    y: number;
+  }): Promise<{ ok: true; mode: "interactive" }>;
+  setValue(input: {
+    element_index: number;
+    value: string;
+    window: ComputerUseWindow;
+  }): Promise<{ ok: true; mode: "interactive" }>;
+  typeText(input: { text: string; window: ComputerUseWindow }): Promise<{
+    ok: true;
+    mode: "interactive";
+  }>;
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,6 +22,7 @@ import {
   registerPickerProtocolScheme,
 } from "./browser";
 import { buildBrowserUserAgent } from "./browser/userAgent";
+import { ComputerUseMcpIngress } from "./computer-use";
 import { SupervisorClient } from "./supervisor/SupervisorClient";
 import { createAutoUpdaterController } from "./updates/autoUpdater";
 import { createMainWindow } from "./window/createMainWindow";
@@ -126,6 +127,7 @@ let lightcodePaths: LightcodePaths | null = null;
 let windowsJobObjectManager: WindowsJobObjectManager | null = null;
 let browserPanelManager: BrowserPanelManager | null = null;
 let browserMcpIngress: BrowserMcpIngress | null = null;
+let computerUseMcpIngress: ComputerUseMcpIngress | null = null;
 let chromeBridgeServer: ChromeBridgeServer | null = null;
 let chromeMcpIngress: ChromeMcpIngress | null = null;
 let remoteAccessServer: RemoteAccessServer | null = null;
@@ -401,6 +403,11 @@ if (!hasSingleInstanceLock) {
           env.LIGHTCODE_CHROME_MCP_URL = chromeInfo.url;
           env.LIGHTCODE_CHROME_MCP_TOKEN = chromeInfo.token;
         }
+        const computerUseInfo = computerUseMcpIngress?.getInfo();
+        if (computerUseInfo) {
+          env.LIGHTCODE_COMPUTER_USE_MCP_URL = computerUseInfo.url;
+          env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN = computerUseInfo.token;
+        }
         return env;
       },
       assignPid: async (pid) => {
@@ -471,6 +478,11 @@ if (!hasSingleInstanceLock) {
     });
     chromeBridgeServer.start().catch((err) => {
       console.error("[lightcode] chrome bridge server failed to start:", err);
+    });
+    computerUseMcpIngress = new ComputerUseMcpIngress();
+    const computerUseMcpInfoReady = computerUseMcpIngress.start().catch((err) => {
+      console.error("[lightcode] computer use MCP ingress failed to start:", err);
+      return null;
     });
 
     const writeSharedSettingsPatch = (patch: {
@@ -930,8 +942,7 @@ if (!hasSingleInstanceLock) {
       );
     }
 
-    await mcpInfoReady;
-    await chromeMcpReady;
+    await Promise.all([mcpInfoReady, chromeMcpReady, computerUseMcpInfoReady]);
     supervisorClient.start(lightcodePaths.baseDir);
 
     if (readSharedSettingsFile(lightcodePaths.settingsPath).remoteAccessEnabled) {
@@ -1017,6 +1028,8 @@ if (!hasSingleInstanceLock) {
       windowsJobObjectManager = null;
       browserMcpIngress?.dispose();
       browserMcpIngress = null;
+      computerUseMcpIngress?.dispose();
+      computerUseMcpIngress = null;
       chromeMcpIngress?.dispose();
       chromeMcpIngress = null;
       chromeBridgeServer?.dispose();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,7 +22,11 @@ import {
   registerPickerProtocolScheme,
 } from "./browser";
 import { buildBrowserUserAgent } from "./browser/userAgent";
-import { ComputerUseMcpIngress, type ComputerUseMcpIngressInfo } from "./computer-use";
+import {
+  ComputerUseDesktopOverlay,
+  ComputerUseMcpIngress,
+  type ComputerUseMcpIngressInfo,
+} from "./computer-use";
 import { SupervisorClient } from "./supervisor/SupervisorClient";
 import { createAutoUpdaterController } from "./updates/autoUpdater";
 import { createMainWindow } from "./window/createMainWindow";
@@ -128,6 +132,7 @@ let windowsJobObjectManager: WindowsJobObjectManager | null = null;
 let browserPanelManager: BrowserPanelManager | null = null;
 let browserMcpIngress: BrowserMcpIngress | null = null;
 let computerUseMcpIngress: ComputerUseMcpIngress | null = null;
+let computerUseDesktopOverlay: ComputerUseDesktopOverlay | null = null;
 let chromeBridgeServer: ChromeBridgeServer | null = null;
 let chromeMcpIngress: ChromeMcpIngress | null = null;
 let remoteAccessServer: RemoteAccessServer | null = null;
@@ -486,7 +491,22 @@ if (!hasSingleInstanceLock) {
     // nothing because getInfo() stays null.
     let computerUseMcpInfoReady: Promise<ComputerUseMcpIngressInfo | null> = Promise.resolve(null);
     if (process.platform === "win32" || process.platform === "darwin") {
-      computerUseMcpIngress = new ComputerUseMcpIngress();
+      computerUseDesktopOverlay = new ComputerUseDesktopOverlay({
+        onExit: (threadIds) => {
+          computerUseMcpIngress?.interruptActiveActions();
+          for (const threadId of threadIds) {
+            void supervisorClient.call("interruptThread", { threadId }).catch((error) => {
+              console.error(
+                `[lightcode] failed to interrupt computer-use thread ${threadId}:`,
+                error,
+              );
+            });
+          }
+        },
+      });
+      computerUseMcpIngress = new ComputerUseMcpIngress({
+        onActivity: (event) => computerUseDesktopOverlay?.setActivity(event),
+      });
       computerUseMcpInfoReady = computerUseMcpIngress.start().catch((err) => {
         console.error("[lightcode] computer use MCP ingress failed to start:", err);
         return null;
@@ -1038,6 +1058,8 @@ if (!hasSingleInstanceLock) {
       browserMcpIngress = null;
       computerUseMcpIngress?.dispose();
       computerUseMcpIngress = null;
+      computerUseDesktopOverlay?.dispose();
+      computerUseDesktopOverlay = null;
       chromeMcpIngress?.dispose();
       chromeMcpIngress = null;
       chromeBridgeServer?.dispose();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,7 +22,7 @@ import {
   registerPickerProtocolScheme,
 } from "./browser";
 import { buildBrowserUserAgent } from "./browser/userAgent";
-import { ComputerUseMcpIngress } from "./computer-use";
+import { ComputerUseMcpIngress, type ComputerUseMcpIngressInfo } from "./computer-use";
 import { SupervisorClient } from "./supervisor/SupervisorClient";
 import { createAutoUpdaterController } from "./updates/autoUpdater";
 import { createMainWindow } from "./window/createMainWindow";
@@ -479,11 +479,19 @@ if (!hasSingleInstanceLock) {
     chromeBridgeServer.start().catch((err) => {
       console.error("[lightcode] chrome bridge server failed to start:", err);
     });
-    computerUseMcpIngress = new ComputerUseMcpIngress();
-    const computerUseMcpInfoReady = computerUseMcpIngress.start().catch((err) => {
-      console.error("[lightcode] computer use MCP ingress failed to start:", err);
-      return null;
-    });
+    // Computer-use drives the host desktop and is only supported on macOS and
+    // Windows (matches createComputerUseDriver). On other platforms the ingress
+    // would advertise tools that all fail and would still inject a token into
+    // launches, so skip it entirely — resolveExtraEnv then naturally yields
+    // nothing because getInfo() stays null.
+    let computerUseMcpInfoReady: Promise<ComputerUseMcpIngressInfo | null> = Promise.resolve(null);
+    if (process.platform === "win32" || process.platform === "darwin") {
+      computerUseMcpIngress = new ComputerUseMcpIngress();
+      computerUseMcpInfoReady = computerUseMcpIngress.start().catch((err) => {
+        console.error("[lightcode] computer use MCP ingress failed to start:", err);
+        return null;
+      });
+    }
 
     const writeSharedSettingsPatch = (patch: {
       [K in keyof SharedSettings]?: SharedSettings[K];

--- a/src/main/mcp/StreamableHttpMcpIngress.test.ts
+++ b/src/main/mcp/StreamableHttpMcpIngress.test.ts
@@ -1,0 +1,91 @@
+import { request } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { StreamableHttpMcpIngress } from "./StreamableHttpMcpIngress";
+
+let ingress: StreamableHttpMcpIngress<{ ok: true }> | null = null;
+
+function makeIngress(): StreamableHttpMcpIngress<{ ok: true }> {
+  return new StreamableHttpMcpIngress<{ ok: true }>({
+    // Match the computer-use consumer: loopback-only bind.
+    bindHost: "127.0.0.1",
+    serverInfo: { name: "test", version: "0.0.0" },
+    instructions: "test",
+    tools: [{ name: "noop", description: "noop", inputSchema: { type: "object" } }],
+    isKnownToolName: (name) => name === "noop",
+    buildContext: () => ({ ok: true }),
+    dispatchTool: () => Promise.resolve({}),
+    formatToolResult: () => ({ content: [{ type: "text", text: "ok" }] }),
+  });
+}
+
+/**
+ * `fetch` treats `Host` as a forbidden header and silently overrides it, so a
+ * DNS-rebinding test needs a raw request that actually sends the forged host.
+ */
+function rawRequest(port: number, headers: Record<string, string>): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { host: "127.0.0.1", port, path: "/mcp", method: "POST", headers },
+      (res) => {
+        res.resume();
+        res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+      },
+    );
+    req.on("error", reject);
+    req.end(JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }));
+  });
+}
+
+afterEach(() => {
+  ingress?.dispose();
+  ingress = null;
+});
+
+describe("StreamableHttpMcpIngress auth + host guards", () => {
+  it("accepts a valid bearer token and rejects a wrong one", async () => {
+    ingress = makeIngress();
+    const info = await ingress.start();
+
+    const ok = await rawRequest(info.port, {
+      Host: `127.0.0.1:${info.port}`,
+      Authorization: `Bearer ${info.token}`,
+      "Content-Type": "application/json",
+    });
+    expect(ok.status).toBe(200);
+
+    const wrong = await rawRequest(info.port, {
+      Host: `127.0.0.1:${info.port}`,
+      Authorization: "Bearer not-the-token",
+      "Content-Type": "application/json",
+    });
+    expect(wrong.status).toBe(401);
+
+    // A same-length but wrong token must also fail (constant-time compare path).
+    const sameLength = "0".repeat(info.token.length);
+    const wrongSameLength = await rawRequest(info.port, {
+      Host: `127.0.0.1:${info.port}`,
+      Authorization: `Bearer ${sameLength}`,
+      "Content-Type": "application/json",
+    });
+    expect(wrongSameLength.status).toBe(401);
+  });
+
+  it("rejects a foreign DNS Host but allows loopback and IP-literal hosts", async () => {
+    ingress = makeIngress();
+    const info = await ingress.start();
+
+    const base = { Authorization: `Bearer ${info.token}`, "Content-Type": "application/json" };
+
+    // DNS-rebinding: a real hostname is refused even with a valid token.
+    const rebinding = await rawRequest(info.port, { ...base, Host: "evil.example.com" });
+    expect(rebinding.status).toBe(403);
+
+    // Loopback by name and by IP literal are accepted (WSL reaches the browser
+    // ingress via the host-gateway IP literal, which must keep working).
+    const loopbackName = await rawRequest(info.port, { ...base, Host: `localhost:${info.port}` });
+    expect(loopbackName.status).toBe(200);
+
+    const loopbackIp = await rawRequest(info.port, { ...base, Host: `127.0.0.1:${info.port}` });
+    expect(loopbackIp.status).toBe(200);
+  });
+});

--- a/src/main/mcp/StreamableHttpMcpIngress.ts
+++ b/src/main/mcp/StreamableHttpMcpIngress.ts
@@ -1,0 +1,326 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { decodeThreadIdentity, type McpThreadIdentity } from "@/shared/browserMcpThread";
+import { isLocalhostOrigin, readBoundedNodeRequestBody, writeJsonResponse } from "@/shared/http";
+
+export interface StreamableHttpMcpIngressInfo {
+  url: string;
+  token: string;
+  port: number;
+}
+
+export interface StreamableHttpMcpToolSpec {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface StreamableHttpMcpContent {
+  type: "text" | "image";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+}
+
+export interface StreamableHttpMcpToolResult {
+  content: StreamableHttpMcpContent[];
+  isError?: boolean;
+}
+
+export interface StreamableHttpMcpIngressOptions<TContext> {
+  /**
+   * Network interface to bind. Defaults to `0.0.0.0` so WSL agents can reach the
+   * host-side endpoint via the gateway IP. Consumers whose surface must never be
+   * reachable off the host (e.g. computer-use input control) should pass
+   * `"127.0.0.1"` to bind loopback only.
+   */
+  bindHost?: string;
+  contextUnavailableMessage?: string;
+  dispatchTool(name: string, args: Record<string, unknown>, ctx: TContext): Promise<unknown>;
+  formatToolResult(name: string, result: unknown): StreamableHttpMcpToolResult;
+  /**
+   * Build the per-request tool context. Receives the thread identity decoded
+   * from the endpoint URL query (`?thread=&title=`) so each thread can be
+   * scoped/named; consumers that don't need it may ignore the argument.
+   */
+  buildContext(identity: McpThreadIdentity): TContext | null;
+  instructions: string;
+  isKnownToolName(name: string): boolean;
+  onBeforeToolCall?(name: string, ctx: TContext): void;
+  serverInfo: { name: string; version: string };
+  tools: readonly StreamableHttpMcpToolSpec[];
+}
+
+const MAX_BODY = 1024 * 1024;
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: number | string | null;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponseOk {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  result: unknown;
+}
+
+interface JsonRpcResponseErr {
+  jsonrpc: "2.0";
+  id: number | string | null;
+  error: { code: number; message: string; data?: unknown };
+}
+
+type JsonRpcResponse = JsonRpcResponseOk | JsonRpcResponseErr;
+
+export class StreamableHttpMcpIngress<TContext> {
+  private server: Server | null = null;
+  private token = randomBytes(32).toString("hex");
+  private info: StreamableHttpMcpIngressInfo | null = null;
+
+  constructor(private readonly options: StreamableHttpMcpIngressOptions<TContext>) {}
+
+  async start(): Promise<StreamableHttpMcpIngressInfo> {
+    if (this.info) return this.info;
+    const bindHost = this.options.bindHost ?? "0.0.0.0";
+    return await new Promise<StreamableHttpMcpIngressInfo>((resolve, reject) => {
+      const server = createServer((req, res) => this.handle(req, res));
+      server.on("error", reject);
+      // Access is guarded by a 256-bit bearer token regenerated per app launch;
+      // the URL is only ever passed to immediate child processes via env vars.
+      server.listen(0, bindHost, () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        this.server = server;
+        this.info = { url: `http://127.0.0.1:${port}`, token: this.token, port };
+        resolve(this.info);
+      });
+    });
+  }
+
+  getInfo(): StreamableHttpMcpIngressInfo | null {
+    return this.info;
+  }
+
+  dispose(): void {
+    try {
+      this.server?.closeAllConnections?.();
+    } catch {}
+    try {
+      this.server?.close();
+    } catch {}
+    this.server = null;
+  }
+
+  private async readBody(req: IncomingMessage): Promise<string> {
+    const body = await readBoundedNodeRequestBody(req, MAX_BODY, () => new Error("body too large"));
+    return body.toString("utf8");
+  }
+
+  private sendJson(res: ServerResponse, status: number, body: unknown): void {
+    writeJsonResponse(res, status, body, { cacheControl: "no-store" });
+  }
+
+  private checkAuth(req: IncomingMessage): boolean {
+    const auth = req.headers.authorization;
+    if (auth && auth.startsWith("Bearer ") && auth.slice(7).trim() === this.token) {
+      return true;
+    }
+    const xToken = req.headers["x-lightcode-token"];
+    return typeof xToken === "string" && xToken === this.token;
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      if (!req.url) {
+        this.sendJson(res, 404, { error: "not found" });
+        return;
+      }
+      const path = new URL(req.url, "http://x").pathname;
+
+      // CORS preflight — restrict to localhost origins so remote web pages
+      // cannot issue cross-origin requests to the MCP ingress.
+      if (req.method === "OPTIONS") {
+        const origin = req.headers.origin;
+        if (typeof origin === "string" && isLocalhostOrigin(origin)) {
+          res.setHeader("Access-Control-Allow-Origin", origin);
+          res.setHeader(
+            "Access-Control-Allow-Headers",
+            "Authorization, X-Lightcode-Token, Content-Type, Mcp-Session-Id",
+          );
+          res.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+        }
+        res.statusCode = 204;
+        res.end();
+        return;
+      }
+
+      if (!this.checkAuth(req)) {
+        this.sendJson(res, 401, { error: "unauthorized" });
+        return;
+      }
+
+      if (path === "/mcp" || path === "/mcp/") {
+        if (req.method === "GET") {
+          // MCP Streamable HTTP allows GET to open an SSE stream. We don't
+          // push server-initiated events; return 405 with Allow header.
+          res.statusCode = 405;
+          res.setHeader("Allow", "POST");
+          res.end();
+          return;
+        }
+        if (req.method !== "POST") {
+          this.sendJson(res, 405, { error: "method not allowed" });
+          return;
+        }
+        await this.handleMcp(req, res);
+        return;
+      }
+
+      this.sendJson(res, 404, { error: "not found" });
+    } catch (err) {
+      this.sendJson(res, 500, { error: (err as Error).message ?? "internal" });
+    }
+  }
+
+  private async handleMcp(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const identity = decodeThreadIdentity(req.url);
+    const raw = await this.readBody(req);
+    let body: unknown;
+    try {
+      body = raw ? JSON.parse(raw) : {};
+    } catch {
+      this.sendJson(res, 400, {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32700, message: "Parse error" },
+      });
+      return;
+    }
+
+    // Mcp-Session-Id: stateless server, but echo a session id so clients
+    // that key off of it have one.
+    let sessionId = req.headers["mcp-session-id"];
+    if (Array.isArray(sessionId)) sessionId = sessionId[0];
+    if (typeof sessionId !== "string" || !sessionId) {
+      sessionId = randomUUID();
+    }
+    res.setHeader("Mcp-Session-Id", sessionId);
+
+    // Streamable HTTP allows a single response or a batch. Match the input.
+    if (Array.isArray(body)) {
+      const out: JsonRpcResponse[] = [];
+      for (const message of body) {
+        const reply = await this.handleSingle(message, identity);
+        if (reply) out.push(reply);
+      }
+      this.sendJson(res, 200, out);
+      return;
+    }
+    const reply = await this.handleSingle(body, identity);
+    if (!reply) {
+      // notification — no response
+      res.statusCode = 202;
+      res.end();
+      return;
+    }
+    this.sendJson(res, 200, reply);
+  }
+
+  private async handleSingle(
+    message: unknown,
+    identity: McpThreadIdentity,
+  ): Promise<JsonRpcResponse | null> {
+    if (!isJsonRpcRequest(message)) return null;
+    const { id = null, method, params } = message;
+    try {
+      if (method === "initialize") {
+        return {
+          jsonrpc: "2.0",
+          id,
+          result: {
+            protocolVersion: MCP_PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            serverInfo: this.options.serverInfo,
+            instructions: this.options.instructions,
+          },
+        };
+      }
+      if (method === "notifications/initialized" || method === "initialized") {
+        return null;
+      }
+      if (method === "ping") {
+        return { jsonrpc: "2.0", id, result: {} };
+      }
+      if (method === "tools/list") {
+        return { jsonrpc: "2.0", id, result: { tools: this.options.tools } };
+      }
+      if (method === "tools/call") {
+        const p = (params ?? {}) as { name?: string; arguments?: Record<string, unknown> };
+        const name = String(p.name ?? "");
+        const args = (p.arguments ?? {}) as Record<string, unknown>;
+        if (!this.options.isKnownToolName(name)) {
+          return {
+            jsonrpc: "2.0",
+            id,
+            result: {
+              isError: true,
+              content: [{ type: "text", text: `Unknown tool: ${name}` }],
+            },
+          };
+        }
+        const ctx = this.options.buildContext(identity);
+        if (!ctx) {
+          return {
+            jsonrpc: "2.0",
+            id,
+            result: {
+              isError: true,
+              content: [
+                { type: "text", text: this.options.contextUnavailableMessage ?? "not ready" },
+              ],
+            },
+          };
+        }
+        this.options.onBeforeToolCall?.(name, ctx);
+        let raw: unknown;
+        try {
+          raw = await this.options.dispatchTool(name, args, ctx);
+        } catch (err) {
+          return {
+            jsonrpc: "2.0",
+            id,
+            result: {
+              isError: true,
+              content: [{ type: "text", text: (err as Error).message ?? String(err) }],
+            },
+          };
+        }
+        const result = this.options.formatToolResult(name, raw);
+        return { jsonrpc: "2.0", id, result };
+      }
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32601, message: `Method not found: ${method}` },
+      };
+    } catch (err) {
+      return {
+        jsonrpc: "2.0",
+        id,
+        error: { code: -32000, message: (err as Error).message ?? "internal" },
+      };
+    }
+  }
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { jsonrpc?: unknown }).jsonrpc === "2.0" &&
+    typeof (value as { method?: unknown }).method === "string"
+  );
+}

--- a/src/main/mcp/StreamableHttpMcpIngress.ts
+++ b/src/main/mcp/StreamableHttpMcpIngress.ts
@@ -1,5 +1,6 @@
-import { randomBytes, randomUUID } from "node:crypto";
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { isIP } from "node:net";
 import { decodeThreadIdentity, type McpThreadIdentity } from "@/shared/browserMcpThread";
 import { isLocalhostOrigin, readBoundedNodeRequestBody, writeJsonResponse } from "@/shared/http";
 
@@ -125,17 +126,72 @@ export class StreamableHttpMcpIngress<TContext> {
 
   private checkAuth(req: IncomingMessage): boolean {
     const auth = req.headers.authorization;
-    if (auth && auth.startsWith("Bearer ") && auth.slice(7).trim() === this.token) {
+    if (auth && auth.startsWith("Bearer ") && this.tokenMatches(auth.slice(7).trim())) {
       return true;
     }
     const xToken = req.headers["x-lightcode-token"];
-    return typeof xToken === "string" && xToken === this.token;
+    return typeof xToken === "string" && this.tokenMatches(xToken);
+  }
+
+  /**
+   * Constant-time bearer-token comparison. A plain `===` short-circuits on the
+   * first mismatching byte, leaking token bytes through response timing; compare
+   * over the full length instead. `timingSafeEqual` throws on length mismatch,
+   * so gate on length first (the length itself is not secret — the token is a
+   * fixed 64-hex-char string).
+   */
+  private tokenMatches(candidate: string): boolean {
+    const expected = Buffer.from(this.token);
+    const actual = Buffer.from(candidate);
+    if (actual.length !== expected.length) {
+      return false;
+    }
+    return timingSafeEqual(actual, expected);
+  }
+
+  /**
+   * DNS-rebinding defense-in-depth: reject requests whose `Host` header is a
+   * real DNS name rather than a loopback name or a raw IP literal. A rebinding
+   * attack points an attacker-controlled hostname at the loopback address, so
+   * the forged request carries that hostname in `Host`. Loopback (`localhost`)
+   * and IP literals are safe: the browser ingress binds `0.0.0.0` and WSL
+   * agents reach it via the host-gateway IP (an IP literal), so this stays
+   * compatible with every legitimate caller. The port, when present, must match
+   * the bound port.
+   */
+  private isAllowedHost(req: IncomingMessage): boolean {
+    const hostHeader = req.headers.host;
+    if (typeof hostHeader !== "string" || hostHeader.length === 0) {
+      return false;
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(`http://${hostHeader}`);
+    } catch {
+      return false;
+    }
+    const boundPort = this.info?.port;
+    if (boundPort !== undefined && parsed.port !== "" && Number(parsed.port) !== boundPort) {
+      return false;
+    }
+    let hostname = parsed.hostname;
+    if (hostname.startsWith("[") && hostname.endsWith("]")) {
+      hostname = hostname.slice(1, -1);
+    }
+    if (hostname === "localhost") {
+      return true;
+    }
+    return isIP(hostname) !== 0;
   }
 
   private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
     try {
       if (!req.url) {
         this.sendJson(res, 404, { error: "not found" });
+        return;
+      }
+      if (!this.isAllowedHost(req)) {
+        this.sendJson(res, 403, { error: "forbidden host" });
         return;
       }
       const path = new URL(req.url, "http://x").pathname;

--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -593,6 +593,12 @@ describe("RemoteAccessServer", () => {
       desktopId: "desktop-test",
       label: "Test Desktop",
       appVersion: "1.0.0",
+      platform:
+        process.platform === "win32" ||
+        process.platform === "darwin" ||
+        process.platform === "linux"
+          ? process.platform
+          : undefined,
     });
 
     const pairingPageResponse = await fetch(info.pairingUrl);

--- a/src/main/remote/server/snapshots.ts
+++ b/src/main/remote/server/snapshots.ts
@@ -32,11 +32,16 @@ export function sortOrderForThread(threads: readonly Thread[], threadId: string)
 
 export function descriptor(ctx: RemoteServerContext): RemoteEnvironmentDescriptor {
   const info = ctx.requireInfo();
+  const platform =
+    process.platform === "win32" || process.platform === "darwin" || process.platform === "linux"
+      ? process.platform
+      : undefined;
   return remoteEnvironmentDescriptorSchema.parse({
     protocolVersion: LIGHTCODE_REMOTE_PROTOCOL_VERSION,
     desktopId: ctx.options.identity.desktopId,
     label: ctx.options.identity.label,
     appVersion: ctx.options.appVersion,
+    ...(platform ? { platform } : {}),
     auth: {
       policy: "remote-reachable",
       bootstrapMethods: ["one-time-token"],

--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -119,6 +119,7 @@ describe("sharedSettingsFile", () => {
       favoriteModels: [],
       recentModels: [],
       agentHookSupport: {},
+      enabledMcpServers: {},
       browser: {
         allowEval: false,
         allowDataAccess: false,
@@ -228,6 +229,7 @@ describe("sharedSettingsFile", () => {
       favoriteModels: [],
       recentModels: [],
       agentHookSupport: {},
+      enabledMcpServers: {},
       browser: {
         allowEval: false,
         allowDataAccess: false,

--- a/src/mobile/bridge.ts
+++ b/src/mobile/bridge.ts
@@ -37,10 +37,20 @@ import { applyAgentStatuses } from "./storeSync";
  */
 
 let activeClient: RemoteDesktopClient | null = null;
+/** Host OS of the paired desktop (`win32`/`darwin`/`linux`), when known. */
+let hostPlatform: NodeJS.Platform | null = null;
 
-/** The remote session hook keeps this pointing at the active desktop. */
-export function setRemoteBridgeClient(client: RemoteDesktopClient | null): void {
+/**
+ * The remote session hook keeps this pointing at the active desktop.
+ * Pass the desktop's advertised `platform` so host-gated features (Computer Use)
+ * key off the paired machine, not the phone's user-agent.
+ */
+export function setRemoteBridgeClient(
+  client: RemoteDesktopClient | null,
+  platform?: NodeJS.Platform | null,
+): void {
   activeClient = client;
+  hostPlatform = client ? (platform ?? null) : null;
 }
 
 /** Mobile-native views (BrowserView) call the remote API directly. */
@@ -62,11 +72,22 @@ async function runBrowserCommand(command: RemoteBrowserCommand): Promise<Browser
   return state;
 }
 
-function detectPlatform(): NodeJS.Platform {
+function detectClientPlatform(): NodeJS.Platform {
   const ua = navigator.userAgent;
   if (/Mac|iPhone|iPad|iPod/i.test(ua)) return "darwin";
   if (/Win/i.test(ua)) return "win32";
   return "linux";
+}
+
+/**
+ * Prefer the paired desktop's OS. Fall back to the client UA only when the
+ * server hasn't advertised a platform yet (older desktops / pre-pair).
+ */
+function resolveBridgePlatform(): NodeJS.Platform {
+  if (hostPlatform === "win32" || hostPlatform === "darwin" || hostPlatform === "linux") {
+    return hostPlatform;
+  }
+  return detectClientPlatform();
 }
 
 /** Copy a Uint8Array's bytes into a standalone ArrayBuffer for Blob/clipboard. */
@@ -78,7 +99,10 @@ function toArrayBuffer(data: Uint8Array): ArrayBuffer {
 
 const remoteBridge = {
   // Metadata reads. Analytics/diagnostics stay disabled in remote sessions.
-  platform: detectPlatform(),
+  // `platform` is a getter so it tracks the paired desktop after connect.
+  get platform(): NodeJS.Platform {
+    return resolveBridgePlatform();
+  },
   appVersion: "remote",
   arch: "web",
   chromeVersion: "",

--- a/src/mobile/storage.ts
+++ b/src/mobile/storage.ts
@@ -13,6 +13,8 @@ export interface StoredDesktop {
   readonly label: string;
   readonly endpoint: string;
   readonly appVersion: string;
+  /** Host OS of the paired desktop when the server advertises it. */
+  readonly platform?: "win32" | "darwin" | "linux";
   readonly accessToken: string;
   readonly tokenExpiresAt: string;
   readonly scopes: RemoteAccessScope[];
@@ -317,6 +319,7 @@ export async function saveDesktop(input: {
       label: input.descriptor.label,
       endpoint: input.endpoint,
       appVersion: input.descriptor.appVersion,
+      ...(input.descriptor.platform ? { platform: input.descriptor.platform } : {}),
       accessToken: input.accessToken,
       tokenExpiresAt: input.tokenExpiresAt,
       scopes: input.scopes,
@@ -341,6 +344,18 @@ export async function renameDesktop(desktopId: string, label: string): Promise<v
     const existing = await mobileDb.desktops.get(desktopId);
     if (!existing) return;
     await mobileDb.desktops.put({ ...existing, label });
+  });
+}
+
+/** Persist the host OS advertised by the paired desktop (for host-gated UI). */
+export async function updateDesktopPlatform(
+  desktopId: string,
+  platform: "win32" | "darwin" | "linux",
+): Promise<void> {
+  await mobileDb.transaction("rw", mobileDb.desktops, async () => {
+    const existing = await mobileDb.desktops.get(desktopId);
+    if (!existing || existing.platform === platform) return;
+    await mobileDb.desktops.put({ ...existing, platform });
   });
 }
 

--- a/src/mobile/useRemoteDesktop.test.tsx
+++ b/src/mobile/useRemoteDesktop.test.tsx
@@ -189,6 +189,7 @@ vi.mock("./storage", () => ({
     return desktop;
   }),
   renameDesktop: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
+  updateDesktopPlatform: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
   forgetDesktop: (...a: [string]) => h.forgetDesktop(...a),
   getStoredShellSnapshotKey: vi.fn<(...a: unknown[]) => unknown>(),
   getOrCreateDeviceId: vi.fn<() => Promise<string>>(async () => h.deviceId),

--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -65,6 +65,7 @@ import {
   saveThreadSnapshot,
   setActiveDesktopId,
   shouldPersistThreadSnapshot,
+  updateDesktopPlatform,
   type StoredDesktop,
 } from "./storage";
 
@@ -281,7 +282,8 @@ export function useRemoteDesktop() {
   }, []);
 
   // Reused desktop components reach the paired desktop through the bridge
-  // shim; keep it pointed at the active connection.
+  // shim; keep it pointed at the active connection. Pass the host platform so
+  // Computer Use and other host-gated UI key off the desktop, not the phone.
   useEffect(() => {
     if (!activeDesktop) {
       setRemoteBridgeClient(null);
@@ -289,10 +291,16 @@ export function useRemoteDesktop() {
     }
     setRemoteBridgeClient(
       new RemoteDesktopClient(activeDesktop.endpoint, activeDesktop.accessToken),
+      activeDesktop.platform ?? null,
     );
     return () => setRemoteBridgeClient(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the connection identity
-  }, [activeDesktop?.desktopId, activeDesktop?.endpoint, activeDesktop?.accessToken]);
+  }, [
+    activeDesktop?.desktopId,
+    activeDesktop?.endpoint,
+    activeDesktop?.accessToken,
+    activeDesktop?.platform,
+  ]);
 
   useEffect(() => {
     const desktopCandidate = activeDesktop;
@@ -700,13 +708,24 @@ export function useRemoteDesktop() {
       // failure hide threads. Older desktops without the settings endpoint just
       // fall back to cached values.
       if (includeAuxiliary) {
-        const [statuses, desktopSettings] = await Promise.allSettled([
+        const [statuses, desktopSettings, environment] = await Promise.allSettled([
           client.agentStatuses(),
           client.settings(),
+          // Refresh host platform for existing pairings that predate the field
+          // (and keep it current if the user migrates the desktop OS).
+          client.environment(),
         ]);
         if (desktop.desktopId !== activeDesktopIdRef.current) return null;
         if (statuses.status === "fulfilled") applyAgentStatuses(statuses.value);
         if (desktopSettings.status === "fulfilled") applyDesktopSettings(desktopSettings.value);
+        if (environment.status === "fulfilled" && environment.value.platform) {
+          const platform = environment.value.platform;
+          if (desktop.platform !== platform) {
+            await updateDesktopPlatform(desktop.desktopId, platform).catch(() => undefined);
+            // Reload so the bridge effect picks up the new host platform.
+            await reloadDesktops(desktop.desktopId);
+          }
+        }
       }
       setSelectedThreadId((current) => current ?? firstThreadIdByRecency(next.threads) ?? null);
       // Only report a live connection when the socket is actually open. HTTP

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Tooltip } from "@heroui/react";
-import { X } from "lucide-react";
+import { Monitor, X } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { getEntryIconUrl } from "@/renderer/components/common/fileIcons";
 import { toLocalFileUrl } from "@/shared/promptContent";
@@ -58,6 +58,58 @@ export function McpChip(props: {
           type="button"
           className="lightcode-attachment-chip__delete"
           aria-label={t(descriptor.disableLabel)}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+        >
+          <X className="size-2" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function ComputerUseChip(props: {
+  onRemove?: (() => void) | undefined;
+  title?: string;
+  variant?: "chip" | "header";
+}) {
+  const { t } = useLingui();
+  const { onRemove, variant = "chip" } = props;
+  const title = props.title ?? t`Computer Use enabled for this thread`;
+  if (variant === "header") {
+    return (
+      <Tooltip delay={0}>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
+            aria-label={title}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Monitor className="size-3.5" aria-hidden="true" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content>{title}</Tooltip.Content>
+      </Tooltip>
+    );
+  }
+  return (
+    <div
+      className="lightcode-attachment-chip lightcode-browser-chip"
+      title={title}
+      aria-label={title}
+      role={onRemove ? "group" : "img"}
+    >
+      <Monitor className="size-3 text-muted" aria-hidden="true" />
+      <span className="lightcode-attachment-chip__name">{t`Computer Use`}</span>
+      {onRemove ? (
+        <button
+          type="button"
+          className="lightcode-attachment-chip__delete"
+          aria-label={t`Disable Computer Use`}
           onMouseDown={(e) => e.preventDefault()}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -1,7 +1,9 @@
 import type { ReactNode } from "react";
 import { Tooltip } from "@heroui/react";
 import { Monitor, X } from "lucide-react";
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
+import { isRemoteSession } from "@/renderer/bridge";
 import { getEntryIconUrl } from "@/renderer/components/common/fileIcons";
 import { toLocalFileUrl } from "@/shared/promptContent";
 import type { ComposerMcpServerDescriptor } from "./composerMcpServers";
@@ -17,8 +19,14 @@ import type { Attachment } from "./useAttachments";
  *   can't reconfigure the running session — the icon is informational only, but
  *   rendered as a <button> to match the sibling header status controls.
  */
+/** The subset of a composer MCP descriptor the chip actually renders. */
+type McpChipDescriptor = Pick<
+  ComposerMcpServerDescriptor,
+  "icon" | "label" | "enabledTitle" | "disableLabel"
+>;
+
 export function McpChip(props: {
-  descriptor: ComposerMcpServerDescriptor;
+  descriptor: McpChipDescriptor;
   onRemove?: (() => void) | undefined;
   title?: string;
   variant?: "chip" | "header";
@@ -71,55 +79,38 @@ export function McpChip(props: {
   );
 }
 
+/**
+ * Computer Use is not a composer MCP registry entry (its gating lives in
+ * `getComputerUseScope`), but its chip renders through {@link McpChip} with a
+ * descriptor-shaped constant so there is a single chip implementation.
+ */
+const computerUseChipDescriptor: McpChipDescriptor = {
+  icon: Monitor,
+  label: msg`Computer Use`,
+  enabledTitle: msg`Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it`,
+  disableLabel: msg`Disable Computer Use`,
+};
+
 export function ComputerUseChip(props: {
   onRemove?: (() => void) | undefined;
   title?: string;
   variant?: "chip" | "header";
 }) {
   const { t } = useLingui();
-  const { onRemove, variant = "chip" } = props;
-  const title = props.title ?? t`Computer Use enabled for this thread`;
-  if (variant === "header") {
-    return (
-      <Tooltip delay={0}>
-        <Tooltip.Trigger>
-          <button
-            type="button"
-            className="lightcode-overlay-header__controls shrink-0 rounded p-1 text-muted/60 transition-colors hover:bg-white/[0.06] hover:text-foreground"
-            aria-label={title}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Monitor className="size-3.5" aria-hidden="true" />
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Content>{title}</Tooltip.Content>
-      </Tooltip>
-    );
-  }
+  // Interactive actions steal the real mouse/keyboard on the host desktop —
+  // including when driving from a paired phone.
+  const title =
+    props.title ??
+    (isRemoteSession()
+      ? t`Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it`
+      : t`Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it`);
   return (
-    <div
-      className="lightcode-attachment-chip lightcode-browser-chip"
+    <McpChip
+      descriptor={computerUseChipDescriptor}
+      onRemove={props.onRemove}
       title={title}
-      aria-label={title}
-      role={onRemove ? "group" : "img"}
-    >
-      <Monitor className="size-3 text-muted" aria-hidden="true" />
-      <span className="lightcode-attachment-chip__name">{t`Computer Use`}</span>
-      {onRemove ? (
-        <button
-          type="button"
-          className="lightcode-attachment-chip__delete"
-          aria-label={t`Disable Computer Use`}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-        >
-          <X className="size-2" />
-        </button>
-      ) : null}
-    </div>
+      {...(props.variant !== undefined ? { variant: props.variant } : {})}
+    />
   );
 }
 

--- a/src/renderer/components/composer/ComposerAddMenu.test.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.test.tsx
@@ -1,10 +1,39 @@
-import { fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { ComposerAddMenu } from "./ComposerAddMenu";
-import { browserMcpServer } from "./composerMcpServers";
+import {
+  browserMcpServer,
+  chromeMcpServer,
+  mcpTogglePatch,
+  subagentMcpServer,
+} from "./composerMcpServers";
+
+const bridgeMock = vi.hoisted(() => ({
+  isRemoteSession: vi.fn<() => boolean>(() => false),
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  isRemoteSession: bridgeMock.isRemoteSession,
+}));
+
+/** Open the "+" add menu popover. */
+function openMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "Add attachment or capability" }));
+}
+
+/** Open the MCP servers flyout submenu (desktop) by activating the parent row. */
+function openMcpSubmenu() {
+  act(() => {
+    fireEvent.click(screen.getByText("MCP servers"));
+  });
+}
 
 describe("ComposerAddMenu", () => {
+  beforeEach(() => {
+    bridgeMock.isRemoteSession.mockReturnValue(false);
+  });
+
   it("hides the file picker action when file attachments are unavailable", () => {
     render(
       <ComposerAddMenu
@@ -21,9 +50,14 @@ describe("ComposerAddMenu", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Add attachment or capability" }));
+    openMenu();
 
     expect(screen.queryByText("File")).not.toBeInTheDocument();
+    // MCP servers now live behind a parent submenu row, not a flat list.
+    expect(screen.getByText("MCP servers")).toBeInTheDocument();
+    expect(screen.queryByText("Browser")).not.toBeInTheDocument();
+
+    openMcpSubmenu();
     expect(screen.getByText("Browser")).toBeInTheDocument();
   });
 
@@ -33,5 +67,199 @@ describe("ComposerAddMenu", () => {
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the only MCP server is not visible", () => {
+    const { container } = render(
+      <ComposerAddMenu
+        mcpServers={[
+          {
+            descriptor: browserMcpServer,
+            enabled: false,
+            visible: false,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+        ]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the count of enabled servers on the parent row", () => {
+    render(
+      <ComposerAddMenu
+        mcpServers={[
+          {
+            descriptor: browserMcpServer,
+            enabled: true,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+          {
+            descriptor: subagentMcpServer,
+            enabled: true,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+        ]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+
+    // Count is visible on the parent row without opening the submenu.
+    expect(screen.getByText("MCP servers")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.queryByText("Browser")).not.toBeInTheDocument();
+  });
+
+  it("toggles a single server without closing the menu", () => {
+    const browserToggle = vi.fn<(next: boolean) => void>();
+    const subagentToggle = vi.fn<(next: boolean) => void>();
+    render(
+      <ComposerAddMenu
+        mcpServers={[
+          { descriptor: browserMcpServer, enabled: false, visible: true, onToggle: browserToggle },
+          { descriptor: subagentMcpServer, enabled: true, visible: true, onToggle: subagentToggle },
+        ]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+    openMcpSubmenu();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Browser"));
+    });
+
+    // Only the flipped server fires, with the new value.
+    expect(browserToggle).toHaveBeenCalledTimes(1);
+    expect(browserToggle).toHaveBeenCalledWith(true);
+    expect(subagentToggle).not.toHaveBeenCalled();
+
+    // The submenu stays open so multiple toggles are possible.
+    expect(screen.getByText("Subagents")).toBeInTheDocument();
+  });
+
+  it("registers Chrome for native projects and hides it for WSL", () => {
+    const capabilities = {
+      chromeMcpScope: { terminal: "launch", gui: "launch" },
+    } as Parameters<typeof chromeMcpServer.getScope>[0];
+
+    expect(
+      chromeMcpServer.getScope(capabilities, "terminal", {
+        kind: "windows",
+        path: "C:\\repo",
+      }),
+    ).toBe("launch");
+    expect(
+      chromeMcpServer.getScope(capabilities, "terminal", {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/repo",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\repo",
+      }),
+    ).toBe("none");
+    expect(mcpTogglePatch("chromeMcp", true)).toEqual({ chromeMcp: true });
+  });
+
+  it("captions the submenu with the persistence note", () => {
+    render(
+      <ComposerAddMenu
+        mcpServers={[
+          {
+            descriptor: browserMcpServer,
+            enabled: false,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+        ]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+    openMcpSubmenu();
+
+    expect(screen.getByText("Enabled servers stay on for new threads")).toBeInTheDocument();
+  });
+
+  it("shows a foreground-takeover subtitle for Computer Use inside the submenu", () => {
+    render(
+      <ComposerAddMenu
+        mcpServers={[]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+        computerUse={{
+          enabled: false,
+          visible: true,
+          onToggle: vi.fn<(next: boolean) => void>(),
+        }}
+      />,
+    );
+
+    openMenu();
+    openMcpSubmenu();
+
+    expect(screen.getByText("Computer Use")).toBeInTheDocument();
+    expect(
+      screen.getByText("Takes over the desktop while the agent clicks or types"),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles Computer Use from inside the submenu", () => {
+    const computerUseToggle = vi.fn<(next: boolean) => void>();
+    render(
+      <ComposerAddMenu
+        mcpServers={[]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+        computerUse={{ enabled: false, visible: true, onToggle: computerUseToggle }}
+      />,
+    );
+
+    openMenu();
+    openMcpSubmenu();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Computer Use"));
+    });
+
+    expect(computerUseToggle).toHaveBeenCalledTimes(1);
+    expect(computerUseToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("shows a paired-desktop subtitle for Computer Use in a remote session", () => {
+    bridgeMock.isRemoteSession.mockReturnValue(true);
+    render(
+      <ComposerAddMenu
+        mcpServers={[]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+        computerUse={{
+          enabled: false,
+          visible: true,
+          onToggle: vi.fn<(next: boolean) => void>(),
+        }}
+      />,
+    );
+
+    // Remote session renders the mobile bottom-sheet; open it and drill in.
+    fireEvent.click(screen.getByRole("button", { name: "Add attachment or capability" }));
+    act(() => {
+      fireEvent.click(screen.getByText("MCP servers"));
+    });
+
+    expect(
+      screen.getByText("Controls the paired desktop while the agent clicks or types"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -1,14 +1,18 @@
 import { useState } from "react";
-import { Monitor, Paperclip, Plus } from "lucide-react";
+import { ChevronLeft, ChevronRight, Monitor, Paperclip, Plus, Server } from "lucide-react";
 import type { Selection } from "@heroui/react";
-import { Header, Label, ListBox, Tooltip } from "@heroui/react";
+import { Dropdown, Label, Separator, Tooltip } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { isRemoteSession } from "@/renderer/bridge";
 import { Button } from "@/renderer/components/common";
 import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
 } from "@/renderer/components/common/ResponsiveMenuSurface";
 import type { ComposerMcpServerDescriptor } from "./composerMcpServers";
+
+/** Selection id for the Computer Use row inside the MCP submenu. */
+const COMPUTER_USE_KEY = "computer-use";
 
 export type ComposerMcpMenuItem = {
   descriptor: ComposerMcpServerDescriptor;
@@ -19,8 +23,8 @@ export type ComposerMcpMenuItem = {
 
 /**
  * Presentational switch used inside the MCP rows. The desktop rows are a
- * multi-selection listbox, so the accessible checked state comes from
- * selection; this visual is aria-hidden.
+ * multi-selection menu, so the accessible checked state comes from selection;
+ * this visual is aria-hidden.
  */
 function MenuSwitch(props: { checked: boolean }) {
   const { checked } = props;
@@ -59,28 +63,51 @@ export function ComposerAddMenu(props: {
   const { t } = useLingui();
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
+  // Mobile sheet drill-in: the root list swaps to the MCP list in place.
+  const [mobileView, setMobileView] = useState<"root" | "mcp">("root");
   const visibleMcpServers = mcpServers.filter((server) => server.visible);
+  const showComputerUse = computerUse?.visible === true;
+  const hasMcpMenu = visibleMcpServers.length > 0 || showComputerUse;
+  const computerUseSubtitle = isRemoteSession()
+    ? t`Controls the paired desktop while the agent clicks or types`
+    : t`Takes over the desktop while the agent clicks or types`;
 
-  const enabledKeys = new Set(
-    visibleMcpServers.filter((server) => server.enabled).map((server) => server.descriptor.id),
-  );
+  const enabledMcpCount = visibleMcpServers.filter((server) => server.enabled).length;
 
-  if (!showFileOption && visibleMcpServers.length === 0 && computerUse?.visible !== true)
-    return null;
+  if (!showFileOption && !hasMcpMenu) return null;
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    // Reset the drill-in when the sheet closes so it reopens at the root.
+    if (!open) setMobileView("root");
+  };
 
   const handlePickFiles = () => {
     setIsOpen(false);
+    setMobileView("root");
     onPickFiles();
   };
 
-  // Multiple-selection menu: diff the new selection against current state to
-  // fire only the single toggle that changed.
-  const handleMcpSelection = (keys: Selection) => {
+  // The MCP submenu is a multiple-selection menu (Computer Use included as one
+  // of its rows). Diff the new selection against current state to fire only the
+  // single toggle that changed, and never close the parent menu on toggle.
+  const submenuSelectedKeys = new Set<string>([
+    ...visibleMcpServers.filter((server) => server.enabled).map((server) => server.descriptor.id),
+    ...(showComputerUse && computerUse.enabled ? [COMPUTER_USE_KEY] : []),
+  ]);
+
+  const handleSubmenuSelection = (keys: Selection) => {
     for (const server of visibleMcpServers) {
       const next = keys !== "all" && keys.has(server.descriptor.id);
       if (next !== server.enabled) server.onToggle(next);
     }
+    if (showComputerUse) {
+      const next = keys !== "all" && keys.has(COMPUTER_USE_KEY);
+      if (next !== computerUse.enabled) computerUse.onToggle(next);
+    }
   };
+
+  const persistenceCaption = <Trans>Enabled servers stay on for new threads</Trans>;
 
   const button = (
     <Button
@@ -95,7 +122,8 @@ export function ComposerAddMenu(props: {
     </Button>
   );
 
-  const mobileList = (
+  // ── Mobile: bottom-sheet with a drill-in for the MCP list ──────────────
+  const mobileRootList = (
     <div className="m-sheet-list">
       {showFileOption ? (
         <button type="button" className="m-sheet-action" onClick={handlePickFiles}>
@@ -108,151 +136,185 @@ export function ComposerAddMenu(props: {
           </span>
         </button>
       ) : null}
-      {visibleMcpServers.length > 0 ? (
-        <>
-          <span className="px-2 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
+      {hasMcpMenu ? (
+        <button type="button" className="m-sheet-action" onClick={() => setMobileView("mcp")}>
+          <Server className="size-4 text-muted" />
+          <span className="flex-1 truncate">
             <Trans>MCP servers</Trans>
           </span>
-          {visibleMcpServers.map((server) => {
-            const Icon = server.descriptor.icon;
-            const label = t(server.descriptor.label);
-            return (
-              <button
-                key={server.descriptor.id}
-                type="button"
-                className="m-sheet-action"
-                aria-pressed={server.enabled}
-                onClick={() => server.onToggle(!server.enabled)}
-              >
-                <Icon className="size-4 text-muted" />
-                <span className="flex-1 truncate">{label}</span>
-                <MenuSwitch checked={server.enabled} />
-              </button>
-            );
-          })}
-        </>
+          {enabledMcpCount > 0 ? (
+            <span className="shrink-0 text-xs tabular-nums text-muted">{enabledMcpCount}</span>
+          ) : null}
+          <ChevronRight className="size-4 shrink-0 text-muted" />
+        </button>
       ) : null}
-      {computerUse?.visible ? (
+    </div>
+  );
+
+  const mobileMcpList = (
+    <div className="m-sheet-list">
+      <button
+        type="button"
+        className="m-sheet-action"
+        aria-label={t`Back`}
+        onClick={() => setMobileView("root")}
+      >
+        <ChevronLeft className="size-4 text-muted" />
+        <span className="flex-1 truncate font-medium">
+          <Trans>MCP servers</Trans>
+        </span>
+      </button>
+      {visibleMcpServers.map((server) => {
+        const Icon = server.descriptor.icon;
+        const label = t(server.descriptor.label);
+        return (
+          <button
+            key={server.descriptor.id}
+            type="button"
+            className="m-sheet-action"
+            aria-pressed={server.enabled}
+            onClick={() => server.onToggle(!server.enabled)}
+          >
+            <Icon className="size-4 text-muted" />
+            <span className="flex-1 truncate">{label}</span>
+            <MenuSwitch checked={server.enabled} />
+          </button>
+        );
+      })}
+      {showComputerUse ? (
         <button
           type="button"
           className="m-sheet-action"
           aria-pressed={computerUse.enabled}
           onClick={() => computerUse.onToggle(!computerUse.enabled)}
         >
-          <Monitor className="size-4 text-muted" />
-          <span className="flex-1 truncate">
-            <Trans>Computer Use</Trans>
+          <Monitor className="size-4 shrink-0 text-muted" />
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+            <span className="truncate">
+              <Trans>Computer Use</Trans>
+            </span>
+            <span className="text-[11px] leading-snug text-muted">{computerUseSubtitle}</span>
           </span>
           <MenuSwitch checked={computerUse.enabled} />
         </button>
       ) : null}
+      <p className="px-2 pt-0.5 text-[11px] leading-snug text-muted">{persistenceCaption}</p>
     </div>
   );
 
-  const desktopList = (
-    <div className="min-w-52">
-      {showFileOption ? (
-        <ListBox
-          aria-label={t`Add to composer`}
-          className="lightcode-menu max-h-60 overflow-y-auto"
-          selectionMode="none"
-          onAction={handlePickFiles}
-        >
-          <ListBox.Item id="file" textValue={t`File`} className="focus-visible:outline-none">
-            <Paperclip className="size-4 text-muted" />
-            <Label className="flex-1 truncate">
-              <Trans>File</Trans>
-            </Label>
-            <span className="ms-auto truncate text-xs text-muted">
-              <Trans>Attach</Trans>
-            </span>
-          </ListBox.Item>
-        </ListBox>
-      ) : null}
-      {visibleMcpServers.length > 0 ? (
-        <div className={showFileOption ? "mt-1 border-t border-border pt-1" : undefined}>
-          <Header className="block px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
-            <Trans>MCP servers</Trans>
-          </Header>
-          <ListBox
-            aria-label={t`MCP servers`}
-            className="lightcode-menu max-h-60 overflow-y-auto"
-            selectionMode="multiple"
-            selectedKeys={enabledKeys}
-            onSelectionChange={handleMcpSelection}
-          >
-            {visibleMcpServers.map((server) => {
-              const Icon = server.descriptor.icon;
-              const label = t(server.descriptor.label);
-              return (
-                <ListBox.Item
-                  key={server.descriptor.id}
-                  id={server.descriptor.id}
-                  textValue={label}
-                  className="focus-visible:outline-none data-[selected=true]:bg-transparent"
-                >
-                  <Icon className="size-4 text-muted" />
-                  <Label className="flex-1 truncate">{label}</Label>
-                  <MenuSwitch checked={server.enabled} />
-                </ListBox.Item>
-              );
-            })}
-          </ListBox>
-        </div>
-      ) : null}
-      {computerUse?.visible ? (
-        <div
-          className={
-            showFileOption || visibleMcpServers.length > 0
-              ? "mt-1 border-t border-border pt-1"
-              : undefined
-          }
-        >
-          <ListBox
-            aria-label={t`Computer Use`}
-            className="lightcode-menu max-h-60 overflow-y-auto"
-            selectionMode="none"
-            onAction={() => computerUse.onToggle(!computerUse.enabled)}
-          >
-            <ListBox.Item
-              id="computer-use"
-              textValue={t`Computer Use`}
-              className="focus-visible:outline-none"
-            >
-              <Monitor className="size-4 text-muted" />
-              <Label className="flex-1 truncate">
-                <Trans>Computer Use</Trans>
-              </Label>
-              <MenuSwitch checked={computerUse.enabled} />
-            </ListBox.Item>
-          </ListBox>
-        </div>
-      ) : null}
-    </div>
-  );
+  if (mobile) {
+    return (
+      <ResponsiveMenuSurface
+        isOpen={isOpen}
+        onOpenChange={handleOpenChange}
+        label={t`Add to composer`}
+        trigger={button}
+        placement="top"
+        contentClassName="p-0"
+        dialogClassName="overflow-hidden"
+      >
+        {mobileView === "mcp" && hasMcpMenu ? mobileMcpList : mobileRootList}
+      </ResponsiveMenuSurface>
+    );
+  }
 
+  // ── Desktop: HeroUI dropdown with a real flyout submenu for the MCP list ──
   return (
-    <ResponsiveMenuSurface
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-      label={t`Add to composer`}
-      trigger={
-        mobile ? (
-          button
-        ) : (
-          <Tooltip delay={300}>
-            {button}
-            <Tooltip.Content placement="top">
-              <Trans>Add</Trans>
-            </Tooltip.Content>
-          </Tooltip>
-        )
-      }
-      placement="top"
-      contentClassName="p-0"
-      dialogClassName="overflow-hidden"
-    >
-      {mobile ? mobileList : desktopList}
-    </ResponsiveMenuSurface>
+    <Dropdown>
+      <Dropdown.Trigger>
+        <Tooltip delay={300}>
+          {button}
+          <Tooltip.Content placement="top">
+            <Trans>Add</Trans>
+          </Tooltip.Content>
+        </Tooltip>
+      </Dropdown.Trigger>
+      <Dropdown.Popover placement="top start">
+        <Dropdown.Menu
+          aria-label={t`Add to composer`}
+          selectionMode="none"
+          onAction={(key) => {
+            if (key === "file") handlePickFiles();
+          }}
+          className="lightcode-menu min-w-52"
+        >
+          {showFileOption ? (
+            <Dropdown.Item id="file" textValue={t`File`}>
+              <Paperclip className="size-4 text-muted" />
+              <Label className="flex-1 truncate">
+                <Trans>File</Trans>
+              </Label>
+              <span className="ms-auto truncate text-xs text-muted">
+                <Trans>Attach</Trans>
+              </span>
+            </Dropdown.Item>
+          ) : null}
+          {showFileOption && hasMcpMenu ? <Separator /> : null}
+          {hasMcpMenu ? (
+            <Dropdown.SubmenuTrigger>
+              <Dropdown.Item id="mcp-servers" textValue={t`MCP servers`}>
+                <Server className="size-4 text-muted" />
+                <Label className="flex-1 truncate">
+                  <Trans>MCP servers</Trans>
+                </Label>
+                {enabledMcpCount > 0 ? (
+                  <span className="text-xs tabular-nums text-muted">{enabledMcpCount}</span>
+                ) : null}
+                <Dropdown.SubmenuIndicator />
+              </Dropdown.Item>
+              <Dropdown.Popover>
+                <div className="flex flex-col">
+                  <Dropdown.Menu
+                    aria-label={t`MCP servers`}
+                    selectionMode="multiple"
+                    selectedKeys={submenuSelectedKeys}
+                    onSelectionChange={handleSubmenuSelection}
+                    className="lightcode-menu max-h-72 min-w-56 overflow-y-auto"
+                  >
+                    {visibleMcpServers.map((server) => {
+                      const Icon = server.descriptor.icon;
+                      const label = t(server.descriptor.label);
+                      return (
+                        <Dropdown.Item
+                          key={server.descriptor.id}
+                          id={server.descriptor.id}
+                          textValue={label}
+                          className="data-[selected=true]:bg-transparent"
+                        >
+                          <Icon className="size-4 text-muted" />
+                          <Label className="flex-1 truncate">{label}</Label>
+                          <MenuSwitch checked={server.enabled} />
+                        </Dropdown.Item>
+                      );
+                    })}
+                    {showComputerUse ? (
+                      <Dropdown.Item
+                        id={COMPUTER_USE_KEY}
+                        textValue={t`Computer Use`}
+                        className="data-[selected=true]:bg-transparent"
+                      >
+                        <Monitor className="size-4 shrink-0 self-start text-muted" />
+                        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                          <Label className="truncate">
+                            <Trans>Computer Use</Trans>
+                          </Label>
+                          <span className="text-[11px] leading-snug text-muted">
+                            {computerUseSubtitle}
+                          </span>
+                        </div>
+                        <MenuSwitch checked={computerUse.enabled} />
+                      </Dropdown.Item>
+                    ) : null}
+                  </Dropdown.Menu>
+                  <p className="border-t border-border px-3 py-1.5 text-[11px] leading-snug text-muted">
+                    {persistenceCaption}
+                  </p>
+                </div>
+              </Dropdown.Popover>
+            </Dropdown.SubmenuTrigger>
+          ) : null}
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
   );
 }

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Paperclip, Plus } from "lucide-react";
+import { Monitor, Paperclip, Plus } from "lucide-react";
 import type { Selection } from "@heroui/react";
 import { Header, Label, ListBox, Tooltip } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -44,8 +44,18 @@ export function ComposerAddMenu(props: {
   mcpServers: readonly ComposerMcpMenuItem[];
   showFileOption?: boolean;
   onPickFiles: () => void;
+  /**
+   * Computer Use is a launch-time capability handled separately from the MCP
+   * registry (it gates on project location + agent kind, not the shared MCP
+   * scope). Omitted — or with `visible: false` — the row is not offered.
+   */
+  computerUse?: {
+    enabled: boolean;
+    visible: boolean;
+    onToggle: (next: boolean) => void;
+  };
 }) {
-  const { mcpServers, showFileOption = true, onPickFiles } = props;
+  const { mcpServers, showFileOption = true, onPickFiles, computerUse } = props;
   const { t } = useLingui();
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
@@ -55,7 +65,8 @@ export function ComposerAddMenu(props: {
     visibleMcpServers.filter((server) => server.enabled).map((server) => server.descriptor.id),
   );
 
-  if (!showFileOption && visibleMcpServers.length === 0) return null;
+  if (!showFileOption && visibleMcpServers.length === 0 && computerUse?.visible !== true)
+    return null;
 
   const handlePickFiles = () => {
     setIsOpen(false);
@@ -121,6 +132,20 @@ export function ComposerAddMenu(props: {
           })}
         </>
       ) : null}
+      {computerUse?.visible ? (
+        <button
+          type="button"
+          className="m-sheet-action"
+          aria-pressed={computerUse.enabled}
+          onClick={() => computerUse.onToggle(!computerUse.enabled)}
+        >
+          <Monitor className="size-4 text-muted" />
+          <span className="flex-1 truncate">
+            <Trans>Computer Use</Trans>
+          </span>
+          <MenuSwitch checked={computerUse.enabled} />
+        </button>
+      ) : null}
     </div>
   );
 
@@ -172,6 +197,34 @@ export function ComposerAddMenu(props: {
                 </ListBox.Item>
               );
             })}
+          </ListBox>
+        </div>
+      ) : null}
+      {computerUse?.visible ? (
+        <div
+          className={
+            showFileOption || visibleMcpServers.length > 0
+              ? "mt-1 border-t border-border pt-1"
+              : undefined
+          }
+        >
+          <ListBox
+            aria-label={t`Computer Use`}
+            className="lightcode-menu max-h-60 overflow-y-auto"
+            selectionMode="none"
+            onAction={() => computerUse.onToggle(!computerUse.enabled)}
+          >
+            <ListBox.Item
+              id="computer-use"
+              textValue={t`Computer Use`}
+              className="focus-visible:outline-none"
+            >
+              <Monitor className="size-4 text-muted" />
+              <Label className="flex-1 truncate">
+                <Trans>Computer Use</Trans>
+              </Label>
+              <MenuSwitch checked={computerUse.enabled} />
+            </ListBox.Item>
           </ListBox>
         </div>
       ) : null}

--- a/src/renderer/components/composer/MentionInput.test.ts
+++ b/src/renderer/components/composer/MentionInput.test.ts
@@ -1,39 +1,213 @@
-import { describe, expect, it } from "vitest";
-import { buildMentionResults } from "./MentionInput";
+import { createElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Globe, Monitor, Users } from "lucide-react";
+import type { PromptSegment } from "@/shared/contracts";
+import { buildMentionResults, MentionInput, type McpMentionItem } from "./MentionInput";
+
+vi.mock("./MentionPopover", () => ({ MentionPopover: () => null }));
+
+function typeMention(query: string) {
+  const editor = screen.getByRole("textbox");
+  const text = document.createTextNode(`@${query}`);
+  editor.appendChild(text);
+  const range = document.createRange();
+  range.setStart(text, text.length);
+  range.collapse(true);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  fireEvent.input(editor);
+  return editor;
+}
 
 describe("buildMentionResults", () => {
   const fileResults = [{ type: "file" as const, path: "README.md", name: "README.md" }];
 
+  const browser: McpMentionItem = {
+    id: "browser",
+    name: "Browser",
+    icon: Globe,
+    detail: "MCP server",
+    enabled: false,
+  };
+  const subagents: McpMentionItem = {
+    id: "subagents",
+    name: "Subagents",
+    icon: Users,
+    detail: "MCP server",
+    enabled: true,
+  };
+  const computerUse: McpMentionItem = {
+    id: "computer-use",
+    name: "Computer Use",
+    icon: Monitor,
+    detail: "Computer Use",
+    enabled: true,
+  };
+
   it("shows Browser when typing an empty @ mention", () => {
-    expect(buildMentionResults(fileResults, "", true)).toEqual([
-      { type: "browser", path: "browser", name: "Browser" },
+    expect(buildMentionResults(fileResults, "", [browser])).toEqual([
+      {
+        type: "mcp",
+        path: "browser",
+        name: "Browser",
+        icon: Globe,
+        detail: "MCP server",
+        enabled: false,
+      },
       ...fileResults,
     ]);
   });
 
   it("shows Browser when the query matches browser", () => {
-    expect(buildMentionResults(fileResults, "browser", true)).toEqual([
-      { type: "browser", path: "browser", name: "Browser" },
+    expect(buildMentionResults(fileResults, "browser", [browser])).toEqual([
+      {
+        type: "mcp",
+        path: "browser",
+        name: "Browser",
+        icon: Globe,
+        detail: "MCP server",
+        enabled: false,
+      },
       ...fileResults,
     ]);
   });
 
-  it("does not show Browser until the composer allows it", () => {
-    expect(buildMentionResults(fileResults, "browser", false)).toEqual(fileResults);
+  it("does not show any MCP mention when the list is empty", () => {
+    expect(buildMentionResults(fileResults, "browser", [])).toEqual(fileResults);
+    expect(buildMentionResults(fileResults, "browser")).toEqual(fileResults);
   });
 
-  it("shows Computer Use when enabled and the query matches", () => {
-    expect(buildMentionResults(fileResults, "computer", false, true)).toEqual([
-      { type: "computer_use", path: "computer", name: "Computer Use" },
+  it("filters MCP mentions by case-insensitive name prefix", () => {
+    // "browser" does not prefix-match "Subagents" / "Computer Use".
+    expect(buildMentionResults(fileResults, "browser", [browser, subagents, computerUse])).toEqual([
+      {
+        type: "mcp",
+        path: "browser",
+        name: "Browser",
+        icon: Globe,
+        detail: "MCP server",
+        enabled: false,
+      },
       ...fileResults,
     ]);
   });
 
-  it("shows Browser before Computer Use for an empty @ mention", () => {
-    expect(buildMentionResults(fileResults, "", true, true)).toEqual([
-      { type: "browser", path: "browser", name: "Browser" },
-      { type: "computer_use", path: "computer", name: "Computer Use" },
+  it("shows Subagents when the query matches subagents", () => {
+    expect(buildMentionResults(fileResults, "sub", [browser, subagents])).toEqual([
+      {
+        type: "mcp",
+        path: "subagents",
+        name: "Subagents",
+        icon: Users,
+        detail: "MCP server",
+        enabled: true,
+      },
       ...fileResults,
     ]);
+  });
+
+  it("shows Computer Use when the query matches", () => {
+    expect(buildMentionResults(fileResults, "computer", [computerUse])).toEqual([
+      {
+        type: "mcp",
+        path: "computer-use",
+        name: "Computer Use",
+        icon: Monitor,
+        detail: "Computer Use",
+        enabled: true,
+      },
+      ...fileResults,
+    ]);
+  });
+
+  it("preserves the caller's order for an empty @ mention", () => {
+    expect(buildMentionResults(fileResults, "", [browser, subagents, computerUse])).toEqual([
+      {
+        type: "mcp",
+        path: "browser",
+        name: "Browser",
+        icon: Globe,
+        detail: "MCP server",
+        enabled: false,
+      },
+      {
+        type: "mcp",
+        path: "subagents",
+        name: "Subagents",
+        icon: Users,
+        detail: "MCP server",
+        enabled: true,
+      },
+      {
+        type: "mcp",
+        path: "computer-use",
+        name: "Computer Use",
+        icon: Monitor,
+        detail: "Computer Use",
+        enabled: true,
+      },
+      ...fileResults,
+    ]);
+  });
+});
+
+describe("MCP mention selection", () => {
+  const baseProps = {
+    placeholder: "Send a message...",
+    projectLocation: undefined,
+    onTextChange: vi.fn<(hasText: boolean) => void>(),
+    onSubmit: vi.fn<(segments: PromptSegment[]) => void>(),
+  };
+
+  it("keeps an enabled MCP mention in the prompt for the agent", () => {
+    const onMcpMentionSelect = vi.fn<(id: string) => void>();
+    render(
+      createElement(MentionInput, {
+        ...baseProps,
+        mcpMentions: [
+          {
+            id: "browser",
+            name: "Browser",
+            icon: Globe,
+            detail: "MCP server",
+            enabled: true,
+          },
+        ],
+        onMcpMentionSelect,
+      }),
+    );
+
+    const editor = typeMention("bro");
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor).toHaveTextContent("@Browser");
+    expect(onMcpMentionSelect).not.toHaveBeenCalled();
+  });
+
+  it("enables a disabled MCP without adding prompt text", () => {
+    const onMcpMentionSelect = vi.fn<(id: string) => void>();
+    render(
+      createElement(MentionInput, {
+        ...baseProps,
+        mcpMentions: [
+          {
+            id: "browser",
+            name: "Browser",
+            icon: Globe,
+            detail: "MCP server",
+            enabled: false,
+          },
+        ],
+        onMcpMentionSelect,
+      }),
+    );
+
+    const editor = typeMention("bro");
+    fireEvent.keyDown(editor, { key: "Enter" });
+
+    expect(editor).toBeEmptyDOMElement();
+    expect(onMcpMentionSelect).toHaveBeenCalledWith("browser");
   });
 });

--- a/src/renderer/components/composer/MentionInput.test.ts
+++ b/src/renderer/components/composer/MentionInput.test.ts
@@ -21,4 +21,19 @@ describe("buildMentionResults", () => {
   it("does not show Browser until the composer allows it", () => {
     expect(buildMentionResults(fileResults, "browser", false)).toEqual(fileResults);
   });
+
+  it("shows Computer Use when enabled and the query matches", () => {
+    expect(buildMentionResults(fileResults, "computer", false, true)).toEqual([
+      { type: "computer_use", path: "computer", name: "Computer Use" },
+      ...fileResults,
+    ]);
+  });
+
+  it("shows Browser before Computer Use for an empty @ mention", () => {
+    expect(buildMentionResults(fileResults, "", true, true)).toEqual([
+      { type: "browser", path: "browser", name: "Browser" },
+      { type: "computer_use", path: "computer", name: "Computer Use" },
+      ...fileResults,
+    ]);
+  });
 });

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -9,16 +9,24 @@ import { useDebouncedFileSearch } from "./useDebouncedFileSearch";
 import { serializeToSegments, flattenSegments } from "./serializeMentions";
 
 const BROWSER_MENTION_ENTRY: MentionEntry = { type: "browser", path: "browser", name: "Browser" };
+const COMPUTER_USE_MENTION_ENTRY: MentionEntry = {
+  type: "computer_use",
+  path: "computer",
+  name: "Computer Use",
+};
 
 export function buildMentionResults(
   fileResults: FileEntry[],
   query: string,
   showBrowserMention: boolean,
+  showComputerUseMention = false,
 ): MentionEntry[] {
   const q = query.trim().toLowerCase();
   const browserResults =
     showBrowserMention && "browser".startsWith(q) ? [BROWSER_MENTION_ENTRY] : [];
-  return [...browserResults, ...fileResults];
+  const computerUseResults =
+    showComputerUseMention && "computer use".startsWith(q) ? [COMPUTER_USE_MENTION_ENTRY] : [];
+  return [...browserResults, ...computerUseResults, ...fileResults];
 }
 
 export interface MentionInputHandle {
@@ -249,6 +257,8 @@ export const MentionInput = forwardRef<
     onPasteImage?: (file: File) => void;
     showBrowserMention?: boolean;
     onBrowserMentionSelect?: () => void;
+    showComputerUseMention?: boolean;
+    onComputerUseMentionSelect?: () => void;
     onSlashCommandChange?: (query: string | null) => void;
     /**
      * Trigger words to promote into chips as the user types/pastes (e.g. the
@@ -277,6 +287,8 @@ export const MentionInput = forwardRef<
     onPasteImage,
     showBrowserMention,
     onBrowserMentionSelect,
+    showComputerUseMention,
+    onComputerUseMentionSelect,
     onSlashCommandChange,
     onInterceptKey,
     triggerWords,
@@ -298,11 +310,12 @@ export const MentionInput = forwardRef<
     fileResults,
     mention?.query ?? "",
     showBrowserMention === true,
+    showComputerUseMention === true,
   );
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [mention?.query, fileResults, showBrowserMention]);
+  }, [mention?.query, fileResults, showBrowserMention, showComputerUseMention]);
 
   function insertPlainText(text: string) {
     const editor = editorRef.current;
@@ -560,6 +573,18 @@ export const MentionInput = forwardRef<
       range.deleteContents();
       setMention(null);
       onBrowserMentionSelect?.();
+      notifyTextChange();
+      return;
+    }
+
+    if (entry.type === "computer_use") {
+      const sel = window.getSelection();
+      if (!sel) return;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      range.deleteContents();
+      setMention(null);
+      onComputerUseMentionSelect?.();
       notifyTextChange();
       return;
     }

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { LucideIcon } from "lucide-react";
 import type { FileEntry, ProjectLocation, PromptSegment } from "@/shared/contracts";
 import { fileNameFromPath } from "@/shared/promptContent";
 import { createChipElement, type FileMentionData } from "./FileMentionChip";
@@ -8,25 +9,43 @@ import { MentionPopover, type MentionEntry } from "./MentionPopover";
 import { useDebouncedFileSearch } from "./useDebouncedFileSearch";
 import { serializeToSegments, flattenSegments } from "./serializeMentions";
 
-const BROWSER_MENTION_ENTRY: MentionEntry = { type: "browser", path: "browser", name: "Browser" };
-const COMPUTER_USE_MENTION_ENTRY: MentionEntry = {
-  type: "computer_use",
-  path: "computer",
-  name: "Computer Use",
-};
+/**
+ * A composer MCP server offered as an `@`-mention (Browser, Subagents, Computer
+ * Use, …). The caller supplies already-resolved `name`/`icon`/`detail` so this
+ * component stays registry-agnostic; `id` is echoed back via `onMcpMentionSelect`
+ * when the server still needs enabling. Already-enabled servers are inserted as
+ * prompt text so the mention directs the agent for this turn.
+ */
+export interface McpMentionItem {
+  id: string;
+  name: string;
+  icon: LucideIcon;
+  detail: string;
+  enabled: boolean;
+}
+
+/** Stable empty list so an omitted `mcpMentions` prop doesn't churn renders. */
+const EMPTY_MCP_MENTIONS: readonly McpMentionItem[] = [];
 
 export function buildMentionResults(
   fileResults: FileEntry[],
   query: string,
-  showBrowserMention: boolean,
-  showComputerUseMention = false,
+  mcpMentions: readonly McpMentionItem[] = EMPTY_MCP_MENTIONS,
 ): MentionEntry[] {
   const q = query.trim().toLowerCase();
-  const browserResults =
-    showBrowserMention && "browser".startsWith(q) ? [BROWSER_MENTION_ENTRY] : [];
-  const computerUseResults =
-    showComputerUseMention && "computer use".startsWith(q) ? [COMPUTER_USE_MENTION_ENTRY] : [];
-  return [...browserResults, ...computerUseResults, ...fileResults];
+  // Case-insensitive prefix match on the display name, matching the legacy
+  // "browser".startsWith(q) / "computer use".startsWith(q) behavior.
+  const mcpResults: MentionEntry[] = mcpMentions
+    .filter((item) => item.name.toLowerCase().startsWith(q))
+    .map((item) => ({
+      type: "mcp",
+      path: item.id,
+      name: item.name,
+      icon: item.icon,
+      detail: item.detail,
+      enabled: item.enabled,
+    }));
+  return [...mcpResults, ...fileResults];
 }
 
 export interface MentionInputHandle {
@@ -255,10 +274,13 @@ export const MentionInput = forwardRef<
     onTextChange: (hasText: boolean) => void;
     onSubmit: (segments: PromptSegment[]) => void;
     onPasteImage?: (file: File) => void;
-    showBrowserMention?: boolean;
-    onBrowserMentionSelect?: () => void;
-    showComputerUseMention?: boolean;
-    onComputerUseMentionSelect?: () => void;
+    /**
+     * Composer MCP servers to offer as `@`-mentions (Browser, Subagents,
+     * Computer Use). Enabled entries remain as prompt text; disabled entries
+     * call `onMcpMentionSelect` so the composer can enable them first.
+     */
+    mcpMentions?: readonly McpMentionItem[];
+    onMcpMentionSelect?: (id: string) => void;
     onSlashCommandChange?: (query: string | null) => void;
     /**
      * Trigger words to promote into chips as the user types/pastes (e.g. the
@@ -285,15 +307,16 @@ export const MentionInput = forwardRef<
     onTextChange,
     onSubmit,
     onPasteImage,
-    showBrowserMention,
-    onBrowserMentionSelect,
-    showComputerUseMention,
-    onComputerUseMentionSelect,
+    onMcpMentionSelect,
     onSlashCommandChange,
     onInterceptKey,
     triggerWords,
   } = props;
   const triggerWordDefs = triggerWords ?? EMPTY_TRIGGER_WORDS;
+  const mcpMentions = props.mcpMentions ?? EMPTY_MCP_MENTIONS;
+  // Stable dependency key: which MCP mentions are offered, independent of the
+  // array's per-render identity (mirrors the old boolean flags in the effect).
+  const mcpMentionKey = mcpMentions.map((item) => `${item.id}:${item.enabled}`).join(",");
   const editorRef = useRef<HTMLDivElement>(null);
   const lastSlashQueryRef = useRef<string | null>(null);
   const voicePreviewRef = useRef<HTMLSpanElement | null>(null);
@@ -306,16 +329,11 @@ export const MentionInput = forwardRef<
     mention !== null,
     projectId,
   );
-  const results = buildMentionResults(
-    fileResults,
-    mention?.query ?? "",
-    showBrowserMention === true,
-    showComputerUseMention === true,
-  );
+  const results = buildMentionResults(fileResults, mention?.query ?? "", mcpMentions);
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [mention?.query, fileResults, showBrowserMention, showComputerUseMention]);
+  }, [mention?.query, fileResults, mcpMentionKey]);
 
   function insertPlainText(text: string) {
     const editor = editorRef.current;
@@ -565,26 +583,26 @@ export const MentionInput = forwardRef<
     const range = detectTriggerRange("@");
     if (!range) return;
 
-    if (entry.type === "browser") {
+    if (entry.type === "mcp") {
       const sel = window.getSelection();
       if (!sel) return;
       sel.removeAllRanges();
       sel.addRange(range);
       range.deleteContents();
-      setMention(null);
-      onBrowserMentionSelect?.();
-      notifyTextChange();
-      return;
-    }
 
-    if (entry.type === "computer_use") {
-      const sel = window.getSelection();
-      if (!sel) return;
-      sel.removeAllRanges();
-      sel.addRange(range);
-      range.deleteContents();
+      if (entry.enabled) {
+        const mentionText = document.createTextNode(`@${entry.name} `);
+        range.insertNode(mentionText);
+        const nextRange = document.createRange();
+        nextRange.setStartAfter(mentionText);
+        nextRange.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(nextRange);
+      } else {
+        onMcpMentionSelect?.(entry.path);
+      }
+
       setMention(null);
-      onComputerUseMentionSelect?.();
       notifyTextChange();
       return;
     }

--- a/src/renderer/components/composer/MentionPopover.tsx
+++ b/src/renderer/components/composer/MentionPopover.tsx
@@ -1,23 +1,25 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Globe, Monitor } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import type { LucideIcon } from "lucide-react";
 import type { FileEntry } from "@/shared/contracts";
 import { getEntryIconUrl } from "@/renderer/components/common/fileIcons";
 
-export type BrowserMentionEntry = {
-  type: "browser";
-  path: "browser";
-  name: "Browser";
+/**
+ * A composer MCP server (Browser, Subagents, Computer Use, …) surfaced as an
+ * `@`-mention. `path` doubles as the MCP id passed back on select; `icon` and
+ * `detail` are supplied already-resolved by the composer so the popover stays
+ * registry-agnostic.
+ */
+export type McpMentionEntry = {
+  type: "mcp";
+  path: string;
+  name: string;
+  icon: LucideIcon;
+  detail: string;
+  enabled: boolean;
 };
 
-export type ComputerUseMentionEntry = {
-  type: "computer_use";
-  path: "computer";
-  name: "Computer Use";
-};
-
-export type MentionEntry = FileEntry | BrowserMentionEntry | ComputerUseMentionEntry;
+export type MentionEntry = FileEntry | McpMentionEntry;
 
 function getParentDir(path: string): string {
   const lastSlash = path.lastIndexOf("/");
@@ -66,10 +68,10 @@ export function MentionPopover(props: {
     >
       <div ref={listRef} className="lightcode-mention-popover__list" role="listbox">
         {results.map((entry, index) => {
-          const dir = getParentDir(entry.path);
           const isActive = index === activeIndex;
-          const isBrowser = entry.type === "browser";
-          const isComputerUse = entry.type === "computer_use";
+          const isMcp = entry.type === "mcp";
+          const McpIcon = isMcp ? entry.icon : null;
+          const dir = isMcp ? "" : getParentDir(entry.path);
           return (
             <div
               key={`${entry.type}:${entry.path}`}
@@ -86,10 +88,8 @@ export function MentionPopover(props: {
                 onSelect(entry);
               }}
             >
-              {isBrowser ? (
-                <Globe className="lightcode-mention-popover__icon text-muted" aria-hidden="true" />
-              ) : isComputerUse ? (
-                <Monitor
+              {McpIcon ? (
+                <McpIcon
                   className="lightcode-mention-popover__icon text-muted"
                   aria-hidden="true"
                 />
@@ -102,13 +102,9 @@ export function MentionPopover(props: {
                 />
               )}
               <span className="lightcode-mention-popover__label truncate">{entry.name}</span>
-              {isBrowser ? (
+              {isMcp ? (
                 <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
-                  <Trans>Browser MCP</Trans>
-                </span>
-              ) : isComputerUse ? (
-                <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
-                  <Trans>Computer Use</Trans>
+                  {entry.detail}
                 </span>
               ) : dir ? (
                 <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">

--- a/src/renderer/components/composer/MentionPopover.tsx
+++ b/src/renderer/components/composer/MentionPopover.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Globe } from "lucide-react";
+import { Globe, Monitor } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import type { FileEntry } from "@/shared/contracts";
 import { getEntryIconUrl } from "@/renderer/components/common/fileIcons";
@@ -11,7 +11,13 @@ export type BrowserMentionEntry = {
   name: "Browser";
 };
 
-export type MentionEntry = FileEntry | BrowserMentionEntry;
+export type ComputerUseMentionEntry = {
+  type: "computer_use";
+  path: "computer";
+  name: "Computer Use";
+};
+
+export type MentionEntry = FileEntry | BrowserMentionEntry | ComputerUseMentionEntry;
 
 function getParentDir(path: string): string {
   const lastSlash = path.lastIndexOf("/");
@@ -63,6 +69,7 @@ export function MentionPopover(props: {
           const dir = getParentDir(entry.path);
           const isActive = index === activeIndex;
           const isBrowser = entry.type === "browser";
+          const isComputerUse = entry.type === "computer_use";
           return (
             <div
               key={`${entry.type}:${entry.path}`}
@@ -81,6 +88,11 @@ export function MentionPopover(props: {
             >
               {isBrowser ? (
                 <Globe className="lightcode-mention-popover__icon text-muted" aria-hidden="true" />
+              ) : isComputerUse ? (
+                <Monitor
+                  className="lightcode-mention-popover__icon text-muted"
+                  aria-hidden="true"
+                />
               ) : (
                 <img
                   className="lightcode-mention-popover__icon"
@@ -93,6 +105,10 @@ export function MentionPopover(props: {
               {isBrowser ? (
                 <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
                   <Trans>Browser MCP</Trans>
+                </span>
+              ) : isComputerUse ? (
+                <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">
+                  <Trans>Computer Use</Trans>
                 </span>
               ) : dir ? (
                 <span className="lightcode-mention-popover__detail ml-auto shrink-0 text-xs text-[var(--muted)]">

--- a/src/renderer/components/composer/composerMcpServers.ts
+++ b/src/renderer/components/composer/composerMcpServers.ts
@@ -1,19 +1,19 @@
 import { msg } from "@lingui/core/macro";
 import type { MessageDescriptor } from "@lingui/core";
-import { Globe, Users, type LucideIcon } from "lucide-react";
+import { AppWindow, Globe, Users, type LucideIcon } from "lucide-react";
 import type {
   AgentCapability,
   ComposerMcpScope,
   ComposerMcpScopes,
+  ProjectLocation,
   ThreadConfig,
   ThreadPresentationMode,
 } from "@/shared/contracts";
 
 /**
- * Registry of composer MCP toggles. Adding a third MCP server means appending
- * one descriptor here — the "+" add menu (`ComposerAddMenu`), the enabled chips
- * (`McpChip`), and the draft/active composers all iterate this list, so no new
- * per-MCP menu/chip code is needed.
+ * Registry of composer MCP toggles. Adding a server means appending one
+ * descriptor here — the "+" add menu (`ComposerAddMenu`), the enabled chips
+ * (`McpChip`), and the draft/active composers all iterate this list.
  *
  * Labels/hints are lazy `msg` descriptors (module-level macros must use `msg`,
  * not `t`) resolved to strings at render time via `useLingui` — see the
@@ -23,7 +23,7 @@ import type {
 export type { ComposerMcpScope };
 
 /** `ThreadConfig` keys that hold the per-thread enable flag for each MCP. */
-export type ComposerMcpConfigKey = "browserMcp" | "subagentMcp";
+export type ComposerMcpConfigKey = "browserMcp" | "subagentMcp" | "chromeMcp";
 
 /**
  * Resolve an adapter-declared per-presentation scope pair to the active
@@ -31,7 +31,7 @@ export type ComposerMcpConfigKey = "browserMcp" | "subagentMcp";
  * structured (GUI) runtimes bake MCP config at session start ("launch"),
  * terminal TUIs have no per-thread gating point ("none").
  */
-function resolveMcpScope(
+export function resolveMcpScope(
   scopes: ComposerMcpScopes | undefined,
   presentationMode: ThreadPresentationMode,
 ): ComposerMcpScope {
@@ -42,7 +42,7 @@ function resolveMcpScope(
 }
 
 export interface ComposerMcpServerDescriptor {
-  id: "browser" | "subagents";
+  id: "browser" | "subagents" | "chrome";
   configKey: ComposerMcpConfigKey;
   icon: LucideIcon;
   /** Menu row + chip label. */
@@ -54,6 +54,7 @@ export interface ComposerMcpServerDescriptor {
   getScope: (
     capabilities: AgentCapability,
     presentationMode: ThreadPresentationMode,
+    projectLocation?: ProjectLocation,
   ) => ComposerMcpScope;
 }
 
@@ -79,10 +80,31 @@ export const subagentMcpServer: ComposerMcpServerDescriptor = {
     resolveMcpScope(capabilities.subagentMcpScope, presentationMode),
 };
 
+export const chromeMcpServer: ComposerMcpServerDescriptor = {
+  id: "chrome",
+  configKey: "chromeMcp",
+  icon: AppWindow,
+  label: msg`Chrome`,
+  enabledTitle: msg`Chrome MCP enabled for this thread`,
+  disableLabel: msg`Disable Chrome MCP`,
+  getScope: (capabilities, presentationMode, projectLocation) =>
+    projectLocation?.kind === "wsl"
+      ? "none"
+      : resolveMcpScope(capabilities.chromeMcpScope, presentationMode),
+};
+
 export const composerMcpServers: readonly ComposerMcpServerDescriptor[] = [
   browserMcpServer,
   subagentMcpServer,
+  chromeMcpServer,
 ];
+
+/**
+ * Persistent-enablement key for Computer Use. It is not a registry descriptor
+ * (its gating lives in `getComputerUseScope`), but it shares the same
+ * `enabledMcpServers` map, so it needs a stable id alongside the registry ones.
+ */
+export const COMPUTER_USE_MCP_ID = "computer-use";
 
 /**
  * Build a `ThreadConfig` patch that flips one MCP toggle. Typed on the shared

--- a/src/renderer/components/composer/computerUseScope.test.ts
+++ b/src/renderer/components/composer/computerUseScope.test.ts
@@ -1,15 +1,54 @@
 import { describe, expect, it } from "vitest";
 import { getComputerUseScope } from "./computerUseScope";
 
+// Adapter-declared scope shapes (see src/supervisor/agents/*/detection.ts):
+// most providers declare nothing and inherit the generic gui="launch" /
+// terminal="none" fallback; Codex opts terminal in, OpenCode/Antigravity opt
+// everything out.
+const undeclared = {};
+const codexLike = { computerUseMcpScope: { terminal: "launch", gui: "launch" } } as const;
+const optedOut = { computerUseMcpScope: { terminal: "none", gui: "none" } } as const;
+
 describe("getComputerUseScope", () => {
   it("disables Computer Use for WSL projects", () => {
     expect(
-      getComputerUseScope("codex", "terminal", {
+      getComputerUseScope(codexLike, "terminal", {
         kind: "wsl",
         distro: "Ubuntu",
         linuxPath: "/home/demo/repo",
         uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\repo",
       }),
     ).toBe("none");
+  });
+
+  it("disables Computer Use on Linux hosts (ingress never starts)", () => {
+    expect(getComputerUseScope(undeclared, "gui", { kind: "posix", path: "/tmp" }, "linux")).toBe(
+      "none",
+    );
+  });
+
+  it("disables Computer Use for adapters that opt out in every presentation", () => {
+    expect(
+      getComputerUseScope(optedOut, "gui", { kind: "windows", path: "C:\\repo" }, "win32"),
+    ).toBe("none");
+  });
+
+  it("allows Computer Use from remote/mobile sessions when the host is Windows", () => {
+    // Remote is not a scope gate — agents run on the paired desktop.
+    expect(
+      getComputerUseScope(undeclared, "gui", { kind: "windows", path: "C:\\repo" }, "win32"),
+    ).toBe("launch");
+  });
+
+  it("hides the toggle for terminal threads when the adapter declares no scope", () => {
+    expect(
+      getComputerUseScope(undeclared, "terminal", { kind: "posix", path: "/tmp" }, "darwin"),
+    ).toBe("none");
+  });
+
+  it("allows Computer Use for terminal threads when the adapter opts in (Codex)", () => {
+    expect(
+      getComputerUseScope(codexLike, "terminal", { kind: "posix", path: "/tmp" }, "darwin"),
+    ).toBe("launch");
   });
 });

--- a/src/renderer/components/composer/computerUseScope.test.ts
+++ b/src/renderer/components/composer/computerUseScope.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getComputerUseScope } from "./computerUseScope";
+
+describe("getComputerUseScope", () => {
+  it("disables Computer Use for WSL projects", () => {
+    expect(
+      getComputerUseScope("codex", "terminal", {
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/demo/repo",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\repo",
+      }),
+    ).toBe("none");
+  });
+});

--- a/src/renderer/components/composer/computerUseScope.ts
+++ b/src/renderer/components/composer/computerUseScope.ts
@@ -1,14 +1,35 @@
-import type { AgentKind, ProjectLocation, ThreadPresentationMode } from "@/shared/contracts";
+import type { AgentCapability, ProjectLocation, ThreadPresentationMode } from "@/shared/contracts";
+import { resolveMcpScope } from "./composerMcpServers";
 
 export type ComputerUseScope = "none" | "launch";
 
+/**
+ * Whether Computer Use can be opted into for a thread. Providers declare their
+ * per-presentation gating via `AgentCapability.computerUseMcpScope`; the
+ * cross-cutting host checks live here:
+ *
+ * - Host platform matters: the MCP ingress only starts on win32/darwin, so
+ *   Linux must hide the toggle (otherwise it looks enabled but is a silent
+ *   no-op).
+ * - WSL projects are excluded — agents run inside the distro and can't reach
+ *   the host desktop ingress.
+ *
+ * Remote/mobile sessions are allowed — agents still spawn on the paired
+ * desktop and talk to its loopback Computer Use MCP, so a phone can drive the
+ * host desktop. Callers must pass the *desktop* host platform (not the phone
+ * UA); see the mobile bridge's `setRemoteBridgeClient(..., platform)`.
+ */
 export function getComputerUseScope(
-  agentKind: AgentKind,
+  capabilities: Pick<AgentCapability, "computerUseMcpScope">,
   presentationMode: ThreadPresentationMode,
   projectLocation?: ProjectLocation,
+  hostPlatform?: NodeJS.Platform,
 ): ComputerUseScope {
+  if (hostPlatform === "linux") return "none";
   if (projectLocation?.kind === "wsl") return "none";
-  if (agentKind === "antigravity" || agentKind === "opencode") return "none";
-  if (presentationMode === "gui") return "launch";
-  return agentKind === "codex" ? "launch" : "none";
+  // The composer toggle only distinguishes "available" from "hidden", so the
+  // mid-thread-toggleable "always" scope collapses to "launch".
+  return resolveMcpScope(capabilities.computerUseMcpScope, presentationMode) === "none"
+    ? "none"
+    : "launch";
 }

--- a/src/renderer/components/composer/computerUseScope.ts
+++ b/src/renderer/components/composer/computerUseScope.ts
@@ -1,0 +1,14 @@
+import type { AgentKind, ProjectLocation, ThreadPresentationMode } from "@/shared/contracts";
+
+export type ComputerUseScope = "none" | "launch";
+
+export function getComputerUseScope(
+  agentKind: AgentKind,
+  presentationMode: ThreadPresentationMode,
+  projectLocation?: ProjectLocation,
+): ComputerUseScope {
+  if (projectLocation?.kind === "wsl") return "none";
+  if (agentKind === "antigravity" || agentKind === "opencode") return "none";
+  if (presentationMode === "gui") return "launch";
+  return agentKind === "codex" ? "launch" : "none";
+}

--- a/src/renderer/components/composer/index.ts
+++ b/src/renderer/components/composer/index.ts
@@ -1,5 +1,5 @@
 export { MentionInput, type MentionInputHandle } from "./MentionInput";
-export { AttachmentBar, McpChip } from "./AttachmentBar";
+export { AttachmentBar, ComputerUseChip, McpChip } from "./AttachmentBar";
 export { ComposerAddMenu, type ComposerMcpMenuItem } from "./ComposerAddMenu";
 export {
   browserMcpServer,

--- a/src/renderer/components/composer/index.ts
+++ b/src/renderer/components/composer/index.ts
@@ -1,10 +1,14 @@
-export { MentionInput, type MentionInputHandle } from "./MentionInput";
+export { MentionInput, type MentionInputHandle, type McpMentionItem } from "./MentionInput";
 export { AttachmentBar, ComputerUseChip, McpChip } from "./AttachmentBar";
 export { ComposerAddMenu, type ComposerMcpMenuItem } from "./ComposerAddMenu";
+export { getComputerUseScope } from "./computerUseScope";
 export {
   browserMcpServer,
+  chromeMcpServer,
   composerMcpServers,
+  COMPUTER_USE_MCP_ID,
   mcpTogglePatch,
+  resolveMcpScope,
   subagentMcpServer,
   type ComposerMcpConfigKey,
   type ComposerMcpServerDescriptor,

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -7,7 +7,7 @@ import {
   type RefObject,
 } from "react";
 import { Tooltip, toast } from "@heroui/react";
-import { ChevronDown, GitFork } from "lucide-react";
+import { ChevronDown, GitFork, Monitor } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
@@ -20,11 +20,12 @@ import {
   composerMcpServers,
   mcpTogglePatch,
   ComposerVoiceInput,
+  COMPUTER_USE_MCP_ID,
   MentionInput,
   openAttachmentLightbox,
   useAttachments,
 } from "../composer";
-import type { MentionInputHandle, VoiceInputHandle } from "../composer";
+import type { McpMentionItem, MentionInputHandle, VoiceInputHandle } from "../composer";
 import { getTriggerWords } from "@/renderer/components/providers";
 import { isRemoteSession, readBridge } from "@/renderer/bridge";
 import { captureProductEvent, threadProductProperties } from "@/renderer/analytics/posthog";
@@ -186,6 +187,28 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         ...mcpTogglePatch(descriptor.configKey, next),
       }),
   }));
+  const mcpMentions: McpMentionItem[] = [
+    ...composerMcpServers
+      .filter((descriptor) => thread.config[descriptor.configKey] === true)
+      .map((descriptor) => ({
+        id: descriptor.id,
+        name: t(descriptor.label),
+        icon: descriptor.icon,
+        detail: t`MCP server`,
+        enabled: true,
+      })),
+    ...(thread.config.computerUse === true
+      ? [
+          {
+            id: COMPUTER_USE_MCP_ID,
+            name: t`Computer Use`,
+            icon: Monitor,
+            detail: t`Computer Use`,
+            enabled: true,
+          },
+        ]
+      : []),
+  ];
   const availableCommands = resolveAvailableSlashCommands(
     thread.slashCommands,
     agentStatus?.capabilities.slashCommands,
@@ -608,6 +631,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                       }
                       projectLocation={projectLocation}
                       projectId={thread.projectId}
+                      mcpMentions={mcpMentions}
                       triggerWords={getTriggerWords(thread.agentKind, thread.config.model)}
                       onTextChange={(hasText) => {
                         setHasContent(hasText);

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { Tooltip, toast } from "@heroui/react";
-import { Download, Webhook, X } from "lucide-react";
+import { Download, Monitor, Webhook, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   AgentHookPluginStatus,
@@ -17,6 +17,7 @@ import {
   AttachmentBar,
   ComposerAddMenu,
   composerMcpServers,
+  COMPUTER_USE_MCP_ID,
   ComputerUseChip,
   McpChip,
   mcpTogglePatch,
@@ -24,11 +25,11 @@ import {
   MentionInput,
   openAttachmentLightbox,
   type ComposerMcpMenuItem,
+  type McpMentionItem,
   type MentionInputHandle,
   type VoiceInputHandle,
   useAttachments,
 } from "@/renderer/components/composer";
-import { browserMcpServer } from "@/renderer/components/composer/composerMcpServers";
 import { getTriggerWords } from "@/renderer/components/providers";
 import { getComputerUseScope } from "@/renderer/components/composer/computerUseScope";
 import { useBrowserAttachInbox } from "@/renderer/state/browserAttachInbox";
@@ -250,6 +251,9 @@ export function ThreadDraftComposerArea(props: {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isRemote = isRemoteSession();
   const showVoiceInputButton = useSharedSettings((s) => s.audio.showVoiceInputButton) && !isRemote;
+  // Persistent (standing-default) composer MCP enablement, keyed by MCP id.
+  const persistentMcpServers = useSharedSettings((s) => s.enabledMcpServers);
+  const setMcpServerEnabled = useSharedSettings((s) => s.setMcpServerEnabled);
   const mentionRef = useRef<MentionInputHandle>(null);
   const voiceInputRef = useRef<VoiceInputHandle>(null);
   const attachments = useAttachments();
@@ -312,20 +316,28 @@ export function ThreadDraftComposerArea(props: {
   const showCommandPanel = filteredCommands.length > 0;
   const authRequired = props.selectedAgent.authState === "missing";
   const isHomeScope = isHomeProjectId(props.project.id);
-  const browserMcpScope = browserMcpServer.getScope(
-    props.selectedAgent.capabilities,
-    props.presentationMode,
-  );
-  // Registry-driven MCP toggles: the "+" add menu and enabled chips both iterate
-  // this list, so a new MCP server means adding one descriptor to the registry.
+  // Registry-driven MCP toggles. The "+" add menu now flips the *persistent*
+  // enablement (a standing default applied to every new thread), keyed by MCP
+  // id — not the per-thread config flag. A new MCP server means adding one
+  // descriptor to the registry.
   const mcpServers = composerMcpServers.map((descriptor) => ({
     descriptor,
-    enabled: props.config[descriptor.configKey] === true,
+    enabled: persistentMcpServers[descriptor.id] === true,
     visible:
-      descriptor.getScope(props.selectedAgent.capabilities, props.presentationMode) !== "none",
-    onToggle: (next: boolean) => props.onConfigChange(mcpTogglePatch(descriptor.configKey, next)),
+      descriptor.getScope(
+        props.selectedAgent.capabilities,
+        props.presentationMode,
+        props.project.location,
+      ) !== "none",
+    onToggle: (next: boolean) => setMcpServerEnabled(descriptor.id, next),
   }));
-  const enabledMcpServers = mcpServers.filter((server) => server.enabled);
+  // Composer chips represent per-thread *mentions* only: a server whose config
+  // flag is on for this draft but that isn't persistently enabled. Persistently
+  // enabled servers are on for every thread and show no chip.
+  const mentionedMcpServers = composerMcpServers.filter(
+    (descriptor) =>
+      props.config[descriptor.configKey] === true && persistentMcpServers[descriptor.id] !== true,
+  );
 
   // Worktree creation lives in the composer toolbar. The "bring over uncommitted
   // changes" affordance only appears when the new worktree forks from the
@@ -369,12 +381,58 @@ export function ThreadDraftComposerArea(props: {
   }
 
   const computerUseScope = getComputerUseScope(
-    props.selectedAgent.kind,
+    props.selectedAgent.capabilities,
     props.presentationMode,
     props.project.location,
+    readBridge()?.platform,
   );
   const computerUseEnabled = props.config.computerUse === true;
+  const computerUsePersistent = persistentMcpServers[COMPUTER_USE_MCP_ID] === true;
+  // Same chip rule as the registry servers: a chip only for a per-thread mention,
+  // never for the persistent standing default.
+  const showComputerUseChip =
+    computerUseScope !== "none" && computerUseEnabled && !computerUsePersistent;
   const onConfigChange = props.onConfigChange;
+  // `@`-mention affordances: disabled servers enable the capability for this
+  // draft; already-effective servers remain available and insert a textual
+  // mention that directs the agent to use them for this turn.
+  const mcpMentions: McpMentionItem[] = [
+    ...composerMcpServers
+      .filter(
+        (descriptor) =>
+          descriptor.getScope(
+            props.selectedAgent.capabilities,
+            props.presentationMode,
+            props.project.location,
+          ) !== "none",
+      )
+      .map((descriptor) => ({
+        id: descriptor.id,
+        name: t(descriptor.label),
+        icon: descriptor.icon,
+        detail: t`MCP server`,
+        enabled: props.config[descriptor.configKey] === true,
+      })),
+    ...(computerUseScope !== "none"
+      ? [
+          {
+            id: COMPUTER_USE_MCP_ID,
+            name: t`Computer Use`,
+            icon: Monitor,
+            detail: t`Computer Use`,
+            enabled: computerUseEnabled,
+          },
+        ]
+      : []),
+  ];
+  const onMcpMentionSelect = (id: string) => {
+    if (id === COMPUTER_USE_MCP_ID) {
+      onConfigChange({ computerUse: true });
+      return;
+    }
+    const descriptor = composerMcpServers.find((server) => server.id === id);
+    if (descriptor) onConfigChange(mcpTogglePatch(descriptor.configKey, true));
+  };
   const controls: ComposerControl[] = controlOpenRequest
     ? props.controls.map((control) => {
         if (controlOpenRequest.target === "model" && control.kind === "provider-model") {
@@ -629,17 +687,18 @@ export function ThreadDraftComposerArea(props: {
               if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
             }}
             leading={
-              enabledMcpServers.length > 0 ||
-              (computerUseScope !== "none" && props.config.computerUse === true) ? (
+              mentionedMcpServers.length > 0 || showComputerUseChip ? (
                 <>
-                  {enabledMcpServers.map((server) => (
+                  {mentionedMcpServers.map((descriptor) => (
                     <McpChip
-                      key={server.descriptor.id}
-                      descriptor={server.descriptor}
-                      onRemove={() => server.onToggle(false)}
+                      key={descriptor.id}
+                      descriptor={descriptor}
+                      onRemove={() =>
+                        props.onConfigChange(mcpTogglePatch(descriptor.configKey, false))
+                      }
                     />
                   ))}
-                  {computerUseScope !== "none" && props.config.computerUse === true ? (
+                  {showComputerUseChip ? (
                     <ComputerUseChip
                       onRemove={() => props.onConfigChange({ computerUse: false })}
                     />
@@ -664,13 +723,9 @@ export function ThreadDraftComposerArea(props: {
               const segments = mentionRef.current?.serializeSegments() ?? [];
               latestSegmentsRef.current = segments;
             }}
-            showBrowserMention={browserMcpScope !== "none" && props.config.browserMcp !== true}
-            onBrowserMentionSelect={() => props.onConfigChange({ browserMcp: true })}
+            mcpMentions={mcpMentions}
+            onMcpMentionSelect={onMcpMentionSelect}
             triggerWords={getTriggerWords(props.selectedAgent.kind, props.config.model)}
-            showComputerUseMention={
-              computerUseScope !== "none" && props.config.computerUse !== true
-            }
-            onComputerUseMentionSelect={() => props.onConfigChange({ computerUse: true })}
             {...(!isRemote
               ? {
                   onPasteImage: (file: File) => {
@@ -745,9 +800,9 @@ export function ThreadDraftComposerArea(props: {
             mentionRef={mentionRef}
             voiceInputRef={voiceInputRef}
             computerUse={{
-              enabled: computerUseEnabled,
+              enabled: computerUsePersistent,
               visible: computerUseScope !== "none",
-              onToggle: (next) => onConfigChange({ computerUse: next }),
+              onToggle: (next) => setMcpServerEnabled(COMPUTER_USE_MCP_ID, next),
             }}
           />
         }

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -17,6 +17,7 @@ import {
   AttachmentBar,
   ComposerAddMenu,
   composerMcpServers,
+  ComputerUseChip,
   McpChip,
   mcpTogglePatch,
   ComposerVoiceInput,
@@ -29,6 +30,7 @@ import {
 } from "@/renderer/components/composer";
 import { browserMcpServer } from "@/renderer/components/composer/composerMcpServers";
 import { getTriggerWords } from "@/renderer/components/providers";
+import { getComputerUseScope } from "@/renderer/components/composer/computerUseScope";
 import { useBrowserAttachInbox } from "@/renderer/state/browserAttachInbox";
 import { flattenSegments } from "@/renderer/components/composer/serializeMentions";
 import {
@@ -195,6 +197,11 @@ function DraftComposerAfterControls(props: {
   isDisabled: boolean;
   mentionRef: RefObject<MentionInputHandle | null>;
   voiceInputRef: RefObject<VoiceInputHandle | null>;
+  computerUse: {
+    enabled: boolean;
+    visible: boolean;
+    onToggle: (next: boolean) => void;
+  };
 }) {
   return (
     <>
@@ -202,6 +209,7 @@ function DraftComposerAfterControls(props: {
         mcpServers={props.mcpServers}
         showFileOption={!props.isRemote}
         onPickFiles={props.onPickFiles}
+        computerUse={props.computerUse}
       />
       <ComposerVoiceInput
         show={props.showVoiceInputButton}
@@ -359,6 +367,14 @@ export function ThreadDraftComposerArea(props: {
     if (branchSelection?.worktreePath) return;
     selectNewWorktree({ transferUncommitted: mode === "new-with-changes" });
   }
+
+  const computerUseScope = getComputerUseScope(
+    props.selectedAgent.kind,
+    props.presentationMode,
+    props.project.location,
+  );
+  const computerUseEnabled = props.config.computerUse === true;
+  const onConfigChange = props.onConfigChange;
   const controls: ComposerControl[] = controlOpenRequest
     ? props.controls.map((control) => {
         if (controlOpenRequest.target === "model" && control.kind === "provider-model") {
@@ -389,6 +405,13 @@ export function ThreadDraftComposerArea(props: {
     canTransferUncommitted ? "can-transfer" : "no-transfer",
     controlKinds,
   ].join("|");
+
+  useEffect(() => {
+    if (computerUseScope === "none" && computerUseEnabled) {
+      onConfigChange({ computerUse: false });
+    }
+  }, [computerUseScope, computerUseEnabled, onConfigChange]);
+
   function resetDraftRefs() {
     latestSegmentsRef.current = [];
     attachmentsRef.current = [];
@@ -606,7 +629,8 @@ export function ThreadDraftComposerArea(props: {
               if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
             }}
             leading={
-              enabledMcpServers.length > 0 ? (
+              enabledMcpServers.length > 0 ||
+              (computerUseScope !== "none" && props.config.computerUse === true) ? (
                 <>
                   {enabledMcpServers.map((server) => (
                     <McpChip
@@ -615,6 +639,11 @@ export function ThreadDraftComposerArea(props: {
                       onRemove={() => server.onToggle(false)}
                     />
                   ))}
+                  {computerUseScope !== "none" && props.config.computerUse === true ? (
+                    <ComputerUseChip
+                      onRemove={() => props.onConfigChange({ computerUse: false })}
+                    />
+                  ) : null}
                 </>
               ) : undefined
             }
@@ -638,6 +667,10 @@ export function ThreadDraftComposerArea(props: {
             showBrowserMention={browserMcpScope !== "none" && props.config.browserMcp !== true}
             onBrowserMentionSelect={() => props.onConfigChange({ browserMcp: true })}
             triggerWords={getTriggerWords(props.selectedAgent.kind, props.config.model)}
+            showComputerUseMention={
+              computerUseScope !== "none" && props.config.computerUse !== true
+            }
+            onComputerUseMentionSelect={() => props.onConfigChange({ computerUse: true })}
             {...(!isRemote
               ? {
                   onPasteImage: (file: File) => {
@@ -711,6 +744,11 @@ export function ThreadDraftComposerArea(props: {
             isDisabled={authRequired || agentUpdating || isSubmitting}
             mentionRef={mentionRef}
             voiceInputRef={voiceInputRef}
+            computerUse={{
+              enabled: computerUseEnabled,
+              visible: computerUseScope !== "none",
+              onToggle: (next) => onConfigChange({ computerUse: next }),
+            }}
           />
         }
       />

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -210,6 +210,7 @@ export function ThreadDraftView(props: {
   // Not persisted across drafts — each new thread starts off.
   const [browserMcp, setBrowserMcp] = useState(false);
   const [subagentMcp, setSubagentMcp] = useState(false);
+  const [computerUse, setComputerUse] = useState(false);
   const [worktreeMode, setWorktreeMode] = useState(
     isHomeScope ? false : (lastDraftConfig?.worktreeMode ?? false),
   );
@@ -617,6 +618,11 @@ export function ThreadDraftView(props: {
       setSubagentMcp(patch.subagentMcp === true);
       return;
     }
+    if ("computerUse" in patch) {
+      // Per-thread capability flag — same bypass as browserMcp above.
+      setComputerUse(patch.computerUse === true);
+      return;
+    }
     if (!selectedAgentForConfig) return;
     hasLocalConfigEditRef.current = true;
     const resolved = resolveProviderDraftConfig(selectedAgentForConfig, {
@@ -960,6 +966,7 @@ export function ThreadDraftView(props: {
               ...(sandboxMode ? { sandboxMode } : {}),
               ...(browserMcp ? { browserMcp: true } : {}),
               ...(subagentMcp ? { subagentMcp: true } : {}),
+              ...(computerUse ? { computerUse: true } : {}),
             }}
             compact={props.compact}
             paneCount={props.paneCount}

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -11,6 +11,12 @@ import type {
 } from "@/shared/contracts";
 import { HOME_PROJECT_NAME, isHomeProjectId } from "@/shared/homeScope";
 import { readBridge } from "@/renderer/bridge";
+import {
+  chromeMcpServer,
+  COMPUTER_USE_MCP_ID,
+  getComputerUseScope,
+  resolveMcpScope,
+} from "@/renderer/components/composer";
 import { getConfigNormalizer } from "@/renderer/components/providers/ProviderIcon";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { PixelLoader } from "@/renderer/components/common";
@@ -207,10 +213,14 @@ export function ThreadDraftView(props: {
   const [approvalPolicy, setApprovalPolicy] = useState("");
   const [approvalsReviewer, setApprovalsReviewer] = useState("");
   const [sandboxMode, setSandboxMode] = useState("");
-  // Not persisted across drafts — each new thread starts off.
-  const [browserMcp, setBrowserMcp] = useState(false);
-  const [subagentMcp, setSubagentMcp] = useState(false);
-  const [computerUse, setComputerUse] = useState(false);
+  // Per-draft `@`-mentions of a composer MCP. These are NOT the persistent
+  // enablement (that lives in `enabledMcpServers`); they capture a one-off
+  // mention in this draft and reset with every new thread. The effective launch
+  // flag is `mention || (persistent && scope available)`, computed below.
+  const [browserMcpMention, setBrowserMcpMention] = useState(false);
+  const [subagentMcpMention, setSubagentMcpMention] = useState(false);
+  const [chromeMcpMention, setChromeMcpMention] = useState(false);
+  const [computerUseMention, setComputerUseMention] = useState(false);
   const [worktreeMode, setWorktreeMode] = useState(
     isHomeScope ? false : (lastDraftConfig?.worktreeMode ?? false),
   );
@@ -223,6 +233,8 @@ export function ThreadDraftView(props: {
   // this provider is remembered across new-thread drafts.
   const lastPresentationModeByAgent = useSharedSettings((s) => s.lastPresentationModeByAgent);
   const setLastPresentationMode = useSharedSettings((s) => s.setLastPresentationMode);
+  // Persistent composer MCP enablement (standing default across new threads).
+  const enabledMcpServers = useSharedSettings((s) => s.enabledMcpServers);
   const supportedPresentationModes = selectedAgent
     ? (selectedAgent.capabilities.presentationModes ?? [
         selectedAgent.capabilities.presentationMode,
@@ -608,19 +620,25 @@ export function ThreadDraftView(props: {
   >(() => undefined);
   const onConfigPatch = (patch: Partial<ThreadConfig>) => {
     if ("browserMcp" in patch) {
-      // Per-thread capability flag — not part of ProviderDraftConfig, so it
-      // bypasses the resolver/persistence below.
-      setBrowserMcp(patch.browserMcp === true);
+      // Per-draft mention flag — not part of ProviderDraftConfig, so it bypasses
+      // the resolver/persistence below. Set by an `@browser` mention, cleared by
+      // removing its composer chip.
+      setBrowserMcpMention(patch.browserMcp === true);
       return;
     }
     if ("subagentMcp" in patch) {
-      // Per-thread capability flag — same bypass as browserMcp above.
-      setSubagentMcp(patch.subagentMcp === true);
+      // Per-draft mention flag — same bypass as browserMcp above.
+      setSubagentMcpMention(patch.subagentMcp === true);
+      return;
+    }
+    if ("chromeMcp" in patch) {
+      // Per-draft mention flag — same bypass as browserMcp above.
+      setChromeMcpMention(patch.chromeMcp === true);
       return;
     }
     if ("computerUse" in patch) {
-      // Per-thread capability flag — same bypass as browserMcp above.
-      setComputerUse(patch.computerUse === true);
+      // Per-draft mention flag — same bypass as browserMcp above.
+      setComputerUseMention(patch.computerUse === true);
       return;
     }
     if (!selectedAgentForConfig) return;
@@ -895,6 +913,35 @@ export function ThreadDraftView(props: {
     if (Object.keys(patch).length > 0) onConfigPatch(patch);
   };
 
+  // Effective launch flag for each composer MCP: a per-draft `@`-mention OR a
+  // persistent standing default whose scope the current provider/presentation
+  // actually supports. A persistent enable with a "none" scope must NOT set the
+  // config flag — otherwise the composer would show a phantom "on" state and the
+  // scope-reset effect there would fight it.
+  const hostPlatform = readBridge()?.platform;
+  const effectiveBrowserMcp =
+    browserMcpMention ||
+    (enabledMcpServers.browser === true &&
+      resolveMcpScope(selectedAgent.capabilities.browserMcpScope, presentationMode) !== "none");
+  const effectiveSubagentMcp =
+    subagentMcpMention ||
+    (enabledMcpServers.subagents === true &&
+      resolveMcpScope(selectedAgent.capabilities.subagentMcpScope, presentationMode) !== "none");
+  const effectiveChromeMcp =
+    chromeMcpMention ||
+    (enabledMcpServers.chrome === true &&
+      chromeMcpServer.getScope(selectedAgent.capabilities, presentationMode, project.location) !==
+        "none");
+  const effectiveComputerUse =
+    computerUseMention ||
+    (enabledMcpServers[COMPUTER_USE_MCP_ID] === true &&
+      getComputerUseScope(
+        selectedAgent.capabilities,
+        presentationMode,
+        project.location,
+        hostPlatform,
+      ) !== "none");
+
   return (
     <div
       ref={props.droppableRef}
@@ -964,9 +1011,10 @@ export function ThreadDraftView(props: {
               ...(approvalPolicy ? { approvalPolicy } : {}),
               ...(approvalsReviewer ? { approvalsReviewer } : {}),
               ...(sandboxMode ? { sandboxMode } : {}),
-              ...(browserMcp ? { browserMcp: true } : {}),
-              ...(subagentMcp ? { subagentMcp: true } : {}),
-              ...(computerUse ? { computerUse: true } : {}),
+              ...(effectiveBrowserMcp ? { browserMcp: true } : {}),
+              ...(effectiveSubagentMcp ? { subagentMcp: true } : {}),
+              ...(effectiveChromeMcp ? { chromeMcp: true } : {}),
+              ...(effectiveComputerUse ? { computerUse: true } : {}),
             }}
             compact={props.compact}
             paneCount={props.paneCount}

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -19,7 +19,7 @@ import { buildPromptContentBlocks } from "@/shared/promptContent";
 import { useAppStore } from "@/renderer/state/appStore";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { TuxIcon } from "@/renderer/components/common";
-import { browserMcpServer, McpChip } from "@/renderer/components/composer";
+import { browserMcpServer, ComputerUseChip, McpChip } from "@/renderer/components/composer";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { readBridge } from "@/renderer/bridge";
 import { captureThreadStarted } from "@/renderer/analytics/posthog";
@@ -73,6 +73,7 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.thread.canResumeWithConfig === next.thread.canResumeWithConfig &&
     prev.thread.sessionRef?.providerSessionId === next.thread.sessionRef?.providerSessionId &&
     prev.thread.config.browserMcp === next.thread.config.browserMcp &&
+    prev.thread.config.computerUse === next.thread.config.computerUse &&
     (!configAffectsLaunch || prev.thread.config === next.thread.config) &&
     prev.agentStatus === next.agentStatus &&
     prev.projectLocation === next.projectLocation &&
@@ -193,6 +194,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
   const showBrowserChip =
     thread.config.browserMcp === true ||
     (thread.agentKind === "opencode" && opencodeBrowserMcpEnabled);
+  const showComputerUseChip = thread.config.computerUse === true && !isWsl;
 
   useEffect(() => {
     const presentation =
@@ -391,6 +393,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                     : {})}
                 />
               ) : null}
+              {showComputerUseChip ? <ComputerUseChip variant="header" /> : null}
               <div className="flex shrink-0 items-center">
                 {projectName ? (
                   <span className="px-1 text-sm leading-tight text-muted/60 @max-[560px]:text-xs @max-[360px]:text-[11px]">

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -194,7 +194,8 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
   const showBrowserChip =
     thread.config.browserMcp === true ||
     (thread.agentKind === "opencode" && opencodeBrowserMcpEnabled);
-  const showComputerUseChip = thread.config.computerUse === true && !isWsl;
+  const showComputerUseChip =
+    thread.config.computerUse === true && !isWsl && readBridge().platform !== "linux";
 
   useEffect(() => {
     const presentation =

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Avatar-Farbe {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Zurück"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Browser ist in einem separaten Fenster geöffnet"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Browser-MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Browser-MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Wählen Sie, ob Links von Poracode und Browser-Popups in Poracode bleibe
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Worktree-Basisordner auswählen"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome-MCP für diesen Thread aktiviert"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Composer-Steuerung"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Computernutzung"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use kann den Desktop übernehmen. Nutzen Sie diesen Rechner nicht, während der Agent klickt oder tippt."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use steuert den gekoppelten Desktop. Nutzen Sie diesen Rechner nicht, während der Agent klickt oder tippt."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Computernutzung für diesen Thread aktiviert"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use aktiviert — steuert den gekoppelten Desktop; nutzen Sie diesen Rechner nicht, während der Agent ihn steuert"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use aktiviert — interaktive Aktionen übernehmen den Desktop; nutzen Sie den Rechner nicht, während der Agent ihn steuert"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Computernutzung für diesen Thread aktiviert"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Weiter in..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Steuern Sie, welche Dateien in der @file-Erwähnungssuche angezeigt werden. Projektspezifische Überschreibungen sind in den Einstellungen jedes Projekts verfügbar."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Steuert den gekoppelten Desktop, während der Agent klickt oder tippt"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Stufe {tierLabel} deaktivieren"
 msgid "Disable Browser MCP"
 msgstr "Browser-MCP deaktivieren"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Chrome-MCP deaktivieren"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Aktiviert"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Aktivierte Agenten, Modellsichtbarkeit und Reihenfolge"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Aktivierte Server bleiben für neue Threads aktiv"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maximieren"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Browser maximieren"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCP-Server"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "Tailscale-URL"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Screenshot aufnehmen"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Übernimmt den Desktop, während der Agent klickt oder tippt"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Composer-Steuerung"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Computernutzung"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Computernutzung für diesen Thread aktiviert"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Konfigurationsverzeichnis"
@@ -2465,6 +2475,10 @@ msgstr "Browser-MCP deaktivieren"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "CLI-Hook-Plugin deaktivieren (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Computernutzung deaktivieren"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Avatar color {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Back"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Browser is open in a separate window"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Browser MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Browser MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Choose whether links from Poracode and browser popups stay in Poracode o
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Choose worktree base folder"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome MCP enabled for this thread"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Composer controls"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Computer Use"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Computer Use enabled for this thread"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Computer Use enabled for this thread"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Continue in..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Controls the paired desktop while the agent clicks or types"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Disable {tierLabel} effort"
 msgid "Disable Browser MCP"
 msgstr "Disable Browser MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Disable Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Enabled"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Enabled agents, model visibility and order"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Enabled servers stay on for new threads"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maximize"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Maximize browser"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCP server"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "Tailscale URL"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Take Screenshot"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Takes over the desktop while the agent clicks or types"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Composer controls"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Computer Use"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Computer Use enabled for this thread"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Config directory"
@@ -2465,6 +2475,10 @@ msgstr "Disable Browser MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Disable CLI hook plugin (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Disable Computer Use"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Color del avatar {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Atrás"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "El navegador está abierto en una ventana separada"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Browser MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Browser MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Elige si los enlaces de Poracode y las ventanas emergentes del navegador
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Elegir la carpeta base de worktrees"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome MCP habilitado para este hilo"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Controles del Redactor"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Uso del ordenador"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use puede tomar el control del escritorio. No uses esta máquina mientras el agente hace clic o escribe."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use controla el escritorio emparejado. No uses esa máquina mientras el agente hace clic o escribe."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Uso del ordenador habilitado para este hilo"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use activado: controla el escritorio emparejado; no uses esa máquina mientras el agente la controla"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use activado: las acciones interactivas toman el control del escritorio; no uses la máquina mientras el agente la controla"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Uso del ordenador habilitado para este hilo"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Continuar en..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Controla qué archivos aparecen en la búsqueda de menciones @file. Las anulaciones por proyecto están en la configuración de cada proyecto."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Controla el escritorio emparejado mientras el agente hace clic o escribe"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Desactivar esfuerzo {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Deshabilitar Browser MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Deshabilitar Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Habilitado"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Agentes habilitados, visibilidad y orden de modelos"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Los servidores activados permanecen activos para los nuevos hilos"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maximizar"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Maximizar navegador"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Servidor MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL de Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Hacer captura de pantalla"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Toma el control del escritorio mientras el agente hace clic o escribe"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Redactor"
 msgid "Composer controls"
 msgstr "Controles del Redactor"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Uso del ordenador"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Uso del ordenador habilitado para este hilo"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Directorio de configuración"
@@ -2465,6 +2475,10 @@ msgstr "Deshabilitar Browser MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Deshabilitar el plugin de hook de CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Deshabilitar el uso del ordenador"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Couleur de l'avatar {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Retour"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Le navigateur est ouvert dans une fenêtre séparée"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Navigateur MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Navigateur MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Choisissez si les liens de Poracode et les fenêtres contextuelles du na
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Choisir le dossier de base des arbres de travail"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "MCP Chrome activé pour ce fil de discussion"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Commandes du compositeur"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Utilisation de l'ordinateur"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use peut prendre le contrôle du bureau. N'utilisez pas cette machine pendant que l'agent clique ou tape."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use contrôle le bureau associé. N'utilisez pas cette machine pendant que l'agent clique ou tape."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Utilisation de l'ordinateur activée pour ce fil de discussion"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use activé — contrôle le bureau associé ; n'utilisez pas cette machine pendant que l'agent la contrôle"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use activé — les actions interactives prennent le contrôle du bureau ; n'utilisez pas la machine pendant que l'agent la contrôle"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Utilisation de l'ordinateur activée pour ce fil de discussion"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Continuez dans..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Contrôlez quels fichiers apparaissent dans la recherche de mention @file. Les remplacements par projet sont disponibles dans les paramètres de chaque projet."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Contrôle le bureau associé pendant que l'agent clique ou tape"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Désactiver l'effort {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Désactiver le MCP du navigateur"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Désactiver le MCP Chrome"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Activé"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Agents activés, visibilité et ordre des modèles"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Les serveurs activés restent actifs pour les nouveaux fils de discussion"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maximiser"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Maximiser le navigateur"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Serveur MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6944,6 +6987,10 @@ msgstr "URL Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Prendre une capture d'écran"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Prend le contrôle du bureau pendant que l'agent clique ou tape"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Commandes du compositeur"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Utilisation de l'ordinateur"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Utilisation de l'ordinateur activée pour ce fil de discussion"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Dossier de configuration"
@@ -2465,6 +2475,10 @@ msgstr "Désactiver le MCP du navigateur"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Désactiver le plugin de hook CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Désactiver l'utilisation de l'ordinateur"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1876,6 +1876,16 @@ msgstr "コンポーザー"
 msgid "Composer controls"
 msgstr "コンポーザーの操作"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "コンピュータ操作"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "このスレッドに対してコンピュータ操作が有効になっています"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "設定ディレクトリ"
@@ -2464,6 +2474,10 @@ msgstr "ブラウザMCPを無効にする"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "CLI フック プラグインを無効にする (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "コンピュータ操作を無効にする"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1012,6 +1012,7 @@ msgstr "アバターの色：{color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "戻る"
@@ -1179,8 +1180,8 @@ msgid "Browser is open in a separate window"
 msgstr "ブラウザは別のウィンドウで開いています"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "ブラウザMCP"
+#~ msgid "Browser MCP"
+#~ msgstr "ブラウザMCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1437,6 +1438,14 @@ msgstr "Poracode とブラウザのポップアップからのリンクを Porac
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "ワークツリーのベースフォルダーを選択"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "このスレッドに対して Chrome MCP が有効になっています"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1878,13 +1887,30 @@ msgstr "コンポーザーの操作"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "コンピュータ操作"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use はデスクトップを占有することがあります。エージェントがクリックや入力をしている間は、このマシンを使わないでください。"
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use はペアリングしたデスクトップを操作します。エージェントがクリックや入力をしている間は、そのマシンを使わないでください。"
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "このスレッドに対してコンピュータ操作が有効になっています"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use が有効です — ペアリングしたデスクトップを操作します。エージェントが操作中はそのマシンを使わないでください"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use が有効です — インタラクティブ操作はデスクトップを占有します。エージェントが操作中はマシンを使わないでください"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "このスレッドに対してコンピュータ操作が有効になっています"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2009,6 +2035,10 @@ msgstr "...で続行"
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "@file メンション検索に表示されるファイルを制御します。プロジェクトごとのオーバーライドは、各プロジェクトの設定に反映されます。"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "エージェントがクリックや入力をしている間、ペアリングしたデスクトップを操作します"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2470,6 +2500,10 @@ msgstr "{tierLabel}の推論レベルを無効化"
 msgid "Disable Browser MCP"
 msgstr "ブラウザMCPを無効にする"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Chrome MCPを無効にする"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2711,6 +2745,10 @@ msgstr "有効"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "有効なエージェント、モデルの表示と順序"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "有効なサーバーは新しいスレッドでも有効なままです"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3847,6 +3885,11 @@ msgstr "最大化する"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "ブラウザを最大化する"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCPサーバー"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6943,6 +6986,10 @@ msgstr "Tailscale URL"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "スクリーンショットを撮る"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "エージェントがクリックや入力をしている間、デスクトップを占有します"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1877,6 +1877,16 @@ msgstr "작성기"
 msgid "Composer controls"
 msgstr "작성기 컨트롤"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "컴퓨터 사용"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "이 스레드에 대해 컴퓨터 사용이 활성화되었습니다."
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "설정 디렉터리"
@@ -2465,6 +2475,10 @@ msgstr "브라우저 MCP 비활성화"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "CLI 후크 플러그인 비활성화(L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "컴퓨터 사용 비활성화"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1013,6 +1013,7 @@ msgstr "아바타 색상 {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "뒤로"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "브라우저가 별도의 창에서 열려 있습니다"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "브라우저 MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "브라우저 MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Poracode 및 브라우저 팝업의 링크를 Poracode에 유지할지 �
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "작업 트리 기본 폴더 선택"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "이 스레드에 대해 Chrome MCP가 활성화되었습니다."
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "작성기 컨트롤"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "컴퓨터 사용"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use가 데스크톱을 제어할 수 있습니다. 에이전트가 클릭하거나 입력하는 동안에는 이 컴퓨터를 사용하지 마세요."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use가 페어링된 데스크톱을 제어합니다. 에이전트가 클릭하거나 입력하는 동안에는 해당 컴퓨터를 사용하지 마세요."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "이 스레드에 대해 컴퓨터 사용이 활성화되었습니다."
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use 사용 중 — 페어링된 데스크톱을 제어합니다. 에이전트가 제어하는 동안에는 해당 컴퓨터를 사용하지 마세요"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use 사용 중 — 대화형 작업이 데스크톱을 제어합니다. 에이전트가 제어하는 동안에는 컴퓨터를 사용하지 마세요"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "이 스레드에 대해 컴퓨터 사용이 활성화되었습니다."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "다음에서 계속..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "@file 멘션 검색에 표시되는 파일을 제어합니다. 프로젝트별 재정의는 각 프로젝트의 설정에 적용됩니다."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "에이전트가 클릭하거나 입력하는 동안 페어링된 데스크톱을 제어합니다"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "{tierLabel} 추론 강도 비활성화"
 msgid "Disable Browser MCP"
 msgstr "브라우저 MCP 비활성화"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Chrome MCP 비활성화"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "활성화됨"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "활성화된 에이전트, 모델 표시 여부 및 순서"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "활성화된 서버는 새 스레드에서도 계속 켜져 있습니다"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "최대화"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "브라우저 최대화"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCP 서버"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "Tailscale URL"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "스크린샷 찍기"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "에이전트가 클릭하거나 입력하는 동안 데스크톱을 제어합니다"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Kompozytor"
 msgid "Composer controls"
 msgstr "Sterowanie kompozytorem"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Obsługa komputera"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Włączono obsługę komputera dla tego wątku"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Katalog konfiguracji"
@@ -2465,6 +2475,10 @@ msgstr "Wyłącz Browser MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Wyłącz wtyczkę haka CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Wyłącz obsługę komputera"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Kolor awatara {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Powrót"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Przeglądarka jest otwarta w osobnym oknie"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Przeglądarka MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Przeglądarka MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Wybierz, czy linki z Poracode i wyskakujących okienek przeglądarki maj
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Wybierz folder bazowy drzew roboczych"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome MCP jest włączony dla tego wątku"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Sterowanie kompozytorem"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Obsługa komputera"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use może przejąć pulpit. Nie korzystaj z tego komputera, gdy agent klika lub pisze."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use steruje sparowanym pulpitem. Nie korzystaj z tego komputera, gdy agent klika lub pisze."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Włączono obsługę komputera dla tego wątku"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use włączone — steruje sparowanym pulpitem; nie korzystaj z tego komputera, gdy agent go kontroluje"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use włączone — działania interaktywne przejmują pulpit; nie korzystaj z komputera, gdy agent go kontroluje"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Włączono obsługę komputera dla tego wątku"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Kontynuuj w..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Kontroluj, które pliki pojawiają się w wyszukiwaniu wzmianek @plik. Zastąpienia poszczególnych projektów są dostępne w ustawieniach każdego projektu."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Steruje sparowanym pulpitem, gdy agent klika lub pisze"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Wyłącz poziom {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Wyłącz Browser MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Wyłącz Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Włączone"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Włączeni agenci, widoczność i kolejność modeli"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Włączone serwery pozostają aktywne dla nowych wątków"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maksymalizuj"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Zmaksymalizuj przeglądarkę"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Serwer MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Zrób zrzut ekranu"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Przejmuje pulpit, gdy agent klika lub pisze"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Cor do avatar {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Voltar"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "O navegador está aberto em uma janela separada"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "MCP do navegador"
+#~ msgid "Browser MCP"
+#~ msgstr "MCP do navegador"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Escolha se os links do Poracode e os pop-ups do navegador permanecem no 
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Escolher pasta base da árvore de trabalho"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "MCP do Chrome ativado para este tópico"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Controles do Composer"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Uso do computador"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "O Computer Use pode assumir a área de trabalho. Não use esta máquina enquanto o agente clica ou digita."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "O Computer Use controla a área de trabalho emparelhada. Não use essa máquina enquanto o agente clica ou digita."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Uso do computador ativado para este tópico"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use ativado — controla a área de trabalho emparelhada; não use essa máquina enquanto o agente a controla"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use ativado — ações interativas assumem o controle da área de trabalho; não use a máquina enquanto o agente a controla"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Uso do computador ativado para este tópico"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Continuar em..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Controle quais arquivos aparecem na pesquisa de menção @file. As substituições por projeto estão disponíveis nas configurações de cada projeto."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Controla a área de trabalho emparelhada enquanto o agente clica ou digita"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Desativar esforço {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Desativar MCP do navegador"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Desativar MCP do Chrome"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Habilitado"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Agentes ativados, visibilidade e ordem de modelos"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Os servidores ativados permanecem ativos para novos tópicos"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Maximizar"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Maximizar o navegador"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Servidor MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL do Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Tirar captura de tela"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Assume a área de trabalho enquanto o agente clica ou digita"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Controles do Composer"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Uso do computador"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Uso do computador ativado para este tópico"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Diretório de configuração"
@@ -2465,6 +2475,10 @@ msgstr "Desativar MCP do navegador"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Desativar plug-in de gancho CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Desativar uso do computador"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Цвет аватара {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Назад"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Браузер открыт в отдельном окне"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Browser MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Browser MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Выберите, остаются ли ссылки из Poracode и в
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Выбрать базовую папку worktree"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome MCP включён для этого треда"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Управление полем ввода"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Управление компьютером"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use может захватить рабочий стол. Не пользуйтесь этим компьютером, пока агент кликает или печатает."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use управляет сопряжённым рабочим столом. Не пользуйтесь этим компьютером, пока агент кликает или печатает."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Управление компьютером включено для этого треда"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use включён — управляет сопряжённым рабочим столом; не пользуйтесь этим компьютером, пока агент им управляет"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use включён — интерактивные действия захватывают рабочий стол; не пользуйтесь компьютером, пока агент им управляет"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Управление компьютером включено для этого треда"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Продолжить в..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Управляйте тем, какие файлы появляются в поиске по упоминанию @file. Переопределения для каждого проекта находятся в настройках соответствующего проекта."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Управляет сопряжённым рабочим столом, пока агент кликает или печатает"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Отключить уровень рассуждений {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Отключить Browser MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Отключить Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Включено"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Включённые агенты, видимость и порядок моделей"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Включённые серверы остаются активными для новых тредов"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Развернуть"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Развернуть браузер"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Сервер MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Сделать снимок экрана"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Захватывает рабочий стол, пока агент кликает или печатает"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Поле ввода"
 msgid "Composer controls"
 msgstr "Управление полем ввода"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Управление компьютером"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Управление компьютером включено для этого треда"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Каталог конфигурации"
@@ -2465,6 +2475,10 @@ msgstr "Отключить Browser MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Отключить плагин хука CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Отключить управление компьютером"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Composer denetimleri"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Bilgisayar Kullanımı"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Bu konu için Bilgisayar Kullanımı etkinleştirildi"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Yapılandırma dizini"
@@ -2465,6 +2475,10 @@ msgstr "Tarayıcı MCP'yi Devre Dışı Bırak"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "CLI kanca eklentisini devre dışı bırak (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Bilgisayar Kullanımını Devre Dışı Bırak"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Avatar rengi {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Geri"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Tarayıcı ayrı bir pencerede açık"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Tarayıcı MCP'si"
+#~ msgid "Browser MCP"
+#~ msgstr "Tarayıcı MCP'si"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Poracode ve tarayıcı açılır pencerelerindeki bağlantıların Porac
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Çalışma ağacı temel klasörünü seçin"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Bu konu için Chrome MCP etkinleştirildi"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Composer denetimleri"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Bilgisayar Kullanımı"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use masaüstünü kontrol edebilir. Ajan tıklarken veya yazarken bu makineyi kullanmayın."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use eşleştirilmiş masaüstünü kontrol eder. Ajan tıklarken veya yazarken o makineyi kullanmayın."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Bu konu için Bilgisayar Kullanımı etkinleştirildi"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use etkin — eşleştirilmiş masaüstünü kontrol eder; ajan kontrol ederken o makineyi kullanmayın"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use etkin — etkileşimli eylemler masaüstünü kontrol eder; ajan kontrol ederken makineyi kullanmayın"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Bu konu için Bilgisayar Kullanımı etkinleştirildi"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Şurada devam et..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "@file bahsetme aramasında hangi dosyaların görüneceğini kontrol edin. Projeye özel geçersiz kılmalar her projenin ayarlarında bulunur."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Ajan tıklarken veya yazarken eşleştirilmiş masaüstünü kontrol eder"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "{tierLabel} efor düzeyini devre dışı bırak"
 msgid "Disable Browser MCP"
 msgstr "Tarayıcı MCP'yi Devre Dışı Bırak"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Chrome MCP'yi Devre Dışı Bırak"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Etkin"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Etkin ajanlar, model görünürlüğü ve sırası"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Etkinleştirilen sunucular yeni konular için açık kalır"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Büyüt"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Tarayıcıyı büyüt"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCP sunucusu"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "Tailscale URL'si"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Ekran Görüntüsü Al"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Ajan tıklarken veya yazarken masaüstünü kontrol eder"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Колір аватара {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Назад"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Браузер відкритий в окремому вікні"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "Browser MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "Browser MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Виберіть, чи посилання з Poracode і спливні 
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Виберіть базову папку для worktree"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Chrome MCP увімкнено для цього треду"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Керування полем вводу"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Керування комп'ютером"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use може захопити робочий стіл. Не користуйтеся цим комп'ютером, поки агент клікає або друкує."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use керує спареним робочим столом. Не користуйтеся тим комп'ютером, поки агент клікає або друкує."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Керування комп'ютером увімкнено для цього треду"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use увімкнено — керує спареним робочим столом; не користуйтеся тим комп'ютером, поки агент ним керує"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use увімкнено — інтерактивні дії захоплюють робочий стіл; не користуйтеся комп'ютером, поки агент ним керує"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Керування комп'ютером увімкнено для цього треду"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Продовжити в..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Керуйте тим, які файли з'являються у пошуку згадок @file. Перевизначення для окремих проєктів зберігаються в налаштуваннях кожного проєкту."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Керує спареним робочим столом, поки агент клікає або друкує"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Вимкнути рівень зусиль {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Вимкнути Browser MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Вимкнути Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Увімкнено"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Увімкнені агенти, видимість і порядок моделей"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Увімкнені сервери залишаються активними для нових тредів"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Розгорнути"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Розгорнути браузер"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Сервер MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Зробити знімок екрана"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Захоплює робочий стіл, поки агент клікає або друкує"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Поле вводу"
 msgid "Composer controls"
 msgstr "Керування полем вводу"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Керування комп'ютером"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Керування комп'ютером увімкнено для цього треду"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Каталог конфігурації"
@@ -2465,6 +2475,10 @@ msgstr "Вимкнути Browser MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Вимкнути плагін хука CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Вимкнути керування комп'ютером"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1013,6 +1013,7 @@ msgstr "Màu ảnh đại diện {color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "Quay lại"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "Trình duyệt đang mở trong một cửa sổ riêng"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "MCP trình duyệt"
+#~ msgid "Browser MCP"
+#~ msgstr "MCP trình duyệt"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "Chọn xem các liên kết từ Poracode và cửa sổ bật lên củ
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "Chọn thư mục gốc của cây làm việc"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "Đã bật Chrome MCP cho chủ đề này"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Điều khiển trình soạn thảo"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "Sử dụng máy tính"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use có thể chiếm quyền điều khiển máy tính. Đừng dùng máy này khi agent đang nhấp hoặc gõ."
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use điều khiển máy tính đã ghép nối. Đừng dùng máy đó khi agent đang nhấp hoặc gõ."
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "Đã bật sử dụng máy tính cho chủ đề này"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "Computer Use đã bật — điều khiển máy tính đã ghép nối; đừng dùng máy đó khi agent đang điều khiển"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "Computer Use đã bật — thao tác tương tác chiếm quyền điều khiển máy tính; đừng dùng máy khi agent đang điều khiển"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "Đã bật sử dụng máy tính cho chủ đề này"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "Tiếp tục trong..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "Kiểm soát những tập tin nào xuất hiện trong tìm kiếm đề cập đến @file. Ghi đè cho mỗi dự án trực tiếp trong cài đặt của từng dự án."
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "Điều khiển máy tính đã ghép nối khi agent nhấp hoặc gõ"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "Tắt mức nỗ lực {tierLabel}"
 msgid "Disable Browser MCP"
 msgstr "Tắt MCP trình duyệt"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "Tắt Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "Đã bật"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "Agent đã bật, khả năng hiển thị và thứ tự mô hình"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "Các máy chủ đã bật vẫn hoạt động cho các luồng mới"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "Tối đa hóa"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "Tối đa hóa trình duyệt"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "Máy chủ MCP"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6945,6 +6988,10 @@ msgstr "URL Tailscale"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "Chụp ảnh màn hình"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "Chiếm quyền điều khiển máy tính khi agent nhấp hoặc gõ"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Điều khiển trình soạn thảo"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "Sử dụng máy tính"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "Đã bật sử dụng máy tính cho chủ đề này"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "Thư mục cấu hình"
@@ -2465,6 +2475,10 @@ msgstr "Tắt MCP trình duyệt"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "Vô hiệu hóa plugin hook CLI (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "Tắt sử dụng máy tính"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1013,6 +1013,7 @@ msgstr "头像颜色{color}"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/commands/shortcutCatalog.ts
+#: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Back"
 msgstr "返回"
@@ -1180,8 +1181,8 @@ msgid "Browser is open in a separate window"
 msgstr "浏览器已在单独的窗口中打开"
 
 #: src/renderer/components/composer/MentionPopover.tsx
-msgid "Browser MCP"
-msgstr "浏览器 MCP"
+#~ msgid "Browser MCP"
+#~ msgstr "浏览器 MCP"
 
 #: src/renderer/components/thread/ThreadView.tsx
 msgid "Browser MCP enabled for OpenCode"
@@ -1438,6 +1439,14 @@ msgstr "选择来自 Poracode 和浏览器弹出窗口的链接是保留在 Pora
 #: src/renderer/views/SettingsOverlay/parts/WorktreeBaseFolderField.tsx
 msgid "Choose worktree base folder"
 msgstr "选择工作树基础文件夹"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome"
+msgstr "Chrome"
+
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Chrome MCP enabled for this thread"
+msgstr "为此线程启用 Chrome MCP"
 
 #. placeholder {0}: trimmedName || displayLabel
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -1879,13 +1888,30 @@ msgstr "Composer 控件"
 
 #: src/renderer/components/composer/AttachmentBar.tsx
 #: src/renderer/components/composer/ComposerAddMenu.tsx
-#: src/renderer/components/composer/MentionPopover.tsx
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 msgid "Computer Use"
 msgstr "计算机操作"
 
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use can take over the desktop. Don't use this machine while the agent is clicking or typing."
+#~ msgstr "Computer Use 可能会接管桌面。代理点击或输入时请勿使用本机。"
+
+#: src/renderer/components/composer/ComputerUseOverlay.tsx
+#~ msgid "Computer Use controls the paired desktop. Don't use that machine while the agent is clicking or typing."
+#~ msgstr "Computer Use 会控制已配对的桌面。代理点击或输入时请勿使用该电脑。"
+
 #: src/renderer/components/composer/AttachmentBar.tsx
-msgid "Computer Use enabled for this thread"
-msgstr "为此线程启用计算机操作"
+msgid "Computer Use enabled — controls the paired desktop; don't use that machine while the agent is controlling it"
+msgstr "已启用 Computer Use — 控制已配对的桌面；代理控制期间请勿使用该电脑"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it"
+msgstr "已启用 Computer Use — 交互操作会接管桌面；代理控制期间请勿使用本机"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+#~ msgid "Computer Use enabled for this thread"
+#~ msgstr "为此线程启用计算机操作"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
@@ -2010,6 +2036,10 @@ msgstr "在其他工具中继续..."
 #: src/renderer/views/SettingsOverlay/parts/SearchSettings.tsx
 msgid "Control which files appear in the @file mention search. Per-project overrides live in each project's settings."
 msgstr "控制哪些文件出现在 @file 提及搜索中。可在各项目的设置中进行项目级覆盖。"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Controls the paired desktop while the agent clicks or types"
+msgstr "代理点击或输入时控制已配对的桌面"
 
 #: src/mobile/views/pr/PrConversationPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
@@ -2471,6 +2501,10 @@ msgstr "禁用{tierLabel}级别"
 msgid "Disable Browser MCP"
 msgstr "禁用浏览器 MCP"
 
+#: src/renderer/components/composer/composerMcpServers.ts
+msgid "Disable Chrome MCP"
+msgstr "禁用 Chrome MCP"
+
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
@@ -2712,6 +2746,10 @@ msgstr "启用"
 #: src/mobile/settingsSections.ts
 msgid "Enabled agents, model visibility and order"
 msgstr "已启用的代理、模型可见性和顺序"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Enabled servers stay on for new threads"
+msgstr "已启用的服务器会在新线程中保持开启"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 msgid "Enables <0>cookies</0> and <1>storage</1>. Cookies can contain session tokens and storage often holds auth state — only enable when you trust both the agent and the sites it visits."
@@ -3848,6 +3886,11 @@ msgstr "最大化"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
 msgid "Maximize browser"
 msgstr "最大化浏览器"
+
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
+msgid "MCP server"
+msgstr "MCP服务器"
 
 #: src/renderer/components/composer/ComposerAddMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
@@ -6944,6 +6987,10 @@ msgstr "Tailscale URL"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 msgid "Take Screenshot"
 msgstr "截图"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Takes over the desktop while the agent clicks or types"
+msgstr "代理点击或输入时会接管桌面"
 
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Tap + to add a folder or clone a repository on your desktop."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1877,6 +1877,16 @@ msgstr "Composer"
 msgid "Composer controls"
 msgstr "Composer 控件"
 
+#: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+#: src/renderer/components/composer/MentionPopover.tsx
+msgid "Computer Use"
+msgstr "计算机操作"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Computer Use enabled for this thread"
+msgstr "为此线程启用计算机操作"
+
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Config directory"
 msgstr "配置目录"
@@ -2465,6 +2475,10 @@ msgstr "禁用浏览器 MCP"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Disable CLI hook plugin (L1)"
 msgstr "禁用 CLI 挂钩插件 (L1)"
+
+#: src/renderer/components/composer/AttachmentBar.tsx
+msgid "Disable Computer Use"
+msgstr "禁用计算机操作"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 msgid "Disable Project"

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -83,6 +83,12 @@ interface SharedSettingsState extends SharedSettings {
   setSearchExclude: (value: Record<string, boolean>) => void;
   setDisableCliHookPlugin: (value: boolean) => void;
   dismissHookInstallProposal: (key: string) => void;
+  /**
+   * Turn a composer MCP server on/off persistently, keyed by composer MCP id
+   * (`"browser"`, `"subagents"`, `"computer-use"`). Persisted like the other
+   * setters; consumed as the standing default for every new thread.
+   */
+  setMcpServerEnabled: (id: string, enabled: boolean) => void;
   setBrowserSetting: <K extends keyof SharedSettings["browser"]>(
     key: K,
     value: SharedSettings["browser"][K],
@@ -446,6 +452,12 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({ dismissedHookInstallProposals: { ...current, [key]: true } });
     persistSettings(selectSharedSettings(get()));
   },
+  setMcpServerEnabled: (id, enabled) => {
+    const current = get().enabledMcpServers;
+    if ((current[id] ?? false) === enabled) return;
+    set({ enabledMcpServers: { ...current, [id]: enabled } });
+    persistSettings(selectSharedSettings(get()));
+  },
   setBrowserSetting: (key, value) => {
     const current = get().browser;
     if (current[key] === value) return;
@@ -716,6 +728,7 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     searchExclude: state.searchExclude,
     disableCliHookPlugin: state.disableCliHookPlugin,
     dismissedHookInstallProposals: state.dismissedHookInstallProposals,
+    enabledMcpServers: state.enabledMcpServers,
     notificationsEnabled: state.notificationsEnabled,
     notificationSound: state.notificationSound,
     notificationFilter: state.notificationFilter,

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -254,6 +254,10 @@ export const agentCapabilitySchema = z.object({
   browserMcpScope: composerMcpScopesSchema.optional(),
   /** Composer Subagents-MCP toggle gating. See {@link composerMcpScopesSchema}. */
   subagentMcpScope: composerMcpScopesSchema.optional(),
+  /** Composer Computer-Use-MCP toggle gating. See {@link composerMcpScopesSchema}. */
+  computerUseMcpScope: composerMcpScopesSchema.optional(),
+  /** Composer external-Chrome-MCP toggle gating. See {@link composerMcpScopesSchema}. */
+  chromeMcpScope: composerMcpScopesSchema.optional(),
   settingDefs: z.array(agentSettingDefSchema).default([]),
   /** Populated when the Claude Agent SDK init probe succeeds (install detection). */
   slashCommands: z.array(agentSlashCommandSchema).optional(),

--- a/src/shared/contracts/config.ts
+++ b/src/shared/contracts/config.ts
@@ -13,6 +13,7 @@ const threadConfigShape = {
   sandboxMode: z.string().optional(),
   browserMcp: z.boolean().optional(),
   subagentMcp: z.boolean().optional(),
+  computerUse: z.boolean().optional(),
 } as const;
 
 export const threadConfigBaseSchema = z.object(threadConfigShape);
@@ -55,6 +56,7 @@ export function isThreadConfigEqual(
     left.approvalsReviewer === right.approvalsReviewer &&
     left.sandboxMode === right.sandboxMode &&
     left.browserMcp === right.browserMcp &&
-    left.subagentMcp === right.subagentMcp
+    left.subagentMcp === right.subagentMcp &&
+    left.computerUse === right.computerUse
   );
 }

--- a/src/shared/contracts/config.ts
+++ b/src/shared/contracts/config.ts
@@ -14,6 +14,7 @@ const threadConfigShape = {
   browserMcp: z.boolean().optional(),
   subagentMcp: z.boolean().optional(),
   computerUse: z.boolean().optional(),
+  chromeMcp: z.boolean().optional(),
 } as const;
 
 export const threadConfigBaseSchema = z.object(threadConfigShape);
@@ -57,6 +58,7 @@ export function isThreadConfigEqual(
     left.sandboxMode === right.sandboxMode &&
     left.browserMcp === right.browserMcp &&
     left.subagentMcp === right.subagentMcp &&
-    left.computerUse === right.computerUse
+    left.computerUse === right.computerUse &&
+    left.chromeMcp === right.chromeMcp
   );
 }

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -76,6 +76,12 @@ export const remoteEnvironmentDescriptorSchema = z.object({
   desktopId: z.string().min(1),
   label: z.string().min(1),
   appVersion: z.string().min(1),
+  /**
+   * Host OS of the paired desktop (`win32` / `darwin` / `linux`). Optional for
+   * older servers; clients that need host-gated features (Computer Use) should
+   * treat a missing value as "unknown" rather than the mobile device's OS.
+   */
+  platform: z.enum(["win32", "darwin", "linux"]).optional(),
   auth: z.object({
     policy: z.literal("remote-reachable"),
     bootstrapMethods: z.array(z.literal("one-time-token")),

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -385,9 +385,20 @@ export const sharedSettingsSchema = z.object({
   /** Per-agent CLI hook plugin support cache. Keyed by AgentKind (and WSL distro when applicable). */
   agentHookSupport: z.record(z.string(), agentHookSupportEntrySchema),
   /**
-   * In-app browser panel + agent MCP bridge settings. Per-thread MCP opt-in
-   * is controlled via the composer "+" menu (sets `thread.config.browserMcp`),
-   * not a global toggle.
+   * Composer MCP servers the user has turned on persistently, keyed by composer
+   * MCP id (`"browser"`, `"subagents"`, `"chrome"`, `"computer-use"`). `true` means the
+   * server is on for every *new* thread whose provider/presentation supports it
+   * (baked into `thread.config` at launch) and shows no composer chip — it is a
+   * standing default rather than a per-thread opt-in. Absent/`false` leaves the
+   * server off unless the draft explicitly `@`-mentions it, which stages a
+   * removable chip for that one thread. Toggled by the composer "+" menu.
+   */
+  enabledMcpServers: z.record(z.string(), z.boolean()).default({}),
+  /**
+   * In-app browser panel + agent MCP bridge settings. Whether the Browser MCP
+   * attaches to a thread is decided per thread: a persistent default in
+   * `enabledMcpServers.browser` or a one-off `@browser` mention, resolved to
+   * `thread.config.browserMcp` at launch. These are the bridge/panel knobs.
    */
   browser: browserSettingsSchema,
   /** Local audio capture and speech-to-text settings. */
@@ -399,8 +410,9 @@ export const sharedSettingsSchema = z.object({
    * `instructions`, guiding how an agent picks which connected agent/model to
    * delegate to when spawning subagents (e.g. "Codex GPT-5.5 fast for quick
    * lookups, Claude Opus for anything subtle"). Empty string = no guidance.
-   * Per-thread opt-in lives on `thread.config.subagentMcp`; this is the global
-   * guidance text shared across every subagent-enabled thread.
+   * Whether a thread gets the subagents MCP lives on `thread.config.subagentMcp`
+   * (persistent default in `enabledMcpServers.subagents` or a `@subagents`
+   * mention); this is the global guidance text shared across every such thread.
    */
   subagentRoutingGuide: z.string(),
 });
@@ -497,6 +509,7 @@ export const defaultSharedSettings: SharedSettings = {
   disableCliHookPlugin: false,
   dismissedHookInstallProposals: {},
   agentHookSupport: {},
+  enabledMcpServers: {},
   browser: {
     allowEval: false,
     allowDataAccess: false,

--- a/src/supervisor/agents/acp/mcpChrome.ts
+++ b/src/supervisor/agents/acp/mcpChrome.ts
@@ -1,0 +1,25 @@
+import {
+  CHROME_MCP_SERVER_NAME,
+  resolveOrFallbackChromeMcpConfig,
+  type ChromeMcpHttpConfig,
+  type ChromeMcpLocation,
+} from "@/supervisor/agents/chromeMcp";
+import type { AcpHttpMcpServer } from "./mcpBrowser";
+
+export function buildAcpChromeMcpServers(
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  chromeMcp?: ChromeMcpHttpConfig,
+): AcpHttpMcpServer[] {
+  if (!enabled) return [];
+  const cfg = resolveOrFallbackChromeMcpConfig(location, chromeMcp);
+  if (!cfg) return [];
+  return [
+    {
+      type: "http",
+      name: CHROME_MCP_SERVER_NAME,
+      url: cfg.url,
+      headers: Object.entries(cfg.headers).map(([name, value]) => ({ name, value })),
+    },
+  ];
+}

--- a/src/supervisor/agents/acp/mcpComputerUse.ts
+++ b/src/supervisor/agents/acp/mcpComputerUse.ts
@@ -1,6 +1,6 @@
 import {
   COMPUTER_USE_MCP_SERVER_NAME,
-  resolveComputerUseMcpHttpConfig,
+  resolveOrFallbackComputerUseMcpConfig,
   type ComputerUseMcpHttpConfig,
   type ComputerUseMcpLocation,
 } from "@/supervisor/agents/computerUseMcp";
@@ -12,8 +12,7 @@ export function buildAcpComputerUseMcpServers(
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): AcpHttpMcpServer[] {
   if (!enabled) return [];
-  if (location.kind === "wsl" && !computerUseMcp) return [];
-  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  const cfg = resolveOrFallbackComputerUseMcpConfig(location, computerUseMcp);
   if (!cfg) return [];
   return [
     {

--- a/src/supervisor/agents/acp/mcpComputerUse.ts
+++ b/src/supervisor/agents/acp/mcpComputerUse.ts
@@ -1,0 +1,26 @@
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  resolveComputerUseMcpHttpConfig,
+  type ComputerUseMcpHttpConfig,
+  type ComputerUseMcpLocation,
+} from "@/supervisor/agents/computerUseMcp";
+import type { AcpHttpMcpServer } from "./mcpBrowser";
+
+export function buildAcpComputerUseMcpServers(
+  location: ComputerUseMcpLocation,
+  enabled: boolean,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): AcpHttpMcpServer[] {
+  if (!enabled) return [];
+  if (location.kind === "wsl" && !computerUseMcp) return [];
+  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  if (!cfg) return [];
+  return [
+    {
+      type: "http",
+      name: COMPUTER_USE_MCP_SERVER_NAME,
+      url: cfg.url,
+      headers: Object.entries(cfg.headers).map(([name, value]) => ({ name, value })),
+    },
+  ];
+}

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -18,6 +18,7 @@ import {
 } from "./mcpBrowser";
 import { buildAcpSubagentMcpServers } from "./mcpSubagent";
 import { buildAcpComputerUseMcpServers } from "./mcpComputerUse";
+import { buildAcpChromeMcpServers } from "./mcpChrome";
 import { readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { homedir } from "node:os";
@@ -64,6 +65,7 @@ import type {
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import { areAgentSlashCommandsEqual, isThreadConfigEqual } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import {
@@ -156,6 +158,7 @@ export interface AcpStructuredSessionOptions {
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
   computerUseMcp?: ComputerUseMcpHttpConfig;
+  chromeMcp?: ChromeMcpHttpConfig;
 }
 
 export class AcpStructuredSession implements StructuredSessionHandle {
@@ -176,6 +179,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly browserMcp: BrowserMcpHttpConfig | undefined;
   private readonly subagentMcp: SubagentMcpHttpConfig | undefined;
   private readonly computerUseMcp: ComputerUseMcpHttpConfig | undefined;
+  private readonly chromeMcp: ChromeMcpHttpConfig | undefined;
   /** Poracode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
   private readonly stderrChunks: string[] = [];
@@ -272,6 +276,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     this.browserMcp = options?.browserMcp;
     this.subagentMcp = options?.subagentMcp;
     this.computerUseMcp = options?.computerUseMcp;
+    this.chromeMcp = options?.chromeMcp;
   }
 
   private shouldAutoApproveSyntheticPermissionRequest(): boolean {
@@ -700,6 +705,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         config.computerUse === true,
         this.computerUseMcp,
       ),
+      ...buildAcpChromeMcpServers(this.projectLocation, config.chromeMcp === true, this.chromeMcp),
     ]);
 
     if (sessionRef) {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -17,6 +17,7 @@ import {
   type AcpHttpMcpServer,
 } from "./mcpBrowser";
 import { buildAcpSubagentMcpServers } from "./mcpSubagent";
+import { buildAcpComputerUseMcpServers } from "./mcpComputerUse";
 import { readFile, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { homedir } from "node:os";
@@ -62,6 +63,7 @@ import type {
 } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import { areAgentSlashCommandsEqual, isThreadConfigEqual } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import {
@@ -153,6 +155,7 @@ export interface AcpStructuredSessionOptions {
   extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
+  computerUseMcp?: ComputerUseMcpHttpConfig;
 }
 
 export class AcpStructuredSession implements StructuredSessionHandle {
@@ -172,6 +175,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly projectLocation: ProjectLocation;
   private readonly browserMcp: BrowserMcpHttpConfig | undefined;
   private readonly subagentMcp: SubagentMcpHttpConfig | undefined;
+  private readonly computerUseMcp: ComputerUseMcpHttpConfig | undefined;
   /** Poracode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
   private readonly stderrChunks: string[] = [];
@@ -267,6 +271,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     }
     this.browserMcp = options?.browserMcp;
     this.subagentMcp = options?.subagentMcp;
+    this.computerUseMcp = options?.computerUseMcp;
   }
 
   private shouldAutoApproveSyntheticPermissionRequest(): boolean {
@@ -690,6 +695,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         this.browserMcp,
       )),
       ...buildAcpSubagentMcpServers(config.subagentMcp === true, this.subagentMcp),
+      ...buildAcpComputerUseMcpServers(
+        this.projectLocation,
+        config.computerUse === true,
+        this.computerUseMcp,
+      ),
     ]);
 
     if (sessionRef) {

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -54,5 +54,6 @@ export function createAcpStructuredSession(
       : {}),
     ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
     ...(input.subagentMcp !== undefined ? { subagentMcp: input.subagentMcp } : {}),
+    ...(input.computerUseMcp !== undefined ? { computerUseMcp: input.computerUseMcp } : {}),
   });
 }

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -55,5 +55,6 @@ export function createAcpStructuredSession(
     ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
     ...(input.subagentMcp !== undefined ? { subagentMcp: input.subagentMcp } : {}),
     ...(input.computerUseMcp !== undefined ? { computerUseMcp: input.computerUseMcp } : {}),
+    ...(input.chromeMcp !== undefined ? { chromeMcp: input.chromeMcp } : {}),
   });
 }

--- a/src/supervisor/agents/antigravity/detection.ts
+++ b/src/supervisor/agents/antigravity/detection.ts
@@ -35,6 +35,8 @@ export const defaultAntigravityCapabilities: AgentCapability = {
   // No dedicated-server hosting path in any presentation.
   browserMcpScope: { terminal: "none", gui: "none" },
   subagentMcpScope: { terminal: "none", gui: "none" },
+  computerUseMcpScope: { terminal: "none", gui: "none" },
+  chromeMcpScope: { terminal: "none", gui: "none" },
   settingDefs: [],
 };
 

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -21,6 +21,7 @@ import type { OscNotification, OscShellEvent, OscTitle } from "@/shared/osc";
 import type { McpThreadIdentity } from "@/shared/browserMcpThread";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 
 export interface CommandSpec {
   command: string;
@@ -47,6 +48,8 @@ export interface AgentEnvContext {
   baseDir?: string;
   browserMcpEnabled?: boolean;
   browserMcp?: BrowserMcpHttpConfig;
+  computerUseMcpEnabled?: boolean;
+  computerUseMcp?: ComputerUseMcpHttpConfig;
 }
 
 export interface AgentLaunchOptions {
@@ -55,6 +58,7 @@ export interface AgentLaunchOptions {
   agentSettings?: Record<string, boolean | string>;
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
+  computerUseMcp?: ComputerUseMcpHttpConfig;
 }
 
 export interface StructuredSessionUpdate {
@@ -134,6 +138,7 @@ export interface CreateStructuredSessionInput {
   mcpIdentity?: McpThreadIdentity;
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
+  computerUseMcp?: ComputerUseMcpHttpConfig;
   sessionRef?: SessionRef;
   presentationMode?: ThreadPresentationMode;
   loadSessionErrorRewriter?: (error: unknown, sessionId: string) => Error;

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -22,6 +22,7 @@ import type { McpThreadIdentity } from "@/shared/browserMcpThread";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 
 export interface CommandSpec {
   command: string;
@@ -50,6 +51,8 @@ export interface AgentEnvContext {
   browserMcp?: BrowserMcpHttpConfig;
   computerUseMcpEnabled?: boolean;
   computerUseMcp?: ComputerUseMcpHttpConfig;
+  chromeMcpEnabled?: boolean;
+  chromeMcp?: ChromeMcpHttpConfig;
 }
 
 export interface AgentLaunchOptions {
@@ -59,6 +62,7 @@ export interface AgentLaunchOptions {
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
   computerUseMcp?: ComputerUseMcpHttpConfig;
+  chromeMcp?: ChromeMcpHttpConfig;
 }
 
 export interface StructuredSessionUpdate {
@@ -139,6 +143,7 @@ export interface CreateStructuredSessionInput {
   browserMcp?: BrowserMcpHttpConfig;
   subagentMcp?: SubagentMcpHttpConfig;
   computerUseMcp?: ComputerUseMcpHttpConfig;
+  chromeMcp?: ChromeMcpHttpConfig;
   sessionRef?: SessionRef;
   presentationMode?: ThreadPresentationMode;
   loadSessionErrorRewriter?: (error: unknown, sessionId: string) => Error;

--- a/src/supervisor/agents/chromeMcp/index.ts
+++ b/src/supervisor/agents/chromeMcp/index.ts
@@ -1,17 +1,24 @@
 /**
- * External-Chrome MCP wiring — the sibling of `../browserMcp`. Where
- * `browserMcp` points agents at the embedded browser panel, this points them at
- * the `chrome` Streamable-HTTP ingress that relays to the user's REAL Chrome via
- * the companion extension. The main process injects the URL + token at launch.
+ * External-Chrome MCP wiring — the sibling of `../browserMcp` and
+ * `../computerUseMcp`. Where `browserMcp` points agents at the embedded browser
+ * panel, this points them at the `chrome` Streamable-HTTP ingress that relays to
+ * the user's REAL Chrome via the companion extension. The main process injects
+ * the URL + token at launch. Wired per-thread across every provider (Claude SDK,
+ * Codex argv, ACP, Gemini/OpenCode plugins) and gated behind `config.chromeMcp`.
  *
- * Native (windows/posix) only for now: a WSL agent would need the in-distro
- * bridge reverse-proxy, matching the embedded browser MCP path.
+ * Native (windows/posix) only: a WSL agent would need the in-distro bridge
+ * reverse-proxy, matching the embedded browser MCP path — so WSL declines.
  */
 
 import { encodeThreadQuery, type McpThreadIdentity } from "@/shared/browserMcpThread";
 import type { BrowserMcpLocation } from "@/supervisor/agents/browserMcp";
 
+export type ChromeMcpLocation = BrowserMcpLocation;
+
 export const CHROME_MCP_SERVER_NAME = "chrome";
+
+export const CHROME_MCP_URL_ENV = "LIGHTCODE_CHROME_MCP_URL";
+export const CHROME_MCP_TOKEN_ENV = "LIGHTCODE_CHROME_MCP_TOKEN";
 
 export interface ChromeMcpHttpConfig {
   url: string;
@@ -20,14 +27,14 @@ export interface ChromeMcpHttpConfig {
 }
 
 export function readChromeMcpEnv(): { url: string; token: string } | null {
-  const url = process.env.LIGHTCODE_CHROME_MCP_URL;
-  const token = process.env.LIGHTCODE_CHROME_MCP_TOKEN;
+  const url = process.env[CHROME_MCP_URL_ENV];
+  const token = process.env[CHROME_MCP_TOKEN_ENV];
   if (!url || !token) return null;
   return { url, token };
 }
 
 export function resolveChromeMcpHttpConfig(
-  location: BrowserMcpLocation,
+  location: ChromeMcpLocation,
   identity?: McpThreadIdentity,
 ): ChromeMcpHttpConfig | null {
   const env = readChromeMcpEnv();
@@ -39,4 +46,28 @@ export function resolveChromeMcpHttpConfig(
     token: env.token,
     headers: { Authorization: `Bearer ${env.token}` },
   };
+}
+
+/**
+ * Resolve a ChromeMcpHttpConfig from an optional pre-resolved config or by
+ * falling back to the environment. Returns `undefined` when the config cannot
+ * be resolved (WSL without a launch-time config, or env vars absent).
+ *
+ * Shared guard used by every provider's `buildXxxChromeMcp*()` function.
+ */
+export function resolveOrFallbackChromeMcpConfig(
+  location: ChromeMcpLocation,
+  chromeMcp?: ChromeMcpHttpConfig,
+): ChromeMcpHttpConfig | undefined {
+  if (location.kind === "wsl" && !chromeMcp) return undefined;
+  return chromeMcp ?? resolveChromeMcpHttpConfig(location) ?? undefined;
+}
+
+export function resolveChromeMcpHttpConfigForLaunch(
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  identity?: McpThreadIdentity,
+): ChromeMcpHttpConfig | undefined {
+  if (!enabled) return undefined;
+  return resolveChromeMcpHttpConfig(location, identity) ?? undefined;
 }

--- a/src/supervisor/agents/chromeMcp/providers.test.ts
+++ b/src/supervisor/agents/chromeMcp/providers.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildAcpChromeMcpServers } from "../acp/mcpChrome";
+import { buildClaudeChromeMcpServers } from "../claude/mcpChrome";
+import { buildCodexChromeMcpArgs, buildCodexChromeMcpEnv } from "../codex/mcpChrome";
+import { buildGeminiChromeMcpServers } from "../gemini/mcpChrome";
+import { buildOpenCodeChromeMcp } from "../opencode/mcpChrome";
+import { resolveChromeMcpHttpConfigForLaunch, type ChromeMcpHttpConfig } from "./index";
+
+const windowsLocation = { kind: "windows" } as const;
+const wslLocation = { kind: "wsl", distro: "Ubuntu" } as const;
+const chromeMcp: ChromeMcpHttpConfig = {
+  url: "http://127.0.0.1:45678/mcp",
+  token: "chrome-secret",
+  headers: { Authorization: "Bearer chrome-secret" },
+};
+
+afterEach(() => {
+  delete process.env.LIGHTCODE_CHROME_MCP_URL;
+  delete process.env.LIGHTCODE_CHROME_MCP_TOKEN;
+});
+
+describe("Chrome MCP provider configs", () => {
+  it("resolves the local HTTP endpoint from supervisor env", () => {
+    process.env.LIGHTCODE_CHROME_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_CHROME_MCP_TOKEN = "host-token";
+
+    expect(resolveChromeMcpHttpConfigForLaunch(windowsLocation, true)).toEqual({
+      url: "http://127.0.0.1:65094/mcp",
+      token: "host-token",
+      headers: { Authorization: "Bearer host-token" },
+    });
+  });
+
+  it("tags the endpoint with the owning thread identity", () => {
+    process.env.LIGHTCODE_CHROME_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_CHROME_MCP_TOKEN = "host-token";
+
+    expect(
+      resolveChromeMcpHttpConfigForLaunch(windowsLocation, true, {
+        threadId: "thread-1",
+        title: "Chrome task",
+      })?.url,
+    ).toBe("http://127.0.0.1:65094/mcp?thread=thread-1&title=Chrome%20task");
+  });
+
+  it("declines for WSL projects (no in-distro bridge)", () => {
+    process.env.LIGHTCODE_CHROME_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_CHROME_MCP_TOKEN = "host-token";
+
+    expect(resolveChromeMcpHttpConfigForLaunch(wslLocation, true)).toBeUndefined();
+    // The pre-resolved config is never handed to WSL, so every builder declines.
+    expect(buildAcpChromeMcpServers(wslLocation, true)).toEqual([]);
+    expect(buildClaudeChromeMcpServers(wslLocation, true)).toBeUndefined();
+    expect(buildCodexChromeMcpArgs(wslLocation, true)).toEqual([]);
+    expect(buildGeminiChromeMcpServers(wslLocation, true)).toBeUndefined();
+    expect(buildOpenCodeChromeMcp(wslLocation, true)).toBeUndefined();
+  });
+
+  it("uses the same MCP server shape for each provider adapter", () => {
+    expect(buildAcpChromeMcpServers(windowsLocation, true, chromeMcp)).toEqual([
+      {
+        type: "http",
+        name: "chrome",
+        url: chromeMcp.url,
+        headers: [{ name: "Authorization", value: "Bearer chrome-secret" }],
+      },
+    ]);
+    expect(buildClaudeChromeMcpServers(windowsLocation, true, chromeMcp)).toEqual({
+      chrome: {
+        type: "http",
+        url: chromeMcp.url,
+        headers: chromeMcp.headers,
+      },
+    });
+    expect(buildCodexChromeMcpArgs(windowsLocation, true, chromeMcp)).toContain(
+      'mcp_servers.chrome.url="http://127.0.0.1:45678/mcp"',
+    );
+    expect(buildCodexChromeMcpEnv(chromeMcp)).toEqual({
+      LIGHTCODE_CHROME_MCP_TOKEN: "chrome-secret",
+    });
+    expect(buildGeminiChromeMcpServers(windowsLocation, true, chromeMcp)).toEqual({
+      chrome: {
+        httpUrl: chromeMcp.url,
+        headers: chromeMcp.headers,
+        timeout: 30_000,
+      },
+    });
+    expect(buildOpenCodeChromeMcp(windowsLocation, true, chromeMcp)).toEqual({
+      chrome: {
+        type: "remote",
+        url: chromeMcp.url,
+        headers: chromeMcp.headers,
+        enabled: true,
+      },
+    });
+  });
+
+  it("early-returns for every provider when the thread did not opt in", () => {
+    // The gate must live inside each builder so a call site can never forget it
+    // and leak the external-Chrome endpoint into a non-opted-in thread. Env is
+    // set to prove the builders honor `enabled` rather than the env fallback.
+    process.env.LIGHTCODE_CHROME_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_CHROME_MCP_TOKEN = "host-token";
+
+    expect(buildAcpChromeMcpServers(windowsLocation, false, chromeMcp)).toEqual([]);
+    expect(buildClaudeChromeMcpServers(windowsLocation, false, chromeMcp)).toBeUndefined();
+    expect(buildCodexChromeMcpArgs(windowsLocation, false, chromeMcp)).toEqual([]);
+    expect(buildGeminiChromeMcpServers(windowsLocation, false, chromeMcp)).toBeUndefined();
+    expect(buildOpenCodeChromeMcp(windowsLocation, false, chromeMcp)).toBeUndefined();
+  });
+
+  it("uses a token env var distinct from the browser and computer-use ones", () => {
+    expect(buildCodexChromeMcpEnv(chromeMcp)).toHaveProperty("LIGHTCODE_CHROME_MCP_TOKEN");
+    expect(buildCodexChromeMcpEnv(chromeMcp)).not.toHaveProperty("LIGHTCODE_BROWSER_MCP_TOKEN");
+    expect(buildCodexChromeMcpEnv(chromeMcp)).not.toHaveProperty(
+      "LIGHTCODE_COMPUTER_USE_MCP_TOKEN",
+    );
+    expect(buildCodexChromeMcpEnv(undefined)).toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/claude/detection.ts
+++ b/src/supervisor/agents/claude/detection.ts
@@ -92,6 +92,7 @@ export const claudeCapabilities: AgentCapability = {
   // toggles stay live mid-thread. The TUI has no per-thread MCP gating.
   browserMcpScope: { terminal: "none", gui: "always" },
   subagentMcpScope: { terminal: "none", gui: "always" },
+  chromeMcpScope: { terminal: "none", gui: "always" },
   settingDefs: [
     {
       key: "usePowershellTool",

--- a/src/supervisor/agents/claude/mcpChrome.ts
+++ b/src/supervisor/agents/claude/mcpChrome.ts
@@ -1,11 +1,15 @@
-import type { McpThreadIdentity } from "@/shared/browserMcpThread";
-import type { BrowserMcpLocation } from "@/supervisor/agents/browserMcp";
-import { CHROME_MCP_SERVER_NAME, resolveChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
+import {
+  CHROME_MCP_SERVER_NAME,
+  resolveOrFallbackChromeMcpConfig,
+  type ChromeMcpHttpConfig,
+  type ChromeMcpLocation,
+} from "@/supervisor/agents/chromeMcp";
 
 /**
  * Claude Agent SDK `mcpServers` entry for the external-Chrome control server.
- * Mirrors `./mcpBrowser.ts` but for the `chrome` ingress. Returns `undefined`
- * when the ingress is not running (env absent) or the location is unsupported.
+ * Mirrors `./mcpComputerUse.ts` but for the `chrome` ingress. Returns
+ * `undefined` when the thread did not opt in, the ingress is not running (env
+ * absent), or the location is unsupported (WSL declines).
  */
 interface ClaudeMcpServers {
   [name: string]: {
@@ -16,10 +20,12 @@ interface ClaudeMcpServers {
 }
 
 export function buildClaudeChromeMcpServers(
-  location: BrowserMcpLocation,
-  identity?: McpThreadIdentity,
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  chromeMcp?: ChromeMcpHttpConfig,
 ): ClaudeMcpServers | undefined {
-  const cfg = resolveChromeMcpHttpConfig(location, identity);
+  if (!enabled) return undefined;
+  const cfg = resolveOrFallbackChromeMcpConfig(location, chromeMcp);
   if (!cfg) return undefined;
   return {
     [CHROME_MCP_SERVER_NAME]: {

--- a/src/supervisor/agents/claude/mcpComputerUse.ts
+++ b/src/supervisor/agents/claude/mcpComputerUse.ts
@@ -1,6 +1,6 @@
 import {
   COMPUTER_USE_MCP_SERVER_NAME,
-  resolveComputerUseMcpHttpConfig,
+  resolveOrFallbackComputerUseMcpConfig,
   type ComputerUseMcpHttpConfig,
   type ComputerUseMcpLocation,
 } from "@/supervisor/agents/computerUseMcp";
@@ -19,8 +19,7 @@ export function buildClaudeComputerUseMcpServers(
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): ClaudeMcpServers | undefined {
   if (!enabled) return undefined;
-  if (location.kind === "wsl" && !computerUseMcp) return undefined;
-  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  const cfg = resolveOrFallbackComputerUseMcpConfig(location, computerUseMcp);
   if (!cfg) return undefined;
   return {
     [COMPUTER_USE_MCP_SERVER_NAME]: {

--- a/src/supervisor/agents/claude/mcpComputerUse.ts
+++ b/src/supervisor/agents/claude/mcpComputerUse.ts
@@ -1,0 +1,32 @@
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  resolveComputerUseMcpHttpConfig,
+  type ComputerUseMcpHttpConfig,
+  type ComputerUseMcpLocation,
+} from "@/supervisor/agents/computerUseMcp";
+
+interface ClaudeMcpServers {
+  [name: string]: {
+    type: "http";
+    url: string;
+    headers: Record<string, string>;
+  };
+}
+
+export function buildClaudeComputerUseMcpServers(
+  location: ComputerUseMcpLocation,
+  enabled: boolean,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): ClaudeMcpServers | undefined {
+  if (!enabled) return undefined;
+  if (location.kind === "wsl" && !computerUseMcp) return undefined;
+  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  if (!cfg) return undefined;
+  return {
+    [COMPUTER_USE_MCP_SERVER_NAME]: {
+      type: "http",
+      url: cfg.url,
+      headers: cfg.headers,
+    },
+  };
+}

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -27,6 +27,7 @@ import { terminateChildProcessTree } from "@/shared/processTree";
 import { buildClaudeBrowserMcpServers } from "./mcpBrowser";
 import { buildClaudeChromeMcpServers } from "./mcpChrome";
 import { buildClaudeSubagentMcpServers } from "./mcpSubagent";
+import { buildClaudeComputerUseMcpServers } from "./mcpComputerUse";
 import {
   createKnownSessionRef,
   getPrimedPosixEnv,
@@ -683,7 +684,17 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
         this.input.projectLocation,
         this.input.mcpIdentity ?? { threadId: this.input.threadId },
       );
-      const mcpServers = { ...browserMcpServers, ...subagentMcpServers, ...chromeMcpServers };
+      const computerUseMcpServers = buildClaudeComputerUseMcpServers(
+        this.input.projectLocation,
+        this.currentConfig.computerUse === true,
+        this.input.computerUseMcp,
+      );
+      const mcpServers = {
+        ...browserMcpServers,
+        ...subagentMcpServers,
+        ...chromeMcpServers,
+        ...computerUseMcpServers,
+      };
       const hasMcpServers = Object.keys(mcpServers).length > 0;
       let spawnClaudeCodeProcess: ((spawnOptions: SpawnOptions) => SpawnedProcess) | undefined;
       switch (this.input.projectLocation.kind) {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -682,7 +682,8 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       );
       const chromeMcpServers = buildClaudeChromeMcpServers(
         this.input.projectLocation,
-        this.input.mcpIdentity ?? { threadId: this.input.threadId },
+        this.currentConfig.chromeMcp === true,
+        this.input.chromeMcp,
       );
       const computerUseMcpServers = buildClaudeComputerUseMcpServers(
         this.input.projectLocation,

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -401,6 +401,8 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(input.subagentMcp !== undefined ? { subagentMcp: input.subagentMcp } : {}),
         computerUseMcpEnabled: input.config.computerUse === true,
         ...(input.computerUseMcp !== undefined ? { computerUseMcp: input.computerUseMcp } : {}),
+        chromeMcpEnabled: input.config.chromeMcp === true,
+        ...(input.chromeMcp !== undefined ? { chromeMcp: input.chromeMcp } : {}),
       }),
     );
     const transport = new CodexStdioTransport(appServer);

--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -399,6 +399,8 @@ export class CodexStructuredSession implements StructuredSessionHandle {
         ...(input.browserMcp !== undefined ? { browserMcp: input.browserMcp } : {}),
         subagentMcpEnabled: input.config.subagentMcp === true,
         ...(input.subagentMcp !== undefined ? { subagentMcp: input.subagentMcp } : {}),
+        computerUseMcpEnabled: input.config.computerUse === true,
+        ...(input.computerUseMcp !== undefined ? { computerUseMcp: input.computerUseMcp } : {}),
       }),
     );
     const transport = new CodexStdioTransport(appServer);

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -1,6 +1,7 @@
 import { dirname as posixDirname } from "node:path/posix";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import type { ProjectLocation, SessionRef, ThreadConfig } from "@/shared/contracts";
 import {
   buildAgentCommand,
@@ -18,6 +19,7 @@ import {
 import { buildCodexBrowserMcpArgs, buildCodexBrowserMcpEnv } from "./mcpBrowser";
 import { buildCodexSubagentMcpArgs, buildCodexSubagentMcpEnv } from "./mcpSubagent";
 import { resolveCodexWindowsLaunchBinary } from "./windowsExecutable";
+import { buildCodexComputerUseMcpArgs, buildCodexComputerUseMcpEnv } from "./mcpComputerUse";
 
 const CODEX_GOALS_FEATURE_FLAG = "goals";
 const codexGoalsSupportCache = new Map<string, boolean>();
@@ -52,6 +54,11 @@ function buildCodexArgs(opts: BuildCodexArgsOptions): string[] {
   if (location) {
     args.push(
       ...buildCodexBrowserMcpArgs(location, config.browserMcp === true, launchOptions?.browserMcp),
+      ...buildCodexComputerUseMcpArgs(
+        location,
+        config.computerUse === true,
+        launchOptions?.computerUseMcp,
+      ),
     );
     args.push(
       ...buildCodexSubagentMcpArgs(config.subagentMcp === true, launchOptions?.subagentMcp),
@@ -117,6 +124,7 @@ export function buildCodexArgvFor(
   const mcpEnv = {
     ...buildCodexBrowserMcpEnv(launchOptions?.browserMcp),
     ...buildCodexSubagentMcpEnv(launchOptions?.subagentMcp),
+    ...buildCodexComputerUseMcpEnv(launchOptions?.computerUseMcp),
   };
   const hasMcpEnv = Object.keys(mcpEnv).length > 0;
   const enableGoals = isCodexGoalsSupported(location);
@@ -172,6 +180,8 @@ export function buildCodexAppServerCommand(
     browserMcp?: BrowserMcpHttpConfig;
     subagentMcpEnabled?: boolean;
     subagentMcp?: SubagentMcpHttpConfig;
+    computerUseMcpEnabled?: boolean;
+    computerUseMcp?: ComputerUseMcpHttpConfig;
   },
 ): CommandSpec {
   const wslExecPath = options?.wslExecPath;
@@ -185,15 +195,22 @@ export function buildCodexAppServerCommand(
     options?.subagentMcpEnabled === true,
     options?.subagentMcp,
   );
+  const computerUseMcpArgs = buildCodexComputerUseMcpArgs(
+    location,
+    options?.computerUseMcpEnabled === true,
+    options?.computerUseMcp,
+  );
   const mcpEnv = {
     ...buildCodexBrowserMcpEnv(options?.browserMcp),
     ...buildCodexSubagentMcpEnv(options?.subagentMcp),
+    ...buildCodexComputerUseMcpEnv(options?.computerUseMcp),
   };
   const hasMcpEnv = Object.keys(mcpEnv).length > 0;
   const args = [
     ...(isCodexGoalsSupported(location, wslExecPath) ? ["--enable", CODEX_GOALS_FEATURE_FLAG] : []),
     ...browserMcpArgs,
     ...subagentMcpArgs,
+    ...computerUseMcpArgs,
     "app-server",
   ];
   if (location.kind === "wsl") {

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -2,6 +2,7 @@ import { dirname as posixDirname } from "node:path/posix";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import type { ProjectLocation, SessionRef, ThreadConfig } from "@/shared/contracts";
 import {
   buildAgentCommand,
@@ -20,6 +21,7 @@ import { buildCodexBrowserMcpArgs, buildCodexBrowserMcpEnv } from "./mcpBrowser"
 import { buildCodexSubagentMcpArgs, buildCodexSubagentMcpEnv } from "./mcpSubagent";
 import { resolveCodexWindowsLaunchBinary } from "./windowsExecutable";
 import { buildCodexComputerUseMcpArgs, buildCodexComputerUseMcpEnv } from "./mcpComputerUse";
+import { buildCodexChromeMcpArgs, buildCodexChromeMcpEnv } from "./mcpChrome";
 
 const CODEX_GOALS_FEATURE_FLAG = "goals";
 const codexGoalsSupportCache = new Map<string, boolean>();
@@ -59,6 +61,7 @@ function buildCodexArgs(opts: BuildCodexArgsOptions): string[] {
         config.computerUse === true,
         launchOptions?.computerUseMcp,
       ),
+      ...buildCodexChromeMcpArgs(location, config.chromeMcp === true, launchOptions?.chromeMcp),
     );
     args.push(
       ...buildCodexSubagentMcpArgs(config.subagentMcp === true, launchOptions?.subagentMcp),
@@ -125,6 +128,7 @@ export function buildCodexArgvFor(
     ...buildCodexBrowserMcpEnv(launchOptions?.browserMcp),
     ...buildCodexSubagentMcpEnv(launchOptions?.subagentMcp),
     ...buildCodexComputerUseMcpEnv(launchOptions?.computerUseMcp),
+    ...buildCodexChromeMcpEnv(launchOptions?.chromeMcp),
   };
   const hasMcpEnv = Object.keys(mcpEnv).length > 0;
   const enableGoals = isCodexGoalsSupported(location);
@@ -182,6 +186,8 @@ export function buildCodexAppServerCommand(
     subagentMcp?: SubagentMcpHttpConfig;
     computerUseMcpEnabled?: boolean;
     computerUseMcp?: ComputerUseMcpHttpConfig;
+    chromeMcpEnabled?: boolean;
+    chromeMcp?: ChromeMcpHttpConfig;
   },
 ): CommandSpec {
   const wslExecPath = options?.wslExecPath;
@@ -200,10 +206,16 @@ export function buildCodexAppServerCommand(
     options?.computerUseMcpEnabled === true,
     options?.computerUseMcp,
   );
+  const chromeMcpArgs = buildCodexChromeMcpArgs(
+    location,
+    options?.chromeMcpEnabled === true,
+    options?.chromeMcp,
+  );
   const mcpEnv = {
     ...buildCodexBrowserMcpEnv(options?.browserMcp),
     ...buildCodexSubagentMcpEnv(options?.subagentMcp),
     ...buildCodexComputerUseMcpEnv(options?.computerUseMcp),
+    ...buildCodexChromeMcpEnv(options?.chromeMcp),
   };
   const hasMcpEnv = Object.keys(mcpEnv).length > 0;
   const args = [
@@ -211,6 +223,7 @@ export function buildCodexAppServerCommand(
     ...browserMcpArgs,
     ...subagentMcpArgs,
     ...computerUseMcpArgs,
+    ...chromeMcpArgs,
     "app-server",
   ];
   if (location.kind === "wsl") {

--- a/src/supervisor/agents/codex/detection.ts
+++ b/src/supervisor/agents/codex/detection.ts
@@ -206,6 +206,8 @@ export const codexDefaultCapabilities: AgentCapability = {
   // spawn, read-only once the session is running.
   browserMcpScope: { terminal: "launch", gui: "launch" },
   subagentMcpScope: { terminal: "launch", gui: "launch" },
+  computerUseMcpScope: { terminal: "launch", gui: "launch" },
+  chromeMcpScope: { terminal: "launch", gui: "launch" },
   settingDefs: [],
   slashCommands: CODEX_BUILT_IN_SLASH_COMMANDS,
 };

--- a/src/supervisor/agents/codex/mcpChrome.ts
+++ b/src/supervisor/agents/codex/mcpChrome.ts
@@ -1,0 +1,43 @@
+import {
+  CHROME_MCP_SERVER_NAME,
+  CHROME_MCP_TOKEN_ENV,
+  resolveOrFallbackChromeMcpConfig,
+  type ChromeMcpHttpConfig,
+  type ChromeMcpLocation,
+} from "@/supervisor/agents/chromeMcp";
+
+export const CODEX_CHROME_MCP_TOKEN_ENV = CHROME_MCP_TOKEN_ENV;
+
+/**
+ * Codex CLI inline TOML overrides (`-c key.path=value`) registering the
+ * external-Chrome MCP server for a single invocation. Mirrors
+ * `./mcpComputerUse.ts`; the bearer token is read from an env var (passing the
+ * literal makes current Codex builds reject the whole config). Returns an empty
+ * array when the thread did not opt in or no config resolves.
+ */
+export function buildCodexChromeMcpArgs(
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  chromeMcp?: ChromeMcpHttpConfig,
+): string[] {
+  if (!enabled) return [];
+  const cfg = resolveOrFallbackChromeMcpConfig(location, chromeMcp);
+  if (!cfg) return [];
+
+  const name = CHROME_MCP_SERVER_NAME;
+
+  return [
+    "-c",
+    `experimental_use_rmcp_client=true`,
+    "-c",
+    `mcp_servers.${name}.url=${JSON.stringify(cfg.url)}`,
+    "-c",
+    `mcp_servers.${name}.bearer_token_env_var="${CODEX_CHROME_MCP_TOKEN_ENV}"`,
+  ];
+}
+
+export function buildCodexChromeMcpEnv(
+  chromeMcp: ChromeMcpHttpConfig | undefined,
+): Record<string, string> | undefined {
+  return chromeMcp ? { [CODEX_CHROME_MCP_TOKEN_ENV]: chromeMcp.token } : undefined;
+}

--- a/src/supervisor/agents/codex/mcpComputerUse.ts
+++ b/src/supervisor/agents/codex/mcpComputerUse.ts
@@ -1,11 +1,12 @@
 import {
   COMPUTER_USE_MCP_SERVER_NAME,
-  resolveComputerUseMcpHttpConfig,
+  COMPUTER_USE_MCP_TOKEN_ENV,
+  resolveOrFallbackComputerUseMcpConfig,
   type ComputerUseMcpHttpConfig,
   type ComputerUseMcpLocation,
 } from "@/supervisor/agents/computerUseMcp";
 
-export const CODEX_COMPUTER_USE_MCP_TOKEN_ENV = "LIGHTCODE_COMPUTER_USE_MCP_TOKEN";
+export const CODEX_COMPUTER_USE_MCP_TOKEN_ENV = COMPUTER_USE_MCP_TOKEN_ENV;
 
 export function buildCodexComputerUseMcpArgs(
   location: ComputerUseMcpLocation,
@@ -13,8 +14,7 @@ export function buildCodexComputerUseMcpArgs(
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): string[] {
   if (!enabled) return [];
-  if (location.kind === "wsl" && !computerUseMcp) return [];
-  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  const cfg = resolveOrFallbackComputerUseMcpConfig(location, computerUseMcp);
   if (!cfg) return [];
 
   const name = COMPUTER_USE_MCP_SERVER_NAME;

--- a/src/supervisor/agents/codex/mcpComputerUse.ts
+++ b/src/supervisor/agents/codex/mcpComputerUse.ts
@@ -1,0 +1,36 @@
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  resolveComputerUseMcpHttpConfig,
+  type ComputerUseMcpHttpConfig,
+  type ComputerUseMcpLocation,
+} from "@/supervisor/agents/computerUseMcp";
+
+export const CODEX_COMPUTER_USE_MCP_TOKEN_ENV = "LIGHTCODE_COMPUTER_USE_MCP_TOKEN";
+
+export function buildCodexComputerUseMcpArgs(
+  location: ComputerUseMcpLocation,
+  enabled: boolean,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): string[] {
+  if (!enabled) return [];
+  if (location.kind === "wsl" && !computerUseMcp) return [];
+  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  if (!cfg) return [];
+
+  const name = COMPUTER_USE_MCP_SERVER_NAME;
+
+  return [
+    "-c",
+    `experimental_use_rmcp_client=true`,
+    "-c",
+    `mcp_servers.${name}.url=${JSON.stringify(cfg.url)}`,
+    "-c",
+    `mcp_servers.${name}.bearer_token_env_var="${CODEX_COMPUTER_USE_MCP_TOKEN_ENV}"`,
+  ];
+}
+
+export function buildCodexComputerUseMcpEnv(
+  computerUseMcp: ComputerUseMcpHttpConfig | undefined,
+): Record<string, string> | undefined {
+  return computerUseMcp ? { [CODEX_COMPUTER_USE_MCP_TOKEN_ENV]: computerUseMcp.token } : undefined;
+}

--- a/src/supervisor/agents/commandcode/detection.ts
+++ b/src/supervisor/agents/commandcode/detection.ts
@@ -294,6 +294,7 @@ export const defaultCommandCodeCapabilities: AgentCapability = {
   // No dedicated-server hosting path in any presentation.
   browserMcpScope: { terminal: "none", gui: "none" },
   subagentMcpScope: { terminal: "none", gui: "none" },
+  chromeMcpScope: { terminal: "none", gui: "none" },
   settingDefs: [],
 };
 

--- a/src/supervisor/agents/computerUseMcp/index.ts
+++ b/src/supervisor/agents/computerUseMcp/index.ts
@@ -1,0 +1,53 @@
+import type { ProjectLocation } from "@/shared/contracts";
+
+export type ComputerUseMcpLocation =
+  | ProjectLocation
+  | { kind: "windows" }
+  | { kind: "posix" }
+  | { kind: "wsl"; distro: string };
+
+export interface ComputerUseMcpEnv {
+  url: string;
+  token: string;
+}
+
+export function readComputerUseMcpEnv(): ComputerUseMcpEnv | null {
+  const url = process.env.LIGHTCODE_COMPUTER_USE_MCP_URL;
+  const token = process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN;
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+export const COMPUTER_USE_MCP_SERVER_NAME = "computer_use";
+
+export interface ComputerUseMcpHttpConfig {
+  url: string;
+  token: string;
+  headers: Record<string, string>;
+}
+
+export function resolveComputerUseMcpHttpConfig(
+  location: ComputerUseMcpLocation,
+): ComputerUseMcpHttpConfig | null {
+  const env = readComputerUseMcpEnv();
+  if (!env) return null;
+  // WSL projects can't reach the host MCP endpoint over loopback; the
+  // host-gateway rewrite was removed when WSL exec moved to the supervisor
+  // bridge. Mirror browserMcp and decline here — callers short-circuit WSL
+  // unless a launch-time config is supplied.
+  if (location.kind === "wsl") return null;
+  const mcpUrl = `${env.url.replace(/\/$/, "")}/mcp`;
+  return {
+    url: mcpUrl,
+    token: env.token,
+    headers: { Authorization: `Bearer ${env.token}` },
+  };
+}
+
+export function resolveComputerUseMcpHttpConfigForLaunch(
+  location: ComputerUseMcpLocation,
+  enabled: boolean,
+): ComputerUseMcpHttpConfig | undefined {
+  if (!enabled) return undefined;
+  return resolveComputerUseMcpHttpConfig(location) ?? undefined;
+}

--- a/src/supervisor/agents/computerUseMcp/index.ts
+++ b/src/supervisor/agents/computerUseMcp/index.ts
@@ -1,4 +1,5 @@
 import type { ProjectLocation } from "@/shared/contracts";
+import { encodeThreadQuery, type McpThreadIdentity } from "@/shared/browserMcpThread";
 
 export type ComputerUseMcpLocation =
   | ProjectLocation
@@ -11,9 +12,12 @@ export interface ComputerUseMcpEnv {
   token: string;
 }
 
+export const COMPUTER_USE_MCP_URL_ENV = "LIGHTCODE_COMPUTER_USE_MCP_URL";
+export const COMPUTER_USE_MCP_TOKEN_ENV = "LIGHTCODE_COMPUTER_USE_MCP_TOKEN";
+
 export function readComputerUseMcpEnv(): ComputerUseMcpEnv | null {
-  const url = process.env.LIGHTCODE_COMPUTER_USE_MCP_URL;
-  const token = process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN;
+  const url = process.env[COMPUTER_USE_MCP_URL_ENV];
+  const token = process.env[COMPUTER_USE_MCP_TOKEN_ENV];
   if (!url || !token) return null;
   return { url, token };
 }
@@ -28,6 +32,7 @@ export interface ComputerUseMcpHttpConfig {
 
 export function resolveComputerUseMcpHttpConfig(
   location: ComputerUseMcpLocation,
+  identity?: McpThreadIdentity,
 ): ComputerUseMcpHttpConfig | null {
   const env = readComputerUseMcpEnv();
   if (!env) return null;
@@ -36,7 +41,7 @@ export function resolveComputerUseMcpHttpConfig(
   // bridge. Mirror browserMcp and decline here — callers short-circuit WSL
   // unless a launch-time config is supplied.
   if (location.kind === "wsl") return null;
-  const mcpUrl = `${env.url.replace(/\/$/, "")}/mcp`;
+  const mcpUrl = encodeThreadQuery(`${env.url.replace(/\/$/, "")}/mcp`, identity);
   return {
     url: mcpUrl,
     token: env.token,
@@ -44,10 +49,26 @@ export function resolveComputerUseMcpHttpConfig(
   };
 }
 
+/**
+ * Resolve a ComputerUseMcpHttpConfig from an optional pre-resolved config or by
+ * falling back to the environment. Returns `undefined` when the config cannot
+ * be resolved (WSL without a launch-time config, or env vars absent).
+ *
+ * Shared guard used by every provider's `buildXxxComputerUseMcp*()` function.
+ */
+export function resolveOrFallbackComputerUseMcpConfig(
+  location: ComputerUseMcpLocation,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): ComputerUseMcpHttpConfig | undefined {
+  if (location.kind === "wsl" && !computerUseMcp) return undefined;
+  return computerUseMcp ?? resolveComputerUseMcpHttpConfig(location) ?? undefined;
+}
+
 export function resolveComputerUseMcpHttpConfigForLaunch(
   location: ComputerUseMcpLocation,
   enabled: boolean,
+  identity?: McpThreadIdentity,
 ): ComputerUseMcpHttpConfig | undefined {
   if (!enabled) return undefined;
-  return resolveComputerUseMcpHttpConfig(location) ?? undefined;
+  return resolveComputerUseMcpHttpConfig(location, identity) ?? undefined;
 }

--- a/src/supervisor/agents/computerUseMcp/providers.test.ts
+++ b/src/supervisor/agents/computerUseMcp/providers.test.ts
@@ -52,14 +52,14 @@ describe("Computer Use MCP provider configs", () => {
     expect(buildCodexComputerUseMcpEnv(computerUseMcp)).toEqual({
       LIGHTCODE_COMPUTER_USE_MCP_TOKEN: "computer-use-secret",
     });
-    expect(buildGeminiComputerUseMcpServers(windowsLocation, computerUseMcp)).toEqual({
+    expect(buildGeminiComputerUseMcpServers(windowsLocation, true, computerUseMcp)).toEqual({
       computer_use: {
         httpUrl: computerUseMcp.url,
         headers: computerUseMcp.headers,
         timeout: 30_000,
       },
     });
-    expect(buildOpenCodeComputerUseMcp(windowsLocation, computerUseMcp)).toEqual({
+    expect(buildOpenCodeComputerUseMcp(windowsLocation, true, computerUseMcp)).toEqual({
       computer_use: {
         type: "remote",
         url: computerUseMcp.url,
@@ -67,5 +67,23 @@ describe("Computer Use MCP provider configs", () => {
         enabled: true,
       },
     });
+  });
+
+  it("early-returns for every provider when the thread did not opt in", () => {
+    // The gate must live inside each builder so a call site can never forget it
+    // and leak the desktop-control endpoint into a non-opted-in thread. Env is
+    // set to prove the builders honor `enabled` rather than the env fallback.
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN = "host-token";
+
+    expect(buildAcpComputerUseMcpServers(windowsLocation, false, computerUseMcp)).toEqual([]);
+    expect(
+      buildClaudeComputerUseMcpServers(windowsLocation, false, computerUseMcp),
+    ).toBeUndefined();
+    expect(buildCodexComputerUseMcpArgs(windowsLocation, false, computerUseMcp)).toEqual([]);
+    expect(
+      buildGeminiComputerUseMcpServers(windowsLocation, false, computerUseMcp),
+    ).toBeUndefined();
+    expect(buildOpenCodeComputerUseMcp(windowsLocation, false, computerUseMcp)).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/computerUseMcp/providers.test.ts
+++ b/src/supervisor/agents/computerUseMcp/providers.test.ts
@@ -30,6 +30,18 @@ describe("Computer Use MCP provider configs", () => {
     });
   });
 
+  it("tags the endpoint with the owning thread identity", () => {
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN = "host-token";
+
+    expect(
+      resolveComputerUseMcpHttpConfigForLaunch(windowsLocation, true, {
+        threadId: "thread-1",
+        title: "Desktop task",
+      })?.url,
+    ).toBe("http://127.0.0.1:65094/mcp?thread=thread-1&title=Desktop%20task");
+  });
+
   it("uses the same MCP server shape for each provider adapter", () => {
     expect(buildAcpComputerUseMcpServers(windowsLocation, true, computerUseMcp)).toEqual([
       {

--- a/src/supervisor/agents/computerUseMcp/providers.test.ts
+++ b/src/supervisor/agents/computerUseMcp/providers.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildAcpComputerUseMcpServers } from "../acp/mcpComputerUse";
+import { buildClaudeComputerUseMcpServers } from "../claude/mcpComputerUse";
+import { buildCodexComputerUseMcpArgs, buildCodexComputerUseMcpEnv } from "../codex/mcpComputerUse";
+import { buildGeminiComputerUseMcpServers } from "../gemini/mcpComputerUse";
+import { buildOpenCodeComputerUseMcp } from "../opencode/mcpComputerUse";
+import { resolveComputerUseMcpHttpConfigForLaunch, type ComputerUseMcpHttpConfig } from "./index";
+
+const windowsLocation = { kind: "windows" } as const;
+const computerUseMcp: ComputerUseMcpHttpConfig = {
+  url: "http://127.0.0.1:45678/mcp",
+  token: "computer-use-secret",
+  headers: { Authorization: "Bearer computer-use-secret" },
+};
+
+afterEach(() => {
+  delete process.env.LIGHTCODE_COMPUTER_USE_MCP_URL;
+  delete process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN;
+});
+
+describe("Computer Use MCP provider configs", () => {
+  it("resolves the local HTTP endpoint from supervisor env", () => {
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_URL = "http://127.0.0.1:65094";
+    process.env.LIGHTCODE_COMPUTER_USE_MCP_TOKEN = "host-token";
+
+    expect(resolveComputerUseMcpHttpConfigForLaunch(windowsLocation, true)).toEqual({
+      url: "http://127.0.0.1:65094/mcp",
+      token: "host-token",
+      headers: { Authorization: "Bearer host-token" },
+    });
+  });
+
+  it("uses the same MCP server shape for each provider adapter", () => {
+    expect(buildAcpComputerUseMcpServers(windowsLocation, true, computerUseMcp)).toEqual([
+      {
+        type: "http",
+        name: "computer_use",
+        url: computerUseMcp.url,
+        headers: [{ name: "Authorization", value: "Bearer computer-use-secret" }],
+      },
+    ]);
+    expect(buildClaudeComputerUseMcpServers(windowsLocation, true, computerUseMcp)).toEqual({
+      computer_use: {
+        type: "http",
+        url: computerUseMcp.url,
+        headers: computerUseMcp.headers,
+      },
+    });
+    expect(buildCodexComputerUseMcpArgs(windowsLocation, true, computerUseMcp)).toContain(
+      'mcp_servers.computer_use.url="http://127.0.0.1:45678/mcp"',
+    );
+    expect(buildCodexComputerUseMcpEnv(computerUseMcp)).toEqual({
+      LIGHTCODE_COMPUTER_USE_MCP_TOKEN: "computer-use-secret",
+    });
+    expect(buildGeminiComputerUseMcpServers(windowsLocation, computerUseMcp)).toEqual({
+      computer_use: {
+        httpUrl: computerUseMcp.url,
+        headers: computerUseMcp.headers,
+        timeout: 30_000,
+      },
+    });
+    expect(buildOpenCodeComputerUseMcp(windowsLocation, computerUseMcp)).toEqual({
+      computer_use: {
+        type: "remote",
+        url: computerUseMcp.url,
+        headers: computerUseMcp.headers,
+        enabled: true,
+      },
+    });
+  });
+});

--- a/src/supervisor/agents/gemini/detection.ts
+++ b/src/supervisor/agents/gemini/detection.ts
@@ -50,6 +50,7 @@ export const defaultGeminiCapabilities: AgentCapability = {
   presentationModes: ["terminal", "gui"],
   defaultApprovalPolicy: "never",
   bypassPermissions: { approvalPolicy: "never" },
+  chromeMcpScope: { terminal: "launch", gui: "launch" },
   settingDefs: [],
 };
 

--- a/src/supervisor/agents/gemini/index.ts
+++ b/src/supervisor/agents/gemini/index.ts
@@ -100,7 +100,7 @@ export function createGeminiAdapter(): AgentAdapter {
       uninstallGeminiPlugin(ctx);
     },
     async pluginLaunchExtras(ctx) {
-      syncGeminiBrowserMcpSettings(ctx, ctx.browserMcp);
+      syncGeminiBrowserMcpSettings(ctx, ctx.browserMcp, ctx.computerUseMcp);
       const paths = getGeminiPluginPaths(ctx);
       return { env: { GEMINI_CLI_SYSTEM_SETTINGS_PATH: paths.settingsPath } };
     },

--- a/src/supervisor/agents/gemini/index.ts
+++ b/src/supervisor/agents/gemini/index.ts
@@ -100,7 +100,7 @@ export function createGeminiAdapter(): AgentAdapter {
       uninstallGeminiPlugin(ctx);
     },
     async pluginLaunchExtras(ctx) {
-      syncGeminiBrowserMcpSettings(ctx, ctx.browserMcp, ctx.computerUseMcp);
+      syncGeminiBrowserMcpSettings(ctx, ctx.browserMcp, ctx.computerUseMcp, ctx.chromeMcp);
       const paths = getGeminiPluginPaths(ctx);
       return { env: { GEMINI_CLI_SYSTEM_SETTINGS_PATH: paths.settingsPath } };
     },

--- a/src/supervisor/agents/gemini/mcpChrome.ts
+++ b/src/supervisor/agents/gemini/mcpChrome.ts
@@ -1,0 +1,24 @@
+import {
+  CHROME_MCP_SERVER_NAME,
+  resolveOrFallbackChromeMcpConfig,
+  type ChromeMcpHttpConfig,
+  type ChromeMcpLocation,
+} from "@/supervisor/agents/chromeMcp";
+import type { GeminiMcpServers } from "./mcpBrowser";
+
+export function buildGeminiChromeMcpServers(
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  chromeMcp?: ChromeMcpHttpConfig,
+): GeminiMcpServers | undefined {
+  if (!enabled) return undefined;
+  const cfg = resolveOrFallbackChromeMcpConfig(location, chromeMcp);
+  if (!cfg) return undefined;
+  return {
+    [CHROME_MCP_SERVER_NAME]: {
+      httpUrl: cfg.url,
+      headers: cfg.headers,
+      timeout: 30_000,
+    },
+  };
+}

--- a/src/supervisor/agents/gemini/mcpComputerUse.ts
+++ b/src/supervisor/agents/gemini/mcpComputerUse.ts
@@ -1,0 +1,23 @@
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  resolveComputerUseMcpHttpConfig,
+  type ComputerUseMcpHttpConfig,
+  type ComputerUseMcpLocation,
+} from "@/supervisor/agents/computerUseMcp";
+import type { GeminiMcpServers } from "./mcpBrowser";
+
+export function buildGeminiComputerUseMcpServers(
+  location: ComputerUseMcpLocation,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): GeminiMcpServers | undefined {
+  if (location.kind === "wsl" && !computerUseMcp) return undefined;
+  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  if (!cfg) return undefined;
+  return {
+    [COMPUTER_USE_MCP_SERVER_NAME]: {
+      httpUrl: cfg.url,
+      headers: cfg.headers,
+      timeout: 30_000,
+    },
+  };
+}

--- a/src/supervisor/agents/gemini/mcpComputerUse.ts
+++ b/src/supervisor/agents/gemini/mcpComputerUse.ts
@@ -8,8 +8,10 @@ import type { GeminiMcpServers } from "./mcpBrowser";
 
 export function buildGeminiComputerUseMcpServers(
   location: ComputerUseMcpLocation,
+  enabled: boolean,
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): GeminiMcpServers | undefined {
+  if (!enabled) return undefined;
   if (location.kind === "wsl" && !computerUseMcp) return undefined;
   const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
   if (!cfg) return undefined;

--- a/src/supervisor/agents/gemini/mcpComputerUse.ts
+++ b/src/supervisor/agents/gemini/mcpComputerUse.ts
@@ -1,6 +1,6 @@
 import {
   COMPUTER_USE_MCP_SERVER_NAME,
-  resolveComputerUseMcpHttpConfig,
+  resolveOrFallbackComputerUseMcpConfig,
   type ComputerUseMcpHttpConfig,
   type ComputerUseMcpLocation,
 } from "@/supervisor/agents/computerUseMcp";
@@ -12,8 +12,7 @@ export function buildGeminiComputerUseMcpServers(
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): GeminiMcpServers | undefined {
   if (!enabled) return undefined;
-  if (location.kind === "wsl" && !computerUseMcp) return undefined;
-  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  const cfg = resolveOrFallbackComputerUseMcpConfig(location, computerUseMcp);
   if (!cfg) return undefined;
   return {
     [COMPUTER_USE_MCP_SERVER_NAME]: {

--- a/src/supervisor/agents/gemini/plugin/install.test.ts
+++ b/src/supervisor/agents/gemini/plugin/install.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import type { SubagentMcpHttpConfig } from "@/supervisor/agents/subagentMcp";
 import {
   getGeminiPluginPaths,
@@ -134,6 +135,12 @@ const browserCfg: BrowserMcpHttpConfig = {
   headers: { Authorization: "Bearer browser-secret" },
 };
 
+const chromeCfg: ChromeMcpHttpConfig = {
+  url: "http://127.0.0.1:45679/mcp",
+  token: "chrome-secret",
+  headers: { Authorization: "Bearer chrome-secret" },
+};
+
 type McpSettings = {
   mcpServers?: Record<string, { httpUrl?: string; headers?: Record<string, string> }>;
 };
@@ -165,7 +172,7 @@ describe("syncGeminiSubagentMcpSettings", () => {
     expect(readSettings(settingsPath).mcpServers).toBeUndefined();
   });
 
-  it("coexists with the browser MCP entry (neither sync clobbers the other)", () => {
+  it("coexists with the browser and Chrome MCP entries", () => {
     const baseDir = makeBaseDir();
     const ctx = { envKind: "posix" as const, baseDir };
     const install = installGeminiPlugin(ctx);
@@ -175,6 +182,12 @@ describe("syncGeminiSubagentMcpSettings", () => {
 
     syncGeminiSubagentMcpSettings(ctx, subagentCfg);
     syncGeminiBrowserMcpSettings({ ...ctx, browserMcpEnabled: true }, browserCfg);
+    syncGeminiBrowserMcpSettings(
+      { ...ctx, chromeMcpEnabled: true },
+      undefined,
+      undefined,
+      chromeCfg,
+    );
 
     expect(readSettings(settingsPath).mcpServers).toEqual({
       subagents: {
@@ -187,10 +200,29 @@ describe("syncGeminiSubagentMcpSettings", () => {
         headers: browserCfg.headers,
         timeout: 30_000,
       },
+      chrome: {
+        httpUrl: chromeCfg.url,
+        headers: chromeCfg.headers,
+        timeout: 30_000,
+      },
     });
 
-    // Disabling the browser MCP leaves the subagents entry intact.
+    // Disabling one MCP leaves the other entries intact.
     syncGeminiBrowserMcpSettings({ ...ctx, browserMcpEnabled: false }, undefined);
+    expect(readSettings(settingsPath).mcpServers).toEqual({
+      subagents: {
+        httpUrl: subagentCfg.url,
+        headers: subagentCfg.headers,
+        timeout: 300_000,
+      },
+      chrome: {
+        httpUrl: chromeCfg.url,
+        headers: chromeCfg.headers,
+        timeout: 30_000,
+      },
+    });
+
+    syncGeminiBrowserMcpSettings({ ...ctx, chromeMcpEnabled: false });
     expect(readSettings(settingsPath).mcpServers).toEqual({
       subagents: {
         httpUrl: subagentCfg.url,

--- a/src/supervisor/agents/gemini/plugin/install.ts
+++ b/src/supervisor/agents/gemini/plugin/install.ts
@@ -7,8 +7,13 @@ import {
   SUBAGENT_MCP_SERVER_NAME,
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  type ComputerUseMcpHttpConfig,
+} from "@/supervisor/agents/computerUseMcp";
 import { buildGeminiBrowserMcpServers, type GeminiMcpServerEntry } from "../mcpBrowser";
 import { buildGeminiSubagentMcpServers } from "../mcpSubagent";
+import { buildGeminiComputerUseMcpServers } from "../mcpComputerUse";
 import type { AgentEnvContext } from "../../base";
 import {
   FORWARD_RUNTIME_FILE,
@@ -180,21 +185,34 @@ function writeGeminiMcpServer(
 export function syncGeminiBrowserMcpSettings(
   ctx: AgentEnvContext | undefined,
   browserMcp?: BrowserMcpHttpConfig,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
 ): void {
-  if (ctx?.browserMcpEnabled === undefined) return;
+  if (!ctx) return;
+  if (ctx.browserMcpEnabled === undefined && ctx.computerUseMcpEnabled === undefined) return;
   const paths = getGeminiPluginPaths(ctx);
   if (!paths.settingsPath) return;
   const settingsPath = resolveSettingsWritePath(ctx, paths.settingsPath);
-  let entry: GeminiMcpServerEntry | undefined;
-  if (ctx.browserMcpEnabled && browserMcp) {
-    const location = isWslPluginContext(ctx)
-      ? ({ kind: "wsl", distro: ctx.wslDistro } as const)
-      : process.platform === "win32"
-        ? ({ kind: "windows" } as const)
-        : ({ kind: "posix" } as const);
-    entry = buildGeminiBrowserMcpServers(location, browserMcp)?.[BROWSER_MCP_SERVER_NAME];
+  const location = isWslPluginContext(ctx)
+    ? ({ kind: "wsl", distro: ctx.wslDistro } as const)
+    : process.platform === "win32"
+      ? ({ kind: "windows" } as const)
+      : ({ kind: "posix" } as const);
+  // Upsert each server independently so a sync for one MCP never clobbers the
+  // other's staged entry (or the subagents entry written by its own sync).
+  if (ctx.browserMcpEnabled !== undefined) {
+    const entry =
+      ctx.browserMcpEnabled && browserMcp
+        ? buildGeminiBrowserMcpServers(location, browserMcp)?.[BROWSER_MCP_SERVER_NAME]
+        : undefined;
+    writeGeminiMcpServer(settingsPath, BROWSER_MCP_SERVER_NAME, entry);
   }
-  writeGeminiMcpServer(settingsPath, BROWSER_MCP_SERVER_NAME, entry);
+  if (ctx.computerUseMcpEnabled !== undefined) {
+    const entry =
+      ctx.computerUseMcpEnabled && computerUseMcp
+        ? buildGeminiComputerUseMcpServers(location, computerUseMcp)?.[COMPUTER_USE_MCP_SERVER_NAME]
+        : undefined;
+    writeGeminiMcpServer(settingsPath, COMPUTER_USE_MCP_SERVER_NAME, entry);
+  }
 }
 
 /**
@@ -258,6 +276,7 @@ export function installGeminiPlugin(
       manifest,
       options.resolvedNodePath,
       ctx.browserMcp,
+      ctx.computerUseMcp,
     );
   }
 
@@ -271,10 +290,13 @@ export function installGeminiPlugin(
 
   const settingsPath = join(pluginDir, "settings.json");
   const nativeCommands = buildNativeHookCommandHeads(wrapperPath);
-  const browserMcpServers = buildGeminiBrowserMcpServers({ kind: "windows" }, ctx?.browserMcp);
+  const mcpServers = {
+    ...(buildGeminiBrowserMcpServers({ kind: "windows" }, ctx?.browserMcp) ?? {}),
+    ...(buildGeminiComputerUseMcpServers({ kind: "windows" }, ctx?.computerUseMcp) ?? {}),
+  };
   const settings = renderGeminiSettings({
     headExpression: nativeCommands.command,
-    ...(browserMcpServers ? { mcpServers: browserMcpServers } : {}),
+    ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
   });
   writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
 
@@ -295,6 +317,7 @@ function installGeminiPluginWsl(
   manifest: PluginManifest,
   resolvedNodePath: string,
   browserMcp?: BrowserMcpHttpConfig,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
 ): { ok: true; paths: GeminiPluginPaths; version: string } | { ok: false; reason: string } {
   const staged = stagePluginAssetsToWsl(distro, sourceDir, "gemini", {
     includeForwardRuntime: true,
@@ -309,10 +332,13 @@ function installGeminiPluginWsl(
 
   try {
     mkdirSync(dirname(uncSettingsPath), { recursive: true });
-    const browserMcpServers = buildGeminiBrowserMcpServers({ kind: "wsl", distro }, browserMcp);
+    const mcpServers = {
+      ...(buildGeminiBrowserMcpServers({ kind: "wsl", distro }, browserMcp) ?? {}),
+      ...(buildGeminiComputerUseMcpServers({ kind: "wsl", distro }, computerUseMcp) ?? {}),
+    };
     const settings = renderGeminiSettings({
       headExpression,
-      ...(browserMcpServers ? { mcpServers: browserMcpServers } : {}),
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
     });
     writeFileSync(uncSettingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
   } catch (error) {

--- a/src/supervisor/agents/gemini/plugin/install.ts
+++ b/src/supervisor/agents/gemini/plugin/install.ts
@@ -207,10 +207,11 @@ export function syncGeminiBrowserMcpSettings(
     writeGeminiMcpServer(settingsPath, BROWSER_MCP_SERVER_NAME, entry);
   }
   if (ctx.computerUseMcpEnabled !== undefined) {
-    const entry =
-      ctx.computerUseMcpEnabled && computerUseMcp
-        ? buildGeminiComputerUseMcpServers(location, computerUseMcp)?.[COMPUTER_USE_MCP_SERVER_NAME]
-        : undefined;
+    const entry = buildGeminiComputerUseMcpServers(
+      location,
+      ctx.computerUseMcpEnabled === true,
+      computerUseMcp,
+    )?.[COMPUTER_USE_MCP_SERVER_NAME];
     writeGeminiMcpServer(settingsPath, COMPUTER_USE_MCP_SERVER_NAME, entry);
   }
 }
@@ -292,7 +293,11 @@ export function installGeminiPlugin(
   const nativeCommands = buildNativeHookCommandHeads(wrapperPath);
   const mcpServers = {
     ...(buildGeminiBrowserMcpServers({ kind: "windows" }, ctx?.browserMcp) ?? {}),
-    ...(buildGeminiComputerUseMcpServers({ kind: "windows" }, ctx?.computerUseMcp) ?? {}),
+    ...(buildGeminiComputerUseMcpServers(
+      { kind: "windows" },
+      ctx?.computerUseMcpEnabled === true,
+      ctx?.computerUseMcp,
+    ) ?? {}),
   };
   const settings = renderGeminiSettings({
     headExpression: nativeCommands.command,
@@ -334,7 +339,11 @@ function installGeminiPluginWsl(
     mkdirSync(dirname(uncSettingsPath), { recursive: true });
     const mcpServers = {
       ...(buildGeminiBrowserMcpServers({ kind: "wsl", distro }, browserMcp) ?? {}),
-      ...(buildGeminiComputerUseMcpServers({ kind: "wsl", distro }, computerUseMcp) ?? {}),
+      ...(buildGeminiComputerUseMcpServers(
+        { kind: "wsl", distro },
+        computerUseMcp !== undefined,
+        computerUseMcp,
+      ) ?? {}),
     };
     const settings = renderGeminiSettings({
       headExpression,

--- a/src/supervisor/agents/gemini/plugin/install.ts
+++ b/src/supervisor/agents/gemini/plugin/install.ts
@@ -11,9 +11,11 @@ import {
   COMPUTER_USE_MCP_SERVER_NAME,
   type ComputerUseMcpHttpConfig,
 } from "@/supervisor/agents/computerUseMcp";
+import { CHROME_MCP_SERVER_NAME, type ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import { buildGeminiBrowserMcpServers, type GeminiMcpServerEntry } from "../mcpBrowser";
 import { buildGeminiSubagentMcpServers } from "../mcpSubagent";
 import { buildGeminiComputerUseMcpServers } from "../mcpComputerUse";
+import { buildGeminiChromeMcpServers } from "../mcpChrome";
 import type { AgentEnvContext } from "../../base";
 import {
   FORWARD_RUNTIME_FILE,
@@ -186,9 +188,16 @@ export function syncGeminiBrowserMcpSettings(
   ctx: AgentEnvContext | undefined,
   browserMcp?: BrowserMcpHttpConfig,
   computerUseMcp?: ComputerUseMcpHttpConfig,
+  chromeMcp?: ChromeMcpHttpConfig,
 ): void {
   if (!ctx) return;
-  if (ctx.browserMcpEnabled === undefined && ctx.computerUseMcpEnabled === undefined) return;
+  if (
+    ctx.browserMcpEnabled === undefined &&
+    ctx.computerUseMcpEnabled === undefined &&
+    ctx.chromeMcpEnabled === undefined
+  ) {
+    return;
+  }
   const paths = getGeminiPluginPaths(ctx);
   if (!paths.settingsPath) return;
   const settingsPath = resolveSettingsWritePath(ctx, paths.settingsPath);
@@ -213,6 +222,12 @@ export function syncGeminiBrowserMcpSettings(
       computerUseMcp,
     )?.[COMPUTER_USE_MCP_SERVER_NAME];
     writeGeminiMcpServer(settingsPath, COMPUTER_USE_MCP_SERVER_NAME, entry);
+  }
+  if (ctx.chromeMcpEnabled !== undefined) {
+    const entry = buildGeminiChromeMcpServers(location, ctx.chromeMcpEnabled === true, chromeMcp)?.[
+      CHROME_MCP_SERVER_NAME
+    ];
+    writeGeminiMcpServer(settingsPath, CHROME_MCP_SERVER_NAME, entry);
   }
 }
 
@@ -278,6 +293,7 @@ export function installGeminiPlugin(
       options.resolvedNodePath,
       ctx.browserMcp,
       ctx.computerUseMcp,
+      ctx.chromeMcp,
     );
   }
 
@@ -297,6 +313,11 @@ export function installGeminiPlugin(
       { kind: "windows" },
       ctx?.computerUseMcpEnabled === true,
       ctx?.computerUseMcp,
+    ) ?? {}),
+    ...(buildGeminiChromeMcpServers(
+      { kind: "windows" },
+      ctx?.chromeMcpEnabled === true,
+      ctx?.chromeMcp,
     ) ?? {}),
   };
   const settings = renderGeminiSettings({
@@ -323,6 +344,7 @@ function installGeminiPluginWsl(
   resolvedNodePath: string,
   browserMcp?: BrowserMcpHttpConfig,
   computerUseMcp?: ComputerUseMcpHttpConfig,
+  chromeMcp?: ChromeMcpHttpConfig,
 ): { ok: true; paths: GeminiPluginPaths; version: string } | { ok: false; reason: string } {
   const staged = stagePluginAssetsToWsl(distro, sourceDir, "gemini", {
     includeForwardRuntime: true,
@@ -343,6 +365,11 @@ function installGeminiPluginWsl(
         { kind: "wsl", distro },
         computerUseMcp !== undefined,
         computerUseMcp,
+      ) ?? {}),
+      ...(buildGeminiChromeMcpServers(
+        { kind: "wsl", distro },
+        chromeMcp !== undefined,
+        chromeMcp,
       ) ?? {}),
     };
     const settings = renderGeminiSettings({

--- a/src/supervisor/agents/opencode/detection.ts
+++ b/src/supervisor/agents/opencode/detection.ts
@@ -85,6 +85,8 @@ export const opencodeDefaultCapabilities: AgentCapability = {
   // sets `subagentMcp`.
   browserMcpScope: { terminal: "none", gui: "none" },
   subagentMcpScope: { terminal: "none", gui: "launch" },
+  computerUseMcpScope: { terminal: "none", gui: "none" },
+  chromeMcpScope: { terminal: "none", gui: "launch" },
   settingDefs: [
     {
       key: OPENCODE_BROWSER_MCP_SETTING_KEY,

--- a/src/supervisor/agents/opencode/index.ts
+++ b/src/supervisor/agents/opencode/index.ts
@@ -113,6 +113,8 @@ export function createOpenCodeAdapter(): AgentAdapter {
         _location,
         isOpenCodeBrowserMcpEnabled(launchOptions?.agentSettings),
         launchOptions?.browserMcp,
+        config.computerUse === true,
+        launchOptions?.computerUseMcp,
       );
       syncOpenCodeSubagentMcpConfigFile(_location, launchOptions?.subagentMcp);
       const sessionId = launchOptions?.resumeThreadId;
@@ -129,6 +131,8 @@ export function createOpenCodeAdapter(): AgentAdapter {
         _location,
         isOpenCodeBrowserMcpEnabled(launchOptions?.agentSettings),
         launchOptions?.browserMcp,
+        config.computerUse === true,
+        launchOptions?.computerUseMcp,
       );
       syncOpenCodeSubagentMcpConfigFile(_location, launchOptions?.subagentMcp);
       return {

--- a/src/supervisor/agents/opencode/index.ts
+++ b/src/supervisor/agents/opencode/index.ts
@@ -115,6 +115,8 @@ export function createOpenCodeAdapter(): AgentAdapter {
         launchOptions?.browserMcp,
         config.computerUse === true,
         launchOptions?.computerUseMcp,
+        config.chromeMcp === true,
+        launchOptions?.chromeMcp,
       );
       syncOpenCodeSubagentMcpConfigFile(_location, launchOptions?.subagentMcp);
       const sessionId = launchOptions?.resumeThreadId;
@@ -133,6 +135,8 @@ export function createOpenCodeAdapter(): AgentAdapter {
         launchOptions?.browserMcp,
         config.computerUse === true,
         launchOptions?.computerUseMcp,
+        config.chromeMcp === true,
+        launchOptions?.chromeMcp,
       );
       syncOpenCodeSubagentMcpConfigFile(_location, launchOptions?.subagentMcp);
       return {

--- a/src/supervisor/agents/opencode/mcpChrome.ts
+++ b/src/supervisor/agents/opencode/mcpChrome.ts
@@ -1,0 +1,25 @@
+import {
+  CHROME_MCP_SERVER_NAME,
+  resolveOrFallbackChromeMcpConfig,
+  type ChromeMcpHttpConfig,
+  type ChromeMcpLocation,
+} from "@/supervisor/agents/chromeMcp";
+import type { OpenCodeMcpServers } from "./mcpBrowser";
+
+export function buildOpenCodeChromeMcp(
+  location: ChromeMcpLocation,
+  enabled: boolean,
+  chromeMcp?: ChromeMcpHttpConfig,
+): OpenCodeMcpServers | undefined {
+  if (!enabled) return undefined;
+  const cfg = resolveOrFallbackChromeMcpConfig(location, chromeMcp);
+  if (!cfg) return undefined;
+  return {
+    [CHROME_MCP_SERVER_NAME]: {
+      type: "remote",
+      url: cfg.url,
+      headers: cfg.headers,
+      enabled: true,
+    },
+  };
+}

--- a/src/supervisor/agents/opencode/mcpComputerUse.ts
+++ b/src/supervisor/agents/opencode/mcpComputerUse.ts
@@ -1,6 +1,6 @@
 import {
   COMPUTER_USE_MCP_SERVER_NAME,
-  resolveComputerUseMcpHttpConfig,
+  resolveOrFallbackComputerUseMcpConfig,
   type ComputerUseMcpHttpConfig,
   type ComputerUseMcpLocation,
 } from "@/supervisor/agents/computerUseMcp";
@@ -12,8 +12,7 @@ export function buildOpenCodeComputerUseMcp(
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): OpenCodeMcpServers | undefined {
   if (!enabled) return undefined;
-  if (location.kind === "wsl" && !computerUseMcp) return undefined;
-  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  const cfg = resolveOrFallbackComputerUseMcpConfig(location, computerUseMcp);
   if (!cfg) return undefined;
   return {
     [COMPUTER_USE_MCP_SERVER_NAME]: {

--- a/src/supervisor/agents/opencode/mcpComputerUse.ts
+++ b/src/supervisor/agents/opencode/mcpComputerUse.ts
@@ -1,0 +1,24 @@
+import {
+  COMPUTER_USE_MCP_SERVER_NAME,
+  resolveComputerUseMcpHttpConfig,
+  type ComputerUseMcpHttpConfig,
+  type ComputerUseMcpLocation,
+} from "@/supervisor/agents/computerUseMcp";
+import type { OpenCodeMcpServers } from "./mcpBrowser";
+
+export function buildOpenCodeComputerUseMcp(
+  location: ComputerUseMcpLocation,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
+): OpenCodeMcpServers | undefined {
+  if (location.kind === "wsl" && !computerUseMcp) return undefined;
+  const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
+  if (!cfg) return undefined;
+  return {
+    [COMPUTER_USE_MCP_SERVER_NAME]: {
+      type: "remote",
+      url: cfg.url,
+      headers: cfg.headers,
+      enabled: true,
+    },
+  };
+}

--- a/src/supervisor/agents/opencode/mcpComputerUse.ts
+++ b/src/supervisor/agents/opencode/mcpComputerUse.ts
@@ -8,8 +8,10 @@ import type { OpenCodeMcpServers } from "./mcpBrowser";
 
 export function buildOpenCodeComputerUseMcp(
   location: ComputerUseMcpLocation,
+  enabled: boolean,
   computerUseMcp?: ComputerUseMcpHttpConfig,
 ): OpenCodeMcpServers | undefined {
+  if (!enabled) return undefined;
   if (location.kind === "wsl" && !computerUseMcp) return undefined;
   const cfg = computerUseMcp ?? resolveComputerUseMcpHttpConfig(location);
   if (!cfg) return undefined;

--- a/src/supervisor/agents/opencode/plugin/install.ts
+++ b/src/supervisor/agents/opencode/plugin/install.ts
@@ -503,8 +503,7 @@ export function syncOpenCodeBrowserMcpConfigFile(
 ): void {
   const add = {
     ...((browserEnabled ? buildOpenCodeBrowserMcp(location, browserMcp) : undefined) ?? {}),
-    ...((computerUseEnabled ? buildOpenCodeComputerUseMcp(location, computerUseMcp) : undefined) ??
-      {}),
+    ...(buildOpenCodeComputerUseMcp(location, computerUseEnabled, computerUseMcp) ?? {}),
   };
   const update: OpenCodeMcpConfigUpdate = {
     remove: [BROWSER_MCP_SERVER_NAME, COMPUTER_USE_MCP_SERVER_NAME],

--- a/src/supervisor/agents/opencode/plugin/install.ts
+++ b/src/supervisor/agents/opencode/plugin/install.ts
@@ -18,10 +18,12 @@ import {
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import { CHROME_MCP_SERVER_NAME, type ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import { getCachedWslHomeDirectory, type AgentEnvContext } from "../../base";
 import { BROWSER_MCP_SERVER_NAME } from "../../browserMcp";
 import { COMPUTER_USE_MCP_SERVER_NAME } from "../../computerUseMcp";
 import { buildOpenCodeComputerUseMcp } from "../mcpComputerUse";
+import { buildOpenCodeChromeMcp } from "../mcpChrome";
 import {
   copyPluginAssetsIfStale,
   createPluginSourceResolver,
@@ -500,13 +502,16 @@ export function syncOpenCodeBrowserMcpConfigFile(
   browserMcp?: BrowserMcpHttpConfig,
   computerUseEnabled = false,
   computerUseMcp?: ComputerUseMcpHttpConfig,
+  chromeEnabled = false,
+  chromeMcp?: ChromeMcpHttpConfig,
 ): void {
   const add = {
     ...((browserEnabled ? buildOpenCodeBrowserMcp(location, browserMcp) : undefined) ?? {}),
     ...(buildOpenCodeComputerUseMcp(location, computerUseEnabled, computerUseMcp) ?? {}),
+    ...(buildOpenCodeChromeMcp(location, chromeEnabled, chromeMcp) ?? {}),
   };
   const update: OpenCodeMcpConfigUpdate = {
-    remove: [BROWSER_MCP_SERVER_NAME, COMPUTER_USE_MCP_SERVER_NAME],
+    remove: [BROWSER_MCP_SERVER_NAME, COMPUTER_USE_MCP_SERVER_NAME, CHROME_MCP_SERVER_NAME],
     ...(Object.keys(add).length > 0 ? { add } : {}),
   };
   writeOpenCodeConfigUpdate(location, update);

--- a/src/supervisor/agents/opencode/plugin/install.ts
+++ b/src/supervisor/agents/opencode/plugin/install.ts
@@ -17,8 +17,11 @@ import {
   SUBAGENT_MCP_SERVER_NAME,
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import { getCachedWslHomeDirectory, type AgentEnvContext } from "../../base";
 import { BROWSER_MCP_SERVER_NAME } from "../../browserMcp";
+import { COMPUTER_USE_MCP_SERVER_NAME } from "../../computerUseMcp";
+import { buildOpenCodeComputerUseMcp } from "../mcpComputerUse";
 import {
   copyPluginAssetsIfStale,
   createPluginSourceResolver,
@@ -106,7 +109,11 @@ const OPENCODE_CONFIG_FILE_NAME = "opencode.json";
  * All `mcp` server keys Lightcode owns in `opencode.json`. Scrubbed together at
  * install/uninstall so no stale lightcode-managed entry survives a reinstall.
  */
-const LIGHTCODE_MANAGED_MCP_KEYS = [BROWSER_MCP_SERVER_NAME, SUBAGENT_MCP_SERVER_NAME] as const;
+const LIGHTCODE_MANAGED_MCP_KEYS = [
+  BROWSER_MCP_SERVER_NAME,
+  SUBAGENT_MCP_SERVER_NAME,
+  COMPUTER_USE_MCP_SERVER_NAME,
+] as const;
 
 export interface OpenCodePluginPaths {
   pluginDir: string;
@@ -489,13 +496,19 @@ function updateOpenCodeConfigFile(configPath: string, update: OpenCodeMcpConfigU
 
 export function syncOpenCodeBrowserMcpConfigFile(
   location: ProjectLocation,
-  enabled: boolean,
+  browserEnabled: boolean,
   browserMcp?: BrowserMcpHttpConfig,
+  computerUseEnabled = false,
+  computerUseMcp?: ComputerUseMcpHttpConfig,
 ): void {
-  const add = enabled ? buildOpenCodeBrowserMcp(location, browserMcp) : undefined;
+  const add = {
+    ...((browserEnabled ? buildOpenCodeBrowserMcp(location, browserMcp) : undefined) ?? {}),
+    ...((computerUseEnabled ? buildOpenCodeComputerUseMcp(location, computerUseMcp) : undefined) ??
+      {}),
+  };
   const update: OpenCodeMcpConfigUpdate = {
-    remove: [BROWSER_MCP_SERVER_NAME],
-    ...(add ? { add } : {}),
+    remove: [BROWSER_MCP_SERVER_NAME, COMPUTER_USE_MCP_SERVER_NAME],
+    ...(Object.keys(add).length > 0 ? { add } : {}),
   };
   writeOpenCodeConfigUpdate(location, update);
 }

--- a/src/supervisor/agents/opencode/sdkClient.test.ts
+++ b/src/supervisor/agents/opencode/sdkClient.test.ts
@@ -123,6 +123,44 @@ describe("acquireOpenCodeServer", () => {
     headers: { Authorization: "Bearer parent-thread-token" },
   };
 
+  const chromeMcp = {
+    url: "http://127.0.0.1:9401/mcp",
+    token: "chrome-token",
+    headers: { Authorization: "Bearer chrome-token" },
+  };
+
+  it("registers the external Chrome MCP on an opted-in server", async () => {
+    const handle = makeHandle("http://127.0.0.1:4199");
+    mocks.spawnOpenCodeServer.mockReturnValue(handle);
+    const client = makeSubagentClient();
+    mocks.createOpencodeClient.mockReturnValue(client);
+
+    const { acquireOpenCodeServer } = await import("./sdkClient");
+    const acquired = await acquireOpenCodeServer({
+      projectLocation: { kind: "posix", path: "/repo-chrome" },
+      chromeMcpEnabled: true,
+      chromeMcp,
+    });
+
+    expect(client.mcp.add).toHaveBeenCalledWith({
+      directory: "/repo-chrome",
+      name: "chrome",
+      config: {
+        type: "remote",
+        url: chromeMcp.url,
+        headers: chromeMcp.headers,
+        enabled: true,
+      },
+    });
+    expect(client.mcp.connect).toHaveBeenCalledWith({
+      directory: "/repo-chrome",
+      name: "chrome",
+    });
+
+    await acquired.dispose();
+    expect(handle.dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("dedicates a per-thread server and registers the subagents MCP via mcp.add", async () => {
     const handle = makeHandle("http://127.0.0.1:4200");
     mocks.spawnOpenCodeServer.mockReturnValue(handle);

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -5,11 +5,14 @@ import {
   SUBAGENT_MCP_SERVER_NAME,
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { BROWSER_MCP_SERVER_NAME } from "../browserMcp";
+import { COMPUTER_USE_MCP_SERVER_NAME } from "../computerUseMcp";
 import { buildOpenCodeServerCommand } from "./argv";
 import { buildOpenCodeBrowserMcp } from "./mcpBrowser";
 import { buildOpenCodeSubagentMcp } from "./mcpSubagent";
+import { buildOpenCodeComputerUseMcp } from "./mcpComputerUse";
 import { classifyOpenCodeError, isOpenCodeConnectionLoss } from "./opencodeErrors";
 import {
   disposeSpawnedOpenCodeServerHandles,
@@ -171,6 +174,8 @@ export interface AcquireOpenCodeServerInput {
   projectLocation: ProjectLocation;
   browserMcpEnabled?: boolean;
   browserMcp?: BrowserMcpHttpConfig;
+  computerUseMcpEnabled?: boolean;
+  computerUseMcp?: ComputerUseMcpHttpConfig;
   /**
    * Per-thread cross-provider subagents MCP config. When present, the server is
    * dedicated (see `dedicatedKey`) and the `subagents` MCP is registered on it
@@ -196,28 +201,51 @@ export interface AcquireOpenCodeServerInput {
 }
 
 async function syncBrowserMcp(
-  input: Pick<AcquireOpenCodeServerInput, "projectLocation" | "browserMcpEnabled" | "browserMcp">,
+  input: Pick<
+    AcquireOpenCodeServerInput,
+    | "projectLocation"
+    | "browserMcpEnabled"
+    | "browserMcp"
+    | "computerUseMcpEnabled"
+    | "computerUseMcp"
+  >,
   client: OpencodeClient,
 ): Promise<void> {
   const directory = resolveOpenCodeSessionDirectory(input.projectLocation);
-  if (input.browserMcpEnabled === undefined) return;
-  if (!input.browserMcpEnabled) {
+  if (input.browserMcpEnabled === true) {
+    const servers = buildOpenCodeBrowserMcp(input.projectLocation, input.browserMcp);
+    const browser = servers?.[BROWSER_MCP_SERVER_NAME];
+    if (browser) {
+      await client.mcp
+        .add({ directory, name: BROWSER_MCP_SERVER_NAME, config: browser })
+        .catch((err) => {
+          if (isOpenCodeConnectionLoss(err)) throw err;
+        });
+      await client.mcp.connect({ directory, name: BROWSER_MCP_SERVER_NAME });
+    }
+  } else if (input.browserMcpEnabled === false) {
     await client.mcp.disconnect({ directory, name: BROWSER_MCP_SERVER_NAME }).catch((error) => {
       console.warn("[opencode] failed to disconnect browser MCP:", error);
     });
-    return;
   }
 
-  const servers = buildOpenCodeBrowserMcp(input.projectLocation, input.browserMcp);
-  const browser = servers?.[BROWSER_MCP_SERVER_NAME];
-  if (!browser) return;
+  if (input.computerUseMcpEnabled === false) {
+    await client.mcp
+      .disconnect({ directory, name: COMPUTER_USE_MCP_SERVER_NAME })
+      .catch(() => undefined);
+    return;
+  }
+  if (input.computerUseMcpEnabled !== true) return;
 
+  const servers = buildOpenCodeComputerUseMcp(input.projectLocation, input.computerUseMcp);
+  const computerUse = servers?.[COMPUTER_USE_MCP_SERVER_NAME];
+  if (!computerUse) return;
   await client.mcp
-    .add({ directory, name: BROWSER_MCP_SERVER_NAME, config: browser })
+    .add({ directory, name: COMPUTER_USE_MCP_SERVER_NAME, config: computerUse })
     .catch((err) => {
       if (isOpenCodeConnectionLoss(err)) throw err;
     });
-  await client.mcp.connect({ directory, name: BROWSER_MCP_SERVER_NAME });
+  await client.mcp.connect({ directory, name: COMPUTER_USE_MCP_SERVER_NAME });
 }
 
 /**

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -6,13 +6,16 @@ import {
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { BROWSER_MCP_SERVER_NAME } from "../browserMcp";
 import { COMPUTER_USE_MCP_SERVER_NAME } from "../computerUseMcp";
+import { CHROME_MCP_SERVER_NAME } from "../chromeMcp";
 import { buildOpenCodeServerCommand } from "./argv";
 import { buildOpenCodeBrowserMcp } from "./mcpBrowser";
 import { buildOpenCodeSubagentMcp } from "./mcpSubagent";
 import { buildOpenCodeComputerUseMcp } from "./mcpComputerUse";
+import { buildOpenCodeChromeMcp } from "./mcpChrome";
 import { classifyOpenCodeError, isOpenCodeConnectionLoss } from "./opencodeErrors";
 import {
   disposeSpawnedOpenCodeServerHandles,
@@ -176,6 +179,8 @@ export interface AcquireOpenCodeServerInput {
   browserMcp?: BrowserMcpHttpConfig;
   computerUseMcpEnabled?: boolean;
   computerUseMcp?: ComputerUseMcpHttpConfig;
+  chromeMcpEnabled?: boolean;
+  chromeMcp?: ChromeMcpHttpConfig;
   /**
    * Per-thread cross-provider subagents MCP config. When present, the server is
    * dedicated (see `dedicatedKey`) and the `subagents` MCP is registered on it
@@ -208,6 +213,8 @@ async function syncBrowserMcp(
     | "browserMcp"
     | "computerUseMcpEnabled"
     | "computerUseMcp"
+    | "chromeMcpEnabled"
+    | "chromeMcp"
   >,
   client: OpencodeClient,
 ): Promise<void> {
@@ -233,19 +240,32 @@ async function syncBrowserMcp(
     await client.mcp
       .disconnect({ directory, name: COMPUTER_USE_MCP_SERVER_NAME })
       .catch(() => undefined);
+  } else if (input.computerUseMcpEnabled === true) {
+    const servers = buildOpenCodeComputerUseMcp(input.projectLocation, true, input.computerUseMcp);
+    const computerUse = servers?.[COMPUTER_USE_MCP_SERVER_NAME];
+    if (computerUse) {
+      await client.mcp
+        .add({ directory, name: COMPUTER_USE_MCP_SERVER_NAME, config: computerUse })
+        .catch((err) => {
+          if (isOpenCodeConnectionLoss(err)) throw err;
+        });
+      await client.mcp.connect({ directory, name: COMPUTER_USE_MCP_SERVER_NAME });
+    }
+  }
+
+  if (input.chromeMcpEnabled === false) {
+    await client.mcp.disconnect({ directory, name: CHROME_MCP_SERVER_NAME }).catch(() => undefined);
     return;
   }
-  if (input.computerUseMcpEnabled !== true) return;
+  if (input.chromeMcpEnabled !== true) return;
 
-  const servers = buildOpenCodeComputerUseMcp(input.projectLocation, true, input.computerUseMcp);
-  const computerUse = servers?.[COMPUTER_USE_MCP_SERVER_NAME];
-  if (!computerUse) return;
-  await client.mcp
-    .add({ directory, name: COMPUTER_USE_MCP_SERVER_NAME, config: computerUse })
-    .catch((err) => {
-      if (isOpenCodeConnectionLoss(err)) throw err;
-    });
-  await client.mcp.connect({ directory, name: COMPUTER_USE_MCP_SERVER_NAME });
+  const servers = buildOpenCodeChromeMcp(input.projectLocation, true, input.chromeMcp);
+  const chrome = servers?.[CHROME_MCP_SERVER_NAME];
+  if (!chrome) return;
+  await client.mcp.add({ directory, name: CHROME_MCP_SERVER_NAME, config: chrome }).catch((err) => {
+    if (isOpenCodeConnectionLoss(err)) throw err;
+  });
+  await client.mcp.connect({ directory, name: CHROME_MCP_SERVER_NAME });
 }
 
 /**

--- a/src/supervisor/agents/opencode/sdkClient.ts
+++ b/src/supervisor/agents/opencode/sdkClient.ts
@@ -237,7 +237,7 @@ async function syncBrowserMcp(
   }
   if (input.computerUseMcpEnabled !== true) return;
 
-  const servers = buildOpenCodeComputerUseMcp(input.projectLocation, input.computerUseMcp);
+  const servers = buildOpenCodeComputerUseMcp(input.projectLocation, true, input.computerUseMcp);
   const computerUse = servers?.[COMPUTER_USE_MCP_SERVER_NAME];
   if (!computerUse) return;
   await client.mcp

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -361,6 +361,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
   private pendingRequests = new Map<ThreadServerRequestId, PendingRequest>();
   private currentSlashCommands: AgentSlashCommand[] | undefined;
   private browserMcpEnabled = false;
+  private computerUseMcpEnabled = false;
 
   private constructor(input: CreateStructuredSessionInput) {
     this.input = input;
@@ -416,10 +417,13 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
 
     try {
       this.browserMcpEnabled = isOpenCodeBrowserMcpEnabled(this.input.agentSettings);
+      this.computerUseMcpEnabled = this.input.config.computerUse === true;
       syncOpenCodeBrowserMcpConfigFile(
         this.input.projectLocation,
         this.browserMcpEnabled,
         this.input.browserMcp,
+        this.computerUseMcpEnabled,
+        this.input.computerUseMcp,
       );
       // The subagents MCP is hosted, when opted in, by registering it on a
       // dedicated per-thread server via `mcp.add` (see `acquireOpenCodeServer`)
@@ -918,6 +922,10 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       projectLocation: this.input.projectLocation,
       browserMcpEnabled: this.browserMcpEnabled,
       ...(this.input.browserMcp !== undefined ? { browserMcp: this.input.browserMcp } : {}),
+      computerUseMcpEnabled: this.computerUseMcpEnabled,
+      ...(this.input.computerUseMcp !== undefined
+        ? { computerUseMcp: this.input.computerUseMcp }
+        : {}),
       ...(this.input.subagentMcp !== undefined
         ? { subagentMcp: this.input.subagentMcp, dedicatedKey: this.threadId }
         : {}),

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -362,6 +362,7 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
   private currentSlashCommands: AgentSlashCommand[] | undefined;
   private browserMcpEnabled = false;
   private computerUseMcpEnabled = false;
+  private chromeMcpEnabled = false;
 
   private constructor(input: CreateStructuredSessionInput) {
     this.input = input;
@@ -418,12 +419,15 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
     try {
       this.browserMcpEnabled = isOpenCodeBrowserMcpEnabled(this.input.agentSettings);
       this.computerUseMcpEnabled = this.input.config.computerUse === true;
+      this.chromeMcpEnabled = this.input.config.chromeMcp === true;
       syncOpenCodeBrowserMcpConfigFile(
         this.input.projectLocation,
         this.browserMcpEnabled,
         this.input.browserMcp,
         this.computerUseMcpEnabled,
         this.input.computerUseMcp,
+        this.chromeMcpEnabled,
+        this.input.chromeMcp,
       );
       // The subagents MCP is hosted, when opted in, by registering it on a
       // dedicated per-thread server via `mcp.add` (see `acquireOpenCodeServer`)
@@ -926,6 +930,8 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       ...(this.input.computerUseMcp !== undefined
         ? { computerUseMcp: this.input.computerUseMcp }
         : {}),
+      chromeMcpEnabled: this.chromeMcpEnabled,
+      ...(this.input.chromeMcp !== undefined ? { chromeMcp: this.input.chromeMcp } : {}),
       ...(this.input.subagentMcp !== undefined
         ? { subagentMcp: this.input.subagentMcp, dedicatedKey: this.threadId }
         : {}),

--- a/src/supervisor/runtime/cliHookPluginCoordinator.ts
+++ b/src/supervisor/runtime/cliHookPluginCoordinator.ts
@@ -21,6 +21,7 @@ import {
 } from "../agents/base";
 import type { BrowserMcpHttpConfig } from "../agents/browserMcp";
 import type { ComputerUseMcpHttpConfig } from "../agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "../agents/chromeMcp";
 import type { WslBridgeServer } from "../wsl/bridge";
 import { isLightcodeHookDebug } from "./hookDebug";
 import { HookIngress, type HookIngressBootInfo } from "./hookIngress";
@@ -192,6 +193,8 @@ export class CliHookPluginCoordinator {
     browserMcp?: BrowserMcpHttpConfig;
     computerUseMcpEnabled?: boolean;
     computerUseMcp?: ComputerUseMcpHttpConfig;
+    chromeMcpEnabled?: boolean;
+    chromeMcp?: ChromeMcpHttpConfig;
   }): Promise<{ env: Record<string, string>; extraArgs: string[] } | undefined> {
     // The `disableCliHookPlugin` dev toggle is handled in the supervisor's
     // hook dispatcher (envelopes are dropped on receive). Install, launch
@@ -219,6 +222,10 @@ export class CliHookPluginCoordinator {
       ctx.computerUseMcpEnabled = input.computerUseMcpEnabled;
     }
     if (input.computerUseMcp) ctx.computerUseMcp = input.computerUseMcp;
+    if (input.chromeMcpEnabled !== undefined) {
+      ctx.chromeMcpEnabled = input.chromeMcpEnabled;
+    }
+    if (input.chromeMcp) ctx.chromeMcp = input.chromeMcp;
     const outcome = await this.ensureInstalledOrUpdated(adapter, slice, ctx);
     if (!outcome.ok) {
       return undefined;

--- a/src/supervisor/runtime/cliHookPluginCoordinator.ts
+++ b/src/supervisor/runtime/cliHookPluginCoordinator.ts
@@ -20,6 +20,7 @@ import {
   resolveWslHomeDirectoryAsync,
 } from "../agents/base";
 import type { BrowserMcpHttpConfig } from "../agents/browserMcp";
+import type { ComputerUseMcpHttpConfig } from "../agents/computerUseMcp";
 import type { WslBridgeServer } from "../wsl/bridge";
 import { isLightcodeHookDebug } from "./hookDebug";
 import { HookIngress, type HookIngressBootInfo } from "./hookIngress";
@@ -189,6 +190,8 @@ export class CliHookPluginCoordinator {
     projectLocation?: ProjectLocation;
     browserMcpEnabled?: boolean;
     browserMcp?: BrowserMcpHttpConfig;
+    computerUseMcpEnabled?: boolean;
+    computerUseMcp?: ComputerUseMcpHttpConfig;
   }): Promise<{ env: Record<string, string>; extraArgs: string[] } | undefined> {
     // The `disableCliHookPlugin` dev toggle is handled in the supervisor's
     // hook dispatcher (envelopes are dropped on receive). Install, launch
@@ -212,6 +215,10 @@ export class CliHookPluginCoordinator {
     const ctx = this.envContext(input.agentKind, input.projectLocation);
     if (input.browserMcpEnabled !== undefined) ctx.browserMcpEnabled = input.browserMcpEnabled;
     if (input.browserMcp) ctx.browserMcp = input.browserMcp;
+    if (input.computerUseMcpEnabled !== undefined) {
+      ctx.computerUseMcpEnabled = input.computerUseMcpEnabled;
+    }
+    if (input.computerUseMcp) ctx.computerUseMcp = input.computerUseMcp;
     const outcome = await this.ensureInstalledOrUpdated(adapter, slice, ctx);
     if (!outcome.ok) {
       return undefined;

--- a/src/supervisor/runtime/threadSession/cliHookPlugin.ts
+++ b/src/supervisor/runtime/threadSession/cliHookPlugin.ts
@@ -7,6 +7,7 @@ import type {
   ThreadStatus,
 } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import { type AgentAdapter, createKnownSessionRef } from "../../agents/base";
 import { hookDebugSpawn } from "../hookDebug";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
@@ -98,6 +99,7 @@ export class CliHookSessionCoordinator {
     projectLocation: ProjectLocation,
     config: ThreadConfig,
     browserMcp: BrowserMcpHttpConfig | undefined,
+    computerUseMcp: ComputerUseMcpHttpConfig | undefined,
   ): Promise<{ env: Record<string, string>; extraArgs: string[] }> {
     const adapter = this.ctx.options.adapters.get(agentKind);
     const liveInputMode = adapter?.capabilities.liveInputMode ?? "terminal";
@@ -120,6 +122,8 @@ export class CliHookSessionCoordinator {
         projectLocation,
         browserMcpEnabled: this.ctx.isBrowserMcpEnabledForLaunch(adapter, config),
         ...(browserMcp !== undefined ? { browserMcp } : {}),
+        computerUseMcpEnabled: config.computerUse === true,
+        ...(computerUseMcp !== undefined ? { computerUseMcp } : {}),
       });
       const merged = resolved ?? { env: {}, extraArgs: [] };
       const hookUrl = merged.env.LIGHTCODE_HOOK_URL;

--- a/src/supervisor/runtime/threadSession/cliHookPlugin.ts
+++ b/src/supervisor/runtime/threadSession/cliHookPlugin.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import { type AgentAdapter, createKnownSessionRef } from "../../agents/base";
 import { hookDebugSpawn } from "../hookDebug";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
@@ -100,6 +101,7 @@ export class CliHookSessionCoordinator {
     config: ThreadConfig,
     browserMcp: BrowserMcpHttpConfig | undefined,
     computerUseMcp: ComputerUseMcpHttpConfig | undefined,
+    chromeMcp: ChromeMcpHttpConfig | undefined,
   ): Promise<{ env: Record<string, string>; extraArgs: string[] }> {
     const adapter = this.ctx.options.adapters.get(agentKind);
     const liveInputMode = adapter?.capabilities.liveInputMode ?? "terminal";
@@ -124,6 +126,8 @@ export class CliHookSessionCoordinator {
         ...(browserMcp !== undefined ? { browserMcp } : {}),
         computerUseMcpEnabled: config.computerUse === true,
         ...(computerUseMcp !== undefined ? { computerUseMcp } : {}),
+        chromeMcpEnabled: config.chromeMcp === true,
+        ...(chromeMcp !== undefined ? { chromeMcp } : {}),
       });
       const merged = resolved ?? { env: {}, extraArgs: [] };
       const hookUrl = merged.env.LIGHTCODE_HOOK_URL;

--- a/src/supervisor/runtime/threadSession/managerOptions.ts
+++ b/src/supervisor/runtime/threadSession/managerOptions.ts
@@ -1,6 +1,7 @@
 import type { SupervisorEvent } from "@/shared/ipc";
 import type { AgentKind, ProjectLocation, ThreadServerRequestId } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
+import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
 import type {
   SubagentMcpHostAccessResolver,
   SubagentMcpHttpConfig,
@@ -28,6 +29,8 @@ export interface ThreadSessionManagerOptions {
     projectLocation: ProjectLocation;
     browserMcpEnabled?: boolean;
     browserMcp?: BrowserMcpHttpConfig;
+    computerUseMcpEnabled?: boolean;
+    computerUseMcp?: ComputerUseMcpHttpConfig;
   }): Promise<{ env: Record<string, string>; extraArgs: string[] } | undefined>;
   wslBridge?: {
     ensureBridge(distro: string): Promise<{ baseUrl: string; secret: string } | undefined>;

--- a/src/supervisor/runtime/threadSession/managerOptions.ts
+++ b/src/supervisor/runtime/threadSession/managerOptions.ts
@@ -2,6 +2,7 @@ import type { SupervisorEvent } from "@/shared/ipc";
 import type { AgentKind, ProjectLocation, ThreadServerRequestId } from "@/shared/contracts";
 import type { BrowserMcpHttpConfig } from "@/supervisor/agents/browserMcp";
 import type { ComputerUseMcpHttpConfig } from "@/supervisor/agents/computerUseMcp";
+import type { ChromeMcpHttpConfig } from "@/supervisor/agents/chromeMcp";
 import type {
   SubagentMcpHostAccessResolver,
   SubagentMcpHttpConfig,
@@ -31,6 +32,8 @@ export interface ThreadSessionManagerOptions {
     browserMcp?: BrowserMcpHttpConfig;
     computerUseMcpEnabled?: boolean;
     computerUseMcp?: ComputerUseMcpHttpConfig;
+    chromeMcpEnabled?: boolean;
+    chromeMcp?: ChromeMcpHttpConfig;
   }): Promise<{ env: Record<string, string>; extraArgs: string[] } | undefined>;
   wslBridge?: {
     ensureBridge(distro: string): Promise<{ baseUrl: string; secret: string } | undefined>;

--- a/src/supervisor/runtime/threadSession/spawnDiagnostics.test.ts
+++ b/src/supervisor/runtime/threadSession/spawnDiagnostics.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ENV_KEYS = [
+  "LIGHTCODE_COMPUTER_USE_MCP_URL",
+  "LIGHTCODE_COMPUTER_USE_MCP_TOKEN",
+  "LIGHTCODE_CHROME_MCP_URL",
+  "LIGHTCODE_CHROME_MCP_TOKEN",
+] as const;
+
+const savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.resetModules();
+});
+
+describe("sanitizedProcessEnv", () => {
+  it("keeps launch-only MCP credentials out of ambient child environments", async () => {
+    for (const key of ENV_KEYS) process.env[key] = `${key}-secret`;
+
+    const { sanitizedProcessEnv } = await import("./spawnDiagnostics");
+
+    for (const key of ENV_KEYS) {
+      expect(sanitizedProcessEnv).not.toHaveProperty(key);
+      expect(process.env[key]).toBe(`${key}-secret`);
+    }
+  });
+});

--- a/src/supervisor/runtime/threadSession/spawnDiagnostics.ts
+++ b/src/supervisor/runtime/threadSession/spawnDiagnostics.ts
@@ -1,5 +1,10 @@
 import { accessSync, constants as fsConstants, existsSync, statSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import {
+  COMPUTER_USE_MCP_TOKEN_ENV,
+  COMPUTER_USE_MCP_URL_ENV,
+} from "@/supervisor/agents/computerUseMcp";
+import { CHROME_MCP_TOKEN_ENV, CHROME_MCP_URL_ENV } from "@/supervisor/agents/chromeMcp";
 
 export function describeSpawnFailure(
   kind: "shell" | "agent",
@@ -66,21 +71,17 @@ export function sanitizeEnv(source: NodeJS.ProcessEnv): Record<string, string> {
   return out;
 }
 
-// The computer-use MCP endpoint drives the host's real mouse/keyboard/windows.
-// Its URL + token arrive in the supervisor's own process.env (the main →
-// supervisor IPC channel) purely so the orchestrator can resolve the per-thread
-// launch config. They must NOT cascade into the base env every spawned PTY /
-// shell inherits — otherwise any subprocess (even a dependency postinstall) in
-// a thread that never opted into computer-use could read the token and drive
-// the desktop, making the per-thread opt-in cosmetic. Strip them from the base
-// env here; the resolved config is injected per-launch only when
-// `config.computerUse === true` (e.g. Codex's `buildCodexComputerUseMcpEnv`,
-// or via MCP-server headers/args for the other providers). `process.env` itself
-// is left intact so `resolveComputerUseMcpHttpConfig` can still resolve the
-// config for opted-in launches.
+// The computer-use and external-Chrome MCP endpoints control the host's real
+// desktop/browser. Their URL + token arrive in the supervisor's process.env
+// purely so the orchestrator can resolve per-thread launch config. They must not
+// cascade into every spawned PTY or shell, which would make opt-in cosmetic.
+// Keep process.env intact for resolution, but strip the secrets from the shared
+// child-process base env; provider adapters inject them only for opted-in launches.
 const SCOPED_LAUNCH_ONLY_ENV_KEYS = [
-  "LIGHTCODE_COMPUTER_USE_MCP_URL",
-  "LIGHTCODE_COMPUTER_USE_MCP_TOKEN",
+  COMPUTER_USE_MCP_URL_ENV,
+  COMPUTER_USE_MCP_TOKEN_ENV,
+  CHROME_MCP_URL_ENV,
+  CHROME_MCP_TOKEN_ENV,
 ] as const;
 
 // process.env is effectively static after supervisor boot — sanitize once

--- a/src/supervisor/runtime/threadSession/spawnDiagnostics.ts
+++ b/src/supervisor/runtime/threadSession/spawnDiagnostics.ts
@@ -66,9 +66,32 @@ export function sanitizeEnv(source: NodeJS.ProcessEnv): Record<string, string> {
   return out;
 }
 
+// The computer-use MCP endpoint drives the host's real mouse/keyboard/windows.
+// Its URL + token arrive in the supervisor's own process.env (the main →
+// supervisor IPC channel) purely so the orchestrator can resolve the per-thread
+// launch config. They must NOT cascade into the base env every spawned PTY /
+// shell inherits — otherwise any subprocess (even a dependency postinstall) in
+// a thread that never opted into computer-use could read the token and drive
+// the desktop, making the per-thread opt-in cosmetic. Strip them from the base
+// env here; the resolved config is injected per-launch only when
+// `config.computerUse === true` (e.g. Codex's `buildCodexComputerUseMcpEnv`,
+// or via MCP-server headers/args for the other providers). `process.env` itself
+// is left intact so `resolveComputerUseMcpHttpConfig` can still resolve the
+// config for opted-in launches.
+const SCOPED_LAUNCH_ONLY_ENV_KEYS = [
+  "LIGHTCODE_COMPUTER_USE_MCP_URL",
+  "LIGHTCODE_COMPUTER_USE_MCP_TOKEN",
+] as const;
+
 // process.env is effectively static after supervisor boot — sanitize once
 // instead of re-scanning ~150–300 entries on every startShell call.
-export const sanitizedProcessEnv = sanitizeEnv(process.env);
+export const sanitizedProcessEnv = ((): Record<string, string> => {
+  const env = sanitizeEnv(process.env);
+  for (const key of SCOPED_LAUNCH_ONLY_ENV_KEYS) {
+    delete env[key];
+  }
+  return env;
+})();
 
 function measureEnvBytes(env: Record<string, string>): number {
   let total = 0;

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -27,6 +27,10 @@ import {
   type SubagentMcpHttpConfig,
 } from "@/supervisor/agents/subagentMcp";
 import {
+  resolveComputerUseMcpHttpConfigForLaunch,
+  type ComputerUseMcpHttpConfig,
+} from "@/supervisor/agents/computerUseMcp";
+import {
   type AgentAdapter,
   type AgentLaunchOptions,
   type CommandSpec,
@@ -195,6 +199,11 @@ export class SpawnPipeline {
       payload.projectLocation,
       payload.config,
     );
+    const computerUse = this.resolveComputerUseMcpForLaunch(
+      adapter,
+      payload.projectLocation,
+      payload.config,
+    );
     const structuredSession = await this.createStructuredSession(
       adapter,
       payload.threadId,
@@ -203,6 +212,7 @@ export class SpawnPipeline {
       payload.config,
       browserMcp,
       subagentMcp,
+      computerUse,
       mcpIdentity,
       payload.sessionRef,
       requestedPresentation,
@@ -333,6 +343,7 @@ export class SpawnPipeline {
       structuredSession?.launchOptions,
       browserMcp,
       subagentMcp,
+      computerUse,
     );
     const argv = payload.sessionRef
       ? adapter.buildResumeArgv(
@@ -363,6 +374,7 @@ export class SpawnPipeline {
       payload.projectLocation,
       payload.config,
       browserMcp,
+      computerUse,
     );
     if (cliHookExtras.extraArgs.length > 0) {
       argv.args = mergeCliHookExtraArgs(
@@ -478,6 +490,11 @@ export class SpawnPipeline {
       session.projectLocation,
       config,
     );
+    const computerUse = this.resolveComputerUseMcpForLaunch(
+      session.adapter,
+      session.projectLocation,
+      config,
+    );
     const structuredSession = await this.createStructuredSession(
       session.adapter,
       session.threadId,
@@ -486,6 +503,7 @@ export class SpawnPipeline {
       config,
       browserMcp,
       subagentMcp,
+      computerUse,
       mcpIdentity,
       session.sessionRef,
       session.presentationMode,
@@ -558,6 +576,7 @@ export class SpawnPipeline {
       session.projectLocation,
       config,
       browserMcp,
+      computerUse,
     );
     if (!ctx.isCurrentSession(session)) {
       await structuredSession?.dispose();
@@ -573,6 +592,7 @@ export class SpawnPipeline {
         structuredSession?.launchOptions,
         browserMcp,
         subagentMcp,
+        computerUse,
       ),
     );
     if (cliHookExtras.extraArgs.length > 0) {
@@ -929,12 +949,14 @@ export class SpawnPipeline {
     launchOptions: AgentLaunchOptions | undefined,
     browserMcp: BrowserMcpHttpConfig | undefined,
     subagentMcp: SubagentMcpHttpConfig | undefined,
+    computerUse: ComputerUseMcpHttpConfig | undefined,
   ): AgentLaunchOptions {
     return {
       ...(launchOptions ?? {}),
       agentSettings: this.ctx.resolveAgentSettings(adapter),
       ...(browserMcp !== undefined ? { browserMcp } : {}),
       ...(subagentMcp !== undefined ? { subagentMcp } : {}),
+      ...(computerUse !== undefined ? { computerUseMcp: computerUse } : {}),
     };
   }
 
@@ -953,6 +975,23 @@ export class SpawnPipeline {
       identity,
     );
     return cfg;
+  }
+
+  /**
+   * Resolve the computer-use MCP http config for a launch when the thread opted
+   * in (`config.computerUse === true`). Unlike browser MCP there is no
+   * force-disable ctx gate — computer-use scope gating happens in the renderer,
+   * so the per-thread config flag is authoritative. The resolver declines for
+   * WSL projects by design (computer-use is disabled for WSL). Parallel to
+   * `resolveBrowserMcpForLaunch`.
+   */
+  resolveComputerUseMcpForLaunch(
+    _adapter: AgentAdapter,
+    location: ProjectLocation,
+    config: ThreadConfig,
+  ): ComputerUseMcpHttpConfig | undefined {
+    const enabled = config.computerUse === true;
+    return resolveComputerUseMcpHttpConfigForLaunch(location, enabled);
   }
 
   /**
@@ -1017,6 +1056,7 @@ export class SpawnPipeline {
     config: ThreadConfig,
     browserMcp: BrowserMcpHttpConfig | undefined,
     subagentMcp: SubagentMcpHttpConfig | undefined,
+    computerUse: ComputerUseMcpHttpConfig | undefined,
     mcpIdentity: McpThreadIdentity | undefined,
     sessionRef?: SessionRef,
     presentationMode?: ThreadPresentationMode,
@@ -1033,6 +1073,7 @@ export class SpawnPipeline {
         ...(mcpIdentity ? { mcpIdentity } : {}),
         ...(browserMcp ? { browserMcp } : {}),
         ...(subagentMcp ? { subagentMcp } : {}),
+        ...(computerUse ? { computerUseMcp: computerUse } : {}),
         ...(sessionRef ? { sessionRef } : {}),
         ...(presentationMode ? { presentationMode } : {}),
       });

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -31,6 +31,10 @@ import {
   type ComputerUseMcpHttpConfig,
 } from "@/supervisor/agents/computerUseMcp";
 import {
+  resolveChromeMcpHttpConfigForLaunch,
+  type ChromeMcpHttpConfig,
+} from "@/supervisor/agents/chromeMcp";
+import {
   type AgentAdapter,
   type AgentLaunchOptions,
   type CommandSpec,
@@ -200,9 +204,14 @@ export class SpawnPipeline {
       payload.config,
     );
     const computerUse = this.resolveComputerUseMcpForLaunch(
-      adapter,
       payload.projectLocation,
       payload.config,
+      mcpIdentity,
+    );
+    const chromeMcp = this.resolveChromeMcpForLaunch(
+      payload.projectLocation,
+      payload.config,
+      mcpIdentity,
     );
     const structuredSession = await this.createStructuredSession(
       adapter,
@@ -213,6 +222,7 @@ export class SpawnPipeline {
       browserMcp,
       subagentMcp,
       computerUse,
+      chromeMcp,
       mcpIdentity,
       payload.sessionRef,
       requestedPresentation,
@@ -344,6 +354,7 @@ export class SpawnPipeline {
       browserMcp,
       subagentMcp,
       computerUse,
+      chromeMcp,
     );
     const argv = payload.sessionRef
       ? adapter.buildResumeArgv(
@@ -375,6 +386,7 @@ export class SpawnPipeline {
       payload.config,
       browserMcp,
       computerUse,
+      chromeMcp,
     );
     if (cliHookExtras.extraArgs.length > 0) {
       argv.args = mergeCliHookExtraArgs(
@@ -491,10 +503,11 @@ export class SpawnPipeline {
       config,
     );
     const computerUse = this.resolveComputerUseMcpForLaunch(
-      session.adapter,
       session.projectLocation,
       config,
+      mcpIdentity,
     );
+    const chromeMcp = this.resolveChromeMcpForLaunch(session.projectLocation, config, mcpIdentity);
     const structuredSession = await this.createStructuredSession(
       session.adapter,
       session.threadId,
@@ -504,6 +517,7 @@ export class SpawnPipeline {
       browserMcp,
       subagentMcp,
       computerUse,
+      chromeMcp,
       mcpIdentity,
       session.sessionRef,
       session.presentationMode,
@@ -577,6 +591,7 @@ export class SpawnPipeline {
       config,
       browserMcp,
       computerUse,
+      chromeMcp,
     );
     if (!ctx.isCurrentSession(session)) {
       await structuredSession?.dispose();
@@ -593,6 +608,7 @@ export class SpawnPipeline {
         browserMcp,
         subagentMcp,
         computerUse,
+        chromeMcp,
       ),
     );
     if (cliHookExtras.extraArgs.length > 0) {
@@ -950,6 +966,7 @@ export class SpawnPipeline {
     browserMcp: BrowserMcpHttpConfig | undefined,
     subagentMcp: SubagentMcpHttpConfig | undefined,
     computerUse: ComputerUseMcpHttpConfig | undefined,
+    chromeMcp: ChromeMcpHttpConfig | undefined,
   ): AgentLaunchOptions {
     return {
       ...(launchOptions ?? {}),
@@ -957,6 +974,7 @@ export class SpawnPipeline {
       ...(browserMcp !== undefined ? { browserMcp } : {}),
       ...(subagentMcp !== undefined ? { subagentMcp } : {}),
       ...(computerUse !== undefined ? { computerUseMcp: computerUse } : {}),
+      ...(chromeMcp !== undefined ? { chromeMcp } : {}),
     };
   }
 
@@ -986,12 +1004,28 @@ export class SpawnPipeline {
    * `resolveBrowserMcpForLaunch`.
    */
   resolveComputerUseMcpForLaunch(
-    _adapter: AgentAdapter,
     location: ProjectLocation,
     config: ThreadConfig,
+    identity?: McpThreadIdentity,
   ): ComputerUseMcpHttpConfig | undefined {
     const enabled = config.computerUse === true;
-    return resolveComputerUseMcpHttpConfigForLaunch(location, enabled);
+    return resolveComputerUseMcpHttpConfigForLaunch(location, enabled, identity);
+  }
+
+  /**
+   * Resolve the external-Chrome MCP http config for a launch when the thread
+   * opted in (`config.chromeMcp === true`). Mirrors
+   * {@link resolveComputerUseMcpForLaunch}: the per-thread config flag is
+   * authoritative (scope gating lives in the renderer) and the resolver declines
+   * for WSL projects by design.
+   */
+  resolveChromeMcpForLaunch(
+    location: ProjectLocation,
+    config: ThreadConfig,
+    identity?: McpThreadIdentity,
+  ): ChromeMcpHttpConfig | undefined {
+    const enabled = config.chromeMcp === true;
+    return resolveChromeMcpHttpConfigForLaunch(location, enabled, identity);
   }
 
   /**
@@ -1057,6 +1091,7 @@ export class SpawnPipeline {
     browserMcp: BrowserMcpHttpConfig | undefined,
     subagentMcp: SubagentMcpHttpConfig | undefined,
     computerUse: ComputerUseMcpHttpConfig | undefined,
+    chromeMcp: ChromeMcpHttpConfig | undefined,
     mcpIdentity: McpThreadIdentity | undefined,
     sessionRef?: SessionRef,
     presentationMode?: ThreadPresentationMode,
@@ -1074,6 +1109,7 @@ export class SpawnPipeline {
         ...(browserMcp ? { browserMcp } : {}),
         ...(subagentMcp ? { subagentMcp } : {}),
         ...(computerUse ? { computerUseMcp: computerUse } : {}),
+        ...(chromeMcp ? { chromeMcp } : {}),
         ...(sessionRef ? { sessionRef } : {}),
         ...(presentationMode ? { presentationMode } : {}),
       });

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -935,12 +935,18 @@ export class ThreadSessionManager {
         session.projectLocation,
         session.config,
       );
+      const computerUse = this.spawnPipeline.resolveComputerUseMcpForLaunch(
+        session.adapter,
+        session.projectLocation,
+        session.config,
+      );
       const cliHookExtras = await this.cliHookPlugin.resolveCliHookPluginExtras(
         session.threadId,
         session.agentKind,
         session.projectLocation,
         session.config,
         browserMcp,
+        computerUse,
       );
       if (!this.isCurrentSession(session)) {
         return;
@@ -955,6 +961,7 @@ export class ThreadSessionManager {
           undefined,
           browserMcp,
           subagentMcp,
+          computerUse,
         ),
       );
       if (cliHookExtras.extraArgs.length > 0) {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -936,9 +936,14 @@ export class ThreadSessionManager {
         session.config,
       );
       const computerUse = this.spawnPipeline.resolveComputerUseMcpForLaunch(
-        session.adapter,
         session.projectLocation,
         session.config,
+        { threadId: session.threadId },
+      );
+      const chromeMcp = this.spawnPipeline.resolveChromeMcpForLaunch(
+        session.projectLocation,
+        session.config,
+        { threadId: session.threadId },
       );
       const cliHookExtras = await this.cliHookPlugin.resolveCliHookPluginExtras(
         session.threadId,
@@ -947,6 +952,7 @@ export class ThreadSessionManager {
         session.config,
         browserMcp,
         computerUse,
+        chromeMcp,
       );
       if (!this.isCurrentSession(session)) {
         return;
@@ -962,6 +968,7 @@ export class ThreadSessionManager {
           browserMcp,
           subagentMcp,
           computerUse,
+          chromeMcp,
         ),
       );
       if (cliHookExtras.extraArgs.length > 0) {


### PR DESCRIPTION
## Summary
Revives **PR #142** ("Add computer-use MCP for desktop control across providers"), which had drifted ~193 commits behind `next`, ports it onto the current runtime, live-probes it on a real Windows 11 host, and hardens it through a 5-dimension adversarial review + two executor rounds. Result: an **opt-in, per-thread** capability letting an agent see and drive native desktop apps (screenshots, window enumeration, mouse/keyboard/scroll/drag, launch) over a **localhost-only** MCP server, wired uniformly across every provider.

Three commits: baseline port → correctness/security hardening → performance.

## Architecture
- **Main process** `src/main/computer-use/`: `ComputerUseMcpIngress` (localhost HTTP MCP, binds `127.0.0.1` only) + platform drivers `windows.ts` (persistent PowerShell 5.1 + inline C#/P-Invoke host) and `macos.ts` (osascript/JXA). Shared transport `src/main/mcp/StreamableHttpMcpIngress.ts`.
- **Supervisor**: `computerUseMcp/index.ts` resolves per-launch HTTP config; per-provider `*/mcpComputerUse.ts` builders wire claude/codex/gemini/opencode + all ACP providers; threaded through the refactored `threadSession/` spawn pipeline (start/resume/recovery, structured + terminal + ACP).
- **Renderer**: composer opt-in (chip + add-menu + `@computer` mention), disabled for WSL; localized across all 12 catalogs.

## Problems found & decisions
1. **Refactor gap** — PR's launch plumbing lived in the old monolithic `threadSessionManager`; re-expressed in the new `threadSession/*` modules mirroring `browserMcp`, full parity across start/resume/recovery + ACP + CLI-hook.
2. **Security (P0)** — the computer-use token leaked into every child process env (opt-in was cosmetic). Scoped it: stripped from the base spawn env, injected per-launch only when `config.computerUse === true`; all 5 providers verified. Also: platform-gate the ingress (no Linux exposure), constant-time token compare, Host-header allow-list.
3. **Activation reliability** — bare `SetForegroundWindow` is refused by the Windows foreground-lock, silently dropping all input. Replaced with `AllowSetForegroundWindow(ASFW_ANY)` + alt-key + `AttachThreadInput` + retry, and **verify foreground before sending input** (fail fast). Probe-validated.
4. **`SW_RESTORE` un-maximized windows** → wrong click coords. Only restore if minimized; re-capture rect after activation.
5. **Input correctness** — `press_key` typed lowercase (dropped VkKeyScan shift bit); emoji surrogate-pair fragmentation; non-DPI-aware; stuck modifiers on crash; coordinate coercion to (0,0). All fixed and live-tested.
6. **macOS parity** (flagged for on-device verification) — `click` ignored `mouse_button` (silent left-click), `scroll` dropped `scrollX`, Retina pixel/point mismatch, geometry-hashed window id changed on move.
7. **Agent ergonomics** — removed two always-failing tools (`set_value`/`perform_secondary_action`) and never-populated accessibility fields; documented coordinate origin + window-refresh recovery; `get_window` now requires `app`.
8. **Speed** — the driver recompiled the inline C# shim on every call (~300ms of ~425ms/action). Replaced with a **long-lived PowerShell host** (compile once, NDJSON over stdin, correlated request queue, per-request timeout + kill/respawn, crash recovery, disposal on teardown). **Steady-state ~75ms/action (~40× faster on cheap ops).** Screenshots gained `max_dimension` (1280) + `format` (jpeg default): a large capture went **9.5MB → 80KB (99.2% smaller)**.

## Live-test evidence (real Win11 host)
Activation reaches a different-process window; `press_key "A"`→`A`, `!`→`!`, `ctrl+a` select-all; `ab😀cd` emoji intact; `launch_app` resolves the new window; UNC/URL launch rejected; persistent host serves concurrent NDJSON requests and recovers from a mid-session kill.

## Deferred (documented)
Per-capture consent/allow-list for sensitive windows (product UX decision); full UIAutomation/AX tree (current tree is an honest placeholder); browser/chrome token env scoping (same pre-existing pattern, out of scope); macOS on-device verification.

## Known limitation
Activating a few specific apps (Character Map, store Notepad, Windows Terminal) destroys their window handle at the OS level — confirmed **pre-existing** `Activate-Window` behavior, not introduced here. Ordinary apps are unaffected.

## Verification
`tsc` 0, `lint` 0, i18n 12/12 catalogs 0-missing, **4661 tests passing**. Windows driver behaviors live-tested with screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
