### PR TITLE
fix(chat): stabilize scroll position during history prepend

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -33,6 +33,14 @@ import { ChatFindBar, type ScrollToIndex } from "@/renderer/components/find/Chat
 import { ChatPaneActionsContext, type ChatPaneActions } from "./chatPaneActionsContext";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
 import { selectVisibleThreadTimelineEntries, type ChatTimelineEntry } from "./chatPaneSelectors";
+import {
+  capturePrependAnchors,
+  measurePrependAnchorDelta,
+  PREPEND_ANCHOR_EPSILON_PX,
+  PREPEND_ANCHOR_MAX_FRAMES,
+  PREPEND_ANCHOR_STABLE_FRAMES,
+  type PrependAnchor,
+} from "./chatPrependAnchor";
 import { shouldMarkUserScrollIntentFromPointerTarget } from "./chatScrollGeometry";
 import { normalizeChatProjectPath } from "./chatPathUtils";
 import { MessageList, type CheckpointRevertActions } from "./parts/MessageList";
@@ -191,33 +199,95 @@ export function ChatPane(props: ChatPaneProps) {
     return () => releaseThreadRuntimeItems(threadId);
   }, [threadId]);
 
+  // Upward pagination. The virtualizer's `anchorTo: "end"` prepend handling
+  // applies the primary key-anchored scroll correction in the prepend commit;
+  // the anchor settle loop below (see chatPrependAnchor.ts) absorbs the
+  // residual estimate→measure drift of the freshly mounted page with absolute
+  // corrections against a row captured before the fetch.
   useEffect(() => {
     if (!scrollEl || !isInitialScrollSettled) return;
     let loading = false;
     let cancelled = false;
+    let anchors: PrependAnchor[] = [];
+    let settleRafId: number | null = null;
+
+    const stopSettleLoop = () => {
+      if (settleRafId !== null) {
+        cancelAnimationFrame(settleRafId);
+        settleRafId = null;
+      }
+    };
+    const restoreAnchors = () => {
+      stopSettleLoop();
+      let stableFrames = 0;
+      let totalFrames = 0;
+      const step = () => {
+        settleRafId = null;
+        if (cancelled || anchors.length === 0) return;
+        const delta = measurePrependAnchorDelta(scrollEl, anchors);
+        if (delta !== null && Math.abs(delta) > PREPEND_ANCHOR_EPSILON_PX) {
+          scrollControlsRef.current?.noteProgrammaticScroll(scrollEl.scrollTop + delta);
+          scrollEl.scrollTop += delta;
+          stableFrames = 0;
+        } else {
+          stableFrames += 1;
+        }
+        totalFrames += 1;
+        if (
+          stableFrames >= PREPEND_ANCHOR_STABLE_FRAMES ||
+          totalFrames >= PREPEND_ANCHOR_MAX_FRAMES
+        ) {
+          if (!loading) anchors = [];
+          return;
+        }
+        settleRafId = requestAnimationFrame(step);
+      };
+      settleRafId = requestAnimationFrame(step);
+    };
+
     const onScroll = () => {
-      if (loading || scrollEl.scrollTop > 160) return;
+      if (loading) {
+        // Keep the anchor matched to wherever the user actually is when the
+        // page lands — they usually keep scrolling while the fetch is in flight.
+        anchors = capturePrependAnchors(scrollEl);
+        return;
+      }
+      if (scrollEl.scrollTop > 160) return;
       loading = true;
-      const previousHeight = scrollEl.scrollHeight;
+      anchors = capturePrependAnchors(scrollEl);
       void loadOlderThreadRuntimeItems(threadId)
         .then((loaded) => {
-          if (!loaded || cancelled) return;
-          requestAnimationFrame(() => {
-            if (cancelled) return;
-            const delta = scrollEl.scrollHeight - previousHeight;
-            if (delta <= 0) return;
-            scrollControlsRef.current?.noteProgrammaticScroll(scrollEl.scrollTop + delta);
-            scrollEl.scrollTop += delta;
-          });
+          if (cancelled) return;
+          if (loaded) restoreAnchors();
         })
         .finally(() => {
           loading = false;
         });
     };
+    // A real gesture takes ownership of the scroll position — never fight it
+    // with anchor corrections. While a fetch is in flight the scroll handler
+    // above re-captures instead, so the landed page still restores correctly.
+    const onUserGesture = () => {
+      if (loading) return;
+      anchors = [];
+      stopSettleLoop();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (isScrollNavigationKey(event.key)) onUserGesture();
+    };
     scrollEl.addEventListener("scroll", onScroll, { passive: true });
+    scrollEl.addEventListener("wheel", onUserGesture, { passive: true });
+    scrollEl.addEventListener("pointerdown", onUserGesture, { passive: true });
+    scrollEl.addEventListener("touchstart", onUserGesture, { passive: true });
+    scrollEl.addEventListener("keydown", onKeyDown);
     return () => {
       cancelled = true;
+      stopSettleLoop();
       scrollEl.removeEventListener("scroll", onScroll);
+      scrollEl.removeEventListener("wheel", onUserGesture);
+      scrollEl.removeEventListener("pointerdown", onUserGesture);
+      scrollEl.removeEventListener("touchstart", onUserGesture);
+      scrollEl.removeEventListener("keydown", onKeyDown);
     };
   }, [isInitialScrollSettled, scrollEl, threadId]);
 

