### PR TITLE
Fix Grok token refresh and grpc-web text billing collection

### DIFF
--- a/packages/agents-usage/src/collectors/grok.test.ts
+++ b/packages/agents-usage/src/collectors/grok.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { createFakeHost } from "../testHost";
-import { collectGrok, parseGrokUsage } from "./grok";
-import { GROK_GRPC_EMPTY_FRAME_BYTES, GROK_GRPC_ENDPOINT } from "./grokGrpc";
+import { createFakeHost, FAKE_NOW_MS } from "../testHost";
+import {
+  collectGrok,
+  GROK_BILLING_ENDPOINT,
+  GROK_OAUTH_TOKEN_ENDPOINT,
+  GROK_SETTINGS_ENDPOINT,
+  parseGrokRefreshResponse,
+  parseGrokUsage,
+  refreshGrokOAuthToken,
+} from "./grok";
+import { GROK_GRPC_EMPTY_FRAME_BASE64, GROK_GRPC_ENDPOINT } from "./grokGrpc";
 
 const NOW = 1_717_000_000_000;
 
@@ -42,7 +50,7 @@ describe("parseGrokUsage", () => {
         billingPeriodEnd: "2026-06-01T00:00:00+00:00",
       },
     };
-    const settings = { tier: { displayName: "SuperGrok" } };
+    const settings = { subscription_tier_display: "SuperGrok" };
     const snap = parseGrokUsage(billing, settings, NOW);
 
     expect(snap.providerId).toBe("grok");
