### PR TITLE
Improve chat transcript scrollback performance

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -49,11 +49,11 @@ const {
   measureMock,
   measureElementMock,
   resizeItemMock,
+  takeSnapshotMock,
   optionsMeasureElementMock,
   scrollToIndexMock,
   getVirtualItemsMock,
   getTotalSizeMock,
-  takeSnapshotMock,
 } = vi.hoisted(() => ({
   useVirtualizerMock: vi.fn<(options: MockVirtualizerOptions) => MockVirtualizer>(),
   measureMock: vi.fn<() => void>(),
@@ -113,8 +113,8 @@ describe("MessageList", () => {
       { key: "row-3", index: 2, start: 192 },
     ]);
     getTotalSizeMock.mockReturnValue(384);
-    takeSnapshotMock.mockReturnValue([]);
     optionsMeasureElementMock.mockReturnValue(96);
+    takeSnapshotMock.mockReturnValue([]);
     useVirtualizerMock.mockReturnValue({
       getVirtualItems: getVirtualItemsMock,
       getTotalSize: getTotalSizeMock,
@@ -244,6 +244,7 @@ describe("MessageList", () => {
   });
 
   it("restores cached measurements only at the same transcript width", () => {
+    hydrateCompletedAssistantMessages("thread-1", ["item-3"]);
     const snapshot: VirtualItem[] = [
       { key: "item-3", index: 2, start: 210, size: 120, end: 330, lane: 0 },
     ];
@@ -288,6 +289,188 @@ describe("MessageList", () => {
       />,
     );
     expect(useVirtualizerMock.mock.calls.at(-1)?.[0].initialMeasurementsCache).toEqual([]);
+  });
+
+  it("estimates collapsed tool, group, and reasoning rows near their one-line height", () => {
+    const threadId = "thread-estimates";
+    useAppStore.getState().hydrateThreadRuntimeItems(threadId, [
+      { id: "tool-1", type: "tool_call", state: "completed", payload: {}, streams: {} },
+      { id: "cmd-1", type: "command_execution", state: "completed", payload: {}, streams: {} },
+      { id: "reason-1", type: "reasoning", state: "completed", payload: {}, streams: {} },
+    ]);
+
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={[
+          { kind: "item", id: "tool-1" },
+          { kind: "item", id: "cmd-1" },
+          { kind: "item", id: "reason-1" },
+          { kind: "tool_call_group", id: "group-1", itemIds: ["tool-2", "tool-3"] },
+        ]}
+        scrollElement={document.createElement("div")}
+      />,
+    );
+
+    const virtualizerOptions = useVirtualizerMock.mock.calls[0]![0];
+    // Collapsed accordion trigger (~27px), not the old 56/64 over-estimate.
+    expect(virtualizerOptions.estimateSize(0)).toBe(28);
+    expect(virtualizerOptions.estimateSize(1)).toBe(28);
+    // Reasoning "Thought" toggle uses py-2, so ~32px.
+    expect(virtualizerOptions.estimateSize(2)).toBe(32);
+    // Collapsed tool-call group shares the accordion trigger.
+    expect(virtualizerOptions.estimateSize(3)).toBe(28);
+  });
+
+  it("snapshots measured sizes on unmount and restores them on remount of the same thread", () => {
+    const threadId = "thread-snapshot-restore";
+    hydrateCompletedAssistantMessages(threadId, ["item-1", "item-2"]);
+    const snapshot = [{ key: "item-1", index: 0, start: 0, end: 40, size: 40, lane: 0 }];
+    takeSnapshotMock.mockReturnValue(snapshot);
+
+    const { unmount } = render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1", "item-2"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+
+    expect(useVirtualizerMock.mock.calls[0]![0].initialMeasurementsCache).toEqual([]);
+
+    unmount();
+    expect(takeSnapshotMock).toHaveBeenCalled();
+
+    useVirtualizerMock.mockClear();
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1", "item-2"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+
+    // The prior snapshot's measurements are handed back so rows never
+    // re-estimate. Content, not array identity, is what virtual-core consumes.
+    expect(useVirtualizerMock.mock.calls[0]![0].initialMeasurementsCache).toEqual(snapshot);
+  });
+
+  it("forwards a stale snapshot verbatim after truncation (virtual-core matches by key)", () => {
+    const threadId = "thread-snapshot-truncated";
+    hydrateCompletedAssistantMessages(threadId, ["item-1", "item-2", "item-3"]);
+    const snapshot = [
+      { key: "item-1", index: 0, start: 0, end: 40, size: 40, lane: 0 },
+      { key: "item-2", index: 1, start: 40, end: 80, size: 40, lane: 0 },
+      { key: "item-3", index: 2, start: 80, end: 120, size: 40, lane: 0 },
+    ];
+    takeSnapshotMock.mockReturnValue(snapshot);
+
+    const { unmount } = render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1", "item-2", "item-3"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+    unmount();
+
+    useVirtualizerMock.mockClear();
+    // Timeline truncated to a single item (e.g. checkpoint revert). Stale keys
+    // in the snapshot are harmless: virtual-core seeds itemSizeCache by key and
+    // reads sizes via getItemKey, so no index-based guard is needed here.
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+
+    expect(useVirtualizerMock.mock.calls[0]![0].initialMeasurementsCache).toEqual(snapshot);
+  });
+
+  it("drops expansion-dependent rows from the snapshot so they re-estimate collapsed", () => {
+    // Regression (adversarial review A3): a group/tool/reasoning/user row the
+    // user expanded before leaving snapshots its TALL measured height under a
+    // content-stable key, but always remounts collapsed — restoring that size
+    // would hand scroll compensation one huge delta on first revisit.
+    const threadId = "thread-snapshot-expandable";
+    useAppStore.getState().hydrateThreadRuntimeItems(threadId, [
+      {
+        id: "assistant-1",
+        type: "assistant_message",
+        state: "completed",
+        payload: {},
+        streams: {},
+      },
+      { id: "assistant-2", type: "assistant_message", state: "updated", payload: {}, streams: {} },
+      { id: "tool-1", type: "tool_call", state: "completed", payload: {}, streams: {} },
+      { id: "reason-1", type: "reasoning", state: "completed", payload: {}, streams: {} },
+      { id: "user-1", type: "user_message", state: "completed", payload: {}, streams: {} },
+    ]);
+    takeSnapshotMock.mockReturnValue([
+      { key: "assistant-1", index: 0, start: 0, end: 200, size: 200, lane: 0 },
+      { key: "assistant-2", index: 1, start: 200, end: 320, size: 120, lane: 0 },
+      { key: "tool-1", index: 2, start: 320, end: 720, size: 400, lane: 0 },
+      { key: "reason-1", index: 3, start: 720, end: 1020, size: 300, lane: 0 },
+      { key: "user-1", index: 4, start: 1020, end: 1260, size: 240, lane: 0 },
+      { key: "tool-call-group:tool-2", index: 5, start: 1260, end: 1660, size: 400, lane: 0 },
+    ]);
+
+    const entries = [
+      ...makeEntries(["assistant-1", "assistant-2", "tool-1", "reason-1", "user-1"]),
+      { kind: "tool_call_group" as const, id: "tool-call-group:tool-2", itemIds: ["tool-2"] },
+    ];
+    const { unmount } = render(
+      <MessageList
+        threadId={threadId}
+        entries={entries}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+    unmount();
+
+    useVirtualizerMock.mockClear();
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={entries}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+
+    // Only the completed assistant message survives: the streaming one is
+    // still changing, and every collapsible row (tool, reasoning, clamped user
+    // message, group) remounts collapsed, so it must fall back to the accurate
+    // collapsed estimate instead of a stale expanded measurement.
+    expect(useVirtualizerMock.mock.calls[0]![0].initialMeasurementsCache).toEqual([
+      { key: "assistant-1", index: 0, start: 0, end: 200, size: 200, lane: 0 },
+    ]);
+  });
+
+  it("does not restore when the prior mount measured nothing", () => {
+    const threadId = "thread-snapshot-empty";
+    takeSnapshotMock.mockReturnValue([]);
+
+    const { unmount } = render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+    unmount();
+
+    useVirtualizerMock.mockClear();
+    render(
+      <MessageList
+        threadId={threadId}
+        entries={makeEntries(["item-1"])}
+        scrollElement={createSizedScrollElement()}
+      />,
+    );
+
+    expect(useVirtualizerMock.mock.calls[0]![0].initialMeasurementsCache).toEqual([]);
   });
 
   it("never lets TanStack adjust scroll itself and compensates rows fully above the viewport on the next commit", () => {
@@ -757,6 +940,29 @@ describe("MessageList", () => {
 
 function makeEntries(itemIds: readonly string[]) {
   return itemIds.map((id) => ({ kind: "item" as const, id }));
+}
+
+function createSizedScrollElement(clientWidth = 500) {
+  const scrollElement = document.createElement("div");
+  Object.defineProperty(scrollElement, "clientWidth", { configurable: true, value: clientWidth });
+  return scrollElement;
+}
+
+/**
+ * Seeds completed assistant messages so snapshot entries under these ids pass
+ * the remount-stable filter (collapsible/streaming rows are dropped on write).
+ */
+function hydrateCompletedAssistantMessages(threadId: string, itemIds: readonly string[]) {
+  useAppStore.getState().hydrateThreadRuntimeItems(
+    threadId,
+    itemIds.map((id) => ({
+      id,
+      type: "assistant_message" as const,
+      state: "completed" as const,
+      payload: {},
+      streams: {},
+    })),
+  );
 }
 
 const idleVirtualizer = { isScrolling: false, scrollDirection: null } as const;

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -28,6 +28,7 @@ import {
 import { ChatItemRow } from "./items/ChatItemRow";
 import { chatMessageSurfaceClass } from "./items/chatMessageSurface";
 import { imageViewRendersInline } from "./items/imageViewSource";
+import { isToolLikeItem } from "./items/toolCallCategorization";
 import {
   getTimelineMeasurementSignature,
   readTimelineMeasurements,
@@ -79,6 +80,18 @@ const CHAT_TRANSCRIPT_OVERSCAN = 16;
 const DEFAULT_ROW_ESTIMATE_PX = 96;
 const INLINE_IMAGE_ROW_ESTIMATE_PX = 320;
 const ASSISTANT_IMAGE_ROW_ESTIMATE_PX = 384;
+// A collapsed tool/command/file/search row — and a collapsed tool-call group —
+// renders a single accordion/disclosure trigger: `chatRowClass`'s `py-1` (8px)
+// wrapping command-size text with `leading-tight` (~15px at the 13px default),
+// plus the virtual row wrapper's `pb-1` (4px) ≈ 27px. Groups are only expanded
+// while they are the live tail (measured immediately), so collapsed is the
+// right default. This was 64 (group) / 56 (items) — a ~2x over-estimate that
+// fed a large estimate→measure delta into scroll compensation on scrollback.
+const COLLAPSED_ROW_ESTIMATE_PX = 28;
+// The completed reasoning "Thought" toggle is a custom row (not the accordion):
+// `py-2` (16px) around a single ~12px icon/label line (`size-3` icons,
+// `leading-none`), plus the virtual row wrapper's `pb-1` (4px) ≈ 32px. Was 52.
+const COLLAPSED_REASONING_ROW_ESTIMATE_PX = 32;
 const SKIP_REVERT_CONFIRM_PREF_KEY = "poracode-chat-checkpoint-revert-skip-confirm";
 // How long the iOS scroll-compensation flush waits for momentum to idle before
 // applying the buffered delta. Matches @tanstack/virtual-core's
@@ -161,7 +174,15 @@ export function MessageList({
       if (!cacheSignature || getTimelineMeasurementSignature(scrollElement) !== cacheSignature) {
         return;
       }
-      writeTimelineMeasurements(threadId, cacheSignature, virtualizer.takeSnapshot());
+      const state = useAppStore.getState();
+      const measurements = virtualizer
+        .takeSnapshot()
+        .filter((measurement) =>
+          isRemountStableSnapshotItem(
+            selectRuntimeItemById(state, threadId, String(measurement.key)),
+          ),
+        );
+      writeTimelineMeasurements(threadId, cacheSignature, measurements);
     };
   }, [scrollElement, threadId, virtualizer]);
 
@@ -676,7 +697,9 @@ function liveStreamMeasureToken(item: RuntimeChatItem | undefined): string | nul
 
 function estimateTimelineEntrySize(entry: ChatTimelineEntry | undefined, threadId: string): number {
   if (!entry) return DEFAULT_ROW_ESTIMATE_PX;
-  if (entry.kind === "tool_call_group") return 64;
+  // A tool-call group only estimates while collapsed (it auto-expands solely as
+  // the live tail, which is measured immediately), so use the collapsed trigger.
+  if (entry.kind === "tool_call_group") return COLLAPSED_ROW_ESTIMATE_PX;
   return estimateRuntimeItemSize(selectRuntimeItemById(useAppStore.getState(), threadId, entry.id));
 }
 
@@ -689,7 +712,7 @@ function estimateRuntimeItemSize(item: ReturnType<typeof selectRuntimeItemById>)
     case "user_message":
       return 88;
     case "reasoning":
-      return item.state === "completed" ? 52 : 128;
+      return item.state === "completed" ? COLLAPSED_REASONING_ROW_ESTIMATE_PX : 128;
     case "plan":
       return 128;
     case "tool_call":
@@ -697,15 +720,42 @@ function estimateRuntimeItemSize(item: ReturnType<typeof selectRuntimeItemById>)
     case "image_view":
     case "dynamic_tool_call":
       if (imageViewRendersInline(item.payload)) return INLINE_IMAGE_ROW_ESTIMATE_PX;
-      return item.state === "completed" ? 56 : 132;
+      return item.state === "completed" ? COLLAPSED_ROW_ESTIMATE_PX : 132;
     case "command_execution":
     case "file_change":
     case "web_search":
-      return item.state === "completed" ? 56 : 132;
+      return item.state === "completed" ? COLLAPSED_ROW_ESTIMATE_PX : 132;
     case "error":
       return 80;
     default:
       return DEFAULT_ROW_ESTIMATE_PX;
+  }
+}
+
+/**
+ * Whether a completed row's measured height survives a remount unchanged, so its
+ * cached measurement may be restored (see `writeTimelineMeasurements`). Kept
+ * beside `estimateRuntimeItemSize` because both are per-type tables that must
+ * stay in sync: a row type with local expand/collapse state remounts collapsed
+ * (its `useState` dies with the fiber), so restoring an expanded-state size
+ * would hand scroll compensation one huge delta on first revisit — the jump the
+ * snapshot cache exists to prevent. Tool-call groups, reasoning ("Thought"
+ * toggle), user messages (clamped "Show more"), and every tool/command/file/
+ * search accordion are therefore unstable; non-completed rows are dropped too
+ * since their height keeps changing while the thread works in the background.
+ */
+function isRemountStableSnapshotItem(item: RuntimeChatItem | undefined): boolean {
+  if (!item || item.state !== "completed") return false;
+  switch (item.type) {
+    case "assistant_message":
+    case "plan":
+    case "question_answer":
+    case "error":
+      return true;
+    default:
+      // Inline image cards have no disclosure; every other tool-like row renders
+      // the collapsible accordion and remounts collapsed.
+      return isToolLikeItem(item) && imageViewRendersInline(item.payload);
   }
 }
 

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -61,6 +61,38 @@ describe("ToolCallGroup", () => {
     expect(viewport.className).not.toContain("overflow-y-auto");
   });
 
+  it("does not mount child rows while collapsed and mounts them once expanded", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeToolItem("tool-1", "Read file one"),
+      makeToolItem("tool-2", "Read file two"),
+    ];
+    seedThread(threadId, items);
+
+    // isLive=false → the group starts collapsed. React Aria keeps the panel
+    // mounted-but-hidden, so this asserts the `isExpanded` gate actually skips
+    // rendering the heavy child rows (not just hiding them).
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+      false,
+    );
+
+    // Header still derives from the summary while collapsed.
+    expect(screen.getByText("2 views")).toBeInTheDocument();
+    // No child row content and no viewport container are mounted.
+    expect(view.container.querySelector(".poracode-tool-call-group-viewport")).toBeNull();
+    expect(screen.queryByText("Read file one")).not.toBeInTheDocument();
+    expect(screen.queryByText("Read file two")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /2 views/i }));
+
+    // Expanded: child rows mount.
+    expect(view.container.querySelector(".poracode-tool-call-group-viewport")).not.toBeNull();
+    expect(screen.getByText("Read file one")).toBeInTheDocument();
+    expect(screen.getByText("Read file two")).toBeInTheDocument();
+  });
+
   it("renders every row inline when the group fits under the cap", () => {
     const threadId = "thread-1";
     const items = Array.from({ length: 6 }, (_, index) =>
@@ -537,10 +569,10 @@ describe("ToolCallGroup", () => {
   });
 });
 
-function renderToolCallGroup(threadId: string, itemIds: readonly string[]) {
+function renderToolCallGroup(threadId: string, itemIds: readonly string[], isLive = true) {
   return render(
     <AppProvider>
-      <ToolCallGroup threadId={threadId} itemIds={itemIds} isLive />
+      <ToolCallGroup threadId={threadId} itemIds={itemIds} isLive={isLive} />
     </AppProvider>,
   );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -149,37 +149,45 @@ export const ToolCallGroup = memo(function ToolCallGroup({
         </Disclosure.Heading>
         <Disclosure.Content>
           <Disclosure.Body className={`ml-1.5 ${chatRowRailClass} pb-0 pl-2.5 pt-0`}>
-            {hasOverflowRows && !sameFileEditSummary ? (
-              <div className="mb-0.5 flex justify-start">
-                <button
-                  type="button"
-                  aria-expanded={showAll}
-                  className="-ml-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-[color:var(--muted)] transition-colors hover:bg-foreground/5 hover:text-foreground"
-                  onClick={() => {
-                    setShowAll((prev) => !prev);
-                    actions?.onContentHeightChange();
-                  }}
-                >
-                  {showAll ? <Trans>Show less</Trans> : <Trans>Show all</Trans>}
-                </button>
-              </div>
-            ) : null}
-            <div
-              ref={scrollRef}
-              className={`poracode-tool-call-group-viewport flex flex-col gap-0.5 pr-1 ${
-                showAll ? "max-h-[420px] overflow-y-auto" : ""
-              }`}
-            >
-              {sameFileEditSummary ? (
-                <SameFileEditGroupBody items={items} />
-              ) : (
-                visibleItems.map((item) => (
-                  <div key={item.id} className="animate-tool-call-enter">
-                    <GroupRowInline item={item} />
+            {/* React Aria keeps collapsed disclosure panels mounted (hidden), so
+                gate the heavy group children on `isExpanded` — matches
+                ChatItemAccordion. Panels snap closed (transitions disabled in
+                styles.css), so a plain conditional is correct; no keep-alive. */}
+            {isExpanded ? (
+              <>
+                {hasOverflowRows && !sameFileEditSummary ? (
+                  <div className="mb-0.5 flex justify-start">
+                    <button
+                      type="button"
+                      aria-expanded={showAll}
+                      className="-ml-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-[color:var(--muted)] transition-colors hover:bg-foreground/5 hover:text-foreground"
+                      onClick={() => {
+                        setShowAll((prev) => !prev);
+                        actions?.onContentHeightChange();
+                      }}
+                    >
+                      {showAll ? <Trans>Show less</Trans> : <Trans>Show all</Trans>}
+                    </button>
                   </div>
-                ))
-              )}
-            </div>
+                ) : null}
+                <div
+                  ref={scrollRef}
+                  className={`poracode-tool-call-group-viewport flex flex-col gap-0.5 pr-1 ${
+                    showAll ? "max-h-[420px] overflow-y-auto" : ""
+                  }`}
+                >
+                  {sameFileEditSummary ? (
+                    <SameFileEditGroupBody items={items} />
+                  ) : (
+                    visibleItems.map((item) => (
+                      <div key={item.id} className="animate-tool-call-enter">
+                        <GroupRowInline item={item} />
+                      </div>
+                    ))
+                  )}
+                </div>
+              </>
+            ) : null}
           </Disclosure.Body>
         </Disclosure.Content>
       </Disclosure>


### PR DESCRIPTION
- **Bugfix:** reduce virtualized transcript scroll compensation by using accurate collapsed estimates for tool, command, group, and reasoning rows.
- Persist only remount-stable timeline measurements to avoid restoring unstable cached row sizes.
- Avoid mounting hidden tool-call group children until the group is expanded, reducing collapsed transcript work.
- Add coverage for collapsed row estimates, measurement caching, and conditional group rendering.