### PR TITLE
Report actionable Kimi ACP empty-turn errors

### DIFF
--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -171,6 +171,14 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "supervisor.restarted": msg({ message: "Background process restarted" }),
   "supervisor.exited": msg({ message: "Background process exited unexpectedly" }),
   "supervisor.notRunning": msg({ message: "Background process is not running" }),
+  "kimi.credentialsLocked": msg({
+    message:
+      "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry.",
+  }),
+  "kimi.emptyResponse": msg({
+    message:
+      "Kimi Code ended the turn without returning a response. Restart the thread and try again.",
+  }),
   "update.error": msg({ message: "Update error: {detail}" }),
 };
 

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Bash beenden"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code konnte seine Anmeldedaten nicht aktualisieren, da ein anderer Prozess die Anmeldedatendatei verwendet. Schließen Sie andere Poracode- oder Kimi-Code-Prozesse und versuchen Sie es erneut."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code hat den Durchlauf beendet, ohne eine Antwort zurückzugeben. Starten Sie den Thread neu und versuchen Sie es erneut."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Kill bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Detener bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code no pudo actualizar sus credenciales porque otro proceso está usando el archivo de credenciales. Cierra otros procesos de Poracode o Kimi Code y vuelve a intentarlo."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code finalizó el turno sin devolver una respuesta. Reinicia el hilo y vuelve a intentarlo."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Arrêter bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code n’a pas pu mettre à jour ses identifiants, car un autre processus utilise le fichier d’identifiants. Fermez les autres processus Poracode ou Kimi Code, puis réessayez."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code a terminé le tour sans renvoyer de réponse. Redémarrez le fil et réessayez."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -4919,6 +4919,14 @@ msgstr "bash を終了"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "別のプロセスが認証情報ファイルを使用しているため、Kimi Code は認証情報を更新できませんでした。他の Poracode または Kimi Code プロセスを終了してから、もう一度お試しください。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code は応答を返さずにターンを終了しました。スレッドを再起動して、もう一度お試しください。"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -4920,6 +4920,14 @@ msgstr "bash 종료"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "다른 프로세스에서 자격 증명 파일을 사용 중이어서 Kimi Code가 자격 증명을 업데이트하지 못했습니다. 다른 Poracode 또는 Kimi Code 프로세스를 닫은 후 다시 시도하세요."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code가 응답을 반환하지 않고 작업을 종료했습니다. 스레드를 다시 시작한 후 다시 시도하세요."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Zakończ bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code nie mógł zaktualizować danych logowania, ponieważ inny proces używa pliku danych logowania. Zamknij inne procesy Poracode lub Kimi Code i spróbuj ponownie."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code zakończył turę bez zwrócenia odpowiedzi. Uruchom wątek ponownie i spróbuj jeszcze raz."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Encerrar bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "O Kimi Code não conseguiu atualizar as credenciais porque outro processo está usando o arquivo de credenciais. Feche outros processos do Poracode ou Kimi Code e tente novamente."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "O Kimi Code encerrou o turno sem retornar uma resposta. Reinicie a conversa e tente novamente."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Завершить bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code не удалось обновить учетные данные, поскольку файл учетных данных используется другим процессом. Закройте другие процессы Poracode или Kimi Code и повторите попытку."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code завершил ход, не вернув ответ. Перезапустите ветку и повторите попытку."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Bash'ı öldür"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Başka bir işlem kimlik bilgileri dosyasını kullandığı için Kimi Code kimlik bilgilerini güncelleyemedi. Diğer Poracode veya Kimi Code işlemlerini kapatıp yeniden deneyin."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code yanıt döndürmeden turu sonlandırdı. İş parçacığını yeniden başlatıp tekrar deneyin."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Завершити bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code не вдалося оновити облікові дані, оскільки файл облікових даних використовується іншим процесом. Закрийте інші процеси Poracode або Kimi Code та повторіть спробу."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code завершив хід, не повернувши відповіді. Перезапустіть гілку та повторіть спробу."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -4920,6 +4920,14 @@ msgstr "Dừng bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "Kimi Code không thể cập nhật thông tin xác thực vì một tiến trình khác đang sử dụng tệp thông tin xác thực. Hãy đóng các tiến trình Poracode hoặc Kimi Code khác rồi thử lại."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code đã kết thúc lượt mà không trả về phản hồi. Hãy khởi động lại luồng rồi thử lại."
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -4920,6 +4920,14 @@ msgstr "终止 bash"
 msgid "Kimi Code"
 msgstr "Kimi Code"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry."
