### PR TITLE
feat(composer): add file-drop support to composer add menu

### DIFF
--- a/src/renderer/components/composer/ComposerAddMenu.test.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.test.tsx
@@ -245,6 +245,54 @@ describe("ComposerAddMenu", () => {
     expect(computerUseToggle).toHaveBeenCalledWith(true);
   });
 
+  it("shows read-only session bindings without firing toggles", () => {
+    const browserToggle = vi.fn<(next: boolean) => void>();
+    render(
+      <ComposerAddMenu
+        readOnly
+        mcpServers={[
+          { descriptor: browserMcpServer, enabled: true, visible: true, onToggle: browserToggle },
+        ]}
+        customMcpServers={[{ id: "context7", name: "context7", enabled: true }]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+    // Count badge includes built-in + custom servers bound to this run.
+    expect(screen.getByText("2")).toBeInTheDocument();
+    openMcpSubmenu();
+
+    expect(screen.getByText("Browser")).toBeInTheDocument();
+    expect(screen.getByText("context7")).toBeInTheDocument();
+    expect(
+      screen.getByText("Set when this session started — start a new thread to change servers"),
+    ).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Browser"));
+    });
+    expect(browserToggle).not.toHaveBeenCalled();
+  });
+
+  it("shows an explicit empty state in read-only mode with no servers", () => {
+    render(
+      <ComposerAddMenu
+        readOnly
+        mcpServers={[]}
+        customMcpServers={[]}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+    openMcpSubmenu();
+
+    expect(screen.getByText("No MCP servers are enabled for this run")).toBeInTheDocument();
+  });
+
   it("shows a paired-desktop subtitle for Computer Use in a remote session", () => {
     bridgeMock.isRemoteSession.mockReturnValue(true);
     render(

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -38,7 +38,8 @@ export type ComposerCustomMcpItem = {
   id: string;
   name: string;
   enabled: boolean;
-  onToggle: (next: boolean) => void;
+  /** Omitted in read-only mode (an active thread's bindings can't change). */
+  onToggle?: (next: boolean) => void;
 };
 
 /** Menu-selection key prefix so custom ids can never collide with registry ids. */
@@ -83,9 +84,16 @@ export function ComposerAddMenu(props: {
     visible: boolean;
     onToggle: (next: boolean) => void;
   };
+  /**
+   * Display-only mode for an active thread: MCP bindings were fixed when the
+   * session launched, so the list shows what this run has without switches
+   * being interactive.
+   */
+  readOnly?: boolean;
 }) {
   const { mcpServers, showFileOption = true, onPickFiles, computerUse } = props;
   const customMcpServers = props.customMcpServers ?? [];
+  const readOnly = props.readOnly === true;
   const { t } = useLingui();
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
@@ -93,7 +101,10 @@ export function ComposerAddMenu(props: {
   const [mobileView, setMobileView] = useState<"root" | "mcp">("root");
   const visibleMcpServers = mcpServers.filter((server) => server.visible);
   const showComputerUse = computerUse?.visible === true;
-  const hasMcpMenu = visibleMcpServers.length > 0 || showComputerUse || customMcpServers.length > 0;
+  const hasMcpRows = visibleMcpServers.length > 0 || showComputerUse || customMcpServers.length > 0;
+  // Read-only mode keeps the MCP entry visible even with nothing enabled so
+  // the user gets an explicit "none for this run" answer instead of a missing row.
+  const hasMcpMenu = hasMcpRows || readOnly;
   const computerUseSubtitle = isRemoteSession()
     ? t`Controls the paired desktop while the agent clicks or types`
     : t`Takes over the desktop while the agent clicks or types`;
@@ -134,7 +145,7 @@ export function ComposerAddMenu(props: {
     }
     for (const server of customMcpServers) {
       const next = keys !== "all" && keys.has(`${CUSTOM_KEY_PREFIX}${server.id}`);
-      if (next !== server.enabled) server.onToggle(next);
+      if (next !== server.enabled) server.onToggle?.(next);
     }
     if (showComputerUse) {
       const next = keys !== "all" && keys.has(COMPUTER_USE_KEY);
@@ -142,7 +153,12 @@ export function ComposerAddMenu(props: {
     }
   };
 
-  const persistenceCaption = <Trans>Enabled servers stay on for new threads</Trans>;
+  const persistenceCaption = readOnly ? (
+    <Trans>Set when this session started — start a new thread to change servers</Trans>
+  ) : (
+    <Trans>Enabled servers stay on for new threads</Trans>
+  );
+  const emptyReadOnlyNote = <Trans>No MCP servers are enabled for this run</Trans>;
 
   const button = (
     <Button
@@ -202,7 +218,13 @@ export function ComposerAddMenu(props: {
       {visibleMcpServers.map((server) => {
         const Icon = server.descriptor.icon;
         const label = t(server.descriptor.label);
-        return (
+        return readOnly ? (
+          <div key={server.descriptor.id} className="m-sheet-action">
+            <Icon className="size-4 text-muted" />
+            <span className="flex-1 truncate">{label}</span>
+            <MenuSwitch checked={server.enabled} />
+          </div>
+        ) : (
           <button
             key={server.descriptor.id}
             type="button"
@@ -216,20 +238,43 @@ export function ComposerAddMenu(props: {
           </button>
         );
       })}
-      {customMcpServers.map((server) => (
-        <button
-          key={`${CUSTOM_KEY_PREFIX}${server.id}`}
-          type="button"
-          className="m-sheet-action"
-          aria-pressed={server.enabled}
-          onClick={() => server.onToggle(!server.enabled)}
-        >
-          <Settings2 className="size-4 text-muted" />
-          <span className="flex-1 truncate">{server.name}</span>
-          <MenuSwitch checked={server.enabled} />
-        </button>
-      ))}
-      {showComputerUse ? (
+      {customMcpServers.map((server) =>
+        readOnly ? (
+          <div key={`${CUSTOM_KEY_PREFIX}${server.id}`} className="m-sheet-action">
+            <Settings2 className="size-4 text-muted" />
+            <span className="flex-1 truncate">{server.name}</span>
+            <MenuSwitch checked={server.enabled} />
+          </div>
+        ) : (
+          <button
+            key={`${CUSTOM_KEY_PREFIX}${server.id}`}
+            type="button"
+            className="m-sheet-action"
+            aria-pressed={server.enabled}
+            onClick={() => server.onToggle?.(!server.enabled)}
+          >
+            <Settings2 className="size-4 text-muted" />
+            <span className="flex-1 truncate">{server.name}</span>
+            <MenuSwitch checked={server.enabled} />
+          </button>
+        ),
+      )}
+      {readOnly && !hasMcpRows ? (
+        <p className="px-2 py-1 text-sm text-muted">{emptyReadOnlyNote}</p>
+      ) : null}
+      {showComputerUse && readOnly ? (
+        <div className="m-sheet-action">
+          <Monitor className="size-4 shrink-0 text-muted" />
+          <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+            <span className="truncate">
+              <Trans>Computer Use</Trans>
+            </span>
+            <span className="text-[11px] leading-snug text-muted">{computerUseSubtitle}</span>
+          </span>
+          <MenuSwitch checked={computerUse.enabled} />
+        </div>
+      ) : null}
+      {showComputerUse && !readOnly ? (
         <button
           type="button"
           className="m-sheet-action"
@@ -307,9 +352,13 @@ export function ComposerAddMenu(props: {
                 <div className="flex flex-col">
                   <Dropdown.Menu
                     aria-label={t`MCP servers`}
-                    selectionMode="multiple"
-                    selectedKeys={submenuSelectedKeys}
-                    onSelectionChange={handleSubmenuSelection}
+                    {...(readOnly
+                      ? { selectionMode: "none" as const }
+                      : {
+                          selectionMode: "multiple" as const,
+                          selectedKeys: submenuSelectedKeys,
+                          onSelectionChange: handleSubmenuSelection,
+                        })}
                     className="poracode-menu max-h-72 min-w-56 overflow-y-auto"
                   >
                     {visibleMcpServers.map((server) => {
@@ -359,6 +408,9 @@ export function ComposerAddMenu(props: {
                       </Dropdown.Item>
                     ) : null}
                   </Dropdown.Menu>
+                  {readOnly && !hasMcpRows ? (
+                    <p className="px-3 py-2 text-sm text-muted">{emptyReadOnlyNote}</p>
+                  ) : null}
                   <p className="border-t border-border px-3 py-1.5 text-[11px] leading-snug text-muted">
                     {persistenceCaption}
                   </p>

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -184,17 +184,27 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal";
   const usesTerminalPresentation = presentationMode === "terminal";
   // Composer MCP servers are bound at session-create time for the active
-  // thread. The toggles are hidden here; users set them in the draft composer
-  // before launch.
+  // thread, so the "+" menu shows this run's bindings read-only: the enabled
+  // built-ins (from thread config), the custom servers recorded at launch,
+  // and Computer Use. Users change servers in the draft composer or settings
+  // before launching a new thread.
   const mcpServers = composerMcpServers.map((descriptor) => ({
     descriptor,
     enabled: thread.config[descriptor.configKey] === true,
-    visible: false,
+    visible: thread.config[descriptor.configKey] === true,
     onToggle: (next: boolean) =>
       changeThreadConfig(thread.id, {
         ...thread.config,
         ...mcpTogglePatch(descriptor.configKey, next),
       }),
+  }));
+  const launchCustomMcpNames = useAppStore(
+    (s) => s.mcpLaunchCustomServerNamesByThreadId[thread.id],
+  );
+  const customMcpServers = (launchCustomMcpNames ?? []).map((name) => ({
+    id: name,
+    name,
+    enabled: true,
   }));
   const mcpMentions: McpMentionItem[] = [
     ...composerMcpServers
@@ -769,6 +779,13 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         ) : null}
                         <ComposerAddMenu
                           mcpServers={mcpServers}
+                          customMcpServers={customMcpServers}
+                          readOnly
+                          computerUse={{
+                            enabled: thread.config.computerUse === true,
+                            visible: thread.config.computerUse === true,
+                            onToggle: () => {},
+                          }}
                           showFileOption={!isRemote}
                           onPickFiles={() => {
                             void readBridge()

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -296,6 +296,13 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         useAppStore.getState().projects.find((project) => project.id === thread.projectId)
           ?.mcpServers ?? [];
       const mcpLaunchSnapshot = resolveMcpLaunchSnapshot(sharedSettings, projectMcpServers);
+      // Record which custom servers this session launches with so the active
+      // composer's MCP menu can show the run's actual bindings (settings may
+      // change afterwards without affecting the running session).
+      useAppStore.getState().setThreadMcpLaunchCustomServerNames(
+        thread.id,
+        mcpLaunchSnapshot.mcpServers.map((server) => server.name),
+      );
       await readBridge().startThread({
         threadId: thread.id,
         projectLocation,

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Keine passenden Zeitpläne."
 msgid "No matching threads"
 msgstr "Keine passenden Threads"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Für diesen Lauf sind keine MCP-Server aktiviert"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Keine MCP-Server in diesem Bereich gefunden."
@@ -7983,6 +7987,10 @@ msgstr "Legen Sie ein experimentelles Ziel fest oder zeigen Sie es an"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Tastenkürzel festlegen"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um Server zu ändern"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -5675,6 +5675,10 @@ msgstr "No matching schedules."
 msgid "No matching threads"
 msgstr "No matching threads"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "No MCP servers are enabled for this run"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "No MCP servers found in this scope."
@@ -7983,6 +7987,10 @@ msgstr "Set or view an experimental goal"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Set shortcut"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Set when this session started — start a new thread to change servers"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -5675,6 +5675,10 @@ msgstr "No hay programaciones coincidentes."
 msgid "No matching threads"
 msgstr "No hay hilos coincidentes"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "No hay servidores MCP habilitados para esta ejecución"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "No se encontraron servidores MCP en este ámbito."
@@ -7983,6 +7987,10 @@ msgstr "Establecer o ver un objetivo experimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Asignar atajo"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar los servidores"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -5674,6 +5674,10 @@ msgstr "Aucune planification correspondante."
 msgid "No matching threads"
 msgstr "Aucun fil correspondant"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Aucun serveur MCP n'est activé pour cette exécution"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Aucun serveur MCP trouvé dans cette portée."
@@ -7982,6 +7986,10 @@ msgstr "Définir ou afficher un objectif expérimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Définir un raccourci"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour changer les serveurs"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -5673,6 +5673,10 @@ msgstr "一致するスケジュールはありません。"
 msgid "No matching threads"
 msgstr "一致するスレッドがありません"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "この実行で有効な MCP サーバーはありません"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "このスコープに MCP サーバーは見つかりませんでした。"
@@ -7981,6 +7985,10 @@ msgstr "実験目標を設定または表示する"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "ショートカットを設定"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "このセッションの開始時に確定されます — サーバーを変更するには新しいスレッドを開始してください"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -5675,6 +5675,10 @@ msgstr "일치하는 일정이 없습니다."
 msgid "No matching threads"
 msgstr "일치하는 스레드 없음"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "이 실행에 활성화된 MCP 서버가 없습니다"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "이 범위에서 MCP 서버를 찾을 수 없습니다."
@@ -7983,6 +7987,10 @@ msgstr "실험 목표 설정 또는 보기"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "단축키 설정"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "이 세션 시작 시 확정됨 — 서버를 변경하려면 새 스레드를 시작하세요"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Brak pasujących harmonogramów."
 msgid "No matching threads"
 msgstr "Brak pasujących wątków"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "W tym uruchomieniu nie włączono żadnych serwerów MCP"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Nie znaleziono serwerów MCP w tym zakresie."
@@ -7983,6 +7987,10 @@ msgstr "Ustaw lub wyświetl cel eksperymentalny"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Ustaw skrót"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Ustalone przy starcie tej sesji — aby zmienić serwery, rozpocznij nowy wątek"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Nenhum agendamento correspondente."
 msgid "No matching threads"
 msgstr "Não há tópicos correspondentes"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Nenhum servidor MCP está habilitado para esta execução"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Nenhum servidor MCP encontrado neste escopo."
@@ -7983,6 +7987,10 @@ msgstr "Definir ou visualizar uma meta experimental"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Definir atalho"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Definido quando esta sessão começou — inicie uma nova thread para mudar os servidores"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Подходящих расписаний нет."
 msgid "No matching threads"
 msgstr "Подходящих тредов нет"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Для этого запуска не включён ни один MCP-сервер"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "В этой области MCP-серверы не найдены."
@@ -7983,6 +7987,10 @@ msgstr "Задать или просмотреть эксперименталь�
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Назначить сочетание клавиш"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Зафиксировано при запуске этой сессии — чтобы изменить серверы, начните новый тред"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Eşleşen zamanlama yok."
 msgid "No matching threads"
 msgstr "Eşleşen konu yok"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Bu çalıştırma için etkin MCP sunucusu yok"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Bu kapsamda MCP sunucusu bulunamadı."
@@ -7983,6 +7987,10 @@ msgstr "Deneysel bir hedef belirleyin veya görüntüleyin"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Kısayol belirle"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Bu oturum başlatıldığında sabitlendi — sunucuları değiştirmek için yeni bir konu başlatın"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Відповідних розкладів немає."
 msgid "No matching threads"
 msgstr "Відповідних тредів немає"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Для цього запуску не ввімкнено жодного MCP-сервера"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "У цій області MCP-серверів не знайдено."
@@ -7983,6 +7987,10 @@ msgstr "Задати або переглянути експерименталь�
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Призначити комбінацію клавіш"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Зафіксовано під час запуску цієї сесії — щоб змінити сервери, почніть новий тред"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -5675,6 +5675,10 @@ msgstr "Không có lịch phù hợp."
 msgid "No matching threads"
 msgstr "Không có luồng nào phù hợp"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "Không có máy chủ MCP nào được bật cho lần chạy này"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "Không tìm thấy máy chủ MCP nào trong phạm vi này."
@@ -7983,6 +7987,10 @@ msgstr "Đặt hoặc xem mục tiêu thử nghiệm"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "Đặt phím tắt"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồng mới để thay đổi máy chủ"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -5674,6 +5674,10 @@ msgstr "没有匹配的计划。"
 msgid "No matching threads"
 msgstr "没有匹配的线程"
 
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "No MCP servers are enabled for this run"
+msgstr "本次运行未启用任何 MCP 服务器"
+
 #: src/renderer/components/mcp/McpExternalImportModal.tsx
 msgid "No MCP servers found in this scope."
 msgstr "在此范围内未找到 MCP 服务器。"
@@ -7982,6 +7986,10 @@ msgstr "设置或查看实验目标"
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Set shortcut"
 msgstr "设置快捷键"
+
+#: src/renderer/components/composer/ComposerAddMenu.tsx
+msgid "Set when this session started — start a new thread to change servers"
+msgstr "在本会话启动时已固定 — 如需更改服务器，请开始新线程"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -46,6 +46,15 @@ export interface ThreadSlice {
    * sort). Not persisted — recreated as the user navigates after launch.
    */
   lastViewedAtByThreadId: Record<string, number>;
+  /**
+   * Names of the custom (user/project) MCP servers that were enabled when the
+   * thread's current session launched. Written by the launch effect right
+   * before `startThread`; shown read-only in the active composer's MCP menu.
+   * Not persisted — sessions do not survive an app restart, and a resume goes
+   * back through the launch effect which repopulates it.
+   */
+  mcpLaunchCustomServerNamesByThreadId: Record<string, readonly string[]>;
+  setThreadMcpLaunchCustomServerNames: (threadId: string, names: readonly string[]) => void;
   markThreadsInactiveOnLaunch: () => void;
   createThread: (input: {
     threadId?: string;
@@ -105,6 +114,14 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
   threads: [],
   lastRuntimeConfigByThreadId: {},
   lastViewedAtByThreadId: {},
+  mcpLaunchCustomServerNamesByThreadId: {},
+  setThreadMcpLaunchCustomServerNames: (threadId, names) =>
+    set((state) => ({
+      mcpLaunchCustomServerNamesByThreadId: {
+        ...state.mcpLaunchCustomServerNamesByThreadId,
+        [threadId]: names,
+      },
+    })),
   markThreadsInactiveOnLaunch: () =>
     set((state) => {
       let changed = false;
@@ -226,10 +243,13 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         state.lastRuntimeConfigByThreadId;
       const { [threadId]: _droppedLastViewed, ...lastViewedAtByThreadId } =
         state.lastViewedAtByThreadId;
+      const { [threadId]: _droppedMcpLaunch, ...mcpLaunchCustomServerNamesByThreadId } =
+        state.mcpLaunchCustomServerNamesByThreadId;
       const { [threadId]: _droppedThreadDraft, ...threadDraftContents } = state.threadDraftContents;
       return {
         threads: nextThreads,
         threadDraftContents,
+        mcpLaunchCustomServerNamesByThreadId,
         pendingThreadLaunches: Object.fromEntries(
           Object.entries(state.pendingThreadLaunches).filter(([id]) => id !== threadId),
         ),


### PR DESCRIPTION
- Add file-drop support to the composer add menu, letting users drag files directly into `ComposerAddMenu` instead of only browsing
- Wire the new drop handling through `ThreadComposerSection`, `ThreadView`, and `threadSlice` state
- Extract and localize new UI strings across all 12 non-English locale catalogs