### PR TITLE
Unwrap Codex Apps MCP calls to their inner app

### DIFF
--- a/src/main/profile/coreStats.ts
+++ b/src/main/profile/coreStats.ts
@@ -197,6 +197,10 @@ function computeSkills(rows: UsageEventRow[]): {
       const name = row.name?.trim();
       if (!name || isGenericMcpName(name) || isGenericMcpName(mcpServerLabel(name))) continue;
       mcpToolCalls++;
+      // New Codex events are unwrapped to the inner app at the provider boundary.
+      // Historical rows only retained this aggregate wrapper, so do not present
+      // it as if it were an MCP server alongside the real app names.
+      if (name.toLowerCase() === "codex_apps") continue;
       mcpCounts.set(name, (mcpCounts.get(name) ?? 0) + 1);
     }
   }

--- a/src/supervisor/agents/codex/canonicalMapping.test.ts
+++ b/src/supervisor/agents/codex/canonicalMapping.test.ts
@@ -681,6 +681,33 @@ describe("mapCodexNotification — item lifecycle (item/started, item/completed)
     });
   });
 
+  it("unwraps Codex Apps MCP calls to the inner app", () => {
+    const state = createCodexMapperState("t-codex");
+    const started = mapCodexNotification(
+      "item/started",
+      {
+        threadId: "x",
+        itemId: "codex-app-github-1",
+        item: {
+          id: "codex-app-github-1",
+          type: "mcpToolCall",
+          server: "codex_apps",
+          tool: "github.fetch_pr",
+          arguments: { repo_full_name: "SDSLeon/lightcode", pr_number: 264 },
+        },
+      },
+      state,
+    );
+
+    expect((started[0] as { itemType: string }).itemType).toBe("mcp_tool_call");
+    expect((started[0] as { payload: Record<string, unknown> }).payload).toMatchObject({
+      name: "mcp__github__fetch_pr",
+      serverId: "github",
+      args: { repo_full_name: "SDSLeon/lightcode", pr_number: 264 },
+      status: "running",
+    });
+  });
+
   it("maps Codex spawnAgent items as subagent tool calls", () => {
     const state = createCodexMapperState("t-codex");
     const started = mapCodexNotification(

--- a/src/supervisor/agents/codex/canonicalMapping/toolExtraction.ts
+++ b/src/supervisor/agents/codex/canonicalMapping/toolExtraction.ts
@@ -142,12 +142,30 @@ export function toolName(source: CodexItemPayload): string | undefined {
 }
 
 function mcpToolName(source: CodexItemPayload): string | undefined {
-  const server = toolServerId(source);
-  const tool = readNonEmptyString(source.tool);
-  return server && tool ? `mcp__${server}__${tool}` : undefined;
+  const identity = mcpToolIdentity(source);
+  return identity ? `mcp__${identity.server}__${identity.tool}` : undefined;
 }
 
 export function toolServerId(source: CodexItemPayload): string | undefined {
+  return mcpToolIdentity(source)?.server ?? rawMcpServerId(source);
+}
+
+function mcpToolIdentity(source: CodexItemPayload): { server: string; tool: string } | undefined {
+  const server = rawMcpServerId(source);
+  const tool = readNonEmptyString(source.tool);
+  if (!server || !tool) return undefined;
+
+  if (server === "codex_apps") {
+    const separator = tool.indexOf(".");
+    if (separator > 0 && separator < tool.length - 1) {
+      return { server: tool.slice(0, separator), tool: tool.slice(separator + 1) };
+    }
+  }
+
+  return { server, tool };
+}
+
+function rawMcpServerId(source: CodexItemPayload): string | undefined {
   if (canonicalTypeFor(source.type ?? source.kind) !== "mcp_tool_call") return undefined;
   return readNonEmptyString(source.server) ?? readNonEmptyString(source.serverId);
 }


### PR DESCRIPTION
- **Bugfix:** Map Codex Apps MCP calls to their underlying app and tool identities for accurate display and handling.
- Add coverage for unwrapping app-qualified Codex MCP tool calls.
- Exclude the historical `codex_apps` wrapper from profile MCP server statistics to avoid misleading server names.