### PR TITLE
Refresh remote pairing links before expiry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -414,7 +414,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/main/remote/DesktopRemoteAccessController.test.ts
+++ b/src/main/remote/DesktopRemoteAccessController.test.ts
@@ -50,6 +50,7 @@ const h = vi.hoisted(() => ({
     localHttpBaseUrl: "http://127.0.0.1:38987",
     wsBaseUrl: "ws://127.0.0.1:38987/",
     pairingUrl: "http://127.0.0.1:38987/pair?token=startup",
+    pairingExpiresAt: "2026-01-01T00:10:00.000Z",
   } satisfies RemoteAccessServerInfo,
   serverPlans: [] as ServerPlan[],
   servers: [] as FakeServer[],

--- a/src/main/remote/RemoteAccessServer.ts
+++ b/src/main/remote/RemoteAccessServer.ts
@@ -55,6 +55,8 @@ export interface RemoteAccessServerInfo {
   readonly tailscaleHttpBaseUrl?: string;
   readonly wsBaseUrl: string;
   readonly pairingUrl: string;
+  /** ISO expiry of the credential carried by `pairingUrl`. */
+  readonly pairingExpiresAt: string;
 }
 
 export interface RemoteAccessServerOptions {
@@ -322,6 +324,7 @@ export class RemoteAccessServer {
         : {}),
       wsBaseUrl: toWebSocketUrl(httpBaseUrl).toString(),
       pairingUrl: this.mintPairingUrl(httpBaseUrl, pairingCredential.credential),
+      pairingExpiresAt: pairingCredential.expiresAt,
     };
     this.heartbeat.start();
     return this.info;
@@ -459,7 +462,7 @@ export class RemoteAccessServer {
     });
     this.activePairingCredential = issued.credential;
     const pairingUrl = this.mintPairingUrl(info.httpBaseUrl, issued.credential);
-    this.info = { ...info, pairingUrl };
+    this.info = { ...info, pairingUrl, pairingExpiresAt: issued.expiresAt };
     this.notifyPairingChanged();
     return pairingUrl;
   }

--- a/src/main/remote/auth.ts
+++ b/src/main/remote/auth.ts
@@ -14,6 +14,12 @@ import {
   type RemoteWebSocketTicketResult,
 } from "@/shared/remote";
 
+/**
+ * How long a one-time pairing credential stays redeemable. The expiry travels to
+ * the settings UI as `pairingExpiresAt`, so a shown code can be replaced before
+ * it lapses — a code redeemed past its TTL fails as `invalid_pairing_token`,
+ * which reads to the user as an unreachable desktop.
+ */
 const DEFAULT_PAIRING_TTL_MS = 10 * 60 * 1000;
 const DEFAULT_ACCESS_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const DEFAULT_WEBSOCKET_TICKET_TTL_MS = 30 * 1000;

--- a/src/main/remote/pairingInfo.ts
+++ b/src/main/remote/pairingInfo.ts
@@ -18,6 +18,7 @@ export function getRemoteAccessPairingInfo(
     ...(info.tailscaleHttpBaseUrl ? { tailscaleHttpBaseUrl: info.tailscaleHttpBaseUrl } : {}),
     wsBaseUrl: info.wsBaseUrl,
     pairingUrl: info.pairingUrl,
+    pairingExpiresAt: info.pairingExpiresAt,
     sessions: server.listAccessSessions(),
   };
 }

--- a/src/main/remote/server/security.ts
+++ b/src/main/remote/server/security.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { isLoopbackHostname } from "@/shared/http";
 import { REMOTE_COMMAND_ID_HEADER, type RemoteAccessScope } from "@/shared/remote";
 import { parseBearerAuthorizationHeader, RemoteHttpError, type RemoteAuthStore } from "../auth";
 import type { RemoteAccessServerOptions } from "../RemoteAccessServer";
@@ -65,14 +66,7 @@ function isLoopbackWebOrigin(origin: string): boolean {
   try {
     const url = new URL(origin);
     if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-    const host = url.hostname;
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host === "[::1]" ||
-      host.endsWith(".localhost")
-    );
+    return isLoopbackHostname(url.hostname);
   } catch {
     return false;
   }

