### PR TITLE
Reorganize settings sidebar and clarify section labels

### DIFF
--- a/src/mobile/settingsSections.ts
+++ b/src/mobile/settingsSections.ts
@@ -27,8 +27,8 @@ export const MOBILE_SETTINGS_SECTION_LABELS: Record<MobileSettingsSectionId, Mes
   schedules: msg`Schedules`,
   terminal: msg`Terminal`,
   git: msg`Git`,
-  usage: msg`Usage`,
-  ai: msg`AI`,
+  usage: msg`Provider Usage`,
+  ai: msg`AI Helpers`,
   models: msg`Agents`,
   archived: msg`Archived Threads`,
 };

--- a/src/mobile/views/SettingsView.test.tsx
+++ b/src/mobile/views/SettingsView.test.tsx
@@ -36,11 +36,11 @@ describe("mobile SettingsView", () => {
       />,
     );
 
-    expect(screen.getByText("AI")).toBeInTheDocument();
+    expect(screen.getByText("AI Helpers")).toBeInTheDocument();
     expect(screen.getByText("Schedules")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
     expect(screen.getByText("Archived Threads")).toBeInTheDocument();
-    expect(screen.getByText("Usage")).toBeInTheDocument();
+    expect(screen.getByText("Provider Usage")).toBeInTheDocument();
     expect(screen.queryByText("Appearance")).not.toBeInTheDocument();
     expect(screen.queryByText("Notifications")).not.toBeInTheDocument();
   });
@@ -90,7 +90,7 @@ describe("mobile SettingsView", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Usage"));
+    fireEvent.click(screen.getByText("Provider Usage"));
 
     expect(onSectionChange).toHaveBeenCalledWith("usage");
   });

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agenten · Allgemein"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "KI"
+#~ msgid "AI"
+#~ msgstr "KI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "KI-Agenten-Orchestrator – Codierungsagenten über Terminal und natives
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "KI-Git-Aktionen"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "KI-Helfer"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "<0>{0}</0> erkannt"
 msgid "Detecting agents…"
 msgstr "Agenten werden erkannt…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Ausstehende Lenkung"
 msgid "permission"
 msgstr "Berechtigung"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Persönlich"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Der Anbieter hat keine Token-Nutzung gemeldet."
 msgid "Provider presets"
 msgstr "Anbieter-Voreinstellungen"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Anbieternutzung"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Browserseite neu laden"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remote"
 
@@ -10709,7 +10724,6 @@ msgstr "URL ist erforderlich."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "URL ist erforderlich."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Nutzung"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Arbeiten…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Arbeitsbereich"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agents · General"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "AI agent orchestrator — manage coding agents via Terminal and Native A
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git actions"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI Helpers"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Detected <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Detecting agents…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Pending steer"
 msgid "permission"
 msgstr "permission"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Personal"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Provider has not reported token usage."
 msgid "Provider presets"
 msgstr "Provider presets"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Provider Usage"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Reload browser page"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remote"
 
@@ -10709,7 +10724,6 @@ msgstr "URL is required."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "URL is required."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Usage"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Working…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Workspace"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agentes · General"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "IA"
+#~ msgid "AI"
+#~ msgstr "IA"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Orquestador de agentes de IA: gestiona agentes de programación mediante
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Acciones de git con IA"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Ayudantes de IA"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Detectado <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Detectando agentes…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Dirección pendiente"
 msgid "permission"
 msgstr "permiso"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Personal"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "El proveedor no ha informado del uso de tokens."
 msgid "Provider presets"
 msgstr "Preajustes de proveedor"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Uso de proveedores"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Recargar página del navegador"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remoto"
 
@@ -10709,7 +10724,6 @@ msgstr "La URL es obligatoria."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "La URL es obligatoria."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Uso"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Trabajando…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Espacio de trabajo"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agents · Général"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "IA"
+#~ msgid "AI"
+#~ msgstr "IA"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Orchestrateur d'agents IA : gérez les agents de codage via Terminal et
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Actions git IA"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Assistants IA"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Détecté <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Détection des agents…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7100,6 +7103,10 @@ msgstr "En attente de direction"
 msgid "permission"
 msgstr "autorisation"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Personnel"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7428,6 +7435,13 @@ msgstr "Le fournisseur n'a pas signalé l'utilisation des jetons."
 msgid "Provider presets"
 msgstr "Préréglages de fournisseur"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Utilisation des fournisseurs"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7731,6 +7745,7 @@ msgid "Reload browser page"
 msgstr "Recharger la page du navigateur"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "À distance"
 
@@ -10708,7 +10723,6 @@ msgstr "L’URL est obligatoire."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10716,8 +10730,6 @@ msgstr "L’URL est obligatoire."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Utilisation"
 
@@ -11175,6 +11187,7 @@ msgid "Working…"
 msgstr "En cours…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Espace de travail"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -897,12 +897,11 @@ msgid "Agents · General"
 msgstr "エージェント · 一般"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -911,6 +910,13 @@ msgstr "AI エージェント オーケストレーター — ターミナルお
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AIによるgit操作"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI ヘルパー"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3269,9 +3275,6 @@ msgstr "<0>{0}</0> を検出しました"
 msgid "Detecting agents…"
 msgstr "エージェントを検出中…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7099,6 +7102,10 @@ msgstr "保留中のステアリング"
 msgid "permission"
 msgstr "許可"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "個人"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7427,6 +7434,13 @@ msgstr "プロバイダーはトークンの使用状況を報告していませ
 msgid "Provider presets"
 msgstr "プロバイダープリセット"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "プロバイダーの使用量"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7730,6 +7744,7 @@ msgid "Reload browser page"
 msgstr "ブラウザのページをリロード"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "リモート"
 
@@ -10707,7 +10722,6 @@ msgstr "URLは必須です。"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10715,8 +10729,6 @@ msgstr "URLは必須です。"
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "使用量"
 
