### PR TITLE
Fix inline reasoning preview line separation

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
@@ -6,7 +6,7 @@ import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice"
 import { useBrainThinking, useShimmer } from "@/renderer/thinkingAnimator";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatRowMetaSeparator, chatRowIndicatorClass, inlineRowTriggerClass } from "./chatRow";
-import { getReasoningLastLine, getReasoningPreview } from "./reasoningPreview";
+import { getReasoningInlinePreview, getReasoningLastLine } from "./reasoningPreview";
 import { ReasoningExpandedBody, ReasoningStreamViewport } from "./ReasoningStreamViewport";
 
 interface ReasoningInlineProps {
@@ -31,7 +31,7 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
     ? ""
     : isStreaming
       ? getReasoningLastLine(rawText)
-      : getReasoningPreview(rawText);
+      : getReasoningInlinePreview(rawText);
   const brainRef = useBrainThinking(isStreaming);
   const shimmerRef = useShimmer<HTMLElement>(isStreaming);
   const title = isStreaming ? t`Thinking` : t`Thought`;

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -485,7 +485,10 @@ describe("ToolCallGroup", () => {
   it("renders completed reasoning as a collapsed Thought row with a text preview", () => {
     const threadId = "thread-1";
     const items = [
-      makeReasoningItem("reasoning-1", "Weighing the tradeoffs before editing the selector."),
+      makeReasoningItem(
+        "reasoning-1",
+        "Weighing the tradeoffs.\nChoosing the focused change.\nEditing the selector.",
+      ),
       makeToolItem("tool-1", "Read file"),
     ];
     seedThread(threadId, items);
@@ -498,12 +501,16 @@ describe("ToolCallGroup", () => {
     expect(screen.getByText("1 thought")).toBeInTheDocument();
     expect(screen.getByText("Thought")).toBeInTheDocument();
     expect(
-      screen.getByText("Weighing the tradeoffs before editing the selector."),
+      screen.getByText(
+        "Weighing the tradeoffs. · Choosing the focused change. · Editing the selector.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByText("Thought").closest("button")).toHaveClass("overflow-hidden");
-    expect(screen.getByText("Weighing the tradeoffs before editing the selector.")).toHaveClass(
-      "truncate",
-    );
+    expect(
+      screen.getByText(
+        "Weighing the tradeoffs. · Choosing the focused change. · Editing the selector.",
+      ),
+    ).toHaveClass("truncate");
   });
 
   it("keeps streaming reasoning collapsed with a live last-line preview, then settles on completion", async () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getReasoningPreview } from "./reasoningPreview";
+import { getReasoningInlinePreview, getReasoningPreview } from "./reasoningPreview";
 
 // @vitest-environment node
 
@@ -7,6 +7,16 @@ describe("getReasoningPreview", () => {
   it("flattens multi-line reasoning into a single-line snippet", () => {
     expect(getReasoningPreview("First I will read the file.\nThen I will edit it.")).toBe(
       "First I will read the file. Then I will edit it.",
+    );
+  });
+
+  it("separates source lines with centered dots for inline Thought rows", () => {
+    expect(
+      getReasoningInlinePreview(
+        "**Designing owner-only retrieval**\n\n**Consolidating worktree candidates**\nPreserving error handling",
+      ),
+    ).toBe(
+      "Designing owner-only retrieval · Consolidating worktree candidates · Preserving error handling",
     );
   });
 

--- a/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/reasoningPreview.ts
@@ -14,6 +14,19 @@ function truncateOneLine(text: string, maxLength: number): string {
   return `${text.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
+function formatReasoningPreview(text: string, maxLength: number, lineSeparator: string): string {
+  const lines = text
+    // Fences must be stripped over the full text (an early fence can swallow
+    // kilobytes); afterwards only a bounded prefix can survive truncation, so
+    // cap the remaining passes instead of scanning the whole block.
+    .replace(/```[\s\S]*?(?:```|$)/g, " ")
+    .slice(0, maxLength * 8)
+    .split(/\r?\n/)
+    .map(stripMarkdownMarkers)
+    .filter(Boolean);
+  return truncateOneLine(lines.join(lineSeparator), maxLength);
+}
+
 /**
  * One-line sneak peek of a reasoning block for collapsed "Thought" rows.
  * Strips markdown structure (fences, list/heading markers, emphasis) so the
@@ -23,13 +36,19 @@ export function getReasoningPreview(
   text: string,
   maxLength: number = REASONING_PREVIEW_MAX_LENGTH,
 ): string {
-  const flattened = stripMarkdownMarkers(
-    // Fences must be stripped over the full text (an early fence can swallow
-    // kilobytes); afterwards only a bounded prefix can survive truncation, so
-    // cap the remaining passes instead of scanning the whole block.
-    text.replace(/```[\s\S]*?(?:```|$)/g, " ").slice(0, maxLength * 8),
-  );
-  return truncateOneLine(flattened, maxLength);
+  return formatReasoningPreview(text, maxLength, " ");
+}
+
+/**
+ * One-line preview for a Thought row inside a tool-call group. Keeps each
+ * non-empty source line visually distinct with the same centered-dot language
+ * used by the surrounding activity rows.
+ */
+export function getReasoningInlinePreview(
+  text: string,
+  maxLength: number = REASONING_PREVIEW_MAX_LENGTH,
+): string {
+  return formatReasoningPreview(text, maxLength, " · ");
 }
 
 /**


### PR DESCRIPTION
- **Bugfix:** make completed inline Thought previews preserve reasoning-line boundaries with centered-dot separators.
- Keep standard reasoning previews unchanged while sharing markdown cleanup and truncation behavior.
- Add coverage for multiline inline previews and collapsed tool-call Thought rows.