### PR TITLE
fix SEO foundations

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -7,6 +7,7 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-visual"
     />
     <meta name="theme-color" content="#070709" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Poracode" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,7 @@
     {
       "source": "/(.*)",
       "headers": [
+        { "key": "X-Robots-Tag", "value": "noindex, nofollow" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }

--- a/website/src/app/(default)/changelog/page.tsx
+++ b/website/src/app/(default)/changelog/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { I18nProvider } from "@/lib/i18n/I18nProvider";
 import { getLocaleMessages } from "@/lib/i18n/messages";
 import { createPageMetadata } from "@/lib/seo";
-import { ChangelogContent } from "./changelog-content";
+import { ChangelogContent } from "@/app/changelog/changelog-content";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Poracode Changelog",

--- a/website/src/app/(default)/download/page.tsx
+++ b/website/src/app/(default)/download/page.tsx
@@ -4,7 +4,7 @@ import { I18nProvider } from "@/lib/i18n/I18nProvider";
 import { getLocaleMessages } from "@/lib/i18n/messages";
 import { getLatestRelease } from "@/lib/releases";
 import { createPageMetadata } from "@/lib/seo";
-import { DownloadContent } from "./download-content";
+import { DownloadContent } from "@/app/download/download-content";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Download Poracode",

--- a/website/src/app/(default)/layout.tsx
+++ b/website/src/app/(default)/layout.tsx
@@ -1,0 +1,7 @@
+import { ROOT_METADATA, SiteDocument } from "@/app/site-document";
+
+export const metadata = ROOT_METADATA;
+
+export default function DefaultRootLayout({ children }: { children: React.ReactNode }) {
+  return <SiteDocument lang="en">{children}</SiteDocument>;
+}

--- a/website/src/app/(default)/nightly/page.tsx
+++ b/website/src/app/(default)/nightly/page.tsx
@@ -3,7 +3,7 @@ import { I18nProvider } from "@/lib/i18n/I18nProvider";
 import { getLocaleMessages } from "@/lib/i18n/messages";
 import { getLatestNightlyRelease } from "@/lib/releases";
 import { createPageMetadata } from "@/lib/seo";
-import { NightlyContent } from "./nightly-content";
+import { NightlyContent } from "@/app/nightly/nightly-content";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Poracode Nightly — Latest pre-release builds",

--- a/website/src/app/(default)/page.tsx
+++ b/website/src/app/(default)/page.tsx
@@ -10,7 +10,7 @@ import {
   SITE_TITLE,
   stringifyJsonLd,
 } from "@/lib/seo";
-import { HomeContent } from "./home-content";
+import { HomeContent } from "@/app/home-content";
 
 export const metadata: Metadata = createPageMetadata({
   title: SITE_TITLE,

--- a/website/src/app/(default)/privacy/page.tsx
+++ b/website/src/app/(default)/privacy/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 
-import contact from "../../../../branding/contact.json";
+import contact from "../../../../../branding/contact.json";
 import { createPageMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata({

--- a/website/src/app/(default)/support/page.tsx
+++ b/website/src/app/(default)/support/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { ArrowLeft, ExternalLink, Mail } from "lucide-react";
 import Link from "next/link";
 
-import contact from "../../../../branding/contact.json";
+import contact from "../../../../../branding/contact.json";
 import { createPageMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = createPageMetadata({

--- a/website/src/app/[locale]/layout.tsx
+++ b/website/src/app/[locale]/layout.tsx
@@ -1,4 +1,7 @@
+import { ROOT_METADATA, SiteDocument } from "@/app/site-document";
 import { DEFAULT_LOCALE, LOCALE_CODES } from "@/lib/i18n/config";
+
+export const metadata = ROOT_METADATA;
 
 // Only the non-default locales are prefixed (the default locale is served at the
 // root). `dynamicParams = false` makes any other segment a 404, so this dynamic
@@ -9,6 +12,13 @@ export function generateStaticParams() {
   return LOCALE_CODES.filter((locale) => locale !== DEFAULT_LOCALE).map((locale) => ({ locale }));
 }
 
-export default function LocaleLayout({ children }: { children: React.ReactNode }) {
-  return children;
+export default async function LocaleRootLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return <SiteDocument lang={locale}>{children}</SiteDocument>;
 }

--- a/website/src/app/site-document.tsx
+++ b/website/src/app/site-document.tsx
@@ -23,7 +23,7 @@ const geistMono = Geist_Mono({
 // the <meta name="google-site-verification"> tag is emitted only when present.
 const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION;
 
-export const metadata: Metadata = {
+export const ROOT_METADATA: Metadata = {
   metadataBase: new URL(SITE_URL),
   applicationName: SITE_NAME,
   ...createPageMetadata({
@@ -63,14 +63,13 @@ export const metadata: Metadata = {
   ...(googleSiteVerification ? { verification: { google: googleSiteVerification } } : {}),
 };
 
-export default function RootLayout({
+export function SiteDocument({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+  lang,
+}: Readonly<{ children: React.ReactNode; lang: string }>) {
   return (
     <html
-      lang="en"
+      lang={lang}
       className={`dark ${geistSans.variable} ${geistMono.variable}`}
       suppressHydrationWarning
     >

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,16 +1,39 @@
 import type { MetadataRoute } from "next";
 
+import { CHANGELOG } from "@/lib/changelog";
 import { LOCALE_CODES } from "@/lib/i18n/config";
+import { getLatestNightlyRelease, getLatestRelease } from "@/lib/releases";
 import { absoluteUrl, buildLanguageAlternates, localizedPath, SITEMAP_ROUTES } from "@/lib/seo";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+function validDate(value: string | null | undefined): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value.includes("T") ? value : `${value}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [stableRelease, nightlyRelease] = await Promise.all([
+    getLatestRelease(),
+    getLatestNightlyRelease(),
+  ]);
+  const changelogDate = validDate(CHANGELOG[0]?.date);
+  const lastModifiedByPath: Readonly<Record<string, Date | undefined>> = {
+    "/": validDate(stableRelease.publishedAt) ?? changelogDate,
+    "/download": validDate(stableRelease.publishedAt) ?? changelogDate,
+    "/changelog": changelogDate,
+    "/nightly": validDate(nightlyRelease.publishedAt),
+    "/privacy": validDate("2026-07-15"),
+  };
+
   // Translated routes carry their full hreflang cluster; English-only routes
   // appear once without language alternatives.
   return SITEMAP_ROUTES.flatMap<MetadataRoute.Sitemap[number]>((route) => {
+    const lastModified = lastModifiedByPath[route.path];
     if (!route.localized) {
       return [
         {
           url: absoluteUrl(route.path),
+          ...(lastModified ? { lastModified } : {}),
           changeFrequency: route.changeFrequency,
           priority: route.priority,
         },
@@ -20,6 +43,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     const languages = buildLanguageAlternates(route.path);
     return LOCALE_CODES.map((locale) => ({
       url: absoluteUrl(localizedPath(route.path, locale)),
+      ...(lastModified ? { lastModified } : {}),
       changeFrequency: route.changeFrequency,
       priority: route.priority,
       alternates: { languages },


### PR DESCRIPTION
## Summary

- add shared root metadata and localized document language handling for the Poracode website
- publish sitemap freshness data and crawler directives for the marketing site
- keep the PWA/mobile shell out of search results with `noindex, nofollow`
- expose optional Google Search Console verification through `GOOGLE_SITE_VERIFICATION`

## Motivation

Establish a clean SEO foundation for `poracode.com` so search engines index the canonical marketing pages, receive localized route metadata, and avoid indexing the application shell.

## Impact

The website emits stronger canonical metadata, correct locale-specific `<html lang>` values, and more useful sitemap timestamps. The application deployment remains excluded from search indexing.

## Validation

- [x] `pnpm --dir website typecheck`
- [x] `git diff --check origin/master...HEAD`
- [ ] `pnpm --dir website lint` — local run is blocked by a missing `oxlint` native binding; GitHub CI lint is running
