### PR TITLE
fix(chat): keep working timer live during background activity

### DIFF
--- a/src/renderer/components/providers/ThreadProviderIcon.tsx
+++ b/src/renderer/components/providers/ThreadProviderIcon.tsx
@@ -4,7 +4,10 @@ import {
   useAgentStatusesStore,
 } from "@/renderer/state/agentStatusesStore";
 import { useProject } from "@/renderer/state/useThread";
-import { useProjectAgentStatuses } from "@/renderer/hooks/uiSelectors";
+import {
+  useProjectAgentStatuses,
+  useThreadHasBackgroundActivity,
+} from "@/renderer/hooks/uiSelectors";
 import { ProviderIcon } from "./ProviderIcon";
 import { getStatusTone, type StatusTone } from "./statusTone";
 
@@ -35,10 +38,14 @@ export function ThreadProviderIcon(props: {
   const pending = useAgentStatusesStore((s) =>
     location ? isDetectingAgentsForLocation(s, location) : false,
   );
+  // Detached background work (native sub-agents, live workflows) must read as
+  // "working" on every surface, not just the sidebar — otherwise the home
+  // page's recent-threads list shows the same thread as idle.
+  const hasBackgroundActivity = useThreadHasBackgroundActivity(thread.id);
   return (
     <ProviderIcon
       kind={thread.agentKind}
-      tone={props.tone ?? getStatusTone(thread)}
+      tone={props.tone ?? getStatusTone(thread, { hasBackgroundActivity })}
       pending={pending}
       fallbackLabel={agent?.label}
       {...(agent?.icon ? { icon: agent.icon } : {})}

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -1304,6 +1304,42 @@ describe("ChatPane", () => {
     expect(screen.queryByText("Worked for 1m 15s")).not.toBeInTheDocument();
   });
 
+  it("suppresses the anchored completed turn while background work keeps the timer live", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:02:00.000Z"));
+    const thread = {
+      ...makeThread(),
+      status: "idle" as const,
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:01:15.000Z",
+    };
+    seedAssistantMessage(thread.id, "Inspect output");
+    useAppStore.getState().hydrateThreadCompletedTurns(thread.id, [
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:01:15.000Z").getTime(),
+        anchorItemId: ASSISTANT_ITEM_ID,
+      },
+    ]);
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "agent-1",
+      itemType: "tool_call",
+      payload: {
+        name: "Agent",
+        status: "running",
+        args: { subagent_type: "Explore" },
+      },
+    });
+
+    renderChatPane(thread);
+
+    expect(screen.getByText("Working for 2m 00s")).toBeInTheDocument();
+    expect(screen.queryByText("Worked for 1m 15s")).not.toBeInTheDocument();
+  });
+
   it("renders anchored completed turn duration inside a chat surface", () => {
     const thread = makeThread();
     seedAssistantMessage(thread.id, "Inspect output");

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -356,15 +356,17 @@ export function ChatPane(props: ChatPaneProps) {
   // turn.
   const turn = resolveTurnTiming(thread, showWorkingTimer);
   const mostRecentDisplayableCompletedTurn = useAppStore((s) =>
-    showWorkingTimer
-      ? null
-      : selectMostRecentDisplayableCompletedTurn(s.runtimeCompletedTurnsByThread[threadId]),
+    selectMostRecentDisplayableCompletedTurn(s.runtimeCompletedTurnsByThread[threadId]),
   );
   const mostRecentCompletedTurnAnchor = mostRecentDisplayableCompletedTurn?.anchorItemId ?? null;
+  const completedTurnAnchorAtTail = isCompletedTurnAnchorAtTimelineTail(
+    mostRecentCompletedTurnAnchor,
+    timelineEntries,
+  );
   const completedTurnCanRenderInTail =
     !showWorkingTimer &&
     (turn?.endedAt != null || mostRecentDisplayableCompletedTurn !== null) &&
-    isCompletedTurnAnchorAtTimelineTail(mostRecentCompletedTurnAnchor, timelineEntries);
+    completedTurnAnchorAtTail;
   const tailTurn =
     completedTurnCanRenderInTail && mostRecentDisplayableCompletedTurn
       ? mostRecentDisplayableCompletedTurn
@@ -384,9 +386,19 @@ export function ChatPane(props: ChatPaneProps) {
   // time when the thread is idle and no newer timeline row exists. Once an
   // optimistic next prompt is appended, keep the completed indicator inline at
   // its anchor so the prompt does not briefly occupy the old footer position.
-  const suppressInlineTurnAnchorId = completedTurnCanRenderInTail
-    ? mostRecentCompletedTurnAnchor
-    : null;
+  // When detached background work keeps the timer live after the foreground
+  // turn settles, the ticking "Working for" reseeds from that turn's start —
+  // its window subsumes the frozen "Worked for" record, so render only the
+  // live timer, never both at once.
+  const liveTimerContinuesCompletedTurn =
+    turn !== null &&
+    turn.endedAt === null &&
+    mostRecentDisplayableCompletedTurn !== null &&
+    turn.startedAt <= mostRecentDisplayableCompletedTurn.startedAt;
+  const suppressInlineTurnAnchorId =
+    completedTurnCanRenderInTail || liveTimerContinuesCompletedTurn
+      ? mostRecentCompletedTurnAnchor
+      : null;
   const checkpointGuard = useAppStore(
     useShallow((s) =>
       resolveCheckpointGuard({


### PR DESCRIPTION
- Fixed the working timer being suppressed once a foreground turn completed while detached background work (native sub-agents, live workflows) was still running.
- `ThreadProviderIcon` now factors in a thread's background-activity state when resolving status tone, so the home page's recent-threads list reflects "working" consistently with other surfaces.
- `ChatPane` reconciles the live timer against the last completed-turn record, suppressing the frozen "Worked for" indicator whenever the ticking timer's window subsumes it, avoiding both being shown at once.
- Added a regression test covering the case where background activity keeps the timer live past the anchored completed turn.