@@ -11174,6 +11186,7 @@ msgid "Working…"
 msgstr "実行中…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "ワークスペース"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "에이전트 · 일반"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "AI 에이전트 오케스트레이터 — 터미널 및 기본 ACP를 �
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git 작업"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI 도우미"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "<0>{0}</0> 감지됨"
 msgid "Detecting agents…"
 msgstr "에이전트 감지 중…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "조정 대기 중"
 msgid "permission"
 msgstr "권한"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "개인"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "공급자가 토큰 사용을 보고하지 않았습니다."
 msgid "Provider presets"
 msgstr "제공자 프리셋"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "공급자 사용량"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "브라우저 페이지 새로고침"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "원격"
 
@@ -10709,7 +10724,6 @@ msgstr "URL을 입력해야 합니다."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "URL을 입력해야 합니다."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "사용량"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "작업 중…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "작업 영역"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agenci · Ogólne"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Koordynator agentów AI — zarządzaj agentami kodującymi za pośredni
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Akcje AI w git"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Pomocnicy AI"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Wykryto <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Wykrywanie agentów…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Oczekujące sterowanie"
 msgid "permission"
 msgstr "pozwolenie"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Osobiste"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Dostawca nie zgłosił użycia tokenów."
 msgid "Provider presets"
 msgstr "Predefiniowani dostawcy"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Użycie dostawców"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Załaduj ponownie stronę przeglądarki"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Zdalny"
 
@@ -10709,7 +10724,6 @@ msgstr "Adres URL jest wymagany."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "Adres URL jest wymagany."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Użycie"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Pracuję…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Obszar roboczy"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Agentes · Geral"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "IA"
+#~ msgid "AI"
+#~ msgstr "IA"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Orquestrador de agentes de IA — gerencie agentes de codificação via 
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Ações de git com IA"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Assistentes de IA"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Detectado <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Detectando agentes…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Orientação pendente"
 msgid "permission"
 msgstr "permissão"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Pessoal"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "O provedor não relatou o uso de token."
 msgid "Provider presets"
 msgstr "Predefinições de provedor"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Uso de provedores"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Recarregar página do navegador"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remoto"
 
@@ -10709,7 +10724,6 @@ msgstr "A URL é obrigatória."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "A URL é obrigatória."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Uso"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Trabalhando…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Espaço de trabalho"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Агенты · Общие"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Оркестратор AI-агентов — управление код
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Действия ИИ в Git"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI-помощники"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Обнаружено <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Обнаружение агентов…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Ожидающее направление"
 msgid "permission"
 msgstr "разрешение"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Личное"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Провайдер не сообщил об использовании �
 msgid "Provider presets"
 msgstr "Пресеты провайдеров"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Использование провайдеров"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Перезагрузить страницу браузера"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Удалённый"
 
@@ -10709,7 +10724,6 @@ msgstr "URL обязателен."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "URL обязателен."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Использование"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Выполняется…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Рабочая область"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Temsilciler · Genel"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "Yapay Zeka"
+#~ msgid "AI"
+#~ msgstr "Yapay Zeka"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "AI aracı orkestratörü — kodlama aracılarını Terminal ve Yerel AC
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Yapay zeka git işlemleri"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Yapay Zeka Yardımcıları"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Algılandı <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Aracılar algılanıyor…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Yönlendirme bekleniyor"
 msgid "permission"
 msgstr "izin"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Kişisel"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Sağlayıcı token kullanımını bildirmedi."
 msgid "Provider presets"
 msgstr "Sağlayıcı hazır ayarları"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Sağlayıcı kullanımı"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Tarayıcı sayfasını yeniden yükle"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Uzak"
 
@@ -10709,7 +10724,6 @@ msgstr "URL gereklidir."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "URL gereklidir."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Kullanım"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Çalışıyor…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Çalışma alanı"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Агенти · Загальні"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Оркестратор AI-агентів — керуйте агента
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Дії AI у git"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI-помічники"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Виявлено <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Виявлення агентів…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Очікуване скерування"
 msgid "permission"
 msgstr "дозвіл"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Особисте"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Провайдер не повідомив про використанн
 msgid "Provider presets"
 msgstr "Пресети провайдерів"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Використання провайдерів"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Перезавантажити сторінку браузера"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Віддалений"
 
@@ -10709,7 +10724,6 @@ msgstr "Потрібно вказати URL."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "Потрібно вказати URL."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Використання"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Виконується…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Робоча область"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "Tác nhân · Chung"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "Trình điều phối tác nhân AI - quản lý các tác nhân mã hó
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "Thao tác git bằng AI"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "Trợ lý AI"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "Đã phát hiện <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "Đang phát hiện tác nhân…"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7101,6 +7104,10 @@ msgstr "Đang chờ chỉ đạo"
 msgid "permission"
 msgstr "sự cho phép"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "Cá nhân"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7429,6 +7436,13 @@ msgstr "Nhà cung cấp chưa báo cáo việc sử dụng mã thông báo."
 msgid "Provider presets"
 msgstr "Cấu hình nhà cung cấp"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "Mức sử dụng nhà cung cấp"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7732,6 +7746,7 @@ msgid "Reload browser page"
 msgstr "Tải lại trang trình duyệt"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Từ xa"
 
@@ -10709,7 +10724,6 @@ msgstr "Bắt buộc phải có URL."
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10717,8 +10731,6 @@ msgstr "Bắt buộc phải có URL."
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "Mức sử dụng"
 
@@ -11176,6 +11188,7 @@ msgid "Working…"
 msgstr "Đang làm việc…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "Không gian làm việc"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -898,12 +898,11 @@ msgid "Agents · General"
 msgstr "代理·一般"
 
 #. Settings section: AI / assistant configuration
-#. Settings section: AI / assistant configuration
 #: src/mobile/settingsSections.ts
 #: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-msgid "AI"
-msgstr "AI"
+#~ msgid "AI"
+#~ msgstr "AI"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "AI agent orchestrator — manage coding agents via Terminal and Native ACP."
@@ -912,6 +911,13 @@ msgstr "AI 代理协调器 — 通过终端和本机 ACP 管理编码代理。"
 #: src/renderer/views/ProfileOverlay/parts/AiActions.tsx
 msgid "AI git actions"
 msgstr "AI git操作"
