### PR TITLE
fix(i18n): correct WorktreeModeSelect label and sync locale catalogs

### DIFF
--- a/src/renderer/components/thread/WorktreeModeSelect.tsx
+++ b/src/renderer/components/thread/WorktreeModeSelect.tsx
@@ -34,7 +34,7 @@ export function WorktreeModeSelect(props: {
   const options: WorktreeModeOption[] = [
     {
       id: "none",
-      label: t`No worktree`,
+      label: t`Branch`,
       description: t`Work in the current checkout`,
       icon: GitBranch,
     },

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Lesezeichen"
 msgid "Bottom"
 msgstr "Unten"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Branch"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "Der Zweig „{branch}“ enthält nicht festgeschriebene Änderungen in „{path}“ – schreiben Sie sie fest oder speichern Sie sie vor dem Zusammenführen"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Keine Fenster gemeldet"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Kein Arbeitsbaum"
+#~ msgid "No worktree"
+#~ msgstr "Kein Arbeitsbaum"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Bookmarks"
 msgid "Bottom"
 msgstr "Bottom"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Branch"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "No windows reported"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "No worktree"
+#~ msgid "No worktree"
+#~ msgstr "No worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Marcadores"
 msgid "Bottom"
 msgstr "Abajo"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Rama"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "La rama '{branch}' tiene cambios sin confirmar en '{path}' — confírmalos o guárdalos en stash antes de fusionar"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "No se informaron ventanas"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Sin worktree"
+#~ msgid "No worktree"
+#~ msgstr "Sin worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Favoris"
 msgid "Bottom"
 msgstr "En bas"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Branche"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "La branche '{branch}' a des modifications non validées dans '{path}' - validez-les ou cachez-les avant de les fusionner"
@@ -5832,8 +5836,8 @@ msgid "No windows reported"
 msgstr "Aucune fenêtre signalée"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Aucun arbre de travail"
+#~ msgid "No worktree"
+#~ msgstr "Aucun arbre de travail"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1312,6 +1312,10 @@ msgstr "ブックマーク"
 msgid "Bottom"
 msgstr "下"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "ブランチ"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "ブランチ「{branch}」には「{path}」にコミットされていない変更があります — マージする前にコミットまたはスタッシュしてください"
@@ -5831,8 +5835,8 @@ msgid "No windows reported"
 msgstr "ウィンドウは報告されませんでした"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "ワークツリーなし"
+#~ msgid "No worktree"
+#~ msgstr "ワークツリーなし"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1313,6 +1313,10 @@ msgstr "북마크"
 msgid "Bottom"
 msgstr "아래쪽"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "브랜치"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "'{branch}' 브랜치에는 '{path}'에 커밋되지 않은 변경 사항이 있습니다. 병합하기 전에 커밋하거나 스태시하세요."
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "보고된 창 없음"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "작업 트리 없음"
+#~ msgid "No worktree"
+#~ msgstr "작업 트리 없음"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Zakładki"
 msgid "Bottom"
 msgstr "Dół"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Gałąź"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "Gałąź „{branch}” zawiera niezatwierdzone zmiany w „{path}” — zatwierdź je lub ukryj (stash) przed scaleniem"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Nie zgłoszono żadnych okien"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Brak drzewa roboczego"
+#~ msgid "No worktree"
+#~ msgstr "Brak drzewa roboczego"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Favoritos"
 msgid "Bottom"
 msgstr "Inferior"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Branch"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "Branch '{branch}' tem alterações não confirmadas em '{path}' - confirme ou guarde-as antes de mesclar"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Nenhuma janela relatada"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Sem árvore de trabalho"
+#~ msgid "No worktree"
+#~ msgstr "Sem árvore de trabalho"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Закладки"
 msgid "Bottom"
 msgstr "Снизу"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Ветка"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "В ветке '{branch}' есть незакоммиченные изменения в '{path}' — закоммитьте их или поместите в stash перед слиянием"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Окна не сообщены"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Нет worktree"
+#~ msgid "No worktree"
+#~ msgstr "Нет worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Yer imleri"
 msgid "Bottom"
 msgstr "Alt"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Şube"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "'{branch}' şubesinde '{path}'de kaydedilmemiş değişiklikler var — birleştirmeden önce bunları kaydedin veya saklayın"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Hiçbir pencere bildirilmedi"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Çalışma ağacı yok"
+#~ msgid "No worktree"
+#~ msgstr "Çalışma ağacı yok"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Закладки"
 msgid "Bottom"
 msgstr "Знизу"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Гілка"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "У гілці '{branch}' є незакомічені зміни в '{path}' — закомітьте їх або помістіть у stash перед злиттям"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Вікна не повідомлені"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Немає worktree"
+#~ msgid "No worktree"
+#~ msgstr "Немає worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1313,6 +1313,10 @@ msgstr "Dấu trang"
 msgid "Bottom"
 msgstr "Dưới cùng"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "Nhánh"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "Nhánh '{branch}' có những thay đổi chưa được cam kết trong '{path}' — cam kết hoặc lưu trữ chúng trước khi hợp nhất"
@@ -5833,8 +5837,8 @@ msgid "No windows reported"
 msgstr "Không có cửa sổ nào được báo cáo"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "Không có worktree"
+#~ msgid "No worktree"
+#~ msgstr "Không có worktree"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1313,6 +1313,10 @@ msgstr "书签"
 msgid "Bottom"
 msgstr "底部"
 
+#: src/renderer/components/thread/WorktreeModeSelect.tsx
+msgid "Branch"
+msgstr "分支"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Branch '{branch}' has uncommitted changes in '{path}' — commit or stash them before merging"
 msgstr "分支“{branch}”在“{path}”中有未提交的更改 - 在合并之前提交或隐藏它们"
@@ -5832,8 +5836,8 @@ msgid "No windows reported"
 msgstr "没有报告窗口"
 
 #: src/renderer/components/thread/WorktreeModeSelect.tsx
-msgid "No worktree"
-msgstr "无工作树"
+#~ msgid "No worktree"
+#~ msgstr "无工作树"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewPanel.tsx
 msgid "No wrap"


### PR DESCRIPTION
- Fixed an incorrect/mistranslated label string in `WorktreeModeSelect.tsx`
- Re-ran i18n extraction to sync all 12 non-English locale catalogs with the corrected source string
- Ensures no locale ships an outdated or English-fallback translation for this label