### PR TITLE
fix(renderer): prevent stale glyph ghosting in thinking-text shimmer

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemAccordion.tsx
@@ -1,5 +1,6 @@
 import { Disclosure, Tooltip } from "@heroui/react";
 import { useRef, useState, type ReactNode } from "react";
+import { useShimmerRef } from "@/renderer/thinkingAnimator";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatFilePath } from "./ChatFilePath";
 import {
@@ -30,6 +31,15 @@ export interface ChatItemAccordionProps {
   rightLabel?: ReactNode;
   /** Tailwind class applied to `rightLabel` (e.g. `"text-danger"`). */
   rightLabelClassName?: string;
+  /**
+   * While true the stable part of the title shimmers (the `titleParts.prefix`,
+   * or the whole title when it is a plain string) — the same treatment as
+   * grouped tool rows, replacing any spinner. Only stable text may shimmer:
+   * mutating text under `background-clip: text` ghosts old glyphs (see
+   * `.poracode-thinking-text` in styles.css). ReactNode titles are the
+   * caller's responsibility.
+   */
+  isRunning?: boolean;
   /** When false the row renders without a trigger / chevron (no body to toggle). */
   hasBody?: boolean;
   /** Controlled expand state. Required when `hasBody`. */
@@ -74,6 +84,7 @@ export function ChatItemAccordion({
   titleParts,
   rightLabel,
   rightLabelClassName = "!text-[color:var(--muted)]",
+  isRunning = false,
   hasBody = true,
   isExpanded,
   onExpandedChange,
@@ -90,6 +101,12 @@ export function ChatItemAccordion({
         : undefined;
   const codeRef = useRef<HTMLElement | null>(null);
   const pathRef = useRef<HTMLSpanElement | null>(null);
+  const prefixRef = useRef<HTMLSpanElement | null>(null);
+  // Shimmer target: the prefix span when the title is structured, otherwise the
+  // whole <code> — but only when it is a plain string (stable text).
+  const shimmerPlainTitle = isRunning && !titleParts && typeof displayTitle === "string";
+  useShimmerRef(prefixRef, isRunning && !!titleParts);
+  useShimmerRef(codeRef, shimmerPlainTitle);
   const [isOverflowing, setIsOverflowing] = useState(false);
 
   // PathDisplay handles its own truncation (basename always visible, head-
@@ -110,7 +127,13 @@ export function ChatItemAccordion({
 
   const titleContent = titleParts ? (
     <code className={`${codeClass} flex items-baseline overflow-hidden`}>
-      <span className="shrink-0 whitespace-pre">{displayPrefix}</span>
+      <span
+        ref={prefixRef}
+        className={`shrink-0 whitespace-pre ${isRunning ? "poracode-thinking-text" : ""}`}
+        {...(isRunning ? { "data-poracode-shimmer-text": displayPrefix } : {})}
+      >
+        {displayPrefix}
+      </span>
       {titleParts.filePath ? (
         <ChatFilePath
           className="flex-1"
@@ -125,7 +148,11 @@ export function ChatItemAccordion({
       )}
     </code>
   ) : (
-    <code ref={codeRef} className={codeClass}>
+    <code
+      ref={codeRef}
+      className={`${codeClass} ${shimmerPlainTitle ? "poracode-thinking-text !block" : ""}`}
+      {...(shimmerPlainTitle ? { "data-poracode-shimmer-text": displayTitle as string } : {})}
+    >
       {displayTitle}
     </code>
   );

--- a/src/renderer/components/thread/ChatPane/parts/items/CommandExecution.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/CommandExecution.tsx
@@ -11,7 +11,6 @@ import {
 } from "lucide-react";
 import type { CommandExecutionPayload } from "@/shared/contracts";
 import { stripAnsiPreservingLayout } from "@/shared/ansi";
-import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
@@ -59,6 +58,7 @@ export const CommandExecution = memo(function CommandExecution({ item }: Command
       icon={<Icon className="size-3" />}
       title={display.title}
       {...(display.parts ? { titleParts: display.parts } : {})}
+      isRunning={isRunning}
       rightLabel={status.rightLabel}
       rightLabelClassName={status.textClass}
       isExpanded={isExpanded}
@@ -97,11 +97,10 @@ function resolveCommandStatus(
   durationMs: number | undefined,
   isPayloadError = false,
 ): CommandStatus {
+  // Running state is signalled by the shimmering title (ChatItemAccordion's
+  // `isRunning`), matching grouped tool rows — no spinner on the right.
   if (isRunning) {
-    return {
-      textClass: "!text-[color:var(--muted)]",
-      rightLabel: <PixelLoader size="xxs" className="text-[color:var(--muted)]" />,
-    };
+    return { textClass: "!text-[color:var(--muted)]", rightLabel: null };
   }
   const dur = durationMs != null ? formatDuration(durationMs) : "";
   if (!isPayloadError && (exitCode === undefined || exitCode === 0)) {

--- a/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/FileChange.tsx
@@ -8,6 +8,7 @@ import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
+import { useShimmer } from "@/renderer/thinkingAnimator";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatFilePath } from "./ChatFilePath";
 import { ChatItemAccordion } from "./ChatItemAccordion";
@@ -40,6 +41,11 @@ export const FileChange = memo(function FileChange({ item }: FileChangeProps) {
   const hasStream = !!stream && stream.length > 0;
   const header = payload ? getFileChangeCollapsedHeader(item, payload) : null;
   const paneActions = useChatPaneActions();
+  const isRunning = item.state !== "completed";
+  // The title is a custom node, so shimmer the stable kind label ("Edit",
+  // "Create") here — never the path, which can change while running (see
+  // .poracode-thinking-text in styles.css). Matches grouped tool rows.
+  const kindLabelRef = useShimmer<HTMLSpanElement>(isRunning);
 
   // Some SDKs (e.g. Claude `Write`) don't surface the new file contents on
   // `args.content`; fall back to an on-demand disk read when expanded.
@@ -81,7 +87,19 @@ export const FileChange = memo(function FileChange({ item }: FileChangeProps) {
   const right = formatRightLabel(header.payloadStatus, header.diffSummary, t);
   const titleNode = (
     <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
-      <span className="shrink-0 !text-[color:var(--muted)]">
+      <span
+        ref={kindLabelRef}
+        className={`shrink-0 !text-[color:var(--muted)] ${isRunning ? "poracode-thinking-text" : ""}`}
+        {...(isRunning
+          ? {
+              "data-poracode-shimmer-text": localizeKindLabel(
+                header.changeKind,
+                header.withPath,
+                t,
+              ),
+            }
+          : {})}
+      >
         {localizeKindLabel(header.changeKind, header.withPath, t)}
       </span>
       {header.withPath ? <ChatRowMetaSeparator /> : null}

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
@@ -120,12 +120,17 @@ export const SubAgentToolCall = memo(function SubAgentToolCall({
           <Icon className="size-3" />
         </span>
         {display.parts ? (
-          <code
-            ref={titleRef}
-            className={`flex min-w-0 items-baseline overflow-hidden font-mono text-[color:var(--muted)] ${isRunning ? "poracode-thinking-text !flex" : ""}`}
-            {...(isRunning ? { "data-poracode-shimmer-text": displayTitle } : {})}
-          >
-            <span className="shrink-0 whitespace-pre">{displayPrefix}</span>
+          // Shimmer only the stable prefix — the path segment can change while
+          // running, and mutating text under `background-clip: text` ghosts old
+          // glyphs (see .poracode-thinking-text in styles.css).
+          <code className="flex min-w-0 items-baseline overflow-hidden font-mono text-[color:var(--muted)]">
+            <span
+              ref={titleRef}
+              className={`shrink-0 whitespace-pre ${isRunning ? "poracode-thinking-text" : ""}`}
+              {...(isRunning ? { "data-poracode-shimmer-text": displayPrefix } : {})}
+            >
+              {displayPrefix}
+            </span>
             {display.parts.filePath ? (
               <ChatFilePath
                 className="flex-1"

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCall.tsx
@@ -4,7 +4,6 @@ import { useLingui } from "@lingui/react/macro";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { CircleAlert } from "lucide-react";
 import type { ToolCallPayload } from "@/shared/contracts";
-import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { ChatItemAccordion } from "./ChatItemAccordion";
@@ -78,13 +77,15 @@ export const ToolCall = memo(function ToolCall({ item }: ToolCallProps) {
     header.hasAuxDetails || fetchTarget !== null || header.hasDiffText || header.hasReadResult;
   const display = header.display;
   const Icon = display.Icon;
-  const status = resolveToolStatus(item, header.payloadStatus, header.diffSummary, t);
+  const isRunning = item.state !== "completed" || header.payloadStatus === "running";
+  const status = resolveToolStatus(isRunning, header.payloadStatus, header.diffSummary, t);
 
   return (
     <ChatItemAccordion
       icon={<Icon className="size-3" />}
       title={display.title}
       {...(display.parts ? { titleParts: display.parts } : {})}
+      isRunning={isRunning}
       rightLabel={status.rightLabel}
       rightLabelClassName={status.rightLabelClassName}
       hasBody={hasDetails}
@@ -121,17 +122,15 @@ interface ToolStatusDisplay {
 }
 
 function resolveToolStatus(
-  item: RuntimeChatItem,
+  isRunning: boolean,
   payloadStatus: ToolCallPayload["status"] | undefined,
   diffSummary: DiffSummary | undefined,
   t: TranslateFn,
 ): ToolStatusDisplay {
-  const isRunning = item.state !== "completed" || payloadStatus === "running";
+  // Running state is signalled by the shimmering title (ChatItemAccordion's
+  // `isRunning`), matching grouped tool rows — no spinner on the right.
   if (isRunning) {
-    return {
-      rightLabel: <PixelLoader size="xxs" className="text-[color:var(--muted)]" />,
-      rightLabelClassName: "!text-[color:var(--muted)]",
-    };
+    return { rightLabel: null, rightLabelClassName: "!text-[color:var(--muted)]" };
   }
   if (payloadStatus === "error") {
     return {

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -487,12 +487,13 @@ describe("ToolCallGroup", () => {
       items.map((item) => item.id),
     );
 
-    const animatedTitles = Array.from(
-      view.container.querySelectorAll("code.poracode-thinking-text"),
-    );
+    // Rows with structured titles shimmer only the stable prefix (a <span>);
+    // plain titles shimmer the whole <code>. The path segment must never be
+    // part of the shimmer — mutating text under background-clip:text ghosts.
+    const animatedTitles = Array.from(view.container.querySelectorAll(".poracode-thinking-text"));
     expect(animatedTitles).toHaveLength(4);
     expect(animatedTitles.map((title) => title.getAttribute("data-poracode-shimmer-text"))).toEqual(
-      ["Read file", "Check · pnpm run test", "Edit · src/foo.ts", "Poracode"],
+      ["Read file", "Check · pnpm run test", "Edit · ", "Poracode"],
     );
     expect(screen.queryByText("Working")).not.toBeInTheDocument();
     expect(view.container.querySelector(".poracode-pixel-loader")).toBeNull();

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -411,13 +411,19 @@ function InlineRowTitle({
   const displayPrefix = titleParts ? normalizeCallTitleSeparator(titleParts.prefix) : undefined;
   const shimmerData = isRunning ? { "data-poracode-shimmer-text": displayTitle } : {};
   if (titleParts) {
+    // Shimmer only the stable prefix ("Edit · "), never the path: the path can
+    // change while running (absolute → project-relative), and mutating text
+    // under `background-clip: text` leaves ghosted glyphs (see
+    // .poracode-thinking-text in styles.css).
     return (
-      <code
-        ref={shimmerRef}
-        className={`flex min-w-0 items-baseline overflow-hidden font-mono !text-[color:var(--muted)] ${isRunning ? "poracode-thinking-text !flex" : ""}`}
-        {...shimmerData}
-      >
-        <span className="shrink-0 whitespace-pre">{displayPrefix}</span>
+      <code className="flex min-w-0 items-baseline overflow-hidden font-mono !text-[color:var(--muted)]">
+        <span
+          ref={shimmerRef}
+          className={`shrink-0 whitespace-pre ${isRunning ? "poracode-thinking-text" : ""}`}
+          {...(isRunning ? { "data-poracode-shimmer-text": displayPrefix } : {})}
+        >
+          {displayPrefix}
+        </span>
         {titleParts.filePath ? (
           <>
             <span className="sr-only">{titleParts.path}</span>

--- a/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
@@ -40,6 +40,7 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
     <ChatItemAccordion
       icon={<Globe className="size-3" />}
       title={title}
+      isRunning={item.state !== "completed"}
       rightLabel={right}
       hasBody={hasDetails}
       isExpanded={isExpanded}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1849,13 +1849,20 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
    repaints AND recalcs style every display refresh (~120fps). Instead the sweep
    is driven from a shared 20fps timer (thinkingAnimator.ts) that writes
    `background-position-x` only ~20×/s, letting the frame pipeline idle between
-   ticks. `contain: paint` keeps each repaint scoped to the label box; the
-   `background-position: 0% 0` below is the static fallback before the timer
-   runs. */
+   ticks. The `background-position: 0% 0` below is the static fallback before
+   the timer runs. */
 .poracode-thinking-text {
   position: relative;
   display: inline-block;
-  contain: paint;
+  /* No `contain: paint` here, and `will-change` promotes the label to its own
+     composited layer: with `background-clip: text` the glyphs are painted as a
+     cached text mask, and combining that with paint containment + the
+     animator's out-of-band background-position writes let Chromium skip
+     invalidating the old mask when the label's text changed mid-shimmer —
+     leaving the previous title ghosted under the new one (overlapping-text
+     corruption in tool-call rows). An isolated layer is fully re-rastered on
+     each tick, so stale glyphs cannot survive in the parent layer's tiles. */
+  will-change: background-position;
   background-image: linear-gradient(
     90deg,
     var(--muted) 0%,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1849,19 +1849,23 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
    repaints AND recalcs style every display refresh (~120fps). Instead the sweep
    is driven from a shared 20fps timer (thinkingAnimator.ts) that writes
    `background-position-x` only ~20×/s, letting the frame pipeline idle between
-   ticks. The `background-position: 0% 0` below is the static fallback before
-   the timer runs. */
+   ticks. `contain: paint` keeps each repaint scoped to the label box; the
+   `background-position: 0% 0` below is the static fallback before the timer
+   runs.
+
+   IMPORTANT: only apply this class to text that is STABLE while shimmering.
+   `background-clip: text` paints the glyphs as a cached text mask, and if the
+   text changes mid-shimmer Chromium can skip invalidating the old mask —
+   leaving the previous string ghosted under the new one (overlapping-text
+   corruption seen in tool-call rows whose file path swapped absolute →
+   project-relative). Tool rows therefore shimmer only their stable prefix
+   ("Edit · "), never the path. `will-change` additionally isolates the label
+   on its own composited layer, fully re-rastered each tick, so a stray text
+   change still cannot strand stale glyphs in the parent layer's tiles. */
 .poracode-thinking-text {
   position: relative;
   display: inline-block;
-  /* No `contain: paint` here, and `will-change` promotes the label to its own
-     composited layer: with `background-clip: text` the glyphs are painted as a
-     cached text mask, and combining that with paint containment + the
-     animator's out-of-band background-position writes let Chromium skip
-     invalidating the old mask when the label's text changed mid-shimmer —
-     leaving the previous title ghosted under the new one (overlapping-text
-     corruption in tool-call rows). An isolated layer is fully re-rastered on
-     each tick, so stale glyphs cannot survive in the parent layer's tiles. */
+  contain: paint;
   will-change: background-position;
   background-image: linear-gradient(
     90deg,


### PR DESCRIPTION
- Fixes overlapping/ghosted text in tool-call rows where the thinking-text shimmer's title change mid-animation left stale glyphs visible under the new title.
- Root cause: `contain: paint` combined with the `background-clip: text` mask let Chromium skip re-rastering the label when its text content changed while the shimmer was mid-cycle.
- Replaces `contain: paint` with `will-change: background-position` to promote the label to its own composited layer, forcing a full re-rasterization each animation tick so stale glyphs cannot persist.