### PR TITLE
Handle Kimi ACP question permissions

### DIFF
--- a/.agents/skills/interactive-testing/SKILL.md
+++ b/.agents/skills/interactive-testing/SKILL.md
@@ -63,6 +63,13 @@ pnpm run smoke:integration -- --scope changed --mode mock
 
 This allocates a free dev-server port and a free CDP port (override with `--vitePort`/`--port`; explicit values are verified free), creates and commits a disposable fixture project, seeds an isolated database, starts Electron with an isolated profile, dismisses and verifies the first-launch welcome screen, runs the integration suite, writes screenshots/report artifacts under `~/.poracode-smoke`, and tears down the process automatically. No provider credentials, PTY input, git mutations, MCP server, mobile device, or native update flow is required for the default mock run.
 
+**`HOME` and provider detection — no drift between test and app.** Poracode's own state is always isolated via `PORACODE_BASE_DIR`, independent of `HOME`. Provider _detection_, however, resolves each CLI through the login-shell `command -v` (e.g. `kimi` → `~/.kimi-code/bin/kimi`) and reads credentials under the home dir — so it only matches the real app when `HOME` is the real home. Therefore:
+
+- **Mock mode** sandboxes `HOME`/`APPDATA` and uses a mock keychain (deterministic isolation; providers are mocked). Real providers legitimately show **"Not found"** here — that is expected, not a bug, and mock gates never depend on real credentials.
+- **Real mode** (`--mode real`) and the manual `dev:test` launch both keep the **real `HOME`**, so authenticated providers (Kimi, Qwen, …) can detect as in the shipped app. Always verify a provider-dependent surface in real mode; never diagnose a real detection issue from a mock-mode "Not found".
+
+Real `HOME` is necessary but not always sufficient: detection probes `command -v <binary>` in a login+interactive shell with **`cwd: homedir()`**, so a CLI whose bin dir is on `PATH` only via a _project-scoped_ mechanism (direnv `.envrc`, `asdf` local, `mise`, a per-repo `.env`) is invisible to the detector even though it works inside the project — direnv unloads at the home cwd. Symptom: the app log prints `direnv: unloading` and the provider shows "Not found". Fix in the environment, not the app: put the binary on a globally-resolvable `PATH` (e.g. symlink into `~/.local/bin`, as qwen/grok are). This is why `~/.kimi-code/bin/kimi` (direnv-only) can miss while `~/.local/bin`-installed providers detect fine.
+
 The runner prints the chosen ports and writes them to `<smoke root>/ports.json` (`{ appUrl, cdpPort, devServerPort }`). Every follow-up command in this skill must target that run's ports — export them before driving manual gates:
 
 ```sh

--- a/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
+++ b/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
@@ -44,6 +44,21 @@ try {
     `Smoke ports: CDP ${port}, dev server ${vitePort}. For manual gates: PORACODE_CDP_PORT=${port} PORACODE_APP_URL=${appUrl}`,
   );
 
+  // Mock mode sandboxes the OS identity (HOME/APPDATA + a mock keychain) so
+  // nothing touches the real user profile. Real mode intentionally keeps the
+  // real home so provider credentials that live under it (e.g. ~/.kimi-code)
+  // resolve — only Poracode's own state stays isolated via PORACODE_BASE_DIR.
+  const identityEnv =
+    mode === "real"
+      ? {}
+      : {
+          ...(process.platform === "darwin" ? { PORACODE_USE_MOCK_KEYCHAIN: "1" } : {}),
+          HOME: homeDir,
+          USERPROFILE: homeDir,
+          LOCALAPPDATA: localAppDataDir,
+          APPDATA: roamingAppDataDir,
+          PSModuleAnalysisCachePath: join(root, "powershell", "ModuleAnalysisCache"),
+        };
   const pnpm = pnpmSpawnCommand();
   appProcess = spawn(pnpm.command, pnpm.args, {
     cwd: repoRoot,
@@ -53,12 +68,7 @@ try {
       PORACODE_CDP_PORT: String(port),
       PORACODE_BASE_DIR: dataDir,
       PORACODE_SMOKE_OUT_DIR: outDir,
-      ...(process.platform === "darwin" ? { PORACODE_USE_MOCK_KEYCHAIN: "1" } : {}),
-      HOME: homeDir,
-      USERPROFILE: homeDir,
-      LOCALAPPDATA: localAppDataDir,
-      APPDATA: roamingAppDataDir,
-      PSModuleAnalysisCachePath: join(root, "powershell", "ModuleAnalysisCache"),
+      ...identityEnv,
     },
     detached: process.platform !== "win32",
     stdio: "inherit",

--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/ThreadRuntimeRequestPanel.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/ThreadRuntimeRequestPanel.tsx
@@ -252,6 +252,7 @@ export function ThreadRuntimeRequestPanel(props: ThreadRuntimeRequestPanelProps)
           formId={formId}
           controller={userInputFormController}
           isDisabled={resolving}
+          {...(summary !== undefined ? { summary } : {})}
           onSubmit={(response, outcome) => submitRaw(response, outcome)}
         />
       ) : isQuestion ? (

--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/userInputForm.tsx
@@ -230,13 +230,23 @@ export function UserInputForm(props: {
   formId: string;
   controller: UserInputFormController;
   isDisabled: boolean;
+  summary?: string;
   onSubmit: (response: unknown, outcome: RequestOutcome) => void;
 }) {
-  const { formId, controller, isDisabled, onSubmit } = props;
+  const { formId, controller, isDisabled, summary, onSubmit } = props;
   const { t } = useLingui();
   const activeQuestion = controller.questions[controller.activeIndex] ?? controller.questions[0];
   if (!activeQuestion) return null;
   const customAnswer = controller.customAnswers[activeQuestion.id] ?? "";
+  // The panel already renders the question as the bold summary/title. Skip a
+  // header/question line here when it only repeats that title or the other line
+  // — e.g. providers (Kimi) that carry a single question with no distinct header
+  // would otherwise show the same sentence three times.
+  const showQuestion = activeQuestion.question !== summary;
+  const showHeader =
+    activeQuestion.header.length > 0 &&
+    activeQuestion.header !== activeQuestion.question &&
+    activeQuestion.header !== summary;
 
   return (
     <form
@@ -248,10 +258,16 @@ export function UserInputForm(props: {
       }}
     >
       <div className="space-y-1">
-        <div>
-          <p className="text-[11px] font-medium text-foreground">{activeQuestion.header}</p>
-          <p className="text-[11px] text-[color:var(--muted)]">{activeQuestion.question}</p>
-        </div>
+        {showHeader || showQuestion ? (
+          <div>
+            {showHeader ? (
+              <p className="text-[11px] font-medium text-foreground">{activeQuestion.header}</p>
+            ) : null}
+            {showQuestion ? (
+              <p className="text-[11px] text-[color:var(--muted)]">{activeQuestion.question}</p>
+            ) : null}
+          </div>
+        ) : null}
         {activeQuestion.options ? (
           <div className="space-y-1">
             <div

--- a/src/supervisor/agents/acp/acpQuestionPermissions.ts
+++ b/src/supervisor/agents/acp/acpQuestionPermissions.ts
@@ -5,6 +5,7 @@ import {
   buildQuestionAnswerEvents,
   type QuestionAnswerSourceQuestion,
 } from "../questionAnswerEvents";
+import { extractToolCallContentText } from "./canonicalMapping/contentExtraction";
 import type { AcpMapperState } from "./canonicalMapping/state";
 
 interface AcpPermissionQuestion {
@@ -20,18 +21,29 @@ type AcpQuestionPermissionResponse = RequestPermissionResponse & {
 };
 
 /**
- * Qwen Code carries AskUserQuestion through ACP's requestPermission method.
- * The extension is deliberately detected from its semantic payload rather
- * than the provider kind: a non-empty `rawInput.questions` array is the same
- * signal Qwen's own ACP clients use.
+ * AskUserQuestion is carried over ACP's requestPermission method in two
+ * provider-native shapes, both normalized to the same AcpPermissionQuestion
+ * contract so shared runtime and renderer code stays provider-agnostic:
+ *  - Qwen Code sends a structured `rawInput.questions` array (header, question,
+ *    options) — the same signal Qwen's own ACP clients use.
+ *  - Kimi Code sends no rawInput at all: the question text arrives in
+ *    `toolCall.content` and the answer choices are the standard requestPermission
+ *    `options`. Detection stays semantic (tool identity + payload shape) rather
+ *    than keyed on the provider kind.
  */
 export function parseAcpPermissionQuestions(
   request: RequestPermissionRequest,
 ): AcpPermissionQuestion[] {
   const rawInput = request.toolCall?.rawInput;
-  if (!isRecord(rawInput) || !Array.isArray(rawInput.questions)) return [];
+  if (isRecord(rawInput) && Array.isArray(rawInput.questions)) {
+    return parseRawInputQuestions(rawInput.questions);
+  }
+  return parseContentPermissionQuestion(request);
+}
 
-  return rawInput.questions.flatMap((entry, index) => {
+/** Qwen shape: structured questions embedded in the tool call's rawInput. */
+function parseRawInputQuestions(rawQuestions: readonly unknown[]): AcpPermissionQuestion[] {
+  return rawQuestions.flatMap((entry, index) => {
     if (!isRecord(entry) || typeof entry.question !== "string" || entry.question.length === 0) {
       return [];
     }
@@ -73,6 +85,29 @@ export function parseAcpPermissionQuestions(
       },
     ];
   });
+}
+
+/**
+ * Kimi shape: no structured rawInput. The question text is carried in
+ * `toolCall.content` and the answer choices are the standard requestPermission
+ * `options` (the rejection option becomes the form's Cancel affordance rather
+ * than a selectable choice). Gated on the AskUserQuestion tool identity so
+ * ordinary approval requests are never reinterpreted as questions.
+ */
+function parseContentPermissionQuestion(
+  request: RequestPermissionRequest,
+): AcpPermissionQuestion[] {
+  if (!isAcpAskUserQuestionToolCall(request.toolCall ?? {})) return [];
+  const question = extractToolCallContentText(request.toolCall?.content)?.trim();
+  if (!question) return [];
+  const options = request.options.flatMap((option) => {
+    if (isRejectionOptionKind(option.kind)) return [];
+    const label =
+      typeof option.name === "string" && option.name.length > 0 ? option.name : option.optionId;
+    return [{ optionId: option.optionId, label }];
+  });
+  if (options.length === 0) return [];
+  return [{ id: "0", header: question, question, options, multiSelect: false }];
 }
 
 export function mapAcpQuestionPermissionRequest(
@@ -146,19 +181,25 @@ export function buildAcpQuestionPermissionAnswerEvents(input: {
   });
 }
 
-/** Suppress the redundant tool row once the same call is presented as a form. */
+/**
+ * Detect an AskUserQuestion tool call by its identity (tool name / title), used
+ * both to gate the Kimi content-shape parser and to suppress the redundant tool
+ * row once the same call is presented as a form. Kept independent of `rawInput`
+ * so it recognizes providers (Kimi Code) that omit structured input.
+ */
 export function isAcpAskUserQuestionToolCall(toolCall: {
   title?: unknown;
   rawInput?: unknown;
   _meta?: unknown;
 }): boolean {
-  if (!isRecord(toolCall.rawInput) || !Array.isArray(toolCall.rawInput.questions)) return false;
   const metaName = isRecord(toolCall._meta) ? toolCall._meta.toolName : undefined;
-  const candidates = [metaName, toolCall.title];
-  return candidates.some(
-    (candidate) =>
-      typeof candidate === "string" &&
-      /^(?:ask[_ ]?user[_ ]?question|ask user \d+ questions?)(?::|\b)/iu.test(candidate.trim()),
+  return [metaName, toolCall.title].some(matchesAskUserQuestionTitle);
+}
+
+function matchesAskUserQuestionTitle(candidate: unknown): boolean {
+  return (
+    typeof candidate === "string" &&
+    /^(?:ask[_ ]?user[_ ]?question|ask user \d+ questions?)(?::|\b)/iu.test(candidate.trim())
   );
 }
 
@@ -196,10 +237,35 @@ function selectedPermissionOptionId(
     isRecord(response) && typeof response.optionId === "string" ? response.optionId : undefined;
   if (requested && request.options.some((option) => option.optionId === requested))
     return requested;
+  const answered = answerSelectedOptionId(request, response);
+  if (answered) return answered;
   return (
     request.options.find((option) => option.kind === "allow_once") ??
-    request.options.find((option) => !option.kind.startsWith("reject"))
+    request.options.find((option) => !isRejectionOptionKind(option.kind))
   )?.optionId;
+}
+
+/**
+ * Providers whose ACP options ARE the answer choices (Kimi Code) submit the
+ * picked choice inside the answers map rather than a top-level `optionId`.
+ * Promote a chosen value that matches a real (non-reject) option so the correct
+ * outcome optionId reaches the agent. Qwen's answers reference its own rawInput
+ * option ids (never the ACP proceed/cancel options), so this is a no-op there.
+ */
+function answerSelectedOptionId(
+  request: RequestPermissionRequest,
+  response: unknown,
+): string | undefined {
+  const selectable = new Set(
+    request.options.filter((option) => !isRejectionOptionKind(option.kind)).map((o) => o.optionId),
+  );
+  if (selectable.size === 0) return undefined;
+  for (const value of Object.values(responseAnswers(response))) {
+    for (const optionId of chosenOptionIds(value)) {
+      if (selectable.has(optionId)) return optionId;
+    }
+  }
+  return undefined;
 }
 
 const REJECTION_OPTION_ID_PATTERN = /(?:cancel|decline|deny|reject|abort)/iu;
@@ -207,6 +273,11 @@ const REJECTION_OPTION_ID_PATTERN = /(?:cancel|decline|deny|reject|abort)/iu;
 /** True when an ACP option id names a decline/cancel/reject/abort choice. */
 export function isRejectionOptionId(optionId: unknown): boolean {
   return typeof optionId === "string" && REJECTION_OPTION_ID_PATTERN.test(optionId);
+}
+
+/** True for ACP permission option kinds that reject rather than approve. */
+function isRejectionOptionKind(kind: unknown): boolean {
+  return typeof kind === "string" && kind.startsWith("reject");
 }
 
 function isCancelledResponse(response: unknown): boolean {

--- a/src/supervisor/agents/acp/sessionRequests.test.ts
+++ b/src/supervisor/agents/acp/sessionRequests.test.ts
@@ -56,6 +56,24 @@ function questionPermissionRequest(): RequestPermissionRequest {
   };
 }
 
+function kimiQuestionPermissionRequest(): RequestPermissionRequest {
+  return {
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "0:tool-kimi",
+      title: "AskUserQuestion",
+      content: [
+        { type: "content", content: { type: "text", text: "Which authentication method?" } },
+      ],
+    },
+    options: [
+      { optionId: "q0_opt_0", name: "Paste a token", kind: "allow_once" },
+      { optionId: "q0_opt_1", name: "Log in via browser", kind: "allow_once" },
+      { optionId: "q0_skip", name: "Skip", kind: "reject_once" },
+    ],
+  };
+}
+
 function formElicitation(): CreateElicitationRequest {
   return {
     mode: "form",
@@ -231,6 +249,58 @@ describe("AcpSessionRequests permissions", () => {
         outcome: "answered",
       },
     ]);
+  });
+
+  it("maps Kimi AskUserQuestion (content + options) to a reply form and returns the picked option", async () => {
+    const { emitRuntimeEvents, requests, setRequestAttention } = makeRequests({
+      config: { model: "model-a", mode: "agent", approvalPolicy: "never" },
+      availableModeIds: ["agent"],
+    });
+
+    const response = requests.requestPermission(kimiQuestionPermissionRequest());
+
+    expect(setRequestAttention).toHaveBeenCalledExactlyOnceWith("needs_reply");
+    expect(emitRuntimeEvents).toHaveBeenCalledWith([
+      {
+        type: "request.opened",
+        threadId: "thread-1",
+        requestId: "acp-perm-0",
+        requestType: "tool_user_input",
+        payload: {
+          summary: "Which authentication method?",
+          details: {
+            userInputForm: {
+              questions: [
+                {
+                  id: "0",
+                  header: "Which authentication method?",
+                  question: "Which authentication method?",
+                  options: [
+                    { optionId: "q0_opt_0", label: "Paste a token" },
+                    { optionId: "q0_opt_1", label: "Log in via browser" },
+                  ],
+                  multiSelect: false,
+                },
+              ],
+            },
+          },
+          options: [
+            { optionId: "q0_opt_0", label: "Paste a token" },
+            { optionId: "q0_opt_1", label: "Log in via browser" },
+          ],
+          multiSelect: false,
+        },
+      },
+    ]);
+
+    // The form submits the picked choice inside the answers map; it must be
+    // promoted to the outcome optionId Kimi expects (not the first allow_once).
+    requests.resolve("acp-perm-0", { answers: { "0": "q0_opt_1" } });
+
+    await expect(response).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "q0_opt_1" },
+      answers: { "0": "Log in via browser" },
+    });
   });
 
   it("reports when a permission request is no longer pending", () => {


### PR DESCRIPTION
- Classify Kimi `AskUserQuestion` permission requests into provider-agnostic reply forms and return the selected option to the agent.
- Avoid repeating question text in runtime request panels when the form content matches the summary.
- Add ACP coverage for Kimi question permissions and document/align smoke-test provider detection behavior in real versus mock modes.