### PR TITLE
Preserve italic text in truncated previews

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/Reasoning.tsx
@@ -61,9 +61,7 @@ export const Reasoning = memo(function Reasoning({ item }: ReasoningProps) {
         >
           {isStreaming ? <Trans>Thinking</Trans> : <Trans>Thought</Trans>}
         </span>
-        {/* pr keeps italic ink past the text advance from being clipped by
-            `truncate`'s overflow, same as ReasoningInline's preview. */}
-        {preview ? <span className="min-w-0 truncate pr-[0.2em] opacity-70">{preview}</span> : null}
+        {preview ? <span className="min-w-0 truncate opacity-70">{preview}</span> : null}
         <ChevronDown
           className={`size-3 shrink-0 opacity-100 transition-[transform,opacity] [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-visible:opacity-100 ${isOpen ? "rotate-180" : ""}`}
         />

--- a/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ReasoningInline.tsx
@@ -79,10 +79,9 @@ export const ReasoningInline = memo(function ReasoningInline({ item }: Reasoning
           {preview ? (
             <>
               <ChatRowMetaSeparator />
-              {/* Italic ink leans past the text advance; `truncate`'s overflow
-                  clips at the padding box, so keep a small right padding or the
-                  last glyph's edge is shaved off. */}
-              <span className="min-w-0 flex-1 truncate pr-[0.2em] italic text-[color:var(--muted)]">
+              {/* Italic-overhang padding comes from the global
+                  `.italic.truncate` rule in styles.css. */}
+              <span className="min-w-0 flex-1 truncate italic text-[color:var(--muted)]">
                 {preview}
               </span>
             </>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -885,6 +885,16 @@
   min-width: 0;
 }
 
+/* Italic ink leans past the text advance on the inline-end side; `truncate`'s
+   hidden overflow clips at the padding box and shaves the last glyph's edge
+   (model-visibility sub-headers, file-editor preview tabs, reasoning previews,
+   agent pending messages). Keep a hair of inline-end padding wherever italic
+   text is or sits inside a truncate box so the overhang stays painted. */
+.italic.truncate,
+.italic .truncate {
+  padding-inline-end: 0.2em;
+}
+
 /* HeroUI Disclosure: drop the default expand/collapse height/opacity
    transition and indicator rotation easing. Long chat threads can host
    hundreds of disclosures (one per tool_call, file_change, web_search,


### PR DESCRIPTION
- Ensure italic glyph overhang remains visible in truncated chat reasoning previews.
- Apply the fix consistently to inline and standard reasoning views.
- Add a shared truncation style that also protects other italic preview surfaces.