### PR TITLE
fix(thread): dedupe same-named slash commands across scopes

### DIFF
--- a/src/renderer/components/thread/ThreadSlashCommands.test.tsx
+++ b/src/renderer/components/thread/ThreadSlashCommands.test.tsx
@@ -568,6 +568,43 @@ describe("ThreadSlashCommands", () => {
     ).toEqual([]);
   });
 
+  it("dedupes same-named provider commands and lets the skill entry win the name", () => {
+    const commands = resolveAvailableSlashCommands(
+      [
+        {
+          id: "simplify",
+          label: "simplify — Review changed code",
+          description: "Review changed code",
+        },
+        {
+          id: "simplify",
+          label: "simplify — Review changed code (user)",
+          description: "Review changed code (user)",
+        },
+        { id: "security-review", label: "security-review" },
+      ],
+      undefined,
+      {
+        skillCommands: [
+          {
+            id: "simplify",
+            label: "simplify",
+            section: "skills",
+            skillName: "simplify",
+            skillPath: "/skills/simplify/SKILL.md",
+            skillInvocation: "/simplify",
+            skillProvider: "Claude Code",
+            skillScope: "global",
+          },
+        ],
+      },
+    );
+    expect(commands.map((command) => `${command.id}:${command.section ?? "commands"}`)).toEqual([
+      "security-review:commands",
+      "simplify:skills",
+    ]);
+  });
+
   it("does not reintroduce locally discovered skills when the provider catalog is authoritative", async () => {
     bridge.scanSkills.mockResolvedValue({
       skills: [

--- a/src/renderer/components/thread/threadSlashCommands.ts
+++ b/src/renderer/components/thread/threadSlashCommands.ts
@@ -27,6 +27,26 @@ function withoutSkillCommands(
   return commands?.filter((command) => !isSkillCommand(command)) ?? EMPTY_SLASH_COMMANDS;
 }
 
+/**
+ * Providers can report the same command name from several scopes (user,
+ * project, plugin), and a name may also resolve to a skill entry. Inserting any
+ * of them types the same `/name`, and a typed name binds to the skill when one
+ * exists, so only the first occurrence per name survives and skill entries win
+ * over plain commands.
+ */
+function dedupeBaseCommands(
+  commands: readonly AgentSlashCommand[] | undefined,
+  skills: readonly AgentSlashCommand[],
+): AgentSlashCommand[] {
+  const seen = new Set(skills.map((skill) => (skill.skillName ?? skill.id).toLowerCase()));
+  return withoutSkillCommands(commands).filter((command) => {
+    const id = command.id.toLowerCase();
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+}
+
 function mergeSkillCommands(
   ...sources: (readonly AgentSlashCommand[] | undefined)[]
 ): AgentSlashCommand[] {
@@ -151,7 +171,7 @@ export function resolveAvailableSlashCommands(
   );
   if (context?.presentationMode === "terminal") {
     const base = threadCommands ?? capabilityCommands ?? EMPTY_SLASH_COMMANDS;
-    return [...withoutSkillCommands(base), ...skills];
+    return [...dedupeBaseCommands(base, skills), ...skills];
   }
   if (context?.agentKind) {
     const registration = getGuiSlashCommands(context.agentKind);
@@ -166,7 +186,7 @@ export function resolveAvailableSlashCommands(
     }
   }
   const base = threadCommands ?? capabilityCommands ?? EMPTY_SLASH_COMMANDS;
-  return [...withoutSkillCommands(base), ...skills];
+  return [...dedupeBaseCommands(base, skills), ...skills];
 }
 
 export function resolveLocalSlashCommandAction(


### PR DESCRIPTION
- Providers can report the same command name from multiple scopes (user/project/plugin), which previously produced duplicate entries in the slash-command list.
- Adds `dedupeBaseCommands` to collapse duplicate base commands by id and ensure skill entries take precedence over plain provider commands with the same name.
- Adds a regression test covering deduped provider commands with a skill entry winning the name.