### PR TITLE
add authoritative Poracode entity profile

### DIFF
--- a/website/src/app/(default)/about/page.tsx
+++ b/website/src/app/(default)/about/page.tsx
@@ -1,0 +1,180 @@
+import type { Metadata } from "next";
+import { ArrowLeft, ArrowUpRight, Download, GitBranch, Globe, Mail } from "lucide-react";
+import Link from "next/link";
+
+import contact from "../../../../../branding/contact.json";
+import { BrandLockup, PoraIconTile } from "@/components/BrandMark";
+import {
+  createAboutJsonLd,
+  createPageMetadata,
+  GITHUB_URL,
+  SITE_DESCRIPTION,
+  stringifyJsonLd,
+} from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "About Poracode — Open-source AI coding agent desktop app",
+  description:
+    "Learn what Poracode is: an open-source desktop workspace for Claude Code, Codex, Gemini, Cursor, OpenCode, and ACP coding agents.",
+  path: "/about",
+});
+
+const OFFICIAL_LINKS = [
+  {
+    label: "Official website",
+    value: "poracode.com",
+    href: "https://poracode.com",
+    icon: Globe,
+  },
+  {
+    label: "Source repository",
+    value: "SDSLeon/lightcode",
+    href: GITHUB_URL,
+    icon: GitBranch,
+  },
+  {
+    label: "Downloads",
+    value: "macOS, Windows, and Linux",
+    href: "/download",
+    icon: Download,
+  },
+  {
+    label: "Support",
+    value: contact.supportEmail,
+    href: `mailto:${contact.supportEmail}`,
+    icon: Mail,
+  },
+] as const;
+
+export default function AboutPage() {
+  return (
+    <div className="relative min-h-screen overflow-x-hidden bg-night text-moon">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: stringifyJsonLd(createAboutJsonLd()) }}
+      />
+
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_80%_55%_at_50%_0%,_rgba(139,123,255,0.14)_0%,_transparent_70%)]" />
+      <div className="brand-grid pointer-events-none fixed inset-x-0 top-0 h-[900px] opacity-60" />
+
+      <nav className="relative z-20 mx-auto flex max-w-6xl items-center justify-between gap-4 px-5 py-6 sm:px-8">
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-dim transition-colors hover:text-moon"
+        >
+          <ArrowLeft className="size-4" />
+          <span className="text-sm font-medium">Back to home</span>
+        </Link>
+        <Link
+          href="/download"
+          className="inline-flex h-10 items-center gap-2 rounded-lg bg-moon px-4 text-sm font-semibold text-night transition hover:brightness-95"
+        >
+          <Download className="size-4" />
+          Download
+        </Link>
+      </nav>
+
+      <main className="relative z-10 mx-auto max-w-4xl px-5 pb-24 pt-12 sm:px-8 md:pt-20">
+        <header className="border-b border-white/[0.08] pb-14">
+          <PoraIconTile className="mb-8 h-14 w-14" />
+          <p className="mb-4 font-mono text-xs uppercase tracking-[0.18em] text-accent">
+            Official project profile
+          </p>
+          <h1 className="max-w-3xl text-4xl font-bold tracking-[-0.035em] sm:text-5xl md:text-6xl">
+            About Poracode
+          </h1>
+          <p className="mt-7 max-w-3xl text-xl leading-9 text-dim">{SITE_DESCRIPTION}</p>
+        </header>
+
+        <div className="grid gap-14 py-14 md:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="space-y-12 text-[16px] leading-8 text-dim">
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold tracking-[-0.02em] text-moon">
+                What Poracode is
+              </h2>
+              <p>
+                Poracode is an open-source developer tool for working with AI coding agents from a
+                single desktop workspace. It brings terminal-native agents and structured chat
+                workflows together with the files, Git changes, browser previews, worktrees, and
+                pull requests involved in a real coding session.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold tracking-[-0.02em] text-moon">
+                Agent choice without lock-in
+              </h2>
+              <p>
+                The app supports Claude Code, OpenAI Codex, Gemini, Cursor, OpenCode, and agents
+                available through the Agent Client Protocol registry. Developers can keep different
+                agents side by side and use the one that fits each task without moving their whole
+                workflow between separate applications.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold tracking-[-0.02em] text-moon">
+                Open source and cross-platform
+              </h2>
+              <p>
+                Poracode is developed in public and distributed under the Apache License 2.0. The
+                desktop app is available for macOS, Windows, and Linux, with a hosted companion at
+                app.poracode.com for connecting to a Poracode desktop that you control.
+              </p>
+            </section>
+
+            <section>
+              <h2 className="mb-4 text-2xl font-semibold tracking-[-0.02em] text-moon">
+                The official identity
+              </h2>
+              <p>
+                Poracode, Pora.code, and poracode.com refer to this AI coding agent software
+                project. The canonical website is poracode.com, and the canonical source repository
+                is SDSLeon/lightcode on GitHub.
+              </p>
+            </section>
+          </div>
+
+          <aside aria-label="Official Poracode links" className="md:pt-1">
+            <div className="sticky top-8 overflow-hidden rounded-2xl border border-white/[0.08] bg-tile/80">
+              <div className="border-b border-white/[0.07] px-5 py-4">
+                <BrandLockup />
+              </div>
+              <ul className="divide-y divide-white/[0.06]">
+                {OFFICIAL_LINKS.map(({ label, value, href, icon: Icon }) => (
+                  <li key={label}>
+                    <a
+                      href={href}
+                      className="group flex items-start gap-3 px-5 py-4 transition-colors hover:bg-white/[0.035]"
+                    >
+                      <Icon className="mt-0.5 size-4 shrink-0 text-accent" />
+                      <span className="min-w-0">
+                        <span className="block text-sm font-medium text-moon">{label}</span>
+                        <span className="mt-0.5 block break-words font-mono text-[12px] leading-5 text-dim">
+                          {value}
+                        </span>
+                      </span>
+                      <ArrowUpRight className="ml-auto mt-0.5 size-4 shrink-0 text-dim transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </aside>
+        </div>
+
+        <footer className="flex flex-wrap items-center gap-x-6 gap-y-3 border-t border-white/[0.08] pt-8 font-mono text-[13px] text-dim">
+          <Link href="/support" className="transition-colors hover:text-moon">
+            Support
+          </Link>
+          <Link href="/privacy" className="transition-colors hover:text-moon">
+            Privacy
+          </Link>
+          <Link href="/changelog" className="transition-colors hover:text-moon">
+            Changelog
+          </Link>
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/website/src/app/home-content.tsx
+++ b/website/src/app/home-content.tsx
@@ -297,6 +297,7 @@ export function HomeContent({ release }: { release: ReleaseInfo }) {
     : t("hero.tagline");
   const downloadHref = downloadUrlFor(release, platform.slug);
   const homeHref = localizedPath("/", locale);
+  const aboutHref = "/about";
   const changelogHref = "/changelog";
   const downloadsHref = localizedPath("/download", locale);
   const nightlyHref = localizedPath("/nightly", locale);
@@ -350,6 +351,13 @@ export function HomeContent({ release }: { release: ReleaseInfo }) {
               <Globe className="h-4 w-4" />
               {t("nav.webApp")}
             </a>
+            <Link
+              href={aboutHref}
+              prefetch={false}
+              className="hidden rounded-md px-3 py-2 font-mono text-[13px] text-dim transition-colors hover:bg-white/[0.04] hover:text-moon lg:inline-flex"
+            >
+              About
+            </Link>
             <Link
               href={changelogHref}
               prefetch={false}
@@ -611,6 +619,12 @@ export function HomeContent({ release }: { release: ReleaseInfo }) {
           </div>
           <p className="font-mono text-[12px] text-dim">{t("footer.copyright", { year: 2026 })}</p>
           <div className="flex items-center gap-6">
+            <Link
+              href={aboutHref}
+              className="font-mono text-[13px] text-dim transition-colors hover:text-moon"
+            >
+              About
+            </Link>
             <Link
               href={changelogHref}
               className="font-mono text-[13px] text-dim transition-colors hover:text-moon"

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -20,6 +20,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const lastModifiedByPath: Readonly<Record<string, Date | undefined>> = {
     "/": validDate(stableRelease.publishedAt) ?? changelogDate,
     "/download": validDate(stableRelease.publishedAt) ?? changelogDate,
+    "/about": validDate("2026-07-20"),
     "/changelog": changelogDate,
     "/nightly": validDate(nightlyRelease.publishedAt),
     "/privacy": validDate("2026-07-15"),

--- a/website/src/lib/seo.ts
+++ b/website/src/lib/seo.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import contact from "../../../branding/contact.json";
 import { LANDING_FAQ_ITEMS } from "@/lib/landingFaq";
 import type { ReleaseInfo } from "@/lib/releases";
 import { DEFAULT_LOCALE, LOCALE_CODES, localizedPath, type Locale } from "./i18n/config";
@@ -54,6 +55,7 @@ export const SEO_KEYWORDS = [
 export const SITEMAP_ROUTES = [
   { path: "/", changeFrequency: "weekly", priority: 1, localized: true },
   { path: "/download", changeFrequency: "daily", priority: 0.9, localized: true },
+  { path: "/about", changeFrequency: "monthly", priority: 0.6, localized: false },
   { path: "/changelog", changeFrequency: "weekly", priority: 0.7, localized: false },
   { path: "/nightly", changeFrequency: "daily", priority: 0.5, localized: true },
   { path: "/support", changeFrequency: "monthly", priority: 0.4, localized: false },
@@ -146,6 +148,8 @@ export function createHomeJsonLd(release: ReleaseInfo, locale: Locale = DEFAULT_
     "@id": `${SITE_URL}/#organization`,
     name: SITE_NAME,
     url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    email: contact.supportEmail,
     logo: {
       "@type": "ImageObject",
       url: absoluteUrl("/icon-512.png"),
@@ -153,6 +157,12 @@ export function createHomeJsonLd(release: ReleaseInfo, locale: Locale = DEFAULT_
       height: 512,
     },
     sameAs: [GITHUB_URL],
+    contactPoint: {
+      "@type": "ContactPoint",
+      contactType: "technical support",
+      email: contact.supportEmail,
+      url: absoluteUrl("/support"),
+    },
   };
 
   const softwareApplication = {
@@ -211,6 +221,7 @@ export function createHomeJsonLd(release: ReleaseInfo, locale: Locale = DEFAULT_
     "@type": "WebSite",
     "@id": `${SITE_URL}/#website`,
     name: SITE_NAME,
+    alternateName: ["Pora.code", "poracode.com"],
     url: SITE_URL,
     description: SITE_DESCRIPTION,
     publisher: {
@@ -232,6 +243,24 @@ export function createHomeJsonLd(release: ReleaseInfo, locale: Locale = DEFAULT_
   };
 
   return [organization, website, softwareApplication, faqPage];
+}
+
+export function createAboutJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "@id": `${absoluteUrl("/about")}#page`,
+    url: absoluteUrl("/about"),
+    name: `About ${SITE_NAME}`,
+    description: SITE_DESCRIPTION,
+    isPartOf: {
+      "@id": `${SITE_URL}/#website`,
+    },
+    mainEntity: {
+      "@id": `${SITE_URL}/#software`,
+    },
+    about: [{ "@id": `${SITE_URL}/#software` }, { "@id": `${SITE_URL}/#organization` }],
+  };
 }
 
 export function stringifyJsonLd(value: unknown): string {


### PR DESCRIPTION
## What changed

- add a crawlable `/about` page that defines Poracode, its supported coding agents, platforms, license, official domain, source repository, and support channel
- link the page from the primary navigation and footer
- add the page to the sitemap with a meaningful `lastmod`
- strengthen the existing Organization and WebSite JSON-LD with an accurate description, support contact, and official aliases
- add AboutPage JSON-LD that references the canonical Poracode software and organization entities

## Why

The bare `poracode` query is ambiguous in Google Search. The site already has solid technical SEO, but the project identity is spread across the landing page, GitHub, and metadata. This creates one visible, authoritative entity profile that search and generative-search systems can crawl and corroborate without relying on unsupported AI-specific markup.

## Impact

Users and search engines get a concise source of truth for what Poracode is and which domains and repositories are official. The existing landing-page design and localized routes remain unchanged.

## Validation

- `pnpm run typecheck` in `website/` passes
- `git diff --check` passes
- React review: semantic navigation/main/section/aside/footer structure, server-only page, no new client state, and stable list keys
- local oxlint could not start because its optional macOS native binding is absent; GitHub CI remains the lint gate