### PR TITLE
Unify slash chip styling in chat

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -997,6 +997,7 @@ describe("ChatPane", () => {
     const badge = container.querySelector('[data-skill-name="simplify"]');
     expect(badge).toHaveTextContent("simplify");
     expect(badge?.querySelector("svg")).toBeInTheDocument();
+    expect(badge).not.toHaveClass("poracode-slash-chip--user-message");
     expect(screen.queryByText("$simplify")).not.toBeInTheDocument();
   });
 
@@ -1047,6 +1048,7 @@ describe("ChatPane", () => {
     renderChatPane(thread);
     await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
 
+    expect(screen.getByText("goal").parentElement).toHaveClass("poracode-slash-chip");
     expect(screen.getByRole("link", { name: url })).toHaveAttribute("href", url);
   });
 

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -367,7 +367,7 @@ function UserMessageSlashChip({
 }) {
   return (
     <span
-      className="poracode-slash-chip poracode-slash-chip--user-message mr-1.5"
+      className="poracode-slash-chip mr-1.5"
       {...(skillName ? { "data-skill-name": skillName } : {})}
     >
       <span className="poracode-slash-chip__slash">{icon}</span>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2519,16 +2519,6 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
   white-space: nowrap;
 }
 
-.poracode-slash-chip--user-message {
-  margin-right: 0.45rem;
-  background: var(--surface-secondary);
-  color: var(--foreground);
-}
-
-.poracode-slash-chip--user-message .poracode-slash-chip__slash {
-  color: var(--foreground);
-}
-
 .poracode-user-message-inline-content .poracode-inline-path-chip {
   background: var(--surface-secondary);
 }


### PR DESCRIPTION
- Bugfix: Apply consistent slash-chip styling across user messages and chat content.
- Update ChatPane coverage to verify the shared chip presentation.