### PR TITLE
Show localized PR check status durations

### DIFF
--- a/src/renderer/components/common/PrCheckStatusText.tsx
+++ b/src/renderer/components/common/PrCheckStatusText.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { useLingui } from "@lingui/react/macro";
+import type { PrCheck } from "@/shared/contracts";
+import {
+  formatPrCheckDuration,
+  getPrCheckPresentation,
+  isPrCheckActive,
+  PR_CHECK_STATUS_LABEL,
+  PR_CHECK_TONE_TEXT_CLASS,
+} from "@/renderer/utils/prStatus";
+
+export function PrCheckStatusText(props: { check: PrCheck; className?: string | undefined }) {
+  const { check, className } = props;
+  const { t } = useLingui();
+  const presentation = getPrCheckPresentation(check);
+  const isActive = isPrCheckActive(check);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const startedAt = check.startedAt ? Date.parse(check.startedAt) : Number.NaN;
+    if (!isActive || !Number.isFinite(startedAt) || startedAt <= 0) return;
+    const interval = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(interval);
+  }, [check.startedAt, isActive]);
+
+  const duration = formatPrCheckDuration(check, now);
+
+  return (
+    <span
+      className={`whitespace-nowrap ${PR_CHECK_TONE_TEXT_CLASS[presentation.tone]} ${className ?? ""}`}
+    >
+      {duration && <span className="text-muted/70 tabular-nums">{duration} · </span>}
+      {t(PR_CHECK_STATUS_LABEL[presentation.status])}
+    </span>
+  );
+}

--- a/src/renderer/components/common/index.ts
+++ b/src/renderer/components/common/index.ts
@@ -12,6 +12,7 @@ export * from "./Input";
 export * from "./OptionMenu";
 export * from "./PathDisplay";
 export * from "./PixelLoader";
+export * from "./PrCheckStatusText";
 export * from "./ProviderModelMenu";
 export * from "./Select";
 export * from "./SidebarButton";

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -18,6 +18,7 @@ import {
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useProjectRootNames } from "@/renderer/state/projectRootNamesStore";
 import { useProjectTreeStore } from "@/renderer/state/projectTreeStore";
