### PR TITLE
Surface Claude goal iterations and completion reasons

### DIFF
--- a/src/renderer/components/thread/ThreadGoalDock.test.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.test.tsx
@@ -1,7 +1,19 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { ThreadGoalDock } from "./ThreadGoalDock";
+
+// Render tooltip content inline — React Aria's hover machinery does not open
+// tooltips under jsdom.
+vi.mock("@heroui/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@heroui/react")>();
+  const Tooltip = Object.assign((props: { children: ReactNode }) => <>{props.children}</>, {
+    Trigger: (props: { children: ReactNode }) => <>{props.children}</>,
+    Content: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  });
+  return { ...actual, Tooltip };
+});
 
 describe("ThreadGoalDock", () => {
   afterEach(() => {
@@ -67,6 +79,35 @@ describe("ThreadGoalDock", () => {
 
     expect(screen.getByText("Complete · 11K tokens")).toBeInTheDocument();
     expect(screen.getByText("10m 21s")).toBeInTheDocument();
+  });
+
+  it("shows evaluator turn count and surfaces the last evaluation reason in the objective tooltip", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-12T10:00:10Z"));
+
+    render(
+      <AppProvider>
+        <ThreadGoalDock
+          state={{
+            sourceItemId: "goal-1",
+            itemState: "completed",
+            objective: "All auth tests pass",
+            status: "active",
+            action: "updated",
+            tokensUsed: 5000,
+            timeUsedSeconds: 60,
+            iterations: 3,
+            lastReason: "login.test.ts still failing",
+            updatedAt: Date.parse("2026-05-12T10:00:10Z") / 1000,
+          }}
+          onDismiss={() => undefined}
+        />
+      </AppProvider>,
+    );
+
+    expect(screen.getByText("3 turns")).toBeInTheDocument();
+
+    expect(screen.getByText(/login\.test\.ts still failing/)).toBeInTheDocument();
   });
 
   it("swaps the dock icon to the achieved indicator when the goal completes", () => {

--- a/src/renderer/components/thread/ThreadGoalDock.tsx
+++ b/src/renderer/components/thread/ThreadGoalDock.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Tooltip } from "@heroui/react";
 import { CircleCheckBig, Target, X } from "lucide-react";
 import { msg } from "@lingui/core/macro";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import type { ThreadGoalDockState } from "./threadGoalState";
 import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { formatElapsed } from "@/renderer/utils/formatTime";
@@ -43,6 +43,7 @@ export function ThreadGoalDock({ state, onDismiss }: ThreadGoalDockProps) {
   const elapsedSeconds = resolveGoalElapsedSeconds(state, nowSeconds, localAnchorSeconds);
   const meta = goalMeta(state, t);
   const elapsedLabel = elapsedSeconds > 0 ? formatElapsed(elapsedSeconds) : null;
+  const evaluatedTurns = state.iterations !== undefined && state.iterations > 0;
   const hasMeta = meta.length > 0;
   const StatusIcon = isComplete ? CircleCheckBig : Target;
   const statusIconClass = isComplete
@@ -65,10 +66,16 @@ export function ThreadGoalDock({ state, onDismiss }: ThreadGoalDockProps) {
         <span className="shrink-0 font-semibold text-foreground">
           <Trans>Goal</Trans>
         </span>
-        {hasMeta || elapsedLabel ? (
+        {hasMeta || evaluatedTurns || elapsedLabel ? (
           <span className="flex min-w-0 shrink items-center gap-1 text-[0.85em] text-[color:var(--muted)] [font-variant-numeric:tabular-nums]">
             {hasMeta ? <span className="truncate">{meta.join(" · ")}</span> : null}
-            {hasMeta && elapsedLabel ? <span aria-hidden="true">·</span> : null}
+            {hasMeta && evaluatedTurns ? <span aria-hidden="true">·</span> : null}
+            {evaluatedTurns ? (
+              <span className="shrink-0">
+                <Plural value={state.iterations ?? 0} one="# turn" other="# turns" />
+              </span>
+            ) : null}
+            {(hasMeta || evaluatedTurns) && elapsedLabel ? <span aria-hidden="true">·</span> : null}
             {elapsedLabel ? (
               <span className="inline-block shrink-0 text-center" style={{ minWidth: "7ch" }}>
                 {elapsedLabel}
@@ -77,7 +84,7 @@ export function ThreadGoalDock({ state, onDismiss }: ThreadGoalDockProps) {
           </span>
         ) : null}
         <span className="h-3 w-px shrink-0 bg-[color:var(--border)]" />
-        <GoalObjectiveText objective={state.objective} />
+        <GoalObjectiveText objective={state.objective} lastReason={state.lastReason} />
         <Tooltip delay={0}>
           <Tooltip.Trigger>
             <button
@@ -98,7 +105,13 @@ export function ThreadGoalDock({ state, onDismiss }: ThreadGoalDockProps) {
   );
 }
 
-function GoalObjectiveText({ objective }: { objective: string }) {
+function GoalObjectiveText({
+  objective,
+  lastReason,
+}: {
+  objective: string;
+  lastReason?: string | undefined;
+}) {
   const textRef = useRef<HTMLSpanElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
 
@@ -123,13 +136,18 @@ function GoalObjectiveText({ objective }: { objective: string }) {
     </span>
   );
 
-  if (!isOverflowing) return <div className="min-w-0 flex-1">{text}</div>;
+  if (!isOverflowing && !lastReason) return <div className="min-w-0 flex-1">{text}</div>;
   return (
     <div className="min-w-0 flex-1">
       <Tooltip delay={0}>
         <Tooltip.Trigger>{text}</Tooltip.Trigger>
         <Tooltip.Content className="max-w-[32rem] whitespace-normal break-words">
-          {objective}
+          <span className="block">{objective}</span>
+          {lastReason ? (
+            <span className="mt-1 block text-muted">
+              <Trans>Last evaluation:</Trans> {lastReason}
+            </span>
+          ) : null}
         </Tooltip.Content>
       </Tooltip>
     </div>

--- a/src/renderer/components/thread/threadGoalState.ts
+++ b/src/renderer/components/thread/threadGoalState.ts
@@ -14,6 +14,8 @@ export interface ThreadGoalDockState {
   tokenBudget?: number | null;
   tokensUsed?: number;
   timeUsedSeconds?: number;
+  iterations?: number;
+  lastReason?: string;
   updatedAt?: number;
 }
 
@@ -80,6 +82,8 @@ export function getThreadGoalDockStateFromThreadItems(
     ...(payload.tokenBudget !== undefined ? { tokenBudget: payload.tokenBudget } : {}),
     ...(payload.tokensUsed !== undefined ? { tokensUsed: payload.tokensUsed } : {}),
     ...(payload.timeUsedSeconds !== undefined ? { timeUsedSeconds: payload.timeUsedSeconds } : {}),
+    ...(payload.iterations !== undefined ? { iterations: payload.iterations } : {}),
+    ...(payload.lastReason ? { lastReason: payload.lastReason } : {}),
     ...(payload.updatedAt !== undefined ? { updatedAt: payload.updatedAt } : {}),
   };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# Skill} other {# Skills}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# Tool} other {# Tools}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# Runde} other {# Runden}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Sprache für KI-generierte Commit-Nachrichten und PR-Zusammenfassungen. 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Sprache, die das Sprachmodell beim Transkribieren des Diktats im Eingabefeld erwarten sollte."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Letzte Bewertung:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie sie vergleichen."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie das Experiment verwerfen."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie das Experiment verwerfen."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# skill} other {# skills}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# tool} other {# tools}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# turn} other {# turns}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Language for AI-generated commit messages and pull request summaries. Th
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Language the speech model should expect when transcribing composer dictation."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Last evaluation:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Wait for every candidate to finish before comparing them."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Wait for every candidate to finish before discarding the experiment."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Wait for every candidate to finish before discarding the experiment."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# skill} other {# skills}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# herramienta} other {# herramientas}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# turno} other {# turnos}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Idioma de los mensajes de commit y los resúmenes de pull request genera
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Idioma que debe esperar el modelo de voz al transcribir el dictado del redactor."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Última evaluación:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Espera a que todos los candidatos terminen antes de compararlos."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Espera a que todos los candidatos terminen antes de descartar el experimento."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Espera a que todos los candidatos terminen antes de descartar el experimento."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# compétence} other {# compétences}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# outil} other {# outils}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# tour} other {# tours}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Langue des messages de commit et des résumés de pull request généré
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Langue que le modèle vocal doit attendre lors de la transcription de la dictée dans le composeur."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Dernière évaluation :"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10603,8 +10612,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Attendez que tous les candidats aient terminé avant de les comparer."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Attendez que tous les candidats aient terminé avant d’abandonner l’expérience."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Attendez que tous les candidats aient terminé avant d’abandonner l’expérience."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# 個のスキル} other {# 個のスキル}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# 個のツール} other {# 個のツール}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, other {# ターン}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4831,6 +4836,10 @@ msgstr "AI が生成するコミットメッセージとプルリクエストの
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "コンポーザーでの音声入力を文字起こしする際に音声モデルが想定する言語。"
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "前回の評価:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10602,8 +10611,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "比較する前に、すべての候補が完了するまで待ってください。"
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "実験を破棄する前に、すべての候補が完了するまで待ってください。"
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "実験を破棄する前に、すべての候補が完了するまで待ってください。"
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {스킬 #개} other {스킬 #개}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {도구 #개} other {도구 #개}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, other {# 턴}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "AI가 생성하는 커밋 메시지와 풀 요청 요약에 사용할 �
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "작성기 받아쓰기를 기록할 때 음성 모델이 예상해야 하는 언어입니다."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "마지막 평가:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "비교하기 전에 모든 후보가 완료될 때까지 기다리세요."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "실험을 폐기하기 전에 모든 후보가 완료될 때까지 기다리세요."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "실험을 폐기하기 전에 모든 후보가 완료될 때까지 기다리세요."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# umiejętność} other {# umiejętności}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# narzędzie} few {# narzędzia} many {# narzędzi} other {# narzędzia}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# tura} few {# tury} many {# tur} other {# tury}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Język komunikatów zatwierdzeń i podsumowań żądań ściągnięcia g
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Język, jakiego powinien spodziewać się model mowy podczas transkrypcji dyktowania w polu wprowadzania."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Ostatnia ocena:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Przed porównaniem zaczekaj, aż wszyscy kandydaci zakończą pracę."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Przed odrzuceniem eksperymentu zaczekaj, aż wszyscy kandydaci zakończą pracę."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Przed odrzuceniem eksperymentu zaczekaj, aż wszyscy kandydaci zakończą pracę."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# skill} other {# skills}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# ferramenta} other {# ferramentas}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# turno} other {# turnos}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Idioma das mensagens de commit e dos resumos de pull request gerados por
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Idioma que o modelo de fala deve esperar ao transcrever o ditado do compositor."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Última avaliação:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Aguarde todos os candidatos terminarem antes de compará-los."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Aguarde todos os candidatos terminarem antes de descartar o experimento."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Aguarde todos os candidatos terminarem antes de descartar o experimento."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# навык} other {# навыков}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# инструмент} few {# инструмента} many {# инструментов} other {# инструмента}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# ход} few {# хода} many {# ходов} other {# хода}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Язык сообщений коммитов и сводок pull reques
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Язык, который должна ожидать модель распознавания речи при транскрибировании диктовки в поле ввода."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Последняя оценка:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Дождитесь завершения работы всех кандидатов перед сравнением."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Дождитесь завершения работы всех кандидатов перед отменой эксперимента."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Дождитесь завершения работы всех кандидатов перед отменой эксперимента."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# beceri} other {# beceri}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# araç} other {# araç}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# tur} other {# tur}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Yapay zeka tarafından oluşturulan commit mesajları ve çekme isteği 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Yazma alanı diktesini yazıya dökerken konuşma modelinin beklemesi gereken dil."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Son değerlendirme:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Karşılaştırmadan önce tüm adayların çalışmasını tamamlamasını bekleyin."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Deneyi silmeden önce tüm adayların çalışmasını tamamlamasını bekleyin."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Deneyi silmeden önce tüm adayların çalışmasını tamamlamasını bekleyin."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# навичка} other {# навичок}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# інструмент} few {# інструменти} many {# інструментів} other {# інструмента}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, one {# хід} few {# ходи} many {# ходів} other {# ходу}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Мова для згенерованих ШІ повідомлень к�
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Мова, яку модель розпізнавання мовлення має очікувати під час транскрибування диктування в полі вводу."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Остання оцінка:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж порівнювати їх."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж відхиляти експеримент."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж відхиляти експеримент."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# skill} other {# skill}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# công cụ} other {# công cụ}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, other {# lượt}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "Ngôn ngữ cho thông điệp commit và tóm tắt pull request do AI 
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "Ngôn ngữ mà mô hình giọng nói cần dùng khi phiên âm lời đọc trong trình soạn thảo."
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "Lần đánh giá gần nhất:"
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10604,8 +10613,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi so sánh."
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi hủy bỏ thử nghiệm."
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi hủy bỏ thử nghiệm."
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -84,6 +84,11 @@ msgstr "{0, plural, one {# 个技能} other {# 个技能}}"
 msgid "{0, plural, one {# tool} other {# tools}}"
 msgstr "{0, plural, one {# 个工具} other {# 个工具}}"
 
+#. placeholder {0}: state.iterations ?? 0
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "{0, plural, one {# turn} other {# turns}}"
+msgstr "{0, plural, other {# 轮}}"
+
 #. placeholder {0}: candidates.length
 #: src/renderer/components/experiment/NewExperimentModal.tsx
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
@@ -4832,6 +4837,10 @@ msgstr "AI 生成的提交信息和拉取请求摘要所使用的语言。线程
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language the speech model should expect when transcribing composer dictation."
 msgstr "语音模型在转录编辑器口述输入时应预期的语言。"
+
+#: src/renderer/components/thread/ThreadGoalDock.tsx
+msgid "Last evaluation:"
+msgstr "上次评估："
 
 #. placeholder {0}: agent.lastToolName
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
@@ -10603,8 +10612,8 @@ msgid "Wait for every candidate to finish before comparing them."
 msgstr "请等待所有候选项完成后再进行比较。"
 
 #: src/renderer/actions/experimentDecisionActions.ts
-msgid "Wait for every candidate to finish before discarding the experiment."
-msgstr "请等待所有候选项完成后再放弃实验。"
+#~ msgid "Wait for every candidate to finish before discarding the experiment."
+#~ msgstr "请等待所有候选项完成后再放弃实验。"
 
 #: src/renderer/views/ExperimentView/ExperimentView.tsx
 msgid "Wait for every candidate to finish before judging."

--- a/src/shared/contracts/runtimeEvent.ts
+++ b/src/shared/contracts/runtimeEvent.ts
@@ -106,6 +106,10 @@ export const goalItemPayloadSchema = z.object({
   tokenBudget: z.number().int().nonnegative().nullable().optional(),
   tokensUsed: z.number().int().nonnegative().optional(),
   timeUsedSeconds: z.number().nonnegative().optional(),
+  /** Number of completed goal evaluations that reported "not yet met". */
+  iterations: z.number().int().nonnegative().optional(),
+  /** The goal evaluator's most recent reason for its met / not-met verdict. */
+  lastReason: z.string().optional(),
   providerThreadId: z.string().optional(),
   updatedAt: z.number().optional(),
 });

--- a/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
@@ -2,7 +2,7 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, ToolCallProgress, TurnState } from "@/shared/contracts";
 import { readFileChangePath, readStringField } from "../../fileChangeSummary";
 import type { ClaudeMapperState } from "../sdkCanonicalMappingState";
-import { completeActiveGoalEvents } from "./goal";
+import { applyActiveGoalMessage, completeActiveGoalEvents, isActiveGoalMessage } from "./goal";
 import {
   extractCompletedStringFields,
   extractText,
@@ -213,6 +213,11 @@ function mapClaudeSdkMessageInner(
   options?: ClaudeSdkMessageMappingOptions,
 ): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
+  // Native /goal Stop-hook verdicts. Typed outside the SDKMessage union but
+  // yielded on the same stream.
+  if (isActiveGoalMessage(message)) {
+    return applyActiveGoalMessage(state, message);
+  }
   if (message.type === "stream_event") {
     // Sub-agent partial streams (parent_tool_use_id set) interleave with the
     // main-thread stream but share the same per-block-index lane maps. Their

--- a/src/supervisor/agents/claude/canonicalMapping/goal.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/goal.ts
@@ -1,8 +1,14 @@
-import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKActiveGoalMessage, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, TurnState } from "@/shared/contracts";
 import { readNonNegativeInteger } from "../../contextUsage";
-import { goalPayloadFromProviderState, updateGoalItemEvents } from "../../goalRuntime";
+import {
+  goalPayloadFromProviderState,
+  startGoalItemEvents,
+  updateGoalItemEvents,
+  type ProviderGoalState,
+} from "../../goalRuntime";
 import type { ClaudeMapperState } from "../sdkCanonicalMappingState";
+import { newItemId } from "./helpers";
 import { readClaudeResultUsage } from "./result";
 
 type ActiveGoalState = ClaudeMapperState & {
@@ -29,7 +35,79 @@ export function clearActiveGoal(state: ClaudeMapperState): void {
   delete state.activeGoalItemId;
   delete state.activeGoalObjective;
   delete state.activeGoalStartedAtMs;
+  delete state.activeGoalIterations;
+  delete state.activeGoalLastReason;
+  delete state.pendingGoalCompletionOnTaskDrain;
   resetActiveGoalTokenAccounting(state);
+}
+
+/**
+ * The SDK yields `active_goal` frames alongside `SDKMessage`s, but the
+ * published union does not include them — detect by shape.
+ */
+export function isActiveGoalMessage(message: unknown): message is SDKActiveGoalMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { type?: unknown }).type === "active_goal"
+  );
+}
+
+/**
+ * Apply the CLI's native /goal evaluation stream. `/goal` is a wrapper around
+ * a prompt-based Stop hook: after each turn a small fast model judges the
+ * condition and the SDK reports the verdict as an `active_goal` message —
+ * non-null `value` means "not yet met" (with bumped `iterations` and the
+ * evaluator's `last_reason`), `value: null` means the goal was met and
+ * cleared. That verdict — not the turn `result` — is the authoritative
+ * completion signal for the goal item.
+ */
+export function applyActiveGoalMessage(
+  state: ClaudeMapperState,
+  message: SDKActiveGoalMessage,
+): RuntimeEvent[] {
+  state.sawActiveGoalMessage = true;
+  // The native evaluator owns completion from here on; drop any legacy
+  // complete-on-task-drain that was pending.
+  delete state.pendingGoalCompletionOnTaskDrain;
+  const value = message.value;
+  if (value === null) return completeGoalFromEvaluatorVerdict(state);
+
+  const objective = value.condition.trim();
+  if (!objective) return [];
+  state.activeGoalIterations = value.iterations;
+  if (typeof value.last_reason === "string" && value.last_reason.trim().length > 0) {
+    state.activeGoalLastReason = value.last_reason.trim();
+  }
+
+  if (!hasActiveGoal(state)) {
+    // A goal can be armed natively without a local `/goal` turn — most
+    // commonly a still-active goal restored by resuming the session. Create
+    // the goal item so the dock reflects it.
+    const itemId = newItemId("goal");
+    state.activeGoalItemId = itemId;
+    state.activeGoalObjective = objective;
+    state.activeGoalStartedAtMs = epochSecondsToMs(value.set_at) ?? Date.now();
+    resetActiveGoalTokenAccounting(state);
+    if (!hasActiveGoal(state)) return []; // unreachable; re-narrows after mutation
+    return startGoalItemEvents(
+      state.threadId,
+      itemId,
+      goalPayloadFromProviderState({ ...activeGoalProviderState(state), status: "active" }, "set"),
+    );
+  }
+
+  // A new `/goal` replacing the old one mid-session also lands here.
+  state.activeGoalObjective = objective;
+  return [activeGoalUpdatedEvent(state)];
+}
+
+/** The evaluator reported the condition met: complete and clear the goal. */
+function completeGoalFromEvaluatorVerdict(state: ClaudeMapperState): RuntimeEvent[] {
+  // A null verdict also follows our own `/goal clear` (handled eagerly in
+  // startClaudeTurn, which already cleared local state) — nothing to do then.
+  if (!hasActiveGoal(state)) return [];
+  return completeActiveGoalNow(state);
 }
 
 export function completeActiveGoalEvents(
@@ -37,54 +115,90 @@ export function completeActiveGoalEvents(
   message: Extract<SDKMessage, { type: "result" }>,
   turnState: TurnState,
 ): RuntimeEvent[] {
-  const goalItemId = state.activeGoalItemId;
-  const objective = state.activeGoalObjective;
-  const startedAtMs = state.activeGoalStartedAtMs;
-  if (!goalItemId || !objective || startedAtMs === undefined) return [];
+  if (!hasActiveGoal(state)) return [];
 
-  const nowMs = Date.now();
   const usage = readClaudeResultUsage(message);
   if (usage !== undefined) {
     state.activeGoalCompletedTurnTokensUsed =
       (state.activeGoalCompletedTurnTokensUsed ?? 0) + usage;
   }
-  const totalTokensUsed = activeGoalAggregateTokens(state);
-  const elapsedSeconds = Math.max(0, Math.round((nowMs - startedAtMs) / 1000));
 
-  if (turnState === "interrupted") {
-    const payload = goalPayloadFromProviderState(
-      {
-        objective,
-        status: "active",
-        ...(totalTokensUsed !== undefined ? { tokensUsed: totalTokensUsed } : {}),
-        timeUsedSeconds: elapsedSeconds,
-        updatedAt: nowMs / 1000,
-      },
-      "updated",
-    );
-    return [
-      {
-        type: "item.updated",
-        threadId: state.threadId,
-        itemId: goalItemId,
-        payload,
-      },
-    ];
+  // While the native Stop-hook evaluator is live, a turn `result` is not a
+  // goal outcome — the evaluator keeps starting turns until the condition is
+  // met and reports that via `active_goal: null`. Only roll the usage/time
+  // counters forward here. Without native goal frames (older CLI), fall back
+  // to treating a clean turn end as completion so the dock never sticks.
+  if (turnState === "interrupted" || state.sawActiveGoalMessage) {
+    return [activeGoalUpdatedEvent(state)];
   }
 
-  clearActiveGoal(state);
+  // Legacy fallback with background subagents still running: the turn end is
+  // not the end of the goal's work. Hold the goal active and complete it when
+  // the last live task drains (completeActiveGoalOnTaskDrainEvents).
+  if (hasLiveSubAgentTaskEntries(state)) {
+    state.pendingGoalCompletionOnTaskDrain = true;
+    return [activeGoalUpdatedEvent(state)];
+  }
 
+  return completeActiveGoalNow(state);
+}
+
+/**
+ * Legacy fallback continuation: a clean turn end deferred goal completion
+ * because background subagent tasks were still live. Called after each task
+ * unregisters; completes the goal once the registry is empty.
+ */
+export function completeActiveGoalOnTaskDrainEvents(state: ClaudeMapperState): RuntimeEvent[] {
+  if (!state.pendingGoalCompletionOnTaskDrain) return [];
+  if (hasLiveSubAgentTaskEntries(state)) return [];
+  delete state.pendingGoalCompletionOnTaskDrain;
+  if (!hasActiveGoal(state)) return [];
+  return completeActiveGoalNow(state);
+}
+
+function completeActiveGoalNow(state: ActiveGoalState): RuntimeEvent[] {
+  const { threadId } = state;
+  const itemId = state.activeGoalItemId;
   const payload = goalPayloadFromProviderState(
-    {
-      objective,
-      status: "complete",
-      ...(totalTokensUsed !== undefined ? { tokensUsed: totalTokensUsed } : {}),
-      timeUsedSeconds: elapsedSeconds,
-      updatedAt: nowMs / 1000,
-    },
+    { ...activeGoalProviderState(state), status: "complete" },
     "updated",
   );
-  return updateGoalItemEvents(state.threadId, goalItemId, payload);
+  clearActiveGoal(state);
+  return updateGoalItemEvents(threadId, itemId, payload);
+}
+
+function hasLiveSubAgentTaskEntries(state: ClaudeMapperState): boolean {
+  return (state.activeSubAgentTaskToTool?.size ?? 0) > 0;
+}
+
+/**
+ * Snapshot of the active goal's payload fields (objective, aggregate token
+ * spend, elapsed time, evaluator iterations/reason). Every goal emission
+ * builds from this so partial updates never wipe fields off the dock.
+ */
+function activeGoalProviderState(state: ActiveGoalState): ProviderGoalState {
+  const nowMs = Date.now();
+  const tokensUsed = activeGoalAggregateTokens(state);
+  return {
+    objective: state.activeGoalObjective,
+    ...(tokensUsed !== undefined ? { tokensUsed } : {}),
+    timeUsedSeconds: Math.max(0, Math.round((nowMs - state.activeGoalStartedAtMs) / 1000)),
+    ...(state.activeGoalIterations !== undefined ? { iterations: state.activeGoalIterations } : {}),
+    ...(state.activeGoalLastReason ? { lastReason: state.activeGoalLastReason } : {}),
+    updatedAt: nowMs / 1000,
+  };
+}
+
+function activeGoalUpdatedEvent(state: ActiveGoalState): RuntimeEvent {
+  return {
+    type: "item.updated",
+    threadId: state.threadId,
+    itemId: state.activeGoalItemId,
+    payload: goalPayloadFromProviderState(
+      { ...activeGoalProviderState(state), status: "active" },
+      "updated",
+    ),
+  };
 }
 
 export function emitActiveGoalTokenUpdate(
@@ -98,25 +212,8 @@ export function emitActiveGoalTokenUpdate(
 
 function emitActiveGoalAggregateTokenUpdate(state: ClaudeMapperState): RuntimeEvent | undefined {
   if (!hasActiveGoal(state)) return undefined;
-  const aggregateTokens = activeGoalAggregateTokens(state);
-  if (aggregateTokens === undefined) return undefined;
-  const elapsedSeconds = Math.max(0, Math.round((Date.now() - state.activeGoalStartedAtMs) / 1000));
-  const payload = goalPayloadFromProviderState(
-    {
-      objective: state.activeGoalObjective,
-      status: "active",
-      tokensUsed: aggregateTokens,
-      timeUsedSeconds: elapsedSeconds,
-      updatedAt: Date.now() / 1000,
-    },
-    "updated",
-  );
-  return {
-    type: "item.updated",
-    threadId: state.threadId,
-    itemId: state.activeGoalItemId,
-    payload,
-  };
+  if (activeGoalAggregateTokens(state) === undefined) return undefined;
+  return activeGoalUpdatedEvent(state);
 }
 
 function activeGoalAggregateTokens(state: ClaudeMapperState): number | undefined {
@@ -133,6 +230,12 @@ function sumActiveGoalTaskTokens(state: ClaudeMapperState): number {
   let total = 0;
   for (const tokens of state.activeGoalTaskTokensByKey?.values() ?? []) total += tokens;
   return total;
+}
+
+function epochSecondsToMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  // Guard against the field ever arriving in milliseconds.
+  return value > 1_000_000_000_000 ? value : value * 1000;
 }
 
 export function emitActiveGoalTaskUsageUpdate(

--- a/src/supervisor/agents/claude/canonicalMapping/goal.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/goal.ts
@@ -145,8 +145,8 @@ export function completeActiveGoalEvents(
 
 /**
  * Legacy fallback continuation: a clean turn end deferred goal completion
- * because background subagent tasks were still live. Called after each task
- * unregisters; completes the goal once the registry is empty.
+ * because background subagent tasks were still live. The session calls this
+ * after its post-drain resume grace expires.
  */
 export function completeActiveGoalOnTaskDrainEvents(state: ClaudeMapperState): RuntimeEvent[] {
   if (!state.pendingGoalCompletionOnTaskDrain) return [];

--- a/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
@@ -1,7 +1,7 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, ToolCallProgress } from "@/shared/contracts";
 import type { ClaudeMapperState, ToolItemState } from "../sdkCanonicalMappingState";
-import { completeActiveGoalOnTaskDrainEvents, emitActiveGoalTaskUsageUpdate } from "./goal";
+import { emitActiveGoalTaskUsageUpdate } from "./goal";
 import { classifyToolItemType, isSubAgentToolName } from "./toolClassification";
 import { syncSubAgentModelProgress } from "./toolItems";
 import { toolPayload } from "./toolPayload";
@@ -168,7 +168,6 @@ export function applyTaskNotification(
   const tool = state.toolItemsById.get(registeredToolUseId);
   if (!tool) {
     unregisterSubAgentTask(state, taskId, registeredToolUseId);
-    events.push(...completeActiveGoalOnTaskDrainEvents(state));
     return events;
   }
 
@@ -197,7 +196,6 @@ export function applyTaskNotification(
     if (value.itemId === registeredToolUseId) state.toolItemsByIndex.delete(idx);
   }
   unregisterSubAgentTask(state, taskId, registeredToolUseId);
-  events.push(...completeActiveGoalOnTaskDrainEvents(state));
   return events;
 }
 

--- a/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
@@ -1,7 +1,7 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, ToolCallProgress } from "@/shared/contracts";
 import type { ClaudeMapperState, ToolItemState } from "../sdkCanonicalMappingState";
-import { emitActiveGoalTaskUsageUpdate } from "./goal";
+import { completeActiveGoalOnTaskDrainEvents, emitActiveGoalTaskUsageUpdate } from "./goal";
 import { classifyToolItemType, isSubAgentToolName } from "./toolClassification";
 import { syncSubAgentModelProgress } from "./toolItems";
 import { toolPayload } from "./toolPayload";
@@ -168,6 +168,7 @@ export function applyTaskNotification(
   const tool = state.toolItemsById.get(registeredToolUseId);
   if (!tool) {
     unregisterSubAgentTask(state, taskId, registeredToolUseId);
+    events.push(...completeActiveGoalOnTaskDrainEvents(state));
     return events;
   }
 
@@ -196,6 +197,7 @@ export function applyTaskNotification(
     if (value.itemId === registeredToolUseId) state.toolItemsByIndex.delete(idx);
   }
   unregisterSubAgentTask(state, taskId, registeredToolUseId);
+  events.push(...completeActiveGoalOnTaskDrainEvents(state));
   return events;
 }
 

--- a/src/supervisor/agents/claude/canonicalMapping/turn.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/turn.ts
@@ -57,6 +57,9 @@ export function startClaudeTurn(
   }
   delete state.currentAssistantMessageId;
   delete state.currentCompactionItemId;
+  // A new turn means the goal's work continues — a legacy complete-on-drain
+  // scheduled by the previous turn end no longer applies.
+  delete state.pendingGoalCompletionOnTaskDrain;
   state.streamedAssistantMessageIds.clear();
 
   const userItemId = userMessageItemId ?? newItemId("user");

--- a/src/supervisor/agents/claude/canonicalMapping/turn.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/turn.ts
@@ -82,6 +82,8 @@ export function startClaudeTurn(
       state.activeGoalItemId = goalItemId;
       state.activeGoalObjective = goalPayload.objective;
       state.activeGoalStartedAtMs = Date.now();
+      delete state.activeGoalIterations;
+      delete state.activeGoalLastReason;
       resetActiveGoalTokenAccounting(state);
     } else {
       clearActiveGoal(state);

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -16,6 +16,23 @@ function streamEvent(event: Record<string, unknown>): SDKMessage {
   return { type: "stream_event", session_id: "claude-session", event } as unknown as SDKMessage;
 }
 
+function activeGoalMessage(
+  value: {
+    condition: string;
+    iterations: number;
+    set_at: number;
+    tokens_at_start: number;
+    last_reason?: string;
+  } | null,
+): SDKMessage {
+  return {
+    type: "active_goal",
+    value,
+    uuid: "goal-uuid",
+    session_id: "claude-session",
+  } as unknown as SDKMessage;
+}
+
 function streamEventWithParent(
   event: Record<string, unknown>,
   parentToolUseId: string,
@@ -374,6 +391,254 @@ describe("sdkCanonicalMapping — prompt content", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("holds a legacy goal open across a clean turn end while background subagents run, completing on drain", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal ship it", undefined, "user-goal");
+      mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "task_started",
+          session_id: "claude-session",
+          task_id: "task-bg",
+          tool_use_id: "toolu_bg",
+          subagent_type: "Explore",
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:01:33Z"));
+      const resultEvents = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { total_tokens: 30_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      // The clean turn end is not the goal outcome — background work is live.
+      const resultGoalUpdate = resultEvents.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(resultGoalUpdate).toMatchObject({
+        payload: { status: "active", timeUsedSeconds: 93 },
+      });
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+
+      vi.setSystemTime(new Date("2026-05-12T10:05:00Z"));
+      const drainEvents = mapClaudeSdkMessage(
+        {
+          type: "system",
+          subtype: "task_notification",
+          session_id: "claude-session",
+          task_id: "task-bg",
+          status: "completed",
+          summary: "Done",
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      // Elapsed time spans the background window — no reset at the turn end.
+      const completion = drainEvents.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(completion).toMatchObject({
+        payload: { status: "complete", timeUsedSeconds: 300 },
+      });
+      expect(state.activeGoalItemId).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("updates the active goal from a native active_goal verdict with iterations and reason", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal all auth tests pass", undefined, "user-goal");
+
+      vi.setSystemTime(new Date("2026-05-12T10:02:00Z"));
+      const events = mapClaudeSdkMessage(
+        activeGoalMessage({
+          condition: "all auth tests pass",
+          iterations: 2,
+          set_at: Date.parse("2026-05-12T10:00:00Z") / 1000,
+          tokens_at_start: 0,
+          last_reason: "login.test.ts still failing",
+        }),
+        state,
+      );
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({
+            action: "updated",
+            objective: "all auth tests pass",
+            status: "active",
+            iterations: 2,
+            lastReason: "login.test.ts still failing",
+            timeUsedSeconds: 120,
+          }),
+        }),
+      );
+      expect(state.sawActiveGoalMessage).toBe(true);
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the goal active on a clean turn result while native goal evaluation is live", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal all auth tests pass", undefined, "user-goal");
+      mapClaudeSdkMessage(
+        activeGoalMessage({
+          condition: "all auth tests pass",
+          iterations: 1,
+          set_at: Date.parse("2026-05-12T10:00:00Z") / 1000,
+          tokens_at_start: 0,
+          last_reason: "tests not run yet",
+        }),
+        state,
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:01:00Z"));
+      const resultEvents = mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { total_tokens: 20_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      const goalUpdate = resultEvents.find(
+        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      );
+      expect(goalUpdate).toMatchObject({
+        payload: {
+          status: "active",
+          tokensUsed: 20_000,
+          iterations: 1,
+          lastReason: "tests not run yet",
+        },
+      });
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("completes the goal when the evaluator reports the condition met", () => {
+    const state = createClaudeMapperState("thread-1");
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-05-12T10:00:00Z"));
+      startClaudeTurn(state, "turn-goal", "/goal all auth tests pass", undefined, "user-goal");
+      mapClaudeSdkMessage(
+        activeGoalMessage({
+          condition: "all auth tests pass",
+          iterations: 3,
+          set_at: Date.parse("2026-05-12T10:00:00Z") / 1000,
+          tokens_at_start: 0,
+          last_reason: "one test still red",
+        }),
+        state,
+      );
+      mapClaudeSdkMessage(
+        {
+          type: "result",
+          subtype: "success",
+          session_id: "claude-session",
+          usage: { total_tokens: 40_000 },
+        } as unknown as SDKMessage,
+        state,
+      );
+
+      vi.setSystemTime(new Date("2026-05-12T10:05:00Z"));
+      const metEvents = mapClaudeSdkMessage(activeGoalMessage(null), state);
+
+      expect(metEvents).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({
+            action: "updated",
+            objective: "all auth tests pass",
+            status: "complete",
+            tokensUsed: 40_000,
+            iterations: 3,
+            timeUsedSeconds: 300,
+          }),
+        }),
+      );
+      expect(metEvents).toContainEqual({
+        type: "item.completed",
+        threadId: "thread-1",
+        itemId: "goal-turn-goal",
+      });
+      expect(state.activeGoalItemId).toBeUndefined();
+      expect(state.activeGoalObjective).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("creates a goal item when a native goal arrives without a local /goal (session resume)", () => {
+    const state = createClaudeMapperState("thread-1");
+
+    const events = mapClaudeSdkMessage(
+      activeGoalMessage({
+        condition: "the migration compiles cleanly",
+        iterations: 4,
+        set_at: Date.now() / 1000 - 600,
+        tokens_at_start: 0,
+        last_reason: "two call sites remain",
+      }),
+      state,
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "goal",
+        payload: expect.objectContaining({
+          action: "set",
+          objective: "the migration compiles cleanly",
+          status: "active",
+          iterations: 4,
+          lastReason: "two call sites remain",
+        }),
+      }),
+    );
+    expect(state.activeGoalItemId).toBeDefined();
+    expect(state.activeGoalObjective).toBe("the migration compiles cleanly");
+  });
+
+  it("ignores a null active_goal verdict when no goal is active", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-goal", "/goal fix the bug", undefined);
+    // `/goal clear` clears local state eagerly in startClaudeTurn; the SDK's
+    // trailing null verdict must not resurrect or re-complete anything.
+    startClaudeTurn(state, "turn-clear", "/goal clear", undefined);
+
+    const events = mapClaudeSdkMessage(activeGoalMessage(null), state);
+
+    expect(events).toEqual([]);
+    expect(state.sawActiveGoalMessage).toBe(true);
   });
 });
 

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -393,7 +393,7 @@ describe("sdkCanonicalMapping — prompt content", () => {
     }
   });
 
-  it("holds a legacy goal open across a clean turn end while background subagents run, completing on drain", () => {
+  it("holds a legacy goal open after background subagents drain for the session grace", () => {
     const state = createClaudeMapperState("thread-1");
     vi.useFakeTimers();
     try {
@@ -431,7 +431,6 @@ describe("sdkCanonicalMapping — prompt content", () => {
       });
       expect(state.activeGoalItemId).toBe("goal-turn-goal");
 
-      vi.setSystemTime(new Date("2026-05-12T10:05:00Z"));
       const drainEvents = mapClaudeSdkMessage(
         {
           type: "system",
@@ -444,14 +443,15 @@ describe("sdkCanonicalMapping — prompt content", () => {
         state,
       );
 
-      // Elapsed time spans the background window — no reset at the turn end.
-      const completion = drainEvents.find(
-        (event) => event.type === "item.updated" && event.itemId === "goal-turn-goal",
+      expect(drainEvents).not.toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: "goal-turn-goal",
+          payload: expect.objectContaining({ status: "complete" }),
+        }),
       );
-      expect(completion).toMatchObject({
-        payload: { status: "complete", timeUsedSeconds: 300 },
-      });
-      expect(state.activeGoalItemId).toBeUndefined();
+      expect(state.activeGoalItemId).toBe("goal-turn-goal");
+      expect(state.pendingGoalCompletionOnTaskDrain).toBe(true);
     } finally {
       vi.useRealTimers();
     }
@@ -495,6 +495,27 @@ describe("sdkCanonicalMapping — prompt content", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("resets evaluator metadata when a new goal replaces the active goal", () => {
+    const state = createClaudeMapperState("thread-1");
+    startClaudeTurn(state, "turn-first", "/goal first objective", undefined, "user-first");
+    mapClaudeSdkMessage(
+      activeGoalMessage({
+        condition: "first objective",
+        iterations: 4,
+        set_at: Date.now() / 1000,
+        tokens_at_start: 0,
+        last_reason: "first objective is not met",
+      }),
+      state,
+    );
+
+    startClaudeTurn(state, "turn-second", "/goal second objective", undefined, "user-second");
+
+    expect(state.activeGoalObjective).toBe("second objective");
+    expect(state.activeGoalIterations).toBeUndefined();
+    expect(state.activeGoalLastReason).toBeUndefined();
   });
 
   it("keeps the goal active on a clean turn result while native goal evaluation is live", () => {

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.ts
@@ -14,7 +14,10 @@ export {
   parseClaudeQuestions,
   type ClaudeQuestion,
 } from "./canonicalMapping/questions";
-export { emitActiveGoalTokenUpdate } from "./canonicalMapping/goal";
+export {
+  completeActiveGoalOnTaskDrainEvents,
+  emitActiveGoalTokenUpdate,
+} from "./canonicalMapping/goal";
 export {
   extractResultErrorMessage,
   isApiErrorResult,

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -73,8 +73,9 @@ export interface ClaudeMapperState {
   /**
    * Legacy (no native `active_goal` frames) only: a clean turn `result`
    * arrived while background subagent tasks were still live, so the goal was
-   * held active instead of completed. The goal completes when the last live
-   * task drains (applyTaskNotification) — unless a new turn starts first.
+   * held active instead of completed. The goal completes after the last live
+   * task drains and the session's resume grace expires — unless a new turn
+   * starts first.
    */
   pendingGoalCompletionOnTaskDrain?: boolean;
   activeGoalCompletedTurnTokensUsed?: number;

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -61,6 +61,22 @@ export interface ClaudeMapperState {
   activeGoalItemId?: string;
   activeGoalObjective?: string;
   activeGoalStartedAtMs?: number;
+  activeGoalIterations?: number;
+  activeGoalLastReason?: string;
+  /**
+   * True once the SDK has emitted any `active_goal` message this session —
+   * i.e. the CLI's native /goal Stop-hook evaluator is live. While true, goal
+   * completion is driven exclusively by `active_goal` with `value: null` (the
+   * evaluator's "met" verdict); a turn `result` no longer completes the goal.
+   */
+  sawActiveGoalMessage?: boolean;
+  /**
+   * Legacy (no native `active_goal` frames) only: a clean turn `result`
+   * arrived while background subagent tasks were still live, so the goal was
+   * held active instead of completed. The goal completes when the last live
+   * task drains (applyTaskNotification) — unless a new turn starts first.
+   */
+  pendingGoalCompletionOnTaskDrain?: boolean;
   activeGoalCompletedTurnTokensUsed?: number;
   activeGoalLiveApiTokensUsed?: number;
   activeGoalTaskTokensByKey?: Map<string, number>;

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -1382,70 +1382,137 @@ describe("ClaudeSdkSession", () => {
     await session.dispose();
   });
 
-  it("emits the deferred idle once the last background task_notification drains the registry", async () => {
-    const fake = createFakeQuery();
-    mockSdk.query.mockReturnValue(fake.runtime);
-    const updates: StructuredSessionUpdate[] = [];
-    const session = await ClaudeSdkSession.create({
-      threadId: "thread-claude-bg-drain",
-      projectLocation,
-      config,
-      presentationMode: "gui",
-    });
-    session.setListener({
-      onRuntimeEvent: () => {},
-      onUpdate: (update) => updates.push(update),
-      onError: () => {},
-      onClose: () => {},
-    });
+  it("emits the deferred idle after the resume grace once the last background task_notification drains the registry", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = createFakeQuery();
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const updates: StructuredSessionUpdate[] = [];
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-bg-drain",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: () => {},
+        onUpdate: (update) => updates.push(update),
+        onError: () => {},
+        onClose: () => {},
+      });
 
-    const openedSessionId = await session.openThread(config);
-    await session.startTurn("launch a background subagent", config);
-    await flushAsyncWork();
-    fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
-    fake.emitMessage(sdkSuccessResult(openedSessionId));
-    await flushAsyncWork();
-    expect(updates.at(-1)).toMatchObject({ status: "working" });
+      const openedSessionId = await session.openThread(config);
+      await session.startTurn("launch a background subagent", config);
+      await vi.advanceTimersByTimeAsync(0);
+      fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
+      fake.emitMessage(sdkSuccessResult(openedSessionId));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
 
-    fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
-    await flushAsyncWork();
+      fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
+      await vi.advanceTimersByTimeAsync(0);
 
-    expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
+      // Held through the resume grace window — the SDK usually wakes the
+      // model right after the notification.
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
 
-    await session.dispose();
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
+
+      await session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the thread working when the model resumes within the drain grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = createFakeQuery();
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const updates: StructuredSessionUpdate[] = [];
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-bg-drain-resume",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: () => {},
+        onUpdate: (update) => updates.push(update),
+        onError: () => {},
+        onClose: () => {},
+      });
+
+      const openedSessionId = await session.openThread(config);
+      await session.startTurn("launch a background subagent", config);
+      await vi.advanceTimersByTimeAsync(0);
+      fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
+      fake.emitMessage(sdkSuccessResult(openedSessionId));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The last task drains, and the SDK wakes the model to consume the
+      // results: session-state running, then assistant activity.
+      fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
+      await vi.advanceTimersByTimeAsync(500);
+      fake.emitMessage(
+        sdkSystemMessage("session_state_changed", openedSessionId, { state: "running" }),
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      fake.emitMessage({
+        type: "stream_event",
+        session_id: openedSessionId,
+        event: { type: "message_start", message: { id: "msg-resumed" } },
+      } as unknown as SDKMessage);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      // The stale held completion never settles the thread: no idle emitted,
+      // so the renderer's working timer and done-notification stay untouched.
+      expect(updates.some((update) => update.status === "idle")).toBe(false);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
+
+      await session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("preserves an error result through the deferral", async () => {
-    const fake = createFakeQuery();
-    mockSdk.query.mockReturnValue(fake.runtime);
-    const updates: StructuredSessionUpdate[] = [];
-    const session = await ClaudeSdkSession.create({
-      threadId: "thread-claude-bg-error",
-      projectLocation,
-      config,
-      presentationMode: "gui",
-    });
-    session.setListener({
-      onRuntimeEvent: () => {},
-      onUpdate: (update) => updates.push(update),
-      onError: () => {},
-      onClose: () => {},
-    });
+    vi.useFakeTimers();
+    try {
+      const fake = createFakeQuery();
+      mockSdk.query.mockReturnValue(fake.runtime);
+      const updates: StructuredSessionUpdate[] = [];
+      const session = await ClaudeSdkSession.create({
+        threadId: "thread-claude-bg-error",
+        projectLocation,
+        config,
+        presentationMode: "gui",
+      });
+      session.setListener({
+        onRuntimeEvent: () => {},
+        onUpdate: (update) => updates.push(update),
+        onError: () => {},
+        onClose: () => {},
+      });
 
-    const openedSessionId = await session.openThread(config);
-    await session.startTurn("launch a background subagent", config);
-    await flushAsyncWork();
-    fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
-    fake.emitMessage(sdkErrorResult(openedSessionId));
-    await flushAsyncWork();
-    expect(updates.at(-1)).toMatchObject({ status: "working" });
+      const openedSessionId = await session.openThread(config);
+      await session.startTurn("launch a background subagent", config);
+      await vi.advanceTimersByTimeAsync(0);
+      fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
+      fake.emitMessage(sdkErrorResult(openedSessionId));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(updates.at(-1)).toMatchObject({ status: "working" });
 
-    fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
-    await flushAsyncWork();
+      fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
+      await vi.advanceTimersByTimeAsync(2_000);
 
-    expect(updates.at(-1)).toMatchObject({ status: "error", attention: "error" });
+      expect(updates.at(-1)).toMatchObject({ status: "error", attention: "error" });
 
-    await session.dispose();
+      await session.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("only emits idle after the last of multiple concurrent background tasks closes", async () => {
@@ -1481,9 +1548,9 @@ describe("ClaudeSdkSession", () => {
 
     fake.emitMessage(sdkTaskNotification(openedSessionId, "task-2"));
     await flushAsyncWork();
-    expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
-
+    // The drain grace holds the settle; dispose flushes it unconditionally.
     await session.dispose();
+    expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
   });
 
   it("suppresses a session-state idle while a completion is deferred behind a live task", async () => {
@@ -1520,9 +1587,9 @@ describe("ClaudeSdkSession", () => {
 
     fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
     await flushAsyncWork();
-    expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
-
+    // The drain grace holds the settle; dispose flushes it unconditionally.
     await session.dispose();
+    expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
   });
 
   it("keeps a deferred error outcome intact across a suppressed session-state idle", async () => {
@@ -1556,10 +1623,10 @@ describe("ClaudeSdkSession", () => {
 
     fake.emitMessage(sdkTaskNotification(openedSessionId, "task-1"));
     await flushAsyncWork();
+    // The drain grace holds the settle; dispose flushes it unconditionally.
+    await session.dispose();
     expect(updates.at(-1)).toMatchObject({ status: "error", attention: "error" });
     expect(updates.some((update) => update.status === "idle")).toBe(false);
-
-    await session.dispose();
   });
 
   it("flushes a deferred idle when the stream throws with a background task still live", async () => {

--- a/src/supervisor/agents/claude/sdkSession.test.ts
+++ b/src/supervisor/agents/claude/sdkSession.test.ts
@@ -1388,6 +1388,7 @@ describe("ClaudeSdkSession", () => {
       const fake = createFakeQuery();
       mockSdk.query.mockReturnValue(fake.runtime);
       const updates: StructuredSessionUpdate[] = [];
+      const runtimeEvents: RuntimeEvent[] = [];
       const session = await ClaudeSdkSession.create({
         threadId: "thread-claude-bg-drain",
         projectLocation,
@@ -1395,15 +1396,20 @@ describe("ClaudeSdkSession", () => {
         presentationMode: "gui",
       });
       session.setListener({
-        onRuntimeEvent: () => {},
+        onRuntimeEvent: (event) => runtimeEvents.push(event),
         onUpdate: (update) => updates.push(update),
         onError: () => {},
         onClose: () => {},
       });
 
       const openedSessionId = await session.openThread(config);
-      await session.startTurn("launch a background subagent", config);
+      await session.startTurn("/goal launch a background subagent", config);
       await vi.advanceTimersByTimeAsync(0);
+      const goalItemId = runtimeEvents.find(
+        (event): event is Extract<RuntimeEvent, { type: "item.started" }> =>
+          event.type === "item.started" && event.itemType === "goal",
+      )?.itemId;
+      expect(goalItemId).toBeDefined();
       fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
       fake.emitMessage(sdkSuccessResult(openedSessionId));
       await vi.advanceTimersByTimeAsync(0);
@@ -1415,9 +1421,23 @@ describe("ClaudeSdkSession", () => {
       // Held through the resume grace window — the SDK usually wakes the
       // model right after the notification.
       expect(updates.at(-1)).toMatchObject({ status: "working" });
+      expect(runtimeEvents).not.toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: goalItemId,
+          payload: expect.objectContaining({ status: "complete" }),
+        }),
+      );
 
       await vi.advanceTimersByTimeAsync(2_000);
       expect(updates.at(-1)).toMatchObject({ status: "idle", attention: "none" });
+      expect(runtimeEvents).toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: goalItemId,
+          payload: expect.objectContaining({ status: "complete" }),
+        }),
+      );
 
       await session.dispose();
     } finally {
@@ -1431,6 +1451,7 @@ describe("ClaudeSdkSession", () => {
       const fake = createFakeQuery();
       mockSdk.query.mockReturnValue(fake.runtime);
       const updates: StructuredSessionUpdate[] = [];
+      const runtimeEvents: RuntimeEvent[] = [];
       const session = await ClaudeSdkSession.create({
         threadId: "thread-claude-bg-drain-resume",
         projectLocation,
@@ -1438,15 +1459,20 @@ describe("ClaudeSdkSession", () => {
         presentationMode: "gui",
       });
       session.setListener({
-        onRuntimeEvent: () => {},
+        onRuntimeEvent: (event) => runtimeEvents.push(event),
         onUpdate: (update) => updates.push(update),
         onError: () => {},
         onClose: () => {},
       });
 
       const openedSessionId = await session.openThread(config);
-      await session.startTurn("launch a background subagent", config);
+      await session.startTurn("/goal launch a background subagent", config);
       await vi.advanceTimersByTimeAsync(0);
+      const goalItemId = runtimeEvents.find(
+        (event): event is Extract<RuntimeEvent, { type: "item.started" }> =>
+          event.type === "item.started" && event.itemType === "goal",
+      )?.itemId;
+      expect(goalItemId).toBeDefined();
       fake.emitMessage(sdkTaskStarted(openedSessionId, "task-1", "toolu_bg1"));
       fake.emitMessage(sdkSuccessResult(openedSessionId));
       await vi.advanceTimersByTimeAsync(0);
@@ -1470,6 +1496,13 @@ describe("ClaudeSdkSession", () => {
       // so the renderer's working timer and done-notification stay untouched.
       expect(updates.some((update) => update.status === "idle")).toBe(false);
       expect(updates.at(-1)).toMatchObject({ status: "working" });
+      expect(runtimeEvents).not.toContainEqual(
+        expect.objectContaining({
+          type: "item.updated",
+          itemId: goalItemId,
+          payload: expect.objectContaining({ status: "complete" }),
+        }),
+      );
 
       await session.dispose();
     } finally {

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -86,6 +86,14 @@ type CompletedClaudeTurn = {
   resumeSessionAt: string | undefined;
 };
 
+/**
+ * How long a drained deferred completion waits before settling the thread.
+ * Sized to cover the SDK's task_notification → model-wake gap (a
+ * session_state "running" restarts it, so it only needs to reach the wake
+ * signal, not the first streamed token).
+ */
+const DEFERRED_FLUSH_RESUME_GRACE_MS = 2000;
+
 export class ClaudeSdkSession implements StructuredSessionHandle {
   launchOptions: AgentLaunchOptions = { suppressResumeConfigOverrides: true };
 
@@ -121,6 +129,12 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
   // thread finished mid-work. Hold the completion status here until the
   // live-task registry drains; flush it if the stream stops first.
   private readonly deferredCompletion = new DeferredTurnCompletion();
+  // Grace timer between the last task_notification draining the registry and
+  // the deferred completion actually flushing. The SDK usually wakes the model
+  // right after that notification to consume the results; flushing idle in
+  // that gap resets the thread's "Working for" timer and fires a premature
+  // done-notification. See flushDeferredCompletionIfDrained.
+  private deferredFlushTimer: ReturnType<typeof setTimeout> | undefined;
   // openThread() fires `startQuery` as a fire-and-forget IIFE and returns
   // synchronously, but the runtime calls `setListener` only afterwards from
   // `spawnThread`. Anything emitted in that window — early SDK system/stream
@@ -240,6 +254,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.currentTurnAssistantUuid = undefined;
     this.currentTurnInFlight = true;
     this.deferredCompletion.clear();
+    this.clearDeferredFlushTimer();
     this.emitRuntimeEvents(
       startClaudeTurn(this.mapperState, turnId, prompt, segments, options?.userMessageItemId),
     );
@@ -894,6 +909,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.currentTurnInFlight = true;
     this.currentTurnAssistantUuid = undefined;
     this.deferredCompletion.clear();
+    this.clearDeferredFlushTimer();
     // Seed the mapper's turn id so the eventual `result` emits the matching
     // `turn.completed`, re-closing the renderer's turn-open gate.
     this.mapperState.currentTurnId = turnId;
@@ -926,6 +942,18 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       // states (working, needs_approval) still pass through.
       if (mapped.status !== "idle" || !this.deferredCompletion.hasPending) {
         this.emitUpdate(mapped);
+      }
+      // A running state while a drained completion sits in its grace window
+      // means the model is waking to consume the task results — restart the
+      // grace so the first assistant activity (beginResumedTurnIfNeeded) can
+      // clear the stale completion instead of it flushing mid-resume.
+      if (
+        mapped.status === "working" &&
+        this.deferredCompletion.hasPending &&
+        this.deferredFlushTimer !== undefined
+      ) {
+        this.clearDeferredFlushTimer();
+        this.scheduleDeferredFlush();
       }
     }
 
@@ -978,9 +1006,10 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
       // Stop the 15s goal-tracking poller on every turn end — including
       // interrupts and steers — so it does not keep firing context-usage
       // round-trips while the thread sits idle. The goal itself is NOT cleared
-      // here: it stays active (completeActiveGoalEvents only completes it on a
-      // clean turn end, and `/clear` clears it explicitly), and the next turn
-      // restarts tracking via startGoalTracking().
+      // here: completion is driven by the SDK's `active_goal` Stop-hook
+      // verdict (see applyActiveGoalMessage; clean turn end is only a
+      // fallback for CLIs that never emit it), and the next turn restarts
+      // tracking via startGoalTracking().
       this.stopGoalTracking();
       const completion: StructuredSessionUpdate = {
         status: failed ? "error" : "idle",
@@ -1006,11 +1035,36 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
    * registry has drained. Called after every SDK message so the authoritative
    * `task_notification` that closes the last subagent task flips the thread to
    * its held idle/error state.
+   *
+   * The release is not immediate: the SDK typically wakes the model right
+   * after that notification to consume the task's results. Settling idle in
+   * that gap resets the renderer's "Working for" timer to zero and fires a
+   * premature done-notification, only for the thread to flip back to working
+   * a moment later. A short grace window lets the resume win: assistant
+   * activity clears the held completion (beginResumedTurnIfNeeded) and the
+   * thread stays continuously live. If nothing resumes, the held status
+   * flushes when the grace expires.
    */
   private flushDeferredCompletionIfDrained(): void {
     if (!this.deferredCompletion.hasPending || this.hasLiveSubAgentTasks()) return;
-    const update = this.deferredCompletion.take();
-    if (update) this.emitUpdate(update);
+    this.scheduleDeferredFlush();
+  }
+
+  private scheduleDeferredFlush(): void {
+    if (this.deferredFlushTimer !== undefined) return;
+    this.deferredFlushTimer = setTimeout(() => {
+      this.deferredFlushTimer = undefined;
+      if (this.disposed || this.hasLiveSubAgentTasks()) return;
+      const update = this.deferredCompletion.take();
+      if (update) this.emitUpdate(update);
+    }, DEFERRED_FLUSH_RESUME_GRACE_MS);
+  }
+
+  private clearDeferredFlushTimer(): void {
+    if (this.deferredFlushTimer !== undefined) {
+      clearTimeout(this.deferredFlushTimer);
+      this.deferredFlushTimer = undefined;
+    }
   }
 
   /**
@@ -1019,6 +1073,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
    * live, so the thread never stays stuck `working`.
    */
   private flushDeferredCompletion(): void {
+    this.clearDeferredFlushTimer();
     const update = this.deferredCompletion.take();
     if (update) this.emitUpdate(update);
   }

--- a/src/supervisor/agents/claude/sdkSession.ts
+++ b/src/supervisor/agents/claude/sdkSession.ts
@@ -52,6 +52,7 @@ import {
   buildClaudeQuestionAnswerEvents,
   buildPromptContentBlocks,
   closeClaudeOpenItems,
+  completeActiveGoalOnTaskDrainEvents,
   createClaudeMapperState,
   emitActiveGoalTokenUpdate,
   extractResultErrorMessage,
@@ -910,6 +911,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.currentTurnAssistantUuid = undefined;
     this.deferredCompletion.clear();
     this.clearDeferredFlushTimer();
+    delete this.mapperState.pendingGoalCompletionOnTaskDrain;
     // Seed the mapper's turn id so the eventual `result` emits the matching
     // `turn.completed`, re-closing the renderer's turn-open gate.
     this.mapperState.currentTurnId = turnId;
@@ -1055,6 +1057,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
     this.deferredFlushTimer = setTimeout(() => {
       this.deferredFlushTimer = undefined;
       if (this.disposed || this.hasLiveSubAgentTasks()) return;
+      this.emitRuntimeEvents(completeActiveGoalOnTaskDrainEvents(this.mapperState));
       const update = this.deferredCompletion.take();
       if (update) this.emitUpdate(update);
     }, DEFERRED_FLUSH_RESUME_GRACE_MS);
@@ -1074,6 +1077,7 @@ export class ClaudeSdkSession implements StructuredSessionHandle {
    */
   private flushDeferredCompletion(): void {
     this.clearDeferredFlushTimer();
+    this.emitRuntimeEvents(completeActiveGoalOnTaskDrainEvents(this.mapperState));
     const update = this.deferredCompletion.take();
     if (update) this.emitUpdate(update);
   }

--- a/src/supervisor/agents/goalRuntime.ts
+++ b/src/supervisor/agents/goalRuntime.ts
@@ -7,6 +7,8 @@ export interface ProviderGoalState {
   tokenBudget?: number | null;
   tokensUsed?: number;
   timeUsedSeconds?: number;
+  iterations?: number;
+  lastReason?: string;
   createdAt?: number;
   updatedAt?: number;
 }
@@ -37,6 +39,8 @@ export function goalPayloadFromProviderState(
     ...(goal.tokenBudget !== undefined ? { tokenBudget: goal.tokenBudget } : {}),
     ...(goal.tokensUsed !== undefined ? { tokensUsed: goal.tokensUsed } : {}),
     ...(goal.timeUsedSeconds !== undefined ? { timeUsedSeconds: goal.timeUsedSeconds } : {}),
+    ...(goal.iterations !== undefined ? { iterations: goal.iterations } : {}),
+    ...(goal.lastReason ? { lastReason: goal.lastReason } : {}),
     ...(goal.providerThreadId ? { providerThreadId: goal.providerThreadId } : {}),
     ...(goal.updatedAt !== undefined ? { updatedAt: goal.updatedAt } : {}),
   };


### PR DESCRIPTION
- **Feature:** Show goal iteration counts and the latest evaluator reason in the thread goal dock, with localized labels.
- Map Claude SDK active-goal updates into the shared goal runtime so goal progress and completion reflect evaluator verdicts.
- Prevent deferred task-drain completion from settling goals while Claude resumes follow-up work.
- Expand renderer and Claude SDK coverage for goal updates, completion, and background-task behavior.