--- a/src/mobile/pairing.ts
+++ b/src/mobile/pairing.ts
@@ -1,4 +1,9 @@
-import { normalizePairingEndpoint, parsePairingUrlParts } from "@/shared/remote/pairingUrl";
+import {
+  buildPairingUrl,
+  isCleartextLanUrl,
+  normalizePairingEndpoint,
+  parsePairingUrlParts,
+} from "@/shared/remote/pairingUrl";
 import { isNativeApp } from "./pwaInstall";
 
 export interface PairingLaunch {
@@ -113,11 +118,14 @@ export function parsePairingUrl(value: string): PairingLaunch | null {
 
 /**
  * Classify an http LAN endpoint requested from a hosted https page. Chromium
- * can allow this through its Local Network Access permission; browsers without
- * that support block it as mixed content. Loopback is exempt because browsers
- * treat it as a secure context. Native shells are exempt too: they serve the
- * bundle from an https/app scheme origin but allow cleartext LAN traffic
- * themselves (Android `cleartext`/`allowMixedContent`, iOS ATS exceptions).
+ * permits both the `fetch` and the `ws://` event stream once its Local Network
+ * Access permission is granted for the site (a private-IP literal is exempted
+ * from mixed content then); browsers without LNA block them, which is what
+ * {@link desktopServedPairingUrl} exists for. Loopback is exempt because
+ * browsers treat it as a secure context. Native shells are exempt too: they
+ * serve the bundle from an https/app scheme origin but allow cleartext LAN
+ * traffic themselves (Android `cleartext`/`allowMixedContent`, iOS ATS
+ * exceptions).
  */
 export function isMixedContentEndpoint(
   endpoint: string,
@@ -125,18 +133,21 @@ export function isMixedContentEndpoint(
 ): boolean {
   if (isNativeApp()) return false;
   if (location.protocol !== "https:") return false;
+  return isCleartextLanUrl(endpoint);
+}
+
+/**
+ * The escape hatch when a browser refuses a cleartext LAN endpoint: the desktop
+ * serves this very app on its own cleartext origin, where both `fetch` and the
+ * `ws://` event stream are same-scheme and always permitted. Reuses the pairing
+ * credential the user already has, so the handoff completes pairing instead of
+ * restarting it. Returns null when the endpoint is unusable as a URL.
+ */
+export function desktopServedPairingUrl(endpoint: string, credential: string): string | null {
   try {
-    const url = new URL(endpoint);
-    if (url.protocol !== "http:") return false;
-    const host = url.hostname;
-    return !(
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "::1" ||
-      host.endsWith(".localhost")
-    );
+    return buildPairingUrl({ httpBaseUrl: endpoint, credential });
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/src/mobile/routeComponents.test.tsx
+++ b/src/mobile/routeComponents.test.tsx
@@ -2,11 +2,13 @@
 // @vitest-environment-options {"url":"https://app.poracode.com/"}
 import { useEffect, type ReactNode } from "react";
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { toast } from "@heroui/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Project, Thread } from "@/shared/contracts";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { clearPairingLaunch, parsePairingLaunch, setPairingLaunch } from "./pairing";
+import { RemoteClientError } from "./remoteClient";
 import {
   DesktopsRoute,
   NotesRoute,
@@ -31,6 +33,7 @@ const desktopView = vi.hoisted(() => ({
     readonly manualToken: string;
     readonly showPairingHint: boolean;
     readonly onPair: () => void;
+    readonly onOpenDesktopServedApp?: () => void;
   },
 }));
 const mobileViews = vi.hoisted(() => ({
@@ -263,6 +266,7 @@ vi.mock("./views/DesktopsView", () => ({
     readonly manualToken: string;
     readonly showPairingHint: boolean;
     readonly onPair: () => void;
+    readonly onOpenDesktopServedApp?: () => void;
   }) => {
     desktopView.lastProps = props;
     return (
@@ -443,6 +447,90 @@ describe("mobile route components", () => {
     );
     expect(parsePairingLaunch().credential).toBeNull();
     expect(fixtures.navigate).toHaveBeenCalledWith({ to: "/threads" });
+  });
+
+  it("offers the desktop-served handoff after the browser refuses a cleartext LAN endpoint", async () => {
+    setPairingLaunch({
+      endpoint: "http://192.168.1.20:38987/",
+      credential: "lc_pair_once",
+    });
+    // A blocked request rejects at the transport layer, with no response.
+    fixtures.remote.pairDesktop.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    // The suite runs on an https origin (see the environment options above), so
+    // the cleartext LAN endpoint is a mixed-content target here. jsdom's own
+    // `assign` is non-configurable, so stub the whole location for this test.
+    const assign = vi.fn<(url: string) => void>();
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        assign,
+        protocol: original.protocol,
+        origin: original.origin,
+        href: original.href,
+        search: "",
+        hash: "",
+      },
+    });
+
+    try {
+      render(<DesktopsRoute />);
+      expect(desktopView.lastProps?.onOpenDesktopServedApp).toBeUndefined();
+
+      fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+      await waitFor(() => expect(desktopView.lastProps?.onOpenDesktopServedApp).toBeDefined());
+      desktopView.lastProps?.onOpenDesktopServedApp?.();
+    } finally {
+      Object.defineProperty(window, "location", { configurable: true, value: original });
+    }
+
+    expect(assign).toHaveBeenCalledWith("http://192.168.1.20:38987/pair#token=lc_pair_once");
+  });
+
+  it("tells the user to mint a new code when the pairing credential is spent", async () => {
+    setPairingLaunch({ endpoint: "https://desktop.tailnet.ts.net/", credential: "lc_pair_once" });
+    fixtures.remote.pairDesktop.mockRejectedValueOnce(
+      new RemoteClientError("Invalid pairing token.", 401, "invalid_pairing_token"),
+    );
+    const danger = vi.spyOn(toast, "danger");
+
+    render(<DesktopsRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+    await waitFor(() =>
+      expect(danger).toHaveBeenCalledWith(expect.stringContaining("no longer valid")),
+    );
+    danger.mockRestore();
+  });
+
+  it("keeps the desktop's own failure reason instead of blaming the browser", async () => {
+    setPairingLaunch({
+      endpoint: "http://192.168.1.20:38987/",
+      credential: "lc_pair_once",
+    });
+    // A consumed one-time credential is a desktop answer, not a blocked request:
+    // the handoff would not help, so it must stay hidden.
+    fixtures.remote.pairDesktop.mockRejectedValueOnce(
+      new RemoteClientError("Invalid pairing token.", 401, "invalid_pairing_token"),
+    );
+
+    render(<DesktopsRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+    await waitFor(() => expect(fixtures.remote.pairDesktop).toHaveBeenCalled());
+    expect(desktopView.lastProps?.onOpenDesktopServedApp).toBeUndefined();
+  });
+
+  it("omits the desktop-served handoff for a loopback endpoint the browser can already reach", async () => {
+    setPairingLaunch({ endpoint: "http://127.0.0.1:38987/", credential: "lc_pair_once" });
+    fixtures.remote.pairDesktop.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    render(<DesktopsRoute />);
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }));
+
+    await waitFor(() => expect(fixtures.remote.pairDesktop).toHaveBeenCalled());
+    expect(desktopView.lastProps?.onOpenDesktopServedApp).toBeUndefined();
   });
 
   it("renders the empty thread state for a missing routed thread instead of the stale selection", () => {

--- a/src/mobile/routeComponents.tsx
+++ b/src/mobile/routeComponents.tsx
@@ -24,12 +24,14 @@ import {
 } from "./navHelpers";
 import {
   clearPairingLaunch,
+  desktopServedPairingUrl,
   isMixedContentEndpoint,
   normalizePairingEndpoint,
   parsePairingLaunch,
   parsePairingUrl,
   subscribePairingLaunch,
 } from "./pairing";
+import { RemoteClientError } from "./remoteClient";
 import { MobileSetupEmptyState, type MobileSetupKind } from "./setupEmptyState";
 import { isDesktopSettingsSection } from "./settingsSections";
 import type { MobileSshPairRequest } from "./views/DesktopsView";
@@ -384,6 +386,9 @@ export function DesktopsRoute() {
   const canPairManually = Boolean(
     manualPairingLink?.credential || (manualEndpointValue && manualTokenValue),
   );
+  // Set only once the browser has actually refused a cleartext LAN endpoint, so
+  // the escape hatch appears exactly when it is the answer.
+  const [blockedHandoffUrl, setBlockedHandoffUrl] = useState<string | null>(null);
 
   async function pair(endpoint: string, credential: string) {
     let normalizedEndpoint: string;
@@ -393,17 +398,30 @@ export function DesktopsRoute() {
       toast.danger(t`Enter a valid desktop endpoint.`);
       return;
     }
+    setBlockedHandoffUrl(null);
     try {
       await remote.pairDesktop(normalizedEndpoint, credential);
       clearPairingLaunch();
       setManualToken("");
       void navigate({ to: "/threads" });
     } catch (error) {
-      // Chromium can prompt for local-network access and permit this request.
-      // Attempt it before showing fallback guidance so that prompt can appear.
-      if (isMixedContentEndpoint(normalizedEndpoint)) {
+      // A desktop that answered has a real reason (expired credential, rate
+      // limit, protocol mismatch) — report it verbatim rather than blaming the
+      // browser. Only a transport failure can be the page being blocked from a
+      // cleartext LAN endpoint, and Chromium reaches it fine once its local
+      // network permission is granted, so the handoff is the last resort.
+      const remoteError = error instanceof RemoteClientError ? error : null;
+      const answered = (remoteError?.status ?? 0) >= 400;
+      if (!answered && isMixedContentEndpoint(normalizedEndpoint)) {
+        setBlockedHandoffUrl(desktopServedPairingUrl(normalizedEndpoint, credential));
+        toast.danger(t`Couldn't reach the desktop from this HTTPS page.`);
+        return;
+      }
+      // A one-time code is also spent or expired under this status; the desktop's
+      // own "Invalid pairing token." says nothing about how to recover.
+      if (remoteError?.code === "invalid_pairing_token") {
         toast.danger(
-          t`Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS.`,
+          t`That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again.`,
         );
         return;
       }
@@ -460,6 +478,9 @@ export function DesktopsRoute() {
       onTokenChange={setManualToken}
       onPair={submitManualPairing}
       onScan={handleScan}
+      {...(blockedHandoffUrl
+        ? { onOpenDesktopServedApp: () => window.location.assign(blockedHandoffUrl) }
+        : {})}
       onSwitch={(desktop) => {
         void remote.switchDesktop(desktop).then(() => navigate({ to: "/threads" }));
       }}

--- a/src/mobile/views/DesktopsView.tsx
+++ b/src/mobile/views/DesktopsView.tsx
@@ -5,6 +5,7 @@ import { Plural, Trans, useLingui } from "@lingui/react/macro";
 import {
   Check,
   Download,
+  ExternalLink,
   KeyRound,
   Laptop,
   Loader2,
@@ -56,6 +57,12 @@ export interface DesktopsViewProps {
   readonly onPair: () => void;
   /** Raw text decoded from a scanned QR; the route parses + pairs. */
   readonly onScan: (value: string) => void;
+  /**
+   * Present only after this https page failed to reach a cleartext LAN endpoint:
+   * leaves for the copy of the app the desktop serves itself, carrying the same
+   * pairing credential.
+   */
+  readonly onOpenDesktopServedApp?: () => void;
   readonly onSwitch: (desktop: StoredDesktop) => void;
   /** Save a local nickname for the desktop. */
   readonly onRename: (desktop: StoredDesktop, label: string) => void;
@@ -508,6 +515,26 @@ export function DesktopsView(props: DesktopsViewProps) {
         {pairing ? <Loader2 className="size-4 m-spin" /> : <Smartphone className="size-4" />}
         {pairing ? t`Pairing…` : t`Pair`}
       </Button>
+      {props.onOpenDesktopServedApp ? (
+        <>
+          <p className="m-card__hint">
+            <Trans>
+              This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access
+              for this site and pair again, or continue on the desktop's own address.
+            </Trans>
+          </p>
+          <Button
+            className="m-form__submit text-foreground"
+            size="sm"
+            variant="tertiary"
+            isDisabled={pairing ?? false}
+            onPress={props.onOpenDesktopServedApp}
+          >
+            <ExternalLink className="size-4" />
+            <Trans>Continue on the desktop address</Trans>
+          </Button>
+        </>
+      ) : null}
     </div>
   );
   return (

--- a/src/renderer/components/common/SidebarButton.tsx
+++ b/src/renderer/components/common/SidebarButton.tsx
@@ -15,6 +15,12 @@ export function SidebarButton(props: {
   /** Row text size. `xs` is used for thread and worktree list rows. */
   size?: "md" | "xs";
   /**
+   * Row height. `compact` trims the vertical padding (32px → 28px rows) and the
+   * icon-rail button box so long navigation lists — e.g. the settings sidebar —
+   * fit without scrolling, while keeping the icon/label gap of a normal row.
+   */
+  density?: "default" | "compact";
+  /**
    * When set, `liveText` defaults to on unless the state is `inactive` or `done`
    * (same rule as list rows for thread status). Overridden by an explicit `liveText` prop.
    */
@@ -38,6 +44,7 @@ export function SidebarButton(props: {
     isActive = false,
     iconOnly = false,
     size = "md",
+    density = "default",
     statusTone,
     tooltip,
     suffix,
@@ -69,6 +76,7 @@ export function SidebarButton(props: {
         : `${inactiveText} ${!isDraggingAnything ? "hover:bg-[var(--row-hover)] hover:text-foreground" : ""}`;
 
   const sizeClass = size === "xs" ? "text-xs" : "text-sm";
+  const compact = density === "compact";
   const dragRowDim = isDragging && !iconOnly && !isDisabled ? " opacity-60" : "";
 
   if (iconOnly) {
@@ -79,7 +87,7 @@ export function SidebarButton(props: {
           <button
             ref={ref as React.Ref<HTMLButtonElement>}
             aria-label={typeof label === "string" ? label : undefined}
-            className={`flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded-3xl outline-none transition-colors focus-visible:focus-ring ${stateClass} ${className ?? ""}`}
+            className={`flex ${compact ? "h-7 w-7" : "h-8 w-8"} shrink-0 cursor-default items-center justify-center rounded-3xl outline-none transition-colors focus-visible:focus-ring ${stateClass} ${className ?? ""}`}
             disabled={isDisabled}
             onClick={onPress}
             onContextMenu={onContextMenu}
@@ -102,7 +110,7 @@ export function SidebarButton(props: {
       tabIndex={isDisabled ? -1 : 0}
       aria-disabled={isDisabled || undefined}
       aria-grabbed={isDragging}
-      className={`group relative flex w-full shrink-0 cursor-default items-center gap-2 rounded-3xl px-2 py-1.5 text-left ${sizeClass} outline-none transition-colors ${stateClass}${dragRowDim} ${className ?? ""}`}
+      className={`group relative flex w-full shrink-0 cursor-default items-center gap-2 ${compact ? "py-1" : "py-1.5"} rounded-3xl px-2 text-left ${sizeClass} outline-none transition-colors ${stateClass}${dragRowDim} ${className ?? ""}`}
       onClick={isDisabled ? undefined : onPress}
       onDoubleClick={onDoubleClick}
       onContextMenu={onContextMenu}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2581,6 +2581,10 @@ msgstr "In einem anderen Anbieter fortfahren"
 msgid "Continue in..."
 msgstr "Weiter in..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Auf der Desktop-Adresse fortfahren"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Steuert einen externen Chrome-Browser."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Ihre Profilstatistiken konnten nicht geladen werden."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Der Desktop ist nicht erreichbar. Wenn der Browser um Zugriff auf dein lokales Netzwerk gebeten hat, erlaube ihn und kopple erneut. Andernfalls öffne den Kopplungslink direkt vom Desktop (LAN), oder stelle den Desktop über HTTPS bereit."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Der Desktop war von dieser HTTPS-Seite nicht erreichbar."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Der Desktop ist von dieser HTTPS-Seite nicht erreichbar. Fahre auf der Adresse des Desktops fort, um die Kopplung abzuschließen, oder stelle den Desktop über HTTPS bereit."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Der Desktop ist nicht erreichbar. Wenn der Browser um Zugriff auf dein lokales Netzwerk gebeten hat, erlaube ihn und kopple erneut. Andernfalls öffne den Kopplungslink direkt vom Desktop (LAN), oder stelle den Desktop über HTTPS bereit."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Diese Unterhaltung ist nicht mehr verfügbar."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Dieser Kopplungscode ist nicht mehr gültig. Öffne auf dem Desktop Einstellungen → Remotezugriff, drücke „Neuer Code“ und kopple erneut."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Dieser QR-Code ist kein Poracode-Kopplungslink."
 
@@ -9935,6 +9951,14 @@ msgstr "Dieser Browser unterstützt hier keine Systembenachrichtigungen; du sieh
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Dieser Katalog benötigt einen eigenen API-Schlüssel."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Dieser Code läuft in {countdown} ab"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Dieser Code ist abgelaufen."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Diese Verbindung kann Projekte anzeigen, aber nicht verwalten. Kopple erneut, um dies zu aktivieren."
@@ -9961,9 +9985,21 @@ msgstr "Diese Datei verwendet eine nicht unterstützte Kodierung."
 msgid "This folder is empty."
 msgstr "Dieser Ordner ist leer."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Diese HTTPS-Seite konnte den Desktop über einfaches HTTP nicht erreichen. Erlaube dieser Website den Zugriff auf das lokale Netzwerk und kopple erneut, oder fahre auf der Adresse des Desktops fort."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Dieser Link öffnet die App, die Poracode in deinem Netzwerk bereitstellt. Die gehostete App wird über HTTPS ausgeliefert, was Browser daran hindert, einen Desktop über einfaches HTTP zu erreichen."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Dieser Name ist für einen integrierten MCP-Server reserviert."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Diese Seite wird über HTTPS ausgeliefert, daher blockiert der Browser den Zugriff auf einen Desktop über einfaches HTTP. Fahre auf der Adresse des Desktops fort, um die Kopplung dort abzuschließen."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Continue in another provider"
 msgid "Continue in..."
 msgstr "Continue in..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Continue on the desktop address"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Control an external Chrome browser."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Couldn't load your profile stats."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Couldn't reach the desktop from this HTTPS page."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "That conversation is no longer available."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "That QR code isn't a Poracode pairing link."
 
@@ -9935,6 +9951,14 @@ msgstr "This browser does not support system notifications here; you will still 
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "This catalog requires its own API key."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "This code expires in {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "This code has expired."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "This connection can view projects but not manage them. Re-pair to enable."
@@ -9961,9 +9985,21 @@ msgstr "This file uses an unsupported encoding."
 msgid "This folder is empty."
 msgstr "This folder is empty."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "This name is reserved by a built-in MCP server."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Continuar en otro proveedor"
 msgid "Continue in..."
 msgstr "Continuar en..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Continuar en la dirección del escritorio"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Controla un navegador Chrome externo."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "No se pudieron cargar las estadísticas de tu perfil."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "No se pudo conectar con el escritorio. Si el navegador pidió acceso a tu red local, permítelo y vuelve a emparejar. Si no, abre el enlace de emparejamiento directamente desde el escritorio (LAN) o expón el escritorio por HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "No se pudo conectar con el escritorio desde esta página HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "No se pudo conectar con el escritorio desde esta página HTTPS. Continúa en la dirección propia del escritorio para terminar el emparejamiento o expón el escritorio por HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "No se pudo conectar con el escritorio. Si el navegador pidió acceso a tu red local, permítelo y vuelve a emparejar. Si no, abre el enlace de emparejamiento directamente desde el escritorio (LAN) o expón el escritorio por HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Esa conversación ya no está disponible."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Ese código de emparejamiento ya no es válido. Abre Ajustes → Acceso remoto en el escritorio, pulsa «Nuevo código» y vuelve a emparejar."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Ese código QR no es un enlace de emparejamiento de Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Este navegador no admite notificaciones del sistema aquí; seguirás vie
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Este catálogo requiere su propia clave de API."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Este código caduca en {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Este código ha caducado."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Esta conexión puede ver proyectos, pero no administrarlos. Vuelve a emparejarla para habilitarlo."
@@ -9961,9 +9985,21 @@ msgstr "Este archivo usa una codificación no compatible."
 msgid "This folder is empty."
 msgstr "Esta carpeta está vacía."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Esta página HTTPS no pudo conectar con el escritorio en HTTP simple. Permite el acceso a la red local para este sitio y vuelve a emparejar, o continúa en la dirección propia del escritorio."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Este enlace abre la app que Poracode sirve en tu red. La app alojada se sirve por HTTPS, lo que impide que los navegadores lleguen a un escritorio en HTTP simple."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Este nombre está reservado para un servidor MCP integrado."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Esta página se sirve por HTTPS, así que el navegador bloquea el acceso a un escritorio en HTTP simple. Continúa en la dirección propia del escritorio para terminar el emparejamiento allí."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Continuer dans un autre fournisseur"
 msgid "Continue in..."
 msgstr "Continuez dans..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Continuer sur l'adresse de l'ordinateur"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Contrôle un navigateur Chrome externe."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Impossible de charger vos statistiques de profil."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Impossible de joindre l'ordinateur. Si le navigateur a demandé l'accès à votre réseau local, autorisez-le et réessayez l'association. Sinon, ouvrez le lien d'association directement depuis l'ordinateur (LAN) ou exposez l'ordinateur en HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Impossible de joindre l'ordinateur depuis cette page HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Impossible de joindre l'ordinateur depuis cette page HTTPS. Continuez sur l'adresse de l'ordinateur pour terminer l'association, ou exposez l'ordinateur en HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Impossible de joindre l'ordinateur. Si le navigateur a demandé l'accès à votre réseau local, autorisez-le et réessayez l'association. Sinon, ouvrez le lien d'association directement depuis l'ordinateur (LAN) ou exposez l'ordinateur en HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9733,6 +9745,10 @@ msgid "That conversation is no longer available."
 msgstr "Cette conversation n'est plus disponible."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Ce code d'association n'est plus valide. Ouvrez Paramètres → Accès distant sur l'ordinateur, appuyez sur « Nouveau code », puis réessayez l'association."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Ce code QR n'est pas un lien d'appairage Poracode."
 
@@ -9934,6 +9950,14 @@ msgstr "Ce navigateur ne prend pas en charge les notifications système ici ; vo
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Ce catalogue nécessite sa propre clé API."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Ce code expire dans {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Ce code a expiré."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Cette connexion peut voir les projets, mais pas les gérer. Associez-la à nouveau pour l’activer."
@@ -9960,9 +9984,21 @@ msgstr "Ce fichier utilise un encodage non pris en charge."
 msgid "This folder is empty."
 msgstr "Ce dossier est vide."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Cette page HTTPS n'a pas pu joindre l'ordinateur en HTTP simple. Autorisez l'accès au réseau local pour ce site puis réessayez l'association, ou continuez sur l'adresse de l'ordinateur."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Ce lien ouvre l'application que Poracode sert sur votre réseau. L'application hébergée est servie en HTTPS, ce qui empêche les navigateurs de joindre un ordinateur en HTTP simple."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Ce nom est réservé à un serveur MCP intégré."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Cette page est servie en HTTPS, le navigateur bloque donc l'accès à un ordinateur en HTTP simple. Continuez sur l'adresse de l'ordinateur pour y terminer l'association."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2580,6 +2580,10 @@ msgstr "別のプロバイダーで続行する"
 msgid "Continue in..."
 msgstr "...で続行"
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "デスクトップのアドレスで続ける"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "外部の Chrome ブラウザを操作します。"
@@ -2792,8 +2796,16 @@ msgid "Couldn't load your profile stats."
 msgstr "プロフィール統計を読み込めませんでした。"
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "デスクトップに接続できませんでした。ブラウザがローカルネットワークへのアクセスを求めた場合は、許可してから再度ペアリングしてください。それ以外の場合は、デスクトップ（LAN）からペアリングリンクを直接開くか、デスクトップを HTTPS で公開してください。"
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "この HTTPS ページからデスクトップに接続できませんでした。"
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "この HTTPS ページからデスクトップに接続できませんでした。デスクトップ自身のアドレスで続けてペアリングを完了するか、デスクトップを HTTPS で公開してください。"
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "デスクトップに接続できませんでした。ブラウザがローカルネットワークへのアクセスを求めた場合は、許可してから再度ペアリングしてください。それ以外の場合は、デスクトップ（LAN）からペアリングリンクを直接開くか、デスクトップを HTTPS で公開してください。"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9732,6 +9744,10 @@ msgid "That conversation is no longer available."
 msgstr "その会話は利用できなくなりました。"
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "このペアリングコードは無効になりました。デスクトップで設定 → リモートアクセスを開き、「新しいコード」を押してから再度ペアリングしてください。"
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "その QR コードは Poracode のペアリングリンクではありません。"
 
@@ -9933,6 +9949,14 @@ msgstr "このブラウザはここでシステム通知をサポートしてい
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "このカタログには専用の API キーが必要です。"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "このコードは {countdown} で期限切れになります"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "このコードは期限切れです。"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "この接続ではプロジェクトを表示できますが、管理はできません。有効にするには再度ペアリングしてください。"
@@ -9959,9 +9983,21 @@ msgstr "このファイルはサポートされていないエンコーディン
 msgid "This folder is empty."
 msgstr "このフォルダーは空です。"
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "この HTTPS ページは平文 HTTP のデスクトップに接続できませんでした。このサイトにローカルネットワークへのアクセスを許可して再度ペアリングするか、デスクトップ自身のアドレスで続けてください。"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "このリンクは Poracode がネットワーク上で提供しているアプリを開きます。ホスト版のアプリは HTTPS で配信されるため、ブラウザは平文 HTTP のデスクトップに接続できません。"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "この名前は組み込みMCPサーバーによって予約されています。"
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "このページは HTTPS で配信されているため、ブラウザは平文 HTTP のデスクトップへの接続をブロックします。デスクトップ自身のアドレスで続けて、そこでペアリングを完了してください。"
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2581,6 +2581,10 @@ msgstr "다른 제공업체에서 계속"
 msgid "Continue in..."
 msgstr "다음에서 계속..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "데스크톱 주소에서 계속"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "외부 Chrome 브라우저를 제어합니다."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "프로필 통계를 불러오지 못했습니다."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "데스크톱에 연결할 수 없습니다. 브라우저가 로컬 네트워크 접근을 요청했다면 허용한 뒤 다시 페어링하세요. 그렇지 않으면 데스크톱(LAN)에서 페어링 링크를 직접 열거나 데스크톱을 HTTPS로 노출하세요."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "이 HTTPS 페이지에서는 데스크톱에 연결할 수 없습니다."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "이 HTTPS 페이지에서는 데스크톱에 연결할 수 없습니다. 데스크톱 자체 주소에서 계속해 페어링을 완료하거나 데스크톱을 HTTPS로 노출하세요."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "데스크톱에 연결할 수 없습니다. 브라우저가 로컬 네트워크 접근을 요청했다면 허용한 뒤 다시 페어링하세요. 그렇지 않으면 데스크톱(LAN)에서 페어링 링크를 직접 열거나 데스크톱을 HTTPS로 노출하세요."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "해당 대화는 더 이상 사용할 수 없습니다."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "이 페어링 코드는 더 이상 유효하지 않습니다. 데스크톱에서 설정 → 원격 액세스를 열고 '새 코드'를 누른 뒤 다시 페어링하세요."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "이 QR 코드는 Poracode 페어링 링크가 아닙니다."
 
@@ -9935,6 +9951,14 @@ msgstr "이 브라우저는 여기에서 시스템 알림을 지원하지 않습
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "이 카탈로그에는 자체 API 키가 필요합니다."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "이 코드는 {countdown} 후 만료됩니다"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "이 코드는 만료되었습니다."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "이 연결은 프로젝트를 볼 수 있지만 관리할 수 없습니다. 활성화하려면 다시 페어링하세요."
@@ -9961,9 +9985,21 @@ msgstr "이 파일은 지원되지 않는 인코딩을 사용합니다."
 msgid "This folder is empty."
 msgstr "이 폴더는 비어 있습니다."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "이 HTTPS 페이지는 일반 HTTP 데스크톱에 연결할 수 없었습니다. 이 사이트에 로컬 네트워크 접근을 허용한 뒤 다시 페어링하거나, 데스크톱 자체 주소에서 계속하세요."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "이 링크는 Poracode가 네트워크에서 제공하는 앱을 엽니다. 호스팅된 앱은 HTTPS로 제공되므로 브라우저가 일반 HTTP 데스크톱에 연결하는 것을 차단합니다."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "이 이름은 기본 제공 MCP 서버용으로 예약되어 있습니다."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "이 페이지는 HTTPS로 제공되므로 브라우저가 일반 HTTP 데스크톱 연결을 차단합니다. 데스크톱 자체 주소에서 계속해 거기서 페어링을 완료하세요."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Kontynuuj u innego dostawcy"
 msgid "Continue in..."
 msgstr "Kontynuuj w..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Kontynuuj na adresie desktopa"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Steruje zewnętrzną przeglądarką Chrome."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Nie udało się wczytać statystyk profilu."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Nie udało się połączyć z desktopem. Jeśli przeglądarka poprosiła o dostęp do sieci lokalnej, zezwól na niego i sparuj ponownie. W przeciwnym razie otwórz link parowania bezpośrednio z desktopa (LAN) albo udostępnij desktop przez HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Nie udało się połączyć z desktopem z tej strony HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Nie udało się połączyć z desktopem z tej strony HTTPS. Kontynuuj na własnym adresie desktopa, aby zakończyć parowanie, albo udostępnij desktop przez HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Nie udało się połączyć z desktopem. Jeśli przeglądarka poprosiła o dostęp do sieci lokalnej, zezwól na niego i sparuj ponownie. W przeciwnym razie otwórz link parowania bezpośrednio z desktopa (LAN) albo udostępnij desktop przez HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Ta rozmowa nie jest już dostępna."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Ten kod parowania jest już nieważny. Otwórz na desktopie Ustawienia → Dostęp zdalny, naciśnij „Nowy kod” i sparuj ponownie."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Ten kod QR nie jest linkiem parowania Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Ta przeglądarka nie obsługuje tutaj powiadomień systemowych; nadal zo
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Ten katalog wymaga własnego klucza API."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Ten kod wygasa za {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Ten kod wygasł."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "To połączenie może wyświetlać projekty, ale nie może nimi zarządzać. Sparuj ponownie, aby włączyć."
@@ -9961,9 +9985,21 @@ msgstr "Ten plik używa nieobsługiwanego kodowania."
 msgid "This folder is empty."
 msgstr "Ten folder jest pusty."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Ta strona HTTPS nie mogła połączyć się z desktopem po zwykłym HTTP. Zezwól tej witrynie na dostęp do sieci lokalnej i sparuj ponownie albo kontynuuj na własnym adresie desktopa."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Ten link otwiera aplikację, którą Poracode udostępnia w twojej sieci. Hostowana aplikacja jest serwowana przez HTTPS, co blokuje przeglądarkom dostęp do desktopa po zwykłym HTTP."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Ta nazwa jest zastrzeżona przez wbudowany serwer MCP."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Ta strona jest serwowana przez HTTPS, więc przeglądarka blokuje dostęp do desktopa po zwykłym HTTP. Kontynuuj na własnym adresie desktopa, aby zakończyć tam parowanie."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Continuar em outro provedor"
 msgid "Continue in..."
 msgstr "Continuar em..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Continuar no endereço do desktop"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Controla um navegador Chrome externo."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Não foi possível carregar as estatísticas do seu perfil."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Não foi possível alcançar o desktop. Se o navegador pediu acesso à sua rede local, permita e pareie novamente. Caso contrário, abra o link de pareamento diretamente no desktop (LAN) ou exponha o desktop por HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Não foi possível alcançar o desktop nesta página HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Não foi possível alcançar o desktop nesta página HTTPS. Continue no endereço do próprio desktop para concluir o pareamento ou exponha o desktop por HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Não foi possível alcançar o desktop. Se o navegador pediu acesso à sua rede local, permita e pareie novamente. Caso contrário, abra o link de pareamento diretamente no desktop (LAN) ou exponha o desktop por HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Essa conversa não está mais disponível."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Esse código de pareamento não é mais válido. Abra Configurações → Acesso remoto no desktop, pressione “Novo código” e pareie novamente."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Esse código QR não é um link de pareamento do Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Este navegador não oferece suporte a notificações do sistema aqui; vo
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Este catálogo requer uma chave de API própria."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Este código expira em {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Este código expirou."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Esta conexão pode ver projetos, mas não gerenciá-los. Faça o pareamento novamente para habilitar."
@@ -9961,9 +9985,21 @@ msgstr "Este arquivo usa uma codificação não suportada."
 msgid "This folder is empty."
 msgstr "Esta pasta está vazia."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Esta página HTTPS não conseguiu alcançar o desktop em HTTP simples. Permita o acesso à rede local para este site e pareie novamente, ou continue no endereço do próprio desktop."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Este link abre o app que o Poracode serve na sua rede. O app hospedado é servido por HTTPS, o que impede os navegadores de alcançar um desktop em HTTP simples."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Este nome é reservado por um servidor MCP integrado."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Esta página é servida por HTTPS, então o navegador bloqueia o acesso a um desktop em HTTP simples. Continue no endereço do próprio desktop para concluir o pareamento lá."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Продолжить в другом провайдере"
 msgid "Continue in..."
 msgstr "Продолжить в..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Продолжить по адресу десктопа"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Управляет внешним браузером Chrome."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Не удалось загрузить статистику профиля."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Не удалось подключиться к десктопу. Если браузер запросил доступ к локальной сети, разрешите его и повторите привязку. Иначе откройте ссылку привязки напрямую с десктопа (LAN) или предоставьте доступ к десктопу через HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Не удалось подключиться к десктопу с этой HTTPS-страницы."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Не удалось подключиться к десктопу с этой HTTPS-страницы. Продолжите по собственному адресу десктопа, чтобы завершить привязку, или предоставьте доступ к десктопу через HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Не удалось подключиться к десктопу. Если браузер запросил доступ к локальной сети, разрешите его и повторите привязку. Иначе откройте ссылку привязки напрямую с десктопа (LAN) или предоставьте доступ к десктопу через HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Эта беседа больше недоступна."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Этот код привязки больше не действует. Откройте на десктопе Настройки → Удалённый доступ, нажмите «Новый код» и повторите привязку."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Этот QR-код не является ссылкой для сопряжения Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Этот браузер не поддерживает здесь сис�
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Для этого каталога требуется отдельный ключ API."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Код истекает через {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Срок действия кода истёк."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Это подключение может просматривать проекты, но не управлять ими. Выполните сопряжение заново, чтобы включить управление."
@@ -9961,9 +9985,21 @@ msgstr "Этот файл использует неподдерживаемую 
 msgid "This folder is empty."
 msgstr "Эта папка пуста."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Эта HTTPS-страница не смогла обратиться к десктопу по обычному HTTP. Разрешите этому сайту доступ к локальной сети и повторите привязку либо продолжите по собственному адресу десктопа."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Эта ссылка открывает приложение, которое Poracode раздаёт в вашей сети. Размещённое приложение работает по HTTPS, поэтому браузеры блокируют обращение к десктопу по обычному HTTP."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Это имя зарезервировано встроенным сервером MCP."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Эта страница работает по HTTPS, поэтому браузер блокирует обращение к десктопу по обычному HTTP. Продолжите по собственному адресу десктопа, чтобы завершить привязку там."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Başka bir sağlayıcıda devam et"
 msgid "Continue in..."
 msgstr "Şurada devam et..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Masaüstü adresinde devam et"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Harici bir Chrome tarayıcısını kontrol eder."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Profil istatistikleriniz yüklenemedi."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Masaüstüne ulaşılamadı. Tarayıcı yerel ağınıza erişim istediyse izin verin ve yeniden eşleştirin. Aksi halde eşleştirme bağlantısını doğrudan masaüstünden (LAN) açın veya masaüstünü HTTPS üzerinden yayımlayın."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Bu HTTPS sayfasından masaüstüne ulaşılamadı."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Bu HTTPS sayfasından masaüstüne ulaşılamadı. Eşleştirmeyi tamamlamak için masaüstünün kendi adresinde devam edin veya masaüstünü HTTPS üzerinden yayımlayın."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Masaüstüne ulaşılamadı. Tarayıcı yerel ağınıza erişim istediyse izin verin ve yeniden eşleştirin. Aksi halde eşleştirme bağlantısını doğrudan masaüstünden (LAN) açın veya masaüstünü HTTPS üzerinden yayımlayın."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Bu konuşma artık kullanılamıyor."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Bu eşleştirme kodu artık geçerli değil. Masaüstünde Ayarlar → Uzaktan Erişim'i açın, «Yeni kod»a basın ve yeniden eşleştirin."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Bu QR kodu bir Poracode eşleştirme bağlantısı değil."
 
@@ -9935,6 +9951,14 @@ msgstr "Bu tarayıcı burada sistem bildirimlerini desteklemiyor; uygulama içi 
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Bu katalog kendi API anahtarını gerektirir."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Bu kodun süresi {countdown} içinde doluyor"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Bu kodun süresi doldu."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Bu bağlantı projeleri görüntüleyebilir ancak yönetemez. Etkinleştirmek için yeniden eşleştirin."
@@ -9961,9 +9985,21 @@ msgstr "Bu dosya desteklenmeyen bir kodlama kullanıyor."
 msgid "This folder is empty."
 msgstr "Bu klasör boş."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Bu HTTPS sayfası düz HTTP kullanan masaüstüne ulaşamadı. Bu siteye yerel ağ erişimi izni verip yeniden eşleştirin veya masaüstünün kendi adresinde devam edin."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Bu bağlantı, Poracode'un ağınızda sunduğu uygulamayı açar. Barındırılan uygulama HTTPS üzerinden sunulduğu için tarayıcılar düz HTTP kullanan bir masaüstüne erişimi engeller."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Bu ad, yerleşik bir MCP sunucusu için ayrılmıştır."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Bu sayfa HTTPS üzerinden sunuluyor, bu yüzden tarayıcı düz HTTP kullanan bir masaüstüne erişimi engelliyor. Eşleştirmeyi orada tamamlamak için masaüstünün kendi adresinde devam edin."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Продовжити в іншому провайдері"
 msgid "Continue in..."
 msgstr "Продовжити в..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Продовжити за адресою десктопа"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Керує зовнішнім браузером Chrome."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Не вдалося завантажити статистику профілю."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Не вдалося з'єднатися з десктопом. Якщо браузер запросив доступ до локальної мережі, дозвольте його та повторіть підключення. Інакше відкрийте посилання підключення безпосередньо з десктопа (LAN) або надайте доступ до десктопа через HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Не вдалося з'єднатися з десктопом із цієї HTTPS-сторінки."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Не вдалося з'єднатися з десктопом із цієї HTTPS-сторінки. Продовжте за власною адресою десктопа, щоб завершити підключення, або надайте доступ до десктопа через HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Не вдалося з'єднатися з десктопом. Якщо браузер запросив доступ до локальної мережі, дозвольте його та повторіть підключення. Інакше відкрийте посилання підключення безпосередньо з десктопа (LAN) або надайте доступ до десктопа через HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Ця розмова більше недоступна."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Цей код підключення більше не діє. Відкрийте на десктопі Налаштування → Віддалений доступ, натисніть «Новий код» і повторіть підключення."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Цей QR-код не є посиланням для сполучення Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Цей браузер не підтримує тут системні с
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Для цього каталогу потрібен окремий ключ API."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Код спливає за {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Термін дії коду сплив."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Це підключення може переглядати проєкти, але не керувати ними. Створіть сполучення заново, щоб увімкнути керування."
@@ -9961,9 +9985,21 @@ msgstr "Цей файл використовує непідтримуване к
 msgid "This folder is empty."
 msgstr "Ця папка порожня."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Ця HTTPS-сторінка не змогла звернутися до десктопа через звичайний HTTP. Дозвольте цьому сайту доступ до локальної мережі та повторіть підключення або продовжте за власною адресою десктопа."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Це посилання відкриває застосунок, який Poracode роздає у вашій мережі. Розміщений застосунок працює через HTTPS, тому браузери блокують звернення до десктопа через звичайний HTTP."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Цю назву зарезервовано вбудованим сервером MCP."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Ця сторінка працює через HTTPS, тому браузер блокує звернення до десктопа через звичайний HTTP. Продовжте за власною адресою десктопа, щоб завершити підключення там."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2581,6 +2581,10 @@ msgstr "Tiếp tục ở nhà cung cấp khác"
 msgid "Continue in..."
 msgstr "Tiếp tục trong..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "Tiếp tục trên địa chỉ của desktop"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "Điều khiển trình duyệt Chrome bên ngoài."
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "Không thể tải thống kê hồ sơ của bạn."
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "Không thể kết nối với desktop. Nếu trình duyệt yêu cầu quyền truy cập mạng cục bộ, hãy cho phép rồi ghép đôi lại. Nếu không, hãy mở liên kết ghép đôi trực tiếp từ desktop (LAN), hoặc cung cấp desktop qua HTTPS."
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "Không thể kết nối với desktop từ trang HTTPS này."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "Không thể kết nối với desktop từ trang HTTPS này. Hãy tiếp tục trên địa chỉ riêng của desktop để hoàn tất ghép đôi, hoặc cung cấp desktop qua HTTPS."
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "Không thể kết nối với desktop. Nếu trình duyệt yêu cầu quyền truy cập mạng cục bộ, hãy cho phép rồi ghép đôi lại. Nếu không, hãy mở liên kết ghép đôi trực tiếp từ desktop (LAN), hoặc cung cấp desktop qua HTTPS."
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9734,6 +9746,10 @@ msgid "That conversation is no longer available."
 msgstr "Cuộc trò chuyện đó không còn khả dụng."
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "Mã ghép đôi này không còn hiệu lực. Trên desktop, hãy mở Cài đặt → Truy cập từ xa, nhấn “Mã mới” rồi ghép đôi lại."
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "Mã QR đó không phải là liên kết ghép nối Poracode."
 
@@ -9935,6 +9951,14 @@ msgstr "Trình duyệt này không hỗ trợ thông báo hệ thống ở đây
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "Danh mục này yêu cầu khóa API riêng."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "Mã này hết hạn sau {countdown}"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "Mã này đã hết hạn."
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "Kết nối này có thể xem dự án nhưng không thể quản lý. Hãy ghép nối lại để bật."
@@ -9961,9 +9985,21 @@ msgstr "Tệp này sử dụng mã hóa không được hỗ trợ."
 msgid "This folder is empty."
 msgstr "Thư mục này trống."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "Trang HTTPS này không thể kết nối tới desktop dùng HTTP thuần. Hãy cho phép trang này truy cập mạng cục bộ rồi ghép đôi lại, hoặc tiếp tục trên địa chỉ riêng của desktop."
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "Liên kết này mở ứng dụng mà Poracode phục vụ trong mạng của bạn. Ứng dụng được host chạy qua HTTPS, nên trình duyệt chặn việc kết nối tới desktop dùng HTTP thuần."
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "Tên này được dành riêng cho máy chủ MCP tích hợp sẵn."
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "Trang này được phục vụ qua HTTPS, nên trình duyệt chặn việc kết nối tới desktop dùng HTTP thuần. Hãy tiếp tục trên địa chỉ riêng của desktop để hoàn tất ghép đôi ở đó."
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2581,6 +2581,10 @@ msgstr "继续使用另一个提供商"
 msgid "Continue in..."
 msgstr "在其他工具中继续..."
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "Continue on the desktop address"
+msgstr "在桌面地址上继续"
+
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Control an external Chrome browser."
 msgstr "控制外部 Chrome 浏览器。"
@@ -2793,8 +2797,16 @@ msgid "Couldn't load your profile stats."
 msgstr "无法加载你的资料统计。"
 
 #: src/mobile/routeComponents.tsx
-msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
-msgstr "无法连接到桌面。如果浏览器请求访问你的本地网络，请允许后重新配对。否则请直接从桌面（LAN）打开配对链接，或通过 HTTPS 暴露桌面。"
+msgid "Couldn't reach the desktop from this HTTPS page."
+msgstr "无法从此 HTTPS 页面连接到桌面。"
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop from this HTTPS page. Continue on the desktop's own address to finish pairing, or expose the desktop over HTTPS."
+#~ msgstr "无法从此 HTTPS 页面连接到桌面。请在桌面自身的地址上继续以完成配对，或通过 HTTPS 暴露桌面。"
+
+#: src/mobile/routeComponents.tsx
+#~ msgid "Couldn't reach the desktop. If the browser asked to access your local network, allow it and pair again. Otherwise open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
+#~ msgstr "无法连接到桌面。如果浏览器请求访问你的本地网络，请允许后重新配对。否则请直接从桌面（LAN）打开配对链接，或通过 HTTPS 暴露桌面。"
 
 #: src/renderer/views/SettingsOverlay/parts/ShortcutsSettings.tsx
 msgid "Couldn't save the shortcut."
@@ -9733,6 +9745,10 @@ msgid "That conversation is no longer available."
 msgstr "该对话已不可用。"
 
 #: src/mobile/routeComponents.tsx
+msgid "That pairing code is no longer valid. Open Settings → Remote Access on the desktop, press New code, and pair again."
+msgstr "该配对代码已失效。请在桌面上打开“设置 → 远程访问”，点击“新代码”后重新配对。"
+
+#: src/mobile/routeComponents.tsx
 msgid "That QR code isn't a Poracode pairing link."
 msgstr "该二维码不是 Poracode 的配对链接。"
 
@@ -9934,6 +9950,14 @@ msgstr "此浏览器不支持在此处显示系统通知；你仍会看到应用
 #~ msgid "This catalog requires its own API key."
 #~ msgstr "此目录需要自己的 API 密钥。"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code expires in {countdown}"
+msgstr "此代码将在 {countdown} 后过期"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+msgid "This code has expired."
+msgstr "此代码已过期。"
+
 #: src/mobile/views/ManageProjectsView.tsx
 msgid "This connection can view projects but not manage them. Re-pair to enable."
 msgstr "此连接可以查看项目，但不能管理项目。请重新配对以启用。"
@@ -9960,9 +9984,21 @@ msgstr "此文件使用不受支持的编码。"
 msgid "This folder is empty."
 msgstr "此文件夹为空。"
 
+#: src/mobile/views/DesktopsView.tsx
+msgid "This HTTPS page couldn't reach the desktop on plain HTTP. Allow local network access for this site and pair again, or continue on the desktop's own address."
+msgstr "此 HTTPS 页面无法连接使用纯 HTTP 的桌面。请允许该站点访问本地网络后重新配对，或在桌面自身的地址上继续。"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+#~ msgid "This link opens the app Poracode serves on your network. The hosted app is served over HTTPS, which browsers block from reaching a plain-HTTP desktop."
+#~ msgstr "此链接会打开 Poracode 在你网络中提供的应用。托管版应用通过 HTTPS 提供，浏览器会因此阻止它连接使用纯 HTTP 的桌面。"
+
 #: src/renderer/components/mcp/McpServerEditor.tsx
 msgid "This name is reserved by a built-in MCP server."
 msgstr "此名称由内置 MCP 服务器保留。"
+
+#: src/mobile/views/DesktopsView.tsx
+#~ msgid "This page is served over HTTPS, so the browser blocks it from reaching a desktop on plain HTTP. Continue on the desktop's own address to finish pairing there."
+#~ msgstr "此页面通过 HTTPS 提供，因此浏览器会阻止它连接使用纯 HTTP 的桌面。请在桌面自身的地址上继续，在那里完成配对。"
 
 #. placeholder {0}: pendingDelete.branch.name
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx

--- a/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.test.tsx
@@ -41,19 +41,32 @@ vi.mock("qrcode", () => ({
   toDataURL: toDataURLMock,
 }));
 
+/** ISO expiry `offsetMs` from now, for the countdown / rotation scheduling. */
+function expiryFromNow(offsetMs: number): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+/** A ready server; the code is fresh by default, so nothing rotates on open. */
+function readyInfo(
+  token: string,
+  pairingExpiresAt: string = expiryFromNow(10 * 60_000),
+): RemoteAccessPairingInfo {
+  return {
+    status: "ready",
+    httpBaseUrl: "https://desktop.tailnet.ts.net/",
+    localHttpBaseUrl: "http://192.168.1.20:49152",
+    tailscaleHttpBaseUrl: "https://desktop.tailnet.ts.net",
+    wsBaseUrl: "wss://desktop.tailnet.ts.net/",
+    pairingUrl: `https://poracode.com/pair?host=https%3A%2F%2Fdesktop.tailnet.ts.net%2F#token=${token}`,
+    pairingExpiresAt,
+    sessions: [],
+  };
+}
+
 describe("RemoteAccessSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    bridgeMock.getRemoteAccessPairing.mockResolvedValue({
-      status: "ready",
-      httpBaseUrl: "https://desktop.tailnet.ts.net/",
-      localHttpBaseUrl: "http://192.168.1.20:49152",
-      tailscaleHttpBaseUrl: "https://desktop.tailnet.ts.net",
-      wsBaseUrl: "wss://desktop.tailnet.ts.net/",
-      pairingUrl:
-        "https://poracode.com/pair?host=https%3A%2F%2Fdesktop.tailnet.ts.net%2F#token=lc_pair_test",
-      sessions: [],
-    });
+    bridgeMock.getRemoteAccessPairing.mockResolvedValue(readyInfo("lc_pair_test"));
     bridgeMock.refreshRemoteAccessPairing.mockImplementation(() =>
       bridgeMock.getRemoteAccessPairing(),
     );
@@ -100,33 +113,55 @@ describe("RemoteAccessSettings", () => {
 
     expect(await screen.findByText("lc_pair_test")).toBeInTheDocument();
     act(() => {
-      pairingChangedState.listener?.({
-        status: "ready",
-        httpBaseUrl: "https://desktop.tailnet.ts.net/",
-        localHttpBaseUrl: "http://192.168.1.20:49152",
-        tailscaleHttpBaseUrl: "https://desktop.tailnet.ts.net",
-        wsBaseUrl: "wss://desktop.tailnet.ts.net/",
-        pairingUrl:
-          "https://poracode.com/pair?host=https%3A%2F%2Fdesktop.tailnet.ts.net%2F#token=lc_pair_rotated",
-        sessions: [],
-      });
+      pairingChangedState.listener?.(readyInfo("lc_pair_rotated"));
     });
 
     expect(await screen.findByText("lc_pair_rotated")).toBeInTheDocument();
     expect(screen.queryByText("lc_pair_test")).not.toBeInTheDocument();
   });
 
+  it("mints on open when the server's code has already lapsed", async () => {
+    // The server mints its startup code once, with a 10-minute TTL; a panel
+    // opened later must not show a credential the desktop has already dropped.
+    bridgeMock.getRemoteAccessPairing.mockResolvedValue(
+      readyInfo("lc_pair_lapsed", expiryFromNow(-60_000)),
+    );
+    bridgeMock.refreshRemoteAccessPairing.mockResolvedValue(readyInfo("lc_pair_fresh"));
+
+    render(<RemoteAccessSettings />);
+
+    expect(await screen.findByText("lc_pair_fresh")).toBeInTheDocument();
+    expect(bridgeMock.refreshRemoteAccessPairing).toHaveBeenCalled();
+  });
+
+  it("counts down the displayed code's remaining validity", async () => {
+    bridgeMock.getRemoteAccessPairing.mockResolvedValue(
+      readyInfo("lc_pair_timed", expiryFromNow(5 * 60_000)),
+    );
+
+    render(<RemoteAccessSettings />);
+
+    // 5:00, or 4:59 if the render lands after the first second ticks over.
+    expect(await screen.findByText(/This code expires in [45]:\d\d/)).toBeInTheDocument();
+    // A fresh code is left alone — no needless rotation just because it is shown.
+    expect(bridgeMock.refreshRemoteAccessPairing).not.toHaveBeenCalled();
+  });
+
+  it("mints ahead of a code that is about to lapse", async () => {
+    bridgeMock.getRemoteAccessPairing.mockResolvedValue(
+      readyInfo("lc_pair_stale", expiryFromNow(10_000)),
+    );
+    bridgeMock.refreshRemoteAccessPairing.mockResolvedValue(
+      readyInfo("lc_pair_renewed", expiryFromNow(10 * 60_000)),
+    );
+
+    render(<RemoteAccessSettings />);
+
+    expect(await screen.findByText("lc_pair_renewed")).toBeInTheDocument();
+  });
+
   it("retires the displayed code when New code is pressed", async () => {
-    bridgeMock.refreshRemoteAccessPairing.mockResolvedValue({
-      status: "ready",
-      httpBaseUrl: "https://desktop.tailnet.ts.net/",
-      localHttpBaseUrl: "http://192.168.1.20:49152",
-      tailscaleHttpBaseUrl: "https://desktop.tailnet.ts.net",
-      wsBaseUrl: "wss://desktop.tailnet.ts.net/",
-      pairingUrl:
-        "https://poracode.com/pair?host=https%3A%2F%2Fdesktop.tailnet.ts.net%2F#token=lc_pair_manual",
-      sessions: [],
-    });
+    bridgeMock.refreshRemoteAccessPairing.mockResolvedValue(readyInfo("lc_pair_manual"));
     render(<RemoteAccessSettings />);
 
     expect(await screen.findByText("lc_pair_test")).toBeInTheDocument();

--- a/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -127,6 +127,39 @@ function RemoteAccessHeaderDescription(props: {
   );
 }
 
+/** Mint the next code this long before the current one lapses. */
+const PAIRING_ROTATE_LEAD_MS = 60_000;
+
+function formatCountdown(remainingMs: number): string {
+  const totalSeconds = Math.ceil(remainingMs / 1000);
+  return `${Math.floor(totalSeconds / 60)}:${String(totalSeconds % 60).padStart(2, "0")}`;
+}
+
+/**
+ * The single reading of a code's expiry, shared by the countdown and the
+ * rotation timer so they cannot disagree. An unparseable value counts as lapsed:
+ * the UI says so and rotation mints immediately, which repairs it.
+ */
+function pairingExpiryMs(expiresAt: string): number {
+  const expiresAtMs = new Date(expiresAt).getTime();
+  return Number.isFinite(expiresAtMs) ? expiresAtMs : 0;
+}
+
+/** Milliseconds left on the displayed code, re-read every second until it lapses. */
+function usePairingCodeRemainingMs(expiresAt: string): number {
+  const expiresAtMs = pairingExpiryMs(expiresAt);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    // Stop once the code has lapsed — further ticks cannot change the output.
+    const timer = setInterval(() => {
+      setNowMs(Date.now());
+      if (Date.now() >= expiresAtMs) clearInterval(timer);
+    }, 1_000);
+    return () => clearInterval(timer);
+  }, [expiresAtMs]);
+  return Math.max(0, expiresAtMs - nowMs);
+}
+
 function CopyValueRow(props: {
   label: string;
   value: string;
@@ -257,6 +290,8 @@ function PairingReady(props: {
     : normalizePairingEndpoint(props.info.httpBaseUrl);
   const pairingUrl = retargetPairingUrl(props.info.pairingUrl, selectedEndpoint);
   const pairingToken = pairingTokenFromUrl(pairingUrl);
+  const remainingMs = usePairingCodeRemainingMs(props.info.pairingExpiresAt);
+  const countdown = formatCountdown(remainingMs);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -342,6 +377,9 @@ function PairingReady(props: {
               <Trans>New code</Trans>
             </Button>
           </div>
+          <p className="text-xs text-muted">
+            {remainingMs > 0 ? t`This code expires in ${countdown}` : t`This code has expired.`}
+          </p>
         </div>
 
         <div className="min-w-0 space-y-1">
@@ -708,6 +746,35 @@ export function RemoteAccessSettings() {
       unsubscribe();
     };
   }, [t]);
+
+  // The code on screen is one-time and short-lived, but the server mints it once
+  // at startup — so a panel opened hours later would show a credential the
+  // desktop has already dropped, and pairing would fail with "Invalid pairing
+  // token" as if the desktop were unreachable. Keep the displayed code inside
+  // its own advertised window: rotating re-runs this with the new expiry, which
+  // schedules the next mint. A code that is still fresh is left alone.
+  const pairingExpiresAt = state.info?.status === "ready" ? state.info.pairingExpiresAt : undefined;
+  useEffect(() => {
+    if (!pairingExpiresAt) return;
+    let cancelled = false;
+    const rotate = async () => {
+      try {
+        const info = await readBridge().refreshRemoteAccessPairing();
+        if (!cancelled) setState(pairingViewStateFromInfo(info));
+      } catch {
+        // Keep the current code on a transient failure; "New code" still works.
+      }
+    };
+    // An already-lapsed code mints immediately (zero delay); a fresh one waits.
+    const timer = setTimeout(
+      () => void rotate(),
+      Math.max(0, pairingExpiryMs(pairingExpiresAt) - PAIRING_ROTATE_LEAD_MS - Date.now()),
+    );
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [pairingExpiresAt]);
 
   const refresh = async () => {
     setIsRefreshing(true);

--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -103,6 +103,15 @@ type SearchRow =
 type SectionMeta = { id: SettingsSection; icon: ReactNode; label: string };
 
 /**
+ * Settings navigation row. The section list is long (5 groups, ~25 rows plus the
+ * expandable agents tree), so every row here uses the compact density to keep the
+ * whole list reachable without scrolling.
+ */
+function SettingsNavButton(props: React.ComponentProps<typeof SidebarButton>) {
+  return <SidebarButton density="compact" {...props} />;
+}
+
+/**
  * A settings-search result row: a small section "eyebrow" (icon + section name)
  * above the matched setting text (its title, or a description snippet when only
  * the description matched). Clicking navigates to the section and scrolls to the
@@ -118,7 +127,7 @@ function SettingsSearchResultRow(props: {
     <button
       type="button"
       onClick={props.onPress}
-      className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-1.5 text-left transition-colors hover:bg-[var(--row-hover)]"
+      className="flex w-full flex-col gap-0.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-[var(--row-hover)]"
     >
       <span className="flex items-center gap-1.5 text-[11px] text-muted [&_svg]:size-3">
         <span className="flex size-3 shrink-0 items-center justify-center">{props.icon}</span>
@@ -357,7 +366,7 @@ export function SettingsSidebar(props: {
               <div key={group.id} className={groupIndex > 0 ? "space-y-0.5 pt-2" : "space-y-0.5"}>
                 {group.hasTree &&
                   (remoteSession ? (
-                    <SidebarButton
+                    <SettingsNavButton
                       iconOnly
                       icon={<Bot className="size-4" />}
                       label={t`Models`}
@@ -366,7 +375,7 @@ export function SettingsSidebar(props: {
                     />
                   ) : (
                     <>
-                      <SidebarButton
+                      <SettingsNavButton
                         iconOnly
                         icon={<Bot className="size-4" />}
                         label={t`Agents`}
@@ -374,7 +383,7 @@ export function SettingsSidebar(props: {
                         onPress={openAgents}
                       />
                       {isAgentsActive && (
-                        <SidebarButton
+                        <SettingsNavButton
                           iconOnly
                           icon={
                             isRefreshingAgents ? (
@@ -389,7 +398,7 @@ export function SettingsSidebar(props: {
                         />
                       )}
                       {isAgentsActive && (
-                        <SidebarButton
+                        <SettingsNavButton
                           iconOnly
                           icon={<Settings2 className="size-4" />}
                           label={t`Agents · General`}
@@ -398,7 +407,7 @@ export function SettingsSidebar(props: {
                         />
                       )}
                       {isAgentsActive && (
-                        <SidebarButton
+                        <SettingsNavButton
                           iconOnly
                           icon={<Boxes className="size-4" />}
                           label={t`Agent Registry`}
@@ -411,7 +420,7 @@ export function SettingsSidebar(props: {
                           const needsAttention = attentionAgentKinds.has(agent.kind);
                           return (
                             <div key={agent.kind} className="space-y-0.5">
-                              <SidebarButton
+                              <SettingsNavButton
                                 iconOnly
                                 icon={
                                   <span className="relative flex size-4 items-center justify-center">
@@ -430,10 +439,10 @@ export function SettingsSidebar(props: {
                               {instanceAgentsFor(agent.kind).map((profile) => {
                                 const profileNeedsAttention = attentionAgentKinds.has(profile.kind);
                                 return (
-                                  <SidebarButton
+                                  <SettingsNavButton
                                     key={profile.kind}
                                     iconOnly
-                                    className="ml-3 h-7 w-7"
+                                    className="ml-3"
                                     icon={
                                       <span className="relative flex size-3.5 items-center justify-center">
                                         {renderAgentIcon(profile, {
@@ -457,7 +466,7 @@ export function SettingsSidebar(props: {
                     </>
                   ))}
                 {group.sections.map((section) => (
-                  <SidebarButton
+                  <SettingsNavButton
                     key={section.id}
                     iconOnly
                     icon={section.icon}
@@ -470,13 +479,13 @@ export function SettingsSidebar(props: {
             ))}
           </div>
           <div className={sidebarIconRailFooterClass}>
-            <SidebarButton
+            <SettingsNavButton
               iconOnly
               icon={<ArrowLeft className="size-4" />}
               label={t`Return to app`}
               onPress={onClose}
             />
-            <SidebarButton
+            <SettingsNavButton
               iconOnly
               icon={<PanelLeft className="size-4" />}
               label={t`Show sidebar`}
@@ -520,7 +529,7 @@ export function SettingsSidebar(props: {
               ) : (
                 searchRows.map((row) =>
                   row.kind === "section" ? (
-                    <SidebarButton
+                    <SettingsNavButton
                       key={row.key}
                       icon={row.icon}
                       label={row.label}
@@ -542,13 +551,16 @@ export function SettingsSidebar(props: {
           ) : (
             <div className="space-y-0.5">
               {visibleGroups.map((group, groupIndex) => (
-                <div key={group.id} className={groupIndex > 0 ? "space-y-0.5 pt-3" : "space-y-0.5"}>
-                  <p className="px-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
+                <div
+                  key={group.id}
+                  className={groupIndex > 0 ? "space-y-0.5 pt-2.5" : "space-y-0.5"}
+                >
+                  <p className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
                     {group.label}
                   </p>
                   {group.hasTree &&
                     (remoteSession ? (
-                      <SidebarButton
+                      <SettingsNavButton
                         icon={<Bot className="size-4" />}
                         label={t`Models`}
                         isActive={activeSection === "agentsGeneral"}
@@ -556,7 +568,7 @@ export function SettingsSidebar(props: {
                       />
                     ) : (
                       <>
-                        <SidebarButton
+                        <SettingsNavButton
                           icon={<Bot className="size-4" />}
                           label={t`Agents`}
                           isActive={activeSection === "agents"}
@@ -582,13 +594,13 @@ export function SettingsSidebar(props: {
                         />
                         {isAgentsActive && (
                           <div className="space-y-0.5 pl-4">
-                            <SidebarButton
+                            <SettingsNavButton
                               icon={<Settings2 className="size-4" />}
                               label={t`General`}
                               isActive={activeSection === "agentsGeneral"}
                               onPress={() => onSectionChange("agentsGeneral")}
                             />
-                            <SidebarButton
+                            <SettingsNavButton
                               icon={<Boxes className="size-4" />}
                               label={t`Agent Registry`}
                               isActive={activeSection === "acpRegistry"}
@@ -599,7 +611,7 @@ export function SettingsSidebar(props: {
                               const needsAttention = attentionAgentKinds.has(agent.kind);
                               return (
                                 <div key={agent.kind} className="space-y-0.5">
-                                  <SidebarButton
+                                  <SettingsNavButton
                                     icon={renderAgentIcon(agent, {
                                       disabled: agentDisabled,
                                     })}
@@ -626,7 +638,7 @@ export function SettingsSidebar(props: {
                                           profile.kind,
                                         );
                                         return (
-                                          <SidebarButton
+                                          <SettingsNavButton
                                             key={profile.kind}
                                             icon={renderAgentIcon(profile, {
                                               disabled: profileDisabled,
@@ -659,7 +671,7 @@ export function SettingsSidebar(props: {
                       </>
                     ))}
                   {group.sections.map((section) => (
-                    <SidebarButton
+                    <SettingsNavButton
                       key={section.id}
                       icon={section.icon}
                       label={section.label}
@@ -674,12 +686,12 @@ export function SettingsSidebar(props: {
         </div>
 
         <div className={sidebarFooterNavClass}>
-          <SidebarButton
+          <SettingsNavButton
             icon={<ArrowLeft className="size-4" />}
             label={t`Return to app`}
             onPress={onClose}
           />
-          <SidebarButton
+          <SettingsNavButton
             icon={<PanelLeftClose className="size-4" />}
             label={t`Hide sidebar`}
             onPress={collapse}

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -95,6 +95,14 @@ export function writeJsonResponse(
   res.end(options?.trailingNewline ? `${json}\n` : json);
 }
 
+/**
+ * A loopback hostname as `URL.hostname` reports it — note the bracketed `[::1]`
+ * form, and the `*.localhost` subdomains browsers also resolve to loopback.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  return LOCALHOST_ORIGIN_HOSTS.has(hostname) || hostname.endsWith(".localhost");
+}
+
 export function isLocalhostOrigin(origin: string): boolean {
   try {
     return LOCALHOST_ORIGIN_HOSTS.has(new URL(origin).hostname);

--- a/src/shared/remote/pairingUrl.ts
+++ b/src/shared/remote/pairingUrl.ts
@@ -6,6 +6,22 @@
  * the pairing app's server logs.
  */
 
+import { isLoopbackHostname } from "../http";
+
+/**
+ * An `http:` endpoint on a non-loopback host. Loopback is excluded because
+ * browsers treat it as a secure context, so a page served over https may still
+ * talk to it.
+ */
+export function isCleartextLanUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" && !isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function buildPairingUrl(input: {
   readonly httpBaseUrl: string;
   readonly credential: string;

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -633,6 +633,8 @@ export const remoteAccessPairingInfoSchema = z.discriminatedUnion("status", [
     tailscaleHttpBaseUrl: z.string().url().optional(),
     wsBaseUrl: z.string().url(),
     pairingUrl: z.string().url(),
+    /** When the credential inside `pairingUrl` stops being redeemable. */
+    pairingExpiresAt: z.string().datetime(),
     sessions: z.array(remoteAccessSessionSchema),
   }),
 ]);


### PR DESCRIPTION
- **Bugfix:** Refresh remote-access pairing credentials before they expire so displayed QR codes and links remain usable.
- Surface pairing expiry through the remote protocol and settings UI, with coverage for automatic and manual refresh flows.
- Handle HTTPS-to-cleartext LAN pairing handoffs by directing mobile users to the desktop-served address when browsers block the connection.
- Consolidate loopback detection and update localized mobile pairing guidance and related UI tests.