### PR TITLE
Show inline reasoning previews while streaming

### DIFF
--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -209,6 +209,60 @@ describe("chatPaneSelectors", () => {
     ]);
   });
 
+  it("folds reasoning items into adjacent tool-call groups", () => {
+    const state = {
+      runtimeItemIdsByThread: {
+        t1: ["reasoning-1", "tool-1", "command-1", "assistant-1", "reasoning-2"],
+      },
+      runtimeItemsByIdByThread: {
+        t1: {
+          "reasoning-1": {
+            id: "reasoning-1",
+            type: "reasoning",
+            state: "completed",
+            streams: { reasoning_text: "planning the change" },
+          },
+          "tool-1": {
+            id: "tool-1",
+            type: "tool_call",
+            state: "completed",
+            payload: { name: "Viewing src/a.ts", status: "success" },
+            streams: {},
+          },
+          "command-1": {
+            id: "command-1",
+            type: "command_execution",
+            state: "completed",
+            payload: { command: "pnpm run lint" },
+            streams: {},
+          },
+          "assistant-1": {
+            id: "assistant-1",
+            type: "assistant_message",
+            state: "completed",
+            streams: { assistant_text: "done" },
+          },
+          "reasoning-2": {
+            id: "reasoning-2",
+            type: "reasoning",
+            state: "updated",
+            streams: { reasoning_text: "wrapping up" },
+          },
+        },
+      },
+    } as unknown as AppStoreState;
+
+    expect(selectVisibleThreadTimelineEntries(state, "t1")).toEqual([
+      {
+        kind: "tool_call_group",
+        id: "tool-call-group:reasoning-1",
+        itemIds: ["reasoning-1", "tool-1", "command-1"],
+      },
+      { kind: "item", id: "assistant-1" },
+      { kind: "item", id: "reasoning-2" },
+    ]);
+  });
+
   it("keeps active Workflow tool calls as standalone background items", () => {
     const state = {
       runtimeItemIdsByThread: {

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -193,6 +193,9 @@ function isToolGroupItem(item: RuntimeChatItem): boolean {
     item.type === "mcp_tool_call" ||
     item.type === "image_view" ||
     item.type === "dynamic_tool_call" ||
+    // Reasoning folds into the group like any other tool row: expanded and
+    // streaming while the model thinks, collapsed to a "Thought" row after.
+    item.type === "reasoning" ||
     item.type === "command_execution" ||
     item.type === "file_change" ||
     item.type === "web_search"

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -6,8 +6,10 @@ import type { AppStoreState } from "@/renderer/state/slices/shared";
 import type { ToolCallPayload } from "@/shared/contracts";
 import { canShareRuntimeToolGroup } from "@/renderer/state/runtimeToolGrouping";
 import { imageViewRendersInline } from "./parts/items/imageViewSource";
-import { isContextCompactionToolCall } from "./parts/items/ContextCompaction";
-import { isPlanProposalToolCall } from "./parts/items/PlanProposal";
+import {
+  isToolGroupItem as isGroupableItemType,
+  isToolLikeItem,
+} from "./parts/items/toolCallCategorization";
 import { isSubAgentTool, isWorkflowTool } from "./parts/items/toolDisplay";
 
 export const EMPTY_THREAD_ITEM_IDS = Object.freeze([]) as readonly string[];
@@ -167,8 +169,6 @@ export function selectVisibleThreadTimelineEntries(
 }
 
 function isToolGroupItem(item: RuntimeChatItem): boolean {
-  if (isContextCompactionToolCall(item)) return false;
-  if (isPlanProposalToolCall(item)) return false;
   // Sub-agent parents render as their own pill (with overlay) — never fold
   // them into a tool-call group.
   if (item.type === "tool_call" && isSubAgentTool(item.payload as ToolCallPayload | undefined)) {
@@ -179,27 +179,12 @@ function isToolGroupItem(item: RuntimeChatItem): boolean {
   // to the generic accordion (still running, errored, or non-image) keep the
   // default grouping — `imageViewRendersInline` mirrors ImageView's render
   // decision so the two never disagree.
-  if (
-    (item.type === "tool_call" ||
-      item.type === "mcp_tool_call" ||
-      item.type === "image_view" ||
-      item.type === "dynamic_tool_call") &&
-    imageViewRendersInline(item.payload)
-  ) {
+  if (isToolLikeItem(item) && imageViewRendersInline(item.payload)) {
     return false;
   }
-  return (
-    item.type === "tool_call" ||
-    item.type === "mcp_tool_call" ||
-    item.type === "image_view" ||
-    item.type === "dynamic_tool_call" ||
-    // Reasoning folds into the group like any other tool row: expanded and
-    // streaming while the model thinks, collapsed to a "Thought" row after.
-    item.type === "reasoning" ||
-    item.type === "command_execution" ||
-    item.type === "file_change" ||
-    item.type === "web_search"
-  );
+  // The groupable type set (tools, reasoning, commands, edits, searches) lives
+  // in toolCallCategorization so it is maintained in one place.
+  return isGroupableItemType(item);
 }
 
 /**
@@ -226,13 +211,22 @@ export function selectChatScrollAnchorForTimeline(
   if (!lastId) return "";
   const last = items?.[lastId];
   if (!last) return "";
-  const streamLen =
-    (last.streams.assistant_text?.length ?? 0) +
-    (last.streams.reasoning_text?.length ?? 0) +
-    (last.streams.plan_text?.length ?? 0) +
-    (last.streams.command_output?.length ?? 0) +
-    (last.streams.file_change_output?.length ?? 0);
-  return `${last.id}:${streamLen}:${last.state}`;
+  return `${last.id}:${growingStreamLength(last)}:${last.state}`;
+}
+
+/**
+ * Total length of an item's growing stream fields — the single encoding of
+ * "which streams make a row taller as they arrive", shared by the scroll
+ * anchor above and the virtualizer's live-measure token in MessageList.
+ */
+export function growingStreamLength(item: RuntimeChatItem): number {
+  return (
+    (item.streams.assistant_text?.length ?? 0) +
+    (item.streams.reasoning_text?.length ?? 0) +
+    (item.streams.plan_text?.length ?? 0) +
+    (item.streams.command_output?.length ?? 0) +
+    (item.streams.file_change_output?.length ?? 0)
+  );
 }
 
 function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -20,6 +20,7 @@ import {
 import { formatElapsed } from "../formatElapsed";
 import { useChatPaneActions } from "../chatPaneActionsContext";
 import {
+  growingStreamLength,
   selectCompletedTurnForEntry,
   selectRuntimeItemById,
   type ChatTimelineEntry,
@@ -529,8 +530,10 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
         if (entry.kind === "item") return liveStreamMeasureToken(items?.[entry.id]);
         // A live tool-call group can hold a streaming row (e.g. reasoning
         // expanded while the model thinks) that grows the virtualized row.
-        for (const itemId of entry.itemIds) {
-          const token = liveStreamMeasureToken(items?.[itemId]);
+        // Scan from the tail — the streaming row is the newest, so the loop
+        // short-circuits without walking the completed rows above it.
+        for (let i = entry.itemIds.length - 1; i >= 0; i -= 1) {
+          const token = liveStreamMeasureToken(items?.[entry.itemIds[i]!]);
           if (token !== null) return token;
         }
         return null;
@@ -646,18 +649,7 @@ function isLastTimelineEntryAssistantMessage(
  */
 function liveStreamMeasureToken(item: RuntimeChatItem | undefined): string | null {
   if (!item || item.state === "completed") return null;
-  switch (item.type) {
-    case "assistant_message":
-      return `${item.id}:${item.state}:${item.streams.assistant_text?.length ?? 0}`;
-    case "reasoning":
-      return `${item.id}:${item.state}:${item.streams.reasoning_text?.length ?? 0}`;
-    case "command_execution":
-      return `${item.id}:${item.state}:${item.streams.command_output?.length ?? 0}`;
-    case "file_change":
-      return `${item.id}:${item.state}:${item.streams.file_change_output?.length ?? 0}`;
-    default:
-      return `${item.id}:${item.state}`;
-  }
+  return `${item.id}:${item.state}:${growingStreamLength(item)}`;
 }
 
 function estimateTimelineEntrySize(entry: ChatTimelineEntry | undefined, threadId: string): number {

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import {
   getRuntimeItemPayload,
   type CompletedTurnRecord,
+  type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import type { AppStoreState } from "@/renderer/state/slices/shared";
 import {
@@ -521,29 +522,24 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
     });
   }, [index, measureElement]);
   useLayoutEffect(() => {
-    if (!isLastEntry || entry.kind !== "item") return;
+    if (!isLastEntry) return;
     return useAppStore.subscribe(
       (state) => {
-        const item = state.runtimeItemsByIdByThread[threadId]?.[entry.id];
-        if (!item || item.state === "completed") return null;
-        switch (item.type) {
-          case "assistant_message":
-            return `${item.type}:${item.state}:${item.streams.assistant_text?.length ?? 0}`;
-          case "reasoning":
-            return `${item.type}:${item.state}:${item.streams.reasoning_text?.length ?? 0}`;
-          case "command_execution":
-            return `${item.type}:${item.state}:${item.streams.command_output?.length ?? 0}`;
-          case "file_change":
-            return `${item.type}:${item.state}:${item.streams.file_change_output?.length ?? 0}`;
-          default:
-            return `${item.type}:${item.state}`;
+        const items = state.runtimeItemsByIdByThread[threadId];
+        if (entry.kind === "item") return liveStreamMeasureToken(items?.[entry.id]);
+        // A live tool-call group can hold a streaming row (e.g. reasoning
+        // expanded while the model thinks) that grows the virtualized row.
+        for (const itemId of entry.itemIds) {
+          const token = liveStreamMeasureToken(items?.[itemId]);
+          if (token !== null) return token;
         }
+        return null;
       },
       (token) => {
         if (token !== null) scheduleLiveMeasure();
       },
     );
-  }, [entry.id, entry.kind, isLastEntry, scheduleLiveMeasure, threadId]);
+  }, [entry, isLastEntry, scheduleLiveMeasure, threadId]);
   useLayoutEffect(
     () => () => {
       if (liveMeasureRafRef.current !== null) {
@@ -641,6 +637,27 @@ function isLastTimelineEntryAssistantMessage(
   const lastEntry = entries[entries.length - 1];
   if (!lastEntry || lastEntry.kind !== "item") return false;
   return state.runtimeItemsByIdByThread[threadId]?.[lastEntry.id]?.type === "assistant_message";
+}
+
+/**
+ * Change token for an in-flight item whose streamed content grows its row.
+ * Includes the item id so back-to-back streaming items inside one group still
+ * produce distinct tokens.
+ */
+function liveStreamMeasureToken(item: RuntimeChatItem | undefined): string | null {
+  if (!item || item.state === "completed") return null;
+  switch (item.type) {
+    case "assistant_message":
+      return `${item.id}:${item.state}:${item.streams.assistant_text?.length ?? 0}`;
+    case "reasoning":
+      return `${item.id}:${item.state}:${item.streams.reasoning_text?.length ?? 0}`;
+    case "command_execution":
+      return `${item.id}:${item.state}:${item.streams.command_output?.length ?? 0}`;
+    case "file_change":
+      return `${item.id}:${item.state}:${item.streams.file_change_output?.length ?? 0}`;
+    default:
+      return `${item.id}:${item.state}`;
+  }
 }
 
 function estimateTimelineEntrySize(entry: ChatTimelineEntry | undefined, threadId: string): number {

--- a/src/renderer/components/thread/ChatPane/parts/items/Reasoning.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/Reasoning.test.tsx
@@ -79,6 +79,23 @@ describe("Reasoning", () => {
     await waitFor(() => expect(metrics.getScrollTop()).toBe(320));
   });
 
+  it("shows a one-line preview on the collapsed Thought row and hides it when expanded", () => {
+    const { container } = renderReasoning({
+      ...makeReasoningItem("Weighing the tradeoffs.\nThen deciding."),
+      state: "completed",
+    });
+
+    const toggle = container.querySelector("button");
+    if (!toggle) throw new Error("missing Thought toggle");
+    expect(toggle.textContent).toContain("Thought");
+    expect(toggle.textContent).toContain("Weighing the tradeoffs. Then deciding.");
+
+    fireEvent.click(toggle);
+
+    expect(toggle.textContent).not.toContain("Weighing the tradeoffs. Then deciding.");
+    expect(container.textContent).toContain("Weighing the tradeoffs.");
+  });
+
   it("stops auto-scrolling once the user scrolls up inside the live reasoning block", async () => {
     const { container, rerender } = renderReasoning(makeReasoningItem("Inspecting logs"));
     const viewport = getReasoningViewport(container);

--- a/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
@@ -6,9 +6,8 @@ import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice"
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
 import { chatMessageSurfaceClass } from "./chatMessageSurface";
-import { ItemMarkdown } from "./ItemMarkdown";
 import { getReasoningPreview } from "./reasoningPreview";
-import { ReasoningStreamViewport } from "./ReasoningStreamViewport";
+import { ReasoningExpandedBody, ReasoningStreamViewport } from "./ReasoningStreamViewport";
 
 interface ReasoningProps {
   item: RuntimeChatItem;
@@ -50,11 +49,7 @@ export const Reasoning = memo(function Reasoning({ item }: ReasoningProps) {
             className={`size-3 shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
           />
         </button>
-        {isOpen ? (
-          <div className="mt-2 max-h-64 overflow-y-auto border-l border-dashed border-[color:var(--border)] pl-3 italic [scrollbar-gutter:stable]">
-            <ItemMarkdown text={rawText} />
-          </div>
-        ) : null}
+        {isOpen ? <ReasoningExpandedBody text={rawText} className="mt-2" /> : null}
       </div>
     );
   }

--- a/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
@@ -1,21 +1,14 @@
-import {
-  memo,
-  useDeferredValue,
-  useEffect,
-  useEffectEvent,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { memo, useState } from "react";
 import { Surface } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Brain, ChevronDown } from "lucide-react";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
-import { isElementAtBottom } from "../../chatScrollGeometry";
 import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
 import { chatMessageSurfaceClass } from "./chatMessageSurface";
 import { ItemMarkdown } from "./ItemMarkdown";
+import { getReasoningPreview } from "./reasoningPreview";
+import { ReasoningStreamViewport } from "./ReasoningStreamViewport";
 
 interface ReasoningProps {
   item: RuntimeChatItem;
@@ -24,75 +17,16 @@ interface ReasoningProps {
 export const Reasoning = memo(function Reasoning({ item }: ReasoningProps) {
   const { t } = useLingui();
   const rawText = item.streams.reasoning_text ?? "";
-  const deferredText = useDeferredValue(rawText);
-  const text = deferredText;
   const hasText = rawText.trim().length > 0;
   const isStreaming = item.state !== "completed";
-  const shouldAutoScroll = isStreaming && hasText;
   const [isOpen, setIsOpen] = useState(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const lastScrollTopRef = useRef(0);
-  const stickToBottomRef = useRef(true);
   const actions = useChatPaneActions();
-
-  const scrollToBottom = useEffectEvent(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollTop = el.scrollHeight;
-    lastScrollTopRef.current = el.scrollTop;
-  });
-
-  useLayoutEffect(() => {
-    if (!shouldAutoScroll) return;
-    stickToBottomRef.current = true;
-    scrollToBottom();
-  }, [shouldAutoScroll]);
-
-  useEffect(() => {
-    if (!shouldAutoScroll) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    const handleScroll = () => {
-      const prevScrollTop = lastScrollTopRef.current;
-      const nextScrollTop = el.scrollTop;
-      lastScrollTopRef.current = nextScrollTop;
-      const isAtBottom = isElementAtBottom(el);
-      if (nextScrollTop < prevScrollTop && !isAtBottom) {
-        stickToBottomRef.current = false;
-      } else if (isAtBottom) {
-        stickToBottomRef.current = true;
-      }
-    };
-
-    lastScrollTopRef.current = el.scrollTop;
-    handleScroll();
-    el.addEventListener("scroll", handleScroll, { passive: true });
-    return () => el.removeEventListener("scroll", handleScroll);
-  }, [shouldAutoScroll]);
-
-  const syncStickyScroll = useEffectEvent(() => {
-    if (!stickToBottomRef.current) return;
-    scrollToBottom();
-  });
-
-  useEffect(() => {
-    if (!shouldAutoScroll) return;
-    const content = contentRef.current;
-    if (!content) return;
-    const observer = new ResizeObserver(() => {
-      // ResizeObserver fires after layout and before paint, so syncing here
-      // keeps the viewport pinned without a visible one-frame catch-up.
-      syncStickyScroll();
-    });
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [shouldAutoScroll]);
 
   const thinkingTextRef = useShimmer<HTMLSpanElement>(isStreaming);
   const brainRef = useBrainThinking(isStreaming);
 
   if (!isStreaming) {
+    const preview = isOpen ? "" : getReasoningPreview(rawText);
     // Compact toggle — visually distinct from tool-call accordions: no border
     // tile, dotted left rule when expanded, italic body. Equal vertical
     // padding so it doesn't visually bias toward the message above or below.
@@ -105,19 +39,20 @@ export const Reasoning = memo(function Reasoning({ item }: ReasoningProps) {
             actions?.onContentHeightChange();
           }}
           aria-expanded={isOpen}
-          className="inline-flex min-w-0 items-center gap-1.5 self-start leading-none italic opacity-80 hover:text-foreground hover:opacity-100"
+          className="inline-flex min-w-0 max-w-full items-center gap-1.5 self-start leading-none italic opacity-80 hover:text-foreground hover:opacity-100"
         >
           <Brain className="size-3 shrink-0" />
-          <span>
+          <span className="shrink-0">
             <Trans>Thought</Trans>
           </span>
+          {preview ? <span className="min-w-0 truncate opacity-70">{preview}</span> : null}
           <ChevronDown
             className={`size-3 shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
           />
         </button>
         {isOpen ? (
           <div className="mt-2 max-h-64 overflow-y-auto border-l border-dashed border-[color:var(--border)] pl-3 italic [scrollbar-gutter:stable]">
-            <ItemMarkdown text={text} />
+            <ItemMarkdown text={rawText} />
           </div>
         ) : null}
       </div>
@@ -141,13 +76,7 @@ export const Reasoning = memo(function Reasoning({ item }: ReasoningProps) {
             <Trans>Thinking</Trans>
           </span>
         </div>
-        {hasText ? (
-          <div ref={scrollRef} className="max-h-64 overflow-y-auto pl-4 [scrollbar-gutter:stable]">
-            <div ref={contentRef}>
-              <ItemMarkdown text={text} />
-            </div>
-          </div>
-        ) : null}
+        {hasText ? <ReasoningStreamViewport text={rawText} className="pl-4" /> : null}
       </div>
     </Surface>
   );

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
@@ -1,0 +1,94 @@
+import { Disclosure } from "@heroui/react";
+import { memo, useState } from "react";
+import { useLingui } from "@lingui/react/macro";
+import { Brain } from "lucide-react";
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
+import { useChatPaneActions } from "../../chatPaneActionsContext";
+import { ChatRowMetaSeparator, chatRowHoverClass } from "./chatRow";
+import { ItemMarkdown } from "./ItemMarkdown";
+import { getReasoningPreview } from "./reasoningPreview";
+import { ReasoningStreamViewport } from "./ReasoningStreamViewport";
+
+interface ReasoningInlineProps {
+  item: RuntimeChatItem;
+}
+
+/**
+ * Reasoning rendered as a row inside a tool-call group. While the model is
+ * thinking the row auto-expands and streams the live reasoning text; on
+ * completion it auto-collapses into a "Thought" row with a one-line preview of
+ * the reasoning as trailing meta. Manual toggles override the automatic state.
+ */
+export const ReasoningInline = memo(function ReasoningInline({ item }: ReasoningInlineProps) {
+  const { t } = useLingui();
+  const actions = useChatPaneActions();
+  const isStreaming = item.state !== "completed";
+  // null = follow the automatic state (open while streaming, closed after).
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
+  const isExpanded = manualExpanded ?? isStreaming;
+  const rawText = item.streams.reasoning_text ?? "";
+  const hasText = rawText.trim().length > 0;
+  const preview = !isStreaming && !isExpanded ? getReasoningPreview(rawText) : "";
+  const brainRef = useBrainThinking(isStreaming);
+  const shimmerRef = useShimmer<HTMLElement>(isStreaming);
+  const title = isStreaming ? t`Thinking` : t`Thought`;
+  const shimmerData = isStreaming ? { "data-lightcode-shimmer-text": title } : {};
+
+  return (
+    <Disclosure
+      className="text-[length:var(--lc-chat-font-size-command)] leading-tight"
+      isExpanded={isExpanded}
+      onExpandedChange={(next) => {
+        setManualExpanded(next);
+        actions?.onContentHeightChange();
+      }}
+    >
+      <Disclosure.Heading>
+        <Disclosure.Trigger
+          className={`flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left ${chatRowHoverClass}`}
+        >
+          <Brain
+            ref={brainRef}
+            className={`size-3 shrink-0 text-[color:var(--muted)] ${
+              isStreaming ? "lightcode-brain-thinking" : ""
+            }`}
+          />
+          <code
+            ref={shimmerRef}
+            className={`shrink-0 font-mono !text-[color:var(--muted)] ${
+              isStreaming ? "lightcode-thinking-text" : ""
+            }`}
+            {...shimmerData}
+          >
+            {title}
+          </code>
+          {preview ? (
+            <>
+              <ChatRowMetaSeparator />
+              <span className="min-w-0 flex-1 truncate italic text-[color:var(--muted)]">
+                {preview}
+              </span>
+            </>
+          ) : null}
+          <Disclosure.Indicator className="size-3.5 shrink-0 text-[color:var(--muted)]" />
+        </Disclosure.Trigger>
+      </Disclosure.Heading>
+      <Disclosure.Content>
+        <Disclosure.Body className="pb-1 pl-4 pt-1">
+          {/* Render the body only while expanded so collapsed rows don't keep
+              hidden markdown mounted (mirrors getInlineRow's isExpanded gating). */}
+          {!isExpanded ? null : isStreaming ? (
+            hasText ? (
+              <ReasoningStreamViewport text={rawText} className="italic" />
+            ) : null
+          ) : (
+            <div className="max-h-64 overflow-y-auto border-l border-dashed border-[color:var(--border)] pl-3 italic [scrollbar-gutter:stable]">
+              <ItemMarkdown text={rawText} />
+            </div>
+          )}
+        </Disclosure.Body>
+      </Disclosure.Content>
+    </Disclosure>
+  );
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
@@ -1,14 +1,13 @@
 import { Disclosure } from "@heroui/react";
-import { memo, useState } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { useLingui } from "@lingui/react/macro";
 import { Brain } from "lucide-react";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
-import { ChatRowMetaSeparator, chatRowHoverClass } from "./chatRow";
-import { ItemMarkdown } from "./ItemMarkdown";
+import { ChatRowMetaSeparator, inlineRowTriggerClass } from "./chatRow";
 import { getReasoningPreview } from "./reasoningPreview";
-import { ReasoningStreamViewport } from "./ReasoningStreamViewport";
+import { ReasoningExpandedBody, ReasoningStreamViewport } from "./ReasoningStreamViewport";
 
 interface ReasoningInlineProps {
   item: RuntimeChatItem;
@@ -35,6 +34,17 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
   const title = isStreaming ? t`Thinking` : t`Thought`;
   const shimmerData = isStreaming ? { "data-lightcode-shimmer-text": title } : {};
 
+  // Render the body only while expanded so collapsed rows don't keep hidden
+  // markdown mounted (mirrors getInlineRow's isExpanded gating).
+  let body: ReactNode = null;
+  if (isExpanded && hasText) {
+    body = isStreaming ? (
+      <ReasoningStreamViewport text={rawText} className="italic" />
+    ) : (
+      <ReasoningExpandedBody text={rawText} />
+    );
+  }
+
   return (
     <Disclosure
       className="text-[length:var(--lc-chat-font-size-command)] leading-tight"
@@ -45,9 +55,7 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
       }}
     >
       <Disclosure.Heading>
-        <Disclosure.Trigger
-          className={`flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left ${chatRowHoverClass}`}
-        >
+        <Disclosure.Trigger className={inlineRowTriggerClass}>
           <Brain
             ref={brainRef}
             className={`size-3 shrink-0 text-[color:var(--muted)] ${
@@ -75,19 +83,7 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
         </Disclosure.Trigger>
       </Disclosure.Heading>
       <Disclosure.Content>
-        <Disclosure.Body className="pb-1 pl-4 pt-1">
-          {/* Render the body only while expanded so collapsed rows don't keep
-              hidden markdown mounted (mirrors getInlineRow's isExpanded gating). */}
-          {!isExpanded ? null : isStreaming ? (
-            hasText ? (
-              <ReasoningStreamViewport text={rawText} className="italic" />
-            ) : null
-          ) : (
-            <div className="max-h-64 overflow-y-auto border-l border-dashed border-[color:var(--border)] pl-3 italic [scrollbar-gutter:stable]">
-              <ItemMarkdown text={rawText} />
-            </div>
-          )}
-        </Disclosure.Body>
+        <Disclosure.Body className="pb-1 pl-4 pt-1">{body}</Disclosure.Body>
       </Disclosure.Content>
     </Disclosure>
   );

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningStreamViewport.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningStreamViewport.tsx
@@ -29,3 +29,19 @@ export function ReasoningStreamViewport({ text, className }: ReasoningStreamView
     </div>
   );
 }
+
+/**
+ * Completed reasoning expanded under a "Thought" toggle: capped-height
+ * viewport with the dotted left rule and italic body. Shared by the
+ * standalone `Reasoning` block and the grouped `ReasoningInline` row so the
+ * two treatments cannot drift.
+ */
+export function ReasoningExpandedBody({ text, className }: ReasoningStreamViewportProps) {
+  return (
+    <div
+      className={`max-h-64 overflow-y-auto border-l border-dashed border-[color:var(--border)] pl-3 italic [scrollbar-gutter:stable] ${className ?? ""}`}
+    >
+      <ItemMarkdown text={text} />
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningStreamViewport.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningStreamViewport.tsx
@@ -1,0 +1,31 @@
+import { useDeferredValue } from "react";
+import { ItemMarkdown } from "./ItemMarkdown";
+import { useStickToBottom } from "./useStickToBottom";
+
+interface ReasoningStreamViewportProps {
+  text: string;
+  className?: string;
+}
+
+/**
+ * Live reasoning text in a capped-height viewport that stays pinned to the
+ * bottom while new content streams in, and releases the pin once the user
+ * scrolls up. Mount it only while the reasoning item is streaming — both the
+ * standalone `Reasoning` block and the grouped `ReasoningInline` row swap to a
+ * static body after completion.
+ */
+export function ReasoningStreamViewport({ text, className }: ReasoningStreamViewportProps) {
+  const deferredText = useDeferredValue(text);
+  const { scrollRef, contentRef } = useStickToBottom();
+
+  return (
+    <div
+      ref={scrollRef}
+      className={`max-h-64 overflow-y-auto [scrollbar-gutter:stable] ${className ?? ""}`}
+    >
+      <div ref={contentRef}>
+        <ItemMarkdown text={deferredText} />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useId, useLayoutEffect, useRef, type ReactNode } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Bot, X } from "lucide-react";
 import type { ProjectLocation, ToolCallPayload } from "@/shared/contracts";
@@ -8,9 +8,9 @@ import { OverlayShell } from "@/renderer/components/layout/OverlayShell";
 import { useAppStore } from "@/renderer/state/appStore";
 import { getRuntimeItemPayload } from "@/renderer/state/slices/runtimeEventSlice";
 import { getChildItemIdsStoreSelector, getRuntimeItemStoreSelector } from "../../chatPaneSelectors";
-import { isElementAtBottom } from "../../chatScrollGeometry";
 import { ChatItemRow } from "./ChatItemRow";
 import { deriveToolDisplay, isWorkflowTool } from "./toolDisplay";
+import { useStickToBottom } from "./useStickToBottom";
 import { WorkflowOverlayBody } from "./WorkflowOverlayBody";
 import { parseWorkflowInfo, type WorkflowInfo } from "./workflowDisplay";
 
@@ -222,59 +222,9 @@ function ChildList({
   workflow: WorkflowInfo | null;
   workflowProgress: WorkflowOverlayProgress | null;
 }) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
-  const stickRef = useRef(true);
-  const lastScrollTopRef = useRef(0);
-
-  const scrollToBottom = useEffectEvent(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollTop = el.scrollHeight;
-    lastScrollTopRef.current = el.scrollTop;
-  });
-
   // Pin to bottom on first paint so opening the overlay lands on the latest
   // child step rather than the start of the trail.
-  useLayoutEffect(() => {
-    stickRef.current = true;
-    scrollToBottom();
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const handleScroll = () => {
-      const prev = lastScrollTopRef.current;
-      const next = el.scrollTop;
-      lastScrollTopRef.current = next;
-      const atBottom = isElementAtBottom(el);
-      if (next < prev && !atBottom) {
-        stickRef.current = false;
-      } else if (atBottom) {
-        stickRef.current = true;
-      }
-    };
-    lastScrollTopRef.current = el.scrollTop;
-    el.addEventListener("scroll", handleScroll, { passive: true });
-    return () => el.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  const syncStickyScroll = useEffectEvent(() => {
-    if (!stickRef.current) return;
-    scrollToBottom();
-  });
-
-  useEffect(() => {
-    if (!stickToBottom) return;
-    const content = contentRef.current;
-    if (!content) return;
-    const observer = new ResizeObserver(() => {
-      syncStickyScroll();
-    });
-    observer.observe(content);
-    return () => observer.disconnect();
-  }, [stickToBottom]);
+  const { scrollRef, contentRef } = useStickToBottom({ enabled: stickToBottom });
 
   return (
     <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
@@ -419,6 +419,58 @@ describe("ToolCallGroup", () => {
     expect(view.container.querySelector(".lightcode-pixel-loader")).toBeNull();
   });
 
+  it("renders completed reasoning as a collapsed Thought row with a text preview", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeReasoningItem("reasoning-1", "Weighing the tradeoffs before editing the selector."),
+      makeToolItem("tool-1", "Read file"),
+    ];
+    seedThread(threadId, items);
+
+    renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    expect(screen.getByText("1 thought")).toBeInTheDocument();
+    expect(screen.getByText("Thought")).toBeInTheDocument();
+    expect(
+      screen.getByText("Weighing the tradeoffs before editing the selector."),
+    ).toBeInTheDocument();
+  });
+
+  it("auto-expands streaming reasoning inside the group and collapses it on completion", async () => {
+    const threadId = "thread-1";
+    const items: RuntimeChatItem[] = [
+      { ...makeReasoningItem("reasoning-1", "Considering the edge cases"), state: "updated" },
+      makeToolItem("tool-1", "Read file"),
+    ];
+    seedThread(threadId, items);
+
+    renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    // Streaming: shimmering "Thinking" title with the live text expanded below.
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(await screen.findByText("Considering the edge cases")).toBeInTheDocument();
+
+    act(() => {
+      seedThread(threadId, [
+        makeReasoningItem("reasoning-1", "Considering the edge cases"),
+        items[1]!,
+      ]);
+    });
+
+    // Completion: auto-collapses into a "Thought" row with the preview as meta.
+    await waitFor(() => expect(screen.getByText("Thought")).toBeInTheDocument());
+    const trigger = screen.getByText("Thought").closest("button");
+    expect(trigger).not.toBeNull();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("Considering the edge cases")).toBeInTheDocument();
+  });
+
   it("categorizes sub-agent tools as commands", () => {
     const threadId = "thread-1";
     const items = [makeAgentItem("agent-1")];
@@ -472,6 +524,15 @@ function makeCommandItem(id: string, command: string): RuntimeChatItem {
     state: "completed",
     payload: { command, exitCode: 0 },
     streams: {},
+  };
+}
+
+function makeReasoningItem(id: string, text: string): RuntimeChatItem {
+  return {
+    id,
+    type: "reasoning",
+    state: "completed",
+    streams: { reasoning_text: text },
   };
 }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -42,6 +42,7 @@ import {
 } from "./acpToolPayload";
 import { commandIntentDisplay } from "./commandSummary";
 import { LazyInlineDiffView } from "./LazyInlineDiffView";
+import { ReasoningInline } from "./ReasoningInline";
 import { detectLanguageFromPath, type ViewportLanguage } from "./languageDetect";
 import {
   getToolLikePayload,
@@ -171,7 +172,11 @@ export const ToolCallGroup = memo(function ToolCallGroup({
               ) : (
                 visibleItems.map((item) => (
                   <div key={item.id} className="animate-tool-call-enter">
-                    <ToolCallInline item={item} />
+                    {item.type === "reasoning" ? (
+                      <ReasoningInline item={item} />
+                    ) : (
+                      <ToolCallInline item={item} />
+                    )}
                   </div>
                 ))
               )}

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -25,6 +25,7 @@ import {
   chatRowClass,
   chatRowHoverClass,
   chatRowShellClass,
+  inlineRowTriggerClass,
 } from "./chatRow";
 import { CommandOutputViewport } from "./CommandOutputViewport";
 import { iconForCommandIntent } from "./CommandExecution";
@@ -172,11 +173,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
               ) : (
                 visibleItems.map((item) => (
                   <div key={item.id} className="animate-tool-call-enter">
-                    {item.type === "reasoning" ? (
-                      <ReasoningInline item={item} />
-                    ) : (
-                      <ToolCallInline item={item} />
-                    )}
+                    <GroupRowInline item={item} />
                   </div>
                 ))
               )}
@@ -225,7 +222,7 @@ function SameFileEditGroupBody({ items }: { items: readonly RuntimeChatItem[] })
         if (!row?.bodyText) {
           return (
             <div key={item.id} className="animate-tool-call-enter">
-              <ToolCallInline item={item} />
+              <GroupRowInline item={item} />
             </div>
           );
         }
@@ -250,6 +247,16 @@ function SameFileEditGroupBody({ items }: { items: readonly RuntimeChatItem[] })
       })}
     </>
   );
+}
+
+/**
+ * Type dispatch for a row inside a tool-call group. Every call site that
+ * renders group children goes through this so non-tool row types (reasoning
+ * today) get their dedicated renderer everywhere.
+ */
+function GroupRowInline({ item }: { item: RuntimeChatItem }) {
+  if (item.type === "reasoning") return <ReasoningInline item={item} />;
+  return <ToolCallInline item={item} />;
 }
 
 function ToolCallInline({ item }: { item: RuntimeChatItem }) {
@@ -290,9 +297,7 @@ function ToolCallInline({ item }: { item: RuntimeChatItem }) {
       }}
     >
       <Disclosure.Heading>
-        <Disclosure.Trigger
-          className={`flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left ${chatRowHoverClass}`}
-        >
+        <Disclosure.Trigger className={inlineRowTriggerClass}>
           <Icon className="size-3 shrink-0 text-[color:var(--muted)]" />
           <InlineRowTitle
             isRunning={isRunning}

--- a/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/chatRow.tsx
@@ -33,6 +33,11 @@ export const chatRowHoverClass = "transition-colors hover:[--muted:var(--foregro
 // (`pt-1` dense, `pt-2.5` roomier).
 export const chatRowBodyClass = "mt-1 border-t border-[var(--hairline)] px-2";
 
+// Disclosure trigger for a dense inline row inside a tool-call group
+// (ToolCallInline, ReasoningInline): icon + title + trailing meta hugging
+// their content, with the shared hover treatment.
+export const inlineRowTriggerClass = `flex w-fit max-w-full min-w-0 items-center gap-1.5 rounded-md py-0.5 text-left ${chatRowHoverClass}`;
+
 // Thin dot between a row's title and its trailing meta label so the two read as
 // distinct once they sit side by side.
 export function ChatRowMetaSeparator() {

--- a/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getReasoningPreview } from "./reasoningPreview";
+
+// @vitest-environment node
+
+describe("getReasoningPreview", () => {
+  it("flattens multi-line reasoning into a single-line snippet", () => {
+    expect(getReasoningPreview("First I will read the file.\nThen I will edit it.")).toBe(
+      "First I will read the file. Then I will edit it.",
+    );
+  });
+
+  it("strips markdown structure so the snippet reads as prose", () => {
+    expect(getReasoningPreview("## Plan\n- check the **selector**\n> quote\n`code` path")).toBe(
+      "Plan check the selector quote code path",
+    );
+  });
+
+  it("drops fenced code blocks, including unterminated ones", () => {
+    expect(getReasoningPreview("Look at\n```ts\nconst a = 1;\n```\nthe result")).toBe(
+      "Look at the result",
+    );
+    expect(getReasoningPreview("Look at\n```ts\nconst a = 1;")).toBe("Look at");
+  });
+
+  it("truncates long reasoning with an ellipsis", () => {
+    const preview = getReasoningPreview("word ".repeat(100), 40);
+    expect(preview.length).toBeLessThanOrEqual(40);
+    expect(preview.endsWith("…")).toBe(true);
+  });
+
+  it("returns an empty string for whitespace-only text", () => {
+    expect(getReasoningPreview("  \n\t")).toBe("");
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
@@ -10,7 +10,11 @@ export function getReasoningPreview(
   maxLength: number = REASONING_PREVIEW_MAX_LENGTH,
 ): string {
   const flattened = text
+    // Fences must be stripped over the full text (an early fence can swallow
+    // kilobytes); afterwards only a bounded prefix can survive truncation, so
+    // cap the remaining passes instead of scanning the whole block.
     .replace(/```[\s\S]*?(?:```|$)/g, " ")
+    .slice(0, maxLength * 8)
     .replace(/^[\s>#+*-]+/gm, "")
     .replace(/[*_`]+/g, "")
     .replace(/\s+/g, " ")

--- a/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
@@ -1,0 +1,20 @@
+const REASONING_PREVIEW_MAX_LENGTH = 120;
+
+/**
+ * One-line sneak peek of a reasoning block for collapsed "Thought" rows.
+ * Strips markdown structure (fences, list/heading markers, emphasis) so the
+ * snippet reads as plain prose, then truncates on a single line.
+ */
+export function getReasoningPreview(
+  text: string,
+  maxLength: number = REASONING_PREVIEW_MAX_LENGTH,
+): string {
+  const flattened = text
+    .replace(/```[\s\S]*?(?:```|$)/g, " ")
+    .replace(/^[\s>#+*-]+/gm, "")
+    .replace(/[*_`]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (flattened.length <= maxLength) return flattened;
+  return `${flattened.slice(0, maxLength - 1).trimEnd()}…`;
+}

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from "vitest";
+import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import {
+  categorizeItem,
   categorizeToolName,
   categorizeVerbPrefix,
   categoryFromSummaryLabel,
+  isToolGroupItem,
 } from "./toolCallCategorization";
+
+describe("categorizeItem", () => {
+  it("maps reasoning items to the thought category and keeps them groupable", () => {
+    const item = {
+      id: "reasoning-1",
+      type: "reasoning",
+      state: "completed",
+      streams: { reasoning_text: "planning" },
+    } as unknown as RuntimeChatItem;
+
+    expect(categorizeItem(item)).toBe("thought");
+    expect(isToolGroupItem(item)).toBe(true);
+  });
+});
 
 describe("categorizeToolName", () => {
   it("maps read tools to viewed", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
@@ -1,4 +1,4 @@
-import { Eye, Pencil, SearchCode, Terminal, Wrench, type LucideIcon } from "lucide-react";
+import { Brain, Eye, Pencil, SearchCode, Terminal, Wrench, type LucideIcon } from "lucide-react";
 import type {
   CommandExecutionPayload,
   FileChangePayload,
@@ -14,7 +14,7 @@ import { isContextCompactionToolCall } from "./ContextCompaction";
 import { isPlanProposalToolCall } from "./PlanProposal";
 import { deriveToolDisplay, isSubAgentTool } from "./toolDisplay";
 
-export type GroupCategory = "viewed" | "searched" | "edited" | "executed" | "other";
+export type GroupCategory = "thought" | "viewed" | "searched" | "edited" | "executed" | "other";
 
 export interface CategoryMeta {
   Icon: LucideIcon;
@@ -25,6 +25,7 @@ export interface CategoryMeta {
 }
 
 export const CATEGORY_META: Record<GroupCategory, CategoryMeta> = {
+  thought: { Icon: Brain, singular: "thought", plural: "thoughts", priority: 5 },
   viewed: { Icon: Eye, singular: "view", plural: "views", priority: 0 },
   searched: { Icon: SearchCode, singular: "search", plural: "searches", priority: 1 },
   edited: { Icon: Pencil, singular: "edit", plural: "edits", priority: 2 },
@@ -140,6 +141,7 @@ export function isToolGroupItem(item: RuntimeChatItem): boolean {
   if (isPlanProposalToolCall(item)) return false;
   return (
     isToolLikeItem(item) ||
+    item.type === "reasoning" ||
     item.type === "command_execution" ||
     item.type === "file_change" ||
     item.type === "web_search"
@@ -147,6 +149,7 @@ export function isToolGroupItem(item: RuntimeChatItem): boolean {
 }
 
 export function categorizeItem(item: RuntimeChatItem): GroupCategory {
+  if (item.type === "reasoning") return "thought";
   if (item.type === "command_execution") return categorizeCommandExecution(item);
   if (item.type === "file_change") return "edited";
   if (item.type === "web_search") return "searched";
@@ -242,6 +245,7 @@ export function categorizeToolName(name: string): GroupCategory {
 }
 
 export const SUMMARY_CATEGORY_LABELS: Record<GroupCategory, readonly string[]> = {
+  thought: ["thought", "thoughts"],
   viewed: ["view", "views"],
   searched: ["search", "searches"],
   edited: ["edit", "edits"],

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
@@ -244,14 +244,17 @@ export function categorizeToolName(name: string): GroupCategory {
   }
 }
 
-export const SUMMARY_CATEGORY_LABELS: Record<GroupCategory, readonly string[]> = {
-  thought: ["thought", "thoughts"],
-  viewed: ["view", "views"],
-  searched: ["search", "searches"],
-  edited: ["edit", "edits"],
-  executed: ["command", "commands"],
-  other: ["tool", "tools"],
-};
+// Derived from CATEGORY_META so a category's noun forms live in one place and
+// `categoryFromSummaryLabel` always round-trips the labels the UI renders.
+export const SUMMARY_CATEGORY_LABELS: Record<GroupCategory, readonly string[]> = (() => {
+  const labels = {} as Record<GroupCategory, readonly string[]>;
+  for (const [category, meta] of Object.entries(CATEGORY_META) as Array<
+    [GroupCategory, CategoryMeta]
+  >) {
+    labels[category] = [meta.singular, meta.plural];
+  }
+  return labels;
+})();
 
 export function categorizePersistedToolSummary(name: string): GroupCategory | null {
   const parts = name

--- a/src/renderer/components/thread/ChatPane/parts/items/useStickToBottom.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/useStickToBottom.ts
@@ -1,0 +1,77 @@
+import { useEffect, useEffectEvent, useLayoutEffect, useRef } from "react";
+import { isElementAtBottom } from "../../chatScrollGeometry";
+
+interface UseStickToBottomOptions {
+  /**
+   * Gates the ResizeObserver-driven re-pin. Leave it on (the default) for a
+   * viewport that only mounts while content streams; pass a flag for a
+   * container whose stickiness is conditional.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Pins a scroll container to its bottom edge while its content grows, releasing
+ * the pin once the user scrolls up and re-engaging when they return to the
+ * bottom. Attach the returned refs to the scrollable element (`scrollRef`) and
+ * its growing content wrapper (`contentRef`).
+ */
+export function useStickToBottom({ enabled = true }: UseStickToBottomOptions = {}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const stickRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
+
+  const scrollToBottom = useEffectEvent(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    lastScrollTopRef.current = el.scrollTop;
+  });
+
+  // Pin on first paint so the container lands on the latest content rather than
+  // the top of the trail.
+  useLayoutEffect(() => {
+    stickRef.current = true;
+    scrollToBottom();
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const handleScroll = () => {
+      const prev = lastScrollTopRef.current;
+      const next = el.scrollTop;
+      lastScrollTopRef.current = next;
+      const atBottom = isElementAtBottom(el);
+      if (next < prev && !atBottom) {
+        stickRef.current = false;
+      } else if (atBottom) {
+        stickRef.current = true;
+      }
+    };
+    lastScrollTopRef.current = el.scrollTop;
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const syncStickyScroll = useEffectEvent(() => {
+    if (!stickRef.current) return;
+    scrollToBottom();
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const content = contentRef.current;
+    if (!content) return;
+    const observer = new ResizeObserver(() => {
+      // ResizeObserver fires after layout and before paint, so syncing here
+      // keeps the viewport pinned without a visible one-frame catch-up.
+      syncStickyScroll();
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  return { scrollRef, contentRef };
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Theme und Chat-Schriftgröße"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Denkt …"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Dieser Worktree weist lokale Änderungen auf. Poracode kann sie vorübergehend stashen, von {0} pullen und Ihre Änderungen dann erneut anwenden."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Gedanke"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Theme and chat font size"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Thinking"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "This worktree has local changes. Poracode can temporarily stash them, pull from {0}, then re-apply your changes."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Thought"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Tema y tamaño de fuente del chat"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Pensando"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Este worktree tiene cambios locales. Poracode puede guardarlos temporalmente en el stash, extraer de {0} y luego volver a aplicar tus cambios."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Pensamiento"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -7170,6 +7170,7 @@ msgstr "Thème et taille de police du chat"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Réflexion"
@@ -7248,6 +7249,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Cet arbre de travail a des modifications locales. Poracode peut les remiser temporairement, récupérer depuis {0}, puis réappliquer vos modifications."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Pensée"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -7169,6 +7169,7 @@ msgstr "テーマとチャットのフォントサイズ"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "思考中"
@@ -7247,6 +7248,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "このワークツリーにはローカルな変更があります。Poracode はそれらを一時的にスタッシュし、{0}からプルして、変更を再適用できます。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "思考"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -7171,6 +7171,7 @@ msgstr "테마 및 채팅 글꼴 크기"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "생각 중"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "이 작업 트리에는 로컬 변경 사항이 있습니다. Poracode는 일시적으로 이를 숨기고 {0}에서 가져온 다음 변경 사항을 다시 적용할 수 있습니다."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "생각"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Motyw i rozmiar czcionki czatu"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Myślenie"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "To drzewo robocze zawiera zmiany lokalne. Poracode może je tymczasowo ukryć, pobrać z {0}, a następnie ponownie zastosować zmiany."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Myśl"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Tema e tamanho da fonte do chat"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Pensando"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Esta árvore de trabalho possui alterações locais. O Poracode pode armazená-las temporariamente, fazer pull de {0} e depois reaplicar suas alterações."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Pensamento"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Тема и размер шрифта чата"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Размышление"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "В этом worktree есть локальные изменения. Poracode может временно спрятать их, получить изменения из {0}, а затем повторно применить ваши изменения."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Мысль"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Tema ve sohbet yazı tipi boyutu"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Düşünme"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Bu çalışma ağacında yerel değişiklikler var. Poracode bunları geçici olarak saklayabilir, {0} öğesinden çekebilir ve ardından değişikliklerinizi yeniden uygulayabilir."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Düşünce"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Тема и размер шрифта чата"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Міркування"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "У цьому worktree є локальні зміни. Poracode може тимчасово сховати їх, отримати зміни з {0}, а потім повторно застосувати ваші зміни."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Думка"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -7171,6 +7171,7 @@ msgstr "Giao diện và cỡ chữ chat"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "Đang suy nghĩ"
@@ -7249,6 +7250,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "Cây làm việc này có các thay đổi cục bộ. Poracode có thể tạm thời lưu trữ (stash) chúng, kéo (pull) từ {0}, sau đó áp dụng lại các thay đổi của bạn."
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "Suy nghĩ"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -7170,6 +7170,7 @@ msgstr "主题和聊天字号"
 
 #: src/renderer/components/common/EffortContextMenu/EffortContextMenu.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Thinking"
 msgstr "思考"
@@ -7248,6 +7249,7 @@ msgid "This worktree has local changes. Poracode can temporarily stash them, pul
 msgstr "该工作树有本地更改。Poracode 可以暂时贮藏（stash）它们，从 {0} 拉取，然后重新应用您的更改。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
 msgid "Thought"
 msgstr "思考"
 


### PR DESCRIPTION
- Add inline Thought previews with expandable reasoning content.
- Keep streaming reasoning pinned to the bottom while allowing user scrolling.
- Group reasoning with tool calls and improve categorization behavior.
- Expand coverage with selector, preview, rendering, and grouping tests.
- Update localized catalog references across supported languages.