### PR TITLE
fix(chat): correct tool call categorization and grouping logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ review.diff
 .spec-workflow/
 **/worktrees/
 .cursor/
+.grok/
 .commandcode/
 mcps/
 .antigravitycli/

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -164,6 +164,9 @@ describe("ToolCallGroup", () => {
       items.map((item) => item.id),
     );
 
+    // Edit-only groups stay collapsed while live — open to inspect per-row diffs.
+    expandGroup(/2 edits/i);
+
     expect(screen.getByText("+4")).toHaveClass("text-success");
     expect(screen.getAllByText("-2")[0]).toHaveClass("text-danger");
     expect(screen.getByText("+5")).toHaveClass("text-success");
@@ -190,6 +193,68 @@ describe("ToolCallGroup", () => {
     expect(within(heading).getByText("-5")).toHaveClass("text-danger");
   });
 
+  it("keeps same-file edit summary when thoughts interleave the patches", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeFileChangeItem("file-1", { added: 4, removed: 2 }),
+      makeReasoningItem("reasoning-1", "planning the next hunk"),
+      makeFileChangeItem("file-2", { added: 5, removed: 3 }),
+    ];
+    seedThread(threadId, items);
+
+    renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+      true,
+    );
+
+    // Compact same-file header, not the generic "2 edits · 1 thought" fallback.
+    const heading = screen.getByRole("button", { name: /2 edits:/i });
+    expect(within(heading).getByText("foo.ts")).toBeInTheDocument();
+    expect(within(heading).getByText("+9")).toHaveClass("text-success");
+    // Live edit groups stay collapsed — no per-edit rows auto-expanded.
+    expect(heading).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("button", { name: /^Edit/i })).not.toBeInTheDocument();
+  });
+
+  it("does not auto-expand live edit-only groups", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeFileChangeItem("file-1", { added: 4, removed: 2 }, "src/a.ts"),
+      makeFileChangeItem("file-2", { added: 5, removed: 3 }, "src/b.ts"),
+    ];
+    seedThread(threadId, items);
+
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+      true,
+    );
+
+    // Multi-file edit run: still "2 edits", but never open by itself while live.
+    const heading = screen.getByRole("button", { name: /2 edits/i });
+    expect(heading).toHaveAttribute("aria-expanded", "false");
+    expect(view.container.querySelector(".poracode-tool-call-group-viewport")).toBeNull();
+  });
+
+  it("still auto-expands live groups that include non-edit tools", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeToolItem("tool-1", "Read file one"),
+      makeFileChangeItem("file-1", { added: 1, removed: 0 }),
+    ];
+    seedThread(threadId, items);
+
+    const view = renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+      true,
+    );
+
+    expect(view.container.querySelector(".poracode-tool-call-group-viewport")).not.toBeNull();
+    expect(screen.getByText("Read file one")).toBeInTheDocument();
+  });
+
   it("flattens same-file edit groups into stacked diffs without per-edit rows", async () => {
     const threadId = "thread-1";
     const items = [
@@ -202,6 +267,8 @@ describe("ToolCallGroup", () => {
       threadId,
       items.map((item) => item.id),
     );
+
+    expandGroup(/2 edits:/i);
 
     // No nested per-edit disclosure rows — diffs render directly.
     expect(screen.queryByRole("button", { name: /^Edit:/i })).not.toBeInTheDocument();
@@ -230,7 +297,7 @@ describe("ToolCallGroup", () => {
       items.map((item) => item.id),
     );
 
-    expect(screen.getByRole("button", { name: /2 edits:/i })).toBeInTheDocument();
+    expandGroup(/2 edits:/i);
     const viewport = getViewport(view.container);
     expect(within(viewport).queryAllByRole("button")).toHaveLength(0);
     await waitFor(() => {
@@ -244,6 +311,8 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    // Edit-only groups stay collapsed while live — open the group, then the row.
+    expandGroup(/1 edit/i);
     fireEvent.click(screen.getByText("src/foo.ts"));
 
     await waitFor(() => {
@@ -260,6 +329,7 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    expandGroup(/1 edit/i);
 
     expect(screen.getByText("+3")).toHaveClass("text-success");
     fireEvent.click(screen.getByText("chatPaneSelectors.ts"));
@@ -278,6 +348,7 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    expandGroup(/1 edit/i);
 
     expect(screen.getByText("+1")).toHaveClass("text-success");
     expect(screen.getByText("-1")).toHaveClass("text-danger");
@@ -297,6 +368,7 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    expandGroup(/1 edit/i);
 
     expect(screen.getByText("+1")).toHaveClass("text-success");
     expect(screen.getByText("-1")).toHaveClass("text-danger");
@@ -353,6 +425,7 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    expandGroup(/1 edit/i);
 
     expect(screen.getByText("+2")).toHaveClass("text-success");
     fireEvent.click(screen.getByText("runtimeToolGrouping.ts"));
@@ -581,6 +654,7 @@ describe("ToolCallGroup", () => {
     seedThread(threadId, [item]);
 
     renderToolCallGroup(threadId, [item.id]);
+    expandGroup(/1 edit/i);
     fireEvent.click(screen.getByText("src/foo.ts"));
 
     await waitFor(() => {
@@ -609,6 +683,11 @@ function renderToolCallGroup(
       />
     </AppProvider>,
   );
+}
+
+/** Open a live edit-only group that stays collapsed by default. */
+function expandGroup(name: RegExp) {
+  fireEvent.click(screen.getByRole("button", { name }));
 }
 
 function seedThread(threadId: string, items: readonly RuntimeChatItem[]) {

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -56,11 +56,11 @@ import { LazyInlineDiffView } from "./LazyInlineDiffView";
 import { ReasoningInline } from "./ReasoningInline";
 import { detectLanguageFromPath, type ViewportLanguage } from "./languageDetect";
 import {
+  analyzeEditToolGroup,
   getToolLikePayload,
   isEditLikeToolPayload,
   isToolGroupItem,
   readCommandPayloadCommand,
-  summarizeSameFileEditGroup,
   summarizeToolCalls,
   type SameFileEditGroupSummary,
 } from "./toolCallCategorization";
@@ -92,14 +92,16 @@ export const ToolCallGroup = memo(function ToolCallGroup({
     ),
   );
   const actions = useChatPaneActions();
-  // Live tail expands by default so the user sees in-flight calls; collapse
-  // automatically once another item arrives after the group (isLive flips
-  // false). Manual toggles still apply afterwards.
-  const [isExpanded, setIsExpanded] = useState(isLive);
+  // Single pass: edit-only groups stay collapsed while live; same-file multi
+  // patches also get the compact "N edits: path" header.
+  const { editOnly: editOnlyGroup, sameFile: sameFileEditSummary } = analyzeEditToolGroup(items);
+  const [isExpanded, setIsExpanded] = useState(() => isLive && !editOnlyGroup);
   const [showAll, setShowAll] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const previousLayoutRef = useRef({ isExpanded, showAll });
   const hasOverflowRows = items.length > TOOL_CALL_GROUP_MAX_VISIBLE_ROWS;
+  // Preserve manual open/close across live-tail item updates.
+  const userToggledRef = useRef(false);
 
   useLayoutEffect(() => {
     const previous = previousLayoutRef.current;
@@ -113,8 +115,13 @@ export const ToolCallGroup = memo(function ToolCallGroup({
   }, [actions, isExpanded, onHeightChange, showAll]);
 
   useEffect(() => {
-    if (!isLive) setIsExpanded(false);
-  }, [isLive]);
+    if (!isLive) {
+      userToggledRef.current = false;
+      setIsExpanded(false);
+      return;
+    }
+    if (!userToggledRef.current) setIsExpanded(!editOnlyGroup);
+  }, [isLive, editOnlyGroup]);
 
   useEffect(() => {
     if (!hasOverflowRows) setShowAll(false);
@@ -130,7 +137,6 @@ export const ToolCallGroup = memo(function ToolCallGroup({
 
   if (items.length === 0) return null;
   const sections = summarizeToolCalls(items);
-  const sameFileEditSummary = summarizeSameFileEditGroup(items);
   const visibleItems =
     !showAll && hasOverflowRows ? items.slice(-TOOL_CALL_GROUP_MAX_VISIBLE_ROWS) : items;
 
@@ -139,7 +145,10 @@ export const ToolCallGroup = memo(function ToolCallGroup({
       <Disclosure
         className="text-[length:var(--lc-chat-font-size-command)] leading-tight"
         isExpanded={isExpanded}
-        onExpandedChange={setIsExpanded}
+        onExpandedChange={(next) => {
+          userToggledRef.current = true;
+          setIsExpanded(next);
+        }}
       >
         <Disclosure.Heading>
           <Disclosure.Trigger className={`group ${chatRowClass} gap-2 ${chatRowHoverClass}`}>

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
@@ -5,7 +5,9 @@ import {
   categorizeToolName,
   categorizeVerbPrefix,
   categoryFromSummaryLabel,
+  isEditOnlyToolGroup,
   isToolGroupItem,
+  summarizeSameFileEditGroup,
 } from "./toolCallCategorization";
 
 describe("categorizeItem", () => {
@@ -79,6 +81,91 @@ describe("categoryFromSummaryLabel", () => {
   });
 });
 
+describe("summarizeSameFileEditGroup", () => {
+  it("summarizes two same-path file_change edits with total diff", () => {
+    const items = [
+      makeFileChange("a", "src/foo.ts", { added: 4, removed: 1 }),
+      makeFileChange("b", "src/foo.ts", { added: 2, removed: 3 }),
+    ];
+    expect(summarizeSameFileEditGroup(items)).toEqual({
+      count: 2,
+      path: "src/foo.ts",
+      diffSummary: { added: 6, removed: 4 },
+    });
+  });
+
+  it("keeps the same-file header when thoughts interleave the edits", () => {
+    const items = [
+      makeFileChange("a", "src/foo.ts", { added: 4, removed: 1 }),
+      makeReasoning("r1", "planning the next patch"),
+      makeFileChange("b", "src/foo.ts", { added: 2, removed: 3 }),
+      makeReasoning("r2", "done"),
+    ];
+    expect(summarizeSameFileEditGroup(items)).toEqual({
+      count: 2,
+      path: "src/foo.ts",
+      diffSummary: { added: 6, removed: 4 },
+    });
+  });
+
+  it("returns null for a single edit even with thoughts", () => {
+    const items = [makeFileChange("a", "src/foo.ts"), makeReasoning("r1", "thinking")];
+    expect(summarizeSameFileEditGroup(items)).toBeNull();
+  });
+
+  it("returns null when edits target different files", () => {
+    const items = [makeFileChange("a", "src/foo.ts"), makeFileChange("b", "src/bar.ts")];
+    expect(summarizeSameFileEditGroup(items)).toBeNull();
+  });
+
+  it("returns null when a non-edit tool breaks the edit run", () => {
+    const items = [
+      makeFileChange("a", "src/foo.ts"),
+      makeTool("t1", "Read"),
+      makeFileChange("b", "src/foo.ts"),
+    ];
+    expect(summarizeSameFileEditGroup(items)).toBeNull();
+  });
+
+  it("normalizes path separators when comparing", () => {
+    const items = [
+      makeFileChange("a", "src\\foo.ts", { added: 1, removed: 0 }),
+      makeFileChange("b", "src/foo.ts", { added: 1, removed: 0 }),
+    ];
+    expect(summarizeSameFileEditGroup(items)).toEqual({
+      count: 2,
+      path: "src\\foo.ts",
+      diffSummary: { added: 2, removed: 0 },
+    });
+  });
+});
+
+describe("isEditOnlyToolGroup", () => {
+  it("is true for pure edit groups and edit+thought groups", () => {
+    expect(
+      isEditOnlyToolGroup([makeFileChange("a", "src/foo.ts"), makeFileChange("b", "src/bar.ts")]),
+    ).toBe(true);
+    expect(
+      isEditOnlyToolGroup([
+        makeFileChange("a", "src/foo.ts"),
+        makeReasoning("r1", "thinking"),
+        makeFileChange("b", "src/foo.ts"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false when any non-edit non-thought tool is present", () => {
+    expect(isEditOnlyToolGroup([makeTool("t1", "Read"), makeFileChange("a", "src/foo.ts")])).toBe(
+      false,
+    );
+  });
+
+  it("is false for empty or thought-only groups", () => {
+    expect(isEditOnlyToolGroup([])).toBe(false);
+    expect(isEditOnlyToolGroup([makeReasoning("r1", "only thinking")])).toBe(false);
+  });
+});
+
 describe("categorizeVerbPrefix", () => {
   it("maps reading/viewing prefixes to viewed", () => {
     expect(categorizeVerbPrefix("Reading src/foo.ts")).toBe("viewed");
@@ -101,4 +188,37 @@ describe("categorizeVerbPrefix", () => {
     expect(categorizeVerbPrefix("Unknown action")).toBe("other");
   });
 });
+
+function makeFileChange(
+  id: string,
+  path: string,
+  diffSummary: { added: number; removed: number } = { added: 1, removed: 1 },
+): RuntimeChatItem {
+  return {
+    id,
+    type: "file_change",
+    state: "completed",
+    payload: { path, changeKind: "edit", diffSummary },
+    streams: {},
+  };
+}
+
+function makeReasoning(id: string, text: string): RuntimeChatItem {
+  return {
+    id,
+    type: "reasoning",
+    state: "completed",
+    streams: { reasoning_text: text },
+  };
+}
+
+function makeTool(id: string, name: string): RuntimeChatItem {
+  return {
+    id,
+    type: "tool_call",
+    state: "completed",
+    payload: { name, status: "success" },
+    streams: {},
+  };
+}
 // @vitest-environment node

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
@@ -68,27 +68,54 @@ export function summarizeToolCalls(items: readonly RuntimeChatItem[]): GroupSect
     });
 }
 
-export function summarizeSameFileEditGroup(
-  items: readonly RuntimeChatItem[],
-): SameFileEditGroupSummary | null {
-  if (items.length <= 1) return null;
+export type EditToolGroupAnalysis = {
+  /** Every non-thought item is an edit (live tail should stay collapsed). */
+  editOnly: boolean;
+  /**
+   * Compact "N edits: path" summary when those edits all share one path.
+   * Thoughts are ignored so interleaved reasoning does not break the header.
+   */
+  sameFile: SameFileEditGroupSummary | null;
+};
 
+/**
+ * One pass over a tool-call group: classify edit-only vs mixed, and detect the
+ * same-file multi-edit case used for the compact path header.
+ */
+export function analyzeEditToolGroup(items: readonly RuntimeChatItem[]): EditToolGroupAnalysis {
   let sharedPath: string | undefined;
+  let editCount = 0;
   let added = 0;
   let removed = 0;
   let hasDiffSummary = false;
   let missingDiffSummary = false;
+  let hasEdit = false;
+  let sameFileOk = true;
 
   for (const item of items) {
-    if (categorizeItem(item) !== "edited") return null;
+    const category = categorizeItem(item);
+    // Thoughts often interleave a multi-patch run; they are noise for both the
+    // edit-only auto-expand rule and the same-file path header.
+    if (category === "thought") continue;
+    if (category !== "edited") {
+      return { editOnly: false, sameFile: null };
+    }
+    hasEdit = true;
+    if (!sameFileOk) continue;
+
     const path = readEditGroupPath(item);
-    if (!path) return null;
+    if (!path) {
+      sameFileOk = false;
+      continue;
+    }
     if (sharedPath === undefined) {
       sharedPath = path;
     } else if (normalizeEditGroupPath(sharedPath) !== normalizeEditGroupPath(path)) {
-      return null;
+      sameFileOk = false;
+      continue;
     }
 
+    editCount += 1;
     const diffSummary = readEditDiffSummary(item);
     if (diffSummary) {
       hasDiffSummary = true;
@@ -99,12 +126,29 @@ export function summarizeSameFileEditGroup(
     }
   }
 
-  if (!sharedPath) return null;
-  return {
-    count: items.length,
-    path: sharedPath,
-    ...(hasDiffSummary && !missingDiffSummary ? { diffSummary: { added, removed } } : {}),
-  };
+  if (!hasEdit) return { editOnly: false, sameFile: null };
+
+  // Compact same-file treatment only once 2+ patches share a path.
+  const sameFile =
+    sameFileOk && sharedPath && editCount > 1
+      ? {
+          count: editCount,
+          path: sharedPath,
+          ...(hasDiffSummary && !missingDiffSummary ? { diffSummary: { added, removed } } : {}),
+        }
+      : null;
+
+  return { editOnly: true, sameFile };
+}
+
+export function summarizeSameFileEditGroup(
+  items: readonly RuntimeChatItem[],
+): SameFileEditGroupSummary | null {
+  return analyzeEditToolGroup(items).sameFile;
+}
+
+export function isEditOnlyToolGroup(items: readonly RuntimeChatItem[]): boolean {
+  return analyzeEditToolGroup(items).editOnly;
 }
 
 export function readEditGroupPath(item: RuntimeChatItem): string | undefined {


### PR DESCRIPTION
- Fixes incorrect categorization and grouping of tool calls in the chat pane's ToolCallGroup component
- Updates test coverage in `toolCallCategorization.test.ts` and `ToolCallGroup.test.tsx` to match corrected logic
- Adjusts `.gitignore` for the change