### PR TITLE
Hide assistant copy actions during active turns

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -1049,6 +1049,30 @@ describe("ChatPane", () => {
     });
   });
 
+  it("hides the assistant copy action until the active turn settles", async () => {
+    const thread = makeThread();
+    seedAssistantMessage(thread.id, "Still working");
+    completeAssistantMessage(thread.id);
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    expect(screen.getByText("Still working")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy message" })).not.toBeInTheDocument();
+    expect(container.querySelector(".poracode-message-action-strip")).toBeNull();
+  });
+
+  it("shows the assistant copy action after the turn settles", async () => {
+    const thread = { ...makeThread(), status: "idle" as const };
+    seedAssistantMessage(thread.id, "Final answer");
+    completeAssistantMessage(thread.id);
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeInTheDocument();
+  });
+
   it("renders links in slash command user messages as links", async () => {
     const thread = makeThread();
     const url = "https://tanstack.com/blog/tanstack-virtual-chat";
@@ -1607,6 +1631,14 @@ function seedAssistantMessage(threadId: string, initialText: string, itemId = AS
     itemId,
     stream: "assistant_text",
     delta: initialText,
+  });
+}
+
+function completeAssistantMessage(threadId: string, itemId = ASSISTANT_ITEM_ID) {
+  useAppStore.getState().applyRuntimeEvent(threadId, {
+    type: "item.completed",
+    threadId,
+    itemId,
   });
 }
 

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -345,6 +345,7 @@ export function ChatPane(props: ChatPaneProps) {
                     key={threadId}
                     threadId={threadId}
                     entries={timelineEntries}
+                    isTurnActive={isLive}
                     scrollElement={scrollEl}
                     registerScrollToIndex={registerScrollToIndex}
                     suppressInlineTurnAnchorId={suppressInlineTurnAnchorId}

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -48,6 +48,7 @@ export interface CheckpointRevertActions {
 interface MessageListProps {
   threadId: string;
   entries: readonly ChatTimelineEntry[];
+  isTurnActive?: boolean;
   scrollElement: HTMLDivElement | null;
   /**
    * Reverting is transcript-local today. Disable it while a turn is live so
@@ -104,6 +105,7 @@ const COMPENSATION_SETTLE_MS = 150;
 export function MessageList({
   threadId,
   entries,
+  isTurnActive = false,
   scrollElement,
   canRevertCheckpoints = true,
   checkpointGuard,
@@ -502,6 +504,7 @@ export function MessageList({
                   entry={entry}
                   index={virtualRow.index}
                   isLastEntry={virtualRow.index === lastLiveIndex}
+                  isTurnActive={isTurnActive}
                   measureElement={measureRowElement}
                   suppressInlineTurnAnchorId={suppressInlineTurnAnchorId}
                   canRevertCheckpoints={canRevertCheckpoints}
@@ -531,6 +534,7 @@ type VirtualChatListRowProps = {
   entry: ChatTimelineEntry;
   index: number;
   isLastEntry: boolean;
+  isTurnActive: boolean;
   measureElement: (index: number, element: HTMLDivElement | null) => void;
   suppressInlineTurnAnchorId: string | null;
   canRevertCheckpoints: boolean;
@@ -542,6 +546,7 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
   entry,
   index,
   isLastEntry,
+  isTurnActive,
   measureElement,
   suppressInlineTurnAnchorId,
   canRevertCheckpoints,
@@ -629,6 +634,7 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
             threadId={threadId}
             entry={entry}
             isLastEntry={isLastEntry}
+            isTurnActive={isTurnActive}
             checkpointRevert={
               checkpointRevertItemId ? { itemId: checkpointRevertItemId, onRequestRevert } : null
             }

--- a/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.test.tsx
@@ -29,7 +29,7 @@ describe("AssistantMessage", () => {
 
     render(
       <AppProvider>
-        <AssistantMessage threadId="thread-1" item={item} />
+        <AssistantMessage threadId="thread-1" item={item} isTurnActive={false} />
       </AppProvider>,
     );
 
@@ -49,7 +49,7 @@ describe("AssistantMessage", () => {
 
     render(
       <AppProvider>
-        <AssistantMessage threadId="thread-1" item={item} />
+        <AssistantMessage threadId="thread-1" item={item} isTurnActive={false} />
       </AppProvider>,
     );
 

--- a/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.tsx
@@ -17,18 +17,22 @@ import { ItemMarkdown } from "./ItemMarkdown";
 interface AssistantMessageProps {
   threadId: string;
   item: RuntimeChatItem;
+  isTurnActive: boolean;
 }
 
 export const AssistantMessage = memo(function AssistantMessage({
   threadId,
   item,
+  isTurnActive,
 }: AssistantMessageProps) {
   const { t } = useLingui();
   // Matching Codex: the copy action only appears under a turn's *final* answer,
   // i.e. the last assistant message before the next user message (or the end of
   // the thread). Every turn keeps its button, not just the most recent one.
   // Sub-agent messages (those nested under a tool call) are ignored so they
-  // neither qualify nor cancel a top-level answer's terminal status.
+  // neither qualify nor cancel a top-level answer's terminal status. A
+  // completed item at the live tail is still an intermediate update until the
+  // turn itself settles, so it must not expose a copy action yet.
   const isFinalAnswer = useAppStore((state) => {
     if (item.parentItemId) return false;
     const ids = state.runtimeItemIdsByThread[threadId];
@@ -42,7 +46,7 @@ export const AssistantMessage = memo(function AssistantMessage({
       if (next.type === "user_message") return true;
       if (next.type === "assistant_message") return false;
     }
-    return true;
+    return !isTurnActive;
   });
   const stream = item.streams.assistant_text ?? "";
   const payload = getRuntimeItemPayload<MessageItemPayload>(item, "assistant_message");

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
@@ -25,6 +25,7 @@ interface ChatItemRowProps {
   entry: ChatTimelineEntry;
   /** True when this is the tail of the visible timeline. Drives live-group expand state. */
   isLastEntry?: boolean;
+  isTurnActive?: boolean;
   checkpointRevert: CheckpointRevertRequest | null;
 }
 
@@ -40,6 +41,7 @@ export const ChatItemRow = memo(function ChatItemRow({
   threadId,
   entry,
   isLastEntry = false,
+  isTurnActive = false,
   checkpointRevert,
 }: ChatItemRowProps) {
   "use no memo";
@@ -47,17 +49,24 @@ export const ChatItemRow = memo(function ChatItemRow({
     return <ToolCallGroup threadId={threadId} itemIds={entry.itemIds} isLive={isLastEntry} />;
   }
   return (
-    <SingleChatItemRow threadId={threadId} itemId={entry.id} checkpointRevert={checkpointRevert} />
+    <SingleChatItemRow
+      threadId={threadId}
+      itemId={entry.id}
+      isTurnActive={isTurnActive}
+      checkpointRevert={checkpointRevert}
+    />
   );
 });
 
 const SingleChatItemRow = memo(function SingleChatItemRow({
   threadId,
   itemId,
+  isTurnActive,
   checkpointRevert,
 }: {
   threadId: string;
   itemId: string;
+  isTurnActive: boolean;
   checkpointRevert: CheckpointRevertRequest | null;
 }) {
   const item = useAppStore(getRuntimeItemStoreSelector(threadId, itemId));
@@ -76,12 +85,13 @@ const SingleChatItemRow = memo(function SingleChatItemRow({
       return <SubAgentToolCall threadId={threadId} item={item} />;
     }
   }
-  return renderItem(threadId, item, checkpointRevert);
+  return renderItem(threadId, item, isTurnActive, checkpointRevert);
 });
 
 function renderItem(
   threadId: string,
   item: RuntimeChatItem,
+  isTurnActive: boolean,
   checkpointRevert: CheckpointRevertRequest | null,
 ) {
   switch (item.type) {
@@ -90,7 +100,7 @@ function renderItem(
     case "question_answer":
       return <QuestionAnswer item={item} checkpointRevert={checkpointRevert} />;
     case "assistant_message":
-      return <AssistantMessage threadId={threadId} item={item} />;
+      return <AssistantMessage threadId={threadId} item={item} isTurnActive={isTurnActive} />;
     case "reasoning":
       return <Reasoning item={item} />;
     case "plan":


### PR DESCRIPTION
- **Bugfix:** prevent assistant copy actions from appearing while a chat turn is still active.
- Show copy actions only after the live turn settles, avoiding copies of intermediate responses.
- Propagate active-turn state through the chat message list and item rows.
- Add coverage for copy-action visibility during and after active turns.