### PR TITLE
Fix chat row measurement after tool group layout changes

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -81,10 +81,16 @@ vi.mock("@/renderer/utils/iosScroll", () => ({
 }));
 
 vi.mock("./items/ChatItemRow", () => ({
-  ChatItemRow: (props: { entry: { id: string } }) => {
+  ChatItemRow: (props: { entry: { id: string }; onHeightChange?: () => void }) => {
     const actions = useChatPaneActions();
     return (
-      <button type="button" onClick={() => actions?.onContentHeightChange()}>
+      <button
+        type="button"
+        onClick={() => {
+          props.onHeightChange?.();
+          actions?.onContentHeightChange();
+        }}
+      >
         {props.entry.id}
       </button>
     );
@@ -868,7 +874,7 @@ describe("MessageList", () => {
     ).toBe("1");
   });
 
-  it("leaves virtual total size changes to native end anchoring", () => {
+  it("notifies the parent when virtual total size changes", () => {
     const onContentHeightChange = vi.fn<() => void>();
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -889,7 +895,7 @@ describe("MessageList", () => {
       </ChatPaneActionsContext.Provider>,
     );
 
-    expect(onContentHeightChange).not.toHaveBeenCalled();
+    onContentHeightChange.mockClear();
 
     getTotalSizeMock.mockReturnValue(288);
     rerender(
@@ -902,10 +908,10 @@ describe("MessageList", () => {
       </ChatPaneActionsContext.Provider>,
     );
 
-    expect(onContentHeightChange).not.toHaveBeenCalled();
+    expect(onContentHeightChange).toHaveBeenCalledOnce();
   });
 
-  it("delegates height change to parent actions without forcing list measurement", () => {
+  it("synchronously remeasures a toggled virtual row before delegating scroll pinning", () => {
     const onContentHeightChange = vi.fn<() => void>();
     const actions = {
       openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
@@ -927,12 +933,15 @@ describe("MessageList", () => {
     );
     onContentHeightChange.mockClear();
     measureElementMock.mockClear();
+    resizeItemMock.mockClear();
+    const row = screen.getByText("item-2").closest("[data-chat-virtual-row='true']");
+    if (!(row instanceof HTMLDivElement)) throw new Error("missing virtual row");
+    Object.defineProperty(row, "offsetHeight", { configurable: true, value: 123 });
 
     fireEvent.click(screen.getByText("item-2"));
 
-    // Row ResizeObservers own size recalculation. This callback is only for
-    // parent scroll pinning; forcing list measurement here creates resize churn.
-    expect(measureElementMock).not.toHaveBeenCalled();
+    expect(measureElementMock).toHaveBeenCalledWith(row);
+    expect(resizeItemMock).toHaveBeenCalledWith(1, 123);
     expect(measureMock).not.toHaveBeenCalled();
     expect(onContentHeightChange).toHaveBeenCalledOnce();
   });

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -361,6 +361,10 @@ export function MessageList({
   const totalSize = virtualizer.getTotalSize();
   const firstVisibleStart = virtualItems[0]?.start ?? 0;
 
+  useLayoutEffect(() => {
+    parentActions?.onContentHeightChange();
+  }, [parentActions, totalSize]);
+
   // The "live tail" index drives the auto-expand on `ToolCallGroup`. Trailing
   // empty/in-flight reasoning items don't count: an agent emitting a reasoning
   // bracket between tool calls would otherwise collapse the group prematurely
@@ -556,15 +560,18 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
     },
     [index, measureElement],
   );
+  const remeasureRow = useCallback(() => {
+    const element = rowElementRef.current;
+    if (!element) return;
+    measureElement(index, element);
+  }, [index, measureElement]);
   const scheduleLiveMeasure = useCallback(() => {
     if (liveMeasureRafRef.current !== null) return;
     liveMeasureRafRef.current = requestAnimationFrame(() => {
       liveMeasureRafRef.current = null;
-      const element = rowElementRef.current;
-      if (!element) return;
-      measureElement(index, element);
+      remeasureRow();
     });
-  }, [index, measureElement]);
+  }, [remeasureRow]);
   useLayoutEffect(() => {
     if (!isLastEntry) return;
     return useAppStore.subscribe(
@@ -629,6 +636,7 @@ const VirtualChatListRow = memo(function VirtualChatListRow({
             threadId={threadId}
             entry={entry}
             isLastEntry={isLastEntry}
+            onHeightChange={remeasureRow}
             checkpointRevert={
               checkpointRevertItemId ? { itemId: checkpointRevertItemId, onRequestRevert } : null
             }

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
@@ -25,6 +25,7 @@ interface ChatItemRowProps {
   entry: ChatTimelineEntry;
   /** True when this is the tail of the visible timeline. Drives live-group expand state. */
   isLastEntry?: boolean;
+  onHeightChange?: () => void;
   checkpointRevert: CheckpointRevertRequest | null;
 }
 
@@ -40,11 +41,19 @@ export const ChatItemRow = memo(function ChatItemRow({
   threadId,
   entry,
   isLastEntry = false,
+  onHeightChange,
   checkpointRevert,
 }: ChatItemRowProps) {
   "use no memo";
   if (entry.kind === "tool_call_group") {
-    return <ToolCallGroup threadId={threadId} itemIds={entry.itemIds} isLive={isLastEntry} />;
+    return (
+      <ToolCallGroup
+        threadId={threadId}
+        itemIds={entry.itemIds}
+        isLive={isLastEntry}
+        {...(onHeightChange ? { onHeightChange } : {})}
+      />
+    );
   }
   return (
     <SingleChatItemRow threadId={threadId} itemId={entry.id} checkpointRevert={checkpointRevert} />

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
@@ -91,6 +91,22 @@ describe("ToolCallGroup", () => {
     expect(view.container.querySelector(".poracode-tool-call-group-viewport")).not.toBeNull();
     expect(screen.getByText("Read file one")).toBeInTheDocument();
     expect(screen.getByText("Read file two")).toBeInTheDocument();
+  });
+
+  it("requests row remeasurement after the collapsed layout commits", () => {
+    const threadId = "thread-1";
+    const items = [makeToolItem("tool-1", "Read file one")];
+    seedThread(threadId, items);
+    let container: HTMLElement | null = null;
+    const onHeightChange = vi.fn<() => void>(() => {
+      expect(container?.querySelector(".poracode-tool-call-group-viewport")).toBeNull();
+    });
+    const view = renderToolCallGroup(threadId, [items[0]!.id], true, onHeightChange);
+    container = view.container;
+
+    fireEvent.click(screen.getByRole("button", { name: /1 view/i }));
+
+    expect(onHeightChange).toHaveBeenCalledOnce();
   });
 
   it("renders every row inline when the group fits under the cap", () => {
@@ -569,10 +585,20 @@ describe("ToolCallGroup", () => {
   });
 });
 
-function renderToolCallGroup(threadId: string, itemIds: readonly string[], isLive = true) {
+function renderToolCallGroup(
+  threadId: string,
+  itemIds: readonly string[],
+  isLive = true,
+  onHeightChange?: () => void,
+) {
   return render(
     <AppProvider>
-      <ToolCallGroup threadId={threadId} itemIds={itemIds} isLive={isLive} />
+      <ToolCallGroup
+        threadId={threadId}
+        itemIds={itemIds}
+        isLive={isLive}
+        {...(onHeightChange ? { onHeightChange } : {})}
+      />
     </AppProvider>,
   );
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -1,5 +1,13 @@
 import { Disclosure } from "@heroui/react";
-import { Fragment, memo, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  Fragment,
+  memo,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { msg } from "@lingui/core/macro";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
@@ -64,6 +72,8 @@ interface ToolCallGroupProps {
   itemIds: readonly string[];
   /** True while this group is the tail of the timeline. Drives default expand state. */
   isLive?: boolean;
+  /** Synchronously remeasure the owning virtual row after an explicit layout change. */
+  onHeightChange?: () => void;
 }
 
 const TOOL_CALL_GROUP_MAX_VISIBLE_ROWS = 8;
@@ -72,6 +82,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
   threadId,
   itemIds,
   isLive = false,
+  onHeightChange,
 }: ToolCallGroupProps) {
   const items = useAppStore(
     useShallow((state) =>
@@ -87,7 +98,19 @@ export const ToolCallGroup = memo(function ToolCallGroup({
   const [isExpanded, setIsExpanded] = useState(isLive);
   const [showAll, setShowAll] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const previousLayoutRef = useRef({ isExpanded, showAll });
   const hasOverflowRows = items.length > TOOL_CALL_GROUP_MAX_VISIBLE_ROWS;
+
+  useLayoutEffect(() => {
+    const previous = previousLayoutRef.current;
+    if (previous.isExpanded === isExpanded && previous.showAll === showAll) return;
+    previousLayoutRef.current = { isExpanded, showAll };
+    if (onHeightChange) {
+      onHeightChange();
+    } else {
+      actions?.onContentHeightChange();
+    }
+  }, [actions, isExpanded, onHeightChange, showAll]);
 
   useEffect(() => {
     if (!isLive) setIsExpanded(false);
@@ -116,10 +139,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
       <Disclosure
         className="text-[length:var(--lc-chat-font-size-command)] leading-tight"
         isExpanded={isExpanded}
-        onExpandedChange={(next) => {
-          setIsExpanded(next);
-          actions?.onContentHeightChange();
-        }}
+        onExpandedChange={setIsExpanded}
       >
         <Disclosure.Heading>
           <Disclosure.Trigger className={`group ${chatRowClass} gap-2 ${chatRowHoverClass}`}>
@@ -161,10 +181,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
                       type="button"
                       aria-expanded={showAll}
                       className="-ml-1 rounded px-1.5 py-0.5 text-[11px] font-medium text-[color:var(--muted)] transition-colors hover:bg-foreground/5 hover:text-foreground"
-                      onClick={() => {
-                        setShowAll((prev) => !prev);
-                        actions?.onContentHeightChange();
-                      }}
+                      onClick={() => setShowAll((prev) => !prev)}
                     >
                       {showAll ? <Trans>Show less</Trans> : <Trans>Show all</Trans>}
                     </button>


### PR DESCRIPTION
- **Bugfix**: Re-measure virtualized chat rows when tool call groups expand, collapse, or change visible rows.
- Notify the chat pane when total virtual content height changes to preserve correct scroll behavior.
- Cover row remeasurement and layout-change behavior with MessageList and ToolCallGroup tests.