--- a/src/renderer/components/thread/ChatPane/chatPrependAnchor.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPrependAnchor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { capturePrependAnchors, measurePrependAnchorDelta } from "./chatPrependAnchor";
+
+interface RowSpec {
+  key: string;
+  top: number;
+  height: number;
+}
+
+function buildScroller(viewTop: number, viewHeight: number, rows: RowSpec[]): HTMLElement {
+  const scroller = document.createElement("div");
+  scroller.getBoundingClientRect = () =>
+    ({ top: viewTop, bottom: viewTop + viewHeight, height: viewHeight }) as DOMRect;
+  for (const row of rows) {
+    const el = document.createElement("div");
+    el.dataset.chatVirtualRow = "true";
+    el.dataset.itemId = row.key;
+    el.getBoundingClientRect = () =>
+      ({ top: row.top, bottom: row.top + row.height, height: row.height }) as DOMRect;
+    scroller.appendChild(el);
+  }
+  return scroller;
+}
+
+describe("capturePrependAnchors", () => {
+  it("captures only rows intersecting the viewport, topmost first", () => {
+    const scroller = buildScroller(100, 400, [
+      { key: "below", top: 520, height: 40 },
+      { key: "partial-top", top: 60, height: 80 },
+      { key: "middle", top: 200, height: 100 },
+      { key: "above", top: 0, height: 90 },
+    ]);
+    expect(capturePrependAnchors(scroller)).toEqual([
+      { key: "partial-top", offset: -40 },
+      { key: "middle", offset: 100 },
+    ]);
+  });
+
+  it("skips rows without an item id", () => {
+    const scroller = buildScroller(0, 400, [{ key: "a", top: 10, height: 20 }]);
+    const bare = document.createElement("div");
+    bare.dataset.chatVirtualRow = "true";
+    bare.getBoundingClientRect = () => ({ top: 50, bottom: 70, height: 20 }) as DOMRect;
+    scroller.appendChild(bare);
+    expect(capturePrependAnchors(scroller)).toEqual([{ key: "a", offset: 10 }]);
+  });
+});
+
+describe("measurePrependAnchorDelta", () => {
+  it("returns how far the anchored row drifted from its captured offset", () => {
+    const scroller = buildScroller(100, 400, [{ key: "anchor", top: 260, height: 40 }]);
+    // Captured at 100px from viewport top, now renders at 160px → drifted +60.
+    expect(measurePrependAnchorDelta(scroller, [{ key: "anchor", offset: 100 }])).toBe(60);
+  });
+
+  it("falls back to the next anchor when the first key no longer exists", () => {
+    const scroller = buildScroller(0, 400, [{ key: "survivor", top: 90, height: 40 }]);
+    const anchors = [
+      { key: "merged-away", offset: 10 },
+      { key: "survivor", offset: 50 },
+    ];
+    expect(measurePrependAnchorDelta(scroller, anchors)).toBe(40);
+  });
+
+  it("returns null when no captured anchor is rendered anymore", () => {
+    const scroller = buildScroller(0, 400, [{ key: "other", top: 10, height: 20 }]);
+    expect(measurePrependAnchorDelta(scroller, [{ key: "gone", offset: 0 }])).toBeNull();
+    expect(measurePrependAnchorDelta(scroller, [])).toBeNull();
+  });
+});

