### PR TITLE
Tighten tool call group rail spacing

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -39,6 +39,7 @@ describe("ToolCallGroup", () => {
     expect(viewport.className).not.toContain("overflow-y-auto");
     expect(viewport).toHaveClass("gap-0.5");
     expect(body).toHaveClass("border-l", "border-dashed");
+    expect(body).toHaveClass("ml-1.5", "pl-2.5");
     expect(body).not.toHaveClass("border-t");
     expect(showAll.parentElement).toHaveClass("justify-start");
     expect(showAll).toHaveClass("-ml-1");

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -148,7 +148,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
           </Disclosure.Trigger>
         </Disclosure.Heading>
         <Disclosure.Content>
-          <Disclosure.Body className={`ml-3 ${chatRowRailClass} pb-0 pl-3 pt-0`}>
+          <Disclosure.Body className={`ml-1.5 ${chatRowRailClass} pb-0 pl-2.5 pt-0`}>
             {hasOverflowRows && !sameFileEditSummary ? (
               <div className="mb-0.5 flex justify-start">
                 <button


### PR DESCRIPTION
- **Bugfix:** reduce tool call group rail indentation for a tighter chat layout.
- Update coverage to lock in the adjusted rail spacing.