### PR TITLE
Add a global pull request view

### DIFF
--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -1532,6 +1532,47 @@ describe("RemoteAccessServer", () => {
     });
   });
 
+  it("allows paired clients to list the global pull request rows", async () => {
+    const callSupervisor = vi.fn<RemoteAccessServerOptions["callSupervisor"]>(async (name) => {
+      if (name === "ghListPullRequests") {
+        return { pullRequests: [], viewerLogin: "remote-user" } as never;
+      }
+      throw new Error(`unexpected supervisor call: ${name}`);
+    });
+    const server = new RemoteAccessServer({
+      appVersion: "1.0.0",
+      identity: { desktopId: "desktop-test", label: "Test Desktop" },
+      host: "127.0.0.1",
+      port: 0,
+      callSupervisor,
+    });
+    servers.push(server);
+    const info = await server.start();
+    const token = await issueAccessToken(info, ["session:read"]);
+
+    const response = await fetch(new URL("/api/git/call", info.httpBaseUrl), {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        procedure: "ghListPullRequests",
+        payload: {
+          projectLocation: { kind: "posix", path: "/tmp/example" },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      result: { pullRequests: [], viewerLogin: "remote-user" },
+    });
+    expect(callSupervisor).toHaveBeenCalledWith("ghListPullRequests", {
+      projectLocation: { kind: "posix", path: "/tmp/example" },
+    });
+  });
+
   it("rate limits pairing token exchange attempts", async () => {
     const server = new RemoteAccessServer({
       appVersion: "1.0.0",

--- a/src/renderer/hooks/usePrWriteActions.ts
+++ b/src/renderer/hooks/usePrWriteActions.ts
@@ -13,6 +13,7 @@ const ADMIN_BYPASS_RX = /--admin|base branch policy|not mergeable/i;
 export interface UsePrWriteActionsArgs {
   projectLocation: ProjectLocation;
   localSyncLocation?: ProjectLocation | undefined;
+  skipLocalSync?: boolean | undefined;
   prKey: string | undefined;
   /** PR head branch — required for the on-demand `handleRefreshPr` refetch. */
   branch?: string | undefined;
@@ -44,7 +45,8 @@ export interface UsePrWriteActionsResult {
  * stay in lockstep across surfaces.
  */
 export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteActionsResult {
-  const { projectLocation, localSyncLocation, prKey, branch, projectId, onRefresh } = args;
+  const { projectLocation, localSyncLocation, skipLocalSync, prKey, branch, projectId, onRefresh } =
+    args;
   const [pendingAction, setPendingAction] = useState<PrWriteAction | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const prLoading = pendingAction !== null;
@@ -159,12 +161,14 @@ export function usePrWriteActions(args: UsePrWriteActionsArgs): UsePrWriteAction
         prNumber: prData.number,
         rebase,
       });
-      const syncPayload = {
-        projectLocation: localSyncLocation ?? projectLocation,
-        remote: "origin",
-      };
-      if (rebase) await readBridge().gitPullRebase(syncPayload);
-      else await readBridge().gitPull(syncPayload);
+      if (!skipLocalSync) {
+        const syncPayload = {
+          projectLocation: localSyncLocation ?? projectLocation,
+          remote: "origin",
+        };
+        if (rebase) await readBridge().gitPullRebase(syncPayload);
+        else await readBridge().gitPull(syncPayload);
+      }
       onRefresh();
     } catch (err) {
       console.error("[git] update PR branch failed", err);

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -540,6 +540,7 @@ msgstr "Konto"
 msgid "Account options"
 msgstr "Kontooptionen"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Konten"
@@ -634,6 +635,10 @@ msgstr "Fügen Sie ein Projekt hinzu, bevor Sie einen Agenten installieren."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Fügen Sie ein Projekt hinzu, bevor Sie sich anmelden."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Fügen Sie ein Projekt hinzu, um Pull Requests anzuzeigen."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Benachrichtigungen, wenn Threads dich brauchen"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Authentifizierung erforderlich"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Die Authentifizierungskonfiguration kann nicht importiert werden"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Erstellt"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Wird überprüft…"
 msgid "Checks"
 msgstr "Prüfungen"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Prüfungen fehlgeschlagen"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Prüfungen bestanden"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Prüfungen ausstehend"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Ordner auswählen"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Nutzungsdetails schließen"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Geschlossen"
 
@@ -2486,6 +2509,11 @@ msgstr "Der Kontext konnte nicht extrahiert werden."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Commit-Nachricht konnte nicht generiert werden: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Pull Requests für {0} konnten nicht geladen werden."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Sprachmodell wird heruntergeladen..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Entwurf"
 
@@ -3640,9 +3669,17 @@ msgstr "Nach Projekt filtern"
 msgid "Filter marketplace by source"
 msgstr "Marketplace nach Quelle filtern"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Pull Requests filtern"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Skills nach Status filtern"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filter"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "PR wird geladen…"
 msgid "Loading previous runs"
 msgstr "Frühere Ausführungen werden geladen"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Pull Requests werden geladen"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Registry wird geladen..."
@@ -4984,6 +5025,7 @@ msgstr "Arbeitsbaum zusammenführen"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Zusammengeführt"
 
@@ -5584,6 +5626,10 @@ msgstr "Keine Übereinstimmungen."
 msgid "No matching agents."
 msgstr "Keine passenden Agenten."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Keine passenden Pull Requests."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Keine passenden Zeitpläne."
@@ -5667,6 +5713,10 @@ msgstr "Noch keine Anbieter verbunden."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Noch kein Anbieter bereit"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Keine Pull Requests gefunden."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Nur wenn nicht fokussiert"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Offen"
@@ -6157,6 +6208,10 @@ msgstr "Optionen"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Oder schreiben Sie eine individuelle Antwort"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Andere"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Projektspezifische Überschreibungen zusätzlich zu den globalen Suchein
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projekte"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull Request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull Request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Pull-Request-Kategorie"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull Request zusammengeführt"
@@ -6735,6 +6795,11 @@ msgstr "Pull Request zusammengeführt"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Pull-Request-Optionen"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull Requests"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Benachrichtigungsinhalt verbergen"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Zum Kontrollpunkt zurückkehren?"
 msgid "Revert to this checkpoint"
 msgstr "Zu diesem Kontrollpunkt zurückkehren"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Arbeit über Ihre GitHub-Konten hinweg prüfen und verfolgen."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "PR #{prNumber} für {0} überprüfen"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Review-Darstellung"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Zu prüfen"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Modelle suchen..."
 msgid "Search or enter address"
 msgstr "Adresse suchen oder eingeben"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Pull Requests durchsuchen"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Repositories durchsuchen"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Zeigen Sie einen projektlosen Home-Bereich für Agentensitzungen auf Betriebssystemebene an."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -540,6 +540,7 @@ msgstr "Account"
 msgid "Account options"
 msgstr "Account options"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Accounts"
@@ -634,6 +635,10 @@ msgstr "Add a project before installing an agent."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Add a project before signing in."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Add a project to see pull requests."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Alerts when threads need you"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Authentication required"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Authentication setup cannot be imported"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Authored"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Checking…"
 msgid "Checks"
 msgstr "Checks"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Checks failed"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Checks passed"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Checks pending"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Choose a folder"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Close usage details"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Closed"
 
@@ -2486,6 +2509,11 @@ msgstr "Could not extract context."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Could not generate commit message: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Could not load pull requests for {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Downloading voice model..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Draft"
 
@@ -3640,9 +3669,17 @@ msgstr "Filter by project"
 msgid "Filter marketplace by source"
 msgstr "Filter marketplace by source"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Filter pull requests"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Filter skills by status"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filters"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Loading PR…"
 msgid "Loading previous runs"
 msgstr "Loading previous runs"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Loading pull requests"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Loading registry..."
@@ -4984,6 +5025,7 @@ msgstr "Merge Worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Merged"
 
@@ -5584,6 +5626,10 @@ msgstr "No matches."
 msgid "No matching agents."
 msgstr "No matching agents."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "No matching pull requests."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "No matching schedules."
@@ -5667,6 +5713,10 @@ msgstr "No providers connected yet."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "No providers ready yet"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "No pull requests found."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Only when unfocused"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Open"
@@ -6157,6 +6208,10 @@ msgstr "Options"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Or write a custom answer"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Other"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Project-specific overrides on top of the global search settings."
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projects"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Pull request category"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request merged"
@@ -6735,6 +6795,11 @@ msgstr "Pull request merged"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Pull request options"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull requests"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Redact notification content"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Revert to checkpoint?"
 msgid "Revert to this checkpoint"
 msgstr "Revert to this checkpoint"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Review and track work across your GitHub accounts."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Review PR #{prNumber} for {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Review presentation"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Reviewing"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Search models..."
 msgid "Search or enter address"
 msgstr "Search or enter address"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Search pull requests"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Search repositories"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Show a projectless Home scope for OS-level agent sessions."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -540,6 +540,7 @@ msgstr "Cuenta"
 msgid "Account options"
 msgstr "Opciones de cuenta"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Cuentas"
@@ -634,6 +635,10 @@ msgstr "Agrega un proyecto antes de instalar un agente."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Agrega un proyecto antes de iniciar sesión."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Agrega un proyecto para ver las pull requests."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Alertas cuando los hilos necesitan tu atención"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Autenticación requerida"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "La configuración de autenticación no se puede importar"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Creadas"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Comprobando…"
 msgid "Checks"
 msgstr "Comprobaciones"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Comprobaciones fallidas"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Comprobaciones superadas"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Comprobaciones pendientes"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Elige una carpeta"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Cerrar detalles de uso"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Cerrado"
 
@@ -2486,6 +2509,11 @@ msgstr "No se pudo extraer el contexto."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "No se pudo generar el mensaje de confirmación: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "No se pudieron cargar las pull requests de {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Descargando modelo de voz..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Borrador"
 
@@ -3640,9 +3669,17 @@ msgstr "Filtrar por proyecto"
 msgid "Filter marketplace by source"
 msgstr "Filtrar el marketplace por fuente"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Filtrar pull requests"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Filtrar skills por estado"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filtros"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Cargando PR…"
 msgid "Loading previous runs"
 msgstr "Cargando ejecuciones anteriores"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Cargando pull requests"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Cargando registro..."
@@ -4984,6 +5025,7 @@ msgstr "Fusionar worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Fusionado"
 
@@ -5584,6 +5626,10 @@ msgstr "Sin coincidencias."
 msgid "No matching agents."
 msgstr "No hay agentes coincidentes."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "No hay pull requests coincidentes."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "No hay programaciones coincidentes."
@@ -5667,6 +5713,10 @@ msgstr "Aún no hay proveedores conectados."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Aún no hay proveedores listos"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "No se encontraron pull requests."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Solo cuando no esté en primer plano"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Abrir"
@@ -6157,6 +6208,10 @@ msgstr "Opciones"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "O escribe una respuesta personalizada"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Otras"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Anulaciones específicas del proyecto sobre los ajustes de búsqueda glo
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Proyectos"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Categoría de pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request fusionado"
@@ -6735,6 +6795,11 @@ msgstr "Pull request fusionado"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Opciones de pull request"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull requests"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Ocultar el contenido de las notificaciones"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "¿Revertir al punto de control?"
 msgid "Revert to this checkpoint"
 msgstr "Revertir a este punto de control"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Revisa y haz seguimiento del trabajo en tus cuentas de GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Revisar PR #{prNumber} de {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Presentación de revisión"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Para revisar"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Buscar modelos..."
 msgid "Search or enter address"
 msgstr "Buscar o introducir dirección"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Buscar pull requests"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Buscar repositorios"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Mostrar un ámbito de inicio sin proyecto para las sesiones de agente a nivel del OS."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -540,6 +540,7 @@ msgstr "Compte"
 msgid "Account options"
 msgstr "Options de compte"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Comptes"
@@ -634,6 +635,10 @@ msgstr "Ajoutez un projet avant d'installer un agent."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Ajoutez un projet avant de vous connecter."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Ajoutez un projet pour voir les pull requests."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Alertes lorsque les fils ont besoin de vous"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Authentification requise"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "La configuration de l’authentification ne peut pas être importée"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Créées"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Vérification…"
 msgid "Checks"
 msgstr "Vérifications"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Vérifications échouées"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Vérifications réussies"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Vérifications en attente"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Choisissez un dossier"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Fermer les détails d'utilisation"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Fermé"
 
@@ -2486,6 +2509,11 @@ msgstr "Impossible d'extraire le contexte."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Impossible de générer le message de validation : {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Impossible de charger les pull requests pour {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Téléchargement du modèle vocal..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Brouillon"
 
@@ -3640,9 +3669,17 @@ msgstr "Filtrer par projet"
 msgid "Filter marketplace by source"
 msgstr "Filtrer la place de marché par source"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Filtrer les pull requests"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Filtrer les compétences par état"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filtres"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Chargement de la PR…"
 msgid "Loading previous runs"
 msgstr "Chargement des exécutions précédentes"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Chargement des pull requests"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Chargement du registre..."
@@ -4983,6 +5024,7 @@ msgstr "Fusionner le worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Fusionné"
 
@@ -5583,6 +5625,10 @@ msgstr "Aucune correspondance."
 msgid "No matching agents."
 msgstr "Aucun agent correspondant."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Aucune pull request correspondante."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Aucune planification correspondante."
@@ -5666,6 +5712,10 @@ msgstr "Aucun fournisseur connecté pour le moment."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Aucun fournisseur n'est prêt pour l'instant"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Aucune pull request trouvée."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5897,6 +5947,7 @@ msgstr "Uniquement lorsque la fenêtre n'est pas active"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Ouvrir"
@@ -6156,6 +6207,10 @@ msgstr "Options"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Ou écrivez une réponse personnalisée"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Autres"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6610,6 +6665,7 @@ msgstr "Remplacements spécifiques au projet en plus des paramètres de recherch
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projets"
 
@@ -6727,6 +6783,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Catégorie de pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request fusionnée"
@@ -6734,6 +6794,11 @@ msgstr "Pull request fusionnée"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Options de demande de tirage"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull requests"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6868,6 +6933,7 @@ msgstr "Masquer le contenu des notifications"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7322,6 +7388,10 @@ msgstr "Revenir au point de contrôle ?"
 msgid "Revert to this checkpoint"
 msgstr "Revenir à ce point de contrôle"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Examinez et suivez le travail sur vos comptes GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7355,6 +7425,10 @@ msgstr "Examiner la PR #{prNumber} pour {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Présentation de la revue"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "À examiner"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7649,6 +7723,10 @@ msgstr "Rechercher des modèles..."
 msgid "Search or enter address"
 msgstr "Rechercher ou saisir une adresse"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Rechercher des pull requests"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Rechercher des dépôts"
@@ -7893,6 +7971,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Afficher une portée Accueil sans projet pour les sessions d'agent au niveau du système d'exploitation."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -539,6 +539,7 @@ msgstr "アカウント"
 msgid "Account options"
 msgstr "アカウントオプション"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "アカウント"
@@ -633,6 +634,10 @@ msgstr "エージェントをインストールする前にプロジェクトを
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "サインインする前にプロジェクトを追加してください。"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "プルリクエストを表示するには、プロジェクトを追加してください。"
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -844,6 +849,7 @@ msgstr "スレッドが対応を必要としたら通知"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1113,6 +1119,10 @@ msgstr "認証が必要です"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "認証設定はインポートできません"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "自分が作成"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1635,6 +1645,18 @@ msgstr "確認中…"
 msgid "Checks"
 msgstr "チェック"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "チェック失敗"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "チェック成功"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "チェック保留中"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "フォルダーを選択"
@@ -1965,6 +1987,7 @@ msgid "Close usage details"
 msgstr "使用状況の詳細を閉じる"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "クローズ"
 
@@ -2485,6 +2508,11 @@ msgstr "コンテキストを抽出できませんでした。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "コミットメッセージを生成できませんでした:{detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "{0} のプルリクエストを読み込めませんでした。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3149,6 +3177,7 @@ msgid "Downloading voice model..."
 msgstr "音声モデルをダウンロードしています..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "草案"
 
@@ -3639,9 +3668,17 @@ msgstr "プロジェクトで絞り込み"
 msgid "Filter marketplace by source"
 msgstr "ソースでマーケットプレイスを絞り込む"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "プルリクエストを絞り込む"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "状態でスキルを絞り込む"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "フィルター"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4596,6 +4633,10 @@ msgstr "PRを読み込み中…"
 msgid "Loading previous runs"
 msgstr "過去の実行を読み込み中"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "プルリクエストを読み込み中"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "レジストリを読み込んでいます..."
@@ -4982,6 +5023,7 @@ msgstr "ワークツリーをマージ"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "マージ済み"
 
@@ -5582,6 +5624,10 @@ msgstr "一致はありません。"
 msgid "No matching agents."
 msgstr "一致するエージェントはありません。"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "条件に一致するプルリクエストはありません。"
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "一致するスケジュールはありません。"
@@ -5665,6 +5711,10 @@ msgstr "接続されているプロバイダーはまだありません。"
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "まだプロバイダーの準備ができていません"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "プルリクエストが見つかりませんでした。"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5896,6 +5946,7 @@ msgstr "焦点が合っていないときのみ"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "開く"
@@ -6155,6 +6206,10 @@ msgstr "オプション"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "またはカスタムの回答を作成します"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "その他"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6609,6 +6664,7 @@ msgstr "グローバル検索設定に加えてプロジェクト固有のオー
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "プロジェクト"
 
@@ -6726,6 +6782,10 @@ msgstr "プルリクエスト {0}"
 msgid "Pull request #{0}"
 msgstr "プルリクエスト #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "プルリクエストのカテゴリ"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request をマージしました"
@@ -6733,6 +6793,11 @@ msgstr "Pull request をマージしました"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "プルリクエストのオプション"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "プルリクエスト"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6867,6 +6932,7 @@ msgstr "通知内容を伏せる"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7321,6 +7387,10 @@ msgstr "チェックポイントに戻りますか?"
 msgid "Revert to this checkpoint"
 msgstr "このチェックポイントに戻る"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "GitHub アカウント全体の作業をレビュー・追跡します。"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7354,6 +7424,10 @@ msgstr "{0}の PR #{prNumber}を確認します"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "レビュー表示"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "レビュー中"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7648,6 +7722,10 @@ msgstr "モデルを検索..."
 msgid "Search or enter address"
 msgstr "アドレスを検索または入力"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "プルリクエストを検索"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "リポジトリの検索"
@@ -7892,6 +7970,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "OS レベルのエージェント セッション用に、プロジェクトに属さないホームスコープを表示します。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -540,6 +540,7 @@ msgstr "계정"
 msgid "Account options"
 msgstr "계정 옵션"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "계정"
@@ -634,6 +635,10 @@ msgstr "에이전트를 설치하기 전에 프로젝트를 추가하세요."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "로그인하기 전에 프로젝트를 추가하세요."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "풀 리퀘스트를 보려면 프로젝트를 추가하세요."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "스레드에 응답이 필요할 때 알림"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "인증 필요"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "인증 설정은 가져올 수 없습니다"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "내가 작성"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "확인 중…"
 msgid "Checks"
 msgstr "검사"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "검사 실패"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "검사 통과"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "검사 대기 중"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "폴더 선택"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "사용 세부정보 닫기"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "닫힘"
 
@@ -2486,6 +2509,11 @@ msgstr "컨텍스트를 추출할 수 없습니다."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "커밋 메시지를 생성할 수 없습니다: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "{0}의 풀 리퀘스트를 불러올 수 없습니다."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "음성 모델 다운로드 중..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "초안"
 
@@ -3640,9 +3669,17 @@ msgstr "프로젝트별 필터"
 msgid "Filter marketplace by source"
 msgstr "소스별로 마켓플레이스 필터링"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "풀 리퀘스트 필터링"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "상태별로 스킬 필터링"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "필터"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "PR 로드 중…"
 msgid "Loading previous runs"
 msgstr "이전 실행 로드 중"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "풀 리퀘스트 불러오는 중"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "레지스트리 로드 중..."
@@ -4984,6 +5025,7 @@ msgstr "작업 트리 병합"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "병합됨"
 
@@ -5584,6 +5626,10 @@ msgstr "일치하는 항목이 없습니다."
 msgid "No matching agents."
 msgstr "일치하는 에이전트가 없습니다."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "일치하는 풀 리퀘스트가 없습니다."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "일치하는 일정이 없습니다."
@@ -5667,6 +5713,10 @@ msgstr "아직 연결된 공급자가 없습니다."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "아직 준비된 공급자가 없습니다."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "풀 리퀘스트를 찾을 수 없습니다."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "포커스가 없을 때만"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "열기"
@@ -6157,6 +6208,10 @@ msgstr "옵션"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "또는 맞춤 답변을 작성하세요."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "기타"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "전역 검색 설정 위에 프로젝트별 재정의가 적용됩니다
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "프로젝트"
 
@@ -6728,6 +6784,10 @@ msgstr "풀 리퀘스트 {0}"
 msgid "Pull request #{0}"
 msgstr "풀 리퀘스트 #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "풀 리퀘스트 카테고리"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request가 병합되었습니다"
@@ -6735,6 +6795,11 @@ msgstr "Pull request가 병합되었습니다"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "풀 요청 옵션"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "풀 리퀘스트"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "알림 내용 가리기"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "체크포인트로 되돌리시겠습니까?"
 msgid "Revert to this checkpoint"
 msgstr "이 체크포인트로 되돌리기"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "여러 GitHub 계정의 작업을 검토하고 추적하세요."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "{0}에 대한 PR #{prNumber} 검토"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "리뷰 표시"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "검토 중"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "모델 검색..."
 msgid "Search or enter address"
 msgstr "주소 검색 또는 입력"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "풀 리퀘스트 검색"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "저장소 검색"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "OS 수준 에이전트 세션에 대해 프로젝트 없는 홈 범위를 표시합니다."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -540,6 +540,7 @@ msgstr "Konto"
 msgid "Account options"
 msgstr "Opcje konta"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Konta"
@@ -634,6 +635,10 @@ msgstr "Dodaj projekt przed zainstalowaniem agenta."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Dodaj projekt przed zalogowaniem."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Dodaj projekt, aby zobaczyć żądania ściągnięcia."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Alerty, gdy wątki wymagają Twojej uwagi"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Wymagane uwierzytelnienie"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Nie można zaimportować konfiguracji uwierzytelniania"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Utworzone przeze mnie"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Sprawdzam…"
 msgid "Checks"
 msgstr "Kontrole"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Kontrole zakończone niepowodzeniem"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Kontrole zaliczone"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Kontrole oczekują na realizację"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Wybierz folder"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Zamknij szczegóły użycia"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Zamknięte"
 
@@ -2486,6 +2509,11 @@ msgstr "Nie udało się wyodrębnić kontekstu."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Nie można wygenerować komunikatu zatwierdzenia: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Nie udało się załadować żądań ściągnięcia dla {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Pobieranie modelu głosu..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Wersja robocza"
 
@@ -3640,9 +3669,17 @@ msgstr "Filtruj według projektu"
 msgid "Filter marketplace by source"
 msgstr "Filtruj marketplace według źródła"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Filtruj żądania ściągnięcia"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Filtruj umiejętności według stanu"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filtry"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Ładowanie PR…"
 msgid "Loading previous runs"
 msgstr "Ładowanie poprzednich uruchomień"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Ładowanie żądań ściągnięcia"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Ładowanie rejestru..."
@@ -4984,6 +5025,7 @@ msgstr "Scal drzewo robocze"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Scalono"
 
@@ -5584,6 +5626,10 @@ msgstr "Brak dopasowań."
 msgid "No matching agents."
 msgstr "Brak pasujących agentów."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Brak pasujących żądań ściągnięcia."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Brak pasujących harmonogramów."
@@ -5667,6 +5713,10 @@ msgstr "Nie połączono jeszcze żadnych dostawców."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Nie ma jeszcze gotowych dostawców"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Nie znaleziono żądań ściągnięcia."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Tylko gdy nieaktywne"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Otwórz"
@@ -6157,6 +6208,10 @@ msgstr "Opcje"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Lub napisz niestandardową odpowiedź"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Inne"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Zastąpienia specyficzne dla projektu ponad globalnymi ustawieniami wysz
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projekty"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Kategoria żądania ściągnięcia"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Żądanie ściągnięcia scalone"
@@ -6735,6 +6795,11 @@ msgstr "Żądanie ściągnięcia scalone"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Opcje żądania ściągnięcia"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Żądania ściągnięcia"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Ukryj treść powiadomień"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Powrócić do punktu kontrolnego?"
 msgid "Revert to this checkpoint"
 msgstr "Wróć do tego punktu kontrolnego"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Przeglądaj i śledź pracę na swoich kontach GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Przejrzyj PR #{prNumber} dla {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Prezentacja recenzji"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Do sprawdzenia"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Wyszukaj modele..."
 msgid "Search or enter address"
 msgstr "Wyszukaj lub wpisz adres"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Szukaj żądań ściągnięcia"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Przeszukaj repozytoria"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Wyświetl bezprojektowy zakres główny dla sesji agenta na poziomie systemu operacyjnego."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -540,6 +540,7 @@ msgstr "Conta"
 msgid "Account options"
 msgstr "Opções de conta"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Contas"
@@ -634,6 +635,10 @@ msgstr "Adicione um projeto antes de instalar um agente."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Adicione um projeto antes de fazer login."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Adicione um projeto para ver os pull requests."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Alertas quando threads precisam de você"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Autenticação necessária"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "A configuração de autenticação não pode ser importada"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "De sua autoria"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Verificando…"
 msgid "Checks"
 msgstr "Verificações"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Verificações falharam"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Verificações aprovadas"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Verificações pendentes"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Escolha uma pasta"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Fechar detalhes de uso"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Fechado"
 
@@ -2486,6 +2509,11 @@ msgstr "Não foi possível extrair o contexto."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Não foi possível gerar mensagem de commit: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Não foi possível carregar os pull requests de {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Baixando modelo de voz..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Rascunho"
 
@@ -3640,9 +3669,17 @@ msgstr "Filtrar por projeto"
 msgid "Filter marketplace by source"
 msgstr "Filtrar o marketplace por fonte"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Filtrar pull requests"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Filtrar skills por status"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filtros"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Carregando PR…"
 msgid "Loading previous runs"
 msgstr "Carregando execuções anteriores"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Carregando pull requests"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Carregando registro..."
@@ -4984,6 +5025,7 @@ msgstr "Mesclar árvore de trabalho"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Mesclado"
 
@@ -5584,6 +5626,10 @@ msgstr "Nenhuma correspondência."
 msgid "No matching agents."
 msgstr "Nenhum agente correspondente."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Nenhum pull request correspondente."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Nenhum agendamento correspondente."
@@ -5667,6 +5713,10 @@ msgstr "Nenhum provedor conectado ainda."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Nenhum provedor pronto ainda"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Nenhum pull request encontrado."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Somente quando estiver fora de foco"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Abrir"
@@ -6157,6 +6208,10 @@ msgstr "Opções"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Ou escreva uma resposta personalizada"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Outros"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Substituições específicas do projeto nas configurações de pesquisa 
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projetos"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Categoria de pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request mesclado"
@@ -6735,6 +6795,11 @@ msgstr "Pull request mesclado"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Opções de pull request"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull requests"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Ocultar o conteúdo das notificações"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Reverter para o ponto de verificação?"
 msgid "Revert to this checkpoint"
 msgstr "Reverter para este ponto de verificação"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Revise e acompanhe o trabalho nas suas contas do GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Revisar PR #{prNumber} para {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Apresentação da revisão"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Para revisar"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Pesquisar modelos..."
 msgid "Search or enter address"
 msgstr "Pesquise ou digite o endereço"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Buscar pull requests"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Pesquisar repositórios"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Mostre um escopo inicial sem projeto para sessões de agente no nível do sistema operacional."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -540,6 +540,7 @@ msgstr "Аккаунт"
 msgid "Account options"
 msgstr "Параметры аккаунта"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Аккаунты"
@@ -634,6 +635,10 @@ msgstr "Добавьте проект перед установкой агент
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Добавьте проект перед входом."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Добавьте проект, чтобы увидеть pull request."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Оповещения, когда потокам нужно ваше вн
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Требуется аутентификация"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Настройку аутентификации нельзя импортировать"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Созданные мной"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Проверка…"
 msgid "Checks"
 msgstr "Проверки"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Проверки не пройдены"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Проверки пройдены"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Проверки ожидают выполнения"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Выберите папку"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Закрыть детали использования"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Закрыто"
 
@@ -2486,6 +2509,11 @@ msgstr "Не удалось извлечь контекст."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Не удалось сгенерировать сообщение коммита: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Не удалось загрузить pull request для {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Загрузка голосовой модели..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Черновик"
 
@@ -3640,9 +3669,17 @@ msgstr "Фильтр по проекту"
 msgid "Filter marketplace by source"
 msgstr "Фильтровать маркетплейс по источнику"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Фильтровать pull request"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Фильтровать навыки по состоянию"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Фильтры"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Загрузка PR…"
 msgid "Loading previous runs"
 msgstr "Загрузка предыдущих запусков"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Загрузка pull request"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Загрузка реестра..."
@@ -4984,6 +5025,7 @@ msgstr "Слить worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Слито"
 
@@ -5584,6 +5626,10 @@ msgstr "Совпадений нет."
 msgid "No matching agents."
 msgstr "Подходящих агентов нет."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Нет подходящих pull request."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Подходящих расписаний нет."
@@ -5667,6 +5713,10 @@ msgstr "Пока нет подключённых провайдеров."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Готовых провайдеров пока нет"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Pull request не найдены."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Только когда окно неактивно"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Открыть"
@@ -6157,6 +6208,10 @@ msgstr "Параметры"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Или напишите свой ответ"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Прочие"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Переопределения для конкретного проек�
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Проекты"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Категория pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request слит"
@@ -6735,6 +6795,11 @@ msgstr "Pull request слит"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Параметры pull request"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull request"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Скрывать содержимое уведомлений"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Откатить к контрольной точке?"
 msgid "Revert to this checkpoint"
 msgstr "Откатить к этой контрольной точке"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Просматривайте и отслеживайте работу в своих аккаунтах GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Просмотреть PR #{prNumber} для {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Отображение ревью"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "На ревью"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Поиск моделей..."
 msgid "Search or enter address"
 msgstr "Поиск или ввод адреса"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Искать pull request"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Поиск репозиториев"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Показывать домашнюю область без проекта для сессий агентов на уровне OS."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -540,6 +540,7 @@ msgstr "Hesap"
 msgid "Account options"
 msgstr "Hesap seçenekleri"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Hesaplar"
@@ -634,6 +635,10 @@ msgstr "Bir aracıyı yüklemeden önce bir proje ekleyin."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Oturum açmadan önce bir proje ekleyin."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Çekme isteklerini görmek için bir proje ekleyin."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "İş parçacıkları size ihtiyaç duyduğunda uyarılar"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Kimlik doğrulama gerekli"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Kimlik doğrulama ayarları içe aktarılamaz"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Oluşturduklarım"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Kontrol ediliyor…"
 msgid "Checks"
 msgstr "Kontroller"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Kontroller başarısız oldu"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Kontroller başarılı"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Kontroller beklemede"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Bir klasör seçin"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Kullanım ayrıntılarını kapat"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Kapalı"
 
@@ -2486,6 +2509,11 @@ msgstr "Bağlam çıkarılamadı."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Commit mesajı oluşturulamadı: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "{0} için çekme istekleri yüklenemedi."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Ses modeli indiriliyor..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Taslak"
 
@@ -3640,9 +3669,17 @@ msgstr "Projeye göre filtrele"
 msgid "Filter marketplace by source"
 msgstr "Marketplace'i kaynağa göre filtrele"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Çekme isteklerini filtrele"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Becerileri duruma göre filtrele"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Filtreler"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "PR yükleniyor…"
 msgid "Loading previous runs"
 msgstr "Önceki çalıştırmalar yükleniyor"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Çekme istekleri yükleniyor"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Kayıt defteri yükleniyor..."
@@ -4984,6 +5025,7 @@ msgstr "Worktree'yi Birleştir"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Birleştirilmiş"
 
@@ -5584,6 +5626,10 @@ msgstr "Eşleşme yok."
 msgid "No matching agents."
 msgstr "Eşleşen temsilci yok."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Eşleşen çekme isteği yok."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Eşleşen zamanlama yok."
@@ -5667,6 +5713,10 @@ msgstr "Henüz bağlı sağlayıcı yok."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Henüz hazır sağlayıcı yok"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Çekme isteği bulunamadı."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Yalnızca odaklanmadığında"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Açık"
@@ -6157,6 +6208,10 @@ msgstr "Seçenekler"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Veya özel bir cevap yazın"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Diğer"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Genel arama ayarlarının yanı sıra projeye özel geçersiz kılmalar.
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Projeler"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Çekme isteği kategorisi"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request birleştirildi"
@@ -6735,6 +6795,11 @@ msgstr "Pull request birleştirildi"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Çekme isteği seçenekleri"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Çekme istekleri"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Bildirim içeriğini gizle"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Kontrol noktasına geri dönülsün mü?"
 msgid "Revert to this checkpoint"
 msgstr "Bu kontrol noktasına geri dön"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "GitHub hesaplarınızdaki çalışmaları inceleyin ve takip edin."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "{0} için PR #{prNumber}'ı inceleyin"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "İnceleme görünümü"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "İncelediklerim"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Modelleri ara..."
 msgid "Search or enter address"
 msgstr "Adres arayın veya girin"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Çekme isteklerinde ara"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Depolarda ara"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "İşletim sistemi düzeyindeki aracı oturumları için projesiz bir Ana Sayfa kapsamı gösterin."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -540,6 +540,7 @@ msgstr "Обліковий запис"
 msgid "Account options"
 msgstr "Параметри облікового запису"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Облікові записи"
@@ -634,6 +635,10 @@ msgstr "Додайте проєкт перед встановленням аге
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Додайте проєкт перед входом."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Додайте проєкт, щоб переглянути pull request."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Сповіщення, коли потокам потрібна ваша 
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Потрібна автентифікація"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Налаштування автентифікації неможливо імпортувати"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Створені мною"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Перевірка…"
 msgid "Checks"
 msgstr "Перевірки"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Перевірки не пройдені"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Перевірки пройдені"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Перевірки очікують виконання"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Виберіть папку"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Закрити деталі використання"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Закрито"
 
@@ -2486,6 +2509,11 @@ msgstr "Не вдалося витягнути контекст."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Не вдалося згенерувати повідомлення коміту: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Не вдалося завантажити pull request для {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Завантаження голосової моделі..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Чернетка"
 
@@ -3640,9 +3669,17 @@ msgstr "Фільтр за проєктом"
 msgid "Filter marketplace by source"
 msgstr "Фільтрувати маркетплейс за джерелом"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Фільтрувати pull request"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Фільтрувати навички за станом"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Фільтри"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Завантаження PR…"
 msgid "Loading previous runs"
 msgstr "Завантаження попередніх запусків"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Завантаження pull request"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Завантаження реєстру..."
@@ -4984,6 +5025,7 @@ msgstr "Злити worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Злито"
 
@@ -5584,6 +5626,10 @@ msgstr "Збігів немає."
 msgid "No matching agents."
 msgstr "Відповідних агентів немає."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Немає відповідних pull request."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Відповідних розкладів немає."
@@ -5667,6 +5713,10 @@ msgstr "Ще немає підключених постачальників."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Готових провайдерів поки немає"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Pull request не знайдено."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Лише коли немає фокусу"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Відкрити"
@@ -6157,6 +6208,10 @@ msgstr "Параметри"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Або напишіть власну відповідь"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Інші"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Перевизначення для конкретного проєкт�
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Проєкти"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Категорія pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request злито"
@@ -6735,6 +6795,11 @@ msgstr "Pull request злито"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Параметри pull request"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull request"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Приховувати вміст сповіщень"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Відкотити до контрольної точки?"
 msgid "Revert to this checkpoint"
 msgstr "Відкотити до цієї контрольної точки"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Переглядайте й відстежуйте роботу у своїх облікових записах GitHub."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Переглянути PR #{prNumber} для {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Відображення рев'ю"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "На перевірці"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Пошук моделей..."
 msgid "Search or enter address"
 msgstr "Пошук або введення адреси"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Шукати pull request"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Пошук репозиторіїв"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Показувати домашню область без проєкту для сеансів агентів на рівні OS."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -540,6 +540,7 @@ msgstr "Tài khoản"
 msgid "Account options"
 msgstr "Tùy chọn tài khoản"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "Tài khoản"
@@ -634,6 +635,10 @@ msgstr "Thêm một dự án trước khi cài đặt một tác nhân."
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "Thêm một dự án trước khi đăng nhập."
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "Thêm một dự án để xem các pull request."
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "Cảnh báo khi luồng cần bạn"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "Yêu cầu xác thực"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "Không thể nhập thiết lập xác thực"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "Do bạn tạo"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "Đang kiểm tra…"
 msgid "Checks"
 msgstr "Kiểm tra"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "Kiểm tra thất bại"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "Kiểm tra thành công"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "Kiểm tra đang chờ"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "Chọn một thư mục"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "Đóng chi tiết sử dụng"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "Đã đóng"
 
@@ -2486,6 +2509,11 @@ msgstr "Không thể trích xuất ngữ cảnh."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "Không thể tạo thông báo commit: {detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "Không thể tải pull request cho {0}."
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "Đang tải xuống mẫu giọng nói..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "Bản nháp"
 
@@ -3640,9 +3669,17 @@ msgstr "Lọc theo dự án"
 msgid "Filter marketplace by source"
 msgstr "Lọc marketplace theo nguồn"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "Lọc pull request"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "Lọc skill theo trạng thái"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "Bộ lọc"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "Đang tải PR…"
 msgid "Loading previous runs"
 msgstr "Đang tải các lần chạy trước"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "Đang tải pull request"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "Đang tải sổ đăng ký..."
@@ -4984,6 +5025,7 @@ msgstr "Hợp nhất Worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "Đã hợp nhất"
 
@@ -5584,6 +5626,10 @@ msgstr "Không tìm thấy kết quả phù hợp."
 msgid "No matching agents."
 msgstr "Không có tác nhân nào phù hợp."
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "Không có pull request nào phù hợp."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "Không có lịch phù hợp."
@@ -5667,6 +5713,10 @@ msgstr "Chưa có nhà cung cấp nào được kết nối."
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "Chưa có nhà cung cấp nào sẵn sàng"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "Không tìm thấy pull request."
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5898,6 +5948,7 @@ msgstr "Chỉ khi không tập trung"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "Mở"
@@ -6157,6 +6208,10 @@ msgstr "Tùy chọn"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "Hoặc viết một câu trả lời tùy chỉnh"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "Khác"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6611,6 +6666,7 @@ msgstr "Ghi đè dành riêng cho dự án ở đầu cài đặt tìm kiếm ch
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "Dự án"
 
@@ -6728,6 +6784,10 @@ msgstr "Pull request {0}"
 msgid "Pull request #{0}"
 msgstr "Pull request #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "Danh mục pull request"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request đã được hợp nhất"
@@ -6735,6 +6795,11 @@ msgstr "Pull request đã được hợp nhất"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "Tùy chọn pull request"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "Pull request"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6869,6 +6934,7 @@ msgstr "Ẩn nội dung thông báo"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7323,6 +7389,10 @@ msgstr "Hoàn nguyên về điểm kiểm tra?"
 msgid "Revert to this checkpoint"
 msgstr "Quay lại điểm kiểm tra này"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "Xem xét và theo dõi công việc trên các tài khoản GitHub của bạn."
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7356,6 +7426,10 @@ msgstr "Xem lại PR #{prNumber} cho {0}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "Hiển thị đánh giá"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "Đang xem xét"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7650,6 +7724,10 @@ msgstr "Tìm kiếm mô hình..."
 msgid "Search or enter address"
 msgstr "Tìm kiếm hoặc nhập địa chỉ"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "Tìm kiếm pull request"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "Tìm kiếm kho lưu trữ"
@@ -7894,6 +7972,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "Hiển thị phạm vi Trang chủ không có dự án cho các phiên tác nhân cấp hệ điều hành."
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -540,6 +540,7 @@ msgstr "帐户"
 msgid "Account options"
 msgstr "账户选项"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Accounts"
 msgstr "账户"
@@ -634,6 +635,10 @@ msgstr "在安装代理之前添加项目。"
 #: src/renderer/actions/agentLoginActions.ts
 msgid "Add a project before signing in."
 msgstr "登录前添加项目。"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Add a project to see pull requests."
+msgstr "添加项目以查看拉取请求。"
 
 #: src/renderer/app.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -845,6 +850,7 @@ msgstr "线程需要你时提醒"
 
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/skills/SkillsManager.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "All"
@@ -1114,6 +1120,10 @@ msgstr "需要身份验证"
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "Authentication setup cannot be imported"
 msgstr "无法导入身份验证设置"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Authored"
+msgstr "我创建的"
 
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "Authorization: Bearer token"
@@ -1636,6 +1646,18 @@ msgstr "正在检查..."
 msgid "Checks"
 msgstr "检查项"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks failed"
+msgstr "检查失败"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks passed"
+msgstr "检查通过"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Checks pending"
+msgstr "检查待定"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "Choose a folder"
 msgstr "选择文件夹"
@@ -1966,6 +1988,7 @@ msgid "Close usage details"
 msgstr "关闭使用详情"
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"
 msgstr "已关闭"
 
@@ -2486,6 +2509,11 @@ msgstr "无法提取上下文。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Could not generate commit message: {detail}"
 msgstr "无法生成提交消息：{detail}"
+
+#. placeholder {0}: failure.project.name
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Could not load pull requests for {0}."
+msgstr "无法加载 {0} 的拉取请求。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/useReadAbsoluteFile.tsx
 msgid "Could not read file."
@@ -3150,6 +3178,7 @@ msgid "Downloading voice model..."
 msgstr "正在下载语音模型..."
 
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Draft"
 msgstr "草稿"
 
@@ -3640,9 +3669,17 @@ msgstr "按项目筛选"
 msgid "Filter marketplace by source"
 msgstr "按来源筛选市场"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filter pull requests"
+msgstr "筛选拉取请求"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "Filter skills by status"
 msgstr "按状态筛选技能"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Filters"
+msgstr "筛选条件"
 
 #: src/renderer/commands/registry.ts
 #: src/renderer/components/find/FindBar.tsx
@@ -4597,6 +4634,10 @@ msgstr "正在加载 PR…"
 msgid "Loading previous runs"
 msgstr "正在加载历史运行记录"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Loading pull requests"
+msgstr "正在加载拉取请求"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Loading registry..."
 msgstr "正在加载注册表..."
@@ -4983,6 +5024,7 @@ msgstr "合并工作树"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Merged"
 msgstr "已合并"
 
@@ -5583,6 +5625,10 @@ msgstr "没有匹配项。"
 msgid "No matching agents."
 msgstr "没有匹配的代理。"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No matching pull requests."
+msgstr "没有匹配的拉取请求。"
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "No matching schedules."
 msgstr "没有匹配的计划。"
@@ -5666,6 +5712,10 @@ msgstr "尚未连接任何提供商。"
 #: src/renderer/components/thread/AgentDiscoveryScreen.tsx
 msgid "No providers ready yet"
 msgstr "尚无就绪的提供商"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "No pull requests found."
+msgstr "未找到拉取请求。"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "No remote configured. Add a remote to enable push and pull."
@@ -5897,6 +5947,7 @@ msgstr "仅当窗口失去焦点时"
 #: src/renderer/notifications.ts
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Open"
 msgstr "打开"
@@ -6156,6 +6207,10 @@ msgstr "选项"
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
 msgid "Or write a custom answer"
 msgstr "或者写一个自定义答案"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Other"
+msgstr "其他"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
@@ -6610,6 +6665,7 @@ msgstr "在全局搜索设置基础上的项目特定覆盖。"
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
 msgstr "项目"
 
@@ -6727,6 +6783,10 @@ msgstr "拉取请求 {0}"
 msgid "Pull request #{0}"
 msgstr "拉取请求 #{0}"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull request category"
+msgstr "拉取请求类别"
+
 #: src/mobile/views/pr/PrOverviewPage.tsx
 msgid "Pull request merged"
 msgstr "Pull request 已合并"
@@ -6734,6 +6794,11 @@ msgstr "Pull request 已合并"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "Pull request options"
 msgstr "拉取请求选项"
+
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Pull requests"
+msgstr "拉取请求"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -6868,6 +6933,7 @@ msgstr "隐藏通知内容"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsagePanelHeaderActions.tsx
 #: src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -7322,6 +7388,10 @@ msgstr "恢复到此检查点？"
 msgid "Revert to this checkpoint"
 msgstr "恢复到此检查点"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Review and track work across your GitHub accounts."
+msgstr "在你的各个 GitHub 账户中审核和跟踪工作。"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -7355,6 +7425,10 @@ msgstr "查看{0}的 PR #{prNumber}"
 #: src/mobile/settingsSections.ts
 msgid "Review presentation"
 msgstr "评审显示"
+
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Reviewing"
+msgstr "待我审核"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Revoke {name}"
@@ -7649,6 +7723,10 @@ msgstr "搜索模型..."
 msgid "Search or enter address"
 msgstr "搜索或输入地址"
 
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
+msgid "Search pull requests"
+msgstr "搜索拉取请求"
+
 #: src/renderer/views/MainView/parts/CreateProject/CloneProjectModal.tsx
 msgid "Search repositories"
 msgstr "搜索存储库"
@@ -7893,6 +7971,7 @@ msgid "Show a projectless Home scope for OS-level agent sessions."
 msgstr "为操作系统级别的代理会话显示一个无项目的主页范围。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+#: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/ModelVisibilityDropdown.tsx
 msgid "Show all"

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -276,6 +276,11 @@ describe("appStore runtime config sync", () => {
     expect(useAppStore.getState().view).toEqual({ kind: "home" });
   });
 
+  it("opens pull requests as a main view", () => {
+    useAppStore.getState().openPullRequests();
+    expect(useAppStore.getState().view).toEqual({ kind: "pullRequests" });
+  });
+
   it("openThread replaces panes[0] and keeps secondary panes", () => {
     const project = useAppStore.getState().addProject({
       kind: "windows",

--- a/src/renderer/state/panelStore.test.ts
+++ b/src/renderer/state/panelStore.test.ts
@@ -85,6 +85,24 @@ describe("selectAnyObstructingOverlayOpen", () => {
   });
 });
 
+describe("setPrReviewContext", () => {
+  beforeEach(() => {
+    resetPanelStore();
+  });
+
+  afterEach(() => {
+    resetPanelStore();
+  });
+
+  it("updates local sync safety when reopening the same pull request", () => {
+    const context = { projectId: "p", prNumber: 42, prKey: "p:42" };
+    usePanelStore.getState().setPrReviewContext({ ...context, skipLocalSync: true });
+    usePanelStore.getState().setPrReviewContext(context);
+
+    expect(usePanelStore.getState().prReviewContext).toEqual(context);
+  });
+});
+
 describe("create project modal", () => {
   beforeEach(() => {
     resetPanelStore();

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -12,6 +12,8 @@ export interface PrReviewContext {
   projectId: string;
   worktreePath?: string;
   prNumber: number;
+  /** Skip pulling locally for PR contexts that are not tied to a verified local checkout. */
+  skipLocalSync?: boolean;
   /**
    * Explicit prData key override for selectors (title/url/checks). Set when
    * opening a PR for a branch that has no worktree, so the overlay reads the
@@ -178,7 +180,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
           prev.projectId === ctx.projectId &&
           prev.worktreePath === ctx.worktreePath &&
           prev.prNumber === ctx.prNumber &&
-          prev.prKey === ctx.prKey)
+          prev.prKey === ctx.prKey &&
+          prev.skipLocalSync === ctx.skipLocalSync)
       ) {
         return {};
       }

--- a/src/renderer/state/slices/viewSlice.ts
+++ b/src/renderer/state/slices/viewSlice.ts
@@ -49,6 +49,7 @@ export interface ViewSlice {
   openDraft: (projectId: string) => void;
   openDraftSideBySide: (projectId: string) => void;
   openHome: () => void;
+  openPullRequests: () => void;
   openSchedules: () => void;
   openThread: (threadId: string) => void;
   openThreadSideBySide: (threadId: string) => void;
@@ -155,6 +156,7 @@ export const createViewSlice: SliceCreator<ViewSlice> = (set) => ({
       };
     }),
   openHome: () => set({ view: { kind: "home" } }),
+  openPullRequests: () => set({ view: { kind: "pullRequests" } }),
   openSchedules: () => set({ view: { kind: "schedules" } }),
   openThread: (threadId) =>
     set((state) => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -50,6 +50,7 @@ export function PrSection(props: {
   prKey: string;
   projectId: string;
   worktreePath?: string | undefined;
+  skipLocalSync?: boolean;
   prLoading: boolean;
   /** Which write action is in flight, so only its button spins (others stay disabled). */
   pendingAction?: PrWriteAction | null | undefined;
@@ -65,6 +66,7 @@ export function PrSection(props: {
     prKey,
     projectId,
     worktreePath,
+    skipLocalSync,
     prLoading,
     pendingAction,
     handleMergePr,
@@ -153,6 +155,8 @@ export function PrSection(props: {
                     projectId,
                     ...(worktreePath !== undefined ? { worktreePath } : {}),
                     prNumber: number,
+                    prKey,
+                    ...(skipLocalSync ? { skipLocalSync: true } : {}),
                   })
                 }
               >

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/renderer/utils/shellUtils";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
 import { HomeView } from "@/renderer/views/HomeView";
+import { PullRequestsView } from "@/renderer/views/PullRequestsView/PullRequestsView";
 import { SchedulesView } from "@/renderer/views/SchedulesView/SchedulesView";
 import { buildProjectDraftConfig } from "./draftConfig";
 import { ThreadPane } from "./parts/ThreadPane";
@@ -278,6 +279,14 @@ export function AppContent() {
     return (
       <div className="h-full overflow-y-auto px-6 pb-8 pt-4 [scrollbar-gutter:stable]">
         <SchedulesView />
+      </div>
+    );
+  }
+
+  if (view.kind === "pullRequests") {
+    return (
+      <div className="h-full overflow-y-auto px-6 pb-8 pt-4 [scrollbar-gutter:stable]">
+        <PullRequestsView />
       </div>
     );
   }

--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -172,6 +172,7 @@ export function AppOverlays() {
                 prReviewContext.prKey ??
                 resolvePrKey(prReviewContext.projectId, prReviewContext.worktreePath)
               }
+              {...(prReviewContext.skipLocalSync ? { skipLocalSync: true } : {})}
               {...(prReviewContext.worktreePath
                 ? {
                     locationOverride: buildWorktreeLocation(

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   CalendarClock,
   ChevronRight,
   Download,
+  GitPullRequest,
   House,
   PanelLeft,
   PanelLeftClose,
@@ -242,6 +243,7 @@ export function Sidebar() {
   const setWorktreeCollapsed = useSidebarUiStore((s) => s.setWorktreeCollapsed);
   const { isCollapsed, collapse, expand } = useSidebar();
   const openHome = useAppStore((s) => s.openHome);
+  const openPullRequests = useAppStore((s) => s.openPullRequests);
   const openSchedules = useAppStore((s) => s.openSchedules);
   const appView = useAppStore((s) => s.view);
   const appNameForHome = getAppName(readBridge().channel, import.meta.env.DEV);
@@ -346,6 +348,13 @@ export function Sidebar() {
             <WhatsNewButton iconOnly />
             <SidebarButton
               iconOnly
+              icon={<GitPullRequest className="size-4" />}
+              label={t`Pull requests`}
+              isActive={appView.kind === "pullRequests"}
+              onPress={() => startTransition(() => openPullRequests())}
+            />
+            <SidebarButton
+              iconOnly
               icon={<CalendarClock className="size-4" />}
               label={t`Schedules`}
               isActive={appView.kind === "schedules"}
@@ -440,6 +449,12 @@ export function Sidebar() {
         <div className={sidebarFooterNavClass}>
           <UpdateButtons />
           <WhatsNewButton />
+          <SidebarButton
+            icon={<GitPullRequest className="size-4" />}
+            label={t`Pull requests`}
+            isActive={appView.kind === "pullRequests"}
+            onPress={() => startTransition(() => openPullRequests())}
+          />
           <SidebarButton
             icon={<CalendarClock className="size-4" />}
             label={t`Schedules`}

--- a/src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
+++ b/src/renderer/views/PrReviewOverlay/PrReviewOverlay.tsx
@@ -121,11 +121,13 @@ export function PrReviewOverlay(props: {
   prNumber: number;
   locationOverride?: ProjectLocation;
   worktreePath?: string | undefined;
+  skipLocalSync?: boolean;
   /** PR key used for selectors (matches PrSection: worktreePath ?? `__branch:${projectId}`). */
   prKey: string;
   onClose: () => void;
 }) {
-  const { project, prNumber, locationOverride, worktreePath, prKey, onClose } = props;
+  const { project, prNumber, locationOverride, worktreePath, skipLocalSync, prKey, onClose } =
+    props;
   const { t } = useLingui();
   const effectiveLocation = locationOverride ?? project.location;
   const cacheKey = `${project.id}#${prNumber}`;
@@ -294,6 +296,7 @@ export function PrReviewOverlay(props: {
           projectLocation={effectiveLocation}
           prKey={prKey}
           worktreePath={worktreePath}
+          {...(skipLocalSync ? { skipLocalSync: true } : {})}
           onSelectFile={(path) => {
             setActiveTab("changes");
             setSelectedFile((curr) => (curr === path ? null : path));

--- a/src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
+++ b/src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
@@ -31,6 +31,7 @@ export function PrReviewSidebar(props: {
   projectLocation: ProjectLocation;
   prKey: string;
   worktreePath?: string | undefined;
+  skipLocalSync?: boolean;
   onSelectFile: (path: string) => void;
   onClose: () => void;
   onRefresh: () => void;
@@ -43,6 +44,7 @@ export function PrReviewSidebar(props: {
     projectLocation,
     prKey,
     worktreePath,
+    skipLocalSync,
     onSelectFile,
     onClose,
     onRefresh,
@@ -60,6 +62,7 @@ export function PrReviewSidebar(props: {
   } = usePrWriteActions({
     projectLocation,
     prKey,
+    ...(skipLocalSync ? { skipLocalSync: true } : {}),
     onRefresh,
   });
 
@@ -155,6 +158,7 @@ export function PrReviewSidebar(props: {
             prKey={prKey}
             projectId={projectId}
             worktreePath={worktreePath}
+            {...(skipLocalSync ? { skipLocalSync: true } : {})}
             prLoading={prLoading}
             pendingAction={pendingAction}
             handleMergePr={handleMergePr}

--- a/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  GhListPullRequestsPayload,
+  GhListPullRequestsResult,
+  Project,
+  PullRequestSummary,
+} from "@/shared/contracts";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { buildBranchNamePrKey } from "@/renderer/state/gitSelectors";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+
+const bridge = vi.hoisted(() => ({
+  ghListPullRequests:
+    vi.fn<(payload: GhListPullRequestsPayload) => Promise<GhListPullRequestsResult>>(),
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+import { PullRequestsView } from "./PullRequestsView";
+
+const windowsProject: Project = {
+  id: "windows-project",
+  name: "Windows app",
+  location: { kind: "windows", path: "E:\\work\\windows-app" },
+  createdAt: "2026-07-13T10:00:00.000Z",
+};
+
+const wslProject: Project = {
+  id: "wsl-project",
+  name: "WSL app",
+  location: {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/work/wsl-app",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\work\\wsl-app",
+  },
+  createdAt: "2026-07-13T10:00:00.000Z",
+};
+
+const summary: PullRequestSummary = {
+  pr: {
+    number: 42,
+    state: "open",
+    title: "Fix the pixel renderer",
+    url: "https://github.com/example/windows-app/pull/42",
+    baseBranch: "main",
+    isDraft: false,
+    viewerDidAuthor: false,
+    updatedAt: "2026-07-13T11:00:00.000Z",
+  },
+  headBranch: "fix/pixels",
+  author: { login: "reviewer" },
+  additions: 12,
+  deletions: 3,
+  repository: "example/windows-app",
+  reviewRequested: true,
+};
+
+describe("PullRequestsView", () => {
+  beforeEach(() => {
+    bridge.ghListPullRequests.mockReset().mockImplementation(async ({ projectLocation }) => {
+      if (projectLocation.kind === "wsl") {
+        throw new Error("WSL GitHub account unavailable");
+      }
+      return { pullRequests: [summary], viewerLogin: "reviewer" };
+    });
+    useAppStore.setState({ projects: [windowsProject, wslProject] });
+    useGitStore.setState({ statuses: {}, worktrees: {}, prData: {} });
+    usePanelStore.setState({ prReviewContext: null });
+  });
+
+  it("loads every project location independently and keeps successful rows visible", async () => {
+    render(<PullRequestsView />);
+
+    const row = await screen.findByRole("button", { name: new RegExp(summary.pr.title) });
+    expect(within(row).getByText(summary.headBranch)).toBeInTheDocument();
+    expect(within(row).getByText(summary.pr.baseBranch)).toBeInTheDocument();
+    expect(screen.getByText("Could not load pull requests for WSL app.")).toBeInTheDocument();
+    expect(bridge.ghListPullRequests).toHaveBeenCalledTimes(2);
+    expect(bridge.ghListPullRequests).toHaveBeenCalledWith({
+      projectLocation: windowsProject.location,
+    });
+    expect(bridge.ghListPullRequests).toHaveBeenCalledWith({
+      projectLocation: wslProject.location,
+    });
+
+    fireEvent.click(row);
+
+    const prKey = buildBranchNamePrKey(windowsProject.id, summary.headBranch);
+    expect(useGitStore.getState().prData[prKey]).toEqual(summary.pr);
+    expect(usePanelStore.getState().prReviewContext).toEqual({
+      projectId: windowsProject.id,
+      prNumber: summary.pr.number,
+      prKey,
+      skipLocalSync: true,
+    });
+
+    act(() => usePanelStore.getState().setPrReviewContext(null));
+    await waitFor(() => expect(bridge.ghListPullRequests).toHaveBeenCalledTimes(4));
+  });
+
+  it("shows a successful project while another project is still loading", async () => {
+    let resolveWsl!: (value: GhListPullRequestsResult) => void;
+    const pendingWsl = new Promise<GhListPullRequestsResult>((resolve) => {
+      resolveWsl = resolve;
+    });
+    bridge.ghListPullRequests.mockImplementation(({ projectLocation }) =>
+      projectLocation.kind === "wsl"
+        ? pendingWsl
+        : Promise.resolve({ pullRequests: [summary], viewerLogin: "reviewer" }),
+    );
+
+    render(<PullRequestsView />);
+
+    expect(await screen.findByText(summary.pr.title)).toBeInTheDocument();
+    expect(
+      screen.getByText("Review and track work across your GitHub accounts."),
+    ).toBeInTheDocument();
+    await act(async () => {
+      resolveWsl({ pullRequests: [], viewerLogin: "wsl-reviewer" });
+      await pendingWsl;
+    });
+    expect(
+      screen.getByText("Review and track work across your GitHub accounts."),
+    ).toBeInTheDocument();
+  });
+
+  it("refreshes every project on demand", async () => {
+    render(<PullRequestsView />);
+
+    expect(await screen.findByText(summary.pr.title)).toBeInTheDocument();
+    const refreshButton = screen.getByRole("button", { name: "Refresh" });
+    await waitFor(() => expect(refreshButton).toBeEnabled());
+
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => expect(bridge.ghListPullRequests).toHaveBeenCalledTimes(4));
+  });
+
+  it("opens a matching worktree without pulling local changes", async () => {
+    useAppStore.setState({ projects: [windowsProject] });
+    useGitStore.setState({
+      worktrees: {
+        [windowsProject.id]: [
+          {
+            path: "E:\\work\\windows-app-fix-pixels",
+            branch: summary.headBranch,
+            commit: "abc123",
+            isMain: false,
+          },
+        ],
+      },
+    });
+
+    render(<PullRequestsView />);
+    fireEvent.click(await screen.findByRole("button", { name: new RegExp(summary.pr.title) }));
+
+    await waitFor(() =>
+      expect(usePanelStore.getState().prReviewContext).toEqual({
+        projectId: windowsProject.id,
+        worktreePath: "E:\\work\\windows-app-fix-pixels",
+        prNumber: summary.pr.number,
+        prKey: buildBranchNamePrKey(windowsProject.id, summary.headBranch),
+        skipLocalSync: true,
+      }),
+    );
+  });
+
+  it("filters rows by relationship and search text", async () => {
+    const authoredSummary: PullRequestSummary = {
+      ...summary,
+      pr: {
+        ...summary.pr,
+        number: 43,
+        title: "Authored dashboard change",
+        viewerDidAuthor: true,
+      },
+      headBranch: "feature/dashboard",
+      author: { login: "reviewer" },
+      reviewRequested: false,
+    };
+    const otherSummary: PullRequestSummary = {
+      ...summary,
+      pr: {
+        ...summary.pr,
+        number: 44,
+        title: "Dependency update",
+      },
+      headBranch: "deps/update",
+      author: { login: "dependabot" },
+      reviewRequested: false,
+    };
+    useAppStore.setState({ projects: [windowsProject] });
+    bridge.ghListPullRequests.mockResolvedValue({
+      pullRequests: [summary, authoredSummary, otherSummary],
+      viewerLogin: "reviewer",
+    });
+
+    render(<PullRequestsView />);
+    expect(await screen.findByText(authoredSummary.pr.title)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Authored" }));
+    expect(screen.getByText(authoredSummary.pr.title)).toBeInTheDocument();
+    expect(screen.queryByText(summary.pr.title)).not.toBeInTheDocument();
+    expect(screen.queryByText(otherSummary.pr.title)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "All" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Search pull requests" }), {
+      target: { value: "deps/update" },
+    });
+    expect(screen.getByText(otherSummary.pr.title)).toBeInTheDocument();
+    expect(screen.queryByText(authoredSummary.pr.title)).not.toBeInTheDocument();
+    expect(screen.queryByText(summary.pr.title)).not.toBeInTheDocument();
+  });
+
+  it("filters rows by the active account", async () => {
+    useAppStore.setState({ projects: [windowsProject] });
+
+    render(<PullRequestsView />);
+    expect(await screen.findByText(summary.pr.title)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter pull requests" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "reviewer" }));
+
+    expect(screen.queryByText(summary.pr.title)).not.toBeInTheDocument();
+    expect(screen.getByText("No matching pull requests.")).toBeInTheDocument();
+  });
+
+  it("orders pull requests from different projects by most recent update", async () => {
+    const newerWslSummary: PullRequestSummary = {
+      ...summary,
+      pr: {
+        ...summary.pr,
+        number: 99,
+        title: "Newer WSL pull request",
+        updatedAt: "2026-07-13T12:00:00.000Z",
+      },
+      repository: "example/wsl-app",
+    };
+    bridge.ghListPullRequests.mockImplementation(async ({ projectLocation }) =>
+      projectLocation.kind === "wsl"
+        ? { pullRequests: [newerWslSummary], viewerLogin: "wsl-reviewer" }
+        : { pullRequests: [summary], viewerLogin: "reviewer" },
+    );
+
+    render(<PullRequestsView />);
+    expect(await screen.findByText(newerWslSummary.pr.title)).toBeInTheDocument();
+
+    const rowTitles = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent ?? "")
+      .filter((text) => text.includes(newerWslSummary.pr.title) || text.includes(summary.pr.title))
+      .map((text) =>
+        text.includes(newerWslSummary.pr.title) ? newerWslSummary.pr.title : summary.pr.title,
+      );
+    expect(rowTitles).toEqual([newerWslSummary.pr.title, summary.pr.title]);
+  });
+});

--- a/src/renderer/views/PullRequestsView/PullRequestsView.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.tsx
@@ -1,0 +1,466 @@
+import { Button, Checkbox, Input, Popover, TextField } from "@heroui/react";
+import { ArrowRight, Funnel, GitPullRequest, Loader2, RefreshCw, Search } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { useShallow } from "zustand/shallow";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { Project, PullRequestSummary } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
+import { friendlyError } from "@/shared/messages";
+import { readBridge } from "@/renderer/bridge";
+import { LightballTabs } from "@/renderer/components/common/LightballTabs";
+import { RelativeTime } from "@/renderer/components/common/RelativeTime";
+import { useAppStore } from "@/renderer/state/appStore";
+import { buildBranchNamePrKey } from "@/renderer/state/gitSelectors";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { getPrStatusTone, PR_TONE_BG_CLASS, PR_TONE_TEXT_CLASS } from "@/renderer/utils/prStatus";
+import { SettingsPage } from "@/renderer/views/SettingsOverlay/parts/SettingsForm";
+
+type FilterMode = "all" | "reviewing" | "authored";
+
+interface LoadedProject {
+  project: Project;
+  pullRequests: PullRequestSummary[];
+  viewerLogin?: string;
+}
+
+interface ProjectFailure {
+  project: Project;
+  message: string;
+}
+
+interface PullRequestEntry {
+  project: Project;
+  summary: PullRequestSummary;
+}
+
+export function PullRequestsView() {
+  const { t } = useLingui();
+  const activeProjects = useAppStore(
+    useShallow((state) =>
+      state.projects.filter((project) => !project.disabled && !isHomeProject(project)),
+    ),
+  );
+  const prReviewOpen = usePanelStore((state) => state.prReviewContext !== null);
+  const [loadedProjects, setLoadedProjects] = useState<LoadedProject[]>([]);
+  const [failures, setFailures] = useState<ProjectFailure[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshVersion, setRefreshVersion] = useState(0);
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<FilterMode>("all");
+  const [hiddenProjectIds, setHiddenProjectIds] = useState<Set<string>>(() => new Set());
+  const [hiddenAccounts, setHiddenAccounts] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    if (prReviewOpen) return;
+
+    let cancelled = false;
+    setLoadedProjects([]);
+    setFailures([]);
+    setLoading(activeProjects.length > 0);
+
+    const requests = activeProjects.map((project) =>
+      readBridge()
+        .ghListPullRequests({ projectLocation: project.location })
+        .then(
+          (result) => {
+            if (cancelled) return;
+            setLoadedProjects((current) => [
+              ...current,
+              {
+                project,
+                pullRequests: result.pullRequests,
+                ...(result.viewerLogin ? { viewerLogin: result.viewerLogin } : {}),
+              },
+            ]);
+          },
+          (reason) => {
+            if (cancelled) return;
+            setFailures((current) => [...current, { project, message: friendlyError(reason) }]);
+          },
+        ),
+    );
+
+    void Promise.allSettled(requests).then(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProjects, prReviewOpen, refreshVersion]);
+
+  const accountLogins = [
+    ...new Set(
+      loadedProjects.flatMap((loaded) => (loaded.viewerLogin ? [loaded.viewerLogin] : [])),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const visibleEntries: PullRequestEntry[] = [];
+
+  for (const loaded of loadedProjects) {
+    if (hiddenProjectIds.has(loaded.project.id)) continue;
+    if (loaded.viewerLogin && hiddenAccounts.has(loaded.viewerLogin)) continue;
+
+    for (const summary of loaded.pullRequests) {
+      if (filter === "reviewing" && !summary.reviewRequested) continue;
+      if (filter === "authored" && summary.pr.viewerDidAuthor !== true) continue;
+      if (
+        normalizedQuery &&
+        ![
+          summary.pr.title,
+          summary.repository,
+          summary.headBranch,
+          summary.author?.login ?? "",
+          loaded.project.name,
+          String(summary.pr.number),
+        ].some((value) => value.toLocaleLowerCase().includes(normalizedQuery))
+      ) {
+        continue;
+      }
+      visibleEntries.push({
+        project: loaded.project,
+        summary,
+      });
+    }
+  }
+
+  visibleEntries.sort((left, right) => {
+    const updated = right.summary.pr.updatedAt.localeCompare(left.summary.pr.updatedAt);
+    if (updated !== 0) return updated;
+    const repository = left.summary.repository.localeCompare(right.summary.repository);
+    if (repository !== 0) return repository;
+    const project = left.project.id.localeCompare(right.project.id);
+    if (project !== 0) return project;
+    return right.summary.pr.number - left.summary.pr.number;
+  });
+
+  const reviewingEntries: PullRequestEntry[] = [];
+  const authoredEntries: PullRequestEntry[] = [];
+  const otherEntries: PullRequestEntry[] = [];
+  if (filter === "all") {
+    for (const entry of visibleEntries) {
+      if (entry.summary.reviewRequested) reviewingEntries.push(entry);
+      else if (entry.summary.pr.viewerDidAuthor === true) authoredEntries.push(entry);
+      else otherEntries.push(entry);
+    }
+  }
+  const totalPullRequests = loadedProjects.reduce(
+    (total, loaded) => total + loaded.pullRequests.length,
+    0,
+  );
+  const hasActiveFilters = hiddenProjectIds.size > 0 || hiddenAccounts.size > 0;
+
+  function openPullRequest(entry: PullRequestEntry) {
+    const { project, summary } = entry;
+    const prKey = buildBranchNamePrKey(project.id, summary.headBranch);
+    const gitState = useGitStore.getState();
+    const projectWorktrees = gitState.worktrees[project.id] ?? [];
+    const matchingWorktree = projectWorktrees.find(
+      (worktree) => !worktree.isMain && worktree.branch === summary.headBranch,
+    );
+
+    gitState.setPrData(prKey, summary.pr);
+    usePanelStore.getState().setPrReviewContext({
+      projectId: project.id,
+      prNumber: summary.pr.number,
+      prKey,
+      ...(matchingWorktree ? { worktreePath: matchingWorktree.path } : {}),
+      skipLocalSync: true,
+    });
+  }
+
+  return (
+    <SettingsPage
+      title={t`Pull requests`}
+      description={t`Review and track work across your GitHub accounts.`}
+      bodyClassName="space-y-5"
+    >
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <div className="relative min-w-0 flex-1">
+          <Search
+            className="pointer-events-none absolute top-1/2 left-3 z-10 size-3.5 -translate-y-1/2 text-muted"
+            aria-hidden
+          />
+          <TextField aria-label={t`Search pull requests`} value={query} onChange={setQuery}>
+            <Input className="pl-9" placeholder={t`Search pull requests`} />
+          </TextField>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <LightballTabs<FilterMode>
+            tabs={[
+              { id: "all", label: t`All` },
+              { id: "reviewing", label: t`Reviewing` },
+              { id: "authored", label: t`Authored` },
+            ]}
+            active={filter}
+            onChange={setFilter}
+            ariaLabel={t`Pull request category`}
+          />
+          <Button
+            isIconOnly
+            size="sm"
+            variant="tertiary"
+            isDisabled={loading}
+            aria-label={t`Refresh`}
+            className="shrink-0"
+            onPress={() => setRefreshVersion((current) => current + 1)}
+          >
+            <RefreshCw className={`size-4 ${loading ? "animate-spin" : ""}`} />
+          </Button>
+          <Popover>
+            <Popover.Trigger>
+              <Button
+                isIconOnly
+                size="sm"
+                variant="tertiary"
+                aria-label={t`Filter pull requests`}
+                className="relative shrink-0"
+              >
+                <Funnel className="size-4" />
+                {hasActiveFilters ? (
+                  <span className="absolute top-1 right-1 size-1.5 rounded-full bg-accent" />
+                ) : null}
+              </Button>
+            </Popover.Trigger>
+            <Popover.Content placement="bottom end" className="w-72 p-0">
+              <Popover.Dialog className="overflow-hidden !p-0">
+                <div className="flex items-center justify-between border-b border-border px-3 py-2">
+                  <span className="text-xs font-semibold text-foreground">
+                    <Trans>Filters</Trans>
+                  </span>
+                  {hasActiveFilters ? (
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onPress={() => {
+                        setHiddenProjectIds(new Set());
+                        setHiddenAccounts(new Set());
+                      }}
+                    >
+                      <Trans>Show all</Trans>
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="max-h-80 space-y-3 overflow-y-auto px-3 py-3">
+                  <FilterGroup title={<Trans>Projects</Trans>}>
+                    {activeProjects.map((project) => (
+                      <Checkbox
+                        key={project.id}
+                        className="block"
+                        isSelected={!hiddenProjectIds.has(project.id)}
+                        onChange={(visible) =>
+                          setHiddenProjectIds((current) => {
+                            const next = new Set(current);
+                            if (visible) next.delete(project.id);
+                            else next.add(project.id);
+                            return next;
+                          })
+                        }
+                      >
+                        <Checkbox.Content className="w-full min-w-0">
+                          <Checkbox.Control>
+                            <Checkbox.Indicator />
+                          </Checkbox.Control>
+                          <span className="truncate text-xs text-foreground">{project.name}</span>
+                        </Checkbox.Content>
+                      </Checkbox>
+                    ))}
+                  </FilterGroup>
+                  {accountLogins.length > 0 ? (
+                    <FilterGroup title={<Trans>Accounts</Trans>}>
+                      {accountLogins.map((login) => (
+                        <Checkbox
+                          key={login}
+                          className="block"
+                          isSelected={!hiddenAccounts.has(login)}
+                          onChange={(visible) =>
+                            setHiddenAccounts((current) => {
+                              const next = new Set(current);
+                              if (visible) next.delete(login);
+                              else next.add(login);
+                              return next;
+                            })
+                          }
+                        >
+                          <Checkbox.Content className="w-full min-w-0">
+                            <Checkbox.Control>
+                              <Checkbox.Indicator />
+                            </Checkbox.Control>
+                            <span className="truncate text-xs text-foreground">{login}</span>
+                          </Checkbox.Content>
+                        </Checkbox>
+                      ))}
+                    </FilterGroup>
+                  ) : null}
+                </div>
+              </Popover.Dialog>
+            </Popover.Content>
+          </Popover>
+        </div>
+      </div>
+
+      {failures.map((failure) => (
+        <div
+          key={failure.project.id}
+          role="alert"
+          className="rounded-lg border border-danger/20 bg-danger/5 px-3 py-2 text-xs"
+        >
+          <p className="font-medium text-danger">
+            <Trans>Could not load pull requests for {failure.project.name}.</Trans>
+          </p>
+          <p className="mt-0.5 text-muted">{failure.message}</p>
+        </div>
+      ))}
+
+      {visibleEntries.length > 0 ? (
+        <div className="space-y-5">
+          {filter === "all" ? (
+            <>
+              <PullRequestSection
+                title={<Trans>Reviewing</Trans>}
+                entries={reviewingEntries}
+                onOpen={openPullRequest}
+              />
+              <PullRequestSection
+                title={<Trans>Authored</Trans>}
+                entries={authoredEntries}
+                onOpen={openPullRequest}
+              />
+              <PullRequestSection
+                title={<Trans>Other</Trans>}
+                entries={otherEntries}
+                onOpen={openPullRequest}
+              />
+            </>
+          ) : (
+            <PullRequestRows entries={visibleEntries} onOpen={openPullRequest} />
+          )}
+        </div>
+      ) : loading ? (
+        <div className="flex justify-center py-12 text-muted">
+          <Loader2 className="size-5 animate-spin" aria-label={t`Loading pull requests`} />
+        </div>
+      ) : (
+        <div className="py-12 text-center text-muted">
+          <GitPullRequest className="mx-auto mb-3 size-8" />
+          <p className="text-sm font-medium text-foreground">
+            {activeProjects.length === 0 ? (
+              <Trans>Add a project to see pull requests.</Trans>
+            ) : totalPullRequests === 0 && failures.length === 0 ? (
+              <Trans>No pull requests found.</Trans>
+            ) : (
+              <Trans>No matching pull requests.</Trans>
+            )}
+          </p>
+        </div>
+      )}
+    </SettingsPage>
+  );
+}
+
+function FilterGroup(props: { title: ReactNode; children: ReactNode }) {
+  return (
+    <section className="space-y-1.5">
+      <h2 className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted">
+        {props.title}
+      </h2>
+      <div className="space-y-1">{props.children}</div>
+    </section>
+  );
+}
+
+function PullRequestSection(props: {
+  title: ReactNode;
+  entries: PullRequestEntry[];
+  onOpen: (entry: PullRequestEntry) => void;
+}) {
+  if (props.entries.length === 0) return null;
+  return (
+    <section className="space-y-1.5">
+      <h2 className="px-1 text-xs font-semibold text-muted">{props.title}</h2>
+      <PullRequestRows entries={props.entries} onOpen={props.onOpen} />
+    </section>
+  );
+}
+
+function PullRequestRows(props: {
+  entries: PullRequestEntry[];
+  onOpen: (entry: PullRequestEntry) => void;
+}) {
+  const { t } = useLingui();
+  return (
+    <div className="overflow-hidden rounded-xl border border-[var(--hairline)] bg-surface-secondary/30">
+      {props.entries.map((entry) => {
+        const { project, summary } = entry;
+        const tone = getPrStatusTone(summary.pr.state, summary.pr.checksStatus);
+        const statusLabel =
+          summary.pr.state === "draft"
+            ? t`Draft`
+            : summary.pr.state === "merged"
+              ? t`Merged`
+              : summary.pr.state === "closed"
+                ? t`Closed`
+                : tone === "danger"
+                  ? t`Checks failed`
+                  : tone === "warning"
+                    ? t`Checks pending`
+                    : summary.pr.checksStatus
+                      ? t`Checks passed`
+                      : t`Open`;
+        return (
+          <button
+            key={`${project.id}:${summary.pr.number}`}
+            type="button"
+            className="group flex w-full items-center gap-3 border-b border-[var(--hairline)] px-3 py-3 text-left outline-none transition-colors last:border-b-0 hover:bg-default-100/60 focus-visible:bg-default-100/60"
+            onClick={() => props.onOpen(entry)}
+          >
+            <span className="relative shrink-0" aria-hidden>
+              <GitPullRequest className={`size-4 ${PR_TONE_TEXT_CLASS[tone]}`} />
+              <span
+                className={`absolute -right-1 -bottom-1 size-1.5 rounded-full ring-2 ring-surface-secondary ${PR_TONE_BG_CLASS[tone]}`}
+              />
+            </span>
+            <span className="sr-only">{statusLabel}</span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-foreground">
+                {summary.pr.title}
+              </span>
+              <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-muted">
+                {summary.author ? (
+                  summary.author.avatarUrl ? (
+                    <img
+                      src={summary.author.avatarUrl}
+                      alt=""
+                      className="size-4 shrink-0 rounded-full"
+                    />
+                  ) : (
+                    <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-default-100 text-[9px] font-semibold text-foreground">
+                      {summary.author.login.slice(0, 1).toUpperCase()}
+                    </span>
+                  )
+                ) : null}
+                {summary.author ? <span className="truncate">{summary.author.login}</span> : null}
+                <span className="text-muted/40">·</span>
+                <span className="truncate">{summary.repository}</span>
+                <span className="text-muted/40">·</span>
+                <span className="flex min-w-0 items-center gap-1 font-mono text-[11px]">
+                  <span className="truncate">{summary.headBranch}</span>
+                  <ArrowRight className="size-3 shrink-0 text-muted/60" aria-hidden />
+                  <span className="truncate">{summary.pr.baseBranch}</span>
+                </span>
+              </span>
+            </span>
+            <span className="flex shrink-0 flex-col items-end gap-1 text-[11px] text-muted">
+              <RelativeTime iso={summary.pr.updatedAt} />
+              <span className="flex items-center gap-1 font-medium tabular-nums">
+                <span className="text-success">+{summary.additions}</span>
+                <span className="text-danger">-{summary.deletions}</span>
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/shared/contracts/appView.ts
+++ b/src/shared/contracts/appView.ts
@@ -2,6 +2,7 @@ import type { PaneLayout } from "../paneLayout";
 
 export type AppView =
   | { kind: "home" }
+  | { kind: "pullRequests" }
   | { kind: "schedules" }
   | { kind: "draft"; projectId: string }
   | {

--- a/src/shared/contracts/github.ts
+++ b/src/shared/contracts/github.ts
@@ -141,6 +141,30 @@ export interface GhListPrsResult {
   prs: Record<string, PrData>;
 }
 
+export interface PullRequestSummary {
+  /** Overlay-ready PR data for this row. */
+  pr: PrData;
+  headBranch: string;
+  author?: PrAuthor;
+  additions: number;
+  deletions: number;
+  /** "owner/repository", derived from the canonical PR URL. */
+  repository: string;
+  /** True when the authenticated viewer is currently requested to review. */
+  reviewRequested: boolean;
+}
+
+export const ghListPullRequestsPayloadSchema = z.object({
+  projectLocation: projectLocationSchema,
+});
+export type GhListPullRequestsPayload = z.infer<typeof ghListPullRequestsPayloadSchema>;
+
+export interface GhListPullRequestsResult {
+  pullRequests: PullRequestSummary[];
+  /** The account active in this project's native or WSL runtime. */
+  viewerLogin?: string;
+}
+
 export const ghMergePrPayloadSchema = z.object({
   projectLocation: projectLocationSchema,
   prNumber: z.number().int().min(1),

--- a/src/shared/ipc/procedures/github.ts
+++ b/src/shared/ipc/procedures/github.ts
@@ -9,6 +9,7 @@ import {
   ghGetPrFilesPayloadSchema,
   ghGetPrForBranchPayloadSchema,
   ghListAccountsPayloadSchema,
+  ghListPullRequestsPayloadSchema,
   ghListPrsPayloadSchema,
   ghListReposPayloadSchema,
   ghMarkPrReadyPayloadSchema,
@@ -36,6 +37,8 @@ import type {
   GhGetPrForBranchPayload,
   GhListAccountsPayload,
   GhListAccountsResult,
+  GhListPullRequestsPayload,
+  GhListPullRequestsResult,
   GhListPrsPayload,
   GhListPrsResult,
   GhListReposPayload,
@@ -72,6 +75,11 @@ export const githubProcedures = {
     "supervisor",
     ghListPrsPayloadSchema,
   ),
+  ghListPullRequests: definePayloadProcedure<
+    GhListPullRequestsPayload,
+    GhListPullRequestsResult,
+    "supervisor"
+  >("ghListPullRequests", "supervisor", ghListPullRequestsPayloadSchema),
   ghMergePr: definePayloadProcedure<GhMergePrPayload, void, "supervisor">(
     "ghMergePr",
     "supervisor",

--- a/src/shared/remote/gitProcedures.ts
+++ b/src/shared/remote/gitProcedures.ts
@@ -57,6 +57,7 @@ export const GIT_REMOTE_PROCEDURE_SCOPES = {
   ghCheckAvailable: "session:read",
   ghGetPrForBranch: "session:read",
   ghListPrs: "session:read",
+  ghListPullRequests: "session:read",
   ghGetPrChecks: "session:read",
   ghGetPrFiles: "session:read",
   ghGetPrDiff: "session:read",

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -393,6 +393,185 @@ describe("GitHubService", () => {
     });
   });
 
+  describe("listPullRequests", () => {
+    it("returns overlay-ready rows scoped to the native runtime account", async () => {
+      execFileAsyncMock.mockImplementation(async (...args: unknown[]) => {
+        const ghArgs = args[1] as string[];
+        if (ghArgs[0] === "api") return { stdout: "WindowsUser\n" };
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 42,
+              headRefName: "feature/review",
+              url: "https://github.com/owner/repo/pull/42",
+              state: "OPEN",
+              title: "Review me",
+              baseRefName: "main",
+              isDraft: false,
+              author: { login: "OtherUser", avatarUrl: "https://avatars.example/other" },
+              additions: 12,
+              deletions: 3,
+              reviewRequests: [{ login: "windowsuser" }],
+              updatedAt: "2026-07-13T10:00:00Z",
+            },
+            {
+              number: 41,
+              headRefName: "feature/authored",
+              url: "https://github.com/owner/repo/pull/41",
+              state: "OPEN",
+              title: "My PR",
+              baseRefName: "main",
+              isDraft: false,
+              author: { login: "WINDOWSUSER" },
+              additions: 5,
+              deletions: 1,
+              reviewRequests: [],
+              updatedAt: "2026-07-12T10:00:00Z",
+            },
+          ]),
+        };
+      });
+
+      const result = await new GitHubService().listPullRequests(location);
+
+      expect(result.viewerLogin).toBe("WindowsUser");
+      expect(result.pullRequests).toEqual([
+        expect.objectContaining({
+          headBranch: "feature/review",
+          repository: "owner/repo",
+          additions: 12,
+          deletions: 3,
+          reviewRequested: true,
+          author: { login: "OtherUser", avatarUrl: "https://avatars.example/other" },
+          pr: expect.objectContaining({ number: 42, viewerDidAuthor: false }),
+        }),
+        expect.objectContaining({
+          headBranch: "feature/authored",
+          reviewRequested: false,
+          pr: expect.objectContaining({ number: 41, viewerDidAuthor: true }),
+        }),
+      ]);
+      const listCall = buildAgentCommandMock.mock.calls.find(
+        (call) => (call[2] as string[])[0] === "pr",
+      );
+      expect(listCall?.[2]).toEqual([
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        expect.stringContaining("reviewRequests"),
+      ]);
+    });
+
+    it("refreshes the native viewer identity on each global list load", async () => {
+      let viewerRequest = 0;
+      execFileAsyncMock.mockImplementation(async (...args: unknown[]) => {
+        const ghArgs = args[1] as string[];
+        if (ghArgs[0] === "api") {
+          viewerRequest += 1;
+          return { stdout: viewerRequest === 1 ? "FirstUser\n" : "SecondUser\n" };
+        }
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 42,
+              headRefName: "feature/authored",
+              url: "https://github.com/owner/repo/pull/42",
+              state: "OPEN",
+              title: "Authored PR",
+              baseRefName: "main",
+              isDraft: false,
+              author: { login: "SecondUser" },
+              additions: 1,
+              deletions: 0,
+              reviewRequests: [],
+              updatedAt: "2026-07-13T10:00:00Z",
+            },
+          ]),
+        };
+      });
+      const service = new GitHubService();
+
+      const first = await service.listPullRequests(location);
+      const second = await service.listPullRequests(location);
+
+      expect(first.viewerLogin).toBe("FirstUser");
+      expect(first.pullRequests[0]?.pr.viewerDidAuthor).toBe(false);
+      expect(second.viewerLogin).toBe("SecondUser");
+      expect(second.pullRequests[0]?.pr.viewerDidAuthor).toBe(true);
+      expect(viewerRequest).toBe(2);
+    });
+
+    it("runs both list and viewer lookup inside the WSL project runtime", async () => {
+      const processBatch = vi.fn<
+        () => Promise<{
+          results: { ok: boolean; stdout: string; stderr: string; exitCode: number }[];
+        }>
+      >(async () => ({
+        results: [
+          {
+            ok: true,
+            stdout: JSON.stringify([
+              {
+                number: 9,
+                headRefName: "wsl/pr",
+                url: "https://github.com/wsl-owner/repo/pull/9",
+                state: "OPEN",
+                title: "WSL PR",
+                baseRefName: "main",
+                isDraft: false,
+                author: { login: "review-author" },
+                additions: 2,
+                deletions: 4,
+                reviewRequests: [{ login: "WslAccount" }],
+                updatedAt: "2026-07-13T11:00:00Z",
+              },
+            ]),
+            stderr: "",
+            exitCode: 0,
+          },
+          { ok: true, stdout: "WslAccount\n", stderr: "", exitCode: 0 },
+        ],
+      }));
+      const service = new GitHubService();
+      service.setWslClient({ processBatch } as never);
+
+      const result = await service.listPullRequests(wslLocation);
+
+      expect(result).toMatchObject({
+        viewerLogin: "WslAccount",
+        pullRequests: [
+          {
+            headBranch: "wsl/pr",
+            repository: "wsl-owner/repo",
+            reviewRequested: true,
+          },
+        ],
+      });
+      expect(execFileAsyncMock).not.toHaveBeenCalled();
+      expect(processBatch).toHaveBeenCalledWith(wslLocation, {
+        timeoutMs: 30_000,
+        commands: [
+          expect.objectContaining({
+            command: "gh",
+            cwd: "/home/demo/repo",
+            args: expect.arrayContaining(["pr", "list", "open"]),
+            loginEnv: true,
+          }),
+          {
+            command: "gh",
+            cwd: "/home/demo/repo",
+            args: ["api", "user", "--jq", ".login"],
+            loginEnv: true,
+          },
+        ],
+      });
+    });
+  });
+
   describe("createPr", () => {
     it("creates a PR using body-file and returns data from pr view", async () => {
       const viewJson = JSON.stringify({

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -17,11 +17,18 @@ import {
   type GhGetPrFilesResult,
   type GhGetPrDiffResult,
   type GhListAccountsResult,
+  type GhListPullRequestsResult,
   type GhListReposResult,
   type GitHubAccountRef,
   type GitHubRepoSummary,
 } from "@/shared/contracts";
-import { mapGitHubApiRepo, mapPrData, mapPrDetails, parseGhAuthAccounts } from "./githubMappers";
+import {
+  mapGitHubApiRepo,
+  mapPrData,
+  mapPrDetails,
+  mapPullRequestSummary,
+  parseGhAuthAccounts,
+} from "./githubMappers";
 
 // Re-export the pure mappers previously defined inline here so the module's
 // public surface stays identical for github.test.ts and bridge consumers.
@@ -39,6 +46,7 @@ const GH_CLONE_TIMEOUT = 600_000;
 // renderer adds client-side search over whatever we return.
 const GH_REPO_PAGE_SIZE = 100;
 const GH_REPO_MAX_PAGES = 5;
+const PULL_REQUEST_LIST_LIMIT = 1_000;
 const CREATE_PR_STATUS_WAIT_MS = 15_000;
 const CREATE_PR_STATUS_POLL_MS = 5_000;
 const PR_VIEW_FIELDS =
@@ -47,6 +55,7 @@ const PR_VIEW_FIELDS =
 // doesn't need viewerDidAuthor, so we skip the extra `gh api user` lookup).
 const PR_LIST_FIELDS =
   "number,headRefName,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus";
+const PULL_REQUEST_LIST_FIELDS = `${PR_LIST_FIELDS},author,additions,deletions,reviewRequests`;
 
 function selectLatestPr(items: unknown[]): Record<string, unknown> | null {
   return items.reduce<Record<string, unknown> | null>((latest, item) => {
@@ -75,6 +84,18 @@ function isRepoNotFoundError(error: unknown): boolean {
     lower.includes("could not resolve to a repository") ||
     lower.includes("no such repository") ||
     lower.includes("repository not found")
+  );
+}
+
+function isNoGitHubRepositoryError(error: unknown): boolean {
+  if (isRepoNotFoundError(error)) return true;
+  const msg = error instanceof Error ? error.message : String(error);
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes("not a git repository") ||
+    lower.includes("no git remotes") ||
+    lower.includes("none of the git remotes") ||
+    lower.includes("unable to determine current repository")
   );
 }
 
@@ -366,10 +387,15 @@ export class GitHubService {
     }
   }
 
-  private async getViewerLogin(location: ProjectLocation): Promise<string | undefined> {
+  private async getViewerLogin(
+    location: ProjectLocation,
+    forceRefresh = false,
+  ): Promise<string | undefined> {
     const key = locationKey(location);
-    const cached = this.viewerLoginCache.get(key);
-    if (cached !== undefined) return cached ?? undefined;
+    if (!forceRefresh) {
+      const cached = this.viewerLoginCache.get(key);
+      if (cached !== undefined) return cached ?? undefined;
+    }
     try {
       const stdout = await this.runGh(location, ["api", "user", "--jq", ".login"]);
       const login = stdout.trim();
@@ -538,6 +564,56 @@ export class GitHubService {
       return result;
     } catch (err) {
       if (isRepoNotFoundError(err)) return {};
+      throw classifyError(err, "pr list");
+    }
+  }
+
+  /** List open PRs with viewer-specific metadata for the global Pull Requests page. */
+  async listPullRequests(location: ProjectLocation): Promise<GhListPullRequestsResult> {
+    const args = [
+      "pr",
+      "list",
+      "--state",
+      "open",
+      "--limit",
+      String(PULL_REQUEST_LIST_LIMIT),
+      "--json",
+      PULL_REQUEST_LIST_FIELDS,
+    ];
+
+    try {
+      let stdout: string;
+      let viewerLogin: string | undefined;
+
+      if (location.kind === "wsl") {
+        const key = locationKey(location);
+        const results = await this.runGhBatch(location, [args, ["api", "user", "--jq", ".login"]]);
+        const listResult = results[0]!;
+        if (!listResult.ok) throw processResultToError(listResult);
+        stdout = listResult.stdout;
+        viewerLogin = results[1]?.ok ? results[1].stdout.trim() || undefined : undefined;
+        this.viewerLoginCache.set(key, viewerLogin ?? null);
+      } else {
+        [stdout, viewerLogin] = await Promise.all([
+          this.runGh(location, args),
+          this.getViewerLogin(location, true),
+        ]);
+      }
+
+      const items = JSON.parse(stdout);
+      const pullRequests = Array.isArray(items)
+        ? items
+            .filter((item): item is Record<string, unknown> =>
+              Boolean(item && typeof item === "object"),
+            )
+            .map((item) => mapPullRequestSummary(item, viewerLogin))
+        : [];
+      return {
+        pullRequests,
+        ...(viewerLogin ? { viewerLogin } : {}),
+      };
+    } catch (err) {
+      if (isNoGitHubRepositoryError(err)) return { pullRequests: [] };
       throw classifyError(err, "pr list");
     }
   }

--- a/src/supervisor/githubMappers.ts
+++ b/src/supervisor/githubMappers.ts
@@ -18,6 +18,7 @@ import {
   type PrReviewState,
   type PrReviewSummary,
   type PrState,
+  type PullRequestSummary,
 } from "@/shared/contracts";
 
 export function mapPrState(raw: { state: string; isDraft: boolean }): PrState {
@@ -67,7 +68,7 @@ export function mapPrData(raw: Record<string, unknown>, viewerLogin?: string): P
   const author = raw.author as { login?: unknown } | null | undefined;
   const authorLogin = author && typeof author.login === "string" ? author.login : undefined;
   if (authorLogin && viewerLogin) {
-    result.viewerDidAuthor = authorLogin === viewerLogin;
+    result.viewerDidAuthor = authorLogin.toLowerCase() === viewerLogin.toLowerCase();
   }
   const cs = aggregateChecksStatus(raw.statusCheckRollup);
   if (cs) result.checksStatus = cs;
@@ -98,6 +99,42 @@ export function mapPrAuthor(raw: unknown): PrAuthor | undefined {
   if (!login) return undefined;
   const avatarUrl = typeof obj.avatarUrl === "string" ? obj.avatarUrl : undefined;
   return avatarUrl ? { login, avatarUrl } : { login };
+}
+
+function repositoryFromPrUrl(rawUrl: unknown): string {
+  if (typeof rawUrl !== "string" || !rawUrl) return "";
+  try {
+    const segments = new URL(rawUrl).pathname.split("/").filter(Boolean);
+    const pullIndex = segments.lastIndexOf("pull");
+    return pullIndex >= 2 ? `${segments[pullIndex - 2]}/${segments[pullIndex - 1]}` : "";
+  } catch {
+    return "";
+  }
+}
+
+export function mapPullRequestSummary(
+  raw: Record<string, unknown>,
+  viewerLogin?: string,
+): PullRequestSummary {
+  const author = mapPrAuthor(raw.author);
+  const reviewRequested =
+    viewerLogin !== undefined &&
+    Array.isArray(raw.reviewRequests) &&
+    raw.reviewRequests.some((request) => {
+      if (!request || typeof request !== "object") return false;
+      const login = (request as Record<string, unknown>).login;
+      return typeof login === "string" && login.toLowerCase() === viewerLogin.toLowerCase();
+    });
+
+  return {
+    pr: mapPrData(raw, viewerLogin),
+    headBranch: typeof raw.headRefName === "string" ? raw.headRefName : "",
+    ...(author ? { author } : {}),
+    additions: typeof raw.additions === "number" ? raw.additions : 0,
+    deletions: typeof raw.deletions === "number" ? raw.deletions : 0,
+    repository: repositoryFromPrUrl(raw.url),
+    reviewRequested,
+  };
 }
 
 export function mapPrCommit(raw: unknown): PrCommitSummary | null {

--- a/src/supervisor/ipcHandlers.ts
+++ b/src/supervisor/ipcHandlers.ts
@@ -210,6 +210,7 @@ export function createSupervisorIpcHandlers(runtime: SupervisorRuntime): Supervi
       ),
     ghGetPrForBranch: (payload) => github.getPrForBranch(payload.projectLocation, payload.branch),
     ghListPrs: async (payload) => ({ prs: await github.listPrs(payload.projectLocation) }),
+    ghListPullRequests: (payload) => github.listPullRequests(payload.projectLocation),
     ghMergePr: (payload) =>
       github.mergePr(payload.projectLocation, payload.prNumber, payload.method, payload.admin),
     ghClosePr: (payload) => github.closePr(payload.projectLocation, payload.prNumber),


### PR DESCRIPTION
- **Feature:** Add a dedicated Pull Requests view in the sidebar for browsing, filtering, and opening pull requests across projects.
- Surface account-scoped pull request summaries through shared GitHub contracts, IPC, supervisor, and paired remote access.
- Support reviewing PRs without a verified local checkout by safely skipping local synchronization.
- Localize the new interface and add coverage for view navigation, PR listing, remote access, and GitHub mapping.