### PR TITLE
Prefill merge commit messages in Git review

### DIFF
--- a/src/renderer/state/gitReviewActionStore.ts
+++ b/src/renderer/state/gitReviewActionStore.ts
@@ -40,6 +40,8 @@ export interface GeneratedDraftMeta {
 export interface GitReviewActionState {
   /** Draft commit message — typed by the user or filled in by generation. */
   commitMessage: string;
+  /** Last Git merge-message template observed for this panel. */
+  mergeMessageTemplate: string | null;
   /** Provenance of the last AI-generated commit message (null once consumed/replaced). */
   commitGen: GeneratedDraftMeta | null;
   /** Draft PR title. */
@@ -73,6 +75,7 @@ export interface GitReviewActionState {
 /** Stable default returned for panels with no state yet — never mutate. */
 const EMPTY_STATE: GitReviewActionState = Object.freeze({
   commitMessage: "",
+  mergeMessageTemplate: null,
   commitGen: null,
   prTitle: "",
   prBody: "",

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
@@ -221,6 +221,7 @@ vi.mock("@/renderer/components/providers/commitGen", () => ({
 }));
 
 import { useGitStore } from "@/renderer/state/gitStore";
+import { useGitReviewActionStore } from "@/renderer/state/gitReviewActionStore";
 import { GitReviewSidebar } from "./GitReviewSidebar";
 import { GitTouchProvider, type GitTouchFileTarget } from "./gitTouchContext";
 import type { ConflictResolverLaunchInput } from "./parts/useConflictResolver";
@@ -246,6 +247,7 @@ describe("GitReviewSidebar", () => {
       statuses: {},
       worktreeStatuses: {},
     });
+    useGitReviewActionStore.setState({ panels: {} });
   });
 
   it("renders worktree changes from the provided git status", () => {
@@ -296,6 +298,160 @@ describe("GitReviewSidebar", () => {
     expect(screen.getByText("worktree-only.ts")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Commit message (Ctrl+Enter)")).toBeInTheDocument();
     expect(screen.queryByText("main-only.ts")).not.toBeInTheDocument();
+  });
+
+  it("uses Git's merge message as an editable commit template", async () => {
+    const project: Project = {
+      id: "merge-project",
+      name: "Poracode",
+      createdAt: new Date().toISOString(),
+      location: { kind: "windows", path: "C:\\repo-worktree" },
+    };
+    const status = (mergeMessage: string): GitStatusResult => ({
+      isRepo: true,
+      branch: "feature",
+      tracking: "origin/feature",
+      hasRemote: true,
+      remoteInfo: null,
+      ahead: 0,
+      behind: 1,
+      staged: [
+        {
+          path: "src/merged.ts",
+          status: "M",
+          staged: true,
+          insertions: 1,
+          deletions: 0,
+        },
+      ],
+      unstaged: [],
+      totalInsertions: 1,
+      totalDeletions: 0,
+      mergeInProgress: true,
+      mergeMessage,
+      conflictFiles: [
+        {
+          path: "src/conflict.ts",
+          status: "U",
+          staged: false,
+          insertions: 1,
+          deletions: 1,
+        },
+      ],
+    });
+    const firstStatus = status("Merge branch 'main' into feature");
+    const view = render(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={firstStatus}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={0}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+
+    const input = screen.getByLabelText("Commit message");
+    await waitFor(() => expect(input).toHaveValue("Merge branch 'main' into feature"));
+
+    view.rerender(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={status("Merge branch 'develop' into feature")}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={1}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+    await waitFor(() => expect(input).toHaveValue("Merge branch 'develop' into feature"));
+
+    fireEvent.change(input, { target: { value: "Custom merge message" } });
+    view.rerender(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={status("Merge branch 'release' into feature")}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={2}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+    await waitFor(() => expect(input).toHaveValue("Custom merge message"));
+
+    fireEvent.change(input, { target: { value: "" } });
+    view.rerender(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={status("Merge branch 'release' into feature")}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={3}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+    await waitFor(() => expect(input).toHaveValue(""));
+  });
+
+  it("does not replace a commit message typed before the conflict", async () => {
+    useGitReviewActionStore.getState().patch("typed-project", {
+      commitMessage: "Keep my message",
+    });
+    const project: Project = {
+      id: "typed-project",
+      name: "Poracode",
+      createdAt: new Date().toISOString(),
+      location: { kind: "windows", path: "C:\\repo" },
+    };
+    const gitStatus: GitStatusResult = {
+      isRepo: true,
+      branch: "feature",
+      tracking: "",
+      hasRemote: false,
+      remoteInfo: null,
+      ahead: 0,
+      behind: 0,
+      staged: [
+        {
+          path: "src/merged.ts",
+          status: "M",
+          staged: true,
+          insertions: 1,
+          deletions: 0,
+        },
+      ],
+      unstaged: [],
+      totalInsertions: 1,
+      totalDeletions: 0,
+      mergeInProgress: true,
+      mergeMessage: "Merge branch 'main' into feature",
+      conflictFiles: [],
+    };
+
+    render(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={gitStatus}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={0}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Commit message")).toHaveValue("Keep my message"),
+    );
   });
 
   it("reports failed file staging before refreshing the git state", async () => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { toast } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import type { GitBranchInfo, GitStatusResult, Project, ProjectLocation } from "@/shared/contracts";
@@ -128,6 +129,7 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
   // gitReviewActionStore.
   const {
     commitMessage,
+    mergeMessageTemplate,
     commitGen,
     prTitle,
     prBody,
@@ -158,6 +160,18 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
   const setIsAbortingMerge = (value: boolean) => patch(storeKey, { isAbortingMerge: value });
   const setIsFinishingMerge = (value: boolean) => patch(storeKey, { isFinishingMerge: value });
   const setIsCreatingPr = (value: boolean) => patch(storeKey, { isCreatingPr: value });
+  const mergeMessage = gitStatus ? gitStatus.mergeMessage || null : undefined;
+
+  useEffect(() => {
+    if (mergeMessage === undefined || mergeMessage === mergeMessageTemplate) return;
+
+    patch(storeKey, {
+      mergeMessageTemplate: mergeMessage,
+      ...(mergeMessage && (!commitMessage || commitMessage === mergeMessageTemplate)
+        ? { commitMessage: mergeMessage, commitGen: null }
+        : {}),
+    });
+  }, [commitMessage, mergeMessage, mergeMessageTemplate, patch, storeKey]);
 
   const writeActions = usePrWriteActions({
     projectLocation: project.location,

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -36,6 +36,7 @@ export interface GitStatusResult {
   totalInsertions: number;
   totalDeletions: number;
   mergeInProgress?: boolean;
+  mergeMessage?: string;
   conflictFiles?: GitFileChange[];
 }
 

--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -1186,8 +1186,22 @@ describe("GitService.getStatus Windows path normalization", () => {
   });
 
   it("reports mergeInProgress when unmerged entries exist", async () => {
+    readFileMock.mockResolvedValue(
+      [
+        "Merge branch 'main' of github.com:owner/repo into feature-a",
+        "",
+        "# Conflicts:",
+        "#\tsrc/file.ts",
+      ].join("\n"),
+    );
     mockGitCommands((args) => {
-      if (args[0] === "rev-parse") return { stdout: "true\n" };
+      if (args[0] === "rev-parse") {
+        return {
+          stdout: args.includes("--git-path")
+            ? "C:/Users/demo/work/poracode/.git/MERGE_MSG\n"
+            : "true\n",
+        };
+      }
       if (args[0] === "status") {
         return {
           stdout: [
@@ -1205,11 +1219,13 @@ describe("GitService.getStatus Windows path normalization", () => {
     const result = await new GitService().getStatus(location);
 
     expect(result.mergeInProgress).toBe(true);
+    expect(result.mergeMessage).toBe("Merge branch 'main' of github.com:owner/repo into feature-a");
     expect(result.conflictFiles).toEqual([
       { path: "src/file.ts", status: "U", staged: false, insertions: 0, deletions: 0 },
     ]);
     expect(result.staged).toEqual([]);
     expect(result.unstaged).toEqual([]);
+    expect(readFileMock).toHaveBeenCalledWith("C:/Users/demo/work/poracode/.git/MERGE_MSG", "utf8");
   });
 
   it("does not report mergeInProgress when no unmerged entries exist", async () => {
@@ -1307,6 +1323,72 @@ describe("GitService.getStatus Windows path normalization", () => {
         }),
       );
       expect(execFileMock).not.toHaveBeenCalled();
+    } finally {
+      service.setWslClient(undefined);
+    }
+  });
+
+  it("reads the merge message from the linked-worktree Git path in WSL", async () => {
+    const gitBatch = vi.fn<
+      (
+        location: WslLocation,
+        input: { commands: WslGitExecInput[]; timeoutMs?: number },
+      ) => Promise<{ results: WslGitExecResult[] }>
+    >(async () => ({
+      results: [
+        { ok: true, stdout: "true\n", stderr: "", exitCode: 0 },
+        {
+          ok: true,
+          stdout: [
+            "# branch.oid abc123",
+            "# branch.head feature-a",
+            "u UU N... 100644 100644 100644 100644 a b c src/file.ts",
+          ].join("\n"),
+          stderr: "",
+          exitCode: 0,
+        },
+        { ok: true, stdout: "", stderr: "", exitCode: 0 },
+        { ok: true, stdout: "", stderr: "", exitCode: 0 },
+        { ok: true, stdout: "", stderr: "", exitCode: 0 },
+      ],
+    }));
+    const mergeMessagePath = "/home/demo/repo/.git/worktrees/feature-a/MERGE_MSG";
+    const gitExec = vi.fn<
+      (location: WslLocation, input: WslGitExecInput) => Promise<WslGitExecResult>
+    >(async (_location, input) => ({
+      ok: true,
+      stdout: input.args.includes("--git-path") ? `${mergeMessagePath}\n` : "",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const readFile = vi.fn<WslBridgeClient["readFile"]>(async () => ({
+      tooLarge: false as const,
+      size: 83,
+      mtimeMs: 1,
+      contentBase64: Buffer.from(
+        "Merge branch 'main' into feature-a\n\n# Conflicts:\n#\tsrc/file.ts\n",
+      ).toString("base64"),
+    }));
+    const service = new GitService();
+    service.setWslClient({ gitBatch, gitExec, readFile } as unknown as WslBridgeClient);
+
+    try {
+      const result = await service.getStatus({
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/demo/repo",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\repo",
+      });
+
+      expect(result.mergeMessage).toBe("Merge branch 'main' into feature-a");
+      expect(readFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          distro: "Ubuntu",
+          linuxPath: "/home/demo/repo/.git/worktrees/feature-a",
+        }),
+        mergeMessagePath,
+        { maxBytes: 64 * 1024 },
+      );
     } finally {
       service.setWslClient(undefined);
     }

--- a/src/supervisor/git.ts
+++ b/src/supervisor/git.ts
@@ -59,6 +59,7 @@ export class GitService {
 
   setWslClient(client: WslBridgeClient | undefined): void {
     setWslGitBridgeClient(client);
+    this.statusService.setWslClient(client);
   }
 
   async getStatus(location: ProjectLocation): Promise<GitStatusResult> {

--- a/src/supervisor/git/statusService.ts
+++ b/src/supervisor/git/statusService.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from "node:fs/promises";
-import { join } from "node:path";
+import { join, posix } from "node:path";
 import {
   type GitDiffBatchResult,
   type GitDiffResult,
@@ -9,6 +9,7 @@ import {
   type ProjectLocation,
 } from "@/shared/contracts";
 import { getProjectFsPath, toWslUncPath } from "@/shared/wsl";
+import type { WslBridgeClient } from "../wsl/bridge/client";
 import {
   execGit,
   execGitBatchWslBridge,
@@ -37,6 +38,11 @@ interface UntrackedStatsCacheEntry {
 }
 
 const BINARY_SCAN_BYTES = 8000;
+const MAX_MERGE_MESSAGE_BYTES = 64 * 1024;
+
+function stripCommitMessageComments(message: string): string {
+  return message.replace(/^\s*#.*$\n?/gm, "").trim();
+}
 
 function isProbablyBinary(buffer: Buffer): boolean {
   const scanLength = Math.min(buffer.length, BINARY_SCAN_BYTES);
@@ -69,6 +75,11 @@ function countTextLines(buffer: Buffer): number {
 
 export class GitStatusService {
   private readonly untrackedStatsCache = new Map<string, UntrackedStatsCacheEntry>();
+  private wslClient: WslBridgeClient | undefined;
+
+  setWslClient(client: WslBridgeClient | undefined): void {
+    this.wslClient = client;
+  }
 
   async getStatus(location: ProjectLocation): Promise<GitStatusResult> {
     if (location.kind === "wsl") {
@@ -121,12 +132,7 @@ export class GitStatusService {
 
     const { totalInsertions, totalDeletions } = sumChangeTotals(parsed);
 
-    const conflictFileChanges: GitFileChange[] =
-      parsed.mergeInProgress && parsed.conflictFiles.length > 0
-        ? await this.buildConflictFileChanges(location, parsed.conflictFiles)
-        : [];
-
-    return {
+    const base: GitStatusResult = {
       isRepo: true,
       branch: parsed.branch,
       tracking: parsed.tracking,
@@ -138,10 +144,8 @@ export class GitStatusService {
       unstaged: parsed.unstaged,
       totalInsertions,
       totalDeletions,
-      ...(parsed.mergeInProgress
-        ? { mergeInProgress: true, conflictFiles: conflictFileChanges }
-        : {}),
     };
+    return this.applyParsedMergeState(location, parsed, base);
   }
 
   async getStatusSummary(location: ProjectLocation): Promise<GitStatusResult> {
@@ -200,12 +204,57 @@ export class GitStatusService {
     base: GitStatusResult,
   ): Promise<GitStatusResult> {
     if (!base.isRepo) return base;
-    const parsed = parseStatusPorcelainV2(statusOutput);
-    if (!parsed.mergeInProgress || parsed.conflictFiles.length === 0) {
-      return base;
+    return this.applyParsedMergeState(location, parseStatusPorcelainV2(statusOutput), base);
+  }
+
+  private async applyParsedMergeState(
+    location: ProjectLocation,
+    parsed: ParsedPorcelainStatus,
+    base: GitStatusResult,
+  ): Promise<GitStatusResult> {
+    if (!parsed.mergeInProgress) return base;
+    const [conflictFileChanges, mergeMessage] = await Promise.all([
+      this.buildConflictFileChanges(location, parsed.conflictFiles),
+      this.getMergeMessage(location),
+    ]);
+    return {
+      ...base,
+      mergeInProgress: true,
+      conflictFiles: conflictFileChanges,
+      ...(mergeMessage ? { mergeMessage } : {}),
+    };
+  }
+
+  private async getMergeMessage(location: ProjectLocation): Promise<string | undefined> {
+    try {
+      const mergeMessagePath = (
+        await execGit(location, ["rev-parse", "--path-format=absolute", "--git-path", "MERGE_MSG"])
+      ).trim();
+      if (!mergeMessagePath) return undefined;
+
+      const raw =
+        location.kind === "wsl"
+          ? await this.readMergeMessageWsl(location, mergeMessagePath)
+          : await readFile(mergeMessagePath, "utf8");
+      const message = stripCommitMessageComments(raw);
+      return message || undefined;
+    } catch {
+      return undefined;
     }
-    const conflictFileChanges = await this.buildConflictFileChanges(location, parsed.conflictFiles);
-    return { ...base, mergeInProgress: true, conflictFiles: conflictFileChanges };
+  }
+
+  private async readMergeMessageWsl(
+    location: ProjectLocation & { kind: "wsl" },
+    mergeMessagePath: string,
+  ): Promise<string> {
+    if (!this.wslClient) throw new Error("WSL bridge unavailable");
+    const result = await this.wslClient.readFile(
+      { ...location, linuxPath: posix.dirname(mergeMessagePath) },
+      mergeMessagePath,
+      { maxBytes: MAX_MERGE_MESSAGE_BYTES },
+    );
+    if (result.tooLarge) return "";
+    return Buffer.from(result.contentBase64, "base64").toString("utf8");
   }
 
   private async getStatusBatchedWsl(


### PR DESCRIPTION
- **Feature:** Populate the Git review commit-message draft with Git’s merge message when resolving a merge.
- Preserve user edits while updating the template when the active merge message changes.
- Read merge messages for Windows and WSL linked worktrees, excluding Git comment lines.
- Add renderer and supervisor coverage for merge-message detection and editing behavior.