### PR TITLE
Fix thread switching to preserve pane, composer, and chat state

### DIFF
--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -53,6 +53,7 @@ describe("threadActions", () => {
       projects: [],
       threads: [],
       view: { kind: "home" },
+      pendingActiveThreadId: null,
       pendingThreadLaunches: {},
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
@@ -162,9 +163,13 @@ describe("threadActions", () => {
     openThread(firstThread.id);
     openThread(secondThread.id);
 
-    expect(useAppStore.getState().view).toEqual({
-      kind: "thread",
-      panes: [secondThread.id],
+    // The newer (terminal) open applies on the next animation frame — deferred
+    // so the sidebar highlight paints before the heavy pane mount.
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({
+        kind: "thread",
+        panes: [secondThread.id],
+      });
     });
 
     resolveFirstHydration();
@@ -462,29 +467,39 @@ describe("threadActions", () => {
       usePanelStore.setState({ threadSortMode: "manual" });
     });
 
-    it("opens the next thread in sidebar order and wraps at the end", () => {
+    // openThread defers the pane swap by a frame (so the sidebar highlight
+    // paints first), so these assertions wait for the swap to land.
+    it("opens the next thread in sidebar order and wraps at the end", async () => {
       const threads = ["a", "b", "c"].map((id) => makeThread({ id }));
       useAppStore.setState((state) => ({ ...state, threads }));
 
       switchToAdjacentThread(threads[1]!, "next");
-      expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["c"] });
+      await waitFor(() =>
+        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["c"] }),
+      );
 
       switchToAdjacentThread(threads[2]!, "next");
-      expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["a"] });
+      await waitFor(() =>
+        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["a"] }),
+      );
     });
 
-    it("opens the previous thread and wraps at the start", () => {
+    it("opens the previous thread and wraps at the start", async () => {
       const threads = ["a", "b", "c"].map((id) => makeThread({ id }));
       useAppStore.setState((state) => ({ ...state, threads }));
 
       switchToAdjacentThread(threads[1]!, "previous");
-      expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["a"] });
+      await waitFor(() =>
+        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["a"] }),
+      );
 
       switchToAdjacentThread(threads[0]!, "previous");
-      expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["c"] });
+      await waitFor(() =>
+        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["c"] }),
+      );
     });
 
