### PR TITLE
Reload Codex MCP servers before starting turns

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -538,13 +538,6 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
     this.remoteThreadId = threadId;
     this.launchOptions = { ...this.launchOptions, resumeThreadId: threadId };
-    if (this.hasUserMcpServers) {
-      await this.rpc.request(
-        "mcpServerStatus/list",
-        { detail: "toolsAndAuthOnly", threadId },
-        30_000,
-      );
-    }
     if (sessionRef) {
       void this.syncRemoteThreadState(threadId, toSessionRef(threadId));
     }
@@ -694,6 +687,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     const sandboxPolicy = toCodexSandboxPolicy(config.sandboxMode);
     const collaborationMode = buildCodexCollaborationMode(config);
     try {
+      if (this.hasUserMcpServers) {
+        await this.rpc.request("config/mcpServer/reload", null);
+      }
       const result = await this.rpc.request("turn/start", {
         threadId,
         input,

--- a/src/supervisor/agents/codex/appServerRpc.ts
+++ b/src/supervisor/agents/codex/appServerRpc.ts
@@ -64,13 +64,17 @@ export class CodexAppServerRpc {
     });
   }
 
-  request(method: string, params: Record<string, unknown>, timeoutMs = 30_000): Promise<unknown> {
+  request(
+    method: string,
+    params: Record<string, unknown> | null,
+    timeoutMs = 30_000,
+  ): Promise<unknown> {
     return this.requestWithRetry(method, params, timeoutMs);
   }
 
   private async requestWithRetry(
     method: string,
-    params: Record<string, unknown>,
+    params: Record<string, unknown> | null,
     timeoutMs: number,
   ): Promise<unknown> {
     for (let attempt = 0; ; attempt += 1) {
@@ -93,7 +97,7 @@ export class CodexAppServerRpc {
 
   private requestOnce(
     method: string,
-    params: Record<string, unknown>,
+    params: Record<string, unknown> | null,
     timeoutMs: number,
   ): Promise<unknown> {
     const id = `poracode-${this.requestSequence++}`;

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -774,7 +774,7 @@ function createRouterWithChild(): CodexSubAgentRouter {
 describe("CodexStructuredSession", () => {
   type CodexRequestRecord = {
     method: string;
-    params: Record<string, unknown>;
+    params: Record<string, unknown> | null;
     timeoutMs?: number;
   };
 
@@ -789,7 +789,11 @@ describe("CodexStructuredSession", () => {
     session["seenErrorMessages"] = new Set<string>();
     session["resumeActiveStatusSuppressionUntil"] = new Map();
     session["rpc"] = {
-      request: async (method: string, params: Record<string, unknown>, timeoutMs?: number) => {
+      request: async (
+        method: string,
+        params: Record<string, unknown> | null,
+        timeoutMs?: number,
+      ) => {
         requests.push({
           method,
           params,
@@ -919,15 +923,15 @@ describe("CodexStructuredSession", () => {
     // Off on the first turn → force null rather than preserving a config.toml tier.
     await structuredSession.startTurn("normal", { model: "gpt-5.4", fast: false });
     expect(requests[0]?.method).toBe("turn/start");
-    expect(requests[0]?.params.serviceTier).toBeNull();
+    expect(requests[0]?.params?.serviceTier).toBeNull();
 
     // On → force "fast".
     await structuredSession.startTurn("go fast", { model: "gpt-5.4", fast: true });
-    expect(requests[1]?.params.serviceTier).toBe("fast");
+    expect(requests[1]?.params?.serviceTier).toBe("fast");
 
     // Back off → force null again to clear the sticky server-side override.
     await structuredSession.startTurn("back to normal", { model: "gpt-5.4", fast: false });
-    expect(requests[2]?.params.serviceTier).toBeNull();
+    expect(requests[2]?.params?.serviceTier).toBeNull();
   });
 
   it("keeps /goal <objective> working until the model turn completes", async () => {
@@ -1103,12 +1107,16 @@ describe("CodexStructuredSession", () => {
     );
   });
 
-  it("waits for configured MCP servers before starting the first turn", async () => {
+  it("reloads configured MCP servers at the turn boundary without delaying thread creation", async () => {
     const requests: CodexRequestRecord[] = [];
     const structuredSession = makeStructuredSession(requests);
     (structuredSession as unknown as Record<string, unknown>)["hasUserMcpServers"] = true;
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
-      request: async (method: string, params: Record<string, unknown>, timeoutMs?: number) => {
+      request: async (
+        method: string,
+        params: Record<string, unknown> | null,
+        timeoutMs?: number,
+      ) => {
         requests.push({
           method,
           params,
@@ -1124,13 +1132,17 @@ describe("CodexStructuredSession", () => {
 
     await structuredSession.openThread({ model: "gpt-5.5" });
 
+    expect(requests).toEqual([expect.objectContaining({ method: "thread/start" })]);
+
+    await structuredSession.startTurn("hello", { model: "gpt-5.5" });
+
     expect(requests).toEqual([
       expect.objectContaining({ method: "thread/start" }),
       {
-        method: "mcpServerStatus/list",
-        params: { detail: "toolsAndAuthOnly", threadId: "provider-thread" },
-        timeoutMs: 30_000,
+        method: "config/mcpServer/reload",
+        params: null,
       },
+      expect.objectContaining({ method: "turn/start" }),
     ]);
   });
 


### PR DESCRIPTION
- **Bugfix:** Reload configured user MCP servers at each Codex turn boundary so tools are available when needed.
- Avoid delaying resumed thread creation while preserving MCP readiness before turn execution.
- Extend RPC and session tests to support parameterless MCP reload requests.