### PR TITLE
Map ACP todo writes to plan lifecycle updates

### DIFF
--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -900,6 +900,218 @@ describe("mapAcpSessionUpdate", () => {
     expect(state.openPlanSteps).toBeUndefined();
   });
 
+  it("extracts plan steps from todo_write tool_call and suppresses the tool row", () => {
+    const state = createAcpMapperState("t-todo-write");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-todo-1",
+        title: "todo_write",
+        kind: "other",
+        status: "in_progress",
+        rawInput: {
+          todos: [
+            { content: "Read files", status: "completed" },
+            { content: "Write code", status: "in_progress" },
+            { content: "Run tests", status: "pending" },
+          ],
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    // The tool row must NOT appear — only plan lifecycle events.
+    expect(
+      events.every(
+        (e) => e.type !== "item.started" || (e as { itemType?: string }).itemType === "plan",
+      ),
+    ).toBe(true);
+    const planStarted = events.find(
+      (e) => e.type === "item.started" && (e as { itemType?: string }).itemType === "plan",
+    ) as { itemId: string; payload: { steps: Array<{ step: string; status: string }> } };
+    expect(planStarted).toBeDefined();
+    expect(planStarted.payload.steps).toEqual([
+      { step: "Read files", status: "completed" },
+      { step: "Write code", status: "in_progress" },
+      { step: "Run tests", status: "pending" },
+    ]);
+    expect(state.suppressedToolCallIds.has("tc-todo-1")).toBe(true);
+    expect(state.suppressedTodoWriteIds.has("tc-todo-1")).toBe(true);
+  });
+
+  it("updates plan steps from todo_write tool_call_update", () => {
+    const state = createAcpMapperState("t-todo-update");
+    // Initial tool_call with partial input
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-todo-2",
+        title: "todowrite",
+        kind: "other",
+        status: "in_progress",
+        rawInput: {
+          todos: [
+            { content: "Step A", status: "in_progress" },
+            { content: "Step B", status: "pending" },
+          ],
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    // tool_call_update with completed steps
+    const updateEvents = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-todo-2",
+        status: "completed",
+        rawInput: {
+          todos: [
+            { content: "Step A", status: "completed" },
+            { content: "Step B", status: "completed" },
+          ],
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    // All steps completed → plan item should be completed and cleared.
+    const planCompleted = updateEvents.find((e) => e.type === "item.completed");
+    expect(planCompleted).toBeDefined();
+    expect(
+      (planCompleted as { payload: { steps: Array<{ status: string }> } }).payload.steps.every(
+        (s) => s.status === "completed",
+      ),
+    ).toBe(true);
+    expect(state.openPlanItemId).toBeUndefined();
+    expect(state.suppressedToolCallIds.has("tc-todo-2")).toBe(false);
+    expect(state.suppressedTodoWriteIds.has("tc-todo-2")).toBe(false);
+  });
+
+  it("does not suppress non-todo tool calls", () => {
+    const state = createAcpMapperState("t-no-todo");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-regular",
+        title: "read_file",
+        kind: "read",
+        status: "in_progress",
+        rawInput: { path: "foo.ts" },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(
+      events.some(
+        (e) => e.type === "item.started" && (e as { itemType?: string }).itemType === "tool_call",
+      ),
+    ).toBe(true);
+    expect(state.suppressedToolCallIds.has("tc-regular")).toBe(false);
+  });
+
+  it("detects todo_write via the ACP 1.3 name field", () => {
+    const state = createAcpMapperState("t-todo-name");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-todo-name",
+        title: "Update task list",
+        kind: "other",
+        name: "todo_write",
+        status: "in_progress",
+        rawInput: {
+          todos: [
+            { content: "Alpha", status: "completed" },
+            { content: "Beta", status: "pending" },
+          ],
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const planStarted = events.find(
+      (e) => e.type === "item.started" && (e as { itemType?: string }).itemType === "plan",
+    ) as { payload: { steps: Array<{ step: string; status: string }> } };
+    expect(planStarted).toBeDefined();
+    expect(planStarted.payload.steps).toEqual([
+      { step: "Alpha", status: "completed" },
+      { step: "Beta", status: "pending" },
+    ]);
+    expect(state.suppressedTodoWriteIds.has("tc-todo-name")).toBe(true);
+  });
+
+  it("handles plan_update with items content", () => {
+    const state = createAcpMapperState("t-plan-update-items");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "plan_update",
+        plan: {
+          type: "items",
+          planId: "p1",
+          entries: [
+            { content: "Design API", status: "completed" },
+            { content: "Implement", status: "in_progress" },
+            { content: "Test", status: "pending" },
+          ],
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const planStarted = events.find(
+      (e) => e.type === "item.started" && (e as { itemType?: string }).itemType === "plan",
+    ) as { payload: { steps: Array<{ step: string; status: string }> } };
+    expect(planStarted).toBeDefined();
+    expect(planStarted.payload.steps).toEqual([
+      { step: "Design API", status: "completed" },
+      { step: "Implement", status: "in_progress" },
+      { step: "Test", status: "pending" },
+    ]);
+  });
+
+  it("handles plan_update with markdown content", () => {
+    const state = createAcpMapperState("t-plan-update-md");
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "plan_update",
+        plan: {
+          type: "markdown",
+          planId: "p2",
+          content: "# Plan\n- [x] Research\n- [ ] Build\n- [ ] Ship",
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const planStarted = events.find(
+      (e) => e.type === "item.started" && (e as { itemType?: string }).itemType === "plan",
+    ) as { payload: { steps: Array<{ step: string; status: string }> } };
+    expect(planStarted).toBeDefined();
+    expect(planStarted.payload.steps).toEqual([
+      { step: "Research", status: "completed" },
+      { step: "Build", status: "pending" },
+      { step: "Ship", status: "pending" },
+    ]);
+  });
+
+  it("handles plan_removed by completing the open plan", () => {
+    const state = createAcpMapperState("t-plan-removed");
+    // First create a plan
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "plan",
+        entries: [{ content: "Step 1", status: "in_progress" }],
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(state.openPlanItemId).toBeDefined();
+    // Then remove it
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "plan_removed",
+        planId: "p1",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    expect(events.some((e) => e.type === "item.completed")).toBe(true);
+    expect(state.openPlanItemId).toBeUndefined();
+    expect(state.openPlanSteps).toBeUndefined();
+  });
+
   it("extracts file_change path and diff from ACP content diff blocks when rawInput is empty", () => {
     const state = createAcpMapperState("t-fc-content-diff");
     const events = mapAcpSessionUpdate(

--- a/src/supervisor/agents/acp/canonicalMapping/contentExtraction.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/contentExtraction.ts
@@ -171,3 +171,89 @@ export function extractToolCallContentImages(content: unknown): string[] {
   }
   return images;
 }
+
+/**
+ * Detect ACP tool calls that represent a todo/plan write operation.
+ *
+ * ACP agents that expose a `todo_write` / `todowrite` / `TodoWrite` tool
+ * (the same shape Claude and OpenCode use) may not emit a separate `plan`
+ * session update. Without this detection the plan dock would never reflect
+ * status changes made through the tool call path.
+ */
+export function isAcpTodoWriteTool(
+  title: string | null | undefined,
+  kind: string | null | undefined,
+  name?: string | null,
+): boolean {
+  const t = (title ?? "").toLowerCase().trim();
+  const k = (kind ?? "").toLowerCase().trim();
+  const n = (name ?? "").toLowerCase().trim();
+  return (
+    t === "todo_write" ||
+    t === "todowrite" ||
+    k === "todo_write" ||
+    k === "todowrite" ||
+    n === "todo_write" ||
+    n === "todowrite"
+  );
+}
+
+/**
+ * Extract canonical plan steps from a `todo_write` tool's `rawInput`.
+ *
+ * The input shape mirrors Claude's `TodoWrite`: `{ todos: [{ content, status }] }`.
+ * Returns an empty array when the input is unrecognisable so callers can
+ * fall through to the default tool-call rendering.
+ */
+export function extractAcpTodoWriteSteps(
+  rawInput: unknown,
+): Array<{ step: string; status: "pending" | "in_progress" | "completed" }> {
+  if (!rawInput || typeof rawInput !== "object" || Array.isArray(rawInput)) return [];
+  const input = rawInput as Record<string, unknown>;
+  const todos = input.todos;
+  if (!Array.isArray(todos)) return [];
+  return todos.flatMap((todo) => {
+    if (!todo || typeof todo !== "object") return [];
+    const obj = todo as Record<string, unknown>;
+    const step =
+      typeof obj.content === "string" && obj.content.trim().length > 0
+        ? obj.content.trim()
+        : "Task";
+    const status =
+      obj.status === "completed"
+        ? "completed"
+        : obj.status === "in_progress"
+          ? "in_progress"
+          : "pending";
+    return [{ step, status }];
+  });
+}
+
+const BULLET_TASK_RE = /^\s*(?:[-*+]|\d+[.)])\s+(?:\[(?<marker>[ xX~>])\]\s+)?(?<text>.+?)\s*$/;
+
+/**
+ * Parse plan steps from a markdown string (the `plan_update` `markdown`
+ * content variant). Recognises bullet/numbered lists with optional checkbox
+ * markers: `- [x] done`, `- [ ] todo`, `- plain`.
+ */
+export function parsePlanMarkdownSteps(
+  markdown: string,
+): Array<{ step: string; status: "pending" | "in_progress" | "completed" }> {
+  if (!markdown.trim()) return [];
+  const steps: Array<{ step: string; status: "pending" | "in_progress" | "completed" }> = [];
+  for (const rawLine of markdown.split(/\r?\n/g)) {
+    const match = BULLET_TASK_RE.exec(rawLine);
+    if (!match?.groups?.text) continue;
+    const text = match.groups.text.replace(/\s+/g, " ").trim();
+    if (!text) continue;
+    const marker = match.groups.marker;
+    const status =
+      marker?.toLowerCase() === "x"
+        ? "completed"
+        : marker === "~" || marker === ">"
+          ? "in_progress"
+          : "pending";
+    steps.push({ step: text, status });
+  }
+  return steps;
+}

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -10,7 +10,12 @@ import {
   usageFromTokenCounts,
 } from "../../contextUsage";
 import { parseAcpAgentMessageApiError } from "../acpUserVisibleErrors";
-import { classifyToolCallItemType } from "./contentExtraction";
+import {
+  classifyToolCallItemType,
+  extractAcpTodoWriteSteps,
+  isAcpTodoWriteTool,
+  parsePlanMarkdownSteps,
+} from "./contentExtraction";
 import {
   applyTerminalToolCallName,
   buildAcpToolCallPayload,
@@ -199,6 +204,8 @@ export function mapAcpSessionUpdate(
         toolCallId: string;
         title?: string | null;
         kind?: string | null;
+        /** ACP SDK ≥1.3 programmatic tool name (UNSTABLE). */
+        name?: string | null;
         status?: "pending" | "in_progress" | "completed" | "failed";
         rawInput?: unknown;
         _meta?: unknown;
@@ -247,6 +254,21 @@ export function mapAcpSessionUpdate(
       if (goalUpdate) {
         state.suppressedToolCallIds.add(toolCall.toolCallId);
         events.push(...mapAcpCommandGoalUpdate(state, goalUpdate));
+        break;
+      }
+      // `todo_write` / `todowrite` tool calls carry the same plan data that
+      // Claude and OpenCode surface through their plan aggregators. Some ACP
+      // agents (Kimi Code) emit these tool calls without a matching `plan`
+      // session update, so we extract the steps here to keep the plan dock
+      // in sync. The tool row itself is suppressed — the plan item is the
+      // visible surface.
+      if (isAcpTodoWriteTool(toolCall.title, toolCall.kind, toolCall.name)) {
+        state.suppressedToolCallIds.add(toolCall.toolCallId);
+        state.suppressedTodoWriteIds.add(toolCall.toolCallId);
+        const steps = extractAcpTodoWriteSteps(toolCall.rawInput);
+        if (steps.length > 0) {
+          events.push(...emitAcpPlanSteps(state, steps));
+        }
         break;
       }
       const itemId = newItemId("tool");
@@ -327,6 +349,8 @@ export function mapAcpSessionUpdate(
         toolCallId: string;
         title?: string | null;
         kind?: string | null;
+        /** ACP SDK ≥1.3 programmatic tool name (UNSTABLE). */
+        name?: string | null;
         status?: "pending" | "in_progress" | "completed" | "failed";
         rawInput?: unknown;
         rawOutput?: unknown;
@@ -335,8 +359,18 @@ export function mapAcpSessionUpdate(
         locations?: Array<{ path?: string | null; line?: number | null }> | null;
       };
       if (state.suppressedToolCallIds.has(toolCall.toolCallId)) {
+        // `todo_write` tool calls may carry a more complete `rawInput` on the
+        // update notification (e.g. after the tool finishes executing). Re-
+        // extract plan steps so the dock reflects the final state.
+        if (state.suppressedTodoWriteIds.has(toolCall.toolCallId)) {
+          const steps = extractAcpTodoWriteSteps(toolCall.rawInput);
+          if (steps.length > 0) {
+            events.push(...emitAcpPlanSteps(state, steps));
+          }
+        }
         if (toolCall.status === "completed" || toolCall.status === "failed") {
           state.suppressedToolCallIds.delete(toolCall.toolCallId);
+          state.suppressedTodoWriteIds.delete(toolCall.toolCallId);
         }
         break;
       }
@@ -445,32 +479,55 @@ export function mapAcpSessionUpdate(
       };
       const rawEntries = plan.entries ?? plan.content?.entries ?? [];
       const steps = rawEntries.map((entry) => ({ step: entry.content, status: entry.status }));
-      state.openPlanSteps = steps;
-      if (!state.openPlanItemId) {
-        events.push(...closeOpenContentItems(state));
-        state.openPlanItemId = newItemId("plan");
-        events.push({
-          type: "item.started",
-          threadId,
-          itemId: state.openPlanItemId,
-          itemType: "plan",
-          payload: { steps },
-        });
-      } else {
-        events.push({
-          type: "item.updated",
-          threadId,
-          itemId: state.openPlanItemId,
-          payload: { steps },
-        });
+      events.push(...emitAcpPlanSteps(state, steps));
+      break;
+    }
+
+    // --- UNSTABLE / experimental plan variants (ACP SDK ≥1.2) ---
+
+    case "plan_update": {
+      const planUpdate = update as {
+        plan?:
+          | {
+              type: "items";
+              planId?: string;
+              entries?: Array<{
+                content: string;
+                status: "pending" | "in_progress" | "completed";
+              }>;
+            }
+          | { type: "file"; planId?: string; uri?: string }
+          | { type: "markdown"; planId?: string; content?: string };
+      };
+      const content = planUpdate.plan;
+      if (!content) break;
+      if (content.type === "items") {
+        const rawEntries = content.entries ?? [];
+        const steps = rawEntries.map((entry) => ({
+          step: entry.content,
+          status: entry.status,
+        }));
+        events.push(...emitAcpPlanSteps(state, steps));
+      } else if (content.type === "markdown" && typeof content.content === "string") {
+        const steps = parsePlanMarkdownSteps(content.content);
+        if (steps.length > 0) {
+          events.push(...emitAcpPlanSteps(state, steps));
+        }
       }
-      // If every step is completed, close the plan.
-      if (steps.length > 0 && steps.every((s) => s.status === "completed")) {
+      // `file` variant: the plan lives in a file referenced by URI. The pure
+      // mapper has no filesystem access; the session layer would need to
+      // resolve the URI and re-emit as `items`. Skipped until a provider
+      // actually uses this variant.
+      break;
+    }
+
+    case "plan_removed": {
+      // Complete and clear the open plan item, if any.
+      if (state.openPlanItemId) {
         events.push({
           type: "item.completed",
           threadId,
           itemId: state.openPlanItemId,
-          payload: { steps },
         });
         delete state.openPlanItemId;
         delete state.openPlanSteps;
@@ -504,9 +561,9 @@ export function mapAcpSessionUpdate(
     }
 
     default:
-      // Other update kinds (`session_info_update`, `config_option_update`, etc.)
-      // don't produce chat items in v1. They flow through the existing
-      // status/text channels untouched.
+      // `session_info_update`, `config_option_update`, and
+      // `available_commands_update` don't produce chat items — they flow
+      // through the session layer's status/config/slash-command channels.
       break;
   }
 
@@ -518,6 +575,49 @@ export function mapAcpSessionUpdate(
   }
   if (pendingSubAgent) {
     state.activeSubAgents.push(pendingSubAgent);
+  }
+  return events;
+}
+
+/**
+ * Create or update the open plan item from a set of steps. Shared between the
+ * ACP `plan` session-update handler and the `todo_write` tool-call handler so
+ * both paths produce identical plan lifecycle events.
+ */
+function emitAcpPlanSteps(
+  state: AcpMapperState,
+  steps: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>,
+): RuntimeEvent[] {
+  const events: RuntimeEvent[] = [];
+  const { threadId } = state;
+  state.openPlanSteps = steps;
+  if (!state.openPlanItemId) {
+    events.push(...closeOpenContentItems(state));
+    state.openPlanItemId = newItemId("plan");
+    events.push({
+      type: "item.started",
+      threadId,
+      itemId: state.openPlanItemId,
+      itemType: "plan",
+      payload: { steps },
+    });
+  } else {
+    events.push({
+      type: "item.updated",
+      threadId,
+      itemId: state.openPlanItemId,
+      payload: { steps },
+    });
+  }
+  if (steps.length > 0 && steps.every((s) => s.status === "completed")) {
+    events.push({
+      type: "item.completed",
+      threadId,
+      itemId: state.openPlanItemId,
+      payload: { steps },
+    });
+    delete state.openPlanItemId;
+    delete state.openPlanSteps;
   }
   return events;
 }

--- a/src/supervisor/agents/acp/canonicalMapping/state.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/state.ts
@@ -63,6 +63,13 @@ export interface AcpMapperState {
    * dropped so we don't emit ghost updates against the wrong item. */
   suppressedToolCallIds: Set<string>;
   /**
+   * Subset of `suppressedToolCallIds` that are `todo_write` / `todowrite`
+   * tool calls. Their `tool_call_update` notifications may carry a more
+   * complete `rawInput` with updated plan steps, so we keep tracking them
+   * separately to re-extract plan state on completion.
+   */
+  suppressedTodoWriteIds: Set<string>;
+  /**
    * Resolve the live output of a client-hosted ACP terminal by its
    * `terminalId`. Gemini's shell tool surfaces output via `createTerminal`
    * (separate JSON-RPC channel) and references the terminal from
@@ -85,6 +92,7 @@ export function createAcpMapperState(threadId: string): AcpMapperState {
     toolCallItems: new Map(),
     activeSubAgents: [],
     suppressedToolCallIds: new Set(),
+    suppressedTodoWriteIds: new Set(),
   };
 }
 
@@ -122,6 +130,7 @@ export function resetMapperForTurnEnd(state: AcpMapperState): void {
     state.toolCallItems.has(active.toolCallId),
   );
   state.suppressedToolCallIds.clear();
+  state.suppressedTodoWriteIds.clear();
   delete state.openPlanItemId;
   delete state.openPlanSteps;
 }


### PR DESCRIPTION
- Feature: surface ACP `todo_write` tool calls as canonical plan lifecycle updates.
- Keep plan state current from tool-call updates and complete or remove plans appropriately.
- Parse structured todo inputs and markdown plan updates into consistent step statuses.
- Suppress duplicate todo tool rows while expanding mapper coverage with lifecycle tests.