### PR TITLE
feat(markdown): render local image attachments in markdown content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ review.diff
 .spec-workflow/
 **/worktrees/
 .cursor/
+.grok/
 .commandcode/
 mcps/
 .antigravitycli/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Universal AI agent orchestrator — Electron desktop app managing Claude, Codex,
 - **Prevent God Files:** Do not allow files to grow indefinitely. If a file becomes complex or violates single-responsibility principles during your work, refactor it by extracting related logic into new modules or sub-components. Splitting files is preferred over extending existing ones.
 - Use `pnpm exec vitest run ...` for targeted Vitest runs; do not use Jest-only flags like `--runInBand`.
 - With `exactOptionalPropertyTypes`, avoid passing explicit `undefined` for optional props; use conditional spreads when needed.
+- Put investigation dumps, screenshots, and other temporary files under `tmp/` or `.tmp/` (both gitignored). Never write scratch artifacts into the repo root or tracked paths like `verification-shots/`.
 
 ## Internationalization (i18n)
 

--- a/src/main/attachments/localFiles.ts
+++ b/src/main/attachments/localFiles.ts
@@ -3,6 +3,7 @@ import { join, normalize, resolve } from "node:path";
 import { net, protocol } from "electron";
 import type { ProjectLocation } from "@/shared/contracts";
 import type { PoracodePaths } from "@/shared/poracodePaths";
