### PR TITLE
Fix ACP tool-call labeling and deferred rendering

### DIFF
--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -91,6 +91,54 @@ describe("chatPaneSelectors", () => {
     expect(selectVisibleThreadRuntimeItemIds(state, "t1")).toEqual(["assistant-1", "assistant-2"]);
   });
 
+  it("defers unnamed tool calls until an update provides a display name", () => {
+    const itemIds = ["assistant-1", "tool-1"];
+    const unnamedItems = {
+      "assistant-1": {
+        id: "assistant-1",
+        type: "assistant_message",
+        state: "completed",
+        streams: { assistant_text: "before" },
+      },
+      "tool-1": {
+        id: "tool-1",
+        type: "tool_call",
+        state: "started",
+        payload: { status: "running" },
+        streams: {},
+      },
+    };
+    const unnamedState = {
+      runtimeItemIdsByThread: { deferred: itemIds },
+      runtimeItemsByIdByThread: { deferred: unnamedItems },
+      runtimeStructuralVersionByThread: { deferred: 1 },
+    } as unknown as AppStoreState;
+    const namedState = {
+      ...unnamedState,
+      runtimeItemsByIdByThread: {
+        deferred: {
+          ...unnamedItems,
+          "tool-1": {
+            ...unnamedItems["tool-1"],
+            state: "updated",
+            payload: { name: "Read", status: "running" },
+          },
+        },
+      },
+      runtimeStructuralVersionByThread: { deferred: 2 },
+    } as unknown as AppStoreState;
+
+    expect(selectVisibleThreadRuntimeItemIds(unnamedState, "deferred")).toEqual(["assistant-1"]);
+    expect(selectVisibleThreadTimelineEntries(unnamedState, "deferred")).toEqual([
+      { kind: "item", id: "assistant-1" },
+    ]);
+    expect(selectVisibleThreadRuntimeItemIds(namedState, "deferred")).toEqual(itemIds);
+    expect(selectVisibleThreadTimelineEntries(namedState, "deferred")).toEqual([
+      { kind: "item", id: "assistant-1" },
+      { kind: "item", id: "tool-1" },
+    ]);
+  });
+
   it("groups adjacent tool calls into one timeline entry", () => {
     const state = {
       runtimeItemIdsByThread: {

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -241,6 +241,17 @@ function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {
   // null for `error`); excluding them here keeps the virtualized list from
   // allocating an empty slot that shows up as a gap.
   if (item.type === "error") return false;
+  // Tool renderers defer rows without a name. Keep those incomplete calls out
+  // of the virtualized timeline and group counts until a later update names them.
+  if (
+    (item.type === "tool_call" ||
+      item.type === "mcp_tool_call" ||
+      item.type === "image_view" ||
+      item.type === "dynamic_tool_call") &&
+    !(item.payload as Partial<ToolCallPayload> | undefined)?.name?.trim()
+  ) {
+    return false;
+  }
   // The raw provider MCP row for the subagents `run_agent` / `spawn_agent`
   // tools duplicates the synthetic sub-agent tile (`payload.isSubAgent` item,
   // which is NOT matched here). Suppress the raw row so it doesn't render next

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -191,6 +191,134 @@ describe("mapAcpSessionUpdate", () => {
     expect(state.toolCallItems.has("tc-1")).toBe(false);
   });
 
+  it("omits `name` on a bare tool_call so the renderer defers the unnamed row", () => {
+    const state = createAcpMapperState("t-bare");
+    const started = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-bare",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(started[0]?.type).toBe("item.started");
+    const payload = (started[0] as { payload: Record<string, unknown> }).payload;
+    expect(payload.name).toBeUndefined();
+  });
+
+  it("keeps a kind-derived name when only `kind` is present on the initial event", () => {
+    const state = createAcpMapperState("t-kindname");
+    const started = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-k",
+        kind: "read",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect((started[0] as { payload: Record<string, unknown> }).payload.name).toBe("read");
+  });
+
+  it("falls back to a generic name when a bare tool_call completes without ever being named", () => {
+    const state = createAcpMapperState("t-bare-complete");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-x",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const completed = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-x",
+        status: "completed",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(completed[0]?.type).toBe("item.completed");
+    expect((completed[0] as { payload: Record<string, unknown> }).payload.name).toBe("Tool");
+  });
+
+  it("names a single-shot completed bare tool_call with the generic fallback", () => {
+    const state = createAcpMapperState("t-single");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-s",
+        status: "completed",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const completed = events.find((e) => e.type === "item.completed");
+    expect((completed as { payload: Record<string, unknown> }).payload.name).toBe("Tool");
+  });
+
+  it("names an orphaned bare tool_call when the turn ends", () => {
+    const state = createAcpMapperState("t-orphan");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-o",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const closed = closeOpenTurnItems(state);
+    const completed = closed.find((e) => e.type === "item.completed");
+    expect((completed as { payload: Record<string, unknown> }).payload.name).toBe("Tool");
+  });
+
+  it("sets the name from a kind-only update when the tool call has no name yet", () => {
+    const state = createAcpMapperState("t-kindupd");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-ku",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const updated = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-ku",
+        kind: "read",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect((updated[0] as { payload: Record<string, unknown> }).payload.name).toBe("read");
+    expect(state.toolCallItems.get("tc-ku")?.payload.name).toBe("read");
+  });
+
+  it("does not let a kind-only update overwrite a title-derived name", () => {
+    const state = createAcpMapperState("t-merge");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-m",
+        title: "Read config",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const updated = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-m",
+        kind: "read",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    // The kind-only update must not carry a name that would clobber the title.
+    expect((updated[0] as { payload: Record<string, unknown> }).payload.name).toBeUndefined();
+    expect(state.toolCallItems.get("tc-m")?.payload.name).toBe("Read config");
+  });
+
   it("preserves generic ACP Skill and MCP tool names for Grok and Factory-style adapters", () => {
     const state = createAcpMapperState("t-generic-tools");
 

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -12,6 +12,7 @@ import {
 import { parseAcpAgentMessageApiError } from "../acpUserVisibleErrors";
 import { classifyToolCallItemType } from "./contentExtraction";
 import {
+  applyTerminalToolCallName,
   buildAcpToolCallPayload,
   buildAcpToolCallUpdatePayload,
   finalizeToolCallPayload,
@@ -312,8 +313,12 @@ export function mapAcpSessionUpdate(
             },
           })
         : payload;
-      const mergedPayload = mergeToolPayload(item.payload, nextPayload);
-      const emittedPayload = mergeProgressForEmission(nextPayload, mergedPayload);
+      const mergedRaw = mergeToolPayload(item.payload, nextPayload);
+      const emittedRaw = mergeProgressForEmission(nextPayload, mergedRaw);
+      // On completion, guarantee a name so a bare tool call can't finish hidden.
+      const { merged: mergedPayload, emitted: emittedPayload } = isTerminal
+        ? applyTerminalToolCallName(mergedRaw, emittedRaw)
+        : { merged: mergedRaw, emitted: emittedRaw };
       item.payload = mergedPayload;
       events.push({
         type: isTerminal ? "item.completed" : "item.updated",

--- a/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
@@ -49,12 +49,18 @@ export function buildAcpToolCallPayload(
   const title = normalizeToolText(toolCall.title);
   const kind = normalizeToolText(toolCall.kind);
   const locations = extractToolLocations(toolCall.locations);
-  const name = title ?? kind ?? "tool";
+  // Only carry a `name` when we actually have one. A bare ACP `tool_call`
+  // (neither `title` nor `kind`, e.g. Cursor's near-empty initial events) must
+  // NOT fabricate a `"tool"` sentinel — that defeats the renderer's
+  // `!payload.name` hide-unnamed guards and paints an anonymous accordion row.
+  // Omitting `name` defers the row until a later update carries a real label;
+  // finalization (`finalizeToolCallPayload`) guarantees it never stays nameless.
+  const name = title ?? kind;
   const contentResult = extractToolCallContentText(toolCall.content, resolveTerminalOutput);
   const images = extractToolCallContentImages(toolCall.content);
   const subAgentModel = isSubAgent ? readStringField(toolCall.rawInput, "model") : undefined;
   const base: Record<string, unknown> = {
-    name,
+    ...(name ? { name } : {}),
     args: toolCall.rawInput,
     status,
     ...(contentResult !== undefined ? { result: contentResult } : {}),
@@ -108,8 +114,8 @@ export function buildAcpToolCallPayload(
     };
   }
   if (itemType === "web_search") {
-    const query = readStringField(toolCall.rawInput, "query") ?? title ?? kind ?? name;
-    return { ...base, query };
+    const query = readStringField(toolCall.rawInput, "query") ?? title ?? kind;
+    return { ...base, ...(query ? { query } : {}) };
   }
   return base;
 }
@@ -154,11 +160,16 @@ export function buildAcpToolCallUpdatePayload(
     payload: item.payload,
     resolveTerminalOutputByCommand,
   });
+  // Never let a kind-only update clobber a better title-derived name. A `title`
+  // always wins; a bare `kind` only sets the name when the tracked item has none
+  // yet (Cursor emits `title`/`kind` piecemeal across updates, and a late `kind`
+  // must not overwrite the human label an earlier `title` already established).
+  const nameUpdate = title ?? (kind && !hasToolCallName(item.payload) ? kind : undefined);
   const payload: Record<string, unknown> = {
     status,
     ...(result !== undefined ? { result } : {}),
     ...(images.length > 0 ? { images } : {}),
-    ...(title || kind ? { name: title ?? kind } : {}),
+    ...(nameUpdate ? { name: nameUpdate } : {}),
     ...(title ? { title } : {}),
     ...(kind ? { kind } : {}),
     ...(locations.length > 0 ? { locations } : {}),
@@ -213,14 +224,57 @@ export function finalizeToolCallPayload(
   state: AcpMapperState,
   item: AcpToolCallItemState,
 ): Record<string, unknown> {
-  if (item.itemType !== "command_execution" || item.payload.result !== undefined) {
-    return item.payload;
+  // A finalized tool call must never remain nameless — the renderer hides
+  // unnamed rows, so a bare ACP call that completes (or is orphaned when the
+  // turn ends) without ever receiving a title/kind would silently vanish.
+  const payload = ensureToolCallName(item.payload);
+  if (item.itemType !== "command_execution" || payload.result !== undefined) {
+    return payload;
   }
   const result = resolveTerminalOutputForCommandPayload(
-    item.payload,
+    payload,
     state.resolveTerminalOutputByCommand,
   );
-  return result !== undefined ? { ...item.payload, result } : item.payload;
+  return result !== undefined ? { ...payload, result } : payload;
+}
+
+const GENERIC_TOOL_NAME = "Tool";
+
+/** Whether a payload already carries a usable (non-empty) `name`. */
+export function hasToolCallName(payload: Record<string, unknown>): boolean {
+  return typeof payload.name === "string" && payload.name.trim().length > 0;
+}
+
+/**
+ * Generic display name for a tool call that reached a terminal state without a
+ * title or kind-derived name. Prefer the tool `kind` if one was ever seen, else
+ * a capitalized generic label the renderer surfaces verbatim (no new
+ * user-facing literal is introduced in the renderer — this originates in the
+ * macro-free supervisor).
+ */
+function toolCallFallbackName(payload: Record<string, unknown>): string {
+  const kind = normalizeToolText(typeof payload.kind === "string" ? payload.kind : undefined);
+  return kind ?? GENERIC_TOOL_NAME;
+}
+
+/** Return `payload` with a guaranteed `name`, falling back when it has none. */
+export function ensureToolCallName(payload: Record<string, unknown>): Record<string, unknown> {
+  return hasToolCallName(payload) ? payload : { ...payload, name: toolCallFallbackName(payload) };
+}
+
+/**
+ * Apply the terminal fallback name to a completing tool call's merged/emitted
+ * payload pair (the `tool_call_update` completion path bypasses
+ * `finalizeToolCallPayload`). Ensures both the tracked state and the emitted
+ * `item.completed` payload carry a name so the row can't finish hidden.
+ */
+export function applyTerminalToolCallName(
+  merged: Record<string, unknown>,
+  emitted: Record<string, unknown>,
+): { merged: Record<string, unknown>; emitted: Record<string, unknown> } {
+  if (hasToolCallName(merged)) return { merged, emitted };
+  const name = toolCallFallbackName(merged);
+  return { merged: { ...merged, name }, emitted: { ...emitted, name } };
 }
 
 /** Close any open assistant/user/reasoning/tool-call/plan items as a turn boundary. */

--- a/src/supervisor/agents/cursor/acpTransform.test.ts
+++ b/src/supervisor/agents/cursor/acpTransform.test.ts
@@ -202,6 +202,65 @@ describe("transformCursorAcpSessionUpdate", () => {
     expect(input).toEqual(original);
   });
 
+  it("derives a title and kind from `rawInput._toolName` when title/kind are absent", () => {
+    const input = toolCall({ rawInput: { _toolName: "read_file", path: "a.ts" } });
+    const update = transformCursorAcpSessionUpdate(input).update as {
+      title?: unknown;
+      kind?: unknown;
+    };
+    expect(update.title).toBe("Read file");
+    expect(update.kind).toBe("read");
+  });
+
+  it("maps a `grep` _toolName to the search kind", () => {
+    const input = toolCall({ rawInput: { _toolName: "grep" } });
+    const update = transformCursorAcpSessionUpdate(input).update as {
+      title?: unknown;
+      kind?: unknown;
+    };
+    expect(update.title).toBe("Grep");
+    expect(update.kind).toBe("search");
+  });
+
+  it("does not overwrite an existing title/kind from _toolName", () => {
+    const input = toolCall({
+      title: "Reading config",
+      kind: "read",
+      rawInput: { _toolName: "grep" },
+    });
+    const update = transformCursorAcpSessionUpdate(input).update as {
+      title?: unknown;
+      kind?: unknown;
+    };
+    expect(update.title).toBe("Reading config");
+    expect(update.kind).toBe("read");
+  });
+
+  it("leaves the notification untouched when there is no _toolName to recover", () => {
+    const input = toolCall({ rawInput: {} });
+    expect(transformCursorAcpSessionUpdate(input)).toBe(input);
+  });
+
+  it("humanizes an unknown _toolName as a title but leaves kind unset", () => {
+    const input = toolCall({ rawInput: { _toolName: "fetch_web_page" } });
+    const update = transformCursorAcpSessionUpdate(input).update as {
+      title?: unknown;
+      kind?: unknown;
+    };
+    expect(update.title).toBe("Fetch web page");
+    expect(update.kind).toBeUndefined();
+  });
+
+  it("preserves a namespaced MCP _toolName so the renderer can identify the server", () => {
+    const input = toolCall({ rawInput: { _toolName: "mcp__github__search_issues" } });
+    const update = transformCursorAcpSessionUpdate(input).update as {
+      title?: unknown;
+      kind?: unknown;
+    };
+    expect(update.title).toBe("mcp__github__search_issues");
+    expect(update.kind).toBeUndefined();
+  });
+
   it("also rewrites rawOutput on a single-shot completed `tool_call`", () => {
     const input = toolCall({
       kind: "execute",

--- a/src/supervisor/agents/cursor/acpTransform.ts
+++ b/src/supervisor/agents/cursor/acpTransform.ts
@@ -10,17 +10,17 @@
  * "View shows {content: …}" / "git diff result empty" / "grep result {totalMatches:N}"
  * symptoms come from.
  *
- * This module is the Cursor adapter's bridge. It rewrites the structured
- * `rawOutput` into a text representation the renderer's existing extractors
- * already handle correctly (string results → `asPart` → plain/JSON/diff
- * detection). It is wired only into the Cursor adapter's
- * `createStructuredSession()` and never touches shared mapping code.
+ * This module is the Cursor adapter's bridge. It recovers missing tool labels
+ * from Cursor metadata and rewrites structured `rawOutput` into a text
+ * representation the renderer's existing extractors already handle correctly
+ * (string results → `asPart` → plain/JSON/diff detection). It is wired only into
+ * the Cursor adapter's `createStructuredSession()` and never touches shared
+ * mapping code.
  *
  * The transform is intentionally narrow:
  *  - It only mutates `tool_call` / `tool_call_update` notifications.
- *  - It only rewrites `rawOutput`; `rawInput`, `kind`, `title`, and `locations`
- *    pass through untouched, so Cursor never sends those, the title stays a
- *    generic `View` / `Run` / `Search` / `Edit` — there is nothing to recover.
+ *  - It preserves provider fields except for recovered task metadata, missing
+ *    `title`/`kind`, and formatted `rawOutput`.
  *  - It is pure (no IO, no state) and never throws.
  */
 
@@ -34,7 +34,7 @@ export function transformCursorAcpSessionUpdate(
   if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
     return notification;
   }
-  const enriched = enrichCursorTaskToolCall(update);
+  const enriched = enrichCursorToolCall(update);
   const rawOutput = (enriched as { rawOutput?: unknown }).rawOutput;
   if (!isPlainRecord(rawOutput)) {
     return enriched === update ? notification : { ...notification, update: enriched };
@@ -48,6 +48,82 @@ export function transformCursorAcpSessionUpdate(
     ...notification,
     update: { ...enriched, rawOutput: replacement } as SessionNotification["update"],
   };
+}
+
+function enrichCursorToolCall(
+  update: SessionNotification["update"],
+): SessionNotification["update"] {
+  return enrichCursorToolCallLabel(enrichCursorTaskToolCall(update));
+}
+
+/**
+ * Cursor's near-empty initial `tool_call` events frequently omit both `title`
+ * and `kind`, but carry the real tool identity on `rawInput._toolName`
+ * (e.g. `"read_file"`, `"grep"`). Without a label the shared mapper would emit a
+ * nameless (now deferred/hidden) row until a later update fills it in — so
+ * derive an immediate human title, and a canonical `kind` for a confident set of
+ * tool names so `classifyToolCallItemType` picks the right row type/icon. This
+ * is provider-specific: `_toolName` never leaks into shared ACP code. A
+ * pre-existing meaningful `title`/`kind` is always preserved.
+ */
+function enrichCursorToolCallLabel(
+  update: SessionNotification["update"],
+): SessionNotification["update"] {
+  const tool = update as { title?: unknown; kind?: unknown; rawInput?: unknown };
+  const rawInput = tool.rawInput;
+  if (!isPlainRecord(rawInput)) return update;
+  const toolName = readString(rawInput._toolName);
+  if (!toolName) return update;
+  const derivedTitle = readString(tool.title) ? undefined : humanizeCursorToolName(toolName);
+  const derivedKind = readString(tool.kind) ? undefined : cursorKindFromToolName(toolName);
+  if (!derivedTitle && !derivedKind) return update;
+  return {
+    ...update,
+    ...(derivedTitle ? { title: derivedTitle } : {}),
+    ...(derivedKind ? { kind: derivedKind } : {}),
+  } as SessionNotification["update"];
+}
+
+/** Humanize a Cursor tool name while preserving MCP namespace identity. */
+function humanizeCursorToolName(name: string): string {
+  if (/^mcp__.+?__.+$/.test(name) || /^.+?-mcp-server-.+$/.test(name)) return name;
+  const spaced = name.replace(/[_-]+/g, " ").trim();
+  if (spaced.length === 0) return name;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Map a confident subset of Cursor `_toolName`s to a canonical ACP tool `kind`
+ * so the row gets the right type/icon before real metadata arrives. Anything
+ * uncertain is left unset (the mapper falls back to the generic bucket).
+ */
+function cursorKindFromToolName(name: string): string | undefined {
+  switch (name.toLowerCase()) {
+    case "read":
+    case "read_file":
+      return "read";
+    case "grep":
+    case "grep_search":
+    case "glob":
+    case "file_search":
+    case "codebase_search":
+    case "list_dir":
+      return "search";
+    case "shell":
+    case "bash":
+    case "terminal":
+    case "run_terminal_cmd":
+      return "execute";
+    case "edit_file":
+    case "write":
+    case "create_file":
+    case "search_replace":
+      return "edit";
+    case "delete_file":
+      return "delete";
+    default:
+      return undefined;
+  }
 }
 
 function enrichCursorTaskToolCall(


### PR DESCRIPTION
- Bugfix with a small provider-adapter follow-up: Cursor and ACP tool calls now recover missing labels instead of rendering anonymous rows.
- Defer unnamed tool-call rows in the chat timeline until a later update provides a display name, so incomplete calls do not appear as blank entries.
- Preserve and finalize tool names more carefully across ACP mapping updates, including bare completions and kind/title recovery.
- Add coverage for the renderer selector behavior and the ACP/Cursor transformation edge cases this fix depends on.