+
+#. Settings section: AI helper features (commit messages, thread titles, conflict resolution)
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "AI Helpers"
+msgstr "AI 助手"
 
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeDialog.tsx
 #: src/renderer/views/ExperimentView/parts/ExperimentJudgeRunDialog.tsx
@@ -3270,9 +3276,6 @@ msgstr "检测到 <0>{0}</0>"
 msgid "Detecting agents…"
 msgstr "正在检测代理……"
 
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
-#. Settings section: developer/debug tools
 #. Settings section: developer/debug tools
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -7100,6 +7103,10 @@ msgstr "等待引导"
 msgid "permission"
 msgstr "权限"
 
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+msgid "Personal"
+msgstr "个人"
+
 #: src/renderer/components/providers/pi/manifest.ts
 msgid "Pi"
 msgstr "Pi"
@@ -7428,6 +7435,13 @@ msgstr "提供商尚未报告令牌使用情况。"
 msgid "Provider presets"
 msgstr "服务商预设"
 
+#. Settings section: provider usage and quota dashboard
+#: src/mobile/settingsSections.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+msgid "Provider Usage"
+msgstr "提供商用量"
+
 #. plural
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/authHelpers.ts
 msgid "providers"
@@ -7731,6 +7745,7 @@ msgid "Reload browser page"
 msgstr "重新加载浏览器页面"
 
 #: src/renderer/components/common/BranchSelector/parts/useBranchList.ts
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "远程"
 
@@ -10708,7 +10723,6 @@ msgstr "URL 为必填项。"
 
 #: src/mobile/chrome.ts
 #: src/mobile/NarrowShell.tsx
-#: src/mobile/settingsSections.ts
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
@@ -10716,8 +10730,6 @@ msgstr "URL 为必填项。"
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
-#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Usage"
 msgstr "用量"
 
@@ -11175,6 +11187,7 @@ msgid "Working…"
 msgstr "工作…"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
+#: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Workspace"
 msgstr "工作区"
 

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -17,6 +17,10 @@ const appState = {
   projects: [] as Project[],
 };
 