@@ -68,13 +76,13 @@ describe("parseGrokUsage", () => {
 
 describe("collectGrok cookie session", () => {
   it("collects credits usage from a captured browser cookie", async () => {
-    const seen: Array<{ bodyBytes?: Uint8Array; headers?: Record<string, string> }> = [];
+    const seen: Array<{ body?: string; headers?: Record<string, string> }> = [];
     const host = createFakeHost({
       secrets: { grok: { cookie: "sso=abc" } },
       routes: { [GROK_GRPC_ENDPOINT]: { bodyBytes: LIVE_GRPC_BODY } },
       onRequest: (req) => {
         seen.push({
-          ...(req.bodyBytes ? { bodyBytes: req.bodyBytes } : {}),
+          ...(req.body ? { body: req.body } : {}),
           ...(req.headers ? { headers: req.headers } : {}),
         });
       },
@@ -89,16 +97,75 @@ describe("collectGrok cookie session", () => {
       usedPercent: 42.5,
       resetsAt: 1_800_000_000_000,
     });
-    expect(seen[0]?.bodyBytes).toEqual(GROK_GRPC_EMPTY_FRAME_BYTES);
+    expect(seen[0]?.body).toBe(GROK_GRPC_EMPTY_FRAME_BASE64);
     expect(seen[0]?.headers).toMatchObject({
       Cookie: "sso=abc",
       Origin: "https://grok.com",
       Referer: "https://grok.com/?_s=usage",
       Accept: "*/*",
-      "Content-Type": "application/grpc-web+proto",
+      "Content-Type": "application/grpc-web-text",
       "x-grpc-web": "1",
       "x-user-agent": "connect-es/2.1.1",
     });
+    // No CLI token on disk: no plan chip, and a reset far outside a plausible
+    // billing cycle stays on the bare label.
+    expect(snap.plan).toBeUndefined();
+    expect(snap.windows[0]!.label).toBe("Credits");
+  });
+
+  it("labels the window monthly when the reset is further out than a weekly cycle", async () => {
+    const resetEpoch = FAKE_NOW_MS / 1000 + 20 * 86_400;
+    const host = createFakeHost({
+      secrets: { grok: { cookie: "sso=abc" } },
+      routes: { [GROK_GRPC_ENDPOINT]: { bodyBytes: frame(creditsPayload(16, resetEpoch)) } },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.windows[0]).toMatchObject({
+      label: "Monthly credits",
+      usedPercent: 16,
+      resetsAt: resetEpoch * 1000,
+    });
+  });
+
+  it("borrows the plan for cookie usage when the token path fails", async () => {
+    const host = createFakeHost({
+      secrets: { grok: { cookie: "sso=abc" } },
+      tokens: { grok: { accessToken: "cli-token" } },
+      routes: {
+        [GROK_BILLING_ENDPOINT]: { status: 500 },
+        [GROK_GRPC_ENDPOINT]: { bodyBytes: LIVE_GRPC_BODY },
+        [GROK_SETTINGS_ENDPOINT]: {
+          body: JSON.stringify({ subscription_tier_display: "SuperGrok Heavy" }),
+        },
+      },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("ok");
+    // Cookie stays the usage source; the token only supplies the tier.
+    expect(snap.windows[0]!.usedPercent).toBe(42.5);
+    expect(snap.plan).toBe("SuperGrok Heavy");
+  });
+
+  it("keeps cookie usage when the plan lookup fails", async () => {
+    const host = createFakeHost({
+      secrets: { grok: { cookie: "sso=abc" } },
+      tokens: { grok: { accessToken: "cli-token" } },
+      routes: {
+        [GROK_BILLING_ENDPOINT]: { status: 500 },
+        [GROK_GRPC_ENDPOINT]: { bodyBytes: LIVE_GRPC_BODY },
+        [GROK_SETTINGS_ENDPOINT]: { status: 500 },
+      },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBeUndefined();
+    expect(snap.windows[0]!.usedPercent).toBe(42.5);
   });
 
   it("keeps the stored session on a transient failure (no token to fall back to)", async () => {
@@ -114,6 +181,25 @@ describe("collectGrok cookie session", () => {
     expect(snap.windows).toEqual([]);
   });
 
+  it("surfaces the gRPC status in the error when the edge rejects the request shape", async () => {
+    // The regression that broke the card: HTTP 200 with a non-zero gRPC status in
+    // the headers, which is how grok.com answers a request encoding it will not
+    // accept. The reason has to reach the card, or the failure is undiagnosable.
+    const host = createFakeHost({
+      secrets: { grok: { cookie: "sso=abc" } },
+      routes: {
+        [GROK_GRPC_ENDPOINT]: {
+          headers: { "grpc-status": "13", "grpc-message": "Missing%20request%20message." },
+        },
+      },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("error");
+    expect(snap.error).toBe("grok.com session check failed (grpc 13: Missing request message.)");
+  });
+
   it("reports auth-missing when the cookie is hard-rejected and there is no token", async () => {
     const host = createFakeHost({
       secrets: { grok: { cookie: "sso=expired" } },
@@ -121,5 +207,213 @@ describe("collectGrok cookie session", () => {
     });
     const snap = await collectGrok(host);
     expect(snap.status).toBe("auth-missing");
+  });
+});
+
+const BILLING_BODY = JSON.stringify({
+  config: {
+    monthlyLimit: { val: 60_000 },
+    used: { val: 9600 },
+    billingPeriodStart: "2024-05-01T00:00:00Z",
+    billingPeriodEnd: "2024-06-01T00:00:00Z",
+  },
+});
+
+describe("collectGrok token path", () => {
+  it("prefers the CLI proxy over the cookie and reports plan plus credit amounts", async () => {
+    const urls: string[] = [];
+    const host = createFakeHost({
+      nowMs: NOW,
+      tokens: { grok: { accessToken: "cli-token" } },
+      secrets: { grok: { cookie: "sso=abc" } },
+      routes: {
+        [GROK_BILLING_ENDPOINT]: { body: BILLING_BODY },
+        // The field the live proxy returns, verbatim.
+        [GROK_SETTINGS_ENDPOINT]: {
+          body: JSON.stringify({ allow_access: true, subscription_tier_display: "X Premium+" }),
+        },
+      },
+      onRequest: (req) => urls.push(req.url),
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("X Premium+");
+    expect(snap.windows[0]).toMatchObject({
+      label: "Monthly credits",
+      used: 9600,
+      limit: 60_000,
+      unit: "credits",
+    });
+    // The cookie path is never touched when the token path answers.
+    expect(urls).not.toContain(GROK_GRPC_ENDPOINT);
+  });
+
+  it("refreshes a rejected token through the host and retries once", async () => {
+    const seen: string[] = [];
+    const host = createFakeHost({
+      nowMs: NOW,
+      tokens: { grok: { accessToken: "stale", refreshToken: "r1" } },
+      routes: {
+        [GROK_BILLING_ENDPOINT]: { status: 401 },
+        [GROK_SETTINGS_ENDPOINT]: { body: "{}" },
+      },
+      refreshOAuthToken: (providerId, token) => {
+        seen.push(`${providerId}:${token.accessToken}`);
+        return Promise.resolve({ accessToken: "fresh" });
+      },
+    });
+    // Serve billing only to the refreshed token.
+    const inner = host.http.request;
+    host.http.request = (req) =>
+      req.url === GROK_BILLING_ENDPOINT && req.headers?.Authorization === "Bearer fresh"
+        ? Promise.resolve({ status: 200, headers: {}, body: BILLING_BODY })
+        : inner(req);
+
+    const snap = await collectGrok(host);
+
+    expect(seen).toEqual(["grok:stale"]);
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]).toMatchObject({ used: 9600, limit: 60_000 });
+  });
+
+  it("reports auth-missing when no refreshed token is available", async () => {
+    const host = createFakeHost({
+      nowMs: NOW,
+      tokens: { grok: { accessToken: "stale" } },
+      routes: { [GROK_BILLING_ENDPOINT]: { status: 401 } },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("auth-missing");
+    expect(snap.error).toBe("token rejected (401)");
+  });
+
+  it("falls back to the cookie when billing carries no credit fields", async () => {
+    // The proxy's on-demand view: real billing dates, no allowance. Verbatim
+    // shape from the live `?format=credits` response — it must not read as 0%.
+    const host = createFakeHost({
+      nowMs: NOW,
+      tokens: { grok: { accessToken: "cli-token" } },
+      secrets: { grok: { cookie: "sso=abc" } },
+      routes: {
+        [GROK_BILLING_ENDPOINT]: {
+          body: JSON.stringify({
+            config: {
+              currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY" },
+              onDemandCap: { val: 0 },
+              onDemandUsed: { val: 0 },
+              billingPeriodStart: "2026-07-23T19:11:31Z",
+              billingPeriodEnd: "2026-07-30T19:11:31Z",
+            },
+          }),
+        },
+        [GROK_GRPC_ENDPOINT]: { bodyBytes: LIVE_GRPC_BODY },
+      },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("ok");
+    expect(snap.windows[0]!.usedPercent).toBe(42.5);
+  });
+
+  it("surfaces the billing failure when there is no cookie to fall back to", async () => {
+    const host = createFakeHost({
+      nowMs: NOW,
+      tokens: { grok: { accessToken: "cli-token" } },
+      routes: { [GROK_BILLING_ENDPOINT]: { status: 503 } },
+    });
+
+    const snap = await collectGrok(host);
+
+    expect(snap.status).toBe("error");
+    expect(snap.error).toBe("grok billing check failed (HTTP 503)");
+  });
+
+  it("reports auth-missing with neither credential", async () => {
+    const snap = await collectGrok(createFakeHost({ nowMs: NOW }));
+    expect(snap.status).toBe("auth-missing");
+  });
+});
+
+describe("grok OAuth refresh", () => {
+  it("maps a refresh response and retains an omitted refresh token", () => {
+    expect(parseGrokRefreshResponse({ access_token: "a", expires_in: 3600 }, NOW, "keep")).toEqual({
+      accessToken: "a",
+      refreshToken: "keep",
+      expiresAt: NOW + 3_600_000,
+    });
+    expect(
+      parseGrokRefreshResponse({ access_token: "a", refresh_token: "b", expires_in: 60 }, NOW, "r"),
+    ).toEqual({ accessToken: "a", refreshToken: "b", expiresAt: NOW + 60_000 });
+  });
+
+  it("rejects malformed bodies rather than writing garbage into the creds file", () => {
+    expect(parseGrokRefreshResponse({ expires_in: 3600 }, NOW, "r")).toBeUndefined();
+    expect(parseGrokRefreshResponse({ access_token: "a" }, NOW, "r")).toBeUndefined();
+    expect(
+      parseGrokRefreshResponse({ access_token: "a", expires_in: 0 }, NOW, "r"),
+    ).toBeUndefined();
+    expect(parseGrokRefreshResponse("nope", NOW, "r")).toBeUndefined();
+  });
+
+  it("posts the refresh_token grant with the creds file's client id", async () => {
+    const seen: Array<{ url: string; body?: string; headers?: Record<string, string> }> = [];
+    const host = createFakeHost({
+      nowMs: NOW,
+      routes: {
+        [GROK_OAUTH_TOKEN_ENDPOINT]: {
+          body: JSON.stringify({ access_token: "fresh", expires_in: 7200 }),
+        },
+      },
+      onRequest: (req) =>
+        seen.push({
+          url: req.url,
+          ...(req.body ? { body: req.body } : {}),
+          ...(req.headers ? { headers: req.headers } : {}),
+        }),
+    });
+
+    const refreshed = await refreshGrokOAuthToken(
+      host.http,
+      { refreshToken: "r1", clientId: "cli-client" },
+      NOW,
+    );
+
+    expect(refreshed).toEqual({
+      accessToken: "fresh",
+      refreshToken: "r1",
+      expiresAt: NOW + 7_200_000,
+    });
+    expect(seen[0]?.url).toBe(GROK_OAUTH_TOKEN_ENDPOINT);
+    expect(seen[0]?.headers).toMatchObject({
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    expect(new URLSearchParams(seen[0]?.body ?? "")).toEqual(
+      new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: "cli-client",
+        refresh_token: "r1",
+      }),
+    );
+  });
+
+  it("returns undefined on a rejected or unparseable refresh", async () => {
+    const failing = createFakeHost({
+      routes: { [GROK_OAUTH_TOKEN_ENDPOINT]: { status: 400 } },
+    });
+    expect(
+      await refreshGrokOAuthToken(failing.http, { refreshToken: "r", clientId: "c" }, NOW),
+    ).toBeUndefined();
+
+    const garbage = createFakeHost({
+      routes: { [GROK_OAUTH_TOKEN_ENDPOINT]: { body: "<html>" } },
+    });
+    expect(
+      await refreshGrokOAuthToken(garbage.http, { refreshToken: "r", clientId: "c" }, NOW),
+    ).toBeUndefined();
   });
 });

--- a/packages/agents-usage/src/collectors/grok.ts
+++ b/packages/agents-usage/src/collectors/grok.ts
@@ -1,25 +1,44 @@
 import { toEpochMs } from "../formatters";
-import type { CollectOptions, HostPort, HttpClient, HttpResponse } from "../host";
+import type { CollectOptions, HostPort, HttpClient, HttpResponse, OAuthToken } from "../host";
 import type { UsageSnapshot, UsageWindow } from "../types";
 import {
-  GROK_GRPC_EMPTY_FRAME_BYTES,
+  GROK_GRPC_EMPTY_FRAME_BASE64,
   GROK_GRPC_ENDPOINT,
   parseGrokGrpcBillingResponse,
 } from "./grokGrpc";
 
 /**
- * Grok (xAI). Reuses the Grok CLI bearer token the host reads from
- * `~/.grok/auth.json` and queries the CLI proxy's billing endpoint. The billing
- * cycle is surfaced as one "monthly" credit window.
+ * Grok (xAI). Two collection paths, tried in that order:
  *
- * Reverse-engineered, undocumented API (per openusage): endpoints/fields may
- * change without notice. `/billing` returns:
+ * 1. The CLI proxy's `/v1/billing` with the Grok CLI bearer token from
+ *    `~/.grok/auth.json` — JSON, and the only path carrying real credit amounts
+ *    (`used` / `monthlyLimit`). Rejected tokens are refreshed through the host
+ *    (see {@link refreshGrokOAuthToken}) and retried, so an expired access token
+ *    no longer silently demotes us to the cookie path.
+ * 2. grok.com's private gRPC-web credits config with a captured browser session
+ *    cookie — percent and period only, and served by an edge that has changed its
+ *    accepted encoding under us more than once.
+ *
+ * The plan name comes from `/v1/settings`, whose `subscription_tier_display`
+ * field carries it (e.g. "X Premium+") — verified live. It is bearer-only, so a
+ * cookie-only session borrows it when a CLI token also happens to be on disk.
+ *
+ * Both are reverse-engineered, undocumented APIs (per openusage/codexbar):
+ * endpoints and fields may change without notice. `/billing` returns:
  *   { config: { monthlyLimit: {val}, used: {val}, onDemandCap: {val},
  *               billingPeriodStart, billingPeriodEnd, history: [...] } }
  */
 
-export const GROK_BILLING_ENDPOINT = "https://cli-chat-proxy.grok.com/v1/billing";
-export const GROK_SETTINGS_ENDPOINT = "https://cli-chat-proxy.grok.com/v1/settings";
+const GROK_PROXY_BASE = "https://cli-chat-proxy.grok.com/v1";
+/**
+ * Plain `/billing`, deliberately not openusage's `?format=credits`. Verified
+ * against the live proxy: the `credits` view returns the weekly on-demand cycle
+ * (`onDemandCap`, `onDemandUsed`, `prepaidBalance`) and omits `monthlyLimit` /
+ * `used` entirely, so reading it would render a confident 0%. The unparameterized
+ * view is the one carrying the allowance this ring reports.
+ */
+export const GROK_BILLING_ENDPOINT = `${GROK_PROXY_BASE}/billing`;
+export const GROK_SETTINGS_ENDPOINT = `${GROK_PROXY_BASE}/settings`;
 const GROK_TOKEN_AUTH_HEADER = "xai-grok-cli";
 
 interface GrokVal {
@@ -40,17 +59,64 @@ function num(v: GrokVal | undefined): number | undefined {
   return typeof v?.val === "number" && Number.isFinite(v.val) ? v.val : undefined;
 }
 
-/** Best-effort plan name from the (loosely specified) /settings body. */
+function grokConfig(billingBody: unknown): NonNullable<GrokBillingResponse["config"]> {
+  return ((billingBody ?? {}) as GrokBillingResponse).config ?? {};
+}
+
+/** A windowless snapshot: every terminal verdict this collector can report. */
+function grokSnapshot(
+  status: UsageSnapshot["status"],
+  nowMs: number,
+  error?: string,
+): UsageSnapshot {
+  return {
+    providerId: "grok",
+    status,
+    windows: [],
+    fetchedAt: nowMs,
+    ...(error ? { error } : {}),
+  };
+}
+
+/**
+ * Does a `/billing` body actually carry credit data? A 200 that parses but holds
+ * none of the fields we read (a shape change, or a proxy's stub response) would
+ * otherwise render as a confident "0% used", so the collector treats it as a
+ * failed attempt and falls back instead.
+ */
+function grokBillingHasData(billingBody: unknown): boolean {
+  const config = grokConfig(billingBody);
+  // Deliberately not satisfied by a period alone: the proxy's on-demand view
+  // carries billing dates with no allowance, and would read as 0% used.
+  return num(config.monthlyLimit) !== undefined || num(config.used) !== undefined;
+}
+
+/**
+ * Plan name from the `/settings` body. `subscription_tier_display` is the field
+ * the live proxy returns and the one the Grok CLI itself renders (values like
+ * "X Premium+", "SuperGrok"). Earlier guesses at `tier.displayName` /
+ * `subscriptionTier` / `plan` were never observed on any response and are gone —
+ * an absent plan is reported honestly instead of hunting for invented shapes.
+ */
 function planFromSettings(settingsBody: unknown): string | undefined {
-  const s = (settingsBody ?? {}) as Record<string, unknown>;
-  const tier = s.tier as { displayName?: string; name?: string } | undefined;
-  const candidate =
-    tier?.displayName ??
-    tier?.name ??
-    (typeof s.subscriptionTier === "string" ? s.subscriptionTier : undefined) ??
-    (typeof s.plan === "string" ? s.plan : undefined);
-  const trimmed = candidate?.trim();
-  return trimmed ? trimmed : undefined;
+  const value = (settingsBody as { subscription_tier_display?: unknown } | null | undefined)
+    ?.subscription_tier_display;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Best-effort `/settings` fetch for the plan name. Bearer-only: the grok.com
+ * session cookie is scoped to a different host, so callers skip this without a
+ * CLI token. Never throws — usage stands on its own without a plan name.
+ */
+async function fetchGrokSettings(host: HostPort, accessToken: string): Promise<unknown> {
+  try {
+    const res = await grokRequest(host, GROK_SETTINGS_ENDPOINT, accessToken);
+    if (res.status < 200 || res.status >= 300) return undefined;
+    return JSON.parse(res.body);
+  } catch {
+    return undefined;
+  }
 }
 
 /** Pure: map a parsed `/billing` body (+ optional `/settings`) to a snapshot. */
@@ -59,7 +125,7 @@ export function parseGrokUsage(
   settingsBody: unknown,
   nowMs: number,
 ): UsageSnapshot {
-  const config = ((billingBody ?? {}) as GrokBillingResponse).config ?? {};
+  const config = grokConfig(billingBody);
   const limit = num(config.monthlyLimit);
   const used = num(config.used);
   const usedPercent =
@@ -70,7 +136,9 @@ export function parseGrokUsage(
 
   const window: UsageWindow = {
     id: "monthly",
-    label: "Monthly credits",
+    // The JSON path carries both cycle bounds, so the label is derived rather
+    // than assumed — a weekly credit cycle reads as weekly.
+    label: grokWindowLabel(toEpochMs(config.billingPeriodStart), resetsAt, nowMs),
     usedPercent,
     unit: "credits",
     ...(used !== undefined ? { used } : {}),
@@ -88,12 +156,28 @@ export function parseGrokUsage(
   };
 }
 
-/** Cycle-length-driven label, per codexbar (Weekly / Monthly / Credits). */
-function grokWindowLabel(periodStartMs: number | undefined, resetsAt: number | undefined): string {
+/**
+ * Cycle-length-driven label, per codexbar (Weekly / Monthly / Credits).
+ *
+ * The cookie path only recovers the reset instant, never the period start, so
+ * fall back to the distance to that reset: a weekly cycle can never sit more
+ * than ~8 days out, so anything further (and still within a plausible monthly
+ * cycle) is monthly. Closer resets stay ambiguous — a monthly cycle near its
+ * end looks exactly like a weekly one — and keep the bare "Credits" label.
+ */
+function grokWindowLabel(
+  periodStartMs: number | undefined,
+  resetsAt: number | undefined,
+  nowMs: number,
+): string {
   if (periodStartMs !== undefined && resetsAt !== undefined) {
     const days = (resetsAt - periodStartMs) / 864e5;
     if (days > 0 && days <= 10) return "Weekly credits";
     if (days <= 40) return "Monthly credits";
+  }
+  if (resetsAt !== undefined) {
+    const daysUntilReset = (resetsAt - nowMs) / 864e5;
+    if (daysUntilReset > 8 && daysUntilReset <= 40) return "Monthly credits";
   }
   return "Credits";
 }
@@ -107,32 +191,45 @@ function grokGrpcRequest(http: HttpClient, cookie: string): Promise<HttpResponse
       Origin: "https://grok.com",
       Referer: "https://grok.com/?_s=usage",
       Accept: "*/*",
-      "Content-Type": "application/grpc-web+proto",
+      // Base64 `grpc-web-text`, not binary `grpc-web+proto`: the edge rejects the
+      // binary form of this call outright (grpc-status 13, "Missing request
+      // message."). See GROK_GRPC_EMPTY_FRAME_BASE64.
+      "Content-Type": "application/grpc-web-text",
       "x-grpc-web": "1",
       "x-user-agent": "connect-es/2.1.1",
       "User-Agent": "Poracode",
     },
-    bodyBytes: GROK_GRPC_EMPTY_FRAME_BYTES,
+    body: GROK_GRPC_EMPTY_FRAME_BASE64,
     timeoutMs: 15_000,
   });
 }
 
 /**
+ * Outcome of one collection attempt: either a snapshot to use (usage, or a
+ * verdict like `auth-missing` / `rate-limited`) or a `detail` describing a
+ * transient failure, so the caller can fall back to the other path and still
+ * report *why* this one failed.
+ */
+interface GrokAttempt {
+  snapshot?: UsageSnapshot;
+  detail?: string;
+}
+
+/**
  * Collect via the grok.com browser session cookie (codexbar's path): POST the
  * gRPC-web `GetGrokCreditsConfig` endpoint and parse the protobuf for used
- * percent + reset. Returns undefined to let the caller fall back to the CLI token
- * path on any transient failure.
+ * percent + reset.
  */
 async function collectGrokViaCookie(
   host: HostPort,
   cookie: string,
   nowMs: number,
-): Promise<UsageSnapshot | undefined> {
+): Promise<GrokAttempt> {
+  const authMissing = (): GrokAttempt => ({ snapshot: grokSnapshot("auth-missing", nowMs) });
+
   const res = await grokGrpcRequest(host.http, cookie);
-  if (res.status === 401 || res.status === 403) {
-    return { providerId: "grok", status: "auth-missing", windows: [], fetchedAt: nowMs };
-  }
-  if (res.status < 200 || res.status >= 300) return undefined;
+  if (res.status === 401 || res.status === 403) return authMissing();
+  if (res.status < 200 || res.status >= 300) return { detail: `HTTP ${res.status}` };
 
   const parsed = parseGrokGrpcBillingResponse({
     headers: res.headers,
@@ -140,19 +237,28 @@ async function collectGrokViaCookie(
     ...(res.bodyBytes ? { bodyBytes: res.bodyBytes } : {}),
     nowMs,
   });
-  if (parsed.kind === "unauthenticated") {
-    return { providerId: "grok", status: "auth-missing", windows: [], fetchedAt: nowMs };
+  if (parsed.kind === "unauthenticated") return authMissing();
+  if (parsed.kind !== "ok") {
+    // The wire dump goes to the logger, never onto the usage card.
+    if (parsed.debug) host.log?.debug("grok credits config unparseable", parsed.debug);
+    return { detail: parsed.detail ?? "unexpected response" };
   }
-  if (parsed.kind !== "ok") return undefined;
 
   const window: UsageWindow = {
     id: "monthly",
-    label: grokWindowLabel(undefined, parsed.billing.resetsAt),
+    label: grokWindowLabel(parsed.billing.periodStartsAt, parsed.billing.resetsAt, nowMs),
     usedPercent: parsed.billing.usedPercent,
     unit: "credits",
     ...(parsed.billing.resetsAt !== undefined ? { resetsAt: parsed.billing.resetsAt } : {}),
   };
-  return { providerId: "grok", status: "ok", windows: [window], fetchedAt: nowMs };
+  return {
+    snapshot: { providerId: "grok", status: "ok", windows: [window], fetchedAt: nowMs },
+  };
+}
+
+/** Parenthesized failure reason for a card error string, or nothing. */
+function grokDetail(attempt: GrokAttempt): string {
+  return attempt.detail ? ` (${attempt.detail})` : "";
 }
 
 function grokRequest(host: HostPort, url: string, accessToken: string): Promise<HttpResponse> {
@@ -168,93 +274,200 @@ function grokRequest(host: HostPort, url: string, accessToken: string): Promise<
   });
 }
 
+/**
+ * Primary path: the CLI proxy's billing JSON. A rejected access token is handed
+ * to the host for refresh and retried, so a stale `~/.grok/auth.json` recovers on
+ * its own instead of falling through to the cookie path.
+ */
+async function collectGrokViaToken(
+  host: HostPort,
+  initialToken: OAuthToken,
+  nowMs: number,
+): Promise<GrokAttempt> {
+  let token = initialToken;
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let res: HttpResponse;
+    try {
+      res = await grokRequest(host, GROK_BILLING_ENDPOINT, token.accessToken);
+    } catch {
+      return { detail: "network error" };
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      // A refresh that hands back the same token is no progress; the attempt
+      // bound then stops a host that cycles between two stale tokens.
+      const next = await host.credentials.refreshOAuthToken?.("grok", token);
+      if (!next?.accessToken || next.accessToken === token.accessToken) {
+        return {
+          snapshot: grokSnapshot("auth-missing", nowMs, `token rejected (${res.status})`),
+        };
+      }
+      token = next;
+      continue;
+    }
+    if (res.status === 429) return { snapshot: grokSnapshot("rate-limited", nowMs) };
+    if (res.status < 200 || res.status >= 300) return { detail: `HTTP ${res.status}` };
+
+    let billing: unknown;
+    try {
+      billing = JSON.parse(res.body);
+    } catch {
+      return { detail: "invalid JSON response" };
+    }
+    if (!grokBillingHasData(billing)) return { detail: "no credit fields in billing response" };
+
+    // Plan name is best-effort; usage stands on its own without it.
+    const settings = await fetchGrokSettings(host, token.accessToken);
+    return { snapshot: parseGrokUsage(billing, settings, nowMs) };
+  }
+
+  return { snapshot: grokSnapshot("auth-missing", nowMs) };
+}
+
 export async function collectGrok(host: HostPort, _opts?: CollectOptions): Promise<UsageSnapshot> {
   const now = host.now();
-
-  // Preferred path: the grok.com browser session cookie captured via the in-app
-  // login (the CLI rarely leaves a token on disk). Falls through to the CLI
-  // token path when no cookie is stored or the gRPC-web call fails.
-  const cookie = await host.credentials.getSecret("grok", "cookie");
-  if (cookie) {
-    let viaCookie: UsageSnapshot | undefined;
-    try {
-      viaCookie = await collectGrokViaCookie(host, cookie, now);
-    } catch {
-      // Network throw — treat as transient below, not a sign-out.
-    }
-    if (viaCookie && viaCookie.status === "ok") return viaCookie;
-
-    // The cookie path produced no usage. Distinguish a hard rejection (401/403 →
-    // auth-missing) from a transient failure (network throw, 5xx, or an
-    // unparseable frame → undefined). Only the CLI token can substitute, so when
-    // there is none we keep the stored session visible: surface a hard rejection
-    // as auth-missing (re-login needed), but a transient failure as a preserved
-    // `error` so a blip (e.g. a not-yet-ready network at startup) never
-    // masquerades as signed out and forces a needless re-login.
-    const token = await host.credentials.getOAuthToken("grok");
-    if (!token?.accessToken) {
-      if (viaCookie?.status === "auth-missing") return viaCookie;
-      return {
-        providerId: "grok",
-        status: "error",
-        windows: [],
-        fetchedAt: now,
-        error: "grok.com session check failed",
-      };
-    }
-    // A CLI token exists — fall through to the token path below.
+  // Independent lookups: the token resolve may hit disk (and a refresh POST),
+  // while the cookie is a safeStorage decrypt.
+  const [token, cookie] = await Promise.all([
+    host.credentials.getOAuthToken("grok"),
+    host.credentials.getSecret("grok", "cookie"),
+  ]);
+  // Token path first: documented-shaped JSON, refreshable credentials, and the
+  // only source of the plan name and real credit amounts.
+  let viaToken: GrokAttempt = {};
+  if (token?.accessToken) {
+    viaToken = await collectGrokViaToken(host, token, now);
+    if (viaToken.snapshot?.status === "ok") return viaToken.snapshot;
   }
 
-  const token = await host.credentials.getOAuthToken("grok");
-  if (!token?.accessToken) {
-    return { providerId: "grok", status: "auth-missing", windows: [], fetchedAt: now };
+  if (!cookie) {
+    if (!token?.accessToken) return grokSnapshot("auth-missing", now);
+    return (
+      viaToken.snapshot ??
+      grokSnapshot("error", now, `grok billing check failed${grokDetail(viaToken)}`)
+    );
   }
 
-  const res = await grokRequest(host, GROK_BILLING_ENDPOINT, token.accessToken);
-  if (res.status === 401 || res.status === 403) {
-    return {
-      providerId: "grok",
-      status: "auth-missing",
-      windows: [],
-      fetchedAt: now,
-      error: `token rejected (${res.status})`,
-    };
-  }
-  if (res.status === 429) {
-    return { providerId: "grok", status: "rate-limited", windows: [], fetchedAt: now };
-  }
-  if (res.status < 200 || res.status >= 300) {
-    return {
-      providerId: "grok",
-      status: "error",
-      windows: [],
-      fetchedAt: now,
-      error: `HTTP ${res.status}`,
-    };
-  }
-
-  let billing: unknown;
+  let viaCookie: GrokAttempt;
   try {
-    billing = JSON.parse(res.body);
+    viaCookie = await collectGrokViaCookie(host, cookie, now);
   } catch {
-    return {
-      providerId: "grok",
-      status: "error",
-      windows: [],
-      fetchedAt: now,
-      error: "invalid JSON response",
-    };
+    // Network throw — treat as transient below, not a sign-out.
+    viaCookie = { detail: "network error" };
   }
 
-  // Plan name is best-effort; usage stands on its own without it.
-  let settings: unknown;
+  if (viaCookie.snapshot?.status === "ok") {
+    const usage = viaCookie.snapshot;
+    // The gRPC-web credits config carries no tier, so borrow it from the CLI
+    // proxy — but not with a token the proxy just rejected, which would spend a
+    // request per cycle to learn nothing. Without a usable token the card simply
+    // shows usage with no plan chip.
+    const tierToken = viaToken.snapshot?.status === "auth-missing" ? undefined : token?.accessToken;
+    if (!tierToken) return usage;
+    const plan = planFromSettings(await fetchGrokSettings(host, tierToken));
+    return plan ? { ...usage, plan } : usage;
+  }
+
+  // Neither path produced usage. A token verdict (auth-missing / rate-limited)
+  // outranks the cookie's, since the token path is the one we ask the user to
+  // fix. Otherwise distinguish a hard cookie rejection (401/403 → auth-missing)
+  // from a transient failure (network throw, 5xx, or an unparseable frame → a
+  // `detail`): keep the stored session visible by reporting a preserved `error`
+  // so a blip (e.g. a not-yet-ready network at startup) never masquerades as
+  // signed out and forces a needless re-login.
+  return (
+    viaToken.snapshot ??
+    viaCookie.snapshot ??
+    grokSnapshot("error", now, `grok.com session check failed${grokDetail(viaCookie)}`)
+  );
+}
+
+/**
+ * xAI's OAuth token endpoint and the grant the Grok CLI itself runs. The CLI's
+ * access token is short-lived, so a host that can persist the rotated pair uses
+ * this to renew it — the `client_id` comes from `~/.grok/auth.json` rather than
+ * being hardcoded, since xAI has not published one for third parties.
+ */
+export const GROK_OAUTH_TOKEN_ENDPOINT = "https://auth.x.ai/oauth2/token";
+
+export interface GrokRefreshedToken {
+  accessToken: string;
+  refreshToken: string;
+  /** Epoch milliseconds. */
+  expiresAt: number;
+}
+
+interface GrokRefreshResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+/**
+ * Pure: map a parsed `/oauth2/token` refresh response to a token bundle. Every
+ * field is type-checked at runtime (the body is untrusted network JSON) so a
+ * malformed 200 — e.g. from a proxy or captive portal — yields undefined, keeping
+ * the stale token rather than writing garbage into the credentials file. A
+ * rotated refresh token replaces the current one; xAI may omit it, in which case
+ * the current one is retained. Requires a finite, positive `expires_in`, or the
+ * derived expiry would be "now" and every cycle would re-refresh.
+ */
+export function parseGrokRefreshResponse(
+  body: unknown,
+  nowMs: number,
+  currentRefreshToken: string,
+): GrokRefreshedToken | undefined {
+  const data = (body ?? {}) as GrokRefreshResponse;
+  if (typeof data.access_token !== "string" || !data.access_token) return undefined;
+  if (
+    typeof data.expires_in !== "number" ||
+    !Number.isFinite(data.expires_in) ||
+    data.expires_in <= 0
+  ) {
+    return undefined;
+  }
+  const rotated =
+    typeof data.refresh_token === "string" && data.refresh_token
+      ? data.refresh_token
+      : currentRefreshToken;
+  return {
+    accessToken: data.access_token,
+    refreshToken: rotated,
+    expiresAt: nowMs + data.expires_in * 1000,
+  };
+}
+
+/** Exchange a stored Grok refresh token for a fresh access token. */
+export async function refreshGrokOAuthToken(
+  http: HttpClient,
+  input: { refreshToken: string; clientId: string },
+  nowMs: number,
+): Promise<GrokRefreshedToken | undefined> {
+  let res: HttpResponse;
   try {
-    const settingsRes = await grokRequest(host, GROK_SETTINGS_ENDPOINT, token.accessToken);
-    if (settingsRes.status >= 200 && settingsRes.status < 300)
-      settings = JSON.parse(settingsRes.body);
+    res = await http.request({
+      method: "POST",
+      url: GROK_OAUTH_TOKEN_ENDPOINT,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+        "User-Agent": "Poracode",
+      },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        client_id: input.clientId,
+        refresh_token: input.refreshToken,
+      }).toString(),
+      timeoutMs: 15_000,
+    });
   } catch {
-    // ignore — plan name is optional
+    return undefined;
   }
-
-  return parseGrokUsage(billing, settings, now);
+  if (res.status < 200 || res.status >= 300) return undefined;
+  try {
+    return parseGrokRefreshResponse(JSON.parse(res.body), nowMs, input.refreshToken);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/agents-usage/src/collectors/grokGrpc.test.ts
+++ b/packages/agents-usage/src/collectors/grokGrpc.test.ts
@@ -55,6 +55,145 @@ describe("grok gRPC-web parsing", () => {
     });
   });
 
+  it("parses a base64 grpc-web-text body, whatever the content-type claims", () => {
+    // What the real client sees: the text stream arrives as ASCII base64 in both
+    // `body` and `bodyBytes`, while the edge still labels it `grpc-web+proto`.
+    const text = Buffer.from(frame(creditsPayload(16, 1_800_000_000))).toString("base64");
+
+    expect(
+      parseGrokGrpcBillingResponse({
+        headers: { "content-type": "application/grpc-web+proto" },
+        body: text,
+        bodyBytes: new Uint8Array(Buffer.from(text, "utf8")),
+        nowMs: NOW_MS,
+      }),
+    ).toEqual({ kind: "ok", billing: { usedPercent: 16, resetsAt: 1_800_000_000_000 } });
+  });
+
+  it("decodes per-frame base64 segments with interior padding", () => {
+    // Envoy-style grpc-web-text: each frame base64'd separately, so the payload
+    // carries interior `=` padding. Decoding the string in one shot truncates at
+    // the first pad and loses the data frame.
+    const data = Buffer.from(frame(creditsPayload(16, 1_800_000_000))).toString("base64");
+    const trailer = Buffer.from(frame(Buffer.from("grpc-status: 0\r\n"), 0x80)).toString("base64");
+    expect(data.includes("=")).toBe(true);
+    const text = `${data}${trailer}`;
+
+    expect(
+      parseGrokGrpcBillingResponse({
+        headers: { "content-type": "application/grpc-web-text" },
+        body: text,
+        bodyBytes: new Uint8Array(Buffer.from(text, "utf8")),
+        nowMs: NOW_MS,
+      }),
+    ).toEqual({ kind: "ok", billing: { usedPercent: 16, resetsAt: 1_800_000_000_000 } });
+  });
+
+  it("reads a freshly reset weekly period as 0% (captured live response)", () => {
+    // Verbatim bytes from a real grok.com response, the day the credits cycle
+    // reset: a data frame plus a `grpc-status:0` trailer, carrying period start
+    // (field 4) and end (field 5) exactly 7 days apart and NO percent field —
+    // proto3 omits the zero. Previously reported as "unparseable frames".
+    const bodyBytes = new Uint8Array(
+      Buffer.from(
+        "00000000440a4212001a00220b08e3ce89d30610f8fde3202a0b08e3c3aed30610f8fde320421c0802120b08e3ce89d30610f8fde3201a0b08e3c3aed30610f8fde320580162006801800000000f677270632d7374617475733a300d0a",
+        "hex",
+      ),
+    );
+
+    const result = parseGrokGrpcBillingResponse({
+      headers: { "content-type": "application/grpc-web+proto" },
+      bodyBytes,
+      // Mid-cycle: after the period start, before the reset.
+      nowMs: 1_784_900_000_000,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      billing: {
+        usedPercent: 0,
+        periodStartsAt: 1_784_833_891_000,
+        resetsAt: 1_785_438_691_000,
+      },
+    });
+    // Exactly one week apart, so the collector can label the cycle weekly.
+    expect(1_785_438_691_000 - 1_784_833_891_000).toBe(7 * 864e5);
+  });
+
+  it("still refuses a message with neither a percent field nor a period", () => {
+    const bodyBytes = frame(Uint8Array.from([0x58, 0x01, 0x68, 0x01]));
+    expect(parseGrokGrpcBillingResponse({ headers: {}, bodyBytes, nowMs: NOW_MS }).kind).toBe(
+      "invalid",
+    );
+  });
+
+  it("reads a percent field declared as a double, not just a float", () => {
+    const value = Buffer.alloc(8);
+    value.writeDoubleLE(16, 0);
+    const payload = Uint8Array.from([0x09, ...value, 0x10, ...varint(1_800_000_000)]);
+
+    expect(
+      parseGrokGrpcBillingResponse({ headers: {}, bodyBytes: frame(payload), nowMs: NOW_MS }),
+    ).toEqual({ kind: "ok", billing: { usedPercent: 16, resetsAt: 1_800_000_000_000 } });
+  });
+
+  it("keeps the card summary short and puts the wire dump in `debug`", () => {
+    // Without the bytes, a server-side proto change is undiagnosable — but they
+    // belong in the host log, not in a user-facing error string.
+    const bodyBytes = frame(Uint8Array.from([0x52, 0x02, 0x08, 0x01]));
+
+    const result = parseGrokGrpcBillingResponse({
+      headers: { "content-type": "application/grpc-web+proto" },
+      bodyBytes,
+      nowMs: NOW_MS,
+    });
+
+    expect(result).toEqual({
+      kind: "invalid",
+      detail: `unparseable frames (${bodyBytes.length}B, application/grpc-web+proto)`,
+      debug: {
+        bytes: bodyBytes.length,
+        contentType: "application/grpc-web+proto",
+        hex: Buffer.from(bodyBytes).toString("hex"),
+      },
+    });
+  });
+
+  it("describes an unparseable body instead of failing silently", () => {
+    const html = "<!DOCTYPE html><html>challenge</html>";
+
+    expect(
+      parseGrokGrpcBillingResponse({
+        headers: { "content-type": "text/html" },
+        body: html,
+        bodyBytes: new Uint8Array(Buffer.from(html, "utf8")),
+        nowMs: NOW_MS,
+      }),
+    ).toEqual({
+      kind: "invalid",
+      detail: `html body (bot challenge?) (${html.length}B, text/html)`,
+    });
+
+    expect(
+      parseGrokGrpcBillingResponse({ headers: {}, bodyBytes: new Uint8Array(), nowMs: NOW_MS }),
+    ).toEqual({ kind: "invalid", detail: "empty body" });
+  });
+
+  it("reads unauthenticated trailers out of a base64 text body", () => {
+    const text = Buffer.from(
+      frame(Buffer.from("grpc-status: 16\r\ngrpc-message: bad%20credentials\r\n"), 0x80),
+    ).toString("base64");
+
+    expect(
+      parseGrokGrpcBillingResponse({
+        headers: { "content-type": "application/grpc-web-text" },
+        body: text,
+        bodyBytes: new Uint8Array(Buffer.from(text, "utf8")),
+        nowMs: NOW_MS,
+      }),
+    ).toEqual({ kind: "unauthenticated" });
+  });
+
   it("turns grpc unauthenticated trailers into auth-missing", () => {
     const result = parseGrokGrpcBillingResponse({
       headers: {},

--- a/packages/agents-usage/src/collectors/grokGrpc.ts
+++ b/packages/agents-usage/src/collectors/grokGrpc.ts
@@ -8,19 +8,41 @@ export const GROK_GRPC_ENDPOINT =
   "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig";
 
 /** Empty unary gRPC-web frame: [flag=0x00, len=0x00000000]. */
-export const GROK_GRPC_EMPTY_FRAME_BYTES = new Uint8Array([0, 0, 0, 0, 0]);
+const GROK_GRPC_EMPTY_FRAME_BYTES = new Uint8Array([0, 0, 0, 0, 0]);
+
+/**
+ * The same empty frame, base64-encoded for the `grpc-web-text` variant.
+ *
+ * grok.com's edge no longer accepts the binary `application/grpc-web+proto`
+ * form of this call: it answers `grpc-status: 13` / "Missing request message."
+ * for identical bytes, with or without credentials. The base64 text form of the
+ * exact same frame is accepted — an unauthenticated probe reaches the handler
+ * and comes back `grpc-status: 16` / "No credentials presented." — so that is
+ * the form we send.
+ */
+export const GROK_GRPC_EMPTY_FRAME_BASE64 = Buffer.from(GROK_GRPC_EMPTY_FRAME_BYTES).toString(
+  "base64",
+);
 
 export interface GrokBilling {
   usedPercent: number;
   resetsAt?: number;
+  /** Billing period start, when the message carries one (field 4). */
+  periodStartsAt?: number;
 }
 
 export type GrokGrpcBillingResult =
   | { kind: "ok"; billing: GrokBilling }
   | { kind: "unauthenticated" }
-  | { kind: "invalid" };
+  /**
+   * `detail` is the short, non-sensitive summary shown on the usage card;
+   * `debug` carries the wire dump for the host's logger, which is where a
+   * protocol change should be diagnosed from.
+   */
+  | { kind: "invalid"; detail?: string; debug?: Record<string, unknown> };
 
-interface Fixed32Field {
+/** A `float`/`double` field, in document order. */
+interface FloatField {
   path: number[];
   value: number;
   order: number;
@@ -32,16 +54,17 @@ interface VarintField {
 }
 
 interface ProtoScan {
-  fixed32Fields: Fixed32Field[];
+  /** `float` (wire type 5) and `double` (wire type 1) fields share one list. */
+  floatFields: FloatField[];
   varintFields: VarintField[];
 }
 
 function emptyScan(): ProtoScan {
-  return { fixed32Fields: [], varintFields: [] };
+  return { floatFields: [], varintFields: [] };
 }
 
 function mergeScan(target: ProtoScan, source: ProtoScan): void {
-  target.fixed32Fields.push(...source.fixed32Fields);
+  target.floatFields.push(...source.floatFields);
   target.varintFields.push(...source.varintFields);
 }
 
@@ -66,6 +89,8 @@ function scanProtobuf(
   const scan = emptyScan();
   const cursor = { index: 0 };
   let nextOrder = order;
+  // One view per message rather than one per numeric field.
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.length);
 
   while (cursor.index < bytes.length) {
     const fieldStart = cursor.index;
@@ -91,6 +116,15 @@ function scanProtobuf(
 
     if (wireType === 1) {
       if (cursor.index + 8 > bytes.length) break;
+      // A percent field declared `double` rather than `float` lands here, so read
+      // it instead of skipping the eight bytes. Non-percent fixed64s (timestamps,
+      // ids) decode to absurd doubles and are dropped by the 0..100 filter below.
+      scan.floatFields.push({
+        path: fieldPath,
+        value: view.getFloat64(cursor.index, true),
+        order: nextOrder,
+      });
+      nextOrder += 1;
       cursor.index += 8;
       continue;
     }
@@ -114,10 +148,9 @@ function scanProtobuf(
 
     if (wireType === 5) {
       if (cursor.index + 4 > bytes.length) break;
-      const view = new DataView(bytes.buffer, bytes.byteOffset + cursor.index, 4);
-      scan.fixed32Fields.push({
+      scan.floatFields.push({
         path: fieldPath,
-        value: view.getFloat32(0, true),
+        value: view.getFloat32(cursor.index, true),
         order: nextOrder,
       });
       nextOrder += 1;
@@ -177,12 +210,15 @@ function grpcWebTrailerFields(bytes: Uint8Array): Record<string, string> {
   return fields;
 }
 
-function normalizeGrpcHeaderFields(headers: Record<string, string>): Record<string, string> {
+/** Lower-case header names once; `grpc-*` values are percent-decoded in place. */
+function lowercaseHeaders(headers: Record<string, string>): Record<string, string> {
   const fields: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     const normalized = key.trim().toLowerCase();
-    if (!normalized.startsWith("grpc-")) continue;
-    fields[normalized] = decodeURIComponent(value.trim());
+    const trimmed = value.trim();
+    fields[normalized] = normalized.startsWith("grpc-")
+      ? decodeURIComponent(trimmed)
+      : trimmed.toLowerCase();
   }
   return fields;
 }
@@ -192,15 +228,13 @@ function grpcStatusResult(fields: Record<string, string>): GrokGrpcBillingResult
   if (rawStatus === undefined) return undefined;
   const status = Number.parseInt(rawStatus, 10);
   if (!Number.isFinite(status) || status === 0) return undefined;
-  return status === 16 ? { kind: "unauthenticated" } : { kind: "invalid" };
+  if (status === 16) return { kind: "unauthenticated" };
+  const message = fields["grpc-message"]?.slice(0, 120).trim();
+  return { kind: "invalid", detail: `grpc ${status}${message ? `: ${message}` : ""}` };
 }
 
 function pathEquals(path: readonly number[], expected: readonly number[]): boolean {
   return path.length === expected.length && path.every((value, index) => value === expected[index]);
-}
-
-function pathStartsWith(path: readonly number[], prefix: readonly number[]): boolean {
-  return prefix.every((value, index) => path[index] === value);
 }
 
 function extractCreditsBilling(frames: Uint8Array[], nowMs: number): GrokBilling | undefined {
@@ -211,7 +245,7 @@ function extractCreditsBilling(frames: Uint8Array[], nowMs: number): GrokBilling
     mergeScan(scan, scanProtobuf(frame, 0).scan);
   }
 
-  const usedPercent = scan.fixed32Fields
+  const usedPercent = scan.floatFields
     .filter((field) => {
       const last = field.path[field.path.length - 1];
       return last === 1 && Number.isFinite(field.value) && field.value >= 0 && field.value <= 100;
@@ -222,28 +256,107 @@ function extractCreditsBilling(frames: Uint8Array[], nowMs: number): GrokBilling
     .at(0)?.value;
 
   const nowSec = nowMs / 1000;
-  const resetCandidates = scan.varintFields
-    .filter((field) => field.value >= 1_700_000_000 && field.value <= 2_100_000_000)
-    .filter((field) => field.value > nowSec);
-  const reset =
-    resetCandidates
-      .filter((field) => pathEquals(field.path, [1, 5, 1]))
-      .map((field) => field.value)
-      .sort((a, b) => a - b)[0] ??
-    resetCandidates.map((field) => field.value).sort((a, b) => a - b)[0];
+  const stamps = scan.varintFields.filter(
+    (field) => field.value >= 1_700_000_000 && field.value <= 2_100_000_000,
+  );
+  const earliest = (fields: VarintField[]): number | undefined =>
+    fields.reduce<number | undefined>(
+      (best, field) => (best === undefined || field.value < best ? field.value : best),
+      undefined,
+    );
 
-  const noUsageYet =
-    usedPercent === undefined &&
-    scan.fixed32Fields.length === 0 &&
-    reset !== undefined &&
-    scan.varintFields.some((field) => pathStartsWith(field.path, [1, 6]));
-  const percent = usedPercent ?? (noUsageYet ? 0 : undefined);
+  const future = stamps.filter((field) => field.value > nowSec);
+  const reset =
+    earliest(future.filter((field) => pathEquals(field.path, [1, 5, 1]))) ?? earliest(future);
+
+  // Billing period start (field 4 of the config), which unlike the reset is in
+  // the past. Used to label the cycle rather than infer it from the reset alone.
+  const periodStart = stamps
+    .filter((field) => field.value <= nowSec && pathEquals(field.path, [1, 4, 1]))
+    .reduce<number | undefined>(
+      (best, field) => (best === undefined || field.value > best ? field.value : best),
+      undefined,
+    );
+
+  // proto3 omits zero-valued scalars, so a config with no percent field at all is
+  // reporting 0% — a freshly reset billing period looks exactly like this. Only
+  // trust that reading when the message carried a period, and when no percent
+  // field was present to be misread.
+  const noPercentField = scan.floatFields.length === 0;
+  const hasPeriod = reset !== undefined || periodStart !== undefined;
+  const percent = usedPercent ?? (noPercentField && hasPeriod ? 0 : undefined);
   if (percent === undefined) return undefined;
 
   return {
     usedPercent: percent,
     ...(reset !== undefined ? { resetsAt: reset * 1000 } : {}),
+    ...(periodStart !== undefined ? { periodStartsAt: periodStart * 1000 } : {}),
   };
+}
+
+/** Upper bound on the hex dump handed to the host logger. */
+const GROK_HEX_DUMP_LIMIT_BYTES = 256;
+
+/**
+ * Decode a `grpc-web-text` body (base64-encoded frames) into raw frame bytes.
+ *
+ * Proxies differ on how they encode the stream: Connect base64s it as a whole,
+ * while Envoy-style intermediaries base64 each frame separately, leaving interior
+ * `=` padding. A single `Buffer.from(body, "base64")` truncates at that padding
+ * and drops every frame after the first, so decode segment by segment.
+ */
+function decodeGrpcWebText(body: string | undefined): Uint8Array | undefined {
+  const cleaned = body?.replace(/\s+/gu, "");
+  if (!cleaned || !/^[A-Za-z0-9+/=]+$/u.test(cleaned)) return undefined;
+  const segments = cleaned.match(/[A-Za-z0-9+/]+={0,2}/gu);
+  if (!segments?.length) return undefined;
+  const bytes = new Uint8Array(
+    Buffer.concat(segments.map((segment) => Buffer.from(segment, "base64"))),
+  );
+  return bytes.length >= 5 ? bytes : undefined;
+}
+
+/**
+ * Classify an unparseable body: a short shape summary for the usage card, plus
+ * an optional wire dump for the host logger. The summary reports shape only —
+ * size, content-type, and which family the payload looks like — never content.
+ */
+function describeUnparseableBody(input: {
+  raw: Uint8Array;
+  body?: string;
+  contentType: string;
+  decoded?: Uint8Array;
+}): { detail: string; debug?: Record<string, unknown> } {
+  const suffix = input.contentType ? `, ${input.contentType}` : "";
+  if (input.raw.length === 0) return { detail: `empty body${suffix}` };
+
+  const size = `(${input.raw.length}B${suffix})`;
+  const head = (input.body ?? "").trimStart().slice(0, 1);
+  if (head === "<") return { detail: `html body (bot challenge?) ${size}` };
+  if (head === "{" || head === "[") return { detail: `json body ${size}` };
+
+  const shape = input.decoded
+    ? "base64 frames without usage fields"
+    : /^[A-Za-z0-9+/=\s]+$/u.test(input.body ?? "")
+      ? "undecodable base64 body"
+      : "unparseable frames";
+
+  // A protobuf shape change is undiagnosable without the bytes, so hand a bounded
+  // hex dump to the logger. This endpoint returns billing scalars only — no
+  // credentials — and text bodies (which could hold account details) never reach
+  // here, having returned above.
+  const frames = input.decoded ?? input.raw;
+  const detail = `${shape} ${size}`;
+  return frames.length > GROK_HEX_DUMP_LIMIT_BYTES
+    ? { detail }
+    : {
+        detail,
+        debug: {
+          bytes: frames.length,
+          contentType: input.contentType,
+          hex: Buffer.from(frames).toString("hex"),
+        },
+      };
 }
 
 export function parseGrokGrpcBillingResponse(input: {
@@ -252,13 +365,37 @@ export function parseGrokGrpcBillingResponse(input: {
   bodyBytes?: Uint8Array;
   nowMs: number;
 }): GrokGrpcBillingResult {
-  const headerStatus = grpcStatusResult(normalizeGrpcHeaderFields(input.headers));
+  const headers = lowercaseHeaders(input.headers);
+  const headerStatus = grpcStatusResult(headers);
   if (headerStatus) return headerStatus;
 
-  const bytes = input.bodyBytes ?? Buffer.from(input.body ?? "", "binary");
-  const trailerStatus = grpcStatusResult(grpcWebTrailerFields(bytes));
-  if (trailerStatus) return trailerStatus;
+  // A `grpc-web-text` request may be answered in either form, so try both
+  // encodings — content-type only decides which one to try first. Trailer status
+  // is consulted after both, so a misread of the wrong encoding cannot mask a
+  // parseable payload in the right one.
+  const raw = input.bodyBytes ?? Buffer.from(input.body ?? "", "binary");
+  const decoded = decodeGrpcWebText(input.body);
+  const contentType = headers["content-type"] ?? "";
+  const prefersText = contentType.includes("grpc-web-text");
+  const candidates = (prefersText ? [decoded, raw] : [raw, decoded]).filter(
+    (bytes): bytes is Uint8Array => bytes !== undefined && bytes.length > 0,
+  );
 
-  const billing = extractCreditsBilling(grpcWebDataFrames(bytes), input.nowMs);
-  return billing ? { kind: "ok", billing } : { kind: "invalid" };
+  let trailerStatus: GrokGrpcBillingResult | undefined;
+  for (const bytes of candidates) {
+    const billing = extractCreditsBilling(grpcWebDataFrames(bytes), input.nowMs);
+    if (billing) return { kind: "ok", billing };
+    trailerStatus ??= grpcStatusResult(grpcWebTrailerFields(bytes));
+  }
+  return (
+    trailerStatus ?? {
+      kind: "invalid",
+      ...describeUnparseableBody({
+        raw,
+        contentType,
+        ...(decoded !== undefined ? { decoded } : {}),
+        ...(input.body !== undefined ? { body: input.body } : {}),
+      }),
+    }
+  );
 }

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -77,9 +77,13 @@ export type { WorkOSRefreshResult } from "./collectors/factory";
 export {
   collectGrok,
   parseGrokUsage,
+  parseGrokRefreshResponse,
+  refreshGrokOAuthToken,
   GROK_BILLING_ENDPOINT,
   GROK_SETTINGS_ENDPOINT,
+  GROK_OAUTH_TOKEN_ENDPOINT,
 } from "./collectors/grok";
+export type { GrokRefreshedToken } from "./collectors/grok";
 export {
   collectGemini,
   parseGeminiUsage,

--- a/src/supervisor/runtime/grokCredentials.ts
+++ b/src/supervisor/runtime/grokCredentials.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { OAuthToken } from "@poracode/agents-usage";
+import { type OAuthToken, toEpochMs } from "@poracode/agents-usage";
 import { readGrokAuthFromWsl } from "./wslCredentials";
 
 /**
@@ -17,30 +17,134 @@ const GROK_TOKEN_KEYS = [
   "apiKey",
   "session_token",
   "jwt",
+  // The OIDC-era CLI stores the bearer under a bare `key`. Last, so an explicit
+  // access-token field always wins when a file carries both.
+  "key",
 ] as const;
 
-/** Parse `~/.grok/auth.json` into an OAuth token bundle (field name varies). */
-export function parseGrokAuth(content: string): OAuthToken | undefined {
-  let parsed: Record<string, unknown> | undefined;
-  try {
-    parsed = JSON.parse(content) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
-  if (!parsed || typeof parsed !== "object") return undefined;
-  const sources: Record<string, unknown>[] = [parsed];
-  const nested = parsed.tokens;
-  if (nested && typeof nested === "object") sources.push(nested as Record<string, unknown>);
-  for (const source of sources) {
-    for (const key of GROK_TOKEN_KEYS) {
-      const value = source[key];
-      if (typeof value === "string" && value.trim()) return { accessToken: value.trim() };
-    }
+export const GROK_REFRESH_TOKEN_KEYS = ["refresh_token", "refreshToken"] as const;
+const GROK_CLIENT_ID_KEYS = ["oidc_client_id", "client_id", "clientId"] as const;
+export const GROK_EXPIRY_KEYS = ["expires_at", "expiresAt", "expiry", "expires"] as const;
+
+/** First non-empty string among `keys`, with the key that carried it. */
+export function pickGrokField(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): { key: string; value: string } | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) return { key, value: value.trim() };
   }
   return undefined;
 }
 
-function grokAuthFilePath(): string {
+/**
+ * Normalize a loosely-specified stored expiry (epoch seconds, epoch millis, or
+ * ISO) to epoch milliseconds; anything else is "no expiry known".
+ */
+function grokExpiryToMs(value: unknown): number | undefined {
+  return typeof value === "string" || typeof value === "number" ? toEpochMs(value) : undefined;
+}
+
+/** First key in `keys` that is present, whatever its type. */
+export function pickGrokRaw(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): { key: string; value: unknown } | undefined {
+  for (const key of keys) {
+    if (source[key] !== undefined) return { key, value: source[key] };
+  }
+  return undefined;
+}
+
+/**
+ * The object inside `auth.json` that actually carries the access token.
+ *
+ * The OIDC-era CLI keys each identity under a dynamic `"<issuer>::<client_id>"`
+ * entry rather than a fixed field, so every object one level down is a candidate.
+ * With several signed-in identities the freshest wins (latest `expires_at`, then
+ * `create_time`), since the CLI itself uses the most recent login.
+ */
+export interface GrokAuthContainer {
+  container: Record<string, unknown>;
+  tokenKey: string;
+  accessToken: string;
+  name?: string;
+}
+
+export function grokAuthContainer(parsed: unknown): GrokAuthContainer | undefined {
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const root = parsed as Record<string, unknown>;
+
+  const rootToken = pickGrokField(root, GROK_TOKEN_KEYS);
+  if (rootToken) {
+    return { container: root, tokenKey: rootToken.key, accessToken: rootToken.value };
+  }
+
+  const freshness = (container: Record<string, unknown>): number =>
+    grokExpiryToMs(pickGrokRaw(container, GROK_EXPIRY_KEYS)?.value) ??
+    grokExpiryToMs(container.create_time) ??
+    0;
+
+  let best: { entry: GrokAuthContainer; freshness: number } | undefined;
+  for (const [name, value] of Object.entries(root)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const container = value as Record<string, unknown>;
+    const found = pickGrokField(container, GROK_TOKEN_KEYS);
+    if (!found) continue;
+    const entry: GrokAuthContainer = {
+      container,
+      tokenKey: found.key,
+      accessToken: found.value,
+      name,
+    };
+    const score = freshness(container);
+    if (!best || score > best.freshness) best = { entry, freshness: score };
+  }
+  return best?.entry;
+}
+
+/** `"https://auth.x.ai::<client_id>"` → the client id, for files that omit the field. */
+function clientIdFromContainerName(name: string | undefined): string | undefined {
+  if (!name?.includes("::")) return undefined;
+  return name.slice(name.lastIndexOf("::") + 2).trim() || undefined;
+}
+
+/**
+ * Parse `~/.grok/auth.json` into an OAuth token bundle (field names vary). The
+ * refresh token, client id, and expiry ride along so the host can renew a
+ * short-lived access token instead of falling back to the cookie path.
+ */
+export function parseGrokAuth(content: string): OAuthToken | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+  const found = grokAuthContainer(parsed);
+  if (!found) return undefined;
+  const { container, accessToken } = found;
+  const root = parsed as Record<string, unknown>;
+  const refreshToken = pickGrokField(container, GROK_REFRESH_TOKEN_KEYS)?.value;
+  // The client id is account-level metadata: on its own field, beside `tokens`,
+  // or only in the container's `"<issuer>::<client_id>"` name.
+  const clientId =
+    pickGrokField(container, GROK_CLIENT_ID_KEYS)?.value ??
+    pickGrokField(root, GROK_CLIENT_ID_KEYS)?.value ??
+    clientIdFromContainerName(found.name);
+  const expiresAt = grokExpiryToMs(
+    (pickGrokRaw(container, GROK_EXPIRY_KEYS) ?? pickGrokRaw(root, GROK_EXPIRY_KEYS))?.value,
+  );
+  return {
+    accessToken,
+    ...(refreshToken ? { refreshToken } : {}),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+    ...(clientId ? { raw: { clientId } } : {}),
+  };
+}
+
+export function grokAuthFilePath(): string {
   const home = process.env.GROK_HOME?.trim();
   return home ? join(home, "auth.json") : join(homedir(), ".grok", "auth.json");
 }

--- a/src/supervisor/runtime/grokTokenRefresh.test.ts
+++ b/src/supervisor/runtime/grokTokenRefresh.test.ts
@@ -1,0 +1,261 @@
+import type { GrokRefreshedToken, OAuthToken } from "@poracode/agents-usage";
+import { describe, expect, it } from "vitest";
+import { parseGrokAuth } from "./grokCredentials";
+import {
+  applyGrokRefreshToAuthJson,
+  type GrokRefreshDeps,
+  refreshGrokTokenIfDue,
+  refreshRejectedGrokToken,
+} from "./grokTokenRefresh";
+
+const NOW = 1_717_000_000_000;
+const PATH = "/tmp/does-not-exist/auth.json";
+
+interface FakeDeps extends GrokRefreshDeps {
+  writes: string[];
+  refreshCalls: Array<{ refreshToken: string; clientId: string }>;
+}
+
+function fakeDeps(options: {
+  content?: string;
+  refreshed?: GrokRefreshedToken;
+  nowMs?: number;
+}): FakeDeps {
+  const writes: string[] = [];
+  const refreshCalls: Array<{ refreshToken: string; clientId: string }> = [];
+  let content = options.content ?? "";
+  return {
+    writes,
+    refreshCalls,
+    now: () => options.nowMs ?? NOW,
+    refresh: (input) => {
+      refreshCalls.push(input);
+      return Promise.resolve(options.refreshed);
+    },
+    readFile: () => {
+      if (!options.content) throw new Error("ENOENT");
+      return content;
+    },
+    writeFile: (_path, next) => {
+      content = next;
+      writes.push(next);
+    },
+  };
+}
+
+function authFile(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    access_token: "stale",
+    refresh_token: "r1",
+    client_id: "cli-client",
+    expires_at: Math.floor((NOW - 60_000) / 1000),
+    ...overrides,
+  });
+}
+
+describe("parseGrokAuth", () => {
+  it("carries the refresh token, client id, and normalized expiry", () => {
+    const token = parseGrokAuth(authFile());
+    expect(token).toEqual({
+      accessToken: "stale",
+      refreshToken: "r1",
+      expiresAt: NOW - 60_000,
+      raw: { clientId: "cli-client" },
+    });
+  });
+
+  it("reads a nested tokens object and a client id beside it", () => {
+    const token = parseGrokAuth(
+      JSON.stringify({
+        client_id: "outer-client",
+        tokens: { accessToken: "a", refreshToken: "r", expiresAt: NOW + 600_000 },
+      }),
+    );
+    expect(token).toEqual({
+      accessToken: "a",
+      refreshToken: "r",
+      expiresAt: NOW + 600_000,
+      raw: { clientId: "outer-client" },
+    });
+  });
+
+  it("still resolves a bare token file", () => {
+    expect(parseGrokAuth(JSON.stringify({ api_key: "k" }))).toEqual({ accessToken: "k" });
+    expect(parseGrokAuth("not json")).toBeUndefined();
+    expect(parseGrokAuth(JSON.stringify({ unrelated: 1 }))).toBeUndefined();
+  });
+});
+
+/** The shape the OIDC-era Grok CLI actually writes. */
+function oidcAuthFile(overrides: Record<string, unknown> = {}, name?: string): string {
+  return JSON.stringify({
+    [name ?? "https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"]: {
+      key: "stale",
+      auth_mode: "oidc",
+      create_time: "2026-07-25T00:27:55.445119Z",
+      email: "user@example.com",
+      refresh_token: "r1",
+      expires_at: "2026-07-25T06:27:55.445119Z",
+      oidc_issuer: "https://auth.x.ai",
+      oidc_client_id: "b1a00492-073a-47ea-816f-4c329264a828",
+      ...overrides,
+    },
+  });
+}
+
+describe("parseGrokAuth on the OIDC CLI layout", () => {
+  it("finds the token under the dynamic issuer::client_id container", () => {
+    expect(parseGrokAuth(oidcAuthFile())).toEqual({
+      accessToken: "stale",
+      refreshToken: "r1",
+      expiresAt: Date.parse("2026-07-25T06:27:55.445119Z"),
+      raw: { clientId: "b1a00492-073a-47ea-816f-4c329264a828" },
+    });
+  });
+
+  it("recovers the client id from the container name when the field is absent", () => {
+    const token = parseGrokAuth(oidcAuthFile({ oidc_client_id: undefined }));
+    expect(token?.raw).toEqual({ clientId: "b1a00492-073a-47ea-816f-4c329264a828" });
+  });
+
+  it("prefers the freshest identity when several are signed in", () => {
+    const parsed = JSON.parse(oidcAuthFile());
+    const older = JSON.parse(
+      oidcAuthFile({ key: "older", expires_at: "2026-07-20T00:00:00Z" }, "https://auth.x.ai::old"),
+    );
+    expect(parseGrokAuth(JSON.stringify({ ...older, ...parsed }))?.accessToken).toBe("stale");
+    expect(parseGrokAuth(JSON.stringify({ ...parsed, ...older }))?.accessToken).toBe("stale");
+  });
+});
+
+describe("applyGrokRefreshToAuthJson", () => {
+  const refreshed: GrokRefreshedToken = {
+    accessToken: "fresh",
+    refreshToken: "r2",
+    expiresAt: NOW + 7_200_000,
+  };
+
+  it("reuses the file's own field names and epoch-seconds unit", () => {
+    const next = JSON.parse(applyGrokRefreshToAuthJson(authFile(), refreshed)!);
+    expect(next).toMatchObject({
+      access_token: "fresh",
+      refresh_token: "r2",
+      client_id: "cli-client",
+      expires_at: Math.floor((NOW + 7_200_000) / 1000),
+    });
+  });
+
+  it("keeps millisecond and ISO expiries in their original form", () => {
+    const ms = JSON.parse(applyGrokRefreshToAuthJson(authFile({ expires_at: NOW }), refreshed)!);
+    expect(ms.expires_at).toBe(NOW + 7_200_000);
+
+    const iso = JSON.parse(
+      applyGrokRefreshToAuthJson(authFile({ expires_at: new Date(NOW).toISOString() }), refreshed)!,
+    );
+    expect(iso.expires_at).toBe(new Date(NOW + 7_200_000).toISOString());
+  });
+
+  it("writes into the nested container and preserves unrelated fields", () => {
+    const next = JSON.parse(
+      applyGrokRefreshToAuthJson(
+        JSON.stringify({ email: "user@example.com", tokens: { accessToken: "a" } }),
+        refreshed,
+      )!,
+    );
+    expect(next).toEqual({
+      email: "user@example.com",
+      tokens: { accessToken: "fresh", refresh_token: "r2", expires_at: 1_717_007_200 },
+    });
+  });
+
+  it("rewrites the OIDC container in place, keeping `key` and the ISO expiry", () => {
+    const next = JSON.parse(applyGrokRefreshToAuthJson(oidcAuthFile(), refreshed)!);
+    const entry = next["https://auth.x.ai::b1a00492-073a-47ea-816f-4c329264a828"];
+    expect(entry).toMatchObject({
+      key: "fresh",
+      refresh_token: "r2",
+      expires_at: new Date(NOW + 7_200_000).toISOString(),
+      oidc_client_id: "b1a00492-073a-47ea-816f-4c329264a828",
+      email: "user@example.com",
+    });
+  });
+
+  it("leaves unrecognized bodies alone", () => {
+    expect(applyGrokRefreshToAuthJson("not json", refreshed)).toBeUndefined();
+    expect(applyGrokRefreshToAuthJson(JSON.stringify({ nope: 1 }), refreshed)).toBeUndefined();
+  });
+});
+
+describe("refreshGrokTokenIfDue", () => {
+  const expired: OAuthToken = {
+    accessToken: "stale",
+    refreshToken: "r1",
+    expiresAt: NOW - 60_000,
+    raw: { clientId: "cli-client" },
+  };
+
+  it("renews an expired token and persists the rotated pair", async () => {
+    const deps = fakeDeps({
+      content: authFile(),
+      refreshed: { accessToken: "fresh", refreshToken: "r2", expiresAt: NOW + 7_200_000 },
+    });
+
+    const token = await refreshGrokTokenIfDue(expired, deps, PATH);
+
+    expect(deps.refreshCalls).toEqual([{ refreshToken: "r1", clientId: "cli-client" }]);
+    expect(token.accessToken).toBe("fresh");
+    expect(token.refreshToken).toBe("r2");
+    expect(JSON.parse(deps.writes.at(-1)!).access_token).toBe("fresh");
+  });
+
+  it("does not call the network for a token that is still good", async () => {
+    const deps = fakeDeps({ content: authFile() });
+    const fresh: OAuthToken = { ...expired, expiresAt: NOW + 3_600_000 };
+
+    expect(await refreshGrokTokenIfDue(fresh, deps, PATH)).toBe(fresh);
+    expect(deps.refreshCalls).toEqual([]);
+  });
+
+  it("keeps the stale token when the file has no client id to refresh with", async () => {
+    const deps = fakeDeps({ content: authFile() });
+    const noClient: OAuthToken = { accessToken: "stale", refreshToken: "r1", expiresAt: NOW - 1 };
+
+    expect(await refreshGrokTokenIfDue(noClient, deps, PATH)).toBe(noClient);
+    expect(deps.refreshCalls).toEqual([]);
+    expect(deps.writes).toEqual([]);
+  });
+
+  it("keeps the stale token when the refresh call fails", async () => {
+    const deps = fakeDeps({ content: authFile() });
+    expect((await refreshGrokTokenIfDue(expired, deps, PATH)).accessToken).toBe("stale");
+    expect(deps.writes).toEqual([]);
+  });
+});
+
+describe("refreshRejectedGrokToken", () => {
+  it("returns a token another process already rotated, without a POST", async () => {
+    const deps = fakeDeps({ content: authFile({ access_token: "rotated-elsewhere" }) });
+
+    const next = await refreshRejectedGrokToken({ accessToken: "stale" }, deps, PATH);
+
+    expect(next?.accessToken).toBe("rotated-elsewhere");
+    expect(deps.refreshCalls).toEqual([]);
+  });
+
+  it("refreshes the stored token when the file still holds the rejected one", async () => {
+    const deps = fakeDeps({
+      content: authFile(),
+      refreshed: { accessToken: "fresh", refreshToken: "r2", expiresAt: NOW + 7_200_000 },
+    });
+
+    const next = await refreshRejectedGrokToken({ accessToken: "stale" }, deps, PATH);
+
+    expect(next?.accessToken).toBe("fresh");
+    expect(deps.refreshCalls).toEqual([{ refreshToken: "r1", clientId: "cli-client" }]);
+  });
+
+  it("returns undefined when refresh cannot produce a different token", async () => {
+    const deps = fakeDeps({ content: authFile() });
+    expect(await refreshRejectedGrokToken({ accessToken: "stale" }, deps, PATH)).toBeUndefined();
+  });
+});

--- a/src/supervisor/runtime/grokTokenRefresh.ts
+++ b/src/supervisor/runtime/grokTokenRefresh.ts
@@ -1,0 +1,198 @@
+import { readFileSync } from "node:fs";
+import {
+  type GrokRefreshedToken,
+  type OAuthToken,
+  refreshGrokOAuthToken,
+} from "@poracode/agents-usage";
+import { writeFileAtomic } from "@/shared/atomicFile";
+import { coalesceByKey } from "@/shared/coalesce";
+import {
+  GROK_EXPIRY_KEYS,
+  GROK_REFRESH_TOKEN_KEYS,
+  grokAuthContainer,
+  grokAuthFilePath,
+  parseGrokAuth,
+  pickGrokField,
+  pickGrokRaw,
+  resolveGrokToken,
+} from "./grokCredentials";
+import { createNodeHttpClient } from "./usageHttpClient";
+
+/**
+ * Renews the Grok CLI's short-lived access token (the grant openusage runs) so
+ * usage collection keeps working when no running CLI keeps `~/.grok/auth.json`
+ * fresh. Without this an expired token silently demotes collection to the
+ * grok.com cookie path, which carries neither the plan name nor credit amounts.
+ *
+ * Refresh requires both a refresh token and the CLI's `client_id` from the creds
+ * file — xAI publishes no third-party client id, so a file without one simply
+ * cannot be renewed. Secrets are never logged.
+ */
+
+/** Refresh once the token is inside this window of its expiry. */
+const GROK_REFRESH_SKEW_MS = 5 * 60_000;
+
+/** Injectable I/O, defaulted for prod. */
+export interface GrokRefreshDeps {
+  now(): number;
+  refresh(
+    input: { refreshToken: string; clientId: string },
+    nowMs: number,
+  ): Promise<GrokRefreshedToken | undefined>;
+  readFile(path: string): string;
+  writeFile(path: string, content: string): void;
+}
+
+function defaultGrokRefreshDeps(): GrokRefreshDeps {
+  const http = createNodeHttpClient();
+  return {
+    now: () => Date.now(),
+    refresh: (input, nowMs) => refreshGrokOAuthToken(http, input, nowMs),
+    readFile: (path) => readFileSync(path, "utf8"),
+    // Atomic write with owner-only perms, so a torn or crashed write never
+    // corrupts or leaks the credentials file.
+    writeFile: (path, content) => writeFileAtomic(path, content, { encoding: "utf8", mode: 0o600 }),
+  };
+}
+
+/** Built once and reused so the http client isn't rebuilt on every resolve. */
+let cachedDeps: GrokRefreshDeps | undefined;
+function prodGrokRefreshDeps(): GrokRefreshDeps {
+  return (cachedDeps ??= defaultGrokRefreshDeps());
+}
+
+/** In-flight refresh per creds path, so same-tick callers share one POST. */
+const grokRefreshInFlight = new Map<string, Promise<OAuthToken | undefined>>();
+
+function isRefreshDue(token: OAuthToken, nowMs: number): boolean {
+  return token.expiresAt !== undefined && token.expiresAt - nowMs <= GROK_REFRESH_SKEW_MS;
+}
+
+function clientIdOf(token: OAuthToken): string | undefined {
+  const value = token.raw?.clientId;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Pure: write a refreshed pair back into an `auth.json` body, reusing whichever
+ * field names and expiry unit the file already used so the Grok CLI keeps reading
+ * its own credentials. Returns undefined when the body is not a shape we
+ * recognize, so the caller leaves the file untouched.
+ */
+export function applyGrokRefreshToAuthJson(
+  content: string,
+  refreshed: GrokRefreshedToken,
+): string | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+  const found = grokAuthContainer(parsed);
+  if (!found) return undefined;
+  const { container, tokenKey } = found;
+
+  container[tokenKey] = refreshed.accessToken;
+  const refreshKey = pickGrokField(container, GROK_REFRESH_TOKEN_KEYS)?.key ?? "refresh_token";
+  container[refreshKey] = refreshed.refreshToken;
+
+  // Match the unit already on disk: ISO, epoch millis, or (default) epoch seconds.
+  const previous = pickGrokRaw(container, GROK_EXPIRY_KEYS);
+  const expiryKey = previous?.key ?? "expires_at";
+  container[expiryKey] =
+    typeof previous?.value === "string"
+      ? new Date(refreshed.expiresAt).toISOString()
+      : typeof previous?.value === "number" && previous.value >= 1e12
+        ? refreshed.expiresAt
+        : Math.floor(refreshed.expiresAt / 1000);
+
+  return JSON.stringify(parsed, null, 2);
+}
+
+async function performGrokRefresh(
+  token: OAuthToken,
+  deps: GrokRefreshDeps,
+  path: string,
+  /** File contents the caller already read, to avoid a second sync read. */
+  content?: string,
+): Promise<OAuthToken | undefined> {
+  const clientId = clientIdOf(token);
+  if (!token.refreshToken || !clientId) return undefined;
+
+  const refreshed = await deps.refresh({ refreshToken: token.refreshToken, clientId }, deps.now());
+  if (!refreshed) return undefined;
+
+  // Persist so the next collection (and the CLI itself) sees the fresh token.
+  // A failed write is not fatal — the token in hand is still usable this cycle.
+  try {
+    const next = applyGrokRefreshToAuthJson(content ?? deps.readFile(path), refreshed);
+    if (next) deps.writeFile(path, next);
+  } catch {
+    // ignore — persistence is best-effort
+  }
+
+  return {
+    ...token,
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+    expiresAt: refreshed.expiresAt,
+  };
+}
+
+/**
+ * Renew the token when it is expired or about to be. Returns the original token
+ * when it is still good, or when renewal is impossible (no refresh token/client
+ * id, network failure) — an expired token is still worth one attempt, and the
+ * collector reports the rejection if it fails.
+ */
+export async function refreshGrokTokenIfDue(
+  token: OAuthToken,
+  deps: GrokRefreshDeps = prodGrokRefreshDeps(),
+  path: string = grokAuthFilePath(),
+): Promise<OAuthToken> {
+  if (!isRefreshDue(token, deps.now())) return token;
+  const refreshed = await coalesceByKey(grokRefreshInFlight, path, () =>
+    performGrokRefresh(token, deps, path),
+  );
+  return refreshed ?? token;
+}
+
+/**
+ * Called by the usage host after the proxy rejected `rejectedToken`. Re-reads the
+ * creds file first: another process (the CLI, or a concurrent collection) may
+ * already have rotated it, in which case that token is returned without a POST.
+ */
+export async function refreshRejectedGrokToken(
+  rejectedToken: OAuthToken,
+  deps: GrokRefreshDeps = prodGrokRefreshDeps(),
+  path: string = grokAuthFilePath(),
+): Promise<OAuthToken | undefined> {
+  let onDisk: OAuthToken | undefined;
+  let content: string | undefined;
+  try {
+    content = deps.readFile(path);
+    onDisk = parseGrokAuth(content);
+  } catch {
+    // No readable creds file; fall back to refreshing the token we were handed.
+  }
+  if (onDisk?.accessToken && onDisk.accessToken !== rejectedToken.accessToken) return onDisk;
+
+  const source = onDisk ?? rejectedToken;
+  const refreshed = await coalesceByKey(grokRefreshInFlight, path, () =>
+    performGrokRefresh(source, deps, path, content),
+  );
+  return refreshed?.accessToken && refreshed.accessToken !== rejectedToken.accessToken
+    ? refreshed
+    : undefined;
+}
+
+/**
+ * Resolver used by the usage credential store: read the CLI's token, renewing it
+ * first when it is expired or nearly so. Keeping the refresh here means the shared
+ * provider table stays one entry per provider, as it is for every other provider.
+ */
+export async function resolveFreshGrokToken(): Promise<OAuthToken | undefined> {
+  const token = await resolveGrokToken();
+  return token ? refreshGrokTokenIfDue(token) : undefined;
+}

--- a/src/supervisor/runtime/usageCredentials.ts
+++ b/src/supervisor/runtime/usageCredentials.ts
@@ -6,7 +6,7 @@ import { resolveCopilotToken } from "./copilotCredentials";
 import { resolveCursorToken } from "./cursorCredentials";
 import { resolveFactoryCliToken } from "./factoryCredentials";
 import { resolveGeminiToken } from "./geminiCredentials";
-import { resolveGrokToken } from "./grokCredentials";
+import { refreshRejectedGrokToken, resolveFreshGrokToken } from "./grokTokenRefresh";
 import { resolveKimiToken } from "./kimiCredentials";
 import { resolveQwenUsageToken } from "./qwenCredentials";
 import { resolveZaiToken } from "./zaiCredentials";
@@ -36,7 +36,7 @@ function tokenResolvers(
     codex: resolveCodexToken,
     copilot: resolveCopilotToken,
     cursor: resolveCursorToken,
-    grok: resolveGrokToken,
+    grok: resolveFreshGrokToken,
     gemini: resolveGeminiToken,
     // resolveFactoryCliToken is sync (returns the token directly, not a Promise);
     // wrap it so every entry shares the () => Promise<OAuthToken | undefined> shape.
@@ -47,9 +47,10 @@ function tokenResolvers(
   };
 }
 
-/** Per-provider refreshers (currently only Claude rejects/expired tokens). */
+/** Per-provider refreshers, called after the provider rejected a token. */
 const tokenRefreshers: Record<string, (token: OAuthToken) => Promise<OAuthToken | undefined>> = {
   claude: refreshRejectedClaudeToken,
+  grok: refreshRejectedGrokToken,
 };
 
 /** Build the native credential store consumed by the usage HostPort. */


### PR DESCRIPTION
- **Bugfix:** refresh expired or rejected Grok CLI access tokens so usage collection retains credit and plan details.
- Support Grok’s grpc-web text billing requests and robustly parse base64-encoded responses and authentication trailers.
- Recognize current Grok credential formats, including refresh tokens, client IDs, expirations, and OIDC token fields.
- Add coverage for token refresh flows, credential updates, and billing response parsing.