+msgstr "由于另一个进程正在使用凭据文件，Kimi Code 无法更新凭据。请关闭其他 Poracode 或 Kimi Code 进程，然后重试。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Kimi Code ended the turn without returning a response. Restart the thread and try again."
+msgstr "Kimi Code 在未返回响应的情况下结束了本轮。请重启会话线程后重试。"
+
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Language"

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -116,6 +116,12 @@ const messages = {
   "supervisor.exited": "Background process exited unexpectedly",
   "supervisor.notRunning": "Background process is not running",
 
+  // ── Kimi Code ─────────────────────────────────────────────
+  "kimi.credentialsLocked":
+    "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry.",
+  "kimi.emptyResponse":
+    "Kimi Code ended the turn without returning a response. Restart the thread and try again.",
+
   // ── App update ────────────────────────────────────────────
   "update.error": "Update error: {detail}",
 } as const;

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -154,6 +154,9 @@ function makeConfigSyncSession(
   session["pendingPromptInterrupt"] = false;
   session["currentTurnInterruptRequested"] = false;
   session["recentInterruptAckTextTail"] = "";
+  session["currentTurnHadAgentActivity"] = false;
+  session["stderrChunks"] = [];
+  session["emptyResponseErrorResolver"] = undefined;
   session["mapperState"] = undefined;
   session["acpTerminals"] = new Map();
   session["acpTerminalSeq"] = 0;
@@ -236,6 +239,63 @@ describe("resolveAcpPromptFailureMessage — prompt rejection after agent-surfac
   it("still emits the RPC error row when no agent-surfaced message exists", () => {
     const transport = RequestError.internalError({ details: "Agent error" });
     expect(shouldEmitAcpPromptRpcErrorItem(transport, undefined)).toBe(true);
+  });
+});
+
+describe("ACP empty-response provider guard", () => {
+  it("turns a provider-diagnosed empty end_turn into a visible failed turn", async () => {
+    const { connection, listener, session } = makeConfigSyncSession();
+    const resolver = vi.fn<(input: { stopReason: string; stderr: readonly string[] }) => Error>(
+      () => new Error("credential file is locked"),
+    );
+    (session as unknown as Record<string, unknown>)["emptyResponseErrorResolver"] = resolver;
+    connection.prompt.mockImplementationOnce(async () => {
+      (session as unknown as Record<string, string[]>)["stderrChunks"]!.push(
+        "EPERM rename kimi-code.json",
+      );
+      return { stopReason: "end_turn" };
+    });
+
+    await session.startTurn("hello", { model: "model-a" });
+
+    expect(resolver).toHaveBeenCalledWith({
+      stopReason: "end_turn",
+      stderr: ["EPERM rename kimi-code.json"],
+    });
+    expect(listener.onUpdate).toHaveBeenLastCalledWith({
+      status: "error",
+      attention: "error",
+      errorMessage: "credential file is locked",
+    });
+    expect(listener.onRuntimeEvent).toHaveBeenCalledWith({
+      type: "error",
+      threadId: "thread-1",
+      message: "credential file is locked",
+    });
+    expect(listener.onRuntimeEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "turn.completed", state: "failed" }),
+    );
+  });
+
+  it("does not invoke the guard after agent activity", async () => {
+    const { connection, session } = makeConfigSyncSession();
+    const resolver = vi.fn<(input: { stopReason: string; stderr: readonly string[] }) => Error>(
+      () => new Error("unexpected"),
+    );
+    (session as unknown as Record<string, unknown>)["emptyResponseErrorResolver"] = resolver;
+    connection.prompt.mockImplementationOnce(async () => {
+      session.handleSessionUpdate({
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "hello" },
+        },
+      });
+      return { stopReason: "end_turn" };
+    });
+
+    await session.startTurn("hello", { model: "model-a" });
+
+    expect(resolver).not.toHaveBeenCalled();
   });
 });
 

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -67,6 +67,7 @@ import { terminateChildProcessTree } from "@/shared/processTree";
 import {
   createKnownSessionRef,
   type AgentLaunchOptions,
+  type AcpEmptyResponseErrorResolver,
   type CommandSpec,
   type StartTurnOptions,
   type StructuredSessionHandle,
@@ -117,6 +118,7 @@ export interface AcpStructuredSessionOptions {
    * sessionId that was being loaded; must return the Error to throw.
    */
   loadSessionErrorRewriter?: (error: unknown, sessionId: string) => Error;
+  emptyResponseErrorResolver?: AcpEmptyResponseErrorResolver;
   /**
    * Per-adapter notification preprocessor. When set, every `session/update`
    * is run through it before the shared canonical mapper consumes it. Use to
@@ -138,6 +140,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private loadSessionErrorRewriter: (error: unknown, sessionId: string) => Error =
     rewriteLoadSessionError;
 
+  private emptyResponseErrorResolver?: AcpEmptyResponseErrorResolver;
+
   private sessionUpdateTransform?: (notification: SessionNotification) => SessionNotification;
 
   private extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
@@ -150,7 +154,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly mcpServers: readonly ResolvedMcpServer[];
   /** Poracode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
-  private readonly stderrChunks: string[] = [];
+  private readonly stderrChunks: string[];
   private listener: StructuredSessionListener | undefined;
   private sessionId: string | undefined;
   private isDisposed = false;
@@ -175,6 +179,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private recentInterruptAckTextTail = "";
   /** User-visible error text from an `agent_message_chunk` before `prompt()` settles. */
   private agentSurfacedErrorMessage: string | undefined;
+  private currentTurnHadAgentActivity = false;
   private agentPromptCapabilities: PromptCapabilities | undefined;
   private agentSessionCapabilities: SessionCapabilities | undefined;
   private agentMcpCapabilities: McpCapabilities | undefined;
@@ -250,6 +255,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     projectLocation: ProjectLocation,
     cwd: string,
     threadId: string,
+    stderrChunks: string[],
     options?: AcpStructuredSessionOptions,
   ) {
     this.child = child;
@@ -257,9 +263,13 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     this.projectLocation = projectLocation;
     this.cwd = cwd;
     this.threadId = threadId;
+    this.stderrChunks = stderrChunks;
     this.launchOptions = { suppressResumeConfigOverrides: true };
     if (options?.loadSessionErrorRewriter) {
       this.loadSessionErrorRewriter = options.loadSessionErrorRewriter;
+    }
+    if (options?.emptyResponseErrorResolver) {
+      this.emptyResponseErrorResolver = options.emptyResponseErrorResolver;
     }
     if (options?.sessionUpdateTransform) {
       this.sessionUpdateTransform = options.sessionUpdateTransform;
@@ -450,10 +460,10 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       projectLocation,
       sessionCwd,
       threadId,
+      stderrChunks,
       options,
     );
     session.spawnReady = spawnReady;
-    session.stderrChunks.push(...stderrChunks);
 
     // Handle connection close
     void connection.closed.then(() => {
@@ -652,6 +662,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     this.currentTurnInterruptRequested = false;
     this.recentInterruptAckTextTail = "";
     this.agentSurfacedErrorMessage = undefined;
+    this.currentTurnHadAgentActivity = false;
+    this.stderrChunks.length = 0;
 
     this.currentConfig = await this.sessionConfigSync.applyTurnConfig(
       this.sessionId,
@@ -717,6 +729,17 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         interruptRequested: this.currentTurnInterruptRequested,
         recentAgentText: this.recentInterruptAckTextTail,
       });
+      if (
+        result.stopReason === "end_turn" &&
+        !this.currentTurnInterruptRequested &&
+        !this.currentTurnHadAgentActivity
+      ) {
+        const emptyResponseError = this.emptyResponseErrorResolver?.({
+          stopReason: result.stopReason,
+          stderr: this.stderrChunks,
+        });
+        if (emptyResponseError) throw emptyResponseError;
+      }
       this.emitTurnStatusAfterPrompt(normalizedStopReason);
       this.completeTurn(
         this.ensureMapperState(),
@@ -963,6 +986,16 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
     const params = this.applySessionUpdateTransform(rawParams);
     const update: SessionUpdate = params.update;
+
+    if (
+      update.sessionUpdate === "agent_message_chunk" ||
+      update.sessionUpdate === "agent_thought_chunk" ||
+      update.sessionUpdate === "tool_call" ||
+      update.sessionUpdate === "tool_call_update" ||
+      update.sessionUpdate === "plan"
+    ) {
+      this.currentTurnHadAgentActivity = true;
+    }
 
     if (update.sessionUpdate === "available_commands_update") {
       this.updateSlashCommands(mapAcpSlashCommands(update.availableCommands));

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -46,6 +46,9 @@ export function createAcpStructuredSession(
     ...(input.loadSessionErrorRewriter
       ? { loadSessionErrorRewriter: input.loadSessionErrorRewriter }
       : {}),
+    ...(input.acpEmptyResponseErrorResolver
+      ? { emptyResponseErrorResolver: input.acpEmptyResponseErrorResolver }
+      : {}),
     ...(input.acpSessionUpdateTransform
       ? { sessionUpdateTransform: input.acpSessionUpdateTransform }
       : {}),

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -42,6 +42,7 @@ import type {
 } from "./types";
 
 export type {
+  AcpEmptyResponseErrorResolver,
   AcpSessionUpdateTransform,
   AgentAcpAuth,
   AgentAdapter,

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -150,6 +150,11 @@ export interface CreateStructuredSessionInput {
   presentationMode?: ThreadPresentationMode;
   loadSessionErrorRewriter?: (error: unknown, sessionId: string) => Error;
   /**
+   * Provider-boundary guard for ACP agents that can incorrectly return a
+   * successful `end_turn` without emitting any agent activity.
+   */
+  acpEmptyResponseErrorResolver?: AcpEmptyResponseErrorResolver;
+  /**
    * Per-adapter hook to normalize a provider's ACP `session/update` wire
    * payload before the shared generic mapper consumes it. Use only to bridge
    * provider-specific quirks (e.g. Cursor's near-empty tool_call payloads) —
@@ -162,6 +167,11 @@ export interface CreateStructuredSessionInput {
    */
   acpExtensionNotificationHandler?: AcpExtensionNotificationHandler;
 }
+
+export type AcpEmptyResponseErrorResolver = (input: {
+  stopReason: string;
+  stderr: readonly string[];
+}) => Error | undefined;
 
 export type AcpSessionUpdateTransform = (
   notification: import("@agentclientprotocol/sdk").SessionNotification,

--- a/src/supervisor/agents/kimi/index.ts
+++ b/src/supervisor/agents/kimi/index.ts
@@ -1,4 +1,5 @@
 import type { PromptSegment } from "@/shared/contracts";
+import { msg } from "@/shared/messages";
 import { inlinePromptSegmentText } from "@/shared/promptContent";
 import { createAcpStructuredSession } from "../acp";
 import {
@@ -27,6 +28,21 @@ import { detectKimiTerminalStatus } from "./terminal";
 // Kimi Code provider implementation (Moonshot AI).
 // Docs: https://www.kimi.com/code/docs/en/
 // npm:  @moonshot-ai/kimi-code
+
+export function resolveKimiEmptyResponseError(input: {
+  stopReason: string;
+  stderr: readonly string[];
+}): Error {
+  const stderr = input.stderr.join("\n").toLowerCase();
+  const credentialRenameBlocked =
+    stderr.includes("kimi-code.json") &&
+    stderr.includes("rename") &&
+    (stderr.includes("eperm") ||
+      stderr.includes("ebusy") ||
+      stderr.includes("operation not permitted") ||
+      stderr.includes("access is denied"));
+  return new Error(msg(credentialRenameBlocked ? "kimi.credentialsLocked" : "kimi.emptyResponse"));
+}
 
 export function createKimiAdapter(): AgentAdapter {
   let capabilities = kimiDefaultCapabilities;
@@ -109,7 +125,10 @@ export function createKimiAdapter(): AgentAdapter {
         [...acpArgs, "acp"],
         resolveAgentBinaryPath(input.projectLocation, "kimi"),
       );
-      return createAcpStructuredSession(command, input);
+      return createAcpStructuredSession(command, {
+        ...input,
+        acpEmptyResponseErrorResolver: resolveKimiEmptyResponseError,
+      });
     },
 
     // Kimi ACP advertises a single "login" auth method; the auth command is the

--- a/src/supervisor/agents/kimi/kimi.test.ts
+++ b/src/supervisor/agents/kimi/kimi.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import { createKnownSessionRef } from "../base";
-import { createKimiAdapter } from "./index";
+import { createKimiAdapter, resolveKimiEmptyResponseError } from "./index";
 
 const location = { kind: "windows", path: "C:\\repo" } as ProjectLocation;
 const config = { mode: "agent" } as ThreadConfig;
@@ -153,5 +153,24 @@ describe("createKimiAdapter terminal heuristics", () => {
     expect(adapter.detectTerminalStatus?.("⠋ working...")?.status).toBe("working");
     expect(adapter.detectTerminalStatus?.("? for shortcuts")?.status).toBe("idle");
     expect(adapter.detectTerminalStatus?.("context: 10% (23.2k/256k)")?.status).toBe("idle");
+  });
+});
+
+describe("resolveKimiEmptyResponseError", () => {
+  it("explains the Windows credential rename lock", () => {
+    expect(
+      resolveKimiEmptyResponseError({
+        stopReason: "end_turn",
+        stderr: [
+          "EPERM: operation not permitted, rename 'C:\\\\Users\\\\demo\\\\.kimi-code\\\\credentials\\\\kimi-code.json.tmp' -> 'C:\\\\Users\\\\demo\\\\.kimi-code\\\\credentials\\\\kimi-code.json'",
+        ],
+      }).message,
+    ).toContain("another process is using the credential file");
+  });
+
+  it("reports an actionable error for any other empty Kimi turn", () => {
+    expect(resolveKimiEmptyResponseError({ stopReason: "end_turn", stderr: [] }).message).toContain(
+      "without returning a response",
+    );
   });
 });


### PR DESCRIPTION
- **Bugfix:** surface actionable errors when Kimi ACP ends a turn without a response.
- Identify credential-file lock failures and guide users to close conflicting processes.
- Localize the new Kimi error guidance across all supported renderer locales.
- Cover empty-turn detection and Kimi-specific error resolution with session and adapter tests.