--- a/src/renderer/components/thread/ChatPane/chatPrependAnchor.ts
+++ b/src/renderer/components/thread/ChatPane/chatPrependAnchor.ts
@@ -1,0 +1,69 @@
+/**
+ * Keeps the viewport visually still while older transcript pages are prepended.
+ *
+ * The virtualizer's native `anchorTo: "end"` prepend handling re-derives the
+ * scroll offset from item estimates in the same commit, but estimate→measure
+ * corrections for freshly mounted rows can land frames later (images, markdown,
+ * measurement caches). Mirroring the OpenCode v2 timeline, we capture the rows
+ * intersecting the viewport (key + offset from the viewport top) before the
+ * fetch, then after the prepend nudge `scrollTop` by the *measured* residual
+ * delta each animation frame until the position has been stable for
+ * `PREPEND_ANCHOR_STABLE_FRAMES` frames — an absolute correction that converges
+ * regardless of how many relative adjustments fired in between.
+ */
+export interface PrependAnchor {
+  /** `data-item-id` of the anchored virtual row (timeline entry id). */
+  key: string;
+  /** Pixel offset of the row's top from the scroller's viewport top. */
+  offset: number;
+}
+
+/** Consecutive sub-epsilon frames required before the settle loop stops. */
+export const PREPEND_ANCHOR_STABLE_FRAMES = 30;
+/** Hard frame cap so the loop can never run unbounded. */
+export const PREPEND_ANCHOR_MAX_FRAMES = 180;
+export const PREPEND_ANCHOR_EPSILON_PX = 0.5;
+
+const ROW_SELECTOR = "[data-chat-virtual-row]";
+
+/**
+ * Snapshot every virtual row currently intersecting the viewport, topmost
+ * first. Capturing the full visible set (instead of a single row) keeps an
+ * anchor available when the topmost entry's id does not survive the prepend —
+ * tool-call groups at the page boundary can merge with prepended rows and
+ * change their entry id.
+ */
+export function capturePrependAnchors(scrollEl: HTMLElement): PrependAnchor[] {
+  const view = scrollEl.getBoundingClientRect();
+  const anchors: Array<PrependAnchor & { top: number }> = [];
+  for (const row of scrollEl.querySelectorAll<HTMLElement>(ROW_SELECTOR)) {
+    const key = row.dataset.itemId;
+    if (!key) continue;
+    const rect = row.getBoundingClientRect();
+    if (rect.bottom <= view.top || rect.top >= view.bottom) continue;
+    anchors.push({ key, offset: rect.top - view.top, top: rect.top });
+  }
+  anchors.sort((a, b) => a.top - b.top);
+  return anchors.map(({ key, offset }) => ({ key, offset }));
+}
+
+/**
+ * How far the best surviving anchor row has drifted from its captured viewport
+ * offset. Positive means the row moved down (scroll must move down with it).
+ * Returns null when none of the captured anchors are rendered anymore.
+ */
+export function measurePrependAnchorDelta(
+  scrollEl: HTMLElement,
+  anchors: readonly PrependAnchor[],
+): number | null {
+  if (anchors.length === 0) return null;
+  const viewTop = scrollEl.getBoundingClientRect().top;
+  for (const anchor of anchors) {
+    const row = scrollEl.querySelector<HTMLElement>(
+      `${ROW_SELECTOR}[data-item-id="${CSS.escape(anchor.key)}"]`,
+    );
+    if (!row) continue;
+    return row.getBoundingClientRect().top - viewTop - anchor.offset;
+  }
+  return null;
+}


### PR DESCRIPTION
- Fixes chat view scroll jumping when older history messages are prepended to the ChatPane
- Extracts a dedicated `chatPrependAnchor` helper to compute/restore the scroll anchor around prepend operations
- Adds unit tests covering the new prepend-anchor logic