### PR TITLE
Preserve npm shims and parse v-prefixed agent versions

### DIFF
--- a/src/supervisor/agents/base.detect-version.test.ts
+++ b/src/supervisor/agents/base.detect-version.test.ts
@@ -82,6 +82,21 @@ describe("detectAgentInstall version probe", () => {
       expect.anything(),
     );
   });
+
+  it("extracts the full semver from a v-prefixed version string", async () => {
+    // Regression: `\b\d+\.\d+…` could not match right after a leading `v`
+    // (no word boundary between two word characters), so "v24.14.0" was
+    // mis-extracted as "14.0" — surfacing a phantom newer version in the UI.
+    execFileAsyncMock.mockImplementation(async (_cmd: unknown, args: unknown) => {
+      const joined = (Array.isArray(args) ? args : []).join(" ");
+      if (joined.includes("command -v")) return { stdout: "/opt/tools/grok\n", stderr: "" };
+      return { stdout: "v24.14.0\n", stderr: "" };
+    });
+
+    const status = await detectAgentInstall(undefined, spec);
+
+    expect(status.version).toBe("24.14.0");
+  });
 });
 
 describe("detectAgentInstall WSL interop guard", () => {

--- a/src/supervisor/agents/base.windows-path.test.ts
+++ b/src/supervisor/agents/base.windows-path.test.ts
@@ -22,6 +22,7 @@ vi.mock("node:child_process", async () => {
 
 import {
   clearExecutablePathCache,
+  extractWindowsCmdShimScript,
   getRefreshedWindowsPath,
   invalidateExecutablePathCache,
   resolveExecutablePath,
@@ -186,6 +187,42 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
     expect(resolveExecutablePath("command-code")).toBe(cmdPath);
   });
 
+  it("keeps the .cmd path for npm shims with an extensionless bin script (e.g. grok.cmd)", () => {
+    // Regression: @xai-official/grok's npm bin entry has no .js extension
+    // (`"%_prog%"  "%dp0%\node_modules\@xai-official\grok\bin\grok" %*`), so
+    // the .js-only shim guard missed it and the exe substitution matched the
+    // shim's `IF EXIST "%dp0%\node.exe"` line — resolving `grok` to node.exe.
+    // Detection then read node's version and the ACP probe spawned
+    // `node.exe agent stdio`, breaking version, models, and account info.
+    const root = mkdtempSync(join(tmpdir(), "poracode-grok-shim-"));
+    tempDirs.push(root);
+    const cmdPath = join(root, "grok.cmd");
+    const nodeExePath = join(root, "node.exe");
+    writeFileSync(nodeExePath, "");
+    writeFileSync(
+      cmdPath,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        'IF EXIST "%dp0%\\node.exe" (',
+        '  SET "_prog=%dp0%\\node.exe"',
+        ") ELSE (",
+        '  SET "_prog=node"',
+        ")",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@xai-official\\grok\\bin\\grok" %*',
+        "",
+      ].join("\r\n"),
+    );
+    spawnSyncMock.mockReturnValueOnce({
+      error: undefined,
+      status: 0,
+      stdout: [join(root, "grok"), cmdPath].join("\r\n"),
+      stderr: "",
+    });
+
+    expect(resolveExecutablePath("grok")).toBe(cmdPath);
+  });
+
   it("applies the same fallback to async resolution", async () => {
     execFileAsyncMock.mockRejectedValueOnce(new Error("not found")).mockResolvedValueOnce({
       stdout: "C:\\Users\\demo\\scoop\\shims\\opencode.exe\r\n",
@@ -273,5 +310,22 @@ describe.skipIf(process.platform !== "win32")("Windows executable path fallback"
       .mockReturnValueOnce({ error: undefined, status: 0, stdout: USER_REG_QUERY, stderr: "" })
       .mockReturnValueOnce({ error: undefined, status: 0, stdout: MACHINE_REG_QUERY, stderr: "" });
     expect(getRefreshedWindowsPath()).toContain("C:\\Users\\demo\\.local\\bin");
+  });
+});
+
+describe("extractWindowsCmdShimScript", () => {
+  it("extracts .js/.mjs script entries", () => {
+    const body = '"%dp0%\\node.exe"  "%dp0%\\node_modules\\command-code\\dist\\index.mjs" %*';
+    expect(extractWindowsCmdShimScript(body)).toBe("node_modules\\command-code\\dist\\index.mjs");
+  });
+
+  it("extracts extensionless %_prog% bin scripts", () => {
+    const body = '"%_prog%"  "%dp0%\\node_modules\\@xai-official\\grok\\bin\\grok" %*';
+    expect(extractWindowsCmdShimScript(body)).toBe("node_modules\\@xai-official\\grok\\bin\\grok");
+  });
+
+  it("returns undefined for exe-wrapping shims", () => {
+    const body = '"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*';
+    expect(extractWindowsCmdShimScript(body)).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -15,6 +15,7 @@ import {
   getPrimedPosixEnv,
   getProjectShellEnv,
   getWindowsPathOverrideEnv,
+  extractWindowsCmdShimScript,
   isWslInteropBinaryPath,
   readCommandOutputAsync,
   readWslLoginShellCommandOutputAsync,
@@ -209,8 +210,7 @@ function resolveWindowsNodeCmdShim(commandPath: string):
     return undefined;
   }
 
-  const match = /["']?%dp0%\\([^"']+?\.[cm]?js)["']?\s+%\*/i.exec(content);
-  const relScript = match?.[1];
+  const relScript = extractWindowsCmdShimScript(content);
   if (!relScript) return undefined;
 
   const baseDir = dirname(effectivePath);
@@ -454,8 +454,11 @@ async function resolveDetectedBinary(
 
 function extractSemverFromVersionOutput(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
-  const match = raw.match(/\b\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?\b/);
-  return match ? match[0] : raw.trim() || undefined;
+  // Allow a leading `v` ("v24.14.0"): without it, `\b` cannot match between
+  // `v` and the first digit, so the regex would skip past the major segment
+  // and latch onto "14.0" mid-string.
+  const match = raw.match(/\bv?(\d+\.\d+(?:\.\d+)?(?:[-+][\w.]+)?)\b/i);
+  return match ? match[1] : raw.trim() || undefined;
 }
 
 async function readDetectedVersion(

--- a/src/supervisor/agents/base/processRuntime.ts
+++ b/src/supervisor/agents/base/processRuntime.ts
@@ -287,17 +287,34 @@ function parseWindowsExecutablePath(stdout: string): string | undefined {
   return resolveWindowsCmdExeTarget(resolved) ?? resolved;
 }
 
+/**
+ * Extract the `%dp0%`-relative Node script entry from an npm-style `.cmd`
+ * shim body. Matches explicit `.js/.cjs/.mjs` entries as well as the
+ * extensionless bin scripts npm's cmd-shim writes for packages whose bin file
+ * has no extension (e.g. @xai-official/grok:
+ * `"%_prog%"  "%dp0%\node_modules\@xai-official\grok\bin\grok" %*`).
+ * Returns undefined for exe-wrapping shims.
+ */
+export function extractWindowsCmdShimScript(body: string): string | undefined {
+  const js = /["']?%dp0%\\([^"']+?\.[cm]?js)["']?\s+%\*/i.exec(body)?.[1];
+  if (js) return js;
+  const prog = /"%_prog%"\s+["']?%dp0%\\([^"']+?)["']?\s+%\*/i.exec(body)?.[1];
+  if (prog && !/\.(?:exe|cmd|bat|com|ps1)$/i.test(prog)) return prog;
+  return undefined;
+}
+
 function resolveWindowsCmdExeTarget(path: string | undefined): string | undefined {
   if (!path || !/\.cmd$/i.test(path)) return undefined;
   try {
     const body = readFileSync(path, "utf8");
-    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.mjs" %*`.
+    // npm's standard Node-script shim wraps `"%dp0%\node.exe" "%dp0%\…\entry.mjs" %*`
+    // (or `"%_prog%" "%dp0%\node_modules\…\bin\<name>" %*` for extensionless bins).
     // Leave those alone so the downstream resolveWindowsNodeCmdShim (in base/index.ts)
     // can extract the script entry and invoke node with it directly. Substituting to
     // node.exe here would strip the script arg and pass agent flags straight to
     // node, which rejects them ("bad option: --model", etc.) and exits — breaking
     // every npm-installed agent (codex, commandcode, gemini, …) on Windows.
-    if (/["']?%dp0%\\[^"']+?\.[cm]?js["']?\s+%\*/i.test(body)) return undefined;
+    if (extractWindowsCmdShimScript(body) !== undefined) return undefined;
     const match = /"%dp0%\\([^"]+?\.exe)"/i.exec(body);
     if (!match?.[1]) return undefined;
     const target = join(dirname(path), match[1]);


### PR DESCRIPTION
- **Bugfix:** Keep Windows npm `.cmd` shims pointing to their intended agent scripts, including extensionless bins such as Grok.
- Correctly detect full semantic versions from `v`-prefixed agent output to avoid false update signals.