### PR TITLE
Add responsive desktop navigation and browser routing

### DIFF
--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -634,6 +634,10 @@ describe("RemoteAccessServer", () => {
     expect(appResponse.status).toBe(200);
     await expect(appResponse.text()).resolves.toContain("Poracode");
 
+    const appRouteResponse = await fetch(new URL("/app/settings/appearance", info.httpBaseUrl));
+    expect(appRouteResponse.status).toBe(200);
+    await expect(appRouteResponse.text()).resolves.toContain("Poracode");
+
     const manifestResponse = await fetch(new URL("/manifest.webmanifest", info.httpBaseUrl));
     expect(manifestResponse.status).toBe(200);
     await expect(manifestResponse.json()).resolves.toMatchObject({

--- a/src/main/remote/server/httpRouter.ts
+++ b/src/main/remote/server/httpRouter.ts
@@ -242,9 +242,15 @@ export async function handleHttp(
       writeJson(res, 200, descriptor(ctx));
       return;
     }
-    if (req.method === "GET" && (url.pathname === "/pair" || url.pathname === "/app")) {
+    if (
+      req.method === "GET" &&
+      (url.pathname === "/pair" || url.pathname === "/app" || url.pathname.startsWith("/app/"))
+    ) {
       if (ctx.options.devMobileAppUrl) {
         const target = new URL(ctx.options.devMobileAppUrl);
+        if (url.pathname.startsWith("/app/")) {
+          target.pathname = url.pathname.slice("/app".length);
+        }
         for (const [key, value] of url.searchParams) target.searchParams.set(key, value);
         target.searchParams.set("host", ctx.requireInfo().httpBaseUrl);
         res.writeHead(302, { location: target.toString() });

--- a/src/main/remote/server/portForwardProxy.ts
+++ b/src/main/remote/server/portForwardProxy.ts
@@ -51,7 +51,7 @@ const RESERVED_EXACT_PATHS = new Set([
   "/service-worker.js",
   "/app-icon.svg",
 ]);
-const RESERVED_PATH_PREFIXES = ["/api/", "/oauth/", "/.well-known/", "/forward/"];
+const RESERVED_PATH_PREFIXES = ["/api/", "/oauth/", "/.well-known/", "/forward/", "/app/"];
 
 export function isReservedForwardProxyPath(pathname: string): boolean {
   if (RESERVED_EXACT_PATHS.has(pathname)) return true;

--- a/src/main/remote/staticMobileApp.ts
+++ b/src/main/remote/staticMobileApp.ts
@@ -21,7 +21,7 @@ const CONTENT_TYPES: Record<string, string> = {
 const RENDERER_DIST_DIR = resolve(__dirname, "../renderer");
 
 export function tryServeBuiltMobileApp(pathname: string, res: ServerResponse): boolean {
-  if (pathname === "/pair" || pathname === "/app") {
+  if (pathname === "/pair" || pathname === "/app" || pathname.startsWith("/app/")) {
     return streamFile(join(RENDERER_DIST_DIR, MOBILE_HTML_FILE), res);
   }
 

--- a/src/mobile/NarrowShell.tsx
+++ b/src/mobile/NarrowShell.tsx
@@ -12,6 +12,7 @@ import {
   Settings2,
 } from "lucide-react";
 import { Outlet, useNavigate } from "@tanstack/react-router";
+import { BrandWordmark } from "@/renderer/components/common/BrandWordmark";
 import { ConnectionPill, SheetMenu } from "./components";
 import { preselectWorktreeDraft, runThreadAction } from "./navHelpers";
 import { ThreadTitleRow } from "./ThreadTitleRow";
@@ -21,19 +22,11 @@ import type { RemoteDesktopSession } from "./useRemoteDesktop";
 import { useSwipeBack } from "./useSwipeBack";
 import type { Chrome } from "./chrome";
 
-/** Header/sidebar brand mark: the desktop's paired label, or "Poracode".
- * Shared by {@link NarrowShell} and the wide-shell sidebar. */
-export function Brand(props: {
-  readonly subtitle?: string | undefined;
-  readonly onPress: () => void;
-}) {
-  // Desktop labels default to "Poracode on <host>"; the header only needs the
-  // host. Accept the legacy "Lightcode on …" prefix for desktops paired before
-  // the rebrand so their stored labels still render cleanly.
-  const label = props.subtitle?.replace(/^(?:Poracode|Lightcode)\s+on\s+/i, "");
+/** Header/sidebar brand mark shared by {@link NarrowShell} and the wide shell. */
+export function Brand(props: { readonly onPress: () => void }) {
   return (
     <button className="m-brand" type="button" onClick={props.onPress}>
-      <span className="m-brand__title">{label || "Poracode"}</span>
+      <BrandWordmark className="m-brand__wordmark" />
     </button>
   );
 }
@@ -104,6 +97,7 @@ export function NarrowShell(props: {
   const { remote, chrome, pathname } = props;
   const navigate = useNavigate();
   const { t } = useLingui();
+  const hasActiveDesktop = remote.activeDesktop !== null;
   const shellRef = useRef<HTMLDivElement | null>(null);
   const ignoreSearchClickRef = useRef(false);
   const ignoreSearchClickTimerRef = useRef<number | null>(null);
@@ -217,10 +211,7 @@ export function NarrowShell(props: {
         ) : (
           <>
             <div className="m-home-brand-cluster">
-              <Brand
-                subtitle={remote.activeDesktop?.label}
-                onPress={() => void navigate({ to: "/threads" })}
-              />
+              <Brand onPress={() => void navigate({ to: "/threads" })} />
               <ConnectionControl
                 remote={remote}
                 onPair={() => void navigate({ to: "/desktops" })}
@@ -299,7 +290,12 @@ export function NarrowShell(props: {
           <SheetMenu
             label={t`More`}
             items={[
-              { id: "usage", label: t`Usage`, icon: <Gauge className="size-4 text-muted" /> },
+              {
+                id: "usage",
+                label: t`Usage`,
+                icon: <Gauge className="size-4 text-muted" />,
+                disabled: !hasActiveDesktop,
+              },
               {
                 id: "desktops",
                 label: t`Connections`,
@@ -309,9 +305,20 @@ export function NarrowShell(props: {
                 id: "projects",
                 label: t`Projects`,
                 icon: <FolderGit2 className="size-4 text-muted" />,
+                disabled: !hasActiveDesktop,
               },
-              { id: "browser", label: t`Browser`, icon: <Globe className="size-4 text-muted" /> },
-              { id: "ports", label: t`Ports`, icon: <Plug className="size-4 text-muted" /> },
+              {
+                id: "browser",
+                label: t`Browser`,
+                icon: <Globe className="size-4 text-muted" />,
+                disabled: !hasActiveDesktop,
+              },
+              {
+                id: "ports",
+                label: t`Ports`,
+                icon: <Plug className="size-4 text-muted" />,
+                disabled: !hasActiveDesktop,
+              },
               {
                 id: "settings",
                 label: t`Settings`,
@@ -321,16 +328,16 @@ export function NarrowShell(props: {
             onSelect={(id) => {
               const to =
                 id === "usage"
-                  ? "/more/usage"
+                  ? "/usage"
                   : id === "desktops"
                     ? "/desktops"
                     : id === "projects"
-                      ? "/more/projects"
+                      ? "/projects"
                       : id === "browser"
-                        ? "/more/browser"
+                        ? "/browser"
                         : id === "ports"
-                          ? "/more/ports"
-                          : "/more";
+                          ? "/ports"
+                          : "/settings";
               void navigate({ to });
             }}
             trigger={renderMoreMenuTrigger}

--- a/src/mobile/RootLayout.test.tsx
+++ b/src/mobile/RootLayout.test.tsx
@@ -11,6 +11,8 @@ const routerMock = vi.hoisted(() => ({
   pathname: "/threads",
 }));
 
+const mediaMock = vi.hoisted(() => ({ isWide: false }));
+
 const remoteMock = vi.hoisted(() => ({
   session: {
     booted: true,
@@ -70,7 +72,9 @@ vi.mock("@/renderer/views/MainView/parts/PullFromSourceDialog", () => ({
 }));
 
 vi.mock("./components", () => ({
-  ConnectionBanner: () => null,
+  ConnectionBanner: (props: { state: string }) => (
+    <div data-testid="connection-banner" data-state={props.state} />
+  ),
   ConnectionPill: (props: { state: string }) => (
     <button
       type="button"
@@ -79,17 +83,29 @@ vi.mock("./components", () => ({
       aria-label="Connection status"
     />
   ),
+  EmptyState: (props: { title: ReactNode; hint?: ReactNode; action?: ReactNode }) => (
+    <div>
+      <strong>{props.title}</strong>
+      {props.hint}
+      {props.action}
+    </div>
+  ),
   // Functional stand-in: renders the trigger plus one button per item, so
   // tests can drive the header quick menu without the portal/animation layer.
   SheetMenu: (props: {
-    items: readonly { id: string; label: string }[];
+    items: readonly { id: string; label: string; disabled?: boolean }[];
     onSelect: (id: string) => void;
     trigger: (api: { open: () => void; isOpen: boolean }) => ReactNode;
   }) => (
     <>
       {props.trigger({ open: () => {}, isOpen: false })}
       {props.items.map((item) => (
-        <button key={item.id} type="button" onClick={() => props.onSelect(item.id)}>
+        <button
+          key={item.id}
+          type="button"
+          disabled={item.disabled}
+          onClick={() => props.onSelect(item.id)}
+        >
           {item.label}
         </button>
       ))}
@@ -122,7 +138,7 @@ vi.mock("./ThreadUsageIndicator", () => ({
 
 vi.mock("./useMediaQuery", () => ({
   WIDE_SHELL_QUERY: "(min-width: 900px)",
-  useMediaQuery: () => false,
+  useMediaQuery: () => mediaMock.isWide,
 }));
 
 vi.mock("./useRemoteDesktop", () => ({
@@ -130,13 +146,17 @@ vi.mock("./useRemoteDesktop", () => ({
 }));
 
 vi.mock("./views/ThreadsView", () => ({
-  ThreadsView: () => <div data-testid="threads-view" />,
+  ThreadsView: (props: { emptyStateOverride?: ReactNode }) => (
+    <div data-testid="threads-view">{props.emptyStateOverride}</div>
+  ),
 }));
 
 describe("mobile RootLayout", () => {
   beforeEach(() => {
+    localStorage.removeItem("poracode-mobile.sidebar-width");
     routerMock.navigate.mockReset();
     routerMock.pathname = "/threads";
+    mediaMock.isWide = false;
     remoteMock.session.connection = "online";
     remoteMock.session.desktops = [{ id: "desktop-1", label: "Poracode on Mac" }];
     remoteMock.session.activeDesktop = { id: "desktop-1", label: "Poracode on Mac" };
@@ -166,11 +186,11 @@ describe("mobile RootLayout", () => {
 
     // The ⋯ quick menu hosts every secondary destination; Settings is last.
     fireEvent.click(screen.getByText("Usage"));
-    expect(routerMock.navigate).toHaveBeenCalledWith({ to: "/more/usage" });
+    expect(routerMock.navigate).toHaveBeenCalledWith({ to: "/usage" });
     fireEvent.click(screen.getByText("Connections"));
     expect(routerMock.navigate).toHaveBeenCalledWith({ to: "/desktops" });
     fireEvent.click(screen.getByText("Settings"));
-    expect(routerMock.navigate).toHaveBeenCalledWith({ to: "/more" });
+    expect(routerMock.navigate).toHaveBeenCalledWith({ to: "/settings" });
   });
 
   it("keeps the disconnected icon hidden until a desktop is active", () => {
@@ -183,17 +203,88 @@ describe("mobile RootLayout", () => {
     expect(screen.queryByTestId("connection-pill")).not.toBeInTheDocument();
   });
 
-  it("places the home connection indicator after the desktop name before the More menu", () => {
+  it("disables desktop-backed quick-menu destinations when no desktop is paired", () => {
+    remoteMock.session.connection = "offline";
+    remoteMock.session.desktops = [];
+    remoteMock.session.activeDesktop = null;
+
+    render(<RootLayout />);
+
+    expect(screen.getByRole("button", { name: "Usage" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Projects" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Browser" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Ports" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Connections" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeEnabled();
+  });
+
+  it("keeps local settings deep links open when no desktop is paired", () => {
+    routerMock.pathname = "/settings/appearance";
+    remoteMock.session.desktops = [];
+    remoteMock.session.activeDesktop = null;
+
+    render(<RootLayout />);
+
+    expect(routerMock.navigate).not.toHaveBeenCalledWith({ to: "/desktops" });
+  });
+
+  it("disables wide-shell desktop actions and hides the banner with no selected desktop", () => {
+    mediaMock.isWide = true;
+    remoteMock.session.connection = "offline";
+    remoteMock.session.desktops = [];
+    remoteMock.session.activeDesktop = null;
+
+    render(<RootLayout />);
+
+    expect(screen.getByRole("button", { name: "New thread" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Usage" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Projects" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Browser" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Ports" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeEnabled();
+    expect(screen.queryByTestId("connection-banner")).not.toBeInTheDocument();
+    expect(screen.getByText("Connect desktop")).toBeInTheDocument();
+  });
+
+  it("shows the offline banner when the selected desktop is offline", () => {
+    mediaMock.isWide = true;
     remoteMock.session.connection = "offline";
 
     render(<RootLayout />);
 
-    const brand = screen.getByText("Mac").closest("button");
+    expect(screen.getByTestId("connection-banner")).toHaveAttribute("data-state", "offline");
+  });
+
+  it("resizes and persists the wide-shell sidebar", () => {
+    mediaMock.isWide = true;
+    localStorage.setItem("poracode-mobile.sidebar-width", "360");
+
+    const { container } = render(<RootLayout />);
+    const shell = container.querySelector<HTMLElement>(".m-shell--wide");
+    const resizeHandle = screen.getByRole("separator", { name: "Resize sidebar" });
+    expect(shell?.style.getPropertyValue("--m-sidebar-width")).toBe("360px");
+
+    fireEvent.keyDown(resizeHandle, { key: "ArrowRight" });
+    expect(shell?.style.getPropertyValue("--m-sidebar-width")).toBe("384px");
+    expect(localStorage.getItem("poracode-mobile.sidebar-width")).toBe("384");
+
+    fireEvent.mouseDown(resizeHandle, { button: 0, clientX: 384 });
+    fireEvent.mouseMove(document, { clientX: 424 });
+    fireEvent.mouseUp(document, { clientX: 424 });
+    expect(shell?.style.getPropertyValue("--m-sidebar-width")).toBe("424px");
+    expect(localStorage.getItem("poracode-mobile.sidebar-width")).toBe("424");
+  });
+
+  it("places the home connection indicator after the brand before the More menu", () => {
+    remoteMock.session.connection = "offline";
+
+    render(<RootLayout />);
+
+    const brand = screen.getByRole("button", { name: "Poracode" });
     const connection = screen.getByTestId("connection-pill");
     const more = screen.getByLabelText("More");
-    expect(brand).not.toBeNull();
     expect(
-      brand!.compareDocumentPosition(connection) & Node.DOCUMENT_POSITION_FOLLOWING,
+      brand.compareDocumentPosition(connection) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
       connection.compareDocumentPosition(more) & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/src/mobile/RootLayout.tsx
+++ b/src/mobile/RootLayout.tsx
@@ -72,10 +72,10 @@ export function RootLayout() {
 
   // First launch without a paired desktop lands on pairing.
   useEffect(() => {
-    if (remote.booted && remote.desktops.length === 0) {
+    if (pathname === "/threads" && remote.booted && remote.desktops.length === 0) {
       void navigate({ to: "/desktops" });
     }
-  }, [remote.booted, remote.desktops.length, navigate]);
+  }, [pathname, remote.booted, remote.desktops.length, navigate]);
 
   // Connection-state problems (offline / reconnecting / unauthorized / error)
   // are shown by the ConnectionBanner; only surface action-level errors that

--- a/src/mobile/ThreadUsageIndicator.tsx
+++ b/src/mobile/ThreadUsageIndicator.tsx
@@ -150,7 +150,7 @@ function UsageDrawer(props: {
         className="m-sheet-action"
         onClick={() => {
           props.onClose();
-          void navigate({ to: "/more/usage" });
+          void navigate({ to: "/usage" });
         }}
       >
         <Gauge className="size-4" />

--- a/src/mobile/WideShell.tsx
+++ b/src/mobile/WideShell.tsx
@@ -1,12 +1,75 @@
-import { Button } from "@heroui/react";
 import { Plural, Trans, useLingui } from "@lingui/react/macro";
-import { Ellipsis, Gauge, Plus, Server } from "lucide-react";
+import { FolderKanban, Gauge, Globe2, Plus, Server, Settings2, Waypoints } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from "react";
 import { Outlet, useNavigate } from "@tanstack/react-router";
 import { ConnectionBanner } from "./components";
 import { Brand, ConnectionControl } from "./NarrowShell";
 import { preselectWorktreeDraft, threadIdFromPath } from "./navHelpers";
+import { MobileSetupEmptyState } from "./setupEmptyState";
 import type { RemoteDesktopSession } from "./useRemoteDesktop";
 import { ThreadsView } from "./views/ThreadsView";
+
+const SIDEBAR_WIDTH_KEY = "poracode-mobile.sidebar-width";
+const SIDEBAR_MIN_WIDTH = 240;
+const SIDEBAR_MAX_WIDTH = 500;
+const SIDEBAR_MIN_CONTENT_WIDTH = 320;
+const SIDEBAR_RESIZE_STEP = 24;
+
+function getSidebarMaxWidth(): number {
+  return Math.min(
+    SIDEBAR_MAX_WIDTH,
+    Math.max(SIDEBAR_MIN_WIDTH, window.innerWidth - SIDEBAR_MIN_CONTENT_WIDTH),
+  );
+}
+
+function clampSidebarWidth(width: number): number {
+  return Math.min(getSidebarMaxWidth(), Math.max(SIDEBAR_MIN_WIDTH, Math.round(width)));
+}
+
+function readSidebarWidth(): number {
+  const responsiveDefault = Math.min(304, Math.max(248, window.innerWidth * 0.2));
+  try {
+    const stored = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY));
+    return clampSidebarWidth(Number.isFinite(stored) && stored > 0 ? stored : responsiveDefault);
+  } catch {
+    return clampSidebarWidth(responsiveDefault);
+  }
+}
+
+function persistSidebarWidth(width: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  } catch {
+    // Resizing still works when storage is unavailable.
+  }
+}
+
+function SidebarDestination(props: {
+  readonly active: boolean;
+  readonly disabled?: boolean;
+  readonly icon: ReactNode;
+  readonly label: ReactNode;
+  readonly onPress: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="m-sidebar__destination"
+      data-active={props.active || undefined}
+      disabled={props.disabled}
+      onClick={props.onPress}
+    >
+      {props.icon}
+      <span>{props.label}</span>
+    </button>
+  );
+}
 
 /** Tablet/desktop chrome: a persistent thread sidebar + the routed detail pane. */
 export function WideShell(props: {
@@ -19,47 +82,92 @@ export function WideShell(props: {
   const navigate = useNavigate();
   const { t } = useLingui();
   const selectedThreadId = threadIdFromPath(pathname);
+  const hasActiveDesktop = remote.activeDesktop !== null;
+  const [sidebarWidth, setSidebarWidth] = useState(readSidebarWidth);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const shellRef = useRef<HTMLDivElement>(null);
+  const teardownResizeRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => () => teardownResizeRef.current?.(), []);
+
+  function applySidebarWidth(next: number): number {
+    const width = clampSidebarWidth(next);
+    sidebarWidthRef.current = width;
+    shellRef.current?.style.setProperty("--m-sidebar-width", `${width}px`);
+    return width;
+  }
+
+  function commitSidebarWidth(next: number): void {
+    const width = applySidebarWidth(next);
+    setSidebarWidth(width);
+    persistSidebarWidth(width);
+  }
+
+  function startSidebarResize(event: ReactMouseEvent<HTMLDivElement>): void {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    teardownResizeRef.current?.();
+
+    const startX = event.clientX;
+    const startWidth = sidebarWidthRef.current;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    function onMouseMove(moveEvent: MouseEvent): void {
+      applySidebarWidth(startWidth + moveEvent.clientX - startX);
+    }
+
+    function teardown(): void {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+      teardownResizeRef.current = null;
+    }
+
+    function onMouseUp(upEvent: MouseEvent): void {
+      const width = applySidebarWidth(startWidth + upEvent.clientX - startX);
+      teardown();
+      setSidebarWidth(width);
+      persistSidebarWidth(width);
+    }
+
+    teardownResizeRef.current = teardown;
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  function resizeSidebarWithKeyboard(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      commitSidebarWidth(sidebarWidthRef.current - SIDEBAR_RESIZE_STEP);
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      commitSidebarWidth(sidebarWidthRef.current + SIDEBAR_RESIZE_STEP);
+    }
+  }
 
   return (
-    <div className="m-shell m-shell--wide">
+    <div
+      ref={shellRef}
+      className="m-shell m-shell--wide"
+      style={{ "--m-sidebar-width": `${sidebarWidth}px` } as CSSProperties}
+    >
       <aside className="m-sidebar">
         <header className="m-sidebar__head">
-          <Brand
-            subtitle={remote.activeDesktop?.label}
-            onPress={() => void navigate({ to: "/threads" })}
-          />
+          <Brand onPress={() => void navigate({ to: "/threads" })} />
           <ConnectionControl remote={remote} onPair={() => void navigate({ to: "/desktops" })} />
         </header>
-        <div className="m-sidebar__actions">
-          <Button
-            className="flex-1 text-white"
-            size="sm"
-            variant="secondary"
+        <div className="m-sidebar__primary">
+          <SidebarDestination
+            active={pathname === "/new"}
+            disabled={!hasActiveDesktop}
+            icon={<Plus className="size-4" />}
+            label={<Trans>New thread</Trans>}
             onPress={() => void navigate({ to: "/new" })}
-          >
-            <Plus className="size-4" />
-            <Trans>New thread</Trans>
-          </Button>
-          <Button
-            aria-label={t`Usage`}
-            className="text-foreground"
-            size="sm"
-            variant="secondary"
-            isIconOnly
-            onPress={() => void navigate({ to: "/more/usage" })}
-          >
-            <Gauge className="size-4" />
-          </Button>
-          <Button
-            aria-label={t`More`}
-            className="text-foreground"
-            size="sm"
-            variant="secondary"
-            isIconOnly
-            onPress={() => void navigate({ to: "/more" })}
-          >
-            <Ellipsis className="size-4" />
-          </Button>
+          />
         </div>
         <div className="m-sidebar__scroll">
           <ThreadsView
@@ -105,9 +213,55 @@ export function WideShell(props: {
                 },
               })
             }
+            {...(!hasActiveDesktop
+              ? {
+                  emptyStateOverride: (
+                    <MobileSetupEmptyState
+                      kind="desktop"
+                      onAction={() => void navigate({ to: "/desktops" })}
+                    />
+                  ),
+                }
+              : {})}
           />
         </div>
         <footer className="m-sidebar__foot">
+          <nav className="m-sidebar__nav">
+            <SidebarDestination
+              active={pathname === "/usage"}
+              disabled={!hasActiveDesktop}
+              icon={<Gauge className="size-4" />}
+              label={<Trans>Usage</Trans>}
+              onPress={() => void navigate({ to: "/usage" })}
+            />
+            <SidebarDestination
+              active={pathname === "/projects"}
+              disabled={!hasActiveDesktop}
+              icon={<FolderKanban className="size-4" />}
+              label={<Trans>Projects</Trans>}
+              onPress={() => void navigate({ to: "/projects" })}
+            />
+            <SidebarDestination
+              active={pathname === "/browser"}
+              disabled={!hasActiveDesktop}
+              icon={<Globe2 className="size-4" />}
+              label={<Trans>Browser</Trans>}
+              onPress={() => void navigate({ to: "/browser" })}
+            />
+            <SidebarDestination
+              active={pathname === "/ports"}
+              disabled={!hasActiveDesktop}
+              icon={<Waypoints className="size-4" />}
+              label={<Trans>Ports</Trans>}
+              onPress={() => void navigate({ to: "/ports" })}
+            />
+            <SidebarDestination
+              active={pathname.startsWith("/settings")}
+              icon={<Settings2 className="size-4" />}
+              label={<Trans>Settings</Trans>}
+              onPress={() => void navigate({ to: "/settings" })}
+            />
+          </nav>
           <button
             type="button"
             className="m-sidebar__desktops"
@@ -127,14 +281,28 @@ export function WideShell(props: {
             </span>
           </button>
         </footer>
+        <div
+          className="m-sidebar__resize-handle"
+          onMouseDown={startSidebarResize}
+          onKeyDown={resizeSidebarWithKeyboard}
+          role="separator"
+          tabIndex={0}
+          aria-label={t`Resize sidebar`}
+          aria-orientation="vertical"
+          aria-valuemin={SIDEBAR_MIN_WIDTH}
+          aria-valuemax={getSidebarMaxWidth()}
+          aria-valuenow={sidebarWidth}
+        />
       </aside>
       <main className="m-detail">
-        <ConnectionBanner
-          state={remote.connection}
-          message={remote.message}
-          onReconnect={remote.reconnect}
-          onPair={() => void navigate({ to: "/desktops" })}
-        />
+        {hasActiveDesktop ? (
+          <ConnectionBanner
+            state={remote.connection}
+            message={remote.message}
+            onReconnect={remote.reconnect}
+            onPair={() => void navigate({ to: "/desktops" })}
+          />
+        ) : null}
         <Outlet />
       </main>
     </div>

--- a/src/mobile/chrome.ts
+++ b/src/mobile/chrome.ts
@@ -8,7 +8,7 @@ export type Chrome =
   | {
       readonly layout: "subscreen";
       readonly title: MessageDescriptor;
-      readonly backTo: "/threads" | "/more" | "/more/settings";
+      readonly backTo: "/threads" | "/settings" | "/settings/desktop";
     }
   | { readonly layout: "thread" }
   | { readonly layout: "fullscreen" };
@@ -25,34 +25,34 @@ export function getChrome(pathname: string): Chrome {
     // the shell shows no top bar at all.
     return { layout: "fullscreen" };
   }
-  const sectionMatch = /^\/more\/settings\/(.+)$/.exec(pathname);
+  if (pathname === "/settings/desktop") {
+    return { layout: "subscreen", title: msg`Desktop Settings`, backTo: "/settings" };
+  }
+  const sectionMatch = /^\/settings\/(.+)$/.exec(pathname);
   if (sectionMatch?.[1]) {
     const id = decodeURIComponent(sectionMatch[1]);
-    // Device sections are listed flat on the More screen; only desktop-syncing
+    // Device sections are listed flat on the Settings screen; only desktop-syncing
     // sections sit behind the Desktop Settings subscreen.
     return {
       layout: "subscreen",
       title: getSettingsSectionLabel(id) ?? msg`Settings`,
-      backTo: isDesktopSettingsSection(id) ? "/more/settings" : "/more",
+      backTo: isDesktopSettingsSection(id) ? "/settings/desktop" : "/settings",
     };
   }
-  if (pathname === "/more/settings") {
-    return { layout: "subscreen", title: msg`Desktop Settings`, backTo: "/more" };
-  }
   // These are pushed straight from the home header's quick menu.
-  if (pathname === "/more/usage") {
+  if (pathname === "/usage") {
     return { layout: "subscreen", title: msg`Usage`, backTo: "/threads" };
   }
-  if (pathname === "/more/browser") {
+  if (pathname === "/browser") {
     return { layout: "subscreen", title: msg`Browser`, backTo: "/threads" };
   }
-  if (pathname === "/more/ports") {
+  if (pathname === "/ports") {
     return { layout: "subscreen", title: msg`Ports`, backTo: "/threads" };
   }
-  if (pathname === "/more/projects") {
+  if (pathname === "/projects") {
     return { layout: "subscreen", title: msg`Projects`, backTo: "/threads" };
   }
-  if (pathname === "/more") {
+  if (pathname === "/settings") {
     return { layout: "subscreen", title: msg`Settings`, backTo: "/threads" };
   }
   if (pathname === "/new") {

--- a/src/mobile/components.tsx
+++ b/src/mobile/components.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { Popover } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ReactNode } from "react";
 import { Check, ChevronRight, Columns2, Loader2, Plus, Rows2, Wifi, WifiOff } from "lucide-react";
@@ -7,6 +8,7 @@ import { SheetGrabber, useSheetGrabber } from "@/renderer/components/common/useS
 import type { ThreadStatus } from "@/shared/contracts";
 import { CONNECTION_LABELS, type ConnectionState } from "./useRemoteDesktop";
 import { THREAD_STATUS_LABELS, threadStatusTone } from "./presentation";
+import { DESKTOP_POINTER_QUERY, useMediaQuery } from "./useMediaQuery";
 
 export function ConnectionPill(props: {
   readonly state: ConnectionState;
@@ -110,10 +112,16 @@ export function MoreRow(props: {
   readonly icon: ReactNode;
   readonly label: ReactNode;
   readonly hint?: ReactNode;
+  readonly disabled?: boolean;
   readonly onPress: () => void;
 }) {
   return (
-    <button type="button" className="m-more-row" onClick={props.onPress}>
+    <button
+      type="button"
+      className="m-more-row"
+      disabled={props.disabled || undefined}
+      onClick={props.onPress}
+    >
       <span className="m-more-row__icon">{props.icon}</span>
       <span className="m-more-row__body">
         <strong>{props.label}</strong>
@@ -402,10 +410,69 @@ export function SheetMenu(props: {
   readonly trigger: (api: { readonly open: () => void; readonly isOpen: boolean }) => ReactNode;
 }) {
   const sheet = useSheet<true>();
-  const isOpen = sheet.target !== null;
+  const desktop = useMediaQuery(DESKTOP_POINTER_QUERY);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const isOpen = desktop ? popoverOpen : sheet.target !== null;
+  const open = () => {
+    if (desktop) setPopoverOpen(true);
+    else sheet.open(true);
+  };
+  const close = () => {
+    if (desktop) setPopoverOpen(false);
+    else sheet.close();
+  };
+  const items = (
+    <div className="m-sheet-list">
+      {props.items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className={
+            item.tone === "danger"
+              ? "m-sheet-action text-danger"
+              : item.tone === "warning"
+                ? "m-sheet-action text-warning"
+                : "m-sheet-action"
+          }
+          disabled={item.disabled || undefined}
+          aria-pressed={item.selected || undefined}
+          onClick={() => {
+            props.onSelect(item.id);
+            close();
+          }}
+        >
+          {item.icon}
+          <span className="flex-1 truncate">{item.label}</span>
+          {item.hint ? <span className="shrink-0 text-xs text-muted">{item.hint}</span> : null}
+          {item.selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
+        </button>
+      ))}
+    </div>
+  );
+
+  if (desktop) {
+    return (
+      <Popover
+        isOpen={popoverOpen}
+        onOpenChange={(nextOpen) => {
+          // Row triggers keep their normal left-click action; only their
+          // explicit open handler (menu button or context menu) opens this.
+          if (!nextOpen) setPopoverOpen(false);
+        }}
+      >
+        <Popover.Trigger>{props.trigger({ open, isOpen })}</Popover.Trigger>
+        {popoverOpen ? (
+          <Popover.Content placement="bottom start" className="m-menu-popover">
+            <Popover.Dialog aria-label={props.label}>{items}</Popover.Dialog>
+          </Popover.Content>
+        ) : null}
+      </Popover>
+    );
+  }
+
   return (
     <>
-      {props.trigger({ open: () => sheet.open(true), isOpen })}
+      {props.trigger({ open, isOpen })}
       {sheet.target !== null ? (
         <BottomSheet
           label={props.label}
@@ -416,34 +483,7 @@ export function SheetMenu(props: {
           <div className="m-sheet-head">
             <span className="truncate">{props.label}</span>
           </div>
-          <div className="m-sheet-list">
-            {props.items.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={
-                  item.tone === "danger"
-                    ? "m-sheet-action text-danger"
-                    : item.tone === "warning"
-                      ? "m-sheet-action text-warning"
-                      : "m-sheet-action"
-                }
-                disabled={item.disabled || undefined}
-                aria-pressed={item.selected || undefined}
-                onClick={() => {
-                  props.onSelect(item.id);
-                  sheet.close();
-                }}
-              >
-                {item.icon}
-                <span className="flex-1 truncate">{item.label}</span>
-                {item.hint ? (
-                  <span className="shrink-0 text-xs text-muted">{item.hint}</span>
-                ) : null}
-                {item.selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
-              </button>
-            ))}
-          </div>
+          {items}
         </BottomSheet>
       ) : null}
     </>

--- a/src/mobile/navHelpers.test.ts
+++ b/src/mobile/navHelpers.test.ts
@@ -180,18 +180,19 @@ describe("screenDepth", () => {
     // Quick-menu destinations, the Settings page, a thread, and the full
     // new-thread composer are all pushed straight from home.
     expect(screenDepth("/thread/abc")).toBe(1);
-    expect(screenDepth("/more")).toBe(1);
+    expect(screenDepth("/settings")).toBe(1);
     expect(screenDepth("/new")).toBe(1);
     expect(screenDepth("/desktops")).toBe(1);
-    expect(screenDepth("/more/usage")).toBe(1);
-    expect(screenDepth("/more/projects")).toBe(1);
-    expect(screenDepth("/more/browser")).toBe(1);
+    expect(screenDepth("/usage")).toBe(1);
+    expect(screenDepth("/projects")).toBe(1);
+    expect(screenDepth("/browser")).toBe(1);
+    expect(screenDepth("/ports")).toBe(1);
     // Settings drill-down: device sections come off the Settings page, the
     // desktop-syncing ones off the deeper Desktop Settings list.
-    expect(screenDepth("/more/settings")).toBe(2);
-    expect(screenDepth("/more/settings/appearance")).toBe(2);
-    expect(screenDepth("/more/settings/models")).toBe(3);
-    expect(screenDepth("/more/settings/schedules")).toBe(3);
+    expect(screenDepth("/settings/desktop")).toBe(2);
+    expect(screenDepth("/settings/appearance")).toBe(2);
+    expect(screenDepth("/settings/models")).toBe(3);
+    expect(screenDepth("/settings/schedules")).toBe(3);
     expect(screenDepth("/workspace/t1")).toBe(2);
     expect(screenDepth("/terminal/p1")).toBe(2);
     expect(screenDepth("/pr/42")).toBe(2);
@@ -202,20 +203,20 @@ describe("navigationTransitionType", () => {
   it("pushes when going deeper and pops when coming back", () => {
     expect(navigationTransitionType("/threads", "/thread/abc")).toBe("push");
     expect(navigationTransitionType("/thread/abc", "/threads")).toBe("pop");
-    expect(navigationTransitionType("/threads", "/more")).toBe("push");
-    expect(navigationTransitionType("/more", "/threads")).toBe("pop");
+    expect(navigationTransitionType("/threads", "/settings")).toBe("push");
+    expect(navigationTransitionType("/settings", "/threads")).toBe("pop");
     expect(navigationTransitionType("/threads", "/desktops")).toBe("push");
-    expect(navigationTransitionType("/more", "/more/settings")).toBe("push");
-    expect(navigationTransitionType("/more", "/more/settings/appearance")).toBe("push");
-    expect(navigationTransitionType("/more/settings", "/more/settings/models")).toBe("push");
-    expect(navigationTransitionType("/more/settings/models", "/more/settings")).toBe("pop");
+    expect(navigationTransitionType("/settings", "/settings/desktop")).toBe("push");
+    expect(navigationTransitionType("/settings", "/settings/appearance")).toBe("push");
+    expect(navigationTransitionType("/settings/desktop", "/settings/models")).toBe("push");
+    expect(navigationTransitionType("/settings/models", "/settings/desktop")).toBe("pop");
     expect(navigationTransitionType("/thread/abc", "/workspace/abc")).toBe("push");
     expect(navigationTransitionType("/workspace/abc", "/thread/abc")).toBe("pop");
   });
 
   it("fades between same-depth screens (sibling switches)", () => {
-    expect(navigationTransitionType("/more", "/new")).toBe("fade");
-    expect(navigationTransitionType("/desktops", "/more/usage")).toBe("fade");
+    expect(navigationTransitionType("/settings", "/new")).toBe("fade");
+    expect(navigationTransitionType("/desktops", "/usage")).toBe("fade");
     expect(navigationTransitionType("/pr/42", "/pr/42/changes")).toBe("fade");
   });
 

--- a/src/mobile/navHelpers.ts
+++ b/src/mobile/navHelpers.ts
@@ -113,20 +113,21 @@ export function screenDepth(path: string): number {
   if (isFullscreenScreenPath(path)) return 2;
   // A desktop-syncing section is pushed from the Desktop Settings list (depth
   // 2); a device section is pushed straight from the Settings page (depth 1).
-  const sectionMatch = /^\/more\/settings\/(.+)$/.exec(path);
+  if (path === "/settings/desktop") return 2;
+  const sectionMatch = /^\/settings\/(.+)$/.exec(path);
   if (sectionMatch?.[1]) {
     return isDesktopSettingsSection(decodeURIComponent(sectionMatch[1])) ? 3 : 2;
   }
-  if (path === "/more/settings") return 2;
   // First-level screens pushed from home: quick-menu destinations, the
   // Settings page, a thread, the full new-thread composer.
   if (
-    path === "/more" ||
+    path === "/settings" ||
     path === "/new" ||
     path === "/desktops" ||
-    path === "/more/usage" ||
-    path === "/more/projects" ||
-    path === "/more/browser"
+    path === "/usage" ||
+    path === "/projects" ||
+    path === "/browser" ||
+    path === "/ports"
   ) {
     return 1;
   }

--- a/src/mobile/pairing.test.ts
+++ b/src/mobile/pairing.test.ts
@@ -143,7 +143,7 @@ describe("appUrlWithoutPairing", () => {
       appUrlWithoutPairing(
         locationFromUrl("https://poracode.com/pwa/pair?host=https://desktop.test/#token=pair"),
       ),
-    ).toBe("https://poracode.com/pwa/app");
+    ).toBe("https://poracode.com/pwa");
   });
 });
 

--- a/src/mobile/pairing.ts
+++ b/src/mobile/pairing.ts
@@ -48,11 +48,10 @@ let captured: PairingLaunch | null = null;
 
 /**
  * Snapshot the pairing launch parameters (`?host=…#token=…`) exactly once, at
- * boot, BEFORE the hash-history router initializes. When a credential is
- * present the pairing params are stripped from the URL so the router starts on
- * a clean hash rather than trying to route `#token=…`. Idempotent: later calls
- * return the same snapshot, so the bridge/session read consistent values even
- * after the router takes ownership of the URL hash.
+ * boot, BEFORE the router initializes. When a credential is present the
+ * pairing params are stripped from the address bar. Idempotent: later calls
+ * return the same snapshot, so the bridge/session read consistent values after
+ * the router takes ownership of navigation.
  */
 export function capturePairingLaunch(location: Location = window.location): PairingLaunch {
   if (captured) return captured;
@@ -64,7 +63,9 @@ export function capturePairingLaunch(location: Location = window.location): Pair
       ? safeNormalizePairingEndpoint(host)
       : isNativeApp()
         ? ""
-        : safeNormalizePairingEndpoint(location.origin),
+        : import.meta.env.BASE_URL.startsWith("/") && import.meta.env.BASE_URL !== "/"
+          ? ""
+          : safeNormalizePairingEndpoint(location.origin),
     credential: hash.get("token"),
   };
   if (captured.credential) {
@@ -171,7 +172,8 @@ export function appUrlWithoutPairing(location: Location = window.location): stri
   // server serves it at /app.
   if (!url.pathname.endsWith("/mobile.html")) {
     if (url.pathname.endsWith("/pair")) {
-      url.pathname = `${url.pathname.slice(0, -"/pair".length)}/app`;
+      const prefix = url.pathname.slice(0, -"/pair".length);
+      url.pathname = prefix || "/app";
     } else if (!url.pathname.endsWith("/app")) {
       const basePath = import.meta.env.BASE_URL;
       url.pathname = basePath.startsWith("/") ? `${basePath}app` : "/app";

--- a/src/mobile/routeComponents.test.tsx
+++ b/src/mobile/routeComponents.test.tsx
@@ -7,6 +7,7 @@ import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { clearPairingLaunch, parsePairingLaunch, setPairingLaunch } from "./pairing";
 import {
   DesktopsRoute,
+  SettingsSectionRoute,
   TerminalRoute,
   ThreadRoute,
   ThreadsRoute,
@@ -54,7 +55,7 @@ const fixtures = vi.hoisted(() => {
 
   return {
     project,
-    params: { threadId: routedThread.id, projectId: project.id },
+    params: { threadId: routedThread.id, projectId: project.id, section: "usage" },
     search: {} as {
       worktree?: string;
       action?: string;
@@ -69,7 +70,7 @@ const fixtures = vi.hoisted(() => {
         desktopId: "desktop-1",
         label: "Poracode on Mac",
         scopes: ["projects:manage"],
-      },
+      } as { desktopId: string; label: string; scopes: string[] } | null,
       desktops: [],
       activeDesktopId: "desktop-1",
       projects: [project],
@@ -254,13 +255,24 @@ describe("mobile route components", () => {
 
     expect(screen.queryByTestId("quick-compose")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Add project" }));
-    expect(fixtures.navigate).toHaveBeenCalledWith({ to: "/more/projects" });
+    expect(fixtures.navigate).toHaveBeenCalledWith({ to: "/projects" });
   });
 
   it("renders the home composer only after a connected desktop has projects", () => {
     render(<ThreadsRoute />);
 
     expect(screen.getByTestId("quick-compose")).toBeTruthy();
+  });
+
+  it("redirects stale Usage settings when no desktop is paired", async () => {
+    fixtures.remote.activeDesktop = null;
+    fixtures.params.section = "usage";
+
+    render(<SettingsSectionRoute />);
+
+    await waitFor(() =>
+      expect(fixtures.navigate).toHaveBeenCalledWith({ to: "/settings", replace: true }),
+    );
   });
 
   it("consumes a deep-link pairing credential after a successful pair", async () => {

--- a/src/mobile/routeComponents.tsx
+++ b/src/mobile/routeComponents.tsx
@@ -31,6 +31,7 @@ import {
   subscribePairingLaunch,
 } from "./pairing";
 import { MobileSetupEmptyState, type MobileSetupKind } from "./setupEmptyState";
+import { isDesktopSettingsSection } from "./settingsSections";
 import type { MobileSshPairRequest } from "./views/DesktopsView";
 import { useGitSummaryHydration } from "./useGitSummaryHydration";
 import { useMediaQuery, WIDE_SHELL_QUERY } from "./useMediaQuery";
@@ -68,7 +69,7 @@ const UsagePanel = lazy(() =>
 // Typed route APIs (params/search) — decoupled from the route consts so this
 // file never imports router.tsx (which imports these components).
 const threadRouteApi = getRouteApi("/thread/$threadId");
-const settingsSectionRouteApi = getRouteApi("/more/settings/$section");
+const settingsSectionRouteApi = getRouteApi("/settings/$section");
 const workspaceRouteApi = getRouteApi("/workspace/$threadId");
 const terminalRouteApi = getRouteApi("/terminal/$projectId");
 
@@ -233,7 +234,7 @@ export function ThreadsRoute() {
       <MobileSetupEmptyState
         kind={setupKind}
         onAction={(kind) =>
-          void navigate(kind === "desktop" ? { to: "/desktops" } : { to: "/more/projects" })
+          void navigate(kind === "desktop" ? { to: "/desktops" } : { to: "/projects" })
         }
       />
     );
@@ -345,7 +346,7 @@ export function NewThreadRoute() {
     <NewThreadFlow
       onStarted={(threadId) => void navigate({ to: "/thread/$threadId", params: { threadId } })}
       onSetupAction={(kind) =>
-        void navigate(kind === "desktop" ? { to: "/desktops" } : { to: "/more/projects" })
+        void navigate(kind === "desktop" ? { to: "/desktops" } : { to: "/projects" })
       }
     />
   );
@@ -471,12 +472,14 @@ export function DesktopsRoute() {
 }
 
 export function MoreRoute() {
+  const remote = useRemote();
   const navigate = useNavigate();
   return (
     <MoreView
-      onOpen={() => void navigate({ to: "/more/settings" })}
+      hasDesktop={remote.activeDesktop !== null}
+      onOpen={() => void navigate({ to: "/settings/desktop" })}
       onOpenSettingsSection={(section) =>
-        void navigate({ to: "/more/settings/$section", params: { section } })
+        void navigate({ to: "/settings/$section", params: { section } })
       }
     />
   );
@@ -503,7 +506,7 @@ export function UsageRoute() {
       <div className="m-subscreen">
         <UsagePanel
           onOpenUsageSettings={() =>
-            void navigate({ to: "/more/settings/$section", params: { section: "usage" } })
+            void navigate({ to: "/settings/$section", params: { section: "usage" } })
           }
         />
       </div>
@@ -530,6 +533,15 @@ export function PortsRoute() {
 function SettingsRoute(props: { readonly sectionId: string | null }) {
   const remote = useRemote();
   const navigate = useNavigate();
+  const requiresDesktop = props.sectionId === null || isDesktopSettingsSection(props.sectionId);
+
+  useEffect(() => {
+    if (requiresDesktop && remote.booted && !remote.activeDesktop) {
+      void navigate({ to: "/settings", replace: true });
+    }
+  }, [navigate, remote.activeDesktop, remote.booted, requiresDesktop]);
+
+  if (requiresDesktop && !remote.activeDesktop) return null;
 
   return (
     <LazyRoute>
@@ -540,8 +552,8 @@ function SettingsRoute(props: { readonly sectionId: string | null }) {
         onSectionChange={(section) => {
           void navigate(
             section
-              ? { to: "/more/settings/$section", params: { section } }
-              : { to: "/more/settings" },
+              ? { to: "/settings/$section", params: { section } }
+              : { to: "/settings/desktop" },
           );
         }}
         onThreadAction={(thread, action) => {

--- a/src/mobile/router.tsx
+++ b/src/mobile/router.tsx
@@ -1,12 +1,16 @@
 import {
+  createBrowserHistory,
   createHashHistory,
   createRootRoute,
   createRoute,
+  createRouteMask,
   createRouter,
   Navigate,
   redirect,
 } from "@tanstack/react-router";
 import { capturePairingLaunch } from "./pairing";
+import { isNativeApp } from "./pwaInstall";
+import { migrateLegacyBrowserRoute, mobileRouterBasePath } from "./routing";
 import { isFullscreenScreenPath, navigationTransitionType } from "./navHelpers";
 import { RootLayout } from "./RootLayout";
 import { WIDE_SHELL_QUERY } from "./useMediaQuery";
@@ -32,9 +36,11 @@ import { PrConversationPage } from "./views/pr/PrConversationPage";
 import { PrLayout } from "./views/pr/PrLayout";
 import { PrOverviewPage } from "./views/pr/PrOverviewPage";
 
-// Snapshot + strip the pairing launch params BEFORE hash history reads the URL,
-// so a `#token=…` launch never confuses the router (see pairing.ts).
+// Snapshot pairing credentials before history reads the launch URL, then
+// migrate bookmarks from the former hash/state-backed routers.
 capturePairingLaunch();
+const nativeApp = isNativeApp();
+if (!nativeApp) migrateLegacyBrowserRoute(import.meta.env.BASE_URL);
 
 const rootRoute = createRootRoute({ component: RootLayout });
 
@@ -70,43 +76,43 @@ const desktopsRoute = createRoute({
 
 const moreRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more",
+  path: "/settings",
   component: MoreRoute,
 });
 
 const usageRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/usage",
+  path: "/usage",
   component: UsageRoute,
 });
 
 const browserRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/browser",
+  path: "/browser",
   component: BrowserRoute,
 });
 
 const portsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/ports",
+  path: "/ports",
   component: PortsRoute,
 });
 
 const projectsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/projects",
+  path: "/projects",
   component: ProjectsRoute,
 });
 
 const settingsRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/settings",
+  path: "/settings/desktop",
   component: SettingsListRoute,
 });
 
 const settingsSectionRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/more/settings/$section",
+  path: "/settings/$section",
   component: SettingsSectionRoute,
 });
 
@@ -215,6 +221,8 @@ const routeTree = rootRoute.addChildren([
   prRouteTree,
 ]);
 
+const routeMasks = nativeApp ? [] : [createRouteMask({ routeTree, from: "/desktops", to: "/" })];
+
 // TanStack applies `defaultViewTransition` to EVERY navigation, including native
 // back/edge-swipe (popstate) ones, which iOS already animates interactively.
 // The `types` callback isn't told the history action, so we mirror it here:
@@ -238,7 +246,7 @@ function navigationTransitionTypes(fromPath: string | undefined, toPath: string)
   // Leaving the mirrored browser view via a native edge-swipe/back already plays
   // the OS's own interactive back animation; running our `pop` slide on top of it
   // double-animates. Skip our transition for that specific gesture-driven pop.
-  if (lastNavWasGesture && fromPath === "/more/browser") return false;
+  if (lastNavWasGesture && fromPath === "/browser") return false;
   const type = navigationTransitionType(fromPath, toPath);
   if (!type) return false;
   // Fullscreen overlay screens (workspace / PR / terminal) carry the m-screen
@@ -252,7 +260,11 @@ function navigationTransitionTypes(fromPath: string | undefined, toPath: string)
 
 export const router = createRouter({
   routeTree,
-  history: createHashHistory(),
+  history: nativeApp ? createHashHistory() : createBrowserHistory(),
+  basepath: nativeApp
+    ? "/"
+    : mobileRouterBasePath(window.location.pathname, import.meta.env.BASE_URL),
+  routeMasks,
   defaultPreload: false,
   // Native-app screen transitions on the phone layout (View Transitions API).
   defaultViewTransition: {

--- a/src/mobile/routing.test.ts
+++ b/src/mobile/routing.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { legacyBrowserRouteUrl, mobileRouterBasePath } from "./routing";
+
+describe("mobileRouterBasePath", () => {
+  it("resolves hosted, desktop-served, and development bases", () => {
+    expect(mobileRouterBasePath("/pwa/settings/appearance", "/pwa/")).toBe("/pwa");
+    expect(mobileRouterBasePath("/app/settings/appearance", "/")).toBe("/app");
+    expect(mobileRouterBasePath("/settings/appearance", "/")).toBe("/");
+  });
+});
+
+describe("legacyBrowserRouteUrl", () => {
+  it("keeps the internal Connections landing at the hosted PWA root", () => {
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/desktops", "/pwa/")).toBe(
+      "https://poracode.com/pwa",
+    );
+  });
+
+  it("converts real screens to clean browser paths", () => {
+    expect(
+      legacyBrowserRouteUrl("https://poracode.com/pwa#/more/settings/appearance", "/pwa/"),
+    ).toBe("https://poracode.com/pwa/settings/appearance");
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more", "/pwa/")).toBe(
+      "https://poracode.com/pwa/settings",
+    );
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more/usage", "/pwa/")).toBe(
+      "https://poracode.com/pwa/usage",
+    );
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more/projects", "/pwa/")).toBe(
+      "https://poracode.com/pwa/projects",
+    );
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more/browser", "/pwa/")).toBe(
+      "https://poracode.com/pwa/browser",
+    );
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more/ports", "/pwa/")).toBe(
+      "https://poracode.com/pwa/ports",
+    );
+    expect(legacyBrowserRouteUrl("https://poracode.com/pwa#/more/settings", "/pwa/")).toBe(
+      "https://poracode.com/pwa/settings/desktop",
+    );
+  });
+
+  it("migrates the previous state-backed route at the development root", () => {
+    expect(legacyBrowserRouteUrl("http://localhost:3100/", "/", "/settings/appearance")).toBe(
+      "http://localhost:3100/settings/appearance",
+    );
+  });
+});

--- a/src/mobile/routing.ts
+++ b/src/mobile/routing.ts
@@ -1,0 +1,79 @@
+function trimBasePath(basePath: string): string {
+  if (!basePath.startsWith("/") || basePath === "/") return "/";
+  return basePath.replace(/\/+$/, "");
+}
+
+/** Resolve the browser-history base for hosted, desktop-served, and dev PWAs. */
+export function mobileRouterBasePath(pathname: string, buildBasePath: string): string {
+  const buildBase = trimBasePath(buildBasePath);
+  if (buildBase !== "/" && (pathname === buildBase || pathname.startsWith(`${buildBase}/`))) {
+    return buildBase;
+  }
+  if (pathname === "/app" || pathname.startsWith("/app/")) return "/app";
+  return "/";
+}
+
+function validInternalRoute(value: unknown): string | null {
+  return typeof value === "string" && value.startsWith("/") && !value.startsWith("//")
+    ? value
+    : null;
+}
+
+function publicRoutePath(pathname: string): string {
+  if (pathname === "/desktops") return "/";
+  if (pathname === "/more") return "/settings";
+  if (pathname === "/more/settings") return "/settings/desktop";
+  if (pathname.startsWith("/more/settings/")) {
+    return `/settings/${pathname.slice("/more/settings/".length)}`;
+  }
+  if (
+    pathname === "/more/usage" ||
+    pathname === "/more/projects" ||
+    pathname === "/more/browser" ||
+    pathname === "/more/ports"
+  ) {
+    return pathname.slice("/more".length);
+  }
+  return pathname;
+}
+
+/** Convert a former hash/state route to its browser-history URL. */
+export function legacyBrowserRouteUrl(
+  href: string,
+  buildBasePath: string,
+  storedRoute?: unknown,
+): string | null {
+  const url = new URL(href);
+  const route =
+    (url.hash.startsWith("#/") ? validInternalRoute(url.hash.slice(1)) : null) ??
+    validInternalRoute(storedRoute);
+  if (!route) return null;
+
+  const internal = new URL(route, url.origin);
+  const basePath = mobileRouterBasePath(url.pathname, buildBasePath);
+  const publicPath = publicRoutePath(internal.pathname);
+  url.pathname =
+    basePath === "/" ? publicPath : publicPath === "/" ? basePath : `${basePath}${publicPath}`;
+  url.search = internal.search;
+  url.hash = internal.hash;
+  return url.toString();
+}
+
+/** Migrate hash routes and the short-lived state-backed router without a redirect. */
+export function migrateLegacyBrowserRoute(buildBasePath: string): void {
+  const state = (window.history.state ?? {}) as Record<string, unknown>;
+  const basePath = mobileRouterBasePath(window.location.pathname, buildBasePath);
+  const atEntryPath =
+    window.location.pathname === basePath ||
+    window.location.pathname === "/mobile.html" ||
+    window.location.pathname === "/index.html";
+  const nextUrl = legacyBrowserRouteUrl(
+    window.location.href,
+    buildBasePath,
+    atEntryPath ? state.__poracode_route : undefined,
+  );
+  if (!nextUrl) return;
+  const nextState = { ...state };
+  delete nextState.__poracode_route;
+  window.history.replaceState(nextState, "", nextUrl);
+}

--- a/src/mobile/settingsSectionIds.ts
+++ b/src/mobile/settingsSectionIds.ts
@@ -9,11 +9,11 @@ export const DEVICE_SETTINGS_SECTION_IDS = [
   "notifications",
   "terminal",
   "git",
-  "usage",
 ] as const;
 
 export const DESKTOP_SETTINGS_SECTION_IDS = [
   "profile",
+  "usage",
   "schedules",
   "ai",
   "models",

--- a/src/mobile/settingsSections.ts
+++ b/src/mobile/settingsSections.ts
@@ -43,7 +43,7 @@ export interface MobileSettingsSection {
 /**
  * Split by where a setting lives. "This device" keys persist in this
  * browser's storage and shape the PWA itself (the desktop has its own copies);
- * they're listed flat on the More tab. "Desktop" sections edit the paired
+ * they're listed flat on the Settings page. "Desktop" sections edit the paired
  * desktop — AI helper choices sync over the remote API, thread management
  * round-trips through thread commands, and profile identity/usage stats are
  * read from and written to the desktop's local SQLite store — and live behind
@@ -82,12 +82,6 @@ export const DEVICE_SETTINGS_SECTIONS: readonly MobileSettingsSection[] = [
     hint: msg`Review presentation`,
     icon: GitFork,
   },
-  {
-    id: "usage",
-    label: MOBILE_SETTINGS_SECTION_LABELS.usage,
-    hint: msg`Tracking and display`,
-    icon: Gauge,
-  },
 ];
 
 export const DESKTOP_SETTINGS_SECTIONS: readonly MobileSettingsSection[] = [
@@ -96,6 +90,12 @@ export const DESKTOP_SETTINGS_SECTIONS: readonly MobileSettingsSection[] = [
     label: MOBILE_SETTINGS_SECTION_LABELS.profile,
     hint: msg`Identity and usage stats`,
     icon: CircleUserRound,
+  },
+  {
+    id: "usage",
+    label: MOBILE_SETTINGS_SECTION_LABELS.usage,
+    hint: msg`Tracking and display`,
+    icon: Gauge,
   },
   {
     id: "schedules",

--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -98,7 +98,7 @@ body.bg-background {
 
 .m-shell--wide {
   display: grid;
-  grid-template-columns: clamp(264px, 26vw, 340px) minmax(0, 1fr);
+  grid-template-columns: var(--m-sidebar-width, clamp(248px, 20vw, 304px)) minmax(0, 1fr);
   grid-template-rows: 100%;
 }
 
@@ -275,14 +275,9 @@ body.bg-background {
   margin-right: 0;
 }
 
-.m-brand__title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.m-brand__wordmark {
+  flex-shrink: 0;
   font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
 }
 
 /* Icon-only connection/sync affordance. The state word and pill border are
@@ -624,11 +619,45 @@ body.bg-background {
 /* ── Sidebar + detail (wide layout) ────────────────────────────── */
 
 .m-sidebar {
+  position: relative;
   display: flex;
   min-height: 0;
   flex-direction: column;
   border-right: 1px solid var(--hairline, var(--border));
-  background: var(--sidebar-background, var(--background));
+  background: var(--background, #070709);
+}
+
+.m-sidebar__resize-handle {
+  position: absolute;
+  z-index: 20;
+  top: 0;
+  right: -6px;
+  bottom: 0;
+  display: none;
+  width: 12px;
+  cursor: col-resize;
+  outline: none;
+}
+
+.m-sidebar__resize-handle::after {
+  position: absolute;
+  top: 0;
+  right: 5px;
+  bottom: 0;
+  width: 1px;
+  background: transparent;
+  content: "";
+}
+
+.m-sidebar__resize-handle:hover::after,
+.m-sidebar__resize-handle:focus-visible::after {
+  background: var(--accent);
+}
+
+@media (min-width: 768px) and (hover: hover) and (pointer: fine) {
+  .m-sidebar__resize-handle {
+    display: block;
+  }
 }
 
 .m-sidebar__head {
@@ -638,9 +667,7 @@ body.bg-background {
   padding: calc(0.5rem + env(safe-area-inset-top)) 0.75rem 0.375rem;
 }
 
-.m-sidebar__actions {
-  display: flex;
-  gap: 0.375rem;
+.m-sidebar__primary {
   padding: 0 0.75rem 0.5rem;
 }
 
@@ -653,6 +680,41 @@ body.bg-background {
 .m-sidebar__foot {
   border-top: 1px solid var(--hairline, var(--border));
   padding: 0.375rem;
+}
+
+.m-sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding-bottom: 0.375rem;
+}
+
+.m-sidebar__destination {
+  display: flex;
+  width: 100%;
+  min-height: var(--m-tap-min);
+  align-items: center;
+  gap: 0.625rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0.375rem 0.625rem;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-align: left;
+}
+
+.m-sidebar__destination:not(:disabled):hover,
+.m-sidebar__destination[data-active="true"] {
+  background: var(--row-hover);
+  color: var(--foreground, inherit);
+}
+
+.m-sidebar__destination:disabled {
+  opacity: 0.38;
+  cursor: default;
 }
 
 .m-sidebar__desktops {
@@ -705,6 +767,16 @@ body.bg-background {
 .m-detail > .m-threads,
 .m-detail > .m-page {
   overflow-y: auto;
+}
+
+.m-menu-popover {
+  width: min(18rem, calc(100vw - 1rem));
+  padding: 0.25rem;
+}
+
+.m-menu-popover .m-sheet-list {
+  gap: 0.125rem;
+  padding: 0;
 }
 
 /* ── Threads list (desktop sidebar rows, sans hover actions) ───── */
@@ -2057,6 +2129,11 @@ body.bg-background {
   background: var(--row-hover);
 }
 
+.m-sheet-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .m-sheet-action[data-static="true"] {
   cursor: default;
 }
@@ -2862,6 +2939,88 @@ body.bg-background {
   flex-direction: column;
   gap: 0.75rem;
   overflow-y: auto;
+}
+
+/* Wide touch devices keep drawers, but stop them from stretching across the
+   entire tablet. Mouse/trackpad layouts turn menus into popovers and present
+   the remaining form drawers as compact centered dialogs. */
+@media (min-width: 768px) {
+  .m-sheet,
+  .m-drawer,
+  .m-picker {
+    width: min(calc(100% - 2rem), 42rem);
+    align-self: center;
+    border-right: 1px solid var(--hairline, var(--border));
+    border-left: 1px solid var(--hairline, var(--border));
+  }
+}
+
+@media (min-width: 768px) and (hover: hover) and (pointer: fine) {
+  :root {
+    --m-tap-min: 34px;
+  }
+
+  .m-detail > .m-page {
+    width: min(100%, 72rem);
+    align-self: center;
+  }
+
+  .m-sidebar__head {
+    padding: calc(0.375rem + env(safe-area-inset-top)) 0.625rem 0.25rem;
+  }
+
+  .m-sidebar__primary {
+    padding: 0 0.375rem 0.375rem;
+  }
+
+  .m-sidebar .m-thread-list {
+    gap: 0.125rem;
+    padding-right: 0.375rem;
+    padding-left: 0.375rem;
+  }
+
+  .m-thread-row {
+    min-height: 2.625rem;
+    border-color: transparent;
+    border-radius: 0.5rem;
+    background: transparent;
+    padding: 0.375rem 0.5rem;
+  }
+
+  .m-thread-row:hover,
+  .m-thread-row[data-active="true"] {
+    border-color: transparent;
+    background: var(--row-hover);
+  }
+
+  .m-sheet-backdrop {
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .m-sheet,
+  .m-drawer {
+    width: min(100%, 40rem);
+    height: auto;
+    max-height: min(85dvh, 48rem);
+    border: 1px solid var(--hairline, var(--border));
+    border-radius: 1rem;
+    padding-bottom: 0.875rem;
+  }
+
+  .m-sheet {
+    width: min(100%, 28rem);
+  }
+
+  .m-sheet-grabber {
+    display: none;
+  }
+
+  .m-sheet-action {
+    min-height: 2.375rem;
+    border-radius: 0.5rem;
+  }
 }
 
 @keyframes m-sheet-backdrop-in {

--- a/src/mobile/useMediaQuery.ts
+++ b/src/mobile/useMediaQuery.ts
@@ -6,3 +6,6 @@ export { useMediaQuery } from "@heroui/react";
 /** The PWA switches between phone chrome and the sidebar/desktop layout here;
  * matches the 767px guard in styles.css. */
 export const WIDE_SHELL_QUERY = "(min-width: 768px)";
+
+/** Menus use anchored popovers only when the browser has desktop-like input. */
+export const DESKTOP_POINTER_QUERY = "(min-width: 768px) and (hover: hover) and (pointer: fine)";

--- a/src/mobile/views/DesktopsView.test.tsx
+++ b/src/mobile/views/DesktopsView.test.tsx
@@ -6,6 +6,7 @@ import { DesktopsView, type DesktopsViewProps } from "./DesktopsView";
 import type { StoredDesktop } from "../storage";
 
 const platform = vi.hoisted(() => ({ native: false }));
+const media = { desktopPointer: false };
 
 // The QR scanner touches the camera / a decode lib, and the install button reads
 // PWA install state — neither is exercised here, so stub them out of the tree.
@@ -59,6 +60,17 @@ function renderView(overrides?: Partial<DesktopsViewProps>) {
 describe("DesktopsView", () => {
   beforeEach(() => {
     Element.prototype.getAnimations = () => [];
+    media.desktopPointer = false;
+    window.matchMedia = vi.fn<(query: string) => MediaQueryList>((query) => ({
+      matches: media.desktopPointer && query.includes("pointer: fine"),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => true,
+    }));
   });
 
   afterEach(() => {
@@ -89,6 +101,33 @@ describe("DesktopsView", () => {
     // The brand prefix is stripped from the row title.
     expect(screen.getByText("H1FCM6T4GX")).toBeTruthy();
     expect(screen.queryByText("No connections yet")).toBeNull();
+  });
+
+  it("opens connection actions from a desktop right click", async () => {
+    media.desktopPointer = true;
+    const props = renderView({ desktops: [desktop], activeDesktopId: "d1" });
+    const row = screen.getByText("H1FCM6T4GX").closest("button");
+    expect(row).toBeTruthy();
+    fireEvent.click(row!);
+    expect(props.onSwitch).toHaveBeenCalledWith(desktop);
+    expect(screen.queryByRole("dialog", { name: "H1FCM6T4GX" })).toBeNull();
+    await act(async () => {
+      fireEvent.contextMenu(row!);
+    });
+    expect(screen.getByRole("dialog", { name: "H1FCM6T4GX" })).toBeTruthy();
+  });
+
+  it("offers paired local mode to desktop browsers", async () => {
+    media.desktopPointer = true;
+    const props = renderView();
+    fireEvent.click(screen.getByRole("button", { name: "Pair a connection" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: "Local" }));
+    });
+    expect(props.onEndpointChange).toHaveBeenCalledWith("http://localhost:38987/");
+    expect(
+      screen.getByText(/Open Settings .* Remote Access in Poracode on this computer/),
+    ).toBeTruthy();
   });
 
   it("auto-opens the pairing drawer when a deep-link credential is present", async () => {

--- a/src/mobile/views/DesktopsView.tsx
+++ b/src/mobile/views/DesktopsView.tsx
@@ -22,6 +22,9 @@ import { Fab, EmptyState, FullScreenDrawer, SheetMenu, useSheet } from "../compo
 import { QrScanner } from "../QrScanner";
 import { isNativeApp, isStandaloneDisplay, promptInstall, useCanInstall } from "../pwaInstall";
 import type { StoredDesktop } from "../storage";
+import { DESKTOP_POINTER_QUERY, useMediaQuery } from "../useMediaQuery";
+
+const LOCAL_DESKTOP_ENDPOINT = "http://localhost:38987/";
 
 /** "Add to Home Screen" button — only shown when the browser offers install. */
 function InstallAppButton() {
@@ -416,6 +419,9 @@ function DesktopRow(props: {
 export function DesktopsView(props: DesktopsViewProps) {
   const { t } = useLingui();
   const [scanning, setScanning] = useState(false);
+  const [pairingMethod, setPairingMethod] = useState("pairing-link");
+  const desktopPointer = useMediaQuery(DESKTOP_POINTER_QUERY);
+  const showLocalPairing = desktopPointer && !isNativeApp();
   const { pairing, onScan, showPairingHint } = props;
   // The pairing form now lives in a full-screen drawer opened from the FAB.
   const pairDrawer = useSheet<true>();
@@ -472,7 +478,7 @@ export function DesktopsView(props: DesktopsViewProps) {
         <EmptyState
           icon={<Laptop className="size-5" />}
           title={<Trans>No connections yet</Trans>}
-          hint={<Trans>Tap + to pair directly or connect to a remote machine over SSH.</Trans>}
+          hint={<Trans>Use + to pair directly or connect to a remote machine over SSH.</Trans>}
         />
       )}
 
@@ -486,13 +492,27 @@ export function DesktopsView(props: DesktopsViewProps) {
           closing={pairDrawer.closing}
           onClose={pairDrawer.close}
         >
-          <Tabs defaultSelectedKey="pairing-link" variant="secondary">
+          <Tabs
+            selectedKey={pairingMethod}
+            variant="secondary"
+            onSelectionChange={(key) => {
+              const next = String(key);
+              setPairingMethod(next);
+              if (next === "local") props.onEndpointChange(LOCAL_DESKTOP_ENDPOINT);
+            }}
+          >
             <Tabs.ListContainer>
               <Tabs.List aria-label={t`Connection method`}>
                 <Tabs.Tab id="pairing-link">
                   <Trans>Pairing link</Trans>
                   <Tabs.Indicator />
                 </Tabs.Tab>
+                {showLocalPairing ? (
+                  <Tabs.Tab id="local">
+                    <Trans>Local</Trans>
+                    <Tabs.Indicator />
+                  </Tabs.Tab>
+                ) : null}
                 {isNativeApp() ? (
                   <Tabs.Tab id="ssh">
                     <Trans>SSH</Trans>
@@ -570,6 +590,46 @@ export function DesktopsView(props: DesktopsViewProps) {
                 </Button>
               </div>
             </Tabs.Panel>
+            {showLocalPairing ? (
+              <Tabs.Panel id="local">
+                <div className="m-form">
+                  <p className="m-card__hint">
+                    <Trans>
+                      Open Settings → Remote Access in Poracode on this computer, then paste its
+                      pairing token here.
+                    </Trans>
+                  </p>
+                  <label className="m-field">
+                    <span className="m-field__label">
+                      <Trans>Pairing token</Trans>
+                    </span>
+                    <input
+                      value={props.manualToken}
+                      aria-label={t`Pairing token`}
+                      autoCapitalize="off"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      placeholder="lc_pair_…"
+                      onChange={(event) => props.onTokenChange(event.currentTarget.value)}
+                    />
+                  </label>
+                  <Button
+                    className="m-form__submit text-foreground"
+                    size="sm"
+                    variant="tertiary"
+                    isDisabled={pairing || !props.canPair}
+                    onPress={props.onPair}
+                  >
+                    {pairing ? (
+                      <Loader2 className="size-4 m-spin" />
+                    ) : (
+                      <Laptop className="size-4" />
+                    )}
+                    {pairing ? t`Pairing…` : t`Pair`}
+                  </Button>
+                </div>
+              </Tabs.Panel>
+            ) : null}
             {isNativeApp() ? (
               <Tabs.Panel id="ssh">
                 <SshPairingForm onProbe={props.onProbeSsh} onPair={props.onPairSsh} />

--- a/src/mobile/views/MoreView.test.tsx
+++ b/src/mobile/views/MoreView.test.tsx
@@ -8,11 +8,12 @@ describe("mobile MoreView (Settings page)", () => {
   it("lists device settings sections flat and desktop settings behind a subscreen row", () => {
     const onOpen = vi.fn<() => void>();
     const onOpenSettingsSection = vi.fn<(sectionId: string) => void>();
-    render(<MoreView onOpen={onOpen} onOpenSettingsSection={onOpenSettingsSection} />);
+    render(<MoreView hasDesktop onOpen={onOpen} onOpenSettingsSection={onOpenSettingsSection} />);
 
     // Device sections are flattened into the Settings list.
     fireEvent.click(screen.getByText("Appearance"));
     expect(onOpenSettingsSection).toHaveBeenCalledWith("appearance");
+    expect(screen.queryByText("Usage")).not.toBeInTheDocument();
 
     // Desktop-syncing sections stay behind the Desktop Settings subscreen.
     expect(screen.queryByText("Agents")).not.toBeInTheDocument();
@@ -22,10 +23,20 @@ describe("mobile MoreView (Settings page)", () => {
   });
 
   it("carries no quick-access rows — those live in the home header's menu", () => {
-    render(<MoreView onOpen={() => {}} onOpenSettingsSection={() => {}} />);
+    render(<MoreView hasDesktop onOpen={() => {}} onOpenSettingsSection={() => {}} />);
 
     expect(screen.queryByText("Projects")).not.toBeInTheDocument();
     expect(screen.queryByText("Browser")).not.toBeInTheDocument();
     expect(screen.queryByText("Connections")).not.toBeInTheDocument();
+  });
+
+  it("disables desktop settings until a desktop is paired", () => {
+    const onOpen = vi.fn<() => void>();
+    render(<MoreView hasDesktop={false} onOpen={onOpen} onOpenSettingsSection={() => {}} />);
+
+    const desktopSettings = screen.getByRole("button", { name: /Desktop Settings/ });
+    expect(desktopSettings).toBeDisabled();
+    fireEvent.click(desktopSettings);
+    expect(onOpen).not.toHaveBeenCalled();
   });
 });

--- a/src/mobile/views/MoreView.tsx
+++ b/src/mobile/views/MoreView.tsx
@@ -7,6 +7,7 @@ import { DEVICE_SETTINGS_SECTIONS } from "../settingsSections";
  * entry): this device's settings sections flattened in, with the
  * desktop-syncing sections behind the Desktop Settings subscreen. */
 export function MoreView(props: {
+  readonly hasDesktop: boolean;
   readonly onOpen: () => void;
   readonly onOpenSettingsSection: (sectionId: string) => void;
 }) {
@@ -16,7 +17,7 @@ export function MoreView(props: {
       <div className="m-settings-group">
         <div className="m-settings-group__head">
           <span>
-            <Trans>Stored on this phone; the desktop keeps its own values.</Trans>
+            <Trans>Stored on this device; the desktop keeps its own values.</Trans>
           </span>
         </div>
         <div className="m-more-list">
@@ -33,6 +34,7 @@ export function MoreView(props: {
             icon={<MonitorCog className="size-4" />}
             label={<Trans>Desktop Settings</Trans>}
             hint={<Trans>Schedules, AI, agents, and archived threads on the paired desktop</Trans>}
+            disabled={!props.hasDesktop}
             onPress={props.onOpen}
           />
         </div>

--- a/src/mobile/views/SettingsView.test.tsx
+++ b/src/mobile/views/SettingsView.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { SettingsView } from "./SettingsView";
@@ -25,7 +25,7 @@ describe("mobile SettingsView", () => {
     expect(screen.queryByText("Removal behavior")).not.toBeInTheDocument();
   });
 
-  it("lists only desktop-syncing sections — device sections live on the More tab", () => {
+  it("lists only desktop-syncing sections — device sections live on the Settings page", () => {
     render(
       <SettingsView
         threads={[]}
@@ -40,11 +40,12 @@ describe("mobile SettingsView", () => {
     expect(screen.getByText("Schedules")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
     expect(screen.getByText("Archived Threads")).toBeInTheDocument();
+    expect(screen.getByText("Usage")).toBeInTheDocument();
     expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
     expect(screen.queryByText("Notifications")).not.toBeInTheDocument();
   });
 
-  it("still renders device section pages by id (deep links from the More tab)", () => {
+  it("still renders device section pages by id (deep links from the Settings page)", () => {
     render(
       <SettingsView
         threads={[]}
@@ -75,5 +76,22 @@ describe("mobile SettingsView", () => {
       screen.getByText(/Archived threads are managed from the desktop app/i),
     ).toBeInTheDocument();
     expect(screen.queryByText("No archived threads.")).not.toBeInTheDocument();
+  });
+
+  it("opens Usage settings from Desktop Settings", () => {
+    const onSectionChange = vi.fn<(sectionId: string | null) => void>();
+    render(
+      <SettingsView
+        threads={[]}
+        projects={[]}
+        sectionId={null}
+        onSectionChange={onSectionChange}
+        onThreadAction={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Usage"));
+
+    expect(onSectionChange).toHaveBeenCalledWith("usage");
   });
 });

--- a/src/mobile/views/SettingsView.tsx
+++ b/src/mobile/views/SettingsView.tsx
@@ -89,7 +89,7 @@ function RemoteArchivedThreads(props: SettingsThreadHandlers) {
 
 /** Section pages for every remote-safe section id (the section metadata —
  * labels, hints, icons, device/desktop grouping — lives in settingsSections.ts
- * so the eager More tab can list sections without pulling these parts in). */
+ * so the eager Settings page can list sections without pulling these parts in). */
 const SECTION_RENDERERS: Record<
   MobileSettingsSectionId,
   (handlers: SettingsThreadHandlers) => ReactNode
@@ -107,8 +107,8 @@ const SECTION_RENDERERS: Record<
   archived: (handlers) => <RemoteArchivedThreads {...handlers} />,
 };
 
-/** PWA settings behind the More tab. With no section id this is the Desktop
- * Settings subscreen (device sections are flattened into the More tab itself);
+/** PWA settings. With no section id this is the Desktop Settings subscreen
+ * (device sections are flattened into the Settings page itself);
  * with one, that section renders as its own page behind a back button. */
 export function SettingsView(
   props: SettingsThreadHandlers & {

--- a/src/renderer/components/common/ResponsiveMenuSurface.tsx
+++ b/src/renderer/components/common/ResponsiveMenuSurface.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ComponentProps, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Popover } from "@heroui/react";
+import { Popover, useMediaQuery } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { isRemoteSession } from "@/renderer/bridge";
 import { SheetGrabber, useSheetGrabber } from "@/renderer/components/common/useSheetGrabber";
@@ -16,6 +16,12 @@ type Placement = ComponentProps<typeof Popover.Content>["placement"];
  * still fires under reduced motion, where the animation is disabled.
  */
 const SHEET_EXIT_MS = 200;
+const DESKTOP_POINTER_QUERY = "(min-width: 768px) and (hover: hover) and (pointer: fine)";
+
+function useMobileMenuSurface(): boolean {
+  const desktopPointer = useMediaQuery(DESKTOP_POINTER_QUERY);
+  return isRemoteSession() && !desktopPointer;
+}
 
 /**
  * A composer/menu popover on desktop that becomes a bottom drawer in the mobile
@@ -52,7 +58,7 @@ export function ResponsiveMenuSurface(props: {
   readonly triggerClassName?: string;
 }) {
   const { t } = useLingui();
-  const mobile = isRemoteSession();
+  const mobile = useMobileMenuSurface();
 
   // Keep the drawer mounted through its slide-out. `rendered` stays true for
   // SHEET_EXIT_MS after `isOpen` goes false; `closing` toggles `data-closing`
@@ -172,5 +178,5 @@ export function ResponsiveMenuSurface(props: {
 
 /** Whether composer menus should render as a mobile drawer instead of a popover. */
 export function useResponsiveMenu(): { readonly mobile: boolean } {
-  return { mobile: isRemoteSession() };
+  return { mobile: useMobileMenuSurface() };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Durchsuchen Sie Ihre GitHub-Repositorys oder fügen Sie eine Klon-URL ei
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Laden…"
 msgid "local"
 msgstr "lokal"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Modi"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Mehr"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Öffnen Sie Einstellungen"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Öffne auf diesem Computer in Poracode Einstellungen → Remotezugriff und füge dann hier den Kopplungstoken ein."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Öffne Einstellungen → Remotezugriff in Poracode auf deinem Desktop und scanne dann den QR-Code von hier — oder gib Endpunkt und Kopplungstoken manuell ein."
 
@@ -6551,6 +6556,7 @@ msgstr "Portweiterleitung ist nicht aktiviert"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Ports"
 
@@ -6696,6 +6702,7 @@ msgstr "Projektspezifische Überschreibungen zusätzlich zu den globalen Suchein
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Ändern Sie die Größe von Notizen und Aufgaben"
 msgid "Resize row"
 msgstr "Größe der Zeile ändern"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Größe der Seitenleiste ändern"
@@ -7961,6 +7969,7 @@ msgstr "Tastenkürzel festlegen"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Als Geheimnis speichern (verschlüsselt gespeichert)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Auf diesem Telefon gespeichert; der Desktop behält seine eigenen Werte."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Auf diesem Gerät gespeichert; der Desktop behält seine eigenen Werte."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Auf diesem Telefon gespeichert; der Desktop behält seine eigenen Werte."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Tippen Sie auf +, um auf Ihrem Desktop einen Ordner hinzuzufügen oder ein Repository zu klonen."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Tippen Sie auf +, um direkt zu koppeln oder über SSH eine Verbindung zu einem entfernten Computer herzustellen."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Tippen Sie auf +, um direkt zu koppeln oder über SSH eine Verbindung zu einem entfernten Computer herzustellen."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Nutzungseinstellungen"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Verwendung unbekannt"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Verwende +, um direkt zu koppeln oder dich per SSH mit einem entfernten Computer zu verbinden."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Browse your GitHub repositories or paste a clone URL."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Loading…"
 msgid "local"
 msgstr "local"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "More"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Open Settings"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 
@@ -6551,6 +6556,7 @@ msgstr "Port forwarding isn't enabled"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Ports"
 
@@ -6696,6 +6702,7 @@ msgstr "Project-specific overrides on top of the global search settings."
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Resize notes and to-dos"
 msgid "Resize row"
 msgstr "Resize row"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Resize sidebar"
@@ -7961,6 +7969,7 @@ msgstr "Set shortcut"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Store as secret (encrypted at rest)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Stored on this phone; the desktop keeps its own values."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Stored on this device; the desktop keeps its own values."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Stored on this phone; the desktop keeps its own values."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Tap + to add a folder or clone a repository on your desktop."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Tap + to pair directly or connect to a remote machine over SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Usage settings"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Usage unknown"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Use + to pair directly or connect to a remote machine over SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Explora tus repositorios de GitHub o pega una URL de clonación."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Cargando…"
 msgid "local"
 msgstr "local"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Más"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Abrir ajustes"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Abre Configuración → Acceso remoto en Poracode en este equipo y pega aquí el token de emparejamiento."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Abre Ajustes → Acceso remoto en Poracode en tu escritorio y luego escanea el código QR desde aquí, o introduce el endpoint y el token de emparejamiento manualmente."
 
@@ -6551,6 +6556,7 @@ msgstr "El reenvío de puertos no está habilitado"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Puertos"
 
@@ -6696,6 +6702,7 @@ msgstr "Anulaciones específicas del proyecto sobre los ajustes de búsqueda glo
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Redimensionar notas y tareas pendientes"
 msgid "Resize row"
 msgstr "Redimensionar fila"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
@@ -7961,6 +7969,7 @@ msgstr "Asignar atajo"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Guardar como secreto (cifrado en reposo)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Guardado en este teléfono; el escritorio conserva sus propios valores."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Guardado en este dispositivo; el equipo de escritorio conserva sus propios valores."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Guardado en este teléfono; el escritorio conserva sus propios valores."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Toca + para agregar una carpeta o clonar un repositorio en tu escritorio."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Toca + para emparejar directamente o conectarte a una máquina remota mediante SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Toca + para emparejar directamente o conectarte a una máquina remota mediante SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Ajustes de uso"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Uso desconocido"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Usa + para emparejar directamente o conectarte a un equipo remoto mediante SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Parcourez vos référentiels GitHub ou collez une URL de clonage."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Chargement…"
 msgid "local"
 msgstr "local"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5162,7 +5164,6 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Plus"
@@ -6163,6 +6164,10 @@ msgid "Open Settings"
 msgstr "Ouvrir les paramètres"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Ouvrez Paramètres → Accès à distance dans Poracode sur cet ordinateur, puis collez ici son jeton d’appairage."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Ouvrez Paramètres → Accès distant dans Poracode sur votre ordinateur, puis scannez le code QR depuis ici — ou saisissez le point d'accès et le jeton d'appairage manuellement."
 
@@ -6550,6 +6555,7 @@ msgstr "Le transfert de port n'est pas activé"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Ports"
 
@@ -6695,6 +6701,7 @@ msgstr "Remplacements spécifiques au projet en plus des paramètres de recherch
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7308,6 +7315,7 @@ msgstr "Redimensionner les notes et les tâches"
 msgid "Resize row"
 msgstr "Redimensionner la ligne"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionner la barre latérale"
@@ -7960,6 +7968,7 @@ msgstr "Définir un raccourci"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8582,8 +8591,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Stocker comme secret (chiffré au repos)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Stocké sur ce téléphone ; l'ordinateur conserve ses propres valeurs."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Enregistré sur cet appareil ; l’ordinateur conserve ses propres valeurs."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Stocké sur ce téléphone ; l'ordinateur conserve ses propres valeurs."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8799,8 +8812,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Appuyez sur + pour ajouter un dossier ou cloner un dépôt sur votre bureau."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Touchez + pour jumeler directement ou vous connecter à une machine distante via SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Touchez + pour jumeler directement ou vous connecter à une machine distante via SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9806,6 +9819,10 @@ msgstr "Paramètres d'utilisation"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Utilisation inconnue"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Utilisez + pour effectuer un appairage direct ou vous connecter à une machine distante via SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1356,6 +1356,7 @@ msgstr "GitHub リポジトリを参照するか、クローン URL を貼り付
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4697,6 +4698,7 @@ msgstr "読み込み中…"
 msgid "local"
 msgstr "ローカル"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5161,7 +5163,6 @@ msgid "Modes"
 msgstr "モード"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "多い"
@@ -6162,6 +6163,10 @@ msgid "Open Settings"
 msgstr "設定を開く"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "このコンピューターの Poracode で「設定」→「リモートアクセス」を開き、ペアリングトークンをここに貼り付けます。"
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "デスクトップの Poracode で「設定 → リモートアクセス」を開き、ここから QR コードをスキャンしてください。または、エンドポイントとペアリングトークンを手動で入力します。"
 
@@ -6549,6 +6554,7 @@ msgstr "ポート転送が有効になっていません"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "ポート"
 
@@ -6694,6 +6700,7 @@ msgstr "グローバル検索設定に加えてプロジェクト固有のオー
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7307,6 +7314,7 @@ msgstr "メモと ToDo のサイズを変更する"
 msgid "Resize row"
 msgstr "行のサイズを変更する"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "サイドバーのサイズを変更する"
@@ -7959,6 +7967,7 @@ msgstr "ショートカットを設定"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8581,8 +8590,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "シークレットとして保存（保存時に暗号化）"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "このスマートフォンに保存されます。デスクトップ側は独自の値を保持します。"
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "このデバイスに保存されます。デスクトップ側の値は変更されません。"
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "このスマートフォンに保存されます。デスクトップ側は独自の値を保持します。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8798,8 +8811,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "+ をタップしてデスクトップでフォルダーを追加するか、リポジトリをクローンしてください。"
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "+ をタップして直接ペアリングするか、SSH 経由でリモートマシンに接続します。"
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "+ をタップして直接ペアリングするか、SSH 経由でリモートマシンに接続します。"
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9805,6 +9818,10 @@ msgstr "利用設定"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "使用量不明"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "「+」を使用して直接ペアリングするか、SSH 経由でリモートマシンに接続します。"
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1357,6 +1357,7 @@ msgstr "GitHub 리포지토리를 찾아보거나 복제 URL을 붙여넣으세�
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "로드 중…"
 msgid "local"
 msgstr "로컬"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "모드"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "많음"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "설정 열기"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "이 컴퓨터의 Poracode에서 설정 → 원격 액세스를 연 다음 페어링 토큰을 여기에 붙여넣으세요."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "데스크톱의 Poracode에서 설정 → 원격 액세스를 연 다음 여기에서 QR 코드를 스캔하세요. 또는 엔드포인트와 페어링 토큰을 직접 입력하세요."
 
@@ -6551,6 +6556,7 @@ msgstr "포트 포워딩이 활성화되지 않았습니다"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "포트"
 
@@ -6696,6 +6702,7 @@ msgstr "전역 검색 설정 위에 프로젝트별 재정의가 적용됩니다
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "메모 및 할 일 크기 조정"
 msgid "Resize row"
 msgstr "행 크기 조정"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "사이드바 크기 조정"
@@ -7961,6 +7969,7 @@ msgstr "단축키 설정"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "비밀로 저장 (저장 시 암호화)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "이 휴대폰에 저장됩니다. 데스크톱은 자체 값을 유지합니다."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "이 기기에 저장되며 데스크톱은 자체 값을 유지합니다."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "이 휴대폰에 저장됩니다. 데스크톱은 자체 값을 유지합니다."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "+를 탭하여 데스크톱에서 폴더를 추가하거나 저장소를 복제하세요."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "+를 눌러 직접 페어링하거나 SSH를 통해 원격 컴퓨터에 연결하세요."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "+를 눌러 직접 페어링하거나 SSH를 통해 원격 컴퓨터에 연결하세요."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "사용 설정"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "사용량을 알 수 없음"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "+를 사용해 직접 페어링하거나 SSH를 통해 원격 컴퓨터에 연결하세요."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Przeglądaj swoje repozytoria GitHub lub wklej adres URL do klonowania."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Ładowanie…"
 msgid "local"
 msgstr "lokalny"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Tryby"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Więcej"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Otwórz Ustawienia"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Otwórz Ustawienia → Dostęp zdalny w Poracode na tym komputerze, a następnie wklej tutaj token parowania."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Otwórz Ustawienia → Dostęp zdalny w Poracode na komputerze, a następnie zeskanuj kod QR stąd — albo wprowadź adres i token parowania ręcznie."
 
@@ -6551,6 +6556,7 @@ msgstr "Przekierowywanie portów nie jest włączone"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Porty"
 
@@ -6696,6 +6702,7 @@ msgstr "Zastąpienia specyficzne dla projektu ponad globalnymi ustawieniami wysz
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Zmień rozmiar notatek i zadań"
 msgid "Resize row"
 msgstr "Zmień rozmiar wiersza"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Zmień rozmiar paska bocznego"
@@ -7961,6 +7969,7 @@ msgstr "Ustaw skrót"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Przechowuj jako sekret (szyfrowany w spoczynku)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Przechowywane na tym telefonie; desktop zachowuje własne wartości."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Przechowywane na tym urządzeniu; komputer zachowuje własne wartości."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Przechowywane na tym telefonie; desktop zachowuje własne wartości."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Dotknij +, aby dodać folder lub sklonować repozytorium na komputerze."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Naciśnij +, aby sparować bezpośrednio lub połączyć się ze zdalnym komputerem przez SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Naciśnij +, aby sparować bezpośrednio lub połączyć się ze zdalnym komputerem przez SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Ustawienia wykorzystania"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Nieznane wykorzystanie"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Użyj +, aby sparować bezpośrednio lub połączyć się z maszyną zdalną przez SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Navegue pelos seus repositórios do GitHub ou cole uma URL de clonagem."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Carregando…"
 msgid "local"
 msgstr "local"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Mais"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Abrir configurações"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Abra Configurações → Acesso remoto no Poracode neste computador e cole o token de pareamento aqui."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Abra Configurações → Acesso remoto no Poracode no seu desktop e escaneie o código QR daqui — ou insira o endpoint e o token de pareamento manualmente."
 
@@ -6551,6 +6556,7 @@ msgstr "O encaminhamento de portas não está ativado"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Portas"
 
@@ -6696,6 +6702,7 @@ msgstr "Substituições específicas do projeto nas configurações de pesquisa 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Redimensionar notas e tarefas"
 msgid "Resize row"
 msgstr "Redimensionar linha"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
@@ -7961,6 +7969,7 @@ msgstr "Definir atalho"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Armazenar como segredo (criptografado em repouso)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Armazenado neste telefone; o desktop mantém seus próprios valores."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Armazenado neste dispositivo; o desktop mantém os próprios valores."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Armazenado neste telefone; o desktop mantém seus próprios valores."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Toque em + para adicionar uma pasta ou clonar um repositório no seu desktop."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Toque em + para emparelhar diretamente ou se conectar a uma máquina remota via SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Toque em + para emparelhar diretamente ou se conectar a uma máquina remota via SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Configurações de uso"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Uso desconhecido"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Use + para parear diretamente ou se conectar a uma máquina remota por SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Просмотрите свои репозитории GitHub или в�
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Загрузка…"
 msgid "local"
 msgstr "локальный"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Режимы"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Больше"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Открыть настройки"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Откройте Настройки → Удалённый доступ в Poracode на этом компьютере, затем вставьте сюда токен сопряжения."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Откройте «Настройки → Удалённый доступ» в Poracode на компьютере, затем отсканируйте QR-код отсюда — или введите адрес и код сопряжения вручную."
 
@@ -6551,6 +6556,7 @@ msgstr "Перенаправление портов не включено"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Порты"
 
@@ -6696,6 +6702,7 @@ msgstr "Переопределения для конкретного проек�
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Изменить размер заметок и задач"
 msgid "Resize row"
 msgstr "Изменить размер строки"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Изменить размер боковой панели"
@@ -7961,6 +7969,7 @@ msgstr "Назначить сочетание клавиш"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Хранить как секрет (шифруется при хранении)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Хранится на этом телефоне; на десктопе остаются собственные значения."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Сохраняется на этом устройстве; на компьютере остаются собственные значения."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Хранится на этом телефоне; на десктопе остаются собственные значения."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Нажмите +, чтобы добавить папку или клонировать репозиторий на компьютере."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Нажмите +, чтобы выполнить прямое сопряжение или подключиться к удаленному компьютеру по SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Нажмите +, чтобы выполнить прямое сопряжение или подключиться к удаленному компьютеру по SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Настройки использования"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Использование неизвестно"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Используйте + для прямого сопряжения или подключения к удалённому компьютеру по SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1357,6 +1357,7 @@ msgstr "GitHub depolarınıza göz atın veya bir klon URL'si yapıştırın."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Yükleniyor…"
 msgid "local"
 msgstr "yerel"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Modlar"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Çok"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Ayarları Aç"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Bu bilgisayarda Poracode içinden Ayarlar → Uzaktan Erişim'i açın, ardından eşleştirme belirtecini buraya yapıştırın."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Masaüstündeki Poracode'da Ayarlar → Uzaktan Erişim'i aç, ardından QR kodunu buradan tara — ya da uç noktasını ve eşleştirme jetonunu elle gir."
 
@@ -6551,6 +6556,7 @@ msgstr "Port yönlendirme etkin değil"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Portlar"
 
@@ -6696,6 +6702,7 @@ msgstr "Genel arama ayarlarının yanı sıra projeye özel geçersiz kılmalar.
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Notları ve yapılacak işleri yeniden boyutlandırın"
 msgid "Resize row"
 msgstr "Satırı yeniden boyutlandır"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Kenar çubuğunu yeniden boyutlandır"
@@ -7961,6 +7969,7 @@ msgstr "Kısayol belirle"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Gizli olarak sakla (beklemede şifrelenir)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Bu telefonda saklanır; masaüstü kendi değerlerini korur."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Bu cihazda saklanır; masaüstü kendi değerlerini korur."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Bu telefonda saklanır; masaüstü kendi değerlerini korur."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Masaüstünüzde bir klasör eklemek veya bir depoyu klonlamak için + öğesine dokunun."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Doğrudan eşleştirmek veya SSH üzerinden uzak bir makineye bağlanmak için + simgesine dokunun."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Doğrudan eşleştirmek veya SSH üzerinden uzak bir makineye bağlanmak için + simgesine dokunun."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Kullanım ayarları"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Bilinmeyen kullanım"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Doğrudan eşleştirmek veya SSH üzerinden uzak bir makineye bağlanmak için + düğmesini kullanın."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Перегляньте свої репозиторії GitHub або в�
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Завантаження…"
 msgid "local"
 msgstr "локальний"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Режими"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Більше"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Відкрити налаштування"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Відкрийте Налаштування → Віддалений доступ у Poracode на цьому комп’ютері, а потім вставте сюди токен сполучення."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Відкрийте «Налаштування → Віддалений доступ» у Poracode на комп'ютері, потім відскануйте QR-код звідси — або введіть адресу й код сполучення вручну."
 
@@ -6551,6 +6556,7 @@ msgstr "Переспрямування портів не увімкнено"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Порти"
 
@@ -6696,6 +6702,7 @@ msgstr "Перевизначення для конкретного проєкт�
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Змінити розмір нотаток і завдань"
 msgid "Resize row"
 msgstr "Змінити розмір рядка"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Змінити розмір бічної панелі"
@@ -7961,6 +7969,7 @@ msgstr "Призначити комбінацію клавіш"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Зберігати як секрет (зашифровано на диску)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Збережено на цьому телефоні; десктоп зберігає власні значення."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Зберігається на цьому пристрої; на комп’ютері залишаються власні значення."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Збережено на цьому телефоні; десктоп зберігає власні значення."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Натисніть +, щоб додати папку або клонувати репозиторій на вашому робочому столі."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Натисніть +, щоб створити пару напряму або підключитися до віддаленого комп’ютера через SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Натисніть +, щоб створити пару напряму або підключитися до віддаленого комп’ютера через SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Налаштування використання"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Використання невідоме"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Скористайтеся +, щоб створити пару безпосередньо або підключитися до віддаленого комп’ютера через SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1357,6 +1357,7 @@ msgstr "Duyệt qua kho GitHub của bạn hoặc dán URL nhân bản."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "Đang tải…"
 msgid "local"
 msgstr "cục bộ"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5163,7 +5165,6 @@ msgid "Modes"
 msgstr "Chế độ"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Nhiều"
@@ -6164,6 +6165,10 @@ msgid "Open Settings"
 msgstr "Mở Cài đặt"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "Mở Cài đặt → Truy cập từ xa trong Poracode trên máy tính này, rồi dán mã ghép nối vào đây."
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "Mở Cài đặt → Truy cập từ xa trong Poracode trên máy tính của bạn, rồi quét mã QR từ đây — hoặc nhập endpoint và mã ghép nối theo cách thủ công."
 
@@ -6551,6 +6556,7 @@ msgstr "Chưa bật chuyển tiếp cổng"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "Cổng"
 
@@ -6696,6 +6702,7 @@ msgstr "Ghi đè dành riêng cho dự án ở đầu cài đặt tìm kiếm ch
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7309,6 +7316,7 @@ msgstr "Thay đổi kích thước ghi chú và việc cần làm"
 msgid "Resize row"
 msgstr "Thay đổi kích thước hàng"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "Thay đổi kích thước thanh bên"
@@ -7961,6 +7969,7 @@ msgstr "Đặt phím tắt"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8583,8 +8592,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "Lưu dưới dạng bí mật (mã hóa khi lưu trữ)"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "Được lưu trên điện thoại này; desktop giữ các giá trị riêng."
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "Được lưu trên thiết bị này; máy tính để bàn giữ các giá trị riêng."
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "Được lưu trên điện thoại này; desktop giữ các giá trị riêng."
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8800,8 +8813,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "Nhấn + để thêm một thư mục hoặc sao chép một kho lưu trữ trên máy tính của bạn."
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "Nhấn + để ghép đôi trực tiếp hoặc kết nối với máy từ xa qua SSH."
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "Nhấn + để ghép đôi trực tiếp hoặc kết nối với máy từ xa qua SSH."
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9807,6 +9820,10 @@ msgstr "Cài đặt sử dụng"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "Không rõ mức sử dụng"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "Dùng + để ghép nối trực tiếp hoặc kết nối với máy từ xa qua SSH."
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1357,6 +1357,7 @@ msgstr "浏览您的 GitHub 存储库或粘贴克隆 URL。"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
@@ -4698,6 +4699,7 @@ msgstr "加载中..."
 msgid "local"
 msgstr "本地"
 
+#: src/mobile/views/DesktopsView.tsx
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
 #: src/renderer/views/ProfileOverlay/parts/ProfileHeader.tsx
 msgid "Local"
@@ -5162,7 +5164,6 @@ msgid "Modes"
 msgstr "模式"
 
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/WideShell.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "多"
@@ -6163,6 +6164,10 @@ msgid "Open Settings"
 msgstr "打开设置"
 
 #: src/mobile/views/DesktopsView.tsx
+msgid "Open Settings → Remote Access in Poracode on this computer, then paste its pairing token here."
+msgstr "在此计算机上的 Poracode 中打开“设置”→“远程访问”，然后将配对令牌粘贴到此处。"
+
+#: src/mobile/views/DesktopsView.tsx
 msgid "Open Settings → Remote Access in Poracode on your desktop, then scan the QR code from here — or enter the endpoint and pairing token manually."
 msgstr "在桌面端的 Poracode 中打开“设置 → 远程访问”，然后从这里扫描二维码——或手动输入端点和配对令牌。"
 
@@ -6550,6 +6555,7 @@ msgstr "未启用端口转发"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/PortsView.tsx
+#: src/mobile/WideShell.tsx
 msgid "Ports"
 msgstr "端口"
 
@@ -6695,6 +6701,7 @@ msgstr "在全局搜索设置基础上的项目特定覆盖。"
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Projects"
@@ -7308,6 +7315,7 @@ msgstr "调整笔记和待办事项的大小"
 msgid "Resize row"
 msgstr "调整行大小"
 
+#: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
 msgid "Resize sidebar"
 msgstr "调整侧边栏大小"
@@ -7960,6 +7968,7 @@ msgstr "设置快捷键"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
+#: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -8582,8 +8591,12 @@ msgid "Store as secret (encrypted at rest)"
 msgstr "以密文存储（静态加密）"
 
 #: src/mobile/views/MoreView.tsx
-msgid "Stored on this phone; the desktop keeps its own values."
-msgstr "存储在这部手机上；桌面保留自己的值。"
+msgid "Stored on this device; the desktop keeps its own values."
+msgstr "存储在此设备上；桌面端保留自己的设置值。"
+
+#: src/mobile/views/MoreView.tsx
+#~ msgid "Stored on this phone; the desktop keeps its own values."
+#~ msgstr "存储在这部手机上；桌面保留自己的值。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
@@ -8799,8 +8812,8 @@ msgid "Tap + to add a folder or clone a repository on your desktop."
 msgstr "点击 + 在桌面端添加文件夹或克隆存储库。"
 
 #: src/mobile/views/DesktopsView.tsx
-msgid "Tap + to pair directly or connect to a remote machine over SSH."
-msgstr "点按 + 直接配对或通过 SSH 连接到远程计算机。"
+#~ msgid "Tap + to pair directly or connect to a remote machine over SSH."
+#~ msgstr "点按 + 直接配对或通过 SSH 连接到远程计算机。"
 
 #: src/mobile/views/DesktopsView.tsx
 #~ msgid "Tap + to pair with Poracode on your desktop."
@@ -9806,6 +9819,10 @@ msgstr "使用设置"
 #: src/renderer/components/thread/ThreadContextDock.tsx
 msgid "Usage unknown"
 msgstr "用量未知"
+
+#: src/mobile/views/DesktopsView.tsx
+msgid "Use + to pair directly or connect to a remote machine over SSH."
+msgstr "使用 + 直接配对，或通过 SSH 连接到远程计算机。"
 
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectMenu.tsx
 msgid "Use an existing folder"

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,8 @@
     { "source": "/pair", "destination": "/pwa/mobile.html" },
     { "source": "/pwa", "destination": "/pwa/mobile.html" },
     { "source": "/pwa/app", "destination": "/pwa/mobile.html" },
-    { "source": "/pwa/pair", "destination": "/pwa/mobile.html" }
+    { "source": "/pwa/pair", "destination": "/pwa/mobile.html" },
+    { "source": "/pwa/:path*", "destination": "/pwa/mobile.html" }
   ],
   "headers": [
     {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -204,7 +204,14 @@ function mobileDevIndex(): Plugin {
 
       server.middlewares.use((req, _res, next) => {
         const [pathname, query] = (req.url ?? "").split("?", 2);
-        if (pathname === "/" || pathname === "/index.html") {
+        const acceptsHtml = req.headers.accept?.includes("text/html") ?? false;
+        const isClientRoute =
+          pathname === "/" ||
+          pathname === "/index.html" ||
+          (acceptsHtml &&
+            pathname !== "/mobile.html" &&
+            !pathname?.split("/").at(-1)?.includes("."));
+        if (isClientRoute) {
           req.url = `/mobile.html${query ? `?${query}` : ""}`;
         }
         next();


### PR DESCRIPTION
- Feature: add a responsive wide-screen PWA shell with desktop navigation, menus, and adjustable sidebar behavior.
- Support browser-history routes for hosted, desktop-served, and development mobile apps, including deep-link fallbacks.
- Reorganize mobile settings and usage navigation around dedicated routes and paired desktop availability.
- Localize the expanded navigation UI and cover routing, responsive layout, settings, pairing, and remote-server behavior with tests.