### PR TITLE
Update default Codex utility models to GPT-5.6 Luna/Terra/Sol

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
@@ -384,7 +384,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/renderer/components/providers/codex/index.tsx
+++ b/src/renderer/components/providers/codex/index.tsx
@@ -17,35 +17,25 @@ import { registerTitleGenDefaults } from "../titleGen";
 const PROVIDER_KIND = providerManifest.kind;
 
 registerProviderIcon(PROVIDER_KIND, CodexStatusIcon);
-// Title/commit defaults were chosen by an empirical benchmark (latency + blind
-// quality judging) across the Codex model/effort matrix on real prompts and
-// diffs — not by model-tier intuition. Two findings drove these:
-//   1. The dominant latency cost is reasoning effort, not model size. The old
-//      mini-at-xhigh commit default ran ~13-20x slower (≈54s median, 116s max)
-//      than low effort for no quality gain.
-//   2. gpt-5.4-mini at low effort scored in the top quality cluster on BOTH
-//      tasks while being the most consistent (no case bombed) and the cheapest.
-//      Bigger models did not reliably win: gpt-5.4 and gpt-5.3-codex-spark
-//      mislabeled a feature commit as "fix", and the fast lane / xhigh added
-//      latency without quality. So we keep mini and only fix the effort.
-// Frontier gpt-5.5 stays for the conflict resolver (a real interactive task).
+// Codex 5.6 utility defaults: Luna for cheap title gen, Terra for commit
+// messages, Sol for interactive conflict resolution.
 registerCommitGenDefaults(PROVIDER_KIND, {
   label: "Codex",
-  hint: "GPT-5.4 Mini low",
-  model: "gpt-5.4-mini",
+  hint: "GPT-5.6 Terra low",
+  model: "gpt-5.6-terra",
   effort: "low",
 });
 registerTitleGenDefaults(PROVIDER_KIND, {
   label: "Codex",
-  hint: "GPT-5.4 Mini low",
-  model: "gpt-5.4-mini",
+  hint: "GPT-5.6 Luna low",
+  model: "gpt-5.6-luna",
   effort: "low",
 });
 registerConflictResolverDefaults(PROVIDER_KIND, {
   label: "Codex",
-  hint: "GPT-5.5 high",
-  model: "gpt-5.5",
-  effort: "high",
+  hint: "GPT-5.6 Sol medium",
+  model: "gpt-5.6-sol",
+  effort: "medium",
 });
 
 registerConfigNormalizer(PROVIDER_KIND, ({ config, presentationMode }) => {

--- a/src/renderer/components/providers/commitGen.test.ts
+++ b/src/renderer/components/providers/commitGen.test.ts
@@ -22,6 +22,9 @@ const codexStatus: AgentStatus = {
   authState: "authenticated",
   capabilities: {
     models: [
+      { id: "gpt-5.6-luna", label: "5.6 Luna" },
+      { id: "gpt-5.6-terra", label: "5.6 Terra" },
+      { id: "gpt-5.6-sol", label: "5.6 Sol" },
       { id: "gpt-5.5", label: "5.5" },
       { id: "gpt-5.4", label: "5.4" },
       { id: "gpt-5.4-mini", label: "5.4 Mini" },
@@ -79,9 +82,9 @@ const claudeStatus: AgentStatus = {
 };
 
 describe("resolveCommitGenConfig", () => {
-  it("falls back to the registered Codex default (5.4 Mini + low)", () => {
+  it("falls back to the registered Codex default (5.6 Terra + low)", () => {
     expect(resolveCommitGenConfig(codexStatus, "", "")).toEqual({
-      model: "gpt-5.4-mini",
+      model: "gpt-5.6-terra",
       effort: "low",
       availableEfforts: ["low", "medium", "high", "xhigh"],
     });
@@ -127,13 +130,13 @@ describe("getCommitGenCandidates", () => {
   });
 
   it("falls back to all installed agents when no provider has its preferred model", () => {
-    // Codex without its gpt-5.4-mini default — strict filter would empty the
+    // Codex without its gpt-5.6-terra default — strict filter would empty the
     // list, so the helper loosens to the full installed set sorted by preference.
     const codexWithoutPreferred: AgentStatus = {
       ...codexStatus,
       capabilities: {
         ...codexStatus.capabilities,
-        models: [{ id: "gpt-5.5", label: "5.5" }],
+        models: [{ id: "gpt-5.6-sol", label: "5.6 Sol" }],
       },
     };
     expect(getCommitGenCandidates([codexWithoutPreferred], "auto")).toEqual([
@@ -145,7 +148,7 @@ describe("getCommitGenCandidates", () => {
 describe("provider default hints", () => {
   it("builds commit-generation hint text from provider registrations", () => {
     expect(getCommitGenDefaultsHint()).toBe(
-      "Defaults: Claude -> Sonnet medium, Codex -> GPT-5.4 Mini low, Copilot -> auto, Cursor -> Composer 2.5 Fast, Gemini -> 3 Flash",
+      "Defaults: Claude -> Sonnet medium, Codex -> GPT-5.6 Terra low, Copilot -> auto, Cursor -> Composer 2.5 Fast, Gemini -> 3 Flash",
     );
   });
 });
@@ -178,7 +181,7 @@ describe("generateCommitMessageWithFallback", () => {
     expect(invoke).toHaveBeenNthCalledWith(1, {
       projectLocation,
       agentKind: "codex",
-      model: "gpt-5.4-mini",
+      model: "gpt-5.6-terra",
       effort: "low",
     });
     expect(invoke).toHaveBeenNthCalledWith(2, {

--- a/src/renderer/components/providers/conflictResolver.test.ts
+++ b/src/renderer/components/providers/conflictResolver.test.ts
@@ -31,6 +31,7 @@ const codexStatus = {
   kind: "codex",
   capabilities: {
     models: [
+      { id: "gpt-5.6-sol", label: "5.6 Sol" },
       { id: "gpt-5.5", label: "5.5" },
       { id: "gpt-5.4", label: "5.4" },
       { id: "gpt-5.4-mini", label: "5.4 Mini" },
@@ -65,9 +66,13 @@ describe("resolveConflictResolverConfig", () => {
     expect(result.model).toBe("claude-opus-4-8");
   });
 
-  it("falls back to registered defaults (Codex → GPT-5.5)", () => {
+  it("falls back to registered defaults (Codex → GPT-5.6 Sol medium)", () => {
     const result = resolveConflictResolverConfig(codexStatus, "", "");
-    expect(result.model).toBe("gpt-5.5");
+    expect(result).toEqual({
+      model: "gpt-5.6-sol",
+      effort: "medium",
+      availableEfforts: ["low", "medium", "high", "xhigh"],
+    });
   });
 
   it("falls back to registered defaults (Cursor → Composer 2.5 Fast)", () => {


### PR DESCRIPTION
**Type:** Feature

- Point Codex utility defaults at the GPT-5.6 lineup: Luna for title generation, Terra for commit messages, and Sol for conflict resolution
- Use low effort for title/commit defaults and medium for the interactive conflict resolver (was high on GPT-5.5)
- Align commit-gen and conflict-resolver tests with the new models, hints, and effort fallbacks
- Refresh `pnpm-lock.yaml` dependency resolution for `@heroui/styles` / `tailwind-merge`