-    it("stays within the current thread's project", () => {
+    it("stays within the current thread's project", async () => {
       const threads = [
         makeThread({ id: "a", projectId: "p1" }),
         makeThread({ id: "x", projectId: "p2" }),
@@ -493,7 +508,9 @@ describe("threadActions", () => {
       useAppStore.setState((state) => ({ ...state, threads }));
 
       switchToAdjacentThread(threads[0]!, "next");
-      expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["b"] });
+      await waitFor(() =>
+        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["b"] }),
+      );
     });
 
     it("does nothing when the project has a single thread", () => {

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -18,6 +18,7 @@ import {
 const { bridge } = vi.hoisted(() => ({
   bridge: {
     closeThread: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    appendUsageEvents: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   },
 }));
 const { hasHydratedThreadRuntimeItems, hydrateThreadRuntimeItems } = vi.hoisted(() => ({
@@ -480,7 +481,11 @@ describe("threadActions", () => {
 
       switchToAdjacentThread(threads[2]!, "next");
       await waitFor(() =>
-        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["a"] }),
+        expect(useAppStore.getState().view).toEqual({
+          kind: "thread",
+          panes: ["a"],
+          paneLayout: { kind: "leaf", paneId: "a", slotId: "c" },
+        }),
       );
     });
 
@@ -495,7 +500,11 @@ describe("threadActions", () => {
 
       switchToAdjacentThread(threads[0]!, "previous");
       await waitFor(() =>
-        expect(useAppStore.getState().view).toEqual({ kind: "thread", panes: ["c"] }),
+        expect(useAppStore.getState().view).toEqual({
+          kind: "thread",
+          panes: ["c"],
+          paneLayout: { kind: "leaf", paneId: "c", slotId: "a" },
+        }),
       );
     });
 

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -97,15 +97,38 @@ export function openNewThreadInWorktree(input: {
 }
 
 export function openThread(threadId: string, options?: { focusComposer?: boolean }): void {
-  const thread = useAppStore.getState().threads.find((item) => item.id === threadId);
+  const store = useAppStore.getState();
+  const thread = store.threads.find((item) => item.id === threadId);
   const requestId = ++openThreadRequestId;
   const threadIdsToHydrate = getGuiThreadIdsToHydrateBeforeOpen(threadId);
 
+  // Phase 1 (urgent): flip the optimistic active-thread id in its own cheap
+  // commit so the sidebar row highlights immediately. This does not touch
+  // `view.panes`, so it does not trigger the heavy pane remount. Snapshot the
+  // current view so the deferred swap can bail if the user navigates elsewhere
+  // within the frame (setPendingActiveThread leaves `view`'s reference intact).
+  store.setPendingActiveThread(threadId);
+  const viewAtSchedule = store.view;
+
+  // Phase 2 (deferred): perform the real pane swap that mounts the target
+  // thread. Kept behind a frame so the highlight paints first; the previous
+  // pane stays visible until the new one mounts (no blank flash).
   const applyOpen = () => {
+    // Superseded by a newer openThread — that call owns the pending id and will
+    // clear it, so leave it untouched here.
     if (requestId !== openThreadRequestId) return;
+    // The user navigated somewhere else (Home/Draft/another pane) during the
+    // frame; honor that instead of clobbering it, and drop the stale highlight.
+    if (useAppStore.getState().view !== viewAtSchedule) {
+      useAppStore.getState().setPendingActiveThread(null);
+      return;
+    }
 
     startTransition(() => {
       useAppStore.getState().openThread(threadId);
+      // Clear in the same auto-batched commit as the pane swap so the highlight
+      // hands off to `view.panes` without a flicker.
+      useAppStore.getState().setPendingActiveThread(null);
       if (options?.focusComposer) {
         useAppStore.getState().requestComposerFocus(threadId);
       }
@@ -123,6 +146,8 @@ export function openThread(threadId: string, options?: { focusComposer?: boolean
   };
 
   if (threadIdsToHydrate.length > 0) {
+    // Hydration already yields (awaited), so the highlight paints during the
+    // SQLite fetch — no extra frame needed before the swap.
     void Promise.all(threadIdsToHydrate.map((id) => hydrateThreadRuntimeItems(id))).then(
       applyOpen,
       applyOpen,
@@ -130,7 +155,24 @@ export function openThread(threadId: string, options?: { focusComposer?: boolean
     return;
   }
 
-  applyOpen();
+  // Defer the heavy pane swap one frame so the urgent highlight commit paints
+  // first. requestAnimationFrame alone is not enough: Chromium parks rAF
+  // entirely for occluded windows, which would stall the open until the window
+  // is next visible (e.g. thread opens driven from the mobile remote). The
+  // timeout fallback keeps the swap flowing (throttled timers still fire) while
+  // the rAF path preserves the paint-first ordering when visible.
+  let applied = false;
+  let frameId: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const applyOnce = () => {
+    if (applied) return;
+    applied = true;
+    if (frameId !== null) cancelAnimationFrame(frameId);
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    applyOpen();
+  };
+  frameId = requestAnimationFrame(applyOnce);
+  if (!applied) timeoutId = setTimeout(applyOnce, 50);
 }
 
 /**

--- a/src/renderer/components/layout/SplitPaneContainer.test.ts
+++ b/src/renderer/components/layout/SplitPaneContainer.test.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaneLayout } from "@/shared/paneLayout";
-import { computeLayout, SplitPaneContainer } from "./SplitPaneContainer";
+import { computeLayout, resolvePaneDomKey, SplitPaneContainer } from "./SplitPaneContainer";
 import { splitStorageKey, writeStoredSizes } from "./paneSizeStorage";
 
 vi.mock("@dnd-kit/react", () => ({
@@ -207,6 +207,70 @@ describe("SplitPaneContainer", () => {
 
     expect(container.querySelector<HTMLElement>('[role="separator"]')).toBe(divider);
     expect(parseFloat(divider!.style.left)).toBeCloseTo(976 / 3);
+  });
+
+  it("keeps a pane shell mounted when its caller-provided DOM key stays stable", () => {
+    let mountCount = 0;
+    function PaneShell({ paneId }: { paneId: string }) {
+      const instance = React.useRef<number | null>(null);
+      if (instance.current === null) instance.current = ++mountCount;
+      return React.createElement("div", {
+        "data-pane-id": paneId,
+        "data-pane-instance": instance.current,
+      });
+    }
+    const renderPane = (paneId: string) => React.createElement(PaneShell, { paneId });
+    const getPaneDomKey = () => "primary-gui";
+    const { container, rerender } = render(
+      React.createElement(SplitPaneContainer, {
+        layout: { kind: "leaf", paneId: "thread-a" },
+        renderPane,
+        getPaneDomKey,
+      }),
+    );
+    const firstShell = container.querySelector<HTMLElement>("[data-pane-id='thread-a']");
+
+    rerender(
+      React.createElement(SplitPaneContainer, {
+        layout: { kind: "leaf", paneId: "thread-b" },
+        renderPane,
+        getPaneDomKey,
+      }),
+    );
+
+    const secondShell = container.querySelector<HTMLElement>("[data-pane-id='thread-b']");
+    expect(secondShell).toBe(firstShell);
+    expect(secondShell?.dataset.paneInstance).toBe("1");
+    expect(mountCount).toBe(1);
+  });
+
+  it("uses each GUI pane's stable slot key", () => {
+    const guiKey = resolvePaneDomKey({
+      paneId: "thread-a",
+      paneSlotId: "slot-a",
+      presentationMode: "gui",
+    });
+    expect(
+      resolvePaneDomKey({
+        paneId: "thread-a-replacement",
+        paneSlotId: "slot-a",
+        presentationMode: "gui",
+      }),
+    ).toBe(guiKey);
+    expect(
+      resolvePaneDomKey({
+        paneId: "thread-a",
+        paneSlotId: "slot-a",
+        presentationMode: "terminal",
+      }),
+    ).toBe("thread-a");
+    expect(
+      resolvePaneDomKey({
+        paneId: "thread-b",
+        paneSlotId: "slot-b",
+        presentationMode: "gui",
+      }),
+    ).not.toBe(guiKey);
   });
 
   it("rereads projected sizes when returning to a previously cached layout key", () => {

--- a/src/renderer/components/layout/SplitPaneContainer.tsx
+++ b/src/renderer/components/layout/SplitPaneContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useLayoutEffect, useReducer, useRef } from "react";
 import { useDroppable } from "@dnd-kit/react";
 import { msg } from "@lingui/core/macro";
+import type { ThreadPresentationMode } from "@/shared/contracts";
 import { type PaneLayout, type PaneLayoutAxis } from "@/shared/paneLayout";
 import { useIsInsertSplitHighlighted, useIsRootInsertHighlighted } from "@/renderer/dnd";
 import { i18n } from "@/renderer/i18n/i18n";
@@ -21,6 +22,14 @@ const KEY_RESIZE_STEP_PERCENT = 2;
 
 export type Rect = { left: number; top: number; width: number; height: number };
 type ContainerSize = { width: number; height: number };
+
+export function resolvePaneDomKey(input: {
+  paneId: string;
+  paneSlotId: string;
+  presentationMode: ThreadPresentationMode | undefined;
+}): string {
+  return input.presentationMode === "gui" ? `pane-slot:${input.paneSlotId}` : input.paneId;
+}
 
 type ComputedPane = { paneId: string; rect: Rect };
 
@@ -268,6 +277,7 @@ const RootInsertZone = React.memo(function RootInsertZone(props: {
 export function SplitPaneContainer(props: {
   layout: PaneLayout;
   renderPane: (paneId: string, rect: Rect) => React.ReactNode;
+  getPaneDomKey?: (paneId: string) => string;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -550,14 +560,18 @@ export function SplitPaneContainer(props: {
           bottom: ROOT_INSERT_ZONE_INSET,
         }}
       >
-        {/* Sort by id so React keeps the same DOM slot per pane across layout
-            swaps; reparenting an absolutely-positioned pane resets `scrollTop`
-            on the nested chat scroller. */}
-        {[...computed.panes]
-          .sort((a, b) => a.paneId.localeCompare(b.paneId))
-          .map((pane) => (
+        {/* Sort by DOM key so React keeps the same DOM slot per pane across
+            layout swaps; reparenting an absolutely-positioned pane resets
+            `scrollTop` on the nested chat scroller. */}
+        {computed.panes
+          .map((pane) => ({
+            pane,
+            domKey: props.getPaneDomKey?.(pane.paneId) ?? pane.paneId,
+          }))
+          .sort((a, b) => a.domKey.localeCompare(b.domKey))
+          .map(({ pane, domKey }) => (
             <div
-              key={pane.paneId}
+              key={domKey}
               ref={(element) => {
                 if (element) paneElementRefs.current.set(pane.paneId, element);
                 else paneElementRefs.current.delete(pane.paneId);

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@tanstack/react-virtual", () => ({
     measure: vi.fn<() => void>(),
     measureElement: vi.fn<(element: HTMLDivElement | null) => void>(),
     resizeItem: vi.fn<(index: number, size: number) => void>(),
+    takeSnapshot: () => [],
     options: { measureElement: () => 96 },
     scrollToIndex: (
       index: number,
@@ -171,7 +172,7 @@ describe("ChatPane", () => {
     await waitFor(() => expect(metrics.getScrollTop()).toBe(300));
   });
 
-  it("pins sticky content growth without virtualizer reconciliation", async () => {
+  it("does not duplicate native sticky growth with virtualizer reconciliation", async () => {
     const thread = makeThread();
     seedAssistantMessage(thread.id, "Inspect output");
     useAppStore.setState({ projects: [project] });
@@ -195,6 +196,8 @@ describe("ChatPane", () => {
 
     act(() => {
       metrics.setScrollHeight(300);
+      // TanStack's end anchor applies the virtual row delta first.
+      metrics.setScrollTop(300);
       MockResizeObserver.notify(contentElement);
     });
 
@@ -242,7 +245,7 @@ describe("ChatPane", () => {
     expect(getScrollElement(container).className).toContain("[overflow-anchor:none]");
   });
 
-  it("re-pins in the same resize frame when bottom-pinned content collapses", async () => {
+  it("does not disturb the native end anchor when bottom-pinned content collapses", async () => {
     const thread = makeThread();
     seedPlanItem(thread.id, [{ step: "Inspect output", status: "in_progress" }]);
 
@@ -264,6 +267,8 @@ describe("ChatPane", () => {
 
     act(() => {
       metrics.setScrollHeight(220);
+      // TanStack's end anchor applies the virtual row delta first.
+      metrics.setScrollTop(220);
       MockResizeObserver.notify(contentElement);
     });
 
@@ -301,6 +306,8 @@ describe("ChatPane", () => {
     });
 
     act(() => {
+      // TanStack's end anchor applies the delayed virtual row delta.
+      metrics.setScrollTop(300);
       MockResizeObserver.notify(contentElement);
     });
 
@@ -510,6 +517,8 @@ describe("ChatPane", () => {
 
     act(() => {
       metrics.setScrollHeight(300);
+      // TanStack follows the append after sticky mode was re-engaged.
+      metrics.setScrollTop(300);
       MockResizeObserver.notify(contentElement);
     });
 

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -364,10 +364,9 @@ export function ChatPane(props: ChatPaneProps) {
             </div>
           </div>
           <ChatScrollControls
+            key={`scroll:${threadId}`}
             ref={scrollControlsRef}
             scrollRef={scrollRef}
-            contentRef={contentRef}
-            hiddenRuntimeItemId={hiddenRuntimeItemId}
             layoutChangeToken={layoutChangeToken}
             threadId={threadId}
             tailLoaderVisible={showTailLoader}
@@ -376,6 +375,7 @@ export function ChatPane(props: ChatPaneProps) {
             onInitialScrollSettled={() => setInitialScrollSettledThreadId(threadId)}
           />
           <SubAgentOverlay
+            key={`subagent:${threadId}`}
             threadId={threadId}
             {...(project ? { projectLocation: project.location } : {})}
           />

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
@@ -5,14 +5,8 @@ import { renderWithI18n } from "@/renderer/testUtils/i18n";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
 
 vi.mock("@/renderer/state/appStore", () => ({
-  useAppStore: Object.assign(
-    (selector: (s: { chatScrollToBottomTokens: Record<string, number> }) => unknown) =>
-      selector({ chatScrollToBottomTokens: {} }),
-    {
-      subscribe: () => () => undefined,
-      getState: () => ({ chatScrollToBottomTokens: {} }),
-    },
-  ),
+  useAppStore: (selector: (s: { chatScrollToBottomTokens: Record<string, number> }) => unknown) =>
+    selector({ chatScrollToBottomTokens: {} }),
 }));
 
 vi.mock("@/renderer/state/panelResizeSignal", () => ({
@@ -22,19 +16,16 @@ vi.mock("@/renderer/state/panelResizeSignal", () => ({
 
 function Harness(props: {
   scrollEl: HTMLDivElement;
-  contentEl: HTMLDivElement;
   controlsRef: React.RefObject<ChatScrollControlsHandle | null>;
   virtualScrollToBottom: () => void;
   initialScrollSettled?: boolean;
 }) {
   const scrollRef = useRef(props.scrollEl);
-  const contentRef = useRef(props.contentEl);
   const virtualScrollToBottomRef = useRef(props.virtualScrollToBottom);
   return (
     <ChatScrollControls
       ref={props.controlsRef}
       scrollRef={scrollRef}
-      contentRef={contentRef}
       layoutChangeToken={null}
       threadId="thread-1"
       tailLoaderVisible={false}
@@ -48,7 +39,6 @@ function Harness(props: {
 describe("ChatScrollControls", () => {
   it("skips scrollTop writes and virtualizer reconcile when already at bottom", () => {
     const scrollEl = document.createElement("div");
-    const contentEl = document.createElement("div");
     const scrollTopSetter = vi.fn<(value: number) => void>();
     Object.defineProperties(scrollEl, {
       scrollHeight: { configurable: true, get: () => 1000 },
@@ -65,7 +55,6 @@ describe("ChatScrollControls", () => {
     renderWithI18n(
       <Harness
         scrollEl={scrollEl}
-        contentEl={contentEl}
         controlsRef={controlsRef}
         virtualScrollToBottom={virtualScrollToBottom}
       />,
@@ -85,7 +74,6 @@ describe("ChatScrollControls", () => {
   it("reports thread-open settling until a user scroll-away ends the window", () => {
     let scrollTop = 100;
     const scrollEl = document.createElement("div");
-    const contentEl = document.createElement("div");
     Object.defineProperties(scrollEl, {
       scrollHeight: { configurable: true, get: () => 1000 },
       clientHeight: { configurable: true, get: () => 200 },
@@ -102,7 +90,6 @@ describe("ChatScrollControls", () => {
     renderWithI18n(
       <Harness
         scrollEl={scrollEl}
-        contentEl={contentEl}
         controlsRef={controlsRef}
         virtualScrollToBottom={() => undefined}
       />,
@@ -122,7 +109,6 @@ describe("ChatScrollControls", () => {
   it("writes scrollTop when content grows past the bottom pin", () => {
     let scrollTop = 100;
     const scrollEl = document.createElement("div");
-    const contentEl = document.createElement("div");
     Object.defineProperties(scrollEl, {
       scrollHeight: { configurable: true, get: () => 1000 },
       clientHeight: { configurable: true, get: () => 200 },
@@ -140,7 +126,6 @@ describe("ChatScrollControls", () => {
     renderWithI18n(
       <Harness
         scrollEl={scrollEl}
-        contentEl={contentEl}
         controlsRef={controlsRef}
         virtualScrollToBottom={virtualScrollToBottom}
       />,
@@ -159,7 +144,6 @@ describe("ChatScrollControls", () => {
     let scrollHeight = 400;
     let scrollTop = 200;
     const scrollEl = document.createElement("div");
-    const contentEl = document.createElement("div");
     Object.defineProperties(scrollEl, {
       scrollHeight: { configurable: true, get: () => scrollHeight },
       clientHeight: { configurable: true, get: () => 200 },
@@ -177,7 +161,6 @@ describe("ChatScrollControls", () => {
     renderWithI18n(
       <Harness
         scrollEl={scrollEl}
-        contentEl={contentEl}
         controlsRef={controlsRef}
         virtualScrollToBottom={virtualScrollToBottom}
       />,
@@ -210,7 +193,6 @@ describe("ChatScrollControls", () => {
     let scrollHeight = 1000;
     let scrollTop = 800;
     const scrollEl = document.createElement("div");
-    const contentEl = document.createElement("div");
     Object.defineProperties(scrollEl, {
       scrollHeight: { configurable: true, get: () => scrollHeight },
       clientHeight: { configurable: true, get: () => 200 },
@@ -228,7 +210,6 @@ describe("ChatScrollControls", () => {
     renderWithI18n(
       <Harness
         scrollEl={scrollEl}
-        contentEl={contentEl}
         controlsRef={controlsRef}
         virtualScrollToBottom={virtualScrollToBottom}
       />,

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -26,7 +26,6 @@ import {
   shouldRepinForContentGrowth,
   THREAD_OPEN_COALESCE_MS,
 } from "./chatScrollGeometry";
-import { selectChatScrollAnchor, selectChatScrollAnchorForTimeline } from "./chatPaneSelectors";
 
 const USER_SCROLL_INTENT_MS = 750;
 /** Minimum at-bottom cache when no coalesce window is active. */
@@ -52,8 +51,6 @@ export const ChatScrollControls = forwardRef<
   ChatScrollControlsHandle,
   {
     scrollRef: React.RefObject<HTMLDivElement | null>;
-    contentRef: React.RefObject<HTMLDivElement | null>;
-    hiddenRuntimeItemId?: string | undefined;
     layoutChangeToken: string | null | undefined;
     threadId: string;
     tailLoaderVisible: boolean;
@@ -65,8 +62,6 @@ export const ChatScrollControls = forwardRef<
   const { t } = useLingui();
   const {
     scrollRef,
-    contentRef,
-    hiddenRuntimeItemId,
     layoutChangeToken,
     threadId,
     tailLoaderVisible,
@@ -277,12 +272,11 @@ export const ChatScrollControls = forwardRef<
     }
 
     if (hasScheduledLayoutSync()) return;
-    // During an active panel/divider drag the viewport changes every frame, and
-    // both this scroller's ResizeObserver and MessageList's totalSize effect
-    // call in here per frame. Collapse to a single coalesced rAF (no synchronous
+    // During an active panel/divider drag the viewport changes every frame.
+    // Collapse ResizeObserver updates to a single coalesced rAF (no synchronous
     // read, no chained settle passes) so the content still reflows and stays
-    // bottom-pinned live, but we do at most one forced reflow per frame instead
-    // of stacking several. The drag-end reconcile below runs the full settle.
+    // bottom-pinned live, but we do at most one forced reflow per frame. The
+    // drag-end reconcile below runs the full settle.
     //
     // Same coalescing while the initial thread-open settle is still running, and
     // for a short window after open while the virtualizer finishes measuring
@@ -447,22 +441,18 @@ export const ChatScrollControls = forwardRef<
 
   useEffect(() => {
     const el = scrollRef.current;
-    const content = contentRef.current;
-    if (!el && !content) return;
+    if (!el) return;
     const observer = new ResizeObserver(() => {
       // ResizeObserver already runs after layout and before paint, so syncing
-      // immediately here avoids a visible one-frame catch-up when rows collapse
-      // or when the viewport shrinks because surrounding UI grew.
+      // immediately here avoids a visible one-frame catch-up when the viewport
+      // changes because surrounding UI or panel dimensions changed.
       syncLayoutNowAndAfterPaint();
     });
     if (el) {
       observer.observe(el);
     }
-    if (content) {
-      observer.observe(content);
-    }
     return () => observer.disconnect();
-  }, [contentRef, scrollRef, threadId]);
+  }, [scrollRef, threadId]);
 
   const syncPinnedContentChange = useEffectEvent(() => {
     if (pinRafRef.current !== null) {
@@ -489,17 +479,6 @@ export const ChatScrollControls = forwardRef<
       }
     };
   });
-
-  useLayoutEffect(() => {
-    return useAppStore.subscribe(
-      (s) =>
-        hiddenRuntimeItemId
-          ? selectChatScrollAnchorForTimeline(s, threadId, hiddenRuntimeItemId)
-          : selectChatScrollAnchor(s, threadId),
-      () => syncPinnedContentChange(),
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- subscription identity is keyed to the rendered thread; the effect event reads latest layout refs.
-  }, [hiddenRuntimeItemId, threadId]);
 
   useLayoutEffect(() => {
     syncPinnedContentChange();

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { VirtualItem } from "@tanstack/react-virtual";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "@/renderer/state/appStore";
 import {
@@ -7,16 +8,14 @@ import {
   type ChatPaneActions,
 } from "../chatPaneActionsContext";
 import { MessageList } from "./MessageList";
+import { clearTimelineMeasurementCache } from "./timelineMeasurementCache";
 
-type MockVirtualRow = {
-  key: string;
-  index: number;
-  start: number;
-};
+type MockVirtualRow = Pick<VirtualItem, "key" | "index" | "start">;
 
 type MockVirtualizer = {
   getVirtualItems: () => MockVirtualRow[];
   getTotalSize: () => number;
+  takeSnapshot: () => VirtualItem[];
   measure: () => void;
   measureElement: (element: HTMLDivElement | null) => void;
   resizeItem: (index: number, size: number) => void;
@@ -38,6 +37,11 @@ type MockVirtualizerOptions = {
   measureElement?: unknown;
   useFlushSync?: boolean;
   useAnimationFrameWithResizeObserver?: boolean;
+  initialOffset?: () => number;
+  initialMeasurementsCache?: VirtualItem[];
+  anchorTo?: "start" | "end";
+  followOnAppend?: boolean;
+  scrollEndThreshold?: number;
 };
 
 const {
@@ -49,6 +53,7 @@ const {
   scrollToIndexMock,
   getVirtualItemsMock,
   getTotalSizeMock,
+  takeSnapshotMock,
 } = vi.hoisted(() => ({
   useVirtualizerMock: vi.fn<(options: MockVirtualizerOptions) => MockVirtualizer>(),
   measureMock: vi.fn<() => void>(),
@@ -60,6 +65,7 @@ const {
     vi.fn<(index: number, options?: { align?: "start" | "center" | "end" | "auto" }) => void>(),
   getVirtualItemsMock: vi.fn<() => MockVirtualRow[]>(),
   getTotalSizeMock: vi.fn<() => number>(),
+  takeSnapshotMock: vi.fn<() => VirtualItem[]>(),
 }));
 
 const { isIosTouchScrollMock } = vi.hoisted(() => ({
@@ -91,6 +97,7 @@ const PNG_BASE64 =
 describe("MessageList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearTimelineMeasurementCache();
     // Default to the non-iOS (desktop) path; iOS-specific tests opt in.
     // `clearAllMocks` resets call history but not the return value, so reset here.
     isIosTouchScrollMock.mockReturnValue(false);
@@ -106,10 +113,12 @@ describe("MessageList", () => {
       { key: "row-3", index: 2, start: 192 },
     ]);
     getTotalSizeMock.mockReturnValue(384);
+    takeSnapshotMock.mockReturnValue([]);
     optionsMeasureElementMock.mockReturnValue(96);
     useVirtualizerMock.mockReturnValue({
       getVirtualItems: getVirtualItemsMock,
       getTotalSize: getTotalSizeMock,
+      takeSnapshot: takeSnapshotMock,
       measure: measureMock,
       measureElement: measureElementMock,
       resizeItem: resizeItemMock,
@@ -155,6 +164,9 @@ describe("MessageList", () => {
     expect(virtualizerOptions.measureElement).toBeUndefined();
     expect(virtualizerOptions.useFlushSync).toBe(true);
     expect(virtualizerOptions.useAnimationFrameWithResizeObserver).toBe(true);
+    expect(virtualizerOptions.anchorTo).toBe("end");
+    expect(virtualizerOptions.followOnAppend).toBe(true);
+    expect(virtualizerOptions.scrollEndThreshold).toBe(4);
     expect(screen.queryByText("item-1")).not.toBeInTheDocument();
     expect(screen.getByText("item-2")).toBeInTheDocument();
     expect(screen.getByText("item-3")).toBeInTheDocument();
@@ -216,6 +228,66 @@ describe("MessageList", () => {
     const virtualizerOptions = useVirtualizerMock.mock.calls[0]![0];
     expect(virtualizerOptions.estimateSize(0)).toBe(320);
     expect(virtualizerOptions.estimateSize(1)).toBe(384);
+  });
+
+  it("overshoots initialOffset so the first range starts at the transcript tail", () => {
+    render(
+      <MessageList
+        threadId="thread-1"
+        entries={makeEntries(["item-1", "item-2", "item-3"])}
+        scrollElement={document.createElement("div")}
+      />,
+    );
+
+    const virtualizerOptions = useVirtualizerMock.mock.calls[0]![0];
+    expect(virtualizerOptions.initialOffset?.()).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("restores cached measurements only at the same transcript width", () => {
+    const snapshot: VirtualItem[] = [
+      { key: "item-3", index: 2, start: 210, size: 120, end: 330, lane: 0 },
+    ];
+    takeSnapshotMock.mockReturnValue(snapshot);
+    const firstScrollElement = document.createElement("div");
+    Object.defineProperty(firstScrollElement, "clientWidth", { configurable: true, value: 500 });
+    const first = render(
+      <MessageList
+        threadId="thread-1"
+        entries={makeEntries(["item-1", "item-2", "item-3"])}
+        scrollElement={firstScrollElement}
+      />,
+    );
+
+    first.unmount();
+
+    const sameWidthScrollElement = document.createElement("div");
+    Object.defineProperty(sameWidthScrollElement, "clientWidth", {
+      configurable: true,
+      value: 500,
+    });
+    const sameWidth = render(
+      <MessageList
+        threadId="thread-1"
+        entries={makeEntries(["item-1", "item-2", "item-3"])}
+        scrollElement={sameWidthScrollElement}
+      />,
+    );
+    expect(useVirtualizerMock.mock.calls.at(-1)?.[0].initialMeasurementsCache).toEqual(snapshot);
+    sameWidth.unmount();
+
+    const differentWidthScrollElement = document.createElement("div");
+    Object.defineProperty(differentWidthScrollElement, "clientWidth", {
+      configurable: true,
+      value: 600,
+    });
+    render(
+      <MessageList
+        threadId="thread-1"
+        entries={makeEntries(["item-1", "item-2", "item-3"])}
+        scrollElement={differentWidthScrollElement}
+      />,
+    );
+    expect(useVirtualizerMock.mock.calls.at(-1)?.[0].initialMeasurementsCache).toEqual([]);
   });
 
   it("never lets TanStack adjust scroll itself and compensates rows fully above the viewport on the next commit", () => {
@@ -314,7 +386,7 @@ describe("MessageList", () => {
     }
   });
 
-  it("still writes the bottom-sticky compensation immediately on iOS", () => {
+  it("leaves bottom-sticky compensation to native end anchoring on iOS", () => {
     isIosTouchScrollMock.mockReturnValue(true);
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -327,8 +399,8 @@ describe("MessageList", () => {
     };
     const { scrollElement, shouldAdjust, commit } = renderCompensationList(actions);
 
-    // Below-viewport streaming row while pinned: never deferred (no upward
-    // momentum at the bottom), so the pin stays tight.
+    // Below-viewport streaming row while pinned is owned by the native end
+    // anchor, including during iOS momentum tracking.
     expect(
       shouldAdjust({ start: 96, size: 100 }, 24, {
         isScrolling: true,
@@ -337,7 +409,7 @@ describe("MessageList", () => {
     ).toBe(false);
 
     commit();
-    expect(scrollElement.scrollTop).toBe(184);
+    expect(scrollElement.scrollTop).toBe(160);
   });
 
   it("does not apply sticky measure compensation while the user has scroll intent", () => {
@@ -396,7 +468,7 @@ describe("MessageList", () => {
     expect(noteProgrammaticScroll).toHaveBeenCalledWith(80);
   });
 
-  it("compensates streaming row height changes when bottom-sticky", () => {
+  it("leaves bottom-sticky row growth to native end anchoring", () => {
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
       revealProjectFolderInTree: vi.fn<(path: string) => void>(),
@@ -411,7 +483,7 @@ describe("MessageList", () => {
     expect(shouldAdjust({ start: 96, size: 100 }, 24, idleVirtualizer)).toBe(false);
 
     commit();
-    expect(scrollElement.scrollTop).toBe(184);
+    expect(scrollElement.scrollTop).toBe(160);
   });
 
   it("measures newly mounted rows synchronously so estimate corrections land pre-paint", () => {
@@ -613,7 +685,7 @@ describe("MessageList", () => {
     ).toBe("1");
   });
 
-  it("reports virtual total size changes to parent actions", () => {
+  it("leaves virtual total size changes to native end anchoring", () => {
     const onContentHeightChange = vi.fn<() => void>();
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -634,7 +706,7 @@ describe("MessageList", () => {
       </ChatPaneActionsContext.Provider>,
     );
 
-    expect(onContentHeightChange).toHaveBeenCalledOnce();
+    expect(onContentHeightChange).not.toHaveBeenCalled();
 
     getTotalSizeMock.mockReturnValue(288);
     rerender(
@@ -647,7 +719,7 @@ describe("MessageList", () => {
       </ChatPaneActionsContext.Provider>,
     );
 
-    expect(onContentHeightChange).toHaveBeenCalledTimes(2);
+    expect(onContentHeightChange).not.toHaveBeenCalled();
   });
 
   it("delegates height change to parent actions without forcing list measurement", () => {

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -28,6 +28,12 @@ import {
 import { ChatItemRow } from "./items/ChatItemRow";
 import { chatMessageSurfaceClass } from "./items/chatMessageSurface";
 import { imageViewRendersInline } from "./items/imageViewSource";
+import {
+  getTimelineMeasurementSignature,
+  readTimelineMeasurements,
+  writeTimelineMeasurements,
+} from "./timelineMeasurementCache";
+import { BOTTOM_EPSILON_PX } from "../chatScrollGeometry";
 
 export interface CheckpointRevertActions {
   rollbackThreadConversation(input: { threadId: string; numTurns: number }): Promise<void>;
@@ -110,6 +116,13 @@ export function MessageList({
   const [pendingRevertItemId, setPendingRevertItemId] = useState<string | null>(null);
   const [dontAskAgain, setDontAskAgain] = useState(false);
   const [revertError, setRevertError] = useState<string | null>(null);
+  const [initialMeasurementSignature] = useState(() =>
+    getTimelineMeasurementSignature(scrollElement),
+  );
+  const [initialMeasurementsCache] = useState(() =>
+    readTimelineMeasurements(threadId, initialMeasurementSignature),
+  );
+  const measurementSignatureRef = useRef(initialMeasurementSignature);
   const virtualizer = useVirtualizer({
     count: entries.length,
     getScrollElement: useCallback(() => scrollElement, [scrollElement]),
@@ -128,7 +141,29 @@ export function MessageList({
     // off). Keep it on elsewhere — it's load-bearing nowhere else and flipping it
     // for everyone is out of scope for this fix.
     useAnimationFrameWithResizeObserver: !deferScrollCompensation,
+    // Force the first range calculation to the tail. A fixed overshoot avoids
+    // both an extra estimation pass and a mismatch when restored measurements
+    // are taller than the current estimates.
+    initialOffset: () => Number.MAX_SAFE_INTEGER,
+    initialMeasurementsCache,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: BOTTOM_EPSILON_PX,
   });
+
+  useLayoutEffect(() => {
+    const signature = getTimelineMeasurementSignature(scrollElement);
+    if (measurementSignatureRef.current === null) {
+      measurementSignatureRef.current = signature;
+    }
+    return () => {
+      const cacheSignature = measurementSignatureRef.current;
+      if (!cacheSignature || getTimelineMeasurementSignature(scrollElement) !== cacheSignature) {
+        return;
+      }
+      writeTimelineMeasurements(threadId, cacheSignature, virtualizer.takeSnapshot());
+    };
+  }, [scrollElement, threadId, virtualizer]);
 
   useLayoutEffect(() => {
     if (!parentActions?.registerVirtualScrollToBottom) return;
@@ -149,14 +184,10 @@ export function MessageList({
   }, [entries.length, registerScrollToIndex, virtualizer]);
 
   useLayoutEffect(() => {
-    // Compensate scroll when a row above the viewport (or any row while
-    // bottom-sticky) trades its estimated height for a real measurement —
-    // otherwise the estimate error shifts the visible content. Always return
-    // false so TanStack never calls scrollTo itself: that adjustment runs
-    // outside React's commit and paints one frame apart from the translateY /
-    // row-height change, which reads as flicker. Instead the delta is
-    // accumulated here and applied in the layout effect below, in the same
-    // commit (and therefore the same paint) as the DOM change it compensates.
+    // Compensate when a row above a user-controlled scrollback window trades
+    // its estimate for a real measurement. End-pinned growth is owned by
+    // TanStack's native anchor; scrollback corrections stay synchronous with
+    // our row commit so they do not paint a frame apart from the height change.
     virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, delta, instance) => {
       if (!scrollElement) return false;
       const isAboveViewport = item.start + item.size <= scrollElement.scrollTop;
@@ -170,19 +201,14 @@ export function MessageList({
       if (hasIntent && (stickToBottom || !isAboveViewport)) {
         return false;
       }
-      if (stickToBottom || isAboveViewport) {
+      // Native end anchoring owns sticky row growth. Keep the custom buffered
+      // compensation only for rows above a user-controlled scrollback window.
+      if (!stickToBottom && isAboveViewport) {
         pendingScrollCompensationRef.current += delta;
         // Defer above-viewport corrections only for momentum coasts without a
         // hard intent flag (iOS / trackpad). While intent is active we apply
-        // above-viewport deltas in the same frame as the measure. Sticky pin
-        // writes stay synchronous when there is no intent.
-        if (
-          isAboveViewport &&
-          !stickToBottom &&
-          !hasIntent &&
-          instance?.isScrolling &&
-          instance.scrollDirection === "backward"
-        ) {
+        // above-viewport deltas in the same frame as the measure.
+        if (!hasIntent && instance?.isScrolling && instance.scrollDirection === "backward") {
           isCompensationDeferredRef.current = true;
         }
       }
@@ -325,10 +351,6 @@ export function MessageList({
     [entries, threadId],
   );
   const lastLiveIndex = useAppStore(liveTailSelector);
-
-  useLayoutEffect(() => {
-    parentActions?.onContentHeightChange();
-  }, [parentActions, totalSize]);
 
   const measureRowElement = useCallback(
     (index: number, element: HTMLDivElement | null) => {

--- a/src/renderer/components/thread/ChatPane/parts/timelineMeasurementCache.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/timelineMeasurementCache.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { VirtualItem } from "@tanstack/react-virtual";
+import {
+  clearTimelineMeasurementCache,
+  readTimelineMeasurements,
+  writeTimelineMeasurements,
+} from "./timelineMeasurementCache";
+
+const measurement: VirtualItem = {
+  key: "item-1",
+  index: 0,
+  start: 0,
+  size: 100,
+  end: 100,
+  lane: 0,
+};
+
+describe("timelineMeasurementCache", () => {
+  beforeEach(() => clearTimelineMeasurementCache());
+
+  it("rejects measurements captured for a different layout signature", () => {
+    writeTimelineMeasurements("thread-1", "500:14px", [measurement]);
+
+    expect(readTimelineMeasurements("thread-1", "600:14px")).toEqual([]);
+    expect(readTimelineMeasurements("thread-1", "500:14px")).toEqual([measurement]);
+  });
+
+  it("evicts the least recently used thread after sixteen entries", () => {
+    for (let index = 0; index < 16; index += 1) {
+      writeTimelineMeasurements(`thread-${index}`, "500:14px", [measurement]);
+    }
+    readTimelineMeasurements("thread-0", "500:14px");
+    writeTimelineMeasurements("thread-16", "500:14px", [measurement]);
+
+    expect(readTimelineMeasurements("thread-0", "500:14px")).toEqual([measurement]);
+    expect(readTimelineMeasurements("thread-1", "500:14px")).toEqual([]);
+    expect(readTimelineMeasurements("thread-16", "500:14px")).toEqual([measurement]);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/timelineMeasurementCache.ts
+++ b/src/renderer/components/thread/ChatPane/parts/timelineMeasurementCache.ts
@@ -1,0 +1,50 @@
+import type { VirtualItem } from "@tanstack/react-virtual";
+import { CHAT_FONT_SIZE_VAR } from "../chatFontVars";
+
+const MAX_TIMELINE_CACHE_ENTRIES = 16;
+const MAX_TIMELINE_WIDTH_PX = 920;
+
+type TimelineMeasurementCacheEntry = {
+  signature: string;
+  measurements: VirtualItem[];
+};
+
+const timelineMeasurementCache = new Map<string, TimelineMeasurementCacheEntry>();
+
+export function getTimelineMeasurementSignature(
+  scrollElement: HTMLDivElement | null,
+): string | null {
+  if (!scrollElement || scrollElement.clientWidth <= 0) return null;
+  const width = Math.min(scrollElement.clientWidth, MAX_TIMELINE_WIDTH_PX);
+  const fontSize = getComputedStyle(scrollElement).getPropertyValue(CHAT_FONT_SIZE_VAR).trim();
+  return `${width}:${fontSize}`;
+}
+
+export function readTimelineMeasurements(threadId: string, signature: string | null) {
+  if (!signature) return [];
+  const cached = timelineMeasurementCache.get(threadId);
+  if (!cached || cached.signature !== signature) return [];
+
+  timelineMeasurementCache.delete(threadId);
+  timelineMeasurementCache.set(threadId, cached);
+  return cached.measurements;
+}
+
+export function writeTimelineMeasurements(
+  threadId: string,
+  signature: string | null,
+  measurements: VirtualItem[],
+): void {
+  if (!signature || measurements.length === 0) return;
+
+  timelineMeasurementCache.delete(threadId);
+  timelineMeasurementCache.set(threadId, { signature, measurements });
+  if (timelineMeasurementCache.size > MAX_TIMELINE_CACHE_ENTRIES) {
+    const oldestThreadId = timelineMeasurementCache.keys().next().value;
+    if (oldestThreadId !== undefined) timelineMeasurementCache.delete(oldestThreadId);
+  }
+}
+
+export function clearTimelineMeasurementCache(): void {
+  timelineMeasurementCache.clear();
+}

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -102,6 +102,16 @@ const guiThread: Thread = {
   updatedAt: new Date().toISOString(),
 };
 
+const secondGuiThread: Thread = {
+  ...guiThread,
+  id: "thread-gui-second",
+  title: "Second Codex GUI thread",
+  sessionRef: {
+    providerSessionId: "session-gui-second",
+    discoveredAt: new Date().toISOString(),
+  },
+};
+
 const codexGuiStatus: AgentStatus = {
   kind: "codex",
   label: "Codex",
@@ -287,6 +297,67 @@ describe("ThreadComposerSection", () => {
     });
     // The draft is consumed on restore so a later real send can't resurrect it.
     expect(useAppStore.getState().threadDraftContents[guiThread.id]).toBeUndefined();
+  });
+
+  it("switches drafts without remounting the primary GUI composer shell", async () => {
+    useAppStore.setState({
+      threadDraftContents: {
+        [secondGuiThread.id]: {
+          segments: [{ kind: "text", content: "second thread draft" }],
+          attachments: [],
+        },
+      },
+    });
+    const { rerender } = renderComposer();
+    const firstInput = screen.getByRole("textbox");
+    firstInput.appendChild(document.createTextNode("first thread draft"));
+    fireEvent.input(firstInput);
+
+    rerender(
+      composerElement({
+        thread: secondGuiThread,
+        onSubmitInput: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveTextContent("second thread draft");
+    });
+    expect(screen.getByRole("textbox")).toBe(firstInput);
+    expect(useAppStore.getState().threadDraftContents[guiThread.id]?.segments).toEqual([
+      { kind: "text", content: "first thread draft" },
+    ]);
+    expect(useAppStore.getState().threadDraftContents[secondGuiThread.id]).toBeUndefined();
+  });
+
+  it("does not let an older thread's failed submit overwrite the reused composer", async () => {
+    let rejectSubmit: ((reason: Error) => void) | undefined;
+    const onSubmitInput = vi.fn<(prompt: string, segments?: unknown) => Promise<void>>(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSubmit = reject;
+        }),
+    );
+    const { rerender } = renderComposer({ onSubmitInput });
+    const firstInput = screen.getByRole("textbox");
+    firstInput.appendChild(document.createTextNode("send from first"));
+    fireEvent.input(firstInput);
+    fireEvent.click(screen.getByText("send"));
+    await waitFor(() => expect(onSubmitInput).toHaveBeenCalledOnce());
+
+    rerender(composerElement({ thread: secondGuiThread, onSubmitInput }));
+    const secondInput = screen.getByRole("textbox");
+    secondInput.appendChild(document.createTextNode("keep in second"));
+    fireEvent.input(secondInput);
+    await act(async () => {
+      rejectSubmit?.(new Error("send failed"));
+      await Promise.resolve();
+    });
+
+    expect(secondInput).toHaveTextContent("keep in second");
+    expect(useAppStore.getState().threadDraftContents[guiThread.id]?.segments).toEqual([
+      { kind: "text", content: "send from first" },
+    ]);
   });
 
   it("does not leave a draft behind once the message is sent", async () => {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -131,9 +131,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInterrupting, setIsInterrupting] = useState(false);
   const attachments = useAttachments();
-  // Unsent composer content survives leaving this thread: switching panes
-  // remounts this section (ThreadPane is keyed by threadId), so we save the
-  // typed segments + attachments on unmount and restore them on the next mount.
+  // Unsent composer content survives leaving this thread. The primary GUI pane
+  // keeps this section mounted across thread switches, so the thread-keyed
+  // layout effects below save and restore without exposing another thread's
+  // editor state for a paint.
   const saveThreadDraftContent = useAppStore((s) => s.saveThreadDraftContent);
   const clearThreadDraftContent = useAppStore((s) => s.clearThreadDraftContent);
   // The MentionInput owns the live editor DOM; mirror its latest serialized
@@ -149,11 +150,12 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   // re-save the just-sent text as a stale draft. Reset every time (success or
   // failure) because this composer is reused for the next message.
   const submittedRef = useRef(false);
-  // Captured once at mount; consumed (and cleared) by the restore effect below.
-  const initialThreadDraftRef = useRef(useAppStore.getState().threadDraftContents[thread.id]);
-  // Guards the restore effect so it runs exactly once — when the editor first
-  // mounts — even though its dep (`editorMounted`) can flip after mount.
-  const draftRestoredRef = useRef(false);
+  const composerSessionRef = useRef({ threadId: thread.id });
+  if (composerSessionRef.current.threadId !== thread.id) {
+    composerSessionRef.current = { threadId: thread.id };
+  }
+  const preparedThreadIdRef = useRef<string | null>(null);
+  const restoredThreadIdRef = useRef<string | null>(null);
   const pendingPickedAttachments = useBrowserAttachInbox((s) => s.itemsByThread[thread.id]);
   const addPickedRef = useRef(attachments.addPicked);
   addPickedRef.current = attachments.addPicked;
@@ -394,6 +396,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   }
 
   function submitPrompt(segments: PromptSegment[]) {
+    const composerSession = composerSessionRef.current;
     submitComposerPrompt(segments, {
       thread,
       agentStatus,
@@ -410,6 +413,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       terminalPaneRef: props.terminalPaneRef,
       latestSegmentsRef,
       submittedRef,
+      isCurrentSession: () => composerSessionRef.current === composerSession,
       setPrompt,
       setHasContent,
       setIsSubmitting,
@@ -444,19 +448,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     }
   }, [filteredCommands.length, slashActiveIndex]);
 
-  useEffect(() => {
-    setPrompt("");
-    setIsInterrupting(false);
-    setSlashQuery(null);
-    setSlashActiveIndex(0);
-    setContextDockOpen(false);
-    setComposerCollapsed(collapseTerminalComposerSetting);
-  }, [thread.id, collapseTerminalComposerSetting]);
-
   // Restore an unsent draft saved the last time this thread's composer was
-  // mounted. useLayoutEffect (and reading the editor via the imperative handle)
-  // runs before paint so the text never flashes empty. Consume the entry so a
-  // later real send doesn't resurrect it.
+  // active. useLayoutEffect runs before paint so the previous thread's editor
+  // content is cleared before the new thread is visible. Consume the entry so
+  // a later real send doesn't resurrect it.
   //
   // A terminal thread that is still `launching` hides the whole composer (so the
   // MentionInput — and `mentionRef` — does not exist yet). Restoring into a null
@@ -465,9 +460,25 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   // flips, at which point `mentionRef` is attached.
   const editorMounted = !usesTerminalPresentation || thread.status !== "launching";
   useLayoutEffect(() => {
-    if (draftRestoredRef.current || !editorMounted) return;
-    draftRestoredRef.current = true;
-    const saved = initialThreadDraftRef.current;
+    if (preparedThreadIdRef.current !== thread.id) {
+      preparedThreadIdRef.current = thread.id;
+      mentionRef.current?.clear();
+      latestSegmentsRef.current = [];
+      if (attachments.attachments.length > 0) attachments.clearAll();
+      submittedRef.current = false;
+      setPrompt("");
+      setHasContent(false);
+      setIsSubmitting(false);
+      setIsInterrupting(false);
+      setSlashQuery(null);
+      setSlashActiveIndex(0);
+      setControlOpenRequest(null);
+      setContextDockOpen(false);
+      setComposerCollapsed(collapseTerminalComposerSetting);
+    }
+    if (restoredThreadIdRef.current === thread.id || !editorMounted) return;
+    restoredThreadIdRef.current = thread.id;
+    const saved = useAppStore.getState().threadDraftContents[thread.id];
     if (!saved) return;
     if (saved.segments.length > 0) {
       mentionRef.current?.restoreFromSegments(saved.segments);
@@ -477,14 +488,18 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       attachments.restore(saved.attachments);
     }
     clearThreadDraftContent(thread.id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- restore runs once, when the editor first mounts
-  }, [editorMounted]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset/restore is keyed to the active thread and editor mount; attachment/editor methods are read from this render
+  }, [editorMounted, thread.id]);
+
+  useEffect(() => {
+    setComposerCollapsed(collapseTerminalComposerSetting);
+  }, [collapseTerminalComposerSetting]);
 
   // Save whatever is left in the composer when this thread's section unmounts
   // (navigating to another thread/pane). A cleared composer leaves both refs
   // empty, so a just-sent message is not re-saved; an in-flight submit is
   // skipped via submittedRef because its text has already been handed off.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const tid = thread.id;
     return () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps -- reading the latest refs at unmount is the point: they mirror the live composer state
@@ -822,6 +837,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                     );
                     const renderVoiceInput = () => (
                       <ComposerVoiceInput
+                        key={thread.id}
                         show={showVoiceInputButton}
                         isDisabled={
                           authRequired ||

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Tooltip } from "@heroui/react";
 import { ArrowRightLeft, Bug, CircleCheck, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -212,8 +212,10 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     });
   }, [agentStatus?.capabilities.presentationMode, thread.agentKind, thread.presentationMode]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    setContinueDialogOpen(false);
     setRuntimeDebugOpen(false);
+    setIsTitleTooltipOpen(false);
   }, [thread.id]);
 
   useEffect(() => {

--- a/src/renderer/components/thread/threadComposerSubmit.ts
+++ b/src/renderer/components/thread/threadComposerSubmit.ts
@@ -53,6 +53,8 @@ export interface ComposerSubmitContext {
   latestSegmentsRef: { current: PromptSegment[] };
   /** True while a submit is in flight; gates the unmount draft-save. */
   submittedRef: { current: boolean };
+  /** Prevent an older thread's async submit from mutating the reused composer shell. */
+  isCurrentSession: () => boolean;
   setPrompt: (value: string) => void;
   setHasContent: (value: boolean) => void;
   setIsSubmitting: (value: boolean) => void;
@@ -199,20 +201,26 @@ export function submitComposerPrompt(segments: PromptSegment[], ctx: ComposerSub
     .then(denyPendingApproval)
     .then(runSubmission)
     .then(() => {
-      if (!clearedBeforeSendSettled) {
+      if (!clearedBeforeSendSettled && ctx.isCurrentSession()) {
         clearSubmittedComposer();
       }
     })
     .catch((error: unknown) => {
       // Leave the prompt intact so the user can retry.
-      if (clearedBeforeSendSettled) {
+      if (ctx.isCurrentSession()) {
         restoreSubmittedComposer();
+      } else {
+        useAppStore.getState().saveThreadDraftContent(thread.id, {
+          segments: submittedInputSegments,
+          attachments: submittedAttachments,
+        });
       }
       toast.danger(friendlyError(error));
     })
     .finally(() => {
       // The composer is now either cleared (success) or restored (failure);
       // either way the refs reflect the real state, so re-arm draft-saving.
+      if (!ctx.isCurrentSession()) return;
       ctx.submittedRef.current = false;
       ctx.setIsSubmitting(false);
     });

--- a/src/renderer/components/thread/useThreadDockState.ts
+++ b/src/renderer/components/thread/useThreadDockState.ts
@@ -17,6 +17,8 @@ import {
   type ThreadTodoDockState,
 } from "./threadTodoState";
 
+const EMPTY_DISMISSED_ERROR_ITEM_IDS: ReadonlySet<string> = new Set();
+
 export interface ThreadDockState {
   todoDockCollapsed: boolean;
   todoDockPlacement: ThreadTodoDockPlacement;
@@ -55,47 +57,58 @@ export function useThreadDockState(threadId: string): ThreadDockState {
 
   // If the plan is retired, but the agent sends an update (new object reference
   // in the store), un-retire it so the user sees the progress.
-  const lastTodoItemRef = useRef(todoItem);
+  const lastTodoItemRef = useRef({ threadId, item: todoItem });
   useEffect(() => {
+    if (lastTodoItemRef.current.threadId !== threadId) {
+      lastTodoItemRef.current = { threadId, item: todoItem };
+      return;
+    }
     if (
       retiredSourceItemId &&
       todoItem?.id === retiredSourceItemId &&
-      todoItem !== lastTodoItemRef.current
+      todoItem !== lastTodoItemRef.current.item
     ) {
       retireTodoDock(threadId, undefined);
     }
-    lastTodoItemRef.current = todoItem;
+    lastTodoItemRef.current = { threadId, item: todoItem };
   }, [todoItem, retiredSourceItemId, threadId, retireTodoDock]);
 
-  const [dismissedGoalItemId, setDismissedGoalItemId] = useState<string | null>(null);
+  const [dismissedGoal, setDismissedGoal] = useState<{
+    threadId: string;
+    itemId: string;
+  } | null>(null);
   const lastGoalItemRef = useRef(goalItem);
   useEffect(() => {
     if (
-      dismissedGoalItemId &&
-      goalItem?.id === dismissedGoalItemId &&
+      dismissedGoal?.threadId === threadId &&
+      goalItem?.id === dismissedGoal.itemId &&
       goalItem !== lastGoalItemRef.current
     ) {
-      setDismissedGoalItemId(null);
+      setDismissedGoal(null);
     }
     lastGoalItemRef.current = goalItem;
-  }, [dismissedGoalItemId, goalItem]);
+  }, [dismissedGoal, goalItem, threadId]);
 
   const errorDockStatesRaw = useAppStore(
     useShallow((s) => selectThreadErrorDockStates(s, threadId)),
   );
-  const [dismissedErrorItemIds, setDismissedErrorItemIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
-  useEffect(() => {
-    setDismissedErrorItemIds(new Set());
-  }, [threadId]);
+  const [dismissedErrors, setDismissedErrors] = useState<{
+    threadId: string;
+    itemIds: ReadonlySet<string>;
+  }>(() => ({ threadId, itemIds: new Set() }));
+  const dismissedErrorItemIds =
+    dismissedErrors.threadId === threadId
+      ? dismissedErrors.itemIds
+      : EMPTY_DISMISSED_ERROR_ITEM_IDS;
   const errorDockStates = useMemo(
     () => errorDockStatesRaw.filter((state) => !dismissedErrorItemIds.has(state.sourceItemId)),
     [dismissedErrorItemIds, errorDockStatesRaw],
   );
 
   const showTodoDock = todoDockState !== null && todoDockState.sourceItemId !== retiredSourceItemId;
-  const showGoalDock = goalDockState !== null && goalDockState.sourceItemId !== dismissedGoalItemId;
+  const showGoalDock =
+    goalDockState !== null &&
+    (dismissedGoal?.threadId !== threadId || goalDockState.sourceItemId !== dismissedGoal.itemId);
   const visibleTodoDockState = showTodoDock ? todoDockState : null;
   const visibleGoalDockState = showGoalDock ? goalDockState : null;
   const showTodoInRightRail = showTodoDock && todoDockPlacement === "right";
@@ -122,10 +135,15 @@ export function useThreadDockState(threadId: string): ThreadDockState {
     hiddenRuntimeItemId,
     dockLayoutToken,
     onGoalDockDismiss: () => {
-      if (visibleGoalDockState) setDismissedGoalItemId(visibleGoalDockState.sourceItemId);
+      if (visibleGoalDockState) {
+        setDismissedGoal({ threadId, itemId: visibleGoalDockState.sourceItemId });
+      }
     },
     onDismissError: (sourceItemId) =>
-      setDismissedErrorItemIds((prev) => new Set([...prev, sourceItemId])),
+      setDismissedErrors((prev) => ({
+        threadId,
+        itemIds: new Set([...(prev.threadId === threadId ? prev.itemIds : []), sourceItemId]),
+      })),
     onTodoDockCollapsedChange: (collapsed) => setTodoDockCollapsed(threadId, collapsed),
     onTodoDockPlacementChange: (placement) => setTodoDockPlacement(threadId, placement),
     onTodoDockRetire: () => {

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -217,9 +217,23 @@ export function useActiveProjectThreads(projectId: string | undefined): Thread[]
   );
 }
 
-/** Whether a given thread id is currently open in any pane. */
+/**
+ * Whether a given thread id is currently open in any pane — with an optimistic
+ * override while an `openThread` switch is in flight. When `pendingActiveThreadId`
+ * is set, the clicked thread highlights immediately and the previous primary pane
+ * (panes[0]) de-highlights, while any secondary split panes keep their highlight
+ * ("pending replaces panes[0]"). This lets the sidebar acknowledge a click a frame
+ * before the heavy pane remount commits. Returns a primitive (Object.is-stable).
+ */
 export function useIsCurrentThread(threadId: string): boolean {
-  return useAppStore((s) => s.view.kind === "thread" && s.view.panes.includes(threadId));
+  return useAppStore((s) => {
+    const pending = s.pendingActiveThreadId;
+    if (pending !== null) {
+      if (threadId === pending) return true;
+      return s.view.kind === "thread" && s.view.panes.indexOf(threadId, 1) !== -1;
+    }
+    return s.view.kind === "thread" && s.view.panes.includes(threadId);
+  });
 }
 
 /**

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HOME_PROJECT_ID, HOME_PROJECT_NAME } from "@/shared/homeScope";
-import type { PaneLayout } from "@/shared/paneLayout";
+import { findPaneSlotId, type PaneLayout } from "@/shared/paneLayout";
 import {
   readStoredSizes,
   splitStorageKey,
@@ -323,7 +323,10 @@ describe("appStore runtime config sync", () => {
 
     useAppStore.getState().openThread(threadThree.id);
     const view = useAppStore.getState().view;
-    expect(view).toEqual({ kind: "thread", panes: [threadThree.id, t2.id] });
+    expect(view.kind === "thread" && view.panes).toEqual([threadThree.id, t2.id]);
+    expect(view.kind === "thread" && view.paneLayout).toBeTruthy();
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(findPaneSlotId(view.paneLayout, threadThree.id)).toBe(t1.id);
   });
 
   it("openThread is no-op when thread is already in panes", () => {
@@ -1301,7 +1304,10 @@ describe("grid layout actions", () => {
 
     useAppStore.getState().replacePaneAtIndex(ids[3]!, 1);
     const view = useAppStore.getState().view;
-    expect(view).toEqual({ kind: "thread", panes: [ids[0], ids[3], ids[2]] });
+    expect(view.kind === "thread" && view.panes).toEqual([ids[0], ids[3], ids[2]]);
+    expect(view.kind === "thread" && view.paneLayout).toBeTruthy();
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(findPaneSlotId(view.paneLayout, ids[3]!)).toBe(ids[1]);
   });
 
   it("movePaneToIndex reorders pane position", () => {
@@ -1579,6 +1585,43 @@ describe("grid layout actions", () => {
         { kind: "leaf", paneId: ids[3] },
       ],
     });
+  });
+
+  it("keeps a secondary pane slot through replacement, move, and swap", () => {
+    const ids = createThreads(4);
+    useAppStore.setState((state) => ({
+      ...state,
+      view: {
+        kind: "thread",
+        panes: [ids[0]!, ids[1]!, ids[2]!] as [string, ...string[]],
+        paneLayout: {
+          kind: "split",
+          axis: "vertical",
+          children: [
+            { kind: "leaf", paneId: ids[0]!, slotId: "slot-a" },
+            { kind: "leaf", paneId: ids[1]!, slotId: "slot-b" },
+            { kind: "leaf", paneId: ids[2]!, slotId: "slot-c" },
+          ],
+        },
+      },
+    }));
+
+    useAppStore.getState().replacePaneById(ids[3]!, ids[1]!);
+    let view = useAppStore.getState().view;
+    expect(view.kind === "thread" && view.paneLayout).toBeTruthy();
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(findPaneSlotId(view.paneLayout, ids[3]!)).toBe("slot-b");
+
+    useAppStore.getState().movePaneToLayoutTarget(ids[3]!, { paneId: ids[2]!, edge: "right" });
+    view = useAppStore.getState().view;
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(findPaneSlotId(view.paneLayout, ids[3]!)).toBe("slot-b");
+
+    useAppStore.getState().swapPanes(ids[3]!, ids[0]!);
+    view = useAppStore.getState().view;
+    if (view.kind !== "thread" || !view.paneLayout) return;
+    expect(findPaneSlotId(view.paneLayout, ids[3]!)).toBe("slot-b");
+    expect(findPaneSlotId(view.paneLayout, ids[0]!)).toBe("slot-a");
   });
 });
 

--- a/src/renderer/state/slices/helpers.ts
+++ b/src/renderer/state/slices/helpers.ts
@@ -242,13 +242,6 @@ export function replacePaneInView(
   // the user's custom sizes back to an equal split.
   migratePaneSizeStorage(oldPaneId, newPaneId);
 
-  if (!view.paneLayout) {
-    const panes = [...view.panes] as [string, ...string[]];
-    const idx = panes.indexOf(oldPaneId);
-    if (idx !== -1) panes[idx] = newPaneId;
-    return { ...view, panes };
-  }
-
   const layout = replacePaneIdInLayout(currentPaneLayout(view), oldPaneId, newPaneId);
   return {
     kind: "thread",

--- a/src/renderer/state/slices/viewSlice.ts
+++ b/src/renderer/state/slices/viewSlice.ts
@@ -3,6 +3,7 @@ import { makeDraftPaneId } from "@/shared/paneId";
 import {
   adjustInsertTargetForRemoval,
   collectPaneIds,
+  findPaneSlotId,
   insertPaneInLayout,
   removePaneFromLayout,
   splitPaneInLayout,
@@ -32,11 +33,19 @@ export interface ViewSlice {
   focusedPaneId: string | null;
   pendingComposerFocusThreadId: string | null;
   chatScrollToBottomTokens: Record<string, number>;
+  /**
+   * Optimistic, urgent active-thread id used only for instant sidebar-row
+   * highlighting on click. Decoupled from `view.panes` (which drives the heavy
+   * pane remount) so the highlight can paint a frame before the blocking mount.
+   * Non-null only while an `openThread` switch is in flight.
+   */
+  pendingActiveThreadId: string | null;
   groupLayouts: Record<string, SavedGroupLayout>;
   setFocusedPane: (paneId: string) => void;
   requestComposerFocus: (threadId: string) => void;
   clearComposerFocusRequest: (threadId: string) => void;
   requestChatScrollToBottom: (threadId: string) => void;
+  setPendingActiveThread: (threadId: string | null) => void;
   openDraft: (projectId: string) => void;
   openDraftSideBySide: (projectId: string) => void;
   openHome: () => void;
@@ -79,6 +88,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
   focusedPaneId: null,
   pendingComposerFocusThreadId: null,
   chatScrollToBottomTokens: {},
+  pendingActiveThreadId: null,
   groupLayouts: {},
   setFocusedPane: (paneId) => set({ focusedPaneId: paneId }),
   requestComposerFocus: (threadId) => set({ pendingComposerFocusThreadId: threadId }),
@@ -93,6 +103,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
         [threadId]: (state.chatScrollToBottomTokens[threadId] ?? 0) + 1,
       },
     })),
+  setPendingActiveThread: (threadId) => set({ pendingActiveThreadId: threadId }),
   openDraft: (projectId) => set({ view: { kind: "draft", projectId } }),
   openDraftSideBySide: (projectId) =>
     set((state) => {
@@ -312,9 +323,8 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       if (existing.includes(threadId) || index < 0 || index >= existing.length) {
         return {};
       }
-      const nextPanes = [...existing] as [string, ...string[]];
-      nextPanes[index] = threadId;
-      const nextView: AppView = { ...state.view, panes: nextPanes };
+      const nextView = replacePaneInView(state.view, existing[index]!, threadId);
+      const nextPanes = nextView.panes;
       const cleared = clearFinishedAndDone(state.threads, nextPanes);
       return cleared ? { view: nextView, threads: cleared } : { view: nextView };
     }),
@@ -443,6 +453,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       if ("paneId" in target && target.paneId === paneId) return {};
 
       const layout = currentPaneLayout(state.view);
+      const slotId = findPaneSlotId(layout, paneId) ?? paneId;
       const layoutWithoutPane = removePaneFromLayout(layout, paneId);
       if (!layoutWithoutPane) {
         return {};
@@ -450,11 +461,12 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
 
       const nextLayout =
         "paneId" in target
-          ? splitPaneInLayout(layoutWithoutPane, target.paneId, paneId, target.edge)
+          ? splitPaneInLayout(layoutWithoutPane, target.paneId, paneId, target.edge, slotId)
           : insertPaneInLayout(
               layoutWithoutPane,
               adjustInsertTargetForRemoval(layout, paneId, target),
               paneId,
+              slotId,
             );
       preservePaneSizeStorageForLayoutChange(layout, nextLayout);
       return {

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -16,7 +16,7 @@ import { friendlyError } from "@/shared/messages";
 import { isHomeProject } from "@/shared/homeScope";
 import { buildWorktreeLocation } from "@/shared/worktree";
 import { isDraftPaneId, parseDraftProjectId } from "@/shared/paneId";
-import { buildPaneLayoutFromLegacy, findPaneAlign } from "@/shared/paneLayout";
+import { buildPaneLayoutFromLegacy, findPaneAlign, findPaneSlotId } from "@/shared/paneLayout";
 import { titlePromptFromSegments } from "@/shared/threadTitle";
 import { readBridge } from "@/renderer/bridge";
 import { i18n } from "@/renderer/i18n/i18n";
@@ -36,7 +36,11 @@ import {
 import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTerminalStore";
 import { closeAllPanels } from "@/renderer/actions/panelActions";
 import { worktreePlacementPayload } from "@/renderer/actions/worktreePlacement";
-import { SplitPaneContainer, type Rect } from "@/renderer/components/layout/SplitPaneContainer";
+import {
+  resolvePaneDomKey,
+  SplitPaneContainer,
+  type Rect,
+} from "@/renderer/components/layout/SplitPaneContainer";
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
 import { ThreadDraftView } from "@/renderer/components/thread/ThreadDraftView";
 import type { DraftStartInput } from "@/renderer/components/thread/ThreadDraftComposerArea";
@@ -316,6 +320,13 @@ export function AppContent() {
     }
     const activeGroupId = view.activeGroupId;
     const hasGroupHeader = !!(activeGroupId && activeGroupName);
+    function getPaneDomKey(paneId: string) {
+      return resolvePaneDomKey({
+        paneId,
+        paneSlotId: findPaneSlotId(paneLayout, paneId) ?? paneId,
+        presentationMode: storeThreads.find((thread) => thread.id === paneId)?.presentationMode,
+      });
+    }
 
     function renderPane(paneId: string, rect: Rect) {
       const paneDraftProjectId = parseDraftProjectId(paneId);
@@ -326,7 +337,6 @@ export function AppContent() {
       const headerNeedsTrafficLightPad = rect.left === 0 && rect.top === 0 && !hasGroupHeader;
       const paneContent = paneDraftProjectId ? (
         <DraftPane
-          key={paneId}
           paneId={paneId}
           projectId={paneDraftProjectId}
           paneCount={paneCount}
@@ -339,7 +349,6 @@ export function AppContent() {
         />
       ) : (
         <ThreadPane
-          key={paneId}
           threadId={paneId}
           paneCount={paneCount}
           paneAlign={paneAlign}
@@ -350,7 +359,6 @@ export function AppContent() {
       );
       return (
         <div
-          key={paneId}
           className="h-full outline-none"
           tabIndex={-1}
           onFocusCapture={() => useAppStore.getState().setFocusedPane(paneId)}
@@ -378,7 +386,11 @@ export function AppContent() {
           </div>
         )}
         <div className="min-h-0 flex-1">
-          <SplitPaneContainer layout={paneLayout} renderPane={renderPane} />
+          <SplitPaneContainer
+            layout={paneLayout}
+            renderPane={renderPane}
+            getPaneDomKey={getPaneDomKey}
+          />
         </div>
       </div>
     );

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -69,7 +69,6 @@ export function ThreadPane(props: {
   const projectLocation = resolveProjectLocation(project.location, thread.worktreePath);
   return (
     <ThreadView
-      key={props.threadId}
       thread={thread}
       projectName={project.name}
       agentStatus={agentStatus}

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -39,7 +39,7 @@ import { openTerminal } from "@/renderer/actions/terminalActions";
 import { openThread } from "@/renderer/actions/threadActions";
 import {
   useCurrentProjectId,
-  useCurrentThreadIds,
+  useIsCurrentThread,
   useCurrentWorktreePath,
   useIsProjectTerminalActive,
   useIsProjectTerminalBusy,
@@ -167,8 +167,23 @@ function RemoteAccessSidebarIcon(props: { status: RemoteAccessSidebarStatus }) {
   );
 }
 
+function CollapsedThreadRailButton(props: { thread: Thread }) {
+  const { thread } = props;
+  const isActive = useIsCurrentThread(thread.id);
+  return (
+    <SidebarButton
+      iconOnly
+      icon={<ThreadIcon thread={thread} />}
+      label={
+        thread.done ? <span className="opacity-50 line-through">{thread.title}</span> : thread.title
+      }
+      isActive={isActive}
+      onPress={() => openThread(thread.id)}
+    />
+  );
+}
+
 function CollapsedThreadRail() {
-  const currentThreadIds = useCurrentThreadIds();
   const homeScopeEnabled = useSharedSettings((s) => s.homeScopeEnabled);
   const activeThreads = useAppStore(
     useShallow((state) =>
@@ -192,20 +207,7 @@ function CollapsedThreadRail() {
       style={scrollFadeStyle}
     >
       {activeThreads.map((thread) => (
-        <SidebarButton
-          key={thread.id}
-          iconOnly
-          icon={<ThreadIcon thread={thread} />}
-          label={
-            thread.done ? (
-              <span className="opacity-50 line-through">{thread.title}</span>
-            ) : (
-              thread.title
-            )
-          }
-          isActive={currentThreadIds.includes(thread.id)}
-          onPress={() => openThread(thread.id)}
-        />
+        <CollapsedThreadRailButton key={thread.id} thread={thread} />
       ))}
     </div>
   );

--- a/src/shared/paneLayout.test.ts
+++ b/src/shared/paneLayout.test.ts
@@ -145,6 +145,16 @@ describe("replacePaneIdInLayout", () => {
     expect(replacePaneIdInLayout(layout, "old", "new")).toEqual({
       kind: "leaf",
       paneId: "new",
+      slotId: "old",
+    });
+  });
+
+  it("preserves an existing slot identity", () => {
+    const layout: PaneLayout = { kind: "leaf", paneId: "old", slotId: "slot-a" };
+    expect(replacePaneIdInLayout(layout, "old", "new")).toEqual({
+      kind: "leaf",
+      paneId: "new",
+      slotId: "slot-a",
     });
   });
 
@@ -182,6 +192,25 @@ describe("swapPaneIdsInLayout", () => {
     const ids = collectPaneIds(result);
     expect(ids[0]).toBe("b");
     expect(ids[1]).toBe("a");
+  });
+
+  it("moves each pane slot with its pane", () => {
+    const layout: PaneLayout = {
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: "a", slotId: "slot-a" },
+        { kind: "leaf", paneId: "b", slotId: "slot-b" },
+      ],
+    };
+    expect(swapPaneIdsInLayout(layout, "a", "b")).toEqual({
+      kind: "split",
+      axis: "vertical",
+      children: [
+        { kind: "leaf", paneId: "b", slotId: "slot-b" },
+        { kind: "leaf", paneId: "a", slotId: "slot-a" },
+      ],
+    });
   });
 });
 

--- a/src/shared/paneLayout.ts
+++ b/src/shared/paneLayout.ts
@@ -1,7 +1,7 @@
 export type PaneLayoutAxis = "horizontal" | "vertical";
 
 export type PaneLayout =
-  | { kind: "leaf"; paneId: string }
+  | { kind: "leaf"; paneId: string; slotId?: string }
   | { kind: "split"; axis: PaneLayoutAxis; children: [PaneLayout, PaneLayout, ...PaneLayout[]] };
 
 export interface PaneLayoutInsertTarget {
@@ -54,7 +54,9 @@ export function replacePaneIdInLayout(
   newPaneId: string,
 ): PaneLayout {
   if (layout.kind === "leaf") {
-    return layout.paneId === oldPaneId ? { kind: "leaf", paneId: newPaneId } : layout;
+    return layout.paneId === oldPaneId
+      ? { kind: "leaf", paneId: newPaneId, slotId: layout.slotId ?? oldPaneId }
+      : layout;
   }
 
   return normalizeLayout({
@@ -70,10 +72,14 @@ export function swapPaneIdsInLayout(
   firstPaneId: string,
   secondPaneId: string,
 ): PaneLayout {
-  return mapPaneLayout(layout, (paneId) => {
-    if (paneId === firstPaneId) return secondPaneId;
-    if (paneId === secondPaneId) return firstPaneId;
-    return paneId;
+  const firstPane = findPaneLeaf(layout, firstPaneId);
+  const secondPane = findPaneLeaf(layout, secondPaneId);
+  if (!firstPane || !secondPane) return layout;
+
+  return mapPaneLayout(layout, (pane) => {
+    if (pane.paneId === firstPaneId) return secondPane;
+    if (pane.paneId === secondPaneId) return firstPane;
+    return pane;
   });
 }
 
@@ -82,21 +88,22 @@ export function splitPaneInLayout(
   targetPaneId: string,
   newPaneId: string,
   edge: "left" | "right" | "top" | "bottom",
+  slotId?: string,
 ): PaneLayout {
   if (layout.kind === "leaf") {
     if (layout.paneId !== targetPaneId) return layout;
     const axis = edge === "left" || edge === "right" ? "vertical" : "horizontal";
     const children: PaneLayout[] =
       edge === "left" || edge === "top"
-        ? [{ kind: "leaf", paneId: newPaneId }, layout]
-        : [layout, { kind: "leaf", paneId: newPaneId }];
+        ? [makePaneLeaf(newPaneId, slotId), layout]
+        : [layout, makePaneLeaf(newPaneId, slotId)];
     return makeSplit(axis, children);
   }
 
   return normalizeLayout({
     ...layout,
     children: layout.children.map((child) =>
-      splitPaneInLayout(child, targetPaneId, newPaneId, edge),
+      splitPaneInLayout(child, targetPaneId, newPaneId, edge, slotId),
     ) as [PaneLayout, PaneLayout, ...PaneLayout[]],
   });
 }
@@ -123,8 +130,20 @@ export function insertPaneInLayout(
   layout: PaneLayout,
   target: PaneLayoutInsertTarget,
   paneId: string,
+  slotId?: string,
 ): PaneLayout {
-  return insertIntoPath(layout, target.path, target.axis, target.index, { kind: "leaf", paneId });
+  return insertIntoPath(
+    layout,
+    target.path,
+    target.axis,
+    target.index,
+    makePaneLeaf(paneId, slotId),
+  );
+}
+
+export function findPaneSlotId(layout: PaneLayout, paneId: string): string | null {
+  const pane = findPaneLeaf(layout, paneId);
+  return pane ? (pane.slotId ?? pane.paneId) : null;
 }
 
 export function adjustInsertTargetForRemoval(
@@ -233,19 +252,39 @@ function samePath(left: number[], right: number[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function mapPaneLayout(layout: PaneLayout, mapPaneId: (paneId: string) => string): PaneLayout {
+function findPaneLeaf(
+  layout: PaneLayout,
+  paneId: string,
+): Extract<PaneLayout, { kind: "leaf" }> | null {
+  if (layout.kind === "leaf") return layout.paneId === paneId ? layout : null;
+
+  for (const child of layout.children) {
+    const pane = findPaneLeaf(child, paneId);
+    if (pane) return pane;
+  }
+  return null;
+}
+
+function mapPaneLayout(
+  layout: PaneLayout,
+  mapPane: (pane: Extract<PaneLayout, { kind: "leaf" }>) => Extract<PaneLayout, { kind: "leaf" }>,
+): PaneLayout {
   if (layout.kind === "leaf") {
-    return { kind: "leaf", paneId: mapPaneId(layout.paneId) };
+    return mapPane(layout);
   }
 
   return normalizeLayout({
     ...layout,
-    children: layout.children.map((child) => mapPaneLayout(child, mapPaneId)) as [
+    children: layout.children.map((child) => mapPaneLayout(child, mapPane)) as [
       PaneLayout,
       PaneLayout,
       ...PaneLayout[],
     ],
   });
+}
+
+function makePaneLeaf(paneId: string, slotId?: string): PaneLayout {
+  return slotId ? { kind: "leaf", paneId, slotId } : { kind: "leaf", paneId };
 }
 
 function walk(layout: PaneLayout, visitor: (paneId: string) => void) {


### PR DESCRIPTION
- Bugfix: preserve stable pane slots and mounted thread surfaces when switching threads, preventing unnecessary state resets.
- Keep unsent composer content, dialog state, dock state, and asynchronous submits isolated to the active thread.
- Restore compatible chat timeline measurements and scroll behavior to avoid jumps or duplicated scroll handling during thread changes.
- Prioritize sidebar selection feedback while deferring heavier pane updates, with coverage across layouts, thread actions, and chat UI.