### PR TITLE
Throttle background animation updates

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1652,19 +1652,20 @@ html[data-platform="darwin"] .poracode-content-over-drag-region--drag {
   }
 }
 
-/* Pause the always-on status-icon animations when the window is hidden or
-   unfocused (attributes toggled by uiAnimationActivity.ts). The static glow and
-   colour stay, so a backgrounded window still shows which threads are busy — we
-   just stop driving the GPU compositor while nobody is looking. Drop the
-   `data-app-unfocused` selectors if you want the sweep to keep running while the
-   window is visible-but-unfocused. */
+/* Keep status-icon animations alive at about 5fps when the window is hidden or
+   unfocused (attributes toggled by uiAnimationActivity.ts). This preserves the
+   working signal in a visible background window without paying the foreground
+   compositor cost. */
 html[data-app-hidden] .poracode-provider-icon__mask-scan::before,
-html[data-app-unfocused] .poracode-provider-icon__mask-scan::before,
+html[data-app-unfocused] .poracode-provider-icon__mask-scan::before {
+  animation-timing-function: steps(8, jump-end);
+}
+
 html[data-app-hidden] .poracode-provider-icon--attention,
 html[data-app-unfocused] .poracode-provider-icon--attention,
 html[data-app-hidden] .poracode-provider-icon--finished,
 html[data-app-unfocused] .poracode-provider-icon--finished {
-  animation-play-state: paused;
+  animation-timing-function: steps(9, jump-end);
 }
 
 /* Honour the OS "reduce motion" setting — drop the moving sweep/pulse entirely

--- a/src/renderer/thinkingAnimator.test.tsx
+++ b/src/renderer/thinkingAnimator.test.tsx
@@ -64,14 +64,21 @@ describe("thinkingAnimator", () => {
     expect(el.style.backgroundPositionX).toBe("");
   });
 
-  it("freezes ticks while the app is backgrounded", () => {
-    document.documentElement.setAttribute("data-app-hidden", "");
-    const { getByTestId } = render(<ShimmerProbe active={true} />);
-    const el = getByTestId("shimmer") as HTMLSpanElement;
-    const initial = el.style.backgroundPositionX; // painted once on register
-    vi.advanceTimersByTime(1000);
-    expect(el.style.backgroundPositionX).toBe(initial); // ticks are no-ops while hidden
-  });
+  it.each(["data-app-hidden", "data-app-unfocused"])(
+    "continues at a lower rate while the app has %s",
+    (attribute) => {
+      document.documentElement.setAttribute(attribute, "");
+      const { getByTestId } = render(<ShimmerProbe active={true} />);
+      const el = getByTestId("shimmer") as HTMLSpanElement;
+      const initial = el.style.backgroundPositionX;
+
+      vi.advanceTimersByTime(150);
+      expect(el.style.backgroundPositionX).toBe(initial);
+
+      vi.advanceTimersByTime(50);
+      expect(parseFloat(el.style.backgroundPositionX)).toBeCloseTo(-18.2, 1);
+    },
+  );
 
   it("fires the three brain path groups out of phase", () => {
     const { getByTestId } = render(<BrainProbe active={true} />);

--- a/src/renderer/thinkingAnimator.ts
+++ b/src/renderer/thinkingAnimator.ts
@@ -18,8 +18,8 @@
 // element is only dirtied ~20×/s; between ticks nothing is invalidated, so the
 // renderer's frame pipeline goes idle. The visuals are identical (same gradient
 // sweep, same staggered brain firing), and a shared wall-clock phase keeps every
-// instance perfectly in sync. The timer pauses while the window is hidden or
-// unfocused (delegating that policy to uiAnimationActivity.ts), and honours
+// instance perfectly in sync. The timer drops to 5fps while the window is
+// hidden or unfocused (using the state from uiAnimationActivity.ts), and honours
 // `prefers-reduced-motion` by painting one static frame.
 
 import { useEffect, useRef } from "react";
@@ -27,6 +27,8 @@ import type { RefObject } from "react";
 
 const FPS = 20;
 const TICK_MS = Math.round(1000 / FPS); // 50ms
+const BACKGROUND_FPS = 5;
+const BACKGROUND_TICK_MS = Math.round(1000 / BACKGROUND_FPS); // 200ms
 const SHIMMER_PERIOD_MS = 2200; // matches the previous 2.2s background-position sweep
 const BRAIN_PERIOD_MS = 1800; // matches the previous 1.8s opacity pulse
 const BRAIN_GROUP_DELAY_MS = 600; // matches the previous 0s / 0.6s / 1.2s stagger
@@ -36,6 +38,7 @@ const shimmerEls = new Set<HTMLElement>();
 // doesn't re-run querySelectorAll on every frame.
 const brainPaths = new Map<SVGSVGElement, SVGPathElement[]>();
 let timer: ReturnType<typeof setInterval> | null = null;
+let lastPaintAt = Number.NEGATIVE_INFINITY;
 
 function hasRegistered(): boolean {
   return shimmerEls.size > 0 || brainPaths.size > 0;
@@ -49,15 +52,12 @@ function prefersReducedMotion(): boolean {
   );
 }
 
-// Single source of truth for "should UI animations run": uiAnimationActivity.ts
-// toggles these attributes on visibilitychange/focus/blur, and styles.css uses
-// the same attributes to pause the compositor-driven icon animations. Reading
-// them here keeps the JS-driven thinking animations gated by the exact same
-// policy — change "when to pause" in one place and both follow.
-function isAppActive(): boolean {
-  if (typeof document === "undefined") return false;
+// uiAnimationActivity.ts toggles these attributes on visibilitychange/focus/blur,
+// and styles.css uses the same state to slow compositor-driven icon animations.
+function isAppBackgrounded(): boolean {
+  if (typeof document === "undefined") return true;
   const root = document.documentElement;
-  return !root.hasAttribute("data-app-hidden") && !root.hasAttribute("data-app-unfocused");
+  return root.hasAttribute("data-app-hidden") || root.hasAttribute("data-app-unfocused");
 }
 
 // Triangle 0→1→0 over the period, mapped to 0.45..1 (matches the old
@@ -84,10 +84,10 @@ function paintFrame(now: number): void {
 }
 
 function tick(): void {
-  // Freeze (skip writes) while backgrounded/unfocused — nothing to drive, and
-  // the static frozen frame is fine. Next tick resumes within ~50ms on refocus.
-  if (!isAppActive()) return;
-  paintFrame(Date.now());
+  const now = Date.now();
+  if (isAppBackgrounded() && now - lastPaintAt < BACKGROUND_TICK_MS) return;
+  paintFrame(now);
+  lastPaintAt = now;
 }
 
 function ensureRunning(): void {
@@ -97,7 +97,9 @@ function ensureRunning(): void {
     return;
   }
   if (typeof setInterval !== "function") return;
-  paintFrame(Date.now());
+  const now = Date.now();
+  paintFrame(now);
+  lastPaintAt = now;
   timer = setInterval(tick, TICK_MS);
 }
 

--- a/src/renderer/uiAnimationActivity.ts
+++ b/src/renderer/uiAnimationActivity.ts
@@ -1,24 +1,21 @@
-// Pauses the always-on, compositor-driven status-icon animations (the "working"
-// shine sweep and the attention/finished pulses) whenever the app window is
-// hidden or unfocused. Those animations otherwise keep the GPU compositor
-// producing frames at the full display refresh (~120Hz on a ProMotion panel)
-// for as long as any thread is working — even while the window sits in the
-// background. The static glow/colour on the icons is untouched, so a
-// backgrounded window still shows which threads are busy; we just stop driving
-// the GPU while nobody is looking at it.
+// Tracks whether the app window is hidden or unfocused so always-on animations
+// can reduce their update rate in the background without stopping completely.
+// At full speed those animations otherwise keep the GPU compositor producing
+// frames for as long as any thread is working, even while the window is not the
+// active app.
 //
 // Chromium already stops compositing a fully hidden/occluded page (the window's
 // `backgroundThrottling` default), but a window that is merely *unfocused*
 // (another app in front, or a different window on the same screen) stays
-// "visible" and keeps animating at full cost. This guard closes that gap by
-// toggling attributes that styles.css keys `animation-play-state: paused` off.
+// "visible" and keeps animating at full cost. These attributes let the CSS and
+// JS animation drivers use a lower background cadence instead.
 
 function syncAnimationActivity(): void {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
   root.toggleAttribute("data-app-hidden", document.visibilityState === "hidden");
   // `hasFocus()` is false when the renderer's window isn't the key window
-  // (including when DevTools is focused in dev — harmless, the sweep just pauses).
+  // (including when DevTools is focused in dev — harmless, the sweep just slows).
   root.toggleAttribute("data-app-unfocused", !document.hasFocus());
 }
 


### PR DESCRIPTION
- Feature: keep status and thinking animations active at a reduced cadence when the app is hidden or unfocused.
- Preserve background activity signals while lowering compositor and renderer workload.