+import { resolveLocalFileUrlPath } from "@/shared/promptContent";
 import { getProjectFsPath } from "@/shared/wsl";
 
 function sanitizeAttachmentPathPart(value: string): string {
@@ -88,10 +89,8 @@ export function registerLocalFileProtocolScheme(): void {
 export function installLocalFileProtocolHandler(): void {
   for (const scheme of LOCAL_FILE_PROTOCOL_SCHEMES) {
     protocol.handle(scheme, (request) => {
-      const raw = decodeURIComponent(new URL(request.url).pathname);
       const { pathToFileURL } = require("node:url") as typeof import("node:url");
-      const filePath =
-        process.platform === "win32" && /^\/[A-Za-z]:/.test(raw) ? raw.slice(1) : raw;
+      const filePath = resolveLocalFileUrlPath(request.url);
       if (filePath.includes("\0")) {
         return new Response("invalid path", { status: 400 });
       }

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
@@ -153,6 +153,52 @@ describe("ItemMarkdownInner", () => {
     );
   });
 
+  it("renders Windows backslash markdown image paths without CommonMark escape corruption", () => {
+    // Paths with `\.` (dot-folders) are mangled by CommonMark unless rewritten
+    // to poracode-local:// before parse.
+    render(
+      <AppProvider>
+        <ItemMarkdownInner
+          text={
+            "![Before](C:\\Users\\sdsle\\.grok\\sessions\\E%3A%5Cwork\\assets\\image-ea056148.png)"
+          }
+        />
+      </AppProvider>,
+    );
+
+    const src = screen.getByAltText("Before").getAttribute("src") ?? "";
+    expect(src.startsWith("poracode-local://local/")).toBe(true);
+    // Literal percent folder names must be double-encoded in the URL so the
+    // protocol handler's decodeURIComponent restores E%3A… rather than E:…
+    expect(src).toContain("E%253A%255Cwork");
+    expect(src).toContain(".grok");
+    expect(src).not.toContain("sdsle.grok");
+  });
+
+  it("renders project-relative markdown image paths via the local file protocol", () => {
+    const actions = makeActions({
+      projectLocation: {
+        kind: "windows",
+        path: "E:\\work\\lightcode\\.poracode\\worktrees\\poracode-brave-willow-b4fc6c26",
+      },
+    });
+
+    render(
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <ItemMarkdownInner
+            text={"![After](verification-shots/01-collapsed-same-file-edits.png)"}
+          />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>,
+    );
+
+    const src = screen.getByAltText("After").getAttribute("src") ?? "";
+    expect(src.startsWith("poracode-local://local/E:")).toBe(true);
+    expect(src).toContain("verification-shots");
+    expect(src).toContain("01-collapsed-same-file-edits.png");
+  });
+
   it("normalizes absolute markdown link hrefs to project file chips", () => {
     const actions = makeActions();
 
@@ -296,7 +342,7 @@ describe("ItemMarkdownInner", () => {
   });
 });
 
-function makeActions(): ChatPaneActions {
+function makeActions(overrides?: Partial<ChatPaneActions>): ChatPaneActions {
   return {
     openProjectRelativePath: vi.fn<(path: string, lineNumber?: number) => void>(),
     revealProjectFolderInTree: vi.fn<(path: string) => void>(),
@@ -304,5 +350,6 @@ function makeActions(): ChatPaneActions {
     onContentHeightChange: vi.fn<() => void>(),
     projectLocation: { kind: "posix", path: "/Users/serhiivecherenko/work/poracode" },
     projectRootNames: new Set(["src"]),
+    ...overrides,
   };
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
@@ -19,7 +19,11 @@ import {
 } from "streamdown";
 import remarkGfm from "remark-gfm";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
-import { toLocalFileUrl } from "@/shared/promptContent";
+import {
+  resolveMarkdownImageUrl,
+  rewriteMarkdownLocalImageUrls,
+} from "@/shared/markdownLocalImages";
+import { getProjectFsPath } from "@/shared/wsl";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { normalizeChatProjectPath } from "../../chatPathUtils";
 import { CodeBlock } from "./CodeBlock";
@@ -91,8 +95,14 @@ export default function ItemMarkdownInner({ text }: ItemMarkdownInnerProps) {
     ],
     [actions, rootNames],
   );
-  const markdownText = normalizeIncompleteProjectLinkTail(
-    normalizeGfmTableSeparators(normalizeShortCodeFenceClosers(text)),
+  const projectRoot = actions?.projectLocation
+    ? getProjectFsPath(actions.projectLocation)
+    : undefined;
+  const markdownText = rewriteMarkdownLocalImageUrls(
+    normalizeIncompleteProjectLinkTail(
+      normalizeGfmTableSeparators(normalizeShortCodeFenceClosers(text)),
+    ),
+    { ...(projectRoot ? { projectRoot } : {}) },
   );
   return (
     <div className="lc-chat-markdown prose max-w-none text-[length:var(--lc-chat-font-size)] leading-snug text-foreground prose-headings:text-[length:var(--lc-chat-font-size)] prose-p:text-[length:var(--lc-chat-font-size)] prose-p:whitespace-pre-wrap prose-li:text-[length:var(--lc-chat-font-size)] prose-pre:my-2 prose-pre:rounded prose-pre:border-0 prose-pre:bg-foreground/10 prose-pre:px-[0.5em] prose-pre:py-[0.25em] prose-pre:font-mono prose-pre:text-[0.875em] prose-pre:leading-snug prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:overflow-x-hidden prose-code:before:content-none prose-code:after:content-none prose-a:text-foreground prose-a:no-underline prose-a:text-[length:inherit] hover:prose-a:underline hover:prose-a:decoration-1 prose-a:underline-offset-2">
@@ -218,8 +228,11 @@ function rehypeLocalImageUrls() {
 
 function rewriteLocalImageUrls(node: MarkdownHastNode): void {
   const src = node.properties?.src;
-  if (node.tagName === "img" && typeof src === "string" && /^[A-Za-z]:[\\/]/.test(src)) {
-    node.properties!.src = toLocalFileUrl(src);
+  // Fallback for absolute paths that skip the pre-parse rewrite (e.g. HTML
+  // <img>). Relative project paths need projectRoot and are handled only there.
+  if (node.tagName === "img" && typeof src === "string") {
+    const rewritten = resolveMarkdownImageUrl(src);
+    if (rewritten) node.properties!.src = rewritten;
   }
   node.children?.forEach(rewriteLocalImageUrls);
 }

--- a/src/shared/markdownLocalImages.test.ts
+++ b/src/shared/markdownLocalImages.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkdownImageUrl, rewriteMarkdownLocalImageUrls } from "./markdownLocalImages";
+import { resolveLocalFileUrlPath, toLocalFileUrl } from "./promptContent";
+
+describe("resolveMarkdownImageUrl", () => {
+  it("converts Windows absolute paths to poracode-local URLs", () => {
+    expect(resolveMarkdownImageUrl("C:\\Users\\me\\.grok\\sessions\\shot.png")).toBe(
+      toLocalFileUrl("C:\\Users\\me\\.grok\\sessions\\shot.png"),
+    );
+  });
+
+  it("converts POSIX absolute paths to poracode-local URLs", () => {
+    expect(resolveMarkdownImageUrl("/tmp/shot.png")).toBe(toLocalFileUrl("/tmp/shot.png"));
+  });
+
+  it("resolves project-relative image paths against the project root", () => {
+    expect(
+      resolveMarkdownImageUrl("verification-shots/01-collapsed.png", {
+        projectRoot: "E:\\work\\repo",
+      }),
+    ).toBe(toLocalFileUrl("E:/work/repo/verification-shots/01-collapsed.png"));
+  });
+
+  it("refuses relative path traversal", () => {
+    expect(resolveMarkdownImageUrl("../secret.png", { projectRoot: "E:\\work\\repo" })).toBeNull();
+  });
+
+  it("leaves remote and data URLs alone", () => {
+    expect(resolveMarkdownImageUrl("https://example.test/a.png")).toBeNull();
+    expect(resolveMarkdownImageUrl("data:image/png;base64,abc")).toBeNull();
+    expect(resolveMarkdownImageUrl("poracode-local://local/C:/tmp/a.png")).toBeNull();
+  });
+
+  it("does not promote non-image relative paths", () => {
+    expect(resolveMarkdownImageUrl("notes.md", { projectRoot: "E:\\work\\repo" })).toBeNull();
+  });
+});
+
+describe("rewriteMarkdownLocalImageUrls", () => {
+  it("rewrites Windows backslash image targets before markdown can mangle them", () => {
+    // CommonMark treats `\.` as an escaped `.`, which would turn
+    // `C:\Users\me\.grok\…` into `C:\Users\me.grok\…` if left unrewritten.
+    const input = "![Before](C:\\Users\\me\\.grok\\sessions\\E%3A%5Cwork\\assets\\image.png)";
+    const out = rewriteMarkdownLocalImageUrls(input);
+    expect(out).toContain("poracode-local://local/");
+    expect(out).toMatch(/^!\[[^\]]*\]\(<poracode-local:\/\/local\/[^>]+>\)$/);
+
+    const url = out.match(/!\[[^\]]*\]\(<([^>]+)>\)/)?.[1];
+    expect(url).toBeTruthy();
+    expect(resolveLocalFileUrlPath(url!, "win32")).toBe(
+      "C:/Users/me/.grok/sessions/E%3A%5Cwork/assets/image.png",
+    );
+  });
+
+  it("rewrites relative verification-shot paths when a project root is provided", () => {
+    const out = rewriteMarkdownLocalImageUrls(
+      "See ![After](verification-shots/01-collapsed-same-file-edits.png)",
+      { projectRoot: "E:\\work\\lightcode\\.poracode\\worktrees\\poracode-brave-willow" },
+    );
+    expect(out).toContain("poracode-local://local/E:");
+    expect(out).toContain("verification-shots");
+    expect(out).not.toContain("](verification-shots/");
+  });
+
+  it("leaves incomplete streaming image syntax untouched", () => {
+    const partial = "![Before](C:\\Users\\me\\shot";
+    expect(rewriteMarkdownLocalImageUrls(partial)).toBe(partial);
+  });
+
+  it("leaves remote markdown images untouched", () => {
+    const remote = "![Remote](https://example.test/a.png)";
+    expect(rewriteMarkdownLocalImageUrls(remote)).toBe(remote);
+  });
+
+  it("round-trips the nightly Grok ACP verification markdown paths", () => {
+    const projectRoot = "E:\\work\\lightcode\\.poracode\\worktrees\\poracode-brave-willow-b4fc6c26";
+    const sessionAsset =
+      "C:\\Users\\sdsle\\.grok\\sessions\\E%3A%5Cwork%5Clightcode%5C.poracode%5Cworktrees%5Cporacode-brave-willow-b4fc6c26\\019f66fb-2716-7c00-ac5a-85ca2c4e8b58\\assets\\image-ea056148-aef3-4592-a6b7-1b3ec77fe7bd.png";
+    const md = [
+      `![Before: individual Edit rows](${sessionAsset})`,
+      "",
+      "![After: collapsed](verification-shots/01-collapsed-same-file-edits.png)",
+    ].join("\n");
+
+    const out = rewriteMarkdownLocalImageUrls(md, { projectRoot });
+    const urls = [...out.matchAll(/!\[[^\]]*\]\(<([^>]+)>\)/g)].map((m) => m[1]!);
+    expect(urls).toHaveLength(2);
+
+    expect(resolveLocalFileUrlPath(urls[0]!, "win32")).toBe(sessionAsset.replaceAll("\\", "/"));
+    expect(resolveLocalFileUrlPath(urls[1]!, "win32")).toBe(
+      `${projectRoot.replaceAll("\\", "/")}/verification-shots/01-collapsed-same-file-edits.png`,
+    );
+  });
+});

--- a/src/shared/markdownLocalImages.ts
+++ b/src/shared/markdownLocalImages.ts
@@ -1,0 +1,68 @@
+import { isImagePath, toLocalFileUrl } from "./promptContent";
+
+/**
+ * Rewrite local filesystem image targets to `poracode-local://` before markdown
+ * parse. Required because CommonMark treats `\.` as an escape (mangling Windows
+ * paths like `C:\Users\me\.grok\…`), and relative image paths would otherwise
+ * 404 against the app origin.
+ */
+export function rewriteMarkdownLocalImageUrls(
+  text: string,
+  options?: { projectRoot?: string },
+): string {
+  if (!text.includes("![")) return text;
+  // Only complete `![…](…)` forms — incomplete streaming tails stay untouched.
+  return text.replace(
+    /!\[([^\]]*)\]\((?:<([^>\n]+)>|([^)\n]+))\)/g,
+    (full, alt: string, angleUrl: string | undefined, bareUrl: string | undefined) => {
+      const rawUrl = (angleUrl ?? bareUrl ?? "").trim();
+      if (!rawUrl) return full;
+      const rewritten = resolveMarkdownImageUrl(rawUrl, options);
+      if (!rewritten) return full;
+      // Angle brackets keep the URL opaque to markdown's backslash escapes.
+      return `![${alt}](<${rewritten}>)`;
+    },
+  );
+}
+
+/**
+ * Map a markdown image destination to a renderable local URL, or null when it
+ * should be left unchanged (remote / data / already local).
+ */
+export function resolveMarkdownImageUrl(
+  url: string,
+  options?: { projectRoot?: string },
+): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+
+  if (
+    trimmed.startsWith("poracode-local://") ||
+    trimmed.startsWith("lightcode-local://") ||
+    trimmed.startsWith("data:") ||
+    trimmed.startsWith("blob:") ||
+    /^https?:\/\//i.test(trimmed)
+  ) {
+    return null;
+  }
+
+  // Windows drive, UNC (`\\` / `//`), or POSIX absolute.
+  if (/^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.startsWith("\\\\") || trimmed.startsWith("/")) {
+    return toLocalFileUrl(trimmed);
+  }
+
+  const projectRoot = options?.projectRoot?.trim();
+  if (!projectRoot || !isImagePath(trimmed) || trimmed.includes("://")) return null;
+
+  const absolute = joinProjectRoot(projectRoot, trimmed);
+  return absolute ? toLocalFileUrl(absolute) : null;
+}
+
+function joinProjectRoot(projectRoot: string, relativePath: string): string | null {
+  const root = projectRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+  const rel = relativePath.replaceAll("\\", "/").replace(/^\.\//, "").replace(/^\/+/, "");
+  if (!root || !rel) return null;
+  const parts = rel.split("/").filter((part) => part.length > 0 && part !== ".");
+  if (parts.some((part) => part === "..")) return null;
+  return `${root}/${parts.join("/")}`;
+}

--- a/src/shared/promptContent.test.ts
+++ b/src/shared/promptContent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildPromptContentBlocks, toLocalFileUrl } from "./promptContent";
+import { buildPromptContentBlocks, resolveLocalFileUrlPath, toLocalFileUrl } from "./promptContent";
 
 describe("buildPromptContentBlocks", () => {
   it("keeps text-only prompts as a text block", () => {
@@ -75,6 +75,14 @@ describe("toLocalFileUrl", () => {
     );
   });
 
+  it("percent-encodes path segments that contain literal percent signs", () => {
+    // Grok session dirs are named with URL-encoded worktree paths on disk.
+    const path = "C:\\Users\\me\\.grok\\sessions\\E%3A%5Cwork%5Crepo\\assets\\shot.png";
+    expect(toLocalFileUrl(path)).toBe(
+      "poracode-local://local/C:/Users/me/.grok/sessions/E%253A%255Cwork%255Crepo/assets/shot.png",
+    );
+  });
+
   // Regression guard for the `standard: true` scheme privilege (commit bd0faf73).
   // Standard/special schemes parse with WHATWG "special authority ignore
   // slashes": leading slashes collapse and the first path segment is consumed
@@ -82,14 +90,12 @@ describe("toLocalFileUrl", () => {
   // therefore lost its first path segment — `/Users` on macOS, the drive
   // letter on Windows — so the protocol handler resolved the wrong file and
   // pasted images failed to render. The constant `local` host absorbs that
-  // parsing so the real path survives intact in `pathname`. This helper mirrors
-  // the resolution in src/main/attachments/localFiles.ts.
+  // parsing so the real path survives intact in `pathname`.
   function resolveLikeProtocolHandler(url: string, platform: "darwin" | "win32"): string {
     // poracode-local is non-special in Node; swap to a special scheme to
     // reproduce Chromium's standard-scheme canonicalization (host extraction).
     const asSpecial = url.replace(/^poracode-local:/, "https:");
-    const raw = decodeURIComponent(new URL(asSpecial).pathname);
-    return platform === "win32" && /^\/[A-Za-z]:/.test(raw) ? raw.slice(1) : raw;
+    return resolveLocalFileUrlPath(asSpecial, platform);
   }
 
   it("round-trips a POSIX path through standard-scheme parsing", () => {
@@ -107,5 +113,13 @@ describe("toLocalFileUrl", () => {
     expect(resolveLikeProtocolHandler(toLocalFileUrl("C:\\Users\\me\\img.png"), "win32")).toBe(
       "C:/Users/me/img.png",
     );
+  });
+
+  it("round-trips a Windows path with literal percent-encoded folder names", () => {
+    // Without segment encoding, decodeURIComponent would turn E%3A into E:
+    // and the protocol handler would look up a non-existent path.
+    const path =
+      "C:/Users/me/.grok/sessions/E%3A%5Cwork%5C.poracode%5Cworktrees%5Crepo/assets/img.png";
+    expect(resolveLikeProtocolHandler(toLocalFileUrl(path), "win32")).toBe(path);
   });
 });

--- a/src/shared/promptContent.ts
+++ b/src/shared/promptContent.ts
@@ -41,18 +41,36 @@ export function isImagePath(path: string, mimeType?: string): boolean {
   return mimeType?.startsWith("image/") === true || IMAGE_EXTENSIONS.has(getExtension(path));
 }
 
+/**
+ * Build a `poracode-local://` URL for an absolute filesystem path.
+ *
+ * Anchors the path under a constant `local` host so standard-scheme parsing
+ * does not eat `/Users` or the Windows drive letter as the host (see
+ * `localFiles.ts`). Segments are percent-encoded so literal `%` in folder
+ * names (e.g. Grok session dirs `E%3A%5Cwork…`) survives `decodeURIComponent`.
+ */
 export function toLocalFileUrl(absolutePath: string): string {
   const normalized = absolutePath.replaceAll("\\", "/");
-  // The `poracode-local` scheme is registered as `standard: true` (so cached
-  // ACP registry icons can load as CSS mask-image sources). Standard/special
-  // schemes parse with WHATWG "special authority ignore slashes": leading
-  // slashes collapse and the first path segment becomes the host. Anchoring the
-  // path to a constant `local` host keeps the real path intact in the URL's
-  // `pathname` — without it, `/Users/…` (macOS) or the drive letter (Windows)
-  // would be eaten as the host and the protocol handler would resolve the wrong
-  // file. See src/main/attachments/localFiles.ts.
   const path = normalized.startsWith("/") ? normalized : `/${normalized}`;
-  return `poracode-local://local${path}`;
+  const encoded = path
+    .split("/")
+    .map((segment, index) => {
+      if (segment.length === 0) return segment;
+      // Leave `C:` unencoded so pathname stays `/C:/Users/…`.
+      if (index === 1 && /^[A-Za-z]:$/.test(segment)) return segment;
+      return encodeURIComponent(segment);
+    })
+    .join("/");
+  return `poracode-local://local${encoded}`;
+}
+
+/** Inverse of {@link toLocalFileUrl} — same rules as the main-process protocol handler. */
+export function resolveLocalFileUrlPath(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const raw = decodeURIComponent(new URL(url).pathname);
+  return platform === "win32" && /^\/[A-Za-z]:/.test(raw) ? raw.slice(1) : raw;
 }
 
 /**


### PR DESCRIPTION
- Extract local-image-path detection into a shared `markdownLocalImages` module so chat markdown rendering can resolve and display locally attached images inline instead of showing raw file paths
- Wire `ItemMarkdownInner` to use the new resolver, with tests covering rendering behavior
- Extend `promptContent` handling and `localFiles` attachment logic to support the local-image markdown flow
- Update `.gitignore` and `AGENTS.md` for related tooling/documentation upkeep