+const bridgeState = {
+  remote: false,
+};
+
 vi.mock("@/renderer/state/agentStatusesStore", () => {
   const useAgentStatusesStore = (
     selector: (state: {
@@ -88,7 +92,7 @@ vi.mock("@/renderer/views/MainView/parts/AppShell/AppShell", () => ({
 
 vi.mock("@/renderer/bridge", () => ({
   isDevApp: () => false,
-  isRemoteSession: () => false,
+  isRemoteSession: () => bridgeState.remote,
   isWindows: () => false,
   readBridge: () => ({
     refreshAgentStatuses: refreshAgentStatusesMock,
@@ -133,7 +137,7 @@ vi.mock("./parts/NotificationSettings", () => ({
 }));
 
 vi.mock("./parts/AISettings", () => ({
-  AISettings: () => <div>AI</div>,
+  AISettings: () => <div>AI Helpers</div>,
 }));
 
 vi.mock("./parts/AcpRegistrySettings", () => ({
@@ -153,7 +157,7 @@ vi.mock("./parts/ShortcutsSettings", () => ({
 }));
 
 vi.mock("./parts/UsageSettings", () => ({
-  UsageSettings: () => <div>Usage</div>,
+  UsageSettings: () => <div>Provider Usage</div>,
 }));
 
 vi.mock("./parts/ArchivedThreadsSettings", () => ({
@@ -205,10 +209,35 @@ describe("SettingsOverlay", () => {
     statusesState.agentStatuses = [];
     statusesState.wslAgentStatuses = [];
     appState.projects = [];
+    bridgeState.remote = false;
     beginFirstLaunchDiscoveryMock.mockReset();
     resetDiscoveredAgentsMock.mockReset();
     refreshAgentStatusesMock.mockReset();
     refreshAgentStatusesMock.mockResolvedValue(undefined);
+  });
+
+  it("groups sidebar sections under labeled headers", () => {
+    const { container } = render(<SettingsOverlay onClose={() => undefined} />);
+
+    const headers = [...container.querySelectorAll("aside p")].map((el) => el.textContent);
+    expect(headers).toEqual(["Personal", "Workspace", "Agents", "Remote", "About"]);
+
+    const labels = screen.getAllByRole("button").map((button) => button.textContent);
+    expect(labels.indexOf("Notifications")).toBeLessThan(labels.indexOf("Terminal"));
+    expect(labels.indexOf("Archived Threads")).toBeLessThan(labels.indexOf("Agents"));
+    expect(labels.indexOf("Provider Usage")).toBeGreaterThan(labels.indexOf("MCP Servers"));
+    expect(labels.indexOf("Changelog")).toBeGreaterThan(labels.indexOf("Remote Environments"));
+  });
+
+  it("hides groups whose sections are all desktop-only on remote sessions", () => {
+    bridgeState.remote = true;
+    const { container } = render(<SettingsOverlay onClose={() => undefined} />);
+
+    const headers = [...container.querySelectorAll("aside p")].map((el) => el.textContent);
+    expect(headers).toEqual(["Personal", "Workspace", "Agents", "About"]);
+    expect(screen.getByRole("button", { name: "Models" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remote Access" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Browser" })).not.toBeInTheDocument();
   });
 
   it("keeps WSL-only installed agents reachable from the sidebar", () => {
@@ -330,13 +359,13 @@ describe("SettingsOverlay", () => {
     expect(firstScroller).not.toBeNull();
     firstScroller!.scrollTop = 240;
 
-    fireEvent.click(screen.getByRole("button", { name: "Usage" }));
+    fireEvent.click(screen.getByRole("button", { name: "Provider Usage" }));
 
     const nextScroller = container.querySelector<HTMLElement>("[data-settings-scroll-area]");
     expect(nextScroller).not.toBeNull();
     expect(nextScroller).not.toBe(firstScroller);
     expect(nextScroller!.scrollTop).toBe(0);
-    expect(within(screen.getByRole("main")).getByText("Usage")).toBeInTheDocument();
+    expect(within(screen.getByRole("main")).getByText("Provider Usage")).toBeInTheDocument();
   });
 
   it("marks agents that need attention in the sidebar", () => {

--- a/src/renderer/views/SettingsOverlay/parts/AISettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/AISettings.tsx
@@ -357,7 +357,7 @@ export function AISettings() {
 
   return (
     <SettingsPage
-      title={t`AI`}
+      title={t`AI Helpers`}
       bodyClassName="space-y-8"
       actions={
         hasWsl ? (

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -100,6 +100,8 @@ type SearchRow =
       primary: string;
     };
 
+type SectionMeta = { id: SettingsSection; icon: ReactNode; label: string };
+
 /**
  * A settings-search result row: a small section "eyebrow" (icon + section name)
  * above the matched setting text (its title, or a description snippet when only
@@ -204,56 +206,116 @@ export function SettingsSidebar(props: {
   const isSectionVisible = (id: SettingsSection) =>
     !remoteSession || !DESKTOP_ONLY_SECTIONS.has(id);
 
-  const sectionsBeforeAgents: { id: SettingsSection; icon: ReactNode; label: string }[] = [
-    { id: "profile", icon: <UserRound className="size-4" />, label: t`Profile` },
-    { id: "general", icon: <Settings2 className="size-4" />, label: t`General` },
-    { id: "audio", icon: <Mic className="size-4" />, label: t`Audio` },
-    { id: "appearance", icon: <Palette className="size-4" />, label: t`Appearance` },
-    { id: "terminal", icon: <TerminalSquare className="size-4" />, label: t`Terminal` },
-    { id: "threads", icon: <MessageSquare className="size-4" />, label: t`Threads` },
-    { id: "git", icon: <GitFork className="size-4" />, label: t`Git` },
-    { id: "worktrees", icon: <FolderGit2 className="size-4" />, label: t`Worktrees` },
-    { id: "notifications", icon: <Bell className="size-4" />, label: t`Notifications` },
+  // Grouped section model — single source of truth for sidebar order in both
+  // the expanded list (with group headers) and the collapsed icon rail. The
+  // "agents" group is special: its first row is the expandable agents tree
+  // (the "Models" stand-in on remote), followed by its plain sections.
+  const sectionGroups: { id: string; label: string; sections: SectionMeta[] }[] = [
     {
-      id: "ai",
-      icon: <Sparkles className="size-4" />,
-      label: t({ message: "AI", comment: "Settings section: AI / assistant configuration" }),
+      id: "personal",
+      label: t`Personal`,
+      sections: [
+        { id: "profile", icon: <UserRound className="size-4" />, label: t`Profile` },
+        { id: "general", icon: <Settings2 className="size-4" />, label: t`General` },
+        { id: "appearance", icon: <Palette className="size-4" />, label: t`Appearance` },
+        { id: "audio", icon: <Mic className="size-4" />, label: t`Audio` },
+        { id: "notifications", icon: <Bell className="size-4" />, label: t`Notifications` },
+        { id: "shortcuts", icon: <Keyboard className="size-4" />, label: t`Shortcuts` },
+      ],
     },
-    { id: "search", icon: <Search className="size-4" />, label: t`Search` },
-    { id: "shortcuts", icon: <Keyboard className="size-4" />, label: t`Shortcuts` },
-    { id: "remoteAccess", icon: <QrCode className="size-4" />, label: t`Remote Access` },
-    { id: "remoteServers", icon: <Server className="size-4" />, label: t`Remote Environments` },
+    {
+      id: "workspace",
+      label: t`Workspace`,
+      sections: [
+        { id: "terminal", icon: <TerminalSquare className="size-4" />, label: t`Terminal` },
+        { id: "threads", icon: <MessageSquare className="size-4" />, label: t`Threads` },
+        { id: "git", icon: <GitFork className="size-4" />, label: t`Git` },
+        { id: "worktrees", icon: <FolderGit2 className="size-4" />, label: t`Worktrees` },
+        { id: "search", icon: <Search className="size-4" />, label: t`Search` },
+        { id: "browser", icon: <Globe className="size-4" />, label: t`Browser` },
+        { id: "archived", icon: <Archive className="size-4" />, label: t`Archived Threads` },
+      ],
+    },
+    {
+      id: "agents",
+      label: t`Agents`,
+      sections: [
+        {
+          id: "ai",
+          icon: <Sparkles className="size-4" />,
+          label: t({
+            message: "AI Helpers",
+            comment:
+              "Settings section: AI helper features (commit messages, thread titles, conflict resolution)",
+          }),
+        },
+        { id: "skills", icon: <Box className="size-4" />, label: t`Skills` },
+        { id: "mcpServers", icon: <Cable className="size-4" />, label: t`MCP Servers` },
+        {
+          id: "usage",
+          icon: <Gauge className="size-4" />,
+          label: t({
+            message: "Provider Usage",
+            comment: "Settings section: provider usage and quota dashboard",
+          }),
+        },
+      ],
+    },
+    {
+      id: "remote",
+      label: t`Remote`,
+      sections: [
+        { id: "remoteAccess", icon: <QrCode className="size-4" />, label: t`Remote Access` },
+        { id: "remoteServers", icon: <Server className="size-4" />, label: t`Remote Environments` },
+      ],
+    },
+    {
+      id: "about",
+      label: t`About`,
+      sections: [
+        { id: "changelog", icon: <Megaphone className="size-4" />, label: t`Changelog` },
+        { id: "about", icon: <Info className="size-4" />, label: t`About` },
+        ...(devMode
+          ? [
+              {
+                id: "dev" as SettingsSection,
+                icon: <FlaskConical className="size-4" />,
+                label: t({ message: "Dev", comment: "Settings section: developer/debug tools" }),
+              },
+            ]
+          : []),
+      ],
+    },
   ];
-  const sectionsAfterAgents: { id: SettingsSection; icon: ReactNode; label: string }[] = [
-    { id: "skills", icon: <Box className="size-4" />, label: t`Skills` },
-    { id: "mcpServers", icon: <Cable className="size-4" />, label: t`MCP Servers` },
-    { id: "browser", icon: <Globe className="size-4" />, label: t`Browser` },
-    { id: "usage", icon: <Gauge className="size-4" />, label: t`Usage` },
-    { id: "archived", icon: <Archive className="size-4" />, label: t`Archived Threads` },
-    { id: "changelog", icon: <Megaphone className="size-4" />, label: t`Changelog` },
-    { id: "about", icon: <Info className="size-4" />, label: t`About` },
-  ];
+
+  // Desktop-only sections drop out of their group on remote sessions; a group
+  // whose rows are all hidden renders nothing at all, header included.
+  const visibleGroups = sectionGroups
+    .map((group) => ({
+      ...group,
+      hasTree: group.id === "agents",
+      sections: group.sections.filter((section) => isSectionVisible(section.id)),
+    }))
+    .filter((group) => group.hasTree || group.sections.length > 0);
 
   // When the filter has a query, the section list is replaced by a flat results
   // list that also surfaces individual settings (see ./settingsSearchIndex). Each
-  // section's label hit and its setting hits are grouped together, in section
-  // order, with the section icon/label reused as the result "eyebrow".
+  // section's label hit and its setting hits are grouped together, in sidebar
+  // group order, with the section icon/label reused as the result "eyebrow".
   const query = sectionFilter.trim();
-  const sectionMetaList: { id: SettingsSection; icon: ReactNode; label: string }[] = [
-    ...sectionsBeforeAgents,
-    { id: "agents", icon: <Bot className="size-4" />, label: t`Agents` },
-    { id: "agentsGeneral", icon: <Bot className="size-4" />, label: t`Agents · General` },
-    ...sectionsAfterAgents,
-    ...(devMode
+  const sectionMetaList: SectionMeta[] = sectionGroups.flatMap((group) =>
+    group.id === "agents"
       ? [
+          { id: "agents" as SettingsSection, icon: <Bot className="size-4" />, label: t`Agents` },
           {
-            id: "dev" as SettingsSection,
-            icon: <FlaskConical className="size-4" />,
-            label: t({ message: "Dev", comment: "Settings section: developer/debug tools" }),
+            id: "agentsGeneral" as SettingsSection,
+            icon: <Bot className="size-4" />,
+            label: t`Agents · General`,
           },
+          ...group.sections,
         ]
-      : []),
-  ];
+      : group.sections,
+  );
   const settingMatches = query === "" ? [] : searchSettings(query, t, { devMode, remoteSession });
   const matchesBySection = new Map<string, typeof settingMatches>();
   for (const match of settingMatches) {
@@ -291,267 +353,121 @@ export function SettingsSidebar(props: {
       {isCollapsed && (
         <div className="absolute inset-0 z-10 flex h-full min-h-0 flex-col items-start gap-3 pl-2 pb-1 pt-0">
           <div className="min-h-0 flex-1 space-y-0.5 overflow-y-auto">
-            <SidebarButton
-              iconOnly
-              icon={<UserRound className="size-4" />}
-              label={t`Profile`}
-              isActive={activeSection === "profile"}
-              onPress={() => onSectionChange("profile")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Settings2 className="size-4" />}
-              label={t`General`}
-              isActive={activeSection === "general"}
-              onPress={() => onSectionChange("general")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Mic className="size-4" />}
-              label={t`Audio`}
-              isActive={activeSection === "audio"}
-              onPress={() => onSectionChange("audio")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Palette className="size-4" />}
-              label={t`Appearance`}
-              isActive={activeSection === "appearance"}
-              onPress={() => onSectionChange("appearance")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<TerminalSquare className="size-4" />}
-              label={t`Terminal`}
-              isActive={activeSection === "terminal"}
-              onPress={() => onSectionChange("terminal")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<MessageSquare className="size-4" />}
-              label={t`Threads`}
-              isActive={activeSection === "threads"}
-              onPress={() => onSectionChange("threads")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<GitFork className="size-4" />}
-              label={t`Git`}
-              isActive={activeSection === "git"}
-              onPress={() => onSectionChange("git")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<FolderGit2 className="size-4" />}
-              label={t`Worktrees`}
-              isActive={activeSection === "worktrees"}
-              onPress={() => onSectionChange("worktrees")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Bell className="size-4" />}
-              label={t`Notifications`}
-              isActive={activeSection === "notifications"}
-              onPress={() => onSectionChange("notifications")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Sparkles className="size-4" />}
-              label={t({
-                message: "AI",
-                comment: "Settings section: AI / assistant configuration",
-              })}
-              isActive={activeSection === "ai"}
-              onPress={() => onSectionChange("ai")}
-            />
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Box className="size-4" />}
-                label={t`Skills`}
-                isActive={activeSection === "skills"}
-                onPress={() => onSectionChange("skills")}
-              />
-            )}
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Search className="size-4" />}
-                label={t`Search`}
-                isActive={activeSection === "search"}
-                onPress={() => onSectionChange("search")}
-              />
-            )}
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Keyboard className="size-4" />}
-                label={t`Shortcuts`}
-                isActive={activeSection === "shortcuts"}
-                onPress={() => onSectionChange("shortcuts")}
-              />
-            )}
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<QrCode className="size-4" />}
-                label={t`Remote Access`}
-                isActive={activeSection === "remoteAccess"}
-                onPress={() => onSectionChange("remoteAccess")}
-              />
-            )}
-            {remoteSession ? (
-              <SidebarButton
-                iconOnly
-                icon={<Bot className="size-4" />}
-                label={t`Models`}
-                isActive={activeSection === "agentsGeneral"}
-                onPress={() => onSectionChange("agentsGeneral")}
-              />
-            ) : (
-              <SidebarButton
-                iconOnly
-                icon={<Bot className="size-4" />}
-                label={t`Agents`}
-                isActive={isAgentsActive}
-                onPress={openAgents}
-              />
-            )}
-            {!remoteSession && isAgentsActive && (
-              <SidebarButton
-                iconOnly
-                icon={
-                  isRefreshingAgents ? <PixelLoader size="sm" /> : <RefreshCw className="size-4" />
-                }
-                label={t`Refresh detected agents`}
-                isDisabled={isRefreshingAgents}
-                onPress={onRefreshAgents}
-              />
-            )}
-            {!remoteSession && isAgentsActive && (
-              <SidebarButton
-                iconOnly
-                icon={<Settings2 className="size-4" />}
-                label={t`Agents · General`}
-                isActive={activeSection === "agentsGeneral"}
-                onPress={() => onSectionChange("agentsGeneral")}
-              />
-            )}
-            {!remoteSession && isAgentsActive && (
-              <SidebarButton
-                iconOnly
-                icon={<Boxes className="size-4" />}
-                label={t`Agent Registry`}
-                isActive={activeSection === "acpRegistry"}
-                onPress={() => onSectionChange("acpRegistry")}
-              />
-            )}
-            {!remoteSession &&
-              isAgentsActive &&
-              primaryAgents.map((agent) => {
-                const needsAttention = attentionAgentKinds.has(agent.kind);
-                return (
-                  <div key={agent.kind} className="space-y-0.5">
+            {visibleGroups.map((group, groupIndex) => (
+              <div key={group.id} className={groupIndex > 0 ? "space-y-0.5 pt-2" : "space-y-0.5"}>
+                {group.hasTree &&
+                  (remoteSession ? (
                     <SidebarButton
                       iconOnly
-                      icon={
-                        <span className="relative flex size-4 items-center justify-center">
-                          {renderAgentIcon(agent, {
-                            disabled: disabledAgents.includes(agent.kind),
-                          })}
-                          {needsAttention ? (
-                            <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
-                          ) : null}
-                        </span>
-                      }
-                      label={agent.label}
-                      isActive={activeSection === `agents:${agent.kind}`}
-                      onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                      icon={<Bot className="size-4" />}
+                      label={t`Models`}
+                      isActive={activeSection === "agentsGeneral"}
+                      onPress={() => onSectionChange("agentsGeneral")}
                     />
-                    {instanceAgentsFor(agent.kind).map((profile) => {
-                      const profileNeedsAttention = attentionAgentKinds.has(profile.kind);
-                      return (
+                  ) : (
+                    <>
+                      <SidebarButton
+                        iconOnly
+                        icon={<Bot className="size-4" />}
+                        label={t`Agents`}
+                        isActive={isAgentsActive}
+                        onPress={openAgents}
+                      />
+                      {isAgentsActive && (
                         <SidebarButton
-                          key={profile.kind}
                           iconOnly
-                          className="ml-3 h-7 w-7"
                           icon={
-                            <span className="relative flex size-3.5 items-center justify-center">
-                              {renderAgentIcon(profile, {
-                                disabled: disabledAgents.includes(profile.kind),
-                                className: "size-3.5",
-                              })}
-                              {profileNeedsAttention ? (
-                                <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
-                              ) : null}
-                            </span>
+                            isRefreshingAgents ? (
+                              <PixelLoader size="sm" />
+                            ) : (
+                              <RefreshCw className="size-4" />
+                            )
                           }
-                          label={profile.label}
-                          isActive={activeSection === `agents:${profile.kind}`}
-                          onPress={() => onSectionChange(`agents:${profile.kind}`)}
+                          label={t`Refresh detected agents`}
+                          isDisabled={isRefreshingAgents}
+                          onPress={onRefreshAgents}
                         />
-                      );
-                    })}
-                  </div>
-                );
-              })}
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Cable className="size-4" />}
-                label={t`MCP Servers`}
-                isActive={activeSection === "mcpServers"}
-                onPress={() => onSectionChange("mcpServers")}
-              />
-            )}
-            <SidebarButton
-              iconOnly
-              icon={<Globe className="size-4" />}
-              label={t`Browser`}
-              isActive={activeSection === "browser"}
-              onPress={() => onSectionChange("browser")}
-            />
-            <SidebarButton
-              iconOnly
-              icon={<Gauge className="size-4" />}
-              label={t`Usage`}
-              isActive={activeSection === "usage"}
-              onPress={() => onSectionChange("usage")}
-            />
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Archive className="size-4" />}
-                label={t`Archived Threads`}
-                isActive={activeSection === "archived"}
-                onPress={() => onSectionChange("archived")}
-              />
-            )}
-            <SidebarButton
-              iconOnly
-              icon={<Megaphone className="size-4" />}
-              label={t`Changelog`}
-              isActive={activeSection === "changelog"}
-              onPress={() => onSectionChange("changelog")}
-            />
-            {!remoteSession && (
-              <SidebarButton
-                iconOnly
-                icon={<Info className="size-4" />}
-                label={t`About`}
-                isActive={activeSection === "about"}
-                onPress={() => onSectionChange("about")}
-              />
-            )}
-            {devMode && (
-              <SidebarButton
-                iconOnly
-                icon={<FlaskConical className="size-4" />}
-                label={t({ message: "Dev", comment: "Settings section: developer/debug tools" })}
-                isActive={activeSection === "dev"}
-                onPress={() => onSectionChange("dev")}
-              />
-            )}
+                      )}
+                      {isAgentsActive && (
+                        <SidebarButton
+                          iconOnly
+                          icon={<Settings2 className="size-4" />}
+                          label={t`Agents · General`}
+                          isActive={activeSection === "agentsGeneral"}
+                          onPress={() => onSectionChange("agentsGeneral")}
+                        />
+                      )}
+                      {isAgentsActive && (
+                        <SidebarButton
+                          iconOnly
+                          icon={<Boxes className="size-4" />}
+                          label={t`Agent Registry`}
+                          isActive={activeSection === "acpRegistry"}
+                          onPress={() => onSectionChange("acpRegistry")}
+                        />
+                      )}
+                      {isAgentsActive &&
+                        primaryAgents.map((agent) => {
+                          const needsAttention = attentionAgentKinds.has(agent.kind);
+                          return (
+                            <div key={agent.kind} className="space-y-0.5">
+                              <SidebarButton
+                                iconOnly
+                                icon={
+                                  <span className="relative flex size-4 items-center justify-center">
+                                    {renderAgentIcon(agent, {
+                                      disabled: disabledAgents.includes(agent.kind),
+                                    })}
+                                    {needsAttention ? (
+                                      <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
+                                    ) : null}
+                                  </span>
+                                }
+                                label={agent.label}
+                                isActive={activeSection === `agents:${agent.kind}`}
+                                onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                              />
+                              {instanceAgentsFor(agent.kind).map((profile) => {
+                                const profileNeedsAttention = attentionAgentKinds.has(profile.kind);
+                                return (
+                                  <SidebarButton
+                                    key={profile.kind}
+                                    iconOnly
+                                    className="ml-3 h-7 w-7"
+                                    icon={
+                                      <span className="relative flex size-3.5 items-center justify-center">
+                                        {renderAgentIcon(profile, {
+                                          disabled: disabledAgents.includes(profile.kind),
+                                          className: "size-3.5",
+                                        })}
+                                        {profileNeedsAttention ? (
+                                          <AlertTriangle className="absolute -right-1 -top-1 size-2.5 text-warning" />
+                                        ) : null}
+                                      </span>
+                                    }
+                                    label={profile.label}
+                                    isActive={activeSection === `agents:${profile.kind}`}
+                                    onPress={() => onSectionChange(`agents:${profile.kind}`)}
+                                  />
+                                );
+                              })}
+                            </div>
+                          );
+                        })}
+                    </>
+                  ))}
+                {group.sections.map((section) => (
+                  <SidebarButton
+                    key={section.id}
+                    iconOnly
+                    icon={section.icon}
+                    label={section.label}
+                    isActive={activeSection === section.id}
+                    onPress={() => onSectionChange(section.id)}
+                  />
+                ))}
+              </div>
+            ))}
           </div>
           <div className={sidebarIconRailFooterClass}>
             <SidebarButton
@@ -625,150 +541,134 @@ export function SettingsSidebar(props: {
             </div>
           ) : (
             <div className="space-y-0.5">
-              {sectionsBeforeAgents
-                .filter((section) => isSectionVisible(section.id) && matchesFilter(section.label))
-                .map((section) => (
-                  <SidebarButton
-                    key={section.id}
-                    icon={section.icon}
-                    label={section.label}
-                    isActive={activeSection === section.id}
-                    onPress={() => onSectionChange(section.id)}
-                  />
-                ))}
-              {remoteSession && matchesFilter(t`Models`) && (
-                <SidebarButton
-                  icon={<Bot className="size-4" />}
-                  label={t`Models`}
-                  isActive={activeSection === "agentsGeneral"}
-                  onPress={() => onSectionChange("agentsGeneral")}
-                />
-              )}
-              {!remoteSession && matchesFilter(t`Agents`) && (
-                <>
-                  <SidebarButton
-                    icon={<Bot className="size-4" />}
-                    label={t`Agents`}
-                    isActive={activeSection === "agents"}
-                    onPress={openAgents}
-                    suffix={
-                      <button
-                        type="button"
-                        aria-label={t`Refresh detected agents`}
-                        className="flex size-5 shrink-0 cursor-default items-center justify-center text-muted/70 transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:text-muted/40"
-                        disabled={isRefreshingAgents}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRefreshAgents();
-                        }}
-                      >
-                        {isRefreshingAgents ? (
-                          <PixelLoader size="xs" />
-                        ) : (
-                          <RefreshCw className="size-3.5" />
-                        )}
-                      </button>
-                    }
-                  />
-                  {isAgentsActive && (
-                    <div className="space-y-0.5 pl-4">
+              {visibleGroups.map((group, groupIndex) => (
+                <div key={group.id} className={groupIndex > 0 ? "space-y-0.5 pt-3" : "space-y-0.5"}>
+                  <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
+                    {group.label}
+                  </p>
+                  {group.hasTree &&
+                    (remoteSession ? (
                       <SidebarButton
-                        icon={<Settings2 className="size-4" />}
-                        label={t`General`}
+                        icon={<Bot className="size-4" />}
+                        label={t`Models`}
                         isActive={activeSection === "agentsGeneral"}
                         onPress={() => onSectionChange("agentsGeneral")}
                       />
-                      <SidebarButton
-                        icon={<Boxes className="size-4" />}
-                        label={t`Agent Registry`}
-                        isActive={activeSection === "acpRegistry"}
-                        onPress={() => onSectionChange("acpRegistry")}
-                      />
-                      {primaryAgents.map((agent) => {
-                        const agentDisabled = disabledAgents.includes(agent.kind);
-                        const needsAttention = attentionAgentKinds.has(agent.kind);
-                        return (
-                          <div key={agent.kind} className="space-y-0.5">
+                    ) : (
+                      <>
+                        <SidebarButton
+                          icon={<Bot className="size-4" />}
+                          label={t`Agents`}
+                          isActive={activeSection === "agents"}
+                          onPress={openAgents}
+                          suffix={
+                            <button
+                              type="button"
+                              aria-label={t`Refresh detected agents`}
+                              className="flex size-5 shrink-0 cursor-default items-center justify-center text-muted/70 transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:text-muted/40"
+                              disabled={isRefreshingAgents}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onRefreshAgents();
+                              }}
+                            >
+                              {isRefreshingAgents ? (
+                                <PixelLoader size="xs" />
+                              ) : (
+                                <RefreshCw className="size-3.5" />
+                              )}
+                            </button>
+                          }
+                        />
+                        {isAgentsActive && (
+                          <div className="space-y-0.5 pl-4">
                             <SidebarButton
-                              icon={renderAgentIcon(agent, {
-                                disabled: agentDisabled,
-                              })}
-                              label={agent.label}
-                              suffix={
-                                needsAttention ? (
-                                  <AlertTriangle
-                                    aria-hidden="true"
-                                    className="size-3.5 text-warning"
-                                  />
-                                ) : null
-                              }
-                              className={agentDisabled ? "opacity-50" : ""}
-                              isActive={activeSection === `agents:${agent.kind}`}
-                              onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                              icon={<Settings2 className="size-4" />}
+                              label={t`General`}
+                              isActive={activeSection === "agentsGeneral"}
+                              onPress={() => onSectionChange("agentsGeneral")}
                             />
-                            {instanceAgentsFor(agent.kind).length > 0 ? (
-                              <div className="space-y-0.5 pl-5">
-                                {instanceAgentsFor(agent.kind).map((profile) => {
-                                  const profileDisabled = disabledAgents.includes(profile.kind);
-                                  const profileNeedsAttention = attentionAgentKinds.has(
-                                    profile.kind,
-                                  );
-                                  return (
-                                    <SidebarButton
-                                      key={profile.kind}
-                                      icon={renderAgentIcon(profile, {
-                                        disabled: profileDisabled,
-                                        className: "size-3.5",
-                                      })}
-                                      label={claudeProfileSidebarLabel(profile)}
-                                      suffix={
-                                        profileNeedsAttention ? (
-                                          <AlertTriangle
-                                            aria-hidden="true"
-                                            className="size-3.5 text-warning"
+                            <SidebarButton
+                              icon={<Boxes className="size-4" />}
+                              label={t`Agent Registry`}
+                              isActive={activeSection === "acpRegistry"}
+                              onPress={() => onSectionChange("acpRegistry")}
+                            />
+                            {primaryAgents.map((agent) => {
+                              const agentDisabled = disabledAgents.includes(agent.kind);
+                              const needsAttention = attentionAgentKinds.has(agent.kind);
+                              return (
+                                <div key={agent.kind} className="space-y-0.5">
+                                  <SidebarButton
+                                    icon={renderAgentIcon(agent, {
+                                      disabled: agentDisabled,
+                                    })}
+                                    label={agent.label}
+                                    suffix={
+                                      needsAttention ? (
+                                        <AlertTriangle
+                                          aria-hidden="true"
+                                          className="size-3.5 text-warning"
+                                        />
+                                      ) : null
+                                    }
+                                    className={agentDisabled ? "opacity-50" : ""}
+                                    isActive={activeSection === `agents:${agent.kind}`}
+                                    onPress={() => onSectionChange(`agents:${agent.kind}`)}
+                                  />
+                                  {instanceAgentsFor(agent.kind).length > 0 ? (
+                                    <div className="space-y-0.5 pl-5">
+                                      {instanceAgentsFor(agent.kind).map((profile) => {
+                                        const profileDisabled = disabledAgents.includes(
+                                          profile.kind,
+                                        );
+                                        const profileNeedsAttention = attentionAgentKinds.has(
+                                          profile.kind,
+                                        );
+                                        return (
+                                          <SidebarButton
+                                            key={profile.kind}
+                                            icon={renderAgentIcon(profile, {
+                                              disabled: profileDisabled,
+                                              className: "size-3.5",
+                                            })}
+                                            label={claudeProfileSidebarLabel(profile)}
+                                            suffix={
+                                              profileNeedsAttention ? (
+                                                <AlertTriangle
+                                                  aria-hidden="true"
+                                                  className="size-3.5 text-warning"
+                                                />
+                                              ) : null
+                                            }
+                                            className={`text-xs ${profileDisabled ? "opacity-50" : ""}`}
+                                            isActive={activeSection === `agents:${profile.kind}`}
+                                            onPress={() =>
+                                              onSectionChange(`agents:${profile.kind}`)
+                                            }
                                           />
-                                        ) : null
-                                      }
-                                      className={`text-xs ${profileDisabled ? "opacity-50" : ""}`}
-                                      isActive={activeSection === `agents:${profile.kind}`}
-                                      onPress={() => onSectionChange(`agents:${profile.kind}`)}
-                                    />
-                                  );
-                                })}
-                              </div>
-                            ) : null}
+                                        );
+                                      })}
+                                    </div>
+                                  ) : null}
+                                </div>
+                              );
+                            })}
                           </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </>
-              )}
-              {sectionsAfterAgents
-                .filter((section) => isSectionVisible(section.id) && matchesFilter(section.label))
-                .map((section) => (
-                  <SidebarButton
-                    key={section.id}
-                    icon={section.icon}
-                    label={section.label}
-                    isActive={activeSection === section.id}
-                    onPress={() => onSectionChange(section.id)}
-                  />
-                ))}
-              {devMode &&
-                matchesFilter(
-                  t({ message: "Dev", comment: "Settings section: developer/debug tools" }),
-                ) && (
-                  <SidebarButton
-                    icon={<FlaskConical className="size-4" />}
-                    label={t({
-                      message: "Dev",
-                      comment: "Settings section: developer/debug tools",
-                    })}
-                    isActive={activeSection === "dev"}
-                    onPress={() => onSectionChange("dev")}
-                  />
-                )}
+                        )}
+                      </>
+                    ))}
+                  {group.sections.map((section) => (
+                    <SidebarButton
+                      key={section.id}
+                      icon={section.icon}
+                      label={section.label}
+                      isActive={activeSection === section.id}
+                      onPress={() => onSectionChange(section.id)}
+                    />
+                  ))}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -304,7 +304,7 @@ export function UsageSettings() {
 
   return (
     <SettingsPage
-      title={t`Usage`}
+      title={t`Provider Usage`}
       description={t`Track per-provider session, weekly, and monthly usage. Windows are reported by each provider; estimated cost is reconstructed from local logs.`}
       actions={
         <Button


### PR DESCRIPTION
- Refactor desktop settings navigation into clearer sidebar section groups.
- Rename AI and usage settings to “AI Helpers” and “Provider Usage” across desktop and mobile.
- Update localized catalogs for all supported languages.
- Refresh settings view tests to cover the revised labels and navigation.