+import { formatElapsed } from "@/renderer/utils/formatTime";
 import {
   buildFileEditorContext,
   openFileInEditor,
@@ -29,7 +30,6 @@ import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollC
 import { selectVisibleThreadTimelineEntries, type ChatTimelineEntry } from "./chatPaneSelectors";
 import { shouldMarkUserScrollIntentFromPointerTarget } from "./chatScrollGeometry";
 import { normalizeChatProjectPath } from "./chatPathUtils";
-import { formatElapsed } from "./formatElapsed";
 import { MessageList, type CheckpointRevertActions } from "./parts/MessageList";
 import { SubAgentOverlay } from "./parts/items/SubAgentOverlay";
 

--- a/src/renderer/components/thread/ChatPane/formatElapsed.ts
+++ b/src/renderer/components/thread/ChatPane/formatElapsed.ts
@@ -1,9 +1,0 @@
-export function formatElapsed(totalSeconds: number): string {
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (minutes < 60) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
-  const hours = Math.floor(minutes / 60);
-  const remMinutes = minutes % 60;
-  return remMinutes === 0 ? `${hours}h` : `${hours}h ${remMinutes}m`;
-}

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -5,6 +5,7 @@ import { Trans } from "@lingui/react/macro";
 import type { MessageItemPayload, ProjectLocation } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 import { isIosTouchScroll } from "@/renderer/utils/iosScroll";
+import { formatElapsed } from "@/renderer/utils/formatTime";
 import { useAppStore } from "@/renderer/state/appStore";
 import {
   getRuntimeItemPayload,
@@ -17,7 +18,6 @@ import {
   RevertCheckpointDialog,
   type CheckpointGuard,
 } from "./CheckpointRevertControls";
-import { formatElapsed } from "../formatElapsed";
 import { useChatPaneActions } from "../chatPaneActionsContext";
 import {
   growingStreamLength,

--- a/src/renderer/components/thread/ThreadGoalDock.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.tsx
@@ -5,8 +5,8 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ThreadGoalDockState } from "./threadGoalState";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
+import { formatElapsed } from "@/renderer/utils/formatTime";
 import { ThreadDockSection } from "./ThreadDockUI";
-import { formatElapsed } from "./ChatPane/formatElapsed";
 import { formatTokenCount } from "./formatTokenCount";
 
 interface ThreadGoalDockProps {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Entfernen des Projekts abbrechen"
 msgid "cancelled"
 msgstr "abgebrochen"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Abgebrochen"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Ohne Branch-Namen kann kein Standard-Worktree-Pfad erstellt werden"
@@ -1632,6 +1636,7 @@ msgstr "Wird überprüft…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Prüfungen"
@@ -2152,6 +2157,10 @@ msgstr "Füllen Sie die Eingabeaufforderungen in diesem Terminal aus. Wird gesch
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "abgeschlossen"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Abgeschlossen"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Kontext aus {0} extrahieren ..."
 msgid "failed"
 msgstr "fehlgeschlagen"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Fehlgeschlagen"
@@ -5247,6 +5257,10 @@ msgstr "Benötigt Aufmerksamkeit · Antwort erforderlich"
 msgid "Needs reply"
 msgstr "Benötigt eine Antwort"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutral"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Neu"
@@ -5478,6 +5492,7 @@ msgstr "Keine Änderungen"
 msgid "No changes to display"
 msgstr "Keine Änderungen anzuzeigen"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Für diese PR wurden keine Checks gemeldet."
@@ -6280,6 +6295,10 @@ msgstr "Übergeordneter Ordner auf dem Server"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Übergeordneter Ordner, z. B. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Bestanden"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Passphrase (optional)"
@@ -6337,6 +6356,10 @@ msgstr "Spitzentag"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "ausstehend"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Ausstehend"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Diesen Zeitplan automatisch nach dem unten stehenden Zeitplan ausführen
 msgid "running"
 msgstr "läuft"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Wird ausgeführt"
@@ -8165,6 +8189,10 @@ msgstr "Skill-Marketplace"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Übersprungen"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Slash-Befehle"
@@ -8694,6 +8722,7 @@ msgstr "Tippen Sie auf +, um direkt zu koppeln oder über SSH eine Verbindung zu
 #~ msgstr "Tippen Sie auf +, um sich mit Poracode auf Ihrem Desktop zu koppeln."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Zielzweig"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Deinstallieren"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Unbekannt"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Cancel removing project"
 msgid "cancelled"
 msgstr "cancelled"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Cancelled"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Cannot create a default worktree path without a branch name"
@@ -1632,6 +1636,7 @@ msgstr "Checking…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Checks"
@@ -2152,6 +2157,10 @@ msgstr "Complete the prompts in this terminal. Closes when finished."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "completed"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Completed"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Extracting context from {0}..."
 msgid "failed"
 msgstr "failed"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Failed"
@@ -5247,6 +5257,10 @@ msgstr "Needs Attention · Reply required"
 msgid "Needs reply"
 msgstr "Needs reply"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutral"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "New"
@@ -5478,6 +5492,7 @@ msgstr "No changes"
 msgid "No changes to display"
 msgstr "No changes to display"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "No checks reported for this PR."
@@ -6280,6 +6295,10 @@ msgstr "Parent folder on the server"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Parent folder, e.g. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Passed"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Passphrase (optional)"
@@ -6337,6 +6356,10 @@ msgstr "Peak day"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "pending"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Pending"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Run this schedule automatically on the schedule below."
 msgid "running"
 msgstr "running"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Running"
@@ -8165,6 +8189,10 @@ msgstr "Skills marketplace"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Skipped"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Slash commands"
@@ -8694,6 +8722,7 @@ msgstr "Tap + to pair directly or connect to a remote machine over SSH."
 #~ msgstr "Tap + to pair with Poracode on your desktop."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Target branch"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Uninstall"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Unknown"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Cancelar eliminación del proyecto"
 msgid "cancelled"
 msgstr "cancelado"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Cancelado"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "No se puede crear una ruta de worktree predeterminada sin un nombre de rama"
@@ -1632,6 +1636,7 @@ msgstr "Comprobando…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Comprobaciones"
@@ -2152,6 +2157,10 @@ msgstr "Completa las instrucciones en este terminal. Se cerrará al finalizar."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "completado"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Completado"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Extrayendo contexto de {0}..."
 msgid "failed"
 msgstr "fallido"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Fallida"
@@ -5247,6 +5257,10 @@ msgstr "Necesita atención · Respuesta requerida"
 msgid "Needs reply"
 msgstr "Necesita respuesta"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutral"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Nuevo"
@@ -5478,6 +5492,7 @@ msgstr "Sin cambios"
 msgid "No changes to display"
 msgstr "No hay cambios para mostrar"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "No se reportaron comprobaciones para este PR."
@@ -6280,6 +6295,10 @@ msgstr "Carpeta principal en el servidor"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Carpeta principal, p. ej. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Aprobado"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Frase de contraseña (opcional)"
@@ -6337,6 +6356,10 @@ msgstr "Día pico"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "pendiente"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Pendiente"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Ejecutar esta programación automáticamente según la programación de 
 msgid "running"
 msgstr "en ejecución"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Ejecutándose"
@@ -8165,6 +8189,10 @@ msgstr "Marketplace de skills"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Omitido"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Comandos con barra"
@@ -8694,6 +8722,7 @@ msgstr "Toca + para emparejar directamente o conectarte a una máquina remota me
 #~ msgstr "Toca + para emparejar con Poracode en tu escritorio."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Rama de destino"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Desinstalar"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Desconocido"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Annuler la suppression du projet"
 msgid "cancelled"
 msgstr "annulé"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Annulé"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Impossible de créer un chemin d'arbre de travail par défaut sans nom de branche"
@@ -1632,6 +1636,7 @@ msgstr "Vérification…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Vérifications"
@@ -2152,6 +2157,10 @@ msgstr "Complétez les invites dans ce terminal. Se ferme une fois terminé."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "terminé"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Terminé"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Extraction du contexte depuis {0}..."
 msgid "failed"
 msgstr "échoué"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Échouée"
@@ -5246,6 +5256,10 @@ msgstr "A besoin d'attention · Réponse requise"
 msgid "Needs reply"
 msgstr "Besoin d'une réponse"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutre"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Nouveau"
@@ -5477,6 +5491,7 @@ msgstr "Aucun changement"
 msgid "No changes to display"
 msgstr "Aucun changement à afficher"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Aucun contrôle signalé pour cette PR."
@@ -6279,6 +6294,10 @@ msgstr "Dossier parent sur le serveur"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Dossier parent, par ex. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Réussi"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Phrase secrète (facultatif)"
@@ -6336,6 +6355,10 @@ msgstr "Jour de pointe"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "en attente"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "En attente"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7445,6 +7468,7 @@ msgstr "Exécuter cette planification automatiquement selon la planification ci-
 msgid "running"
 msgstr "en cours d'exécution"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "En cours d'exécution"
@@ -8164,6 +8188,10 @@ msgstr "Place de marché des compétences"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Ignoré"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Commandes slash"
@@ -8693,6 +8721,7 @@ msgstr "Touchez + pour jumeler directement ou vous connecter à une machine dist
 #~ msgstr "Appuyez sur + pour vous associer à Poracode sur votre bureau."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Branche cible"
 
@@ -9496,7 +9525,7 @@ msgid "Uninstall"
 msgstr "Désinstaller"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Inconnu"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1506,6 +1506,10 @@ msgstr "プロジェクトの削除をキャンセル"
 msgid "cancelled"
 msgstr "キャンセルされました"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "キャンセル済み"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "ブランチ名がないとデフォルトのワークツリー パスを作成できません"
@@ -1631,6 +1635,7 @@ msgstr "確認中…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "チェック"
@@ -2151,6 +2156,10 @@ msgstr "このターミナルでプロンプトを完了します。終了した
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "完了しました"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "完了"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3522,6 +3531,7 @@ msgstr "{0}からコンテキストを抽出しています ..."
 msgid "failed"
 msgstr "失敗しました"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "失敗"
@@ -5245,6 +5255,10 @@ msgstr "注意が必要 · 返信が必要です"
 msgid "Needs reply"
 msgstr "返信が必要です"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "中立"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "新機能"
@@ -5476,6 +5490,7 @@ msgstr "変更なし"
 msgid "No changes to display"
 msgstr "表示する変更はありません"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "この PR についてはチェックが報告されていません。"
@@ -6278,6 +6293,10 @@ msgstr "サーバー上の親フォルダー"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "親フォルダー（例: /home/me/projects）"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "成功"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "パスフレーズ（任意）"
@@ -6334,6 +6353,10 @@ msgstr "ピークの日"
 #: src/renderer/components/thread/ChatPane/parts/items/PlanItem.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
+msgstr "保留中"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
 msgstr "保留中"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
@@ -7444,6 +7467,7 @@ msgstr "下記のスケジュールでこのスケジュールを自動的に実
 msgid "running"
 msgstr "実行中"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "実行中"
@@ -8163,6 +8187,10 @@ msgstr "スキルマーケットプレイス"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "スキップ済み"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "スラッシュコマンド"
@@ -8692,6 +8720,7 @@ msgstr "+ をタップして直接ペアリングするか、SSH 経由でリモ
 #~ msgstr "+ をタップしてデスクトップの Poracode とペアリングしてください。"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "対象ブランチ"
 
@@ -9495,7 +9524,7 @@ msgid "Uninstall"
 msgstr "アンインストール"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "不明"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1507,6 +1507,10 @@ msgstr "프로젝트 제거 취소"
 msgid "cancelled"
 msgstr "취소됨"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "취소됨"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "브랜치 이름 없이 기본 작업 트리 경로를 생성할 수 없습니다."
@@ -1632,6 +1636,7 @@ msgstr "확인 중…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "검사"
@@ -2152,6 +2157,10 @@ msgstr "이 터미널의 프롬프트를 완료하세요. 완료되면 닫힙니
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "완료"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "완료됨"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "{0}에서 컨텍스트를 추출하는 중..."
 msgid "failed"
 msgstr "실패"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "실패"
@@ -5247,6 +5257,10 @@ msgstr "주의 필요 · 답변 필요"
 msgid "Needs reply"
 msgstr "답장이 필요함"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "중립"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "신규"
@@ -5478,6 +5492,7 @@ msgstr "변경사항 없음"
 msgid "No changes to display"
 msgstr "표시할 변경사항이 없습니다."
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "이 PR에 대해 보고된 검사가 없습니다."
@@ -6280,6 +6295,10 @@ msgstr "서버의 상위 폴더"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "상위 폴더, 예: /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "통과"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "암호 문구(선택 사항)"
@@ -6337,6 +6356,10 @@ msgstr "최고 활동일"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "보류 중"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "대기 중"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "아래 일정에 따라 이 일정을 자동으로 실행합니다."
 msgid "running"
 msgstr "실행 중"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "실행 중"
@@ -8165,6 +8189,10 @@ msgstr "스킬 마켓플레이스"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "건너뜀"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "슬래시 명령"
@@ -8694,6 +8722,7 @@ msgstr "+를 눌러 직접 페어링하거나 SSH를 통해 원격 컴퓨터에 
 #~ msgstr "+를 탭하여 데스크톱의 Poracode와 페어링하세요."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "대상 브랜치"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "제거"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "알 수 없음"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Anuluj usuwanie projektu"
 msgid "cancelled"
 msgstr "anulowane"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Anulowano"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Nie można utworzyć domyślnej ścieżki drzewa roboczego bez nazwy gałęzi"
@@ -1632,6 +1636,7 @@ msgstr "Sprawdzam…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Kontrole"
@@ -2152,6 +2157,10 @@ msgstr "Wypełnij monity w tym terminalu. Zamyka się po zakończeniu."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "ukończone"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Ukończono"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Wyodrębnianie kontekstu z {0}..."
 msgid "failed"
 msgstr "nie powiodło się"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Niepowodzenie"
@@ -5247,6 +5257,10 @@ msgstr "Wymaga uwagi · Wymagana odpowiedź"
 msgid "Needs reply"
 msgstr "Potrzebuje odpowiedzi"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutralny"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Nowość"
@@ -5478,6 +5492,7 @@ msgstr "Żadnych zmian"
 msgid "No changes to display"
 msgstr "Brak zmian do wyświetlenia"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Dla tego PR nie zgłoszono żadnych kontroli."
@@ -6280,6 +6295,10 @@ msgstr "Folder nadrzędny na serwerze"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Folder nadrzędny, np. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Zaliczone"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Fraza hasła (opcjonalnie)"
@@ -6337,6 +6356,10 @@ msgstr "Szczytowy dzień"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "w toku"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Oczekuje"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Automatycznie uruchamiaj ten harmonogram według poniższego harmonogram
 msgid "running"
 msgstr "uruchomiony"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "W trakcie"
@@ -8165,6 +8189,10 @@ msgstr "Marketplace umiejętności"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Pominięto"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Polecenia z ukośnikiem"
@@ -8694,6 +8722,7 @@ msgstr "Naciśnij +, aby sparować bezpośrednio lub połączyć się ze zdalnym
 #~ msgstr "Dotknij +, aby sparować się z Poracode na komputerze."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Gałąź docelowa"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Odinstaluj"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Nieznany"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Cancelar remoção do projeto"
 msgid "cancelled"
 msgstr "cancelado"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Cancelado"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Não é possível criar um caminho de worktree padrão sem um nome de branch"
@@ -1632,6 +1636,7 @@ msgstr "Verificando…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Verificações"
@@ -2152,6 +2157,10 @@ msgstr "Preencha os prompts neste terminal. Fecha quando terminar."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "concluído"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Concluído"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Extraindo contexto de {0}..."
 msgid "failed"
 msgstr "falhou"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Falhou"
@@ -5247,6 +5257,10 @@ msgstr "Precisa de atenção · Resposta obrigatória"
 msgid "Needs reply"
 msgstr "Precisa de resposta"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Neutro"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Novo"
@@ -5478,6 +5492,7 @@ msgstr "Sem alterações"
 msgid "No changes to display"
 msgstr "Nenhuma alteração na exibição"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Nenhuma verificação relatada para este PR."
@@ -6280,6 +6295,10 @@ msgstr "Pasta pai no servidor"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Pasta pai, ex.: /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Aprovado"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Frase secreta (opcional)"
@@ -6337,6 +6356,10 @@ msgstr "Dia de pico"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "pendente"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Pendente"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Executar este agendamento automaticamente conforme o agendamento abaixo.
 msgid "running"
 msgstr "em execução"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Em execução"
@@ -8165,6 +8189,10 @@ msgstr "Marketplace de skills"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Ignorado"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Comandos de barra"
@@ -8694,6 +8722,7 @@ msgstr "Toque em + para emparelhar diretamente ou se conectar a uma máquina rem
 #~ msgstr "Toque em + para parear com o Poracode no seu desktop."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Branch de destino"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Desinstalar"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Desconhecido"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Отменить удаление проекта"
 msgid "cancelled"
 msgstr "отменено"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Отменено"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Невозможно создать путь worktree по умолчанию без имени ветки"
@@ -1632,6 +1636,7 @@ msgstr "Проверка…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Проверки"
@@ -2152,6 +2157,10 @@ msgstr "Выполните подсказки в этом терминале. О
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "завершено"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Завершено"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Извлечение контекста из {0}..."
 msgid "failed"
 msgstr "не удалось"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Ошибка"
@@ -5247,6 +5257,10 @@ msgstr "Требует внимания · Нужен ответ"
 msgid "Needs reply"
 msgstr "Требует ответа"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Нейтрально"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Новое"
@@ -5478,6 +5492,7 @@ msgstr "Нет изменений"
 msgid "No changes to display"
 msgstr "Нет изменений для отображения"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Для этого PR не сообщено о проверках."
@@ -6280,6 +6295,10 @@ msgstr "Родительская папка на сервере"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Родительская папка, например /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Пройдено"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Кодовая фраза (необязательно)"
@@ -6337,6 +6356,10 @@ msgstr "Пиковый день"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "ожидание"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Ожидает"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Автоматически запускать это расписани�
 msgid "running"
 msgstr "выполняется"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Выполняется"
@@ -8165,6 +8189,10 @@ msgstr "Маркетплейс навыков"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Пропущено"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Slash-команды"
@@ -8694,6 +8722,7 @@ msgstr "Нажмите +, чтобы выполнить прямое сопря�
 #~ msgstr "Нажмите +, чтобы подключиться к Poracode на компьютере."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Целевая ветка"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Удалить"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Неизвестно"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Projeyi kaldırmayı iptal et"
 msgid "cancelled"
 msgstr "iptal edildi"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "İptal edildi"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Dal adı olmadan varsayılan çalışma ağacı yolu oluşturulamıyor"
@@ -1632,6 +1636,7 @@ msgstr "Kontrol ediliyor…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Kontroller"
@@ -2152,6 +2157,10 @@ msgstr "Bu terminaldeki istemleri tamamlayın. Bittiğinde kapanır."
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "tamamlandı"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Tamamlandı"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "{0} öğesinden bağlam çıkarılıyor..."
 msgid "failed"
 msgstr "başarısız oldu"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Başarısız"
@@ -5247,6 +5257,10 @@ msgstr "Dikkat Edilmesi Gerekiyor · Yanıt gerekli"
 msgid "Needs reply"
 msgstr "Yanıt gerekiyor"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Nötr"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Yeni"
@@ -5478,6 +5492,7 @@ msgstr "Değişiklik yok"
 msgid "No changes to display"
 msgstr "Görüntülenecek değişiklik yok"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Bu PR için herhangi bir kontrol raporlanmadı."
@@ -6280,6 +6295,10 @@ msgstr "Sunucudaki üst klasör"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Üst klasör, örn. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Geçti"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Parola ifadesi (isteğe bağlı)"
@@ -6337,6 +6356,10 @@ msgstr "En yoğun gün"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "beklemede"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Bekliyor"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Bu zamanlamayı aşağıdaki zamanlamaya göre otomatik olarak çalışt
 msgid "running"
 msgstr "çalışıyor"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Çalışıyor"
@@ -8165,6 +8189,10 @@ msgstr "Beceri marketplace'i"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Atlandı"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Eğik çizgi komutları"
@@ -8694,6 +8722,7 @@ msgstr "Doğrudan eşleştirmek veya SSH üzerinden uzak bir makineye bağlanmak
 #~ msgstr "Masaüstünüzdeki Poracode ile eşleştirmek için + öğesine dokunun."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Hedef şube"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Kaldır"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Bilinmiyor"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Скасувати видалення проєкту"
 msgid "cancelled"
 msgstr "скасовано"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Скасовано"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Неможливо створити шлях worktree за замовчуванням без імені гілки"
@@ -1632,6 +1636,7 @@ msgstr "Перевірка…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Перевірки"
@@ -2152,6 +2157,10 @@ msgstr "Виконайте підказки в цьому терміналі. В
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "завершено"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Завершено"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Видобування контексту з {0}..."
 msgid "failed"
 msgstr "не вдалося"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Помилка"
@@ -5247,6 +5257,10 @@ msgstr "Потребує уваги · Потрібна відповідь"
 msgid "Needs reply"
 msgstr "Потребує відповіді"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Нейтрально"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Нове"
@@ -5478,6 +5492,7 @@ msgstr "Немає змін"
 msgid "No changes to display"
 msgstr "Немає змін для відображення"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Для цього PR не повідомлено про перевірки."
@@ -6280,6 +6295,10 @@ msgstr "Батьківська папка на сервері"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Батьківська папка, напр. /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Пройдено"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Парольна фраза (необов’язково)"
@@ -6337,6 +6356,10 @@ msgstr "Пік активності"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "очікування"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Очікує"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Автоматично запускати цей розклад за р�
 msgid "running"
 msgstr "виконується"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Виконується"
@@ -8165,6 +8189,10 @@ msgstr "Маркетплейс навичок"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Пропущено"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Slash-команди"
@@ -8694,6 +8722,7 @@ msgstr "Натисніть +, щоб створити пару напряму а
 #~ msgstr "Натисніть +, щоб підключитися до Poracode на вашому робочому столі."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Цільова гілка"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Видалити"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Невідомо"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1507,6 +1507,10 @@ msgstr "Hủy xóa dự án"
 msgid "cancelled"
 msgstr "đã hủy"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "Đã hủy"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "Không thể tạo đường dẫn cây làm việc mặc định mà không có tên nhánh"
@@ -1632,6 +1636,7 @@ msgstr "Đang kiểm tra…"
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "Kiểm tra"
@@ -2152,6 +2157,10 @@ msgstr "Hoàn thành các lời nhắc trong thiết bị đầu cuối này. Đ
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
 msgstr "hoàn thành"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
+msgstr "Đã hoàn tất"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
@@ -3523,6 +3532,7 @@ msgstr "Đang trích xuất ngữ cảnh từ {0}..."
 msgid "failed"
 msgstr "thất bại"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "Thất bại"
@@ -5247,6 +5257,10 @@ msgstr "Cần chú ý · Cần trả lời"
 msgid "Needs reply"
 msgstr "Cần trả lời"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "Trung lập"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "Mới"
@@ -5478,6 +5492,7 @@ msgstr "Không có thay đổi"
 msgid "No changes to display"
 msgstr "Không có thay đổi nào để hiển thị"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "Không có kiểm tra nào được báo cáo cho PR này."
@@ -6280,6 +6295,10 @@ msgstr "Thư mục cha trên máy chủ"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "Thư mục cha, ví dụ /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "Đã đạt"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "Cụm mật khẩu (không bắt buộc)"
@@ -6337,6 +6356,10 @@ msgstr "Ngày cao điểm"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "đang chờ xử lý"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "Đang chờ"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7446,6 +7469,7 @@ msgstr "Tự động chạy lịch này theo lịch bên dưới."
 msgid "running"
 msgstr "đang chạy"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "Đang chạy"
@@ -8165,6 +8189,10 @@ msgstr "Marketplace skill"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "Đã bỏ qua"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "Lệnh gạch chéo"
@@ -8694,6 +8722,7 @@ msgstr "Nhấn + để ghép đôi trực tiếp hoặc kết nối với máy t
 #~ msgstr "Nhấn + để ghép đôi với Poracode trên máy tính của bạn."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "Nhánh mục tiêu"
 
@@ -9497,7 +9526,7 @@ msgid "Uninstall"
 msgstr "Gỡ cài đặt"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "Không xác định"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1507,6 +1507,10 @@ msgstr "取消移除项目"
 msgid "cancelled"
 msgstr "已取消"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Cancelled"
+msgstr "已取消"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Cannot create a default worktree path without a branch name"
 msgstr "无法创建没有分支名称的默认工作树路径"
@@ -1632,6 +1636,7 @@ msgstr "正在检查..."
 
 #: src/mobile/views/pr/PrChecksPage.tsx
 #: src/mobile/views/pr/PrOverviewPage.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrTabsPill.tsx
 msgid "Checks"
 msgstr "检查项"
@@ -2151,6 +2156,10 @@ msgstr "完成此终端中的提示。完成后关闭。"
 #: src/renderer/components/thread/ChatPane/parts/items/PlanItem.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "completed"
+msgstr "已完成"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Completed"
 msgstr "已完成"
 
 #: src/renderer/commands/shortcutCatalog.ts
@@ -3523,6 +3532,7 @@ msgstr "从{0}中提取上下文 ..."
 msgid "failed"
 msgstr "失败了"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Failed"
 msgstr "失败"
@@ -5246,6 +5256,10 @@ msgstr "需要关注 · 需要回复"
 msgid "Needs reply"
 msgstr "需要回复"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Neutral"
+msgstr "中立"
+
 #: src/renderer/components/changelog/ChangelogView.tsx
 msgid "New"
 msgstr "新增"
@@ -5477,6 +5491,7 @@ msgstr "没有变化"
 msgid "No changes to display"
 msgstr "没有显示任何变化"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
 msgid "No checks reported for this PR."
 msgstr "没有为此 PR 报告检查。"
@@ -6279,6 +6294,10 @@ msgstr "服务器上的父文件夹"
 msgid "Parent folder, e.g. /home/me/projects"
 msgstr "父文件夹，例如 /home/me/projects"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Passed"
+msgstr "已通过"
+
 #: src/mobile/views/DesktopsView.tsx
 msgid "Passphrase (optional)"
 msgstr "密码短语（可选）"
@@ -6336,6 +6355,10 @@ msgstr "最活跃日"
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "pending"
 msgstr "待定"
+
+#: src/renderer/utils/prStatus.ts
+msgid "Pending"
+msgstr "待处理"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrConversationTab.tsx
 msgid "pending review"
@@ -7445,6 +7468,7 @@ msgstr "按照下方的计划自动运行此计划。"
 msgid "running"
 msgstr "运行中"
 
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SchedulesView/parts/PreviousRunsModal.tsx
 msgid "Running"
 msgstr "正在运行"
@@ -8164,6 +8188,10 @@ msgstr "技能市场"
 msgid "Skills.sh"
 msgstr "Skills.sh"
 
+#: src/renderer/utils/prStatus.ts
+msgid "Skipped"
+msgstr "已跳过"
+
 #: src/renderer/components/thread/ThreadCommandPanel.tsx
 msgid "Slash commands"
 msgstr "斜杠命令"
@@ -8693,6 +8721,7 @@ msgstr "点按 + 直接配对或通过 SSH 连接到远程计算机。"
 #~ msgstr "点击 + 与桌面端的 Poracode 配对。"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Target branch"
 msgstr "目标分支"
 
@@ -9496,7 +9525,7 @@ msgid "Uninstall"
 msgstr "卸载"
 
 #: src/renderer/components/thread/threadContextUsage.ts
-#: src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+#: src/renderer/utils/prStatus.ts
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Unknown"
 msgstr "未知"

--- a/src/renderer/state/gitStore.test.ts
+++ b/src/renderer/state/gitStore.test.ts
@@ -388,6 +388,26 @@ describe("gitStore batch updates", () => {
     expect(secondDetails).not.toBe(firstDetails);
     expect(secondDetails["p1#42"]?.checks[0]?.conclusion).toBe("SUCCESS");
   });
+
+  it("replaces PR details when check timing changes", () => {
+    useGitStore.getState().setPrDetails("p1#42", basePrDetails);
+    const firstDetails = useGitStore.getState().prDetails;
+
+    useGitStore.getState().setPrDetails("p1#42", {
+      ...basePrDetails,
+      checks: [
+        {
+          ...basePrDetails.checks[0]!,
+          startedAt: "2026-07-13T11:25:03Z",
+          completedAt: "2026-07-13T11:25:49Z",
+        },
+      ],
+    });
+
+    const secondDetails = useGitStore.getState().prDetails;
+    expect(secondDetails).not.toBe(firstDetails);
+    expect(secondDetails["p1#42"]?.checks[0]?.completedAt).toBe("2026-07-13T11:25:49Z");
+  });
 });
 
 describe("summaryBackfillMissed", () => {

--- a/src/renderer/state/gitStore.ts
+++ b/src/renderer/state/gitStore.ts
@@ -354,7 +354,9 @@ function arePrChecksEqual(a: PrCheck, b: PrCheck): boolean {
     a.state === b.state &&
     a.conclusion === b.conclusion &&
     a.url === b.url &&
-    a.workflowName === b.workflowName
+    a.workflowName === b.workflowName &&
+    a.startedAt === b.startedAt &&
+    a.completedAt === b.completedAt
   );
 }
 

--- a/src/renderer/utils/formatTime.ts
+++ b/src/renderer/utils/formatTime.ts
@@ -6,6 +6,16 @@ export function formatRelativeTime(iso: string): string {
   return `${Math.floor(deltaHours / 24)}d`;
 }
 
+export function formatElapsed(totalSeconds: number): string {
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes === 0 ? `${hours}h` : `${hours}h ${remMinutes}m`;
+}
+
 export function formatShortDateTime(iso: string | undefined): string {
   if (!iso) return "";
   const date = new Date(iso);

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -1,8 +1,100 @@
+import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
 import { PR_CHECK_FAILURE_CONCLUSIONS, type PrCheck, type PrState } from "@/shared/contracts";
+import { formatElapsed } from "@/renderer/utils/formatTime";
 
 export type PrStatusTone = "merged" | "draft" | "danger" | "warning" | "success";
 export type PrChecksStatus = "FAILURE" | "PENDING" | "SUCCESS";
 export type PrChecksTone = "danger" | "warning" | "success";
+export type PrCheckTone = PrChecksTone | "neutral";
+export type PrCheckDisplayStatus =
+  | "passed"
+  | "failed"
+  | "running"
+  | "pending"
+  | "cancelled"
+  | "skipped"
+  | "neutral"
+  | "completed"
+  | "unknown";
+
+export const PR_CHECK_STATUS_LABEL: Record<PrCheckDisplayStatus, MessageDescriptor> = {
+  passed: msg`Passed`,
+  failed: msg`Failed`,
+  running: msg`Running`,
+  pending: msg`Pending`,
+  cancelled: msg`Cancelled`,
+  skipped: msg`Skipped`,
+  neutral: msg`Neutral`,
+  completed: msg`Completed`,
+  unknown: msg`Unknown`,
+};
+
+export const PR_CHECK_TONE_TEXT_CLASS: Record<PrCheckTone, string> = {
+  success: "text-success",
+  danger: "text-danger",
+  warning: "text-warning",
+  neutral: "text-muted/70",
+};
+
+export function getPrCheckPresentation(check: PrCheck): {
+  status: PrCheckDisplayStatus;
+  tone: PrCheckTone;
+} {
+  const conclusion = check.conclusion.toUpperCase();
+  const state = check.state.toUpperCase();
+  const value = conclusion || state;
+
+  if (value === "SUCCESS") return { status: "passed", tone: "success" };
+  if (value === "IN_PROGRESS") return { status: "running", tone: "warning" };
+  if (
+    value === "PENDING" ||
+    value === "QUEUED" ||
+    value === "EXPECTED" ||
+    value === "WAITING" ||
+    value === "REQUESTED"
+  ) {
+    return { status: "pending", tone: "warning" };
+  }
+  if (value === "CANCELLED" || value === "CANCELED" || value === "STALE") {
+    return { status: "cancelled", tone: "danger" };
+  }
+  if (value === "SKIPPED") return { status: "skipped", tone: "neutral" };
+  if (value === "NEUTRAL") return { status: "neutral", tone: "neutral" };
+  if (PR_CHECK_FAILURE_CONCLUSIONS.has(value) || value === "ERROR") {
+    return { status: "failed", tone: "danger" };
+  }
+  if (value === "COMPLETED") return { status: "completed", tone: "neutral" };
+  return { status: "unknown", tone: "neutral" };
+}
+
+export function countPassedPrChecks(checks: readonly PrCheck[]): number {
+  return checks.filter((check) => getPrCheckPresentation(check).tone === "success").length;
+}
+
+export function isPrCheckActive(check: PrCheck): boolean {
+  const status = getPrCheckPresentation(check).status;
+  return status === "running" || status === "pending";
+}
+
+export function formatPrCheckDuration(check: PrCheck, now = Date.now()): string | undefined {
+  if (!check.startedAt) return undefined;
+  const startedAt = Date.parse(check.startedAt);
+  if (!Number.isFinite(startedAt) || startedAt <= 0) return undefined;
+
+  const completedAt = check.completedAt ? Date.parse(check.completedAt) : undefined;
+  const endedAt =
+    completedAt !== undefined && Number.isFinite(completedAt)
+      ? completedAt
+      : isPrCheckActive(check)
+        ? now
+        : undefined;
+  if (endedAt === undefined || endedAt < startedAt) return undefined;
+
+  const totalSeconds = Math.round((endedAt - startedAt) / 1000);
+  if (totalSeconds < 1) return "<1s";
+  return formatElapsed(totalSeconds);
+}
 
 export function aggregatePrChecksStatus(
   checks: readonly PrCheck[] | undefined,

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrData, PrDetails } from "@/shared/contracts";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { PrSection } from "./PrSection";
+
+vi.mock("@heroui/react", () => {
+  function Wrapper(props: { children?: ReactNode }) {
+    return <>{props.children}</>;
+  }
+
+  function Button(props: {
+    children?: ReactNode | ((state: { isPending: boolean }) => ReactNode);
+    isDisabled?: boolean;
+    isPending?: boolean;
+    onPress?: () => void;
+  }) {
+    return (
+      <button type="button" disabled={props.isDisabled} onClick={props.onPress}>
+        {typeof props.children === "function"
+          ? props.children({ isPending: props.isPending ?? false })
+          : props.children}
+      </button>
+    );
+  }
+
+  const ButtonGroup = Object.assign(Wrapper, { Separator: () => null });
+  const Dropdown = Object.assign(Wrapper, {
+    Popover: Wrapper,
+    Menu: Wrapper,
+    Item: Wrapper,
+  });
+  const Tooltip = Object.assign(Wrapper, {
+    Trigger: Wrapper,
+    Content: Wrapper,
+  });
+
+  return {
+    Button,
+    ButtonGroup,
+    Dropdown,
+    Label: Wrapper,
+    Link: Wrapper,
+    Separator: () => null,
+    ToggleButton: Button,
+    Tooltip,
+  };
+});
+
+const prKey = "C:\\repo-worktree";
+const projectId = "project-1";
+const pr: PrData = {
+  number: 42,
+  state: "open",
+  title: "Improve PR summary",
+  url: "https://github.com/example/poracode/pull/42",
+  baseBranch: "main",
+  isDraft: false,
+  checksStatus: "PENDING",
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  updatedAt: "2026-07-13T12:00:00Z",
+};
+
+const details: PrDetails = {
+  number: 42,
+  title: pr.title,
+  body: "",
+  baseBranch: "main",
+  headBranch: "feature/pr-summary",
+  additions: 51,
+  deletions: 7,
+  changedFiles: 4,
+  mergedAt: null,
+  mergedBy: null,
+  closedAt: null,
+  commits: [],
+  comments: [],
+  reviews: [],
+  checks: [
+    {
+      name: "Lint",
+      state: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-07-13T12:00:00Z",
+      completedAt: "2026-07-13T12:00:46Z",
+    },
+    { name: "Typecheck", state: "SUCCESS", conclusion: "" },
+    { name: "Test", state: "IN_PROGRESS", conclusion: "" },
+  ],
+};
+
+const baseProps = {
+  prKey,
+  projectId,
+  prLoading: false,
+  handleMergePr: vi.fn<(method: "merge" | "squash" | "rebase", admin?: boolean) => Promise<void>>(
+    async () => undefined,
+  ),
+  handleClosePr: vi.fn<() => Promise<void>>(async () => undefined),
+  handleMarkPrReady: vi.fn<() => Promise<void>>(async () => undefined),
+};
+
+describe("PrSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGitStore.setState({ prData: { [prKey]: pr }, prDetails: {} });
+  });
+
+  it("shows target branch, diff totals, and passed checks", () => {
+    useGitStore.getState().setPrDetails(`${projectId}#${pr.number}`, details);
+    const onRefreshPr = vi.fn<() => Promise<void>>(async () => undefined);
+
+    render(<PrSection {...baseProps} onRefreshPr={onRefreshPr} />);
+
+    const branch = screen.getByLabelText("Target branch: main");
+    expect(branch).toHaveTextContent("main");
+    expect(branch).not.toHaveTextContent("Target branch");
+    expect(screen.getByText("+51")).toBeInTheDocument();
+    expect(screen.getByText("−7")).toBeInTheDocument();
+    expect(screen.getByText("2/3").parentElement).toHaveTextContent("Checks: 2/3");
+    expect(screen.getByText("Lint").parentElement).toHaveTextContent("46s · Passed");
+    expect(screen.getByText("Test").parentElement).toHaveTextContent("Running");
+    expect(onRefreshPr).not.toHaveBeenCalled();
+  });
+
+  it("requests details once when the compact PR data has no details", async () => {
+    const onRefreshPr = vi.fn<() => Promise<void>>(async () => undefined);
+    const view = render(<PrSection {...baseProps} onRefreshPr={onRefreshPr} />);
+
+    await waitFor(() => expect(onRefreshPr).toHaveBeenCalledOnce());
+    expect(screen.queryByText("+51")).not.toBeInTheDocument();
+
+    view.rerender(<PrSection {...baseProps} onRefreshPr={onRefreshPr} />);
+    expect(onRefreshPr).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
   ChevronDown,
   Eye,
   ExternalLink,
+  GitBranch,
   GitMerge,
   RefreshCw,
   ShieldOff,
@@ -22,20 +23,22 @@ import {
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { MessageDescriptor } from "@lingui/core";
-import { PixelLoader } from "@/renderer/components/common";
+import { PixelLoader, PrCheckStatusText } from "@/renderer/components/common";
 import type { PrWriteAction } from "@/renderer/hooks/usePrWriteActions";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
 import {
   usePrMergeStateStatus,
   usePrMergeable,
+  usePrBaseBranch,
   usePrNumber,
   usePrState,
   usePrTitle,
   usePrUrl,
 } from "@/renderer/state/gitSelectors";
+import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { usePrCombinedChecksStatus } from "@/renderer/hooks/usePrCombinedChecksStatus";
-import { getPrStatusTone, PR_TONE_BG_CLASS } from "@/renderer/utils/prStatus";
+import { countPassedPrChecks, getPrStatusTone, PR_TONE_BG_CLASS } from "@/renderer/utils/prStatus";
 import { GitReviewSection } from "./GitReviewSection";
 
 const BLOCK_REASON: Record<string, MessageDescriptor> = {
@@ -57,7 +60,7 @@ export function PrSection(props: {
   handleClosePr: () => Promise<void>;
   handleMarkPrReady: () => Promise<void>;
   handleUpdatePrBranch?: ((rebase?: boolean) => Promise<void>) | undefined;
-  /** Refetch this PR's live data on demand. When omitted, no refresh icon shows. */
+  /** Refetch live PR data, hydrate missing details once, and power the refresh icon. */
   onRefreshPr?: (() => void | Promise<void>) | undefined;
   isRefreshingPr?: boolean | undefined;
 }) {
@@ -79,11 +82,30 @@ export function PrSection(props: {
   const number = usePrNumber(prKey);
   const title = usePrTitle(prKey);
   const url = usePrUrl(prKey);
+  const baseBranch = usePrBaseBranch(prKey);
   const cacheKey = number !== undefined ? `${projectId}#${number}` : undefined;
+  const details = useGitStore((s) => (cacheKey ? s.prDetails[cacheKey] : undefined));
   const combinedChecksStatus = usePrCombinedChecksStatus(prKey, cacheKey);
   const mergeStateStatus = usePrMergeStateStatus(prKey);
   const mergeable = usePrMergeable(prKey);
+  const requestedDetailsKey = useRef<string | undefined>(undefined);
   const [bypass, setBypass] = useState(false);
+
+  useEffect(() => {
+    if (
+      !cacheKey ||
+      details ||
+      !onRefreshPr ||
+      isRefreshingPr ||
+      state === "merged" ||
+      state === "closed" ||
+      requestedDetailsKey.current === cacheKey
+    ) {
+      return;
+    }
+    requestedDetailsKey.current = cacheKey;
+    void onRefreshPr();
+  }, [cacheKey, details, isRefreshingPr, onRefreshPr, state]);
 
   const indicatorColor = PR_TONE_BG_CLASS[getPrStatusTone(state, combinedChecksStatus)];
 
@@ -106,6 +128,7 @@ export function PrSection(props: {
   // Offer refresh for live PRs only — a merged/closed PR's head branch is often
   // gone, so a by-branch refetch is pointless. Mirrors `canReview`'s exclusions.
   const canRefresh = Boolean(onRefreshPr) && state !== "merged" && state !== "closed";
+  const passedChecks = details ? countPassedPrChecks(details.checks) : 0;
 
   return (
     <GitReviewSection>
@@ -165,6 +188,61 @@ export function PrSection(props: {
           </Tooltip>
         )}
       </div>
+      {(baseBranch || details) && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] leading-none text-muted tabular-nums">
+          {baseBranch && (
+            <span
+              className="flex min-w-0 items-center gap-1"
+              aria-label={`${t`Target branch`}: ${baseBranch}`}
+              title={`${t`Target branch`}: ${baseBranch}`}
+            >
+              <GitBranch className="size-3 shrink-0" aria-hidden />
+              <span className="truncate font-mono text-foreground">{baseBranch}</span>
+            </span>
+          )}
+          {details && (
+            <>
+              <span className="flex shrink-0 items-center gap-1.5 whitespace-nowrap">
+                <span className="text-success">+{details.additions}</span>
+                <span className="text-danger">−{details.deletions}</span>
+              </span>
+              <Tooltip delay={300}>
+                <Tooltip.Trigger
+                  className="shrink-0 cursor-help whitespace-nowrap"
+                  aria-label={t`Checks`}
+                  tabIndex={0}
+                >
+                  <span>
+                    <Trans>Checks</Trans>:{" "}
+                    <span className="text-foreground">
+                      {passedChecks}/{details.checks.length}
+                    </span>
+                  </span>
+                </Tooltip.Trigger>
+                <Tooltip.Content placement="top" className="min-w-48 max-w-80 text-xs">
+                  {details.checks.length === 0 ? (
+                    <Trans>No checks reported for this PR.</Trans>
+                  ) : (
+                    <ul className="space-y-1 py-0.5">
+                      {details.checks.map((check, index) => {
+                        return (
+                          <li
+                            key={`${check.name}-${index}`}
+                            className="flex items-center justify-between gap-4"
+                          >
+                            <span className="min-w-0 truncate text-foreground">{check.name}</span>
+                            <PrCheckStatusText check={check} className="shrink-0" />
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </Tooltip.Content>
+              </Tooltip>
+            </>
+          )}
+        </div>
+      )}
       {state === "draft" && (
         <ButtonGroup className="w-full">
           <Button

--- a/src/renderer/views/PrReviewOverlay/parts/PrChecksTab.test.tsx
+++ b/src/renderer/views/PrReviewOverlay/parts/PrChecksTab.test.tsx
@@ -1,0 +1,71 @@
+import { act, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrDetails } from "@/shared/contracts";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { PrChecksTab } from "./PrChecksTab";
+
+const cacheKey = "project-1#42";
+const details: PrDetails = {
+  number: 42,
+  title: "Improve check labels",
+  body: "",
+  baseBranch: "main",
+  headBranch: "feature/check-labels",
+  additions: 12,
+  deletions: 3,
+  changedFiles: 2,
+  mergedAt: null,
+  mergedBy: null,
+  closedAt: null,
+  commits: [],
+  comments: [],
+  reviews: [],
+  checks: [
+    {
+      name: "Typecheck",
+      state: "COMPLETED",
+      conclusion: "SUCCESS",
+      startedAt: "2026-07-13T11:25:03Z",
+      completedAt: "2026-07-13T11:25:49Z",
+      workflowName: "CI",
+    },
+    {
+      name: "Windows build",
+      state: "IN_PROGRESS",
+      conclusion: "",
+      startedAt: "2026-07-13T11:57:55Z",
+      workflowName: "Build",
+    },
+    { name: "E2E", state: "COMPLETED", conclusion: "FAILURE" },
+    { name: "Deploy", state: "COMPLETED", conclusion: "CANCELLED" },
+    { name: "Coverage", state: "COMPLETED", conclusion: "SKIPPED" },
+    { name: "Preview", state: "QUEUED", conclusion: "" },
+  ],
+};
+
+describe("PrChecksTab", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-13T12:00:00Z"));
+    useGitStore.setState({ prDetails: { [cacheKey]: details } });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows friendly statuses and check durations", async () => {
+    render(<PrChecksTab cacheKey={cacheKey} loading={false} />);
+
+    expect(screen.getByText("Typecheck").closest("li")).toHaveTextContent("46s · Passed");
+    expect(screen.getByText("Windows build").closest("li")).toHaveTextContent("2m 05s · Running");
+    expect(screen.getByText("E2E").closest("li")).toHaveTextContent("Failed");
+    expect(screen.getByText("Deploy").closest("li")).toHaveTextContent("Cancelled");
+    expect(screen.getByText("Coverage").closest("li")).toHaveTextContent("Skipped");
+    expect(screen.getByText("Preview").closest("li")).toHaveTextContent("Pending");
+
+    await act(() => vi.advanceTimersByTimeAsync(1_000));
+    expect(screen.getByText("Windows build").closest("li")).toHaveTextContent("2m 06s · Running");
+  });
+});

--- a/src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
+++ b/src/renderer/views/PrReviewOverlay/parts/PrChecksTab.tsx
@@ -1,38 +1,20 @@
 import { CheckCircle2, Clock, ExternalLink, XCircle } from "lucide-react";
 import { Link } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { PR_CHECK_FAILURE_CONCLUSIONS, type PrCheck } from "@/shared/contracts";
-import { PixelLoader } from "@/renderer/components/common";
+import { PixelLoader, PrCheckStatusText } from "@/renderer/components/common";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
-
-type CheckTone = "success" | "danger" | "warning" | "neutral";
-
-function getCheckTone(check: PrCheck): CheckTone {
-  const conclusion = check.conclusion?.toUpperCase?.() ?? "";
-  const state = check.state?.toUpperCase?.() ?? "";
-  if (conclusion === "SUCCESS" || state === "SUCCESS") return "success";
-  if (PR_CHECK_FAILURE_CONCLUSIONS.has(conclusion) || state === "ERROR" || state === "FAILURE") {
-    return "danger";
-  }
-  if (state === "PENDING" || state === "EXPECTED" || (state && state !== "COMPLETED")) {
-    return "warning";
-  }
-  return "neutral";
-}
+import {
+  countPassedPrChecks,
+  getPrCheckPresentation,
+  PR_CHECK_TONE_TEXT_CLASS,
+} from "@/renderer/utils/prStatus";
 
 const TONE_ICON = {
   success: CheckCircle2,
   danger: XCircle,
   warning: Clock,
   neutral: Clock,
-} as const;
-
-const TONE_CLASS = {
-  success: "text-success",
-  danger: "text-danger",
-  warning: "text-warning",
-  neutral: "text-muted/70",
 } as const;
 
 export function PrChecksTab(props: { cacheKey: string; loading: boolean }) {
@@ -57,7 +39,7 @@ export function PrChecksTab(props: { cacheKey: string; loading: boolean }) {
     );
   }
 
-  const passed = checks.filter((c) => getCheckTone(c) === "success").length;
+  const passed = countPassedPrChecks(checks);
 
   return (
     <div className="mx-auto w-full max-w-3xl px-6 py-3">
@@ -70,23 +52,21 @@ export function PrChecksTab(props: { cacheKey: string; loading: boolean }) {
       </div>
       <ul className="divide-y divide-[color:var(--border)] overflow-hidden rounded-2xl border border-[color:var(--border)] bg-surface-tertiary/30">
         {checks.map((check, idx) => {
-          const tone = getCheckTone(check);
+          const tone = getPrCheckPresentation(check).tone;
           const Icon = TONE_ICON[tone];
           return (
             <li
               key={`${check.name}-${idx}`}
               className="flex items-center gap-3 px-3 py-2 hover:bg-foreground/[0.03]"
             >
-              <Icon className={`size-4 shrink-0 ${TONE_CLASS[tone]}`} />
+              <Icon className={`size-4 shrink-0 ${PR_CHECK_TONE_TEXT_CLASS[tone]}`} />
               <div className="min-w-0 flex-1">
                 <div className="truncate text-xs font-medium text-foreground">{check.name}</div>
-                {(check.workflowName || check.conclusion || check.state) && (
-                  <div className="mt-0.5 truncate text-[11px] text-muted">
-                    {check.workflowName ? `${check.workflowName} · ` : ""}
-                    {check.conclusion || check.state || t`Unknown`}
-                  </div>
+                {check.workflowName && (
+                  <div className="mt-0.5 truncate text-[11px] text-muted">{check.workflowName}</div>
                 )}
               </div>
+              <PrCheckStatusText check={check} className="shrink-0 text-[11px]" />
               {check.url ? (
                 <Link
                   aria-label={t`Open check`}

--- a/src/shared/contracts/github.ts
+++ b/src/shared/contracts/github.ts
@@ -34,6 +34,8 @@ export interface PrCheck {
   conclusion: string;
   url?: string;
   workflowName?: string;
+  startedAt?: string;
+  completedAt?: string;
 }
 
 export const PR_CHECK_FAILURE_CONCLUSIONS: ReadonlySet<string> = new Set([

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -50,6 +50,7 @@ import {
   mapGitHubApiRepo,
   parseGhAuthAccounts,
 } from "./github";
+import { mapStatusCheck } from "./githubMappers";
 import { resolveClonedProjectPath } from "./git/exec";
 
 const location = { kind: "windows" as const, path: "C:\\Users\\demo\\repo" };
@@ -813,6 +814,42 @@ describe("GitHubService", () => {
         new GitHubService().submitPrReview(location, 42, "request-changes", "   "),
       ).rejects.toThrow(/required/i);
       expect(execFileAsyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mapStatusCheck", () => {
+    it("preserves check run timestamps", () => {
+      expect(
+        mapStatusCheck({
+          name: "Typecheck",
+          status: "COMPLETED",
+          conclusion: "SUCCESS",
+          startedAt: "2026-07-13T11:25:03Z",
+          completedAt: "2026-07-13T11:25:49Z",
+        }),
+      ).toEqual({
+        name: "Typecheck",
+        state: "COMPLETED",
+        conclusion: "SUCCESS",
+        startedAt: "2026-07-13T11:25:03Z",
+        completedAt: "2026-07-13T11:25:49Z",
+      });
+    });
+
+    it("preserves a status context start time without inventing a completion time", () => {
+      expect(
+        mapStatusCheck({
+          context: "Vercel",
+          state: "SUCCESS",
+          startedAt: "2026-07-13T11:25:28Z",
+          completedAt: null,
+        }),
+      ).toEqual({
+        name: "Vercel",
+        state: "SUCCESS",
+        conclusion: "",
+        startedAt: "2026-07-13T11:25:28Z",
+      });
     });
   });
 

--- a/src/supervisor/githubMappers.ts
+++ b/src/supervisor/githubMappers.ts
@@ -172,7 +172,7 @@ export function mapStatusCheck(raw: unknown): PrCheck | null {
   if (!raw || typeof raw !== "object") return null;
   const obj = raw as Record<string, unknown>;
   // statusCheckRollup is a union: CheckRun (workflow check) or StatusContext (legacy commit status).
-  // CheckRun fields: name, status, conclusion, detailsUrl, workflowName
+  // CheckRun fields: name, status, conclusion, detailsUrl, workflowName, startedAt, completedAt
   // StatusContext fields: context (name), state, targetUrl, description
   const name =
     typeof obj.name === "string" ? obj.name : typeof obj.context === "string" ? obj.context : "";
@@ -187,12 +187,16 @@ export function mapStatusCheck(raw: unknown): PrCheck | null {
         ? obj.targetUrl
         : undefined;
   const workflowName = typeof obj.workflowName === "string" ? obj.workflowName : undefined;
+  const startedAt = typeof obj.startedAt === "string" ? obj.startedAt : undefined;
+  const completedAt = typeof obj.completedAt === "string" ? obj.completedAt : undefined;
   return {
     name,
     state,
     conclusion,
     ...(url ? { url } : {}),
     ...(workflowName ? { workflowName } : {}),
+    ...(startedAt ? { startedAt } : {}),
+    ...(completedAt ? { completedAt } : {}),
   };
 }
 


### PR DESCRIPTION
- Feature: display localized status labels and elapsed durations for pull request checks across review views.
- Preserve check-run start and completion timestamps through GitHub mapping and refresh PR state when timing changes.
- Consolidate elapsed-time formatting and add coverage for check status presentation, timing updates, and review surfaces.
- Update all renderer locale catalogs for the new PR check status text.