### PR TITLE
Keep sticky chat scroll stable during native scrollbar drags

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -406,6 +406,7 @@ export function ChatPane(props: ChatPaneProps) {
             key={`scroll:${threadId}`}
             ref={scrollControlsRef}
             scrollRef={scrollRef}
+            contentRef={contentRef}
             layoutChangeToken={layoutChangeToken}
             threadId={threadId}
             tailLoaderVisible={showTailLoader}

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
@@ -24,11 +24,13 @@ function Harness(props: {
   onInitialScrollSettled?: () => void;
 }) {
   const scrollRef = useRef(props.scrollEl);
+  const contentRef = useRef<HTMLDivElement | null>(null);
   const virtualScrollToBottomRef = useRef(props.virtualScrollToBottom);
   return (
     <ChatScrollControls
       ref={props.controlsRef}
       scrollRef={scrollRef}
+      contentRef={contentRef}
       layoutChangeToken={null}
       threadId="thread-1"
       tailLoaderVisible={false}
@@ -208,7 +210,7 @@ describe("ChatScrollControls", () => {
     expect(scrollTop).toBe(1025);
   });
 
-  it("keeps sticky while LegendList adjusts its anchor before scrollHeight changes", () => {
+  it("keeps sticky while LegendList adjusts its anchor before scrollHeight changes", async () => {
     let scrollHeight = 1000;
     let scrollTop = 800;
     const scrollEl = document.createElement("div");
@@ -243,9 +245,15 @@ describe("ChatScrollControls", () => {
 
     expect(controlsRef.current?.isStickToBottom()).toBe(true);
 
+    // The untagged upward move could equally be a native scrollbar-thumb drag
+    // (no pointer events), so pins pause for a short holdoff before the next
+    // content-growth pin reattaches the transcript.
     scrollHeight = 1200;
     act(() => controlsRef.current?.onContentHeightChange());
+    expect(scrollTop).toBe(500);
 
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    act(() => controlsRef.current?.onContentHeightChange());
     expect(scrollTop).toBe(1200);
   });
 

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -31,6 +31,13 @@ const USER_SCROLL_INTENT_MS = 750;
 const VIRTUALIZER_LAYOUT_SETTLE_MS = 250;
 /** Minimum at-bottom cache when no coalesce window is active. */
 const AT_BOTTOM_CACHE_MS = 16;
+/**
+ * How long sticky pins pause after an untagged upward scroll that release
+ * logic classified as layout-driven. Long enough to bridge the gap between a
+ * native scrollbar-thumb drag's scroll events, short enough that a one-shot
+ * virtualizer adjustment recovers on the next streaming pin.
+ */
+const PIN_HOLDOFF_MS = 150;
 
 export type ChatScrollControlsHandle = {
   beginVirtualizerLayoutChange(): void;
@@ -53,6 +60,7 @@ export const ChatScrollControls = forwardRef<
   ChatScrollControlsHandle,
   {
     scrollRef: React.RefObject<HTMLDivElement | null>;
+    contentRef: React.RefObject<HTMLDivElement | null>;
     layoutChangeToken: string | null | undefined;
     threadId: string;
     tailLoaderVisible: boolean;
@@ -64,6 +72,7 @@ export const ChatScrollControls = forwardRef<
   const { t } = useLingui();
   const {
     scrollRef,
+    contentRef,
     layoutChangeToken,
     threadId,
     tailLoaderVisible,
@@ -92,6 +101,7 @@ export const ChatScrollControls = forwardRef<
   const lastPinnedScrollHeightRef = useRef(0);
   const lastSeenScrollHeightRef = useRef(0);
   const disableStickToBottomRef = useRef<() => void>(() => undefined);
+  const pinHoldoffUntilRef = useRef(0);
   const [showScrollDown, setShowScrollDown] = useState(false);
 
   function cancelVirtualizerLayoutChange() {
@@ -119,6 +129,7 @@ export const ChatScrollControls = forwardRef<
     cancelScheduledInitialSettle();
     cancelScheduledExplicitPin();
     cancelScheduledLayoutSync();
+    pinHoldoffUntilRef.current = 0;
     if (pinRafRef.current !== null) {
       cancelAnimationFrame(pinRafRef.current);
       pinRafRef.current = null;
@@ -188,6 +199,16 @@ export const ChatScrollControls = forwardRef<
       return;
     }
     const now = performance.now();
+    // An untagged upward scroll was recently suppressed as layout-driven. It
+    // may equally be a native scrollbar-thumb drag (Windows overlay thumbs emit
+    // no pointer events) — hold pins off briefly so a real drag is not yanked.
+    // A continuing drag keeps re-arming the holdoff via its scroll events; a
+    // one-shot virtualizer adjustment lets it lapse and the next growth pin
+    // reattaches the transcript.
+    if (options.reconcileVirtualizer !== true && now < pinHoldoffUntilRef.current) {
+      if (!isElementAtBottom(el)) return;
+      pinHoldoffUntilRef.current = 0;
+    }
     const scrollHeight = el.scrollHeight;
     const reconcileVirtualizer = options.reconcileVirtualizer === true;
     // Stick-to-bottom storms (thread switch / row measure) call this many times
@@ -482,6 +503,8 @@ export const ChatScrollControls = forwardRef<
       ) {
         return;
       }
+      const isVirtualizerLayoutChange =
+        performance.now() <= virtualizerLayoutChangeUntilRef.current;
       const isAtBottom = isElementAtBottom(el);
       // Release on upward scroll away from the bottom (native scrollbar thumb —
       // often no pointerdown). Layout clamps that shrink scrollHeight and
@@ -498,7 +521,7 @@ export const ChatScrollControls = forwardRef<
           isProgrammaticScroll,
           scrollHeightShrunk,
           scrollHeightGrew,
-          isVirtualizerLayoutChange: performance.now() <= virtualizerLayoutChangeUntilRef.current,
+          isVirtualizerLayoutChange,
           hasRecentUserScrollIntent: hasRecentUserIntent,
         })
       ) {
@@ -518,6 +541,20 @@ export const ChatScrollControls = forwardRef<
         // is still within `BOTTOM_EPSILON_PX` of the bottom — otherwise a tiny
         // wheel-up gets snapped back by the next streaming delta.
         stickToBottomRef.current = true;
+      }
+      if (
+        stickToBottomRef.current &&
+        !isAtBottom &&
+        !isProgrammaticScroll &&
+        nextScrollTop < prevScrollTop
+      ) {
+        // Release was suppressed as layout-driven (virtualizer window / height
+        // growth), but the untagged upward move could equally be a native
+        // scrollbar-thumb drag — those emit no pointer events. Hold pins off:
+        // a real drag keeps re-arming this via its scroll stream and is never
+        // yanked, while a one-shot virtualizer anchor adjustment lets it lapse
+        // and the next streaming pin reattaches. See scrollToBottom.
+        pinHoldoffUntilRef.current = performance.now() + PIN_HOLDOFF_MS;
       }
       setShowScrollDown(
         nextShowScrollDown({ stickToBottom: stickToBottomRef.current, isAtBottom }),
@@ -543,8 +580,18 @@ export const ChatScrollControls = forwardRef<
     if (el) {
       observer.observe(el);
     }
+    // Observing only the scroller misses content growth (its own box never
+    // changes). The virtualizer's totalSize listener reports growth too, but
+    // after paint — the streaming tail then pushes the footer down for one
+    // visible frame before the pin catches up. The content element's resize
+    // fires pre-paint, so the sticky pin lands in the same frame.
+    const content = contentRef.current;
+    if (content) {
+      observer.observe(content);
+    }
     return () => observer.disconnect();
-  }, [scrollRef, threadId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-run on initial settle: the virtualizer assigns contentRef after mount.
+  }, [scrollRef, contentRef, threadId, initialScrollSettled]);
 
   const syncPinnedContentChange = useEffectEvent(() => {
     if (pinRafRef.current !== null) {


### PR DESCRIPTION
- Fix sticky chat scrolling so native scrollbar-thumb drags are not overridden by streaming pins.
- Pin growing chat content before paint to avoid visible footer movement during streaming.
- Extend scroll-control coverage for holdoff and reattachment behavior.