### PR TITLE
Reduce default auto-archive delay to three days

### DIFF
--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -491,7 +491,7 @@ export const defaultSharedSettings: SharedSettings = {
   collapseTerminalComposer: false,
   cliPickerTarget: "ask",
   staleThreadUnloadMinutes: 60,
-  autoArchiveDoneAfterDays: 7,
+  autoArchiveDoneAfterDays: 3,
   scrollSpeed: 2,
   agentTerminalFontSize: 12,
   guiChatFontSize: 13,


### PR DESCRIPTION
- **Bugfix:** archive completed threads after three days by default to keep workspaces cleaner.