### PR TITLE
Fix mobile composer action docks during collapsed input

### DIFF
--- a/src/mobile/ComposerActionDocks.tsx
+++ b/src/mobile/ComposerActionDocks.tsx
@@ -1,0 +1,82 @@
+import type { AgentStatus, Project, Thread } from "@/shared/contracts";
+import {
+  changeThreadConfig,
+  clearThreadPendingSteer,
+  resolveThreadServerRequest,
+} from "@/renderer/actions/threadRuntimeActions";
+import { ThreadAuthRequiredDock } from "@/renderer/components/thread/ThreadAuthRequiredDock";
+import { ThreadPendingSteerStrip } from "@/renderer/components/thread/ThreadPendingSteerStrip";
+import { ThreadRuntimeRequestPanel } from "@/renderer/components/thread/ThreadRuntimeRequestPanel";
+import { resolveThreadAuthState } from "@/renderer/components/thread/threadErrorState";
+import { useDelayedPendingSteer } from "@/renderer/components/thread/useDelayedPendingSteer";
+import type { ThreadDockState } from "@/renderer/components/thread/useThreadDockState";
+import { useAppStore } from "@/renderer/state/appStore";
+
+/**
+ * The composer's action docks — sign-in required, a queued steer, and the open
+ * runtime request (tool approval, plan review, agent question) — hoisted OUT of
+ * the compact mobile composer.
+ *
+ * Desktop keeps these in the composer's `fixedContent`, but the collapsed mobile
+ * bubble clips to a single control line (`.m-compose-bubble` max-height +
+ * overflow), so anything above the input stayed invisible until the user
+ * expanded the composer and summoned the keyboard. The floating dock hosts them
+ * in one card above the bubble instead (see ThreadComposerSection
+ * `hideActionDocks`), where they are answerable straight from the thread and
+ * still ride the dock's keyboard lift. The purely informational docks take the
+ * other route — compact chips (ComposerInfoChips) — and the slash-command panel
+ * stays inline because it only appears while typing, with the composer already
+ * expanded.
+ */
+export function ComposerActionDocks(props: {
+  readonly thread: Thread;
+  readonly agentStatus: AgentStatus | undefined;
+  readonly project: Project | undefined;
+  readonly dockState: ThreadDockState;
+  readonly onOpenPlanFile?: ((path: string) => void) | undefined;
+}) {
+  const { thread, agentStatus, project } = props;
+  const request = useAppStore((state) => state.runtimeRequestsByThread[thread.id]?.[0]);
+  const pendingSteer = useDelayedPendingSteer(
+    useAppStore((state) => state.pendingSteerByThreadId[thread.id]),
+  );
+  const { authRequired } = resolveThreadAuthState({
+    authState: agentStatus?.authState,
+    errorDockStates: props.dockState.errorDockStates,
+  });
+  const showAuthDock = authRequired && agentStatus !== undefined;
+  if (!showAuthDock && !pendingSteer && !request) return null;
+
+  return (
+    <div className="m-thread-action-docks">
+      {showAuthDock ? (
+        <ThreadAuthRequiredDock agentStatus={agentStatus} {...(project ? { project } : {})} />
+      ) : null}
+      {pendingSteer ? (
+        <ThreadPendingSteerStrip
+          pending={pendingSteer}
+          onCancel={() => clearThreadPendingSteer(thread.id)}
+        />
+      ) : null}
+      {request ? (
+        <ThreadRuntimeRequestPanel
+          key={request.requestId}
+          threadId={thread.id}
+          agentLabel={agentStatus?.label}
+          request={request}
+          onResolve={(input) => resolveThreadServerRequest(thread.id, input)}
+          onPlanApproved={(optionId) =>
+            changeThreadConfig(thread.id, {
+              ...thread.config,
+              mode: "agent",
+              ...(optionId === "default" || optionId === "auto"
+                ? { approvalPolicy: optionId }
+                : {}),
+            })
+          }
+          {...(props.onOpenPlanFile ? { onOpenPlanFile: props.onOpenPlanFile } : {})}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/mobile/FloatingComposerDock.tsx
+++ b/src/mobile/FloatingComposerDock.tsx
@@ -26,12 +26,28 @@ function resetCompactComposerScroll(root: HTMLElement | null): void {
 
 export function FloatingComposerDock(props: {
   readonly children: ReactNode;
+  /**
+   * Content pinned above the composer bubble, inside the dock. The bubble clips
+   * its own overflow to the collapsed control line, so chrome that must stay
+   * visible while collapsed (the action docks: auth, pending steer, runtime
+   * requests) lives here — still inside the dock, so it rides the same keyboard
+   * lift and sits above the collapse scrim.
+   */
+  readonly aboveBubble?: ReactNode | undefined;
   readonly keyboardKey: string | null | undefined;
   readonly scrimLabel: string;
   readonly collapsedTapLabel?: string | undefined;
   readonly dockClassName?: string | undefined;
   readonly bubbleClassName?: string | undefined;
   readonly expanded?: boolean | undefined;
+  /**
+   * Pin the dock collapsed: no expansion from a tap, a focus, or a controlled
+   * `expanded`. Used while a blocking approval/question is open above the bubble
+   * — the card owns the surface, and the composer must not open over it. The
+   * collapsed pill stays usable as a one-line input (deny-with-feedback), so it
+   * still takes the keyboard lift while focused.
+   */
+  readonly expansionLocked?: boolean | undefined;
   readonly focusOnExpand?: boolean | undefined;
   /**
    * Collapse on an outside press without mounting the blocking scrim, allowing
@@ -44,12 +60,14 @@ export function FloatingComposerDock(props: {
   readonly onExpandedChange?: ((expanded: boolean) => void) | undefined;
   readonly onComposerFocusChange?: ((focused: boolean) => void) | undefined;
   /**
-   * Reports the bubble's rendered height (border-box px) as it grows and
-   * shrinks, so the host view can keep floating chrome (e.g. the scroll-to-
-   * bottom pin) clear of the composer.
+   * Reports the dock's rendered height (border-box px) as it grows and shrinks,
+   * so the host view can keep floating chrome (e.g. the scroll-to-bottom pin,
+   * the info chips) clear of the composer. Covers `aboveBubble` too — chrome
+   * anchored to this height must clear the whole dock, not just the bubble.
    */
-  readonly onBubbleHeightChange?: ((height: number) => void) | undefined;
+  readonly onDockHeightChange?: ((height: number) => void) | undefined;
 }) {
+  const dockRef = useRef<HTMLDivElement | null>(null);
   const bubbleRef = useRef<HTMLDivElement | null>(null);
   const [internalExpanded, setInternalExpanded] = useState(false);
   // Suppresses the expand transitions for the guarded-focus path: the input
@@ -58,7 +76,8 @@ export function FloatingComposerDock(props: {
   // reveal it (reads as the keyboard pushing the page). Cleared after the
   // expansion has painted so later offset reconciliation animates normally.
   const [instantExpand, setInstantExpand] = useState(false);
-  const expanded = props.expanded ?? internalExpanded;
+  const expansionLocked = props.expansionLocked === true;
+  const expanded = expansionLocked ? false : (props.expanded ?? internalExpanded);
   const wasExpandedRef = useRef(expanded);
   const skipNextFocusOnExpandRef = useRef(false);
   const onComposerFocusChange = props.onComposerFocusChange;
@@ -76,6 +95,7 @@ export function FloatingComposerDock(props: {
   }, [expanded, props.keyboardKey]);
 
   const setExpanded = (next: boolean) => {
+    if (next && expansionLocked) return;
     if (!next) {
       skipNextFocusOnExpandRef.current = false;
     }
@@ -194,17 +214,17 @@ export function FloatingComposerDock(props: {
     onComposerFocusChange?.(inputFocused);
   }, [inputFocused, onComposerFocusChange]);
 
-  const onBubbleHeightChange = props.onBubbleHeightChange;
+  const onDockHeightChange = props.onDockHeightChange;
   useEffect(() => {
-    const bubble = bubbleRef.current;
-    if (!onBubbleHeightChange || !bubble) return;
+    const dock = dockRef.current;
+    if (!onDockHeightChange || !dock) return;
     const observer = new ResizeObserver((entries) => {
       const entry = entries[entries.length - 1];
-      if (entry) onBubbleHeightChange(entry.borderBoxSize?.[0]?.blockSize ?? bubble.offsetHeight);
+      if (entry) onDockHeightChange(entry.borderBoxSize?.[0]?.blockSize ?? dock.offsetHeight);
     });
-    observer.observe(bubble);
+    observer.observe(dock);
     return () => observer.disconnect();
-  }, [onBubbleHeightChange]);
+  }, [onDockHeightChange]);
 
   useEffect(
     () => () => {
@@ -225,6 +245,7 @@ export function FloatingComposerDock(props: {
   };
 
   const handleFocusCapture = (event: ReactFocusEvent<HTMLDivElement>) => {
+    if (expansionLocked) return;
     if (event.target instanceof HTMLElement && !expanded) {
       setExpanded(true);
     }
@@ -240,7 +261,11 @@ export function FloatingComposerDock(props: {
     const handlePointerDown = (event: PointerEvent) => {
       if (event.button !== 0) return;
       const target = event.target;
-      if (!(target instanceof Node) || bubbleRef.current?.contains(target)) return;
+      // Containment is tested against the whole dock, not just the bubble: the
+      // action docks (approvals, pending steer) render above the bubble but are
+      // part of this composer surface. Answering an approval on the desktop PWA
+      // must not read as an outside press and collapse the composer under it.
+      if (!(target instanceof Node) || dockRef.current?.contains(target)) return;
       // Composer menus are portaled outside the bubble. They belong to the
       // current interaction and must not collapse their owning composer.
       if (target instanceof Element && target.closest(COMPOSER_OVERLAY_SELECTOR)) return;
@@ -295,14 +320,18 @@ export function FloatingComposerDock(props: {
         />
       ) : null}
       <div
+        ref={dockRef}
         className={props.dockClassName ?? "m-compose-dock"}
         data-expanded={visuallyExpanded || undefined}
+        data-locked={expansionLocked || undefined}
+        {...(expansionLocked && inputFocused && liftOffset > 0 ? { "data-lifted": "" } : {})}
         data-collapsing={(!expanded && bubblePin !== null) || undefined}
         data-android-runtime={androidRuntime || undefined}
         data-instant-expand={instantExpand || undefined}
         data-measuring-keyboard={hideDockForMeasuring || undefined}
         style={{ "--m-keyboard-offset": `${liftOffset}px` } as CSSProperties}
       >
+        {props.aboveBubble}
         <div
           ref={bubbleRef}
           className={["m-compose-bubble", props.bubbleClassName].filter(Boolean).join(" ")}

--- a/src/mobile/mobileInputStyles.test.ts
+++ b/src/mobile/mobileInputStyles.test.ts
@@ -21,11 +21,14 @@ describe("mobile iOS input ergonomics", () => {
     );
   });
 
-  it("keeps the expanded iOS PWA composer clear of the keyboard accessory strip", () => {
+  it("keeps the lifted iOS PWA composer clear of the keyboard accessory strip", () => {
     const css = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
 
+    // Both lift states get the home-indicator gap: an expanded composer, and a
+    // dock pinned collapsed under an open request whose one-line input is
+    // focused ([data-lifted], see FloatingComposerDock.expansionLocked).
     expect(css).toMatch(
-      /html\[data-mobile-platform="ios"\]\[data-mobile-standalone="true"\]\s*:is\(\.m-compose-dock, \.m-thread-compose-dock\)\[data-expanded\]\s*\{\s*\/\*[\s\S]*?--m-keyboard-gap:\s*env\(safe-area-inset-bottom\);/,
+      /html\[data-mobile-platform="ios"\]\[data-mobile-standalone="true"\]\s*:is\(\s*\.m-compose-dock\[data-expanded\],\s*\.m-thread-compose-dock\[data-expanded\],\s*\.m-thread-compose-dock\[data-lifted\]\s*\)\s*\{\s*\/\*[\s\S]*?--m-keyboard-gap:\s*env\(safe-area-inset-bottom\);/,
     );
   });
 

--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -42,6 +42,16 @@ html {
     var(--composer-surface, var(--surface, var(--content-background))) var(--m-glass-alpha),
     transparent
   );
+  /* The same material a step less translucent, for floating CARDS rather than
+     controls — the composer's action docks and the info-chip panels. They carry
+     dense text (commands, paths, plan steps) over the transcript, so they need
+     more grounding than a pill. Mixing from --m-glass-surface keeps the
+     per-platform alpha ladder below intact. */
+  --m-glass-card-surface: color-mix(
+    in oklab,
+    var(--m-glass-surface) 75%,
+    var(--composer-surface, var(--surface, var(--content-background)))
+  );
 }
 
 /* iOS renders the backdrop blur as a real native material, so the 64% glass
@@ -282,10 +292,7 @@ html[data-mobile-platform="ios"][data-mobile-standalone="true"] #root {
     .m-thread-bar,
   html[data-mobile-platform="ios"][data-mobile-browser-chrome="true"]
     .m-shell[data-chrome="thread"]
-    .m-thread-compose-dock,
-  html[data-mobile-platform="ios"][data-mobile-browser-chrome="true"]
-    .m-shell[data-chrome="thread"]
-    .m-thread-chips {
+    .m-thread-compose-dock {
     position: fixed;
   }
 
@@ -1468,13 +1475,21 @@ html[data-theme="dark"][data-theme-preset="default"] .m-shell:not(.m-shell--wide
 
 /* Ride above the on-screen keyboard while expanded (the dock is anchored to
    the layout viewport, which iOS keeps full-height under the keyboard). */
+/* [data-lifted]: the locked (pinned-collapsed) thread composer still takes the
+   keyboard band while its one-line input is focused — a denial typed under an
+   open approval must not sit behind the keyboard. */
 .m-compose-dock[data-expanded],
-.m-thread-compose-dock[data-expanded] {
+.m-thread-compose-dock[data-expanded],
+.m-thread-compose-dock[data-lifted] {
   transform: translateY(calc(-1 * (var(--m-keyboard-offset, 0px) + var(--m-keyboard-gap, 0px))));
 }
 
 html[data-mobile-platform="ios"][data-mobile-standalone="true"]
-  :is(.m-compose-dock, .m-thread-compose-dock)[data-expanded] {
+  :is(
+    .m-compose-dock[data-expanded],
+    .m-thread-compose-dock[data-expanded],
+    .m-thread-compose-dock[data-lifted]
+  ) {
   /* Installed PWAs have no Safari address pill between app content and the
      keyboard accessory strip. Lift by the device's real home-indicator inset
      instead of a fixed gap so the composer clears that strip on every iPhone. */
@@ -1482,7 +1497,8 @@ html[data-mobile-platform="ios"][data-mobile-standalone="true"]
 }
 
 .m-compose-dock[data-expanded][data-android-runtime],
-.m-thread-compose-dock[data-expanded][data-android-runtime] {
+.m-thread-compose-dock[data-expanded][data-android-runtime],
+.m-thread-compose-dock[data-lifted][data-android-runtime] {
   /* Android resizes the layout viewport around the keyboard, so keep the old
      stable bottom anchor and add the requested keyboard breathing room as a
      paint-only shift. Changing `bottom` during WebView resize can bounce the
@@ -1523,38 +1539,34 @@ html[data-mobile-platform="ios"][data-mobile-standalone="true"]
 /* ── Composer info chips (thread view) ─────────────────────────────
  *
  * The informational dock sections (subagents, crossagents, workflows, context,
- * plan, goal, errors) live OUTSIDE the compact composer as floating icon chips just
- * above it; tapping a chip expands that section into its own bubble. The strip
- * ducks away while the composer itself is expanded. */
+ * plan, goal, errors) live OUTSIDE the compact composer as icon chips stacked
+ * directly on top of it inside the floating dock; tapping a chip expands that
+ * section into its own bubble above the row. The strip ducks away while the
+ * composer itself is expanded. */
 .m-thread-chips {
-  position: absolute;
-  right: 0.75rem;
-  bottom: calc(
-    1.25rem + env(safe-area-inset-bottom) +
-      var(--m-thread-bubble-height, var(--m-floating-control-height))
-  );
-  left: 0.75rem;
-  z-index: 5;
+  /* In-flow inside the floating dock, between the composer bubble below and the
+     action-dock card above: the chips always ride directly on the composer, and
+     a blocking approval/question always sits on top of the whole stack. Being a
+     dock child also means they inherit its keyboard lift and centered column
+     instead of tracking the dock's height from the outside. */
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 0.375rem;
+  margin-bottom: 0.375rem;
+  min-height: 0;
   pointer-events: none;
-  transition:
-    bottom 0.2s cubic-bezier(0.32, 0.72, 0, 1),
-    opacity 0.16s ease;
+  transition: opacity 0.16s ease;
 }
 
 .m-thread-chips > * {
   pointer-events: auto;
 }
 
+/* Ducked (the composer is expanded): in-flow, so the strip must give its row
+   back instead of just fading — otherwise it holds a gap above the composer. */
 .m-thread-chips[data-hidden] {
-  opacity: 0;
-}
-
-.m-thread-chips[data-hidden] > * {
-  pointer-events: none;
+  display: none;
 }
 
 .m-chip-row {
@@ -1653,14 +1665,16 @@ html[data-mobile-platform="ios"][data-mobile-standalone="true"]
 
 /* The expanded section bubble. The shared dock sections it hosts were styled
    for the composer's fixedContent (transparent bg + border-b separators), so
-   the bubble supplies the surface and the trailing separator is dropped. */
+   the bubble supplies the surface and the trailing separator is dropped. Same
+   floating-card glass as the composer's action docks, so the two cards that can
+   sit stacked above the composer read as one material. */
 .m-chip-panel {
   width: 100%;
   max-height: min(45dvh, 22rem);
   overflow-y: auto;
   border: 1px solid var(--hairline, var(--border));
   border-radius: 1rem;
-  background: var(--composer-surface, var(--m-glass-surface));
+  background: var(--m-glass-card-surface);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   box-shadow: 0 8px 24px rgb(0 0 0 / 0.35);
@@ -1701,13 +1715,78 @@ html[data-mobile-platform="ios"][data-mobile-standalone="true"]
   }
 }
 
+/* ── Composer action docks (thread view) ───────────────────────────
+ *
+ * Sign-in required, a queued steer, and an open approval/question all block or
+ * gate the turn, so they must be visible and answerable without first expanding
+ * the composer. They stack in one card hosted by the floating dock above the
+ * composer bubble (ComposerActionDocks) — the bubble itself clips to one control
+ * line while collapsed. Same glass surface as the chip panels; the shared dock
+ * sections it hosts were styled for the composer's fixedContent (transparent bg
+ * + border-b separators), so the surface is supplied here and the trailing
+ * separator dropped. */
+.m-thread-action-docks {
+  /* Shrink before the composer does when both are tall (the dock is a bounded
+     flex column), and scroll internally past that. */
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: min(45dvh, 24rem);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  margin-bottom: 0.375rem;
+  border: 1px solid var(--hairline, var(--border));
+  border-radius: 1rem;
+  /* Same glass as the composer bubble it sits on, one step less translucent —
+     the shared floating-card material. */
+  background: var(--m-glass-card-surface);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.35);
+  padding: 0.25rem;
+  /* Approvals quote commands and paths worth copying; the surrounding dock
+     chrome disables selection. */
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.m-thread-action-docks > section:last-child {
+  border-bottom: none;
+}
+
+/* With a card above the bubble the dock stacks two boxes, each with its own
+   height cap, so the total could run past the top of the viewport — most easily
+   on the desktop PWA, where the composer opens expanded and a long draft can
+   grow it to its own cap. Bound the dock and let it distribute: the card shrinks
+   (and scrolls) first, the composer keeps its geometry. */
+.m-thread-compose-dock {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  max-height: calc(100dvh - var(--m-keyboard-offset, 0px) - env(safe-area-inset-top) - 4.5rem);
+}
+
+/* iOS keeps the layout viewport full-height under the keyboard, so dvh would
+   double-count the band that --m-keyboard-offset already removes (same reasoning
+   as the expanded-bubble cap below). */
+html[data-mobile-platform="ios"] .m-thread-compose-dock {
+  max-height: calc(100lvh - var(--m-keyboard-offset, 0px) - env(safe-area-inset-top) - 4.5rem);
+}
+
+/* Requests that ask for text (elicitation forms, user-input questions) raise the
+   keyboard without ever focusing the composer, so the dock's own composer-focus
+   lift never runs. Ride the raw keyboard band instead. */
+.m-thread-compose-dock:not([data-expanded]):has(.m-thread-action-docks:focus-within) {
+  transform: translateY(
+    calc(-1 * (var(--m-thread-keyboard-band, 0px) + var(--m-keyboard-gap, 0px)))
+  );
+}
+
 /* Wide screens center the chat column at 920px (see ThreadView) — keep the
-   floating composer and its info chips on the same column instead of spanning
-   the whole detail pane. 100% here is the thread section, i.e. the pane.
-   (Must come after the base .m-thread-chips rule — same specificity.) */
+   floating composer dock (and everything it stacks: info chips, action docks) on
+   the same column instead of spanning the whole detail pane. 100% here is the
+   thread section, i.e. the pane. */
 @media (min-width: 768px) {
-  .m-thread-compose-dock,
-  .m-thread-chips {
+  .m-thread-compose-dock {
     right: max(0.75rem, calc((100% - 920px) / 2));
     left: max(0.75rem, calc((100% - 920px) / 2));
   }
@@ -1794,6 +1873,10 @@ html:not([data-touch-device]) .m-compose-scrim {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  /* Inside the bounded dock column the composer keeps its own geometry; the
+     action-dock card above it is the one that gives way (it scrolls). Its own
+     cap always leaves room, so this can never overflow the dock. */
+  flex: 0 0 auto;
 }
 
 /* :not([data-collapsing]) — during the collapse height tween the pin owns the
@@ -2453,13 +2536,10 @@ html[data-touch-device] .m-compose-bubble [data-composer-input-anchor]:not(:focu
     bottom 0.2s ease-out;
 }
 
-/* When the info-chip strip is showing it owns that bottom-right slot
-   (.m-thread-chips bottom + its 1.75rem row); stack the pin one row higher
-   so the two never overlap. The bottom transition above makes the pin slide
-   rather than jump as chips appear and disappear. */
-.m-thread:has(.m-thread-chips:not([data-hidden])) {
-  --m-thread-pin-lift: 3.5rem;
-}
+/* The chips strip and the action-dock card are dock children, so the measured
+   dock height above already covers them and the pin needs no extra row — it
+   slides up as they appear. (It used to add one, back when the strip was
+   positioned outside the dock.) */
 
 /* An expanded chip panel grows over the pin's slot — duck the pin while the
    panel is open instead of letting it float above the panel surface. */

--- a/src/mobile/views/ThreadView.test.tsx
+++ b/src/mobile/views/ThreadView.test.tsx
@@ -49,6 +49,7 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
 
 vi.mock("@/renderer/bridge", () => ({
   readBridge: () => bridgeMock,
+  isRemoteSession: () => true,
 }));
 
 vi.mock("@heroui/react", async (importOriginal) => {
@@ -185,6 +186,7 @@ describe("mobile ThreadView", () => {
       runtimeRequestsByThread: {},
       runtimeStructuralVersionByThread: {},
       openSubAgentByThread: {},
+      pendingSteerByThreadId: {},
       pendingComposerFocusThreadId: null,
     });
   });
@@ -434,6 +436,157 @@ describe("mobile ThreadView", () => {
       />,
     );
     expect(view.container.querySelector(".m-compose-summary .lucide-zap")).toBeNull();
+  });
+
+  it("hosts an open runtime request above the composer bubble, outside its clip", () => {
+    const thread = { ...makeTerminalThread(), presentationMode: "gui" } as Thread;
+    useAppStore.setState({
+      runtimeRequestsByThread: {
+        [thread.id]: [
+          {
+            requestId: "request-1",
+            threadId: thread.id,
+            requestType: "command_execution_approval",
+            payload: {
+              summary: "Run rm -rf build",
+              details: { toolName: "Bash", description: "rm -rf build" },
+            },
+            receivedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const view = render(
+      <ThreadView
+        thread={thread}
+        terminalScrollback=""
+        onThreadAction={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+      />,
+    );
+
+    const card = view.container.querySelector(".m-thread-action-docks");
+    expect(card).not.toBeNull();
+    expect(card).toHaveTextContent("Run rm -rf build");
+    // The collapsed bubble clips to one control line, so the card must be a
+    // sibling of the bubble inside the dock — never nested in it.
+    expect(card?.closest(".m-thread-compose-dock")).not.toBeNull();
+    expect(card?.closest(".m-compose-bubble")).toBeNull();
+  });
+
+  it("pins the touch composer collapsed while a runtime request is open", async () => {
+    const thread = { ...makeTerminalThread(), presentationMode: "gui" } as Thread;
+    useAppStore.setState({
+      runtimeRequestsByThread: {
+        [thread.id]: [
+          {
+            requestId: "request-1",
+            threadId: thread.id,
+            requestType: "command_execution_approval",
+            payload: { summary: "Run rm -rf build", details: { toolName: "Bash" } },
+            receivedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const { container } = render(
+      <ThreadView
+        thread={thread}
+        terminalScrollback=""
+        onThreadAction={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+      />,
+    );
+    const dock = container.querySelector(".m-thread-compose-dock");
+    expect(dock).toHaveAttribute("data-locked");
+
+    // Focusing the pill would normally expand the dock (see the keyboard-dismiss
+    // test below); under an open request it must stay collapsed so the card keeps
+    // the surface. The pill remains a one-line input for deny-with-feedback.
+    fireEvent.focusIn(screen.getByRole("textbox"));
+    await waitFor(() => expect(dock).toBeInTheDocument());
+    expect(dock).not.toHaveAttribute("data-expanded");
+  });
+
+  it("leaves the desktop PWA composer open while a runtime request is up", () => {
+    fixtures.desktopPointer = true;
+    const thread = { ...makeTerminalThread(), presentationMode: "gui" } as Thread;
+    useAppStore.setState({
+      runtimeRequestsByThread: {
+        [thread.id]: [
+          {
+            requestId: "request-1",
+            threadId: thread.id,
+            requestType: "command_execution_approval",
+            payload: { summary: "Run rm -rf build", details: { toolName: "Bash" } },
+            receivedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const { container } = render(
+      <ThreadView
+        thread={thread}
+        terminalScrollback=""
+        onThreadAction={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+      />,
+    );
+    const dock = container.querySelector(".m-thread-compose-dock");
+    expect(dock).not.toHaveAttribute("data-locked");
+    expect(dock).toHaveAttribute("data-expanded");
+  });
+
+  it("hosts a waiting pending steer in the same action-dock card", () => {
+    const thread = {
+      ...makeTerminalThread(),
+      presentationMode: "gui",
+      status: "working",
+    } as Thread;
+    useAppStore.setState({
+      pendingSteerByThreadId: {
+        [thread.id]: {
+          id: "steer-1",
+          prompt: "Focus on the parser instead",
+          // Older than the reveal delay, so it is visible on first render.
+          stagedAt: Date.now() - 10_000,
+        },
+      },
+    });
+
+    const view = render(
+      <ThreadView
+        thread={thread}
+        terminalScrollback=""
+        onThreadAction={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+      />,
+    );
+
+    const card = view.container.querySelector(".m-thread-action-docks");
+    expect(card).toHaveTextContent("Focus on the parser instead");
+    expect(card?.closest(".m-compose-bubble")).toBeNull();
+  });
+
+  it("hosts the auth-required dock in the same action-dock card", () => {
+    fixtures.agentStatuses = [{ ...makeCodexStatus(), authState: "missing" }];
+    const thread = { ...makeTerminalThread(), presentationMode: "gui" } as Thread;
+
+    const view = render(
+      <ThreadView
+        thread={thread}
+        terminalScrollback=""
+        onThreadAction={() => undefined}
+        onSubmitInput={() => Promise.resolve()}
+      />,
+    );
+
+    const card = view.container.querySelector(".m-thread-action-docks");
+    expect(card).not.toBeNull();
+    expect(card?.closest(".m-compose-bubble")).toBeNull();
   });
 
   it("keeps the composer expanded when the keyboard is dismissed (no collapse-on-focus-loss)", async () => {

--- a/src/mobile/views/ThreadView.tsx
+++ b/src/mobile/views/ThreadView.tsx
@@ -29,6 +29,7 @@ import { useProject } from "@/renderer/state/useThread";
 import { MobileTerminal } from "../MobileTerminal";
 import { ComposerCompactSummary } from "../ComposerCompactSummary";
 import { ComposerInfoChips } from "../ComposerInfoChips";
+import { ComposerActionDocks } from "../ComposerActionDocks";
 import { FloatingComposerDock } from "../FloatingComposerDock";
 import { EmptyState } from "../components";
 import { WorkspaceChip } from "../GitSummaryParts";
@@ -119,6 +120,12 @@ export function ThreadView(props: ThreadViewProps) {
   const dockState = useThreadDockState(thread?.id ?? "");
   const reportedContextUsage = useAppStore((state) =>
     thread ? state.runtimeContextByThread[thread.id] : undefined,
+  );
+  // A blocking approval/question owns the surface while it is open: touch
+  // layouts keep the composer collapsed under its card instead of letting a
+  // stray tap open the bubble over it (see FloatingComposerDock.expansionLocked).
+  const requestOpen = useAppStore((state) =>
+    thread ? (state.runtimeRequestsByThread[thread.id]?.length ?? 0) > 0 : false,
   );
   // Raw keyboard band for the PTY/accessory inputs. The composer itself is
   // hosted by FloatingComposerDock, which uses the same focus-gated lift as the
@@ -263,6 +270,13 @@ export function ThreadView(props: ThreadViewProps) {
   };
   const showComposerDock = thread.status !== "launching" || !isTerminal;
   const terminalPageKeyboardOffset = isTerminal && composerInputFocused ? 0 : keyboardOffset;
+  // Desktop-pointer layouts keep their always-open composer; touch layouts pin
+  // it collapsed under the request card.
+  const expansionLocked = requestOpen && !submitOnEnter;
+  // The chips duck for an actually-open composer only — a locked dock renders
+  // collapsed even while this view still holds `composerExpanded` from before
+  // the request arrived.
+  const composerOpen = composerExpanded && !expansionLocked;
   const composerDock = showComposerDock ? (
     <FloatingComposerDock
       dockClassName="m-thread-compose-dock"
@@ -272,9 +286,32 @@ export function ThreadView(props: ThreadViewProps) {
       nonBlockingOutsidePress={submitOnEnter}
       onExpandedChange={setComposerExpanded}
       onComposerFocusChange={setComposerInputFocused}
-      onBubbleHeightChange={(height) => {
+      expansionLocked={expansionLocked}
+      aboveBubble={
+        // Order is the stack, bottom-up: the composer, the info chips riding
+        // directly on it, then a blocking approval/question above everything.
+        <>
+          <ComposerActionDocks
+            thread={thread}
+            agentStatus={agentStatus}
+            project={project}
+            dockState={dockState}
+            {...(props.onOpenWorkspaceFile
+              ? { onOpenPlanFile: (path: string) => props.onOpenWorkspaceFile?.(path) }
+              : {})}
+          />
+          <ComposerInfoChips
+            threadId={thread.id}
+            projectLocation={projectLocation}
+            dockState={dockState}
+            contextSummary={externalContextSummary}
+            hidden={composerOpen}
+          />
+        </>
+      }
+      onDockHeightChange={(height) => {
         // The scroll-to-bottom pin (and other floating chrome) reads this to
-        // stay clear of the composer as the bubble grows and shrinks.
+        // stay clear of the composer as the dock grows and shrinks.
         sectionRef.current?.style.setProperty("--m-thread-bubble-height", `${height}px`);
       }}
     >
@@ -284,6 +321,7 @@ export function ThreadView(props: ThreadViewProps) {
         composerPlaceholder={t`Follow up...`}
         submitOnEnter={submitOnEnter}
         hideInfoDocks
+        hideActionDocks
         todoDockCollapsed={dockState.todoDockCollapsed}
         todoDockPlacement={dockState.todoDockPlacement}
         todoDockState={dockState.todoDockState}
@@ -303,7 +341,15 @@ export function ThreadView(props: ThreadViewProps) {
     <section
       ref={sectionRef}
       className={isTerminal ? "m-thread m-thread--terminal" : "m-thread"}
-      style={{ "--m-keyboard-offset": `${terminalPageKeyboardOffset}px` } as CSSProperties}
+      style={
+        {
+          "--m-keyboard-offset": `${terminalPageKeyboardOffset}px`,
+          // The dock shadows --m-keyboard-offset with its own composer-focus
+          // lift, so request forms above the bubble (which never focus the
+          // composer) need the raw band under a name the dock does not own.
+          "--m-thread-keyboard-band": `${keyboardOffset}px`,
+        } as CSSProperties
+      }
     >
       {props.loading ? (
         <span className="m-loading-bar" role="progressbar" aria-label={t`Loading thread`} />
@@ -385,15 +431,6 @@ export function ThreadView(props: ThreadViewProps) {
           )}
         </div>
       </div>
-      {showComposerDock ? (
-        <ComposerInfoChips
-          threadId={thread.id}
-          projectLocation={projectLocation}
-          dockState={dockState}
-          contextSummary={externalContextSummary}
-          hidden={composerExpanded}
-        />
-      ) : null}
       {composerDock}
     </section>
   );

--- a/src/renderer/actions/threadRuntimeActions.ts
+++ b/src/renderer/actions/threadRuntimeActions.ts
@@ -6,7 +6,9 @@ import type {
   ThreadConfig,
   ThreadServerRequestId,
 } from "@/shared/contracts";
+import { toast } from "@heroui/react";
 import { isHomeProjectId } from "@/shared/homeScope";
+import { friendlyError } from "@/shared/messages";
 import { resolveProjectLocation } from "@/shared/worktree";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
 import { readBridge } from "@/renderer/bridge";
@@ -182,4 +184,18 @@ export function changeThreadConfig(threadId: string, config: ThreadConfig): void
       ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
     });
   }
+}
+
+/**
+ * Drop a queued steer message. Shared by the desktop composer's pending-steer
+ * strip and the mobile PWA's action-dock card, which hosts the same strip
+ * outside the compact composer.
+ */
+export function clearThreadPendingSteer(threadId: string): void {
+  void readBridge()
+    .clearPendingSteer({ threadId })
+    .catch((error: unknown) => {
+      console.error("[thread] failed to clear pending steer", error);
+      toast.danger(friendlyError(error));
+    });
 }

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -25,7 +25,10 @@ const runtimeActions = vi.hoisted(() => ({
   submitThreadInput: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/renderer/actions/threadRuntimeActions", () => ({
+// Partial mock: `clearThreadPendingSteer` keeps its real implementation so the
+// pending-steer cancel path still exercises the (mocked) bridge and its toast.
+vi.mock("@/renderer/actions/threadRuntimeActions", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/renderer/actions/threadRuntimeActions")>()),
   changeThreadConfig: runtimeActions.changeThreadConfig,
   resolveThreadServerRequest: runtimeActions.resolveThreadServerRequest,
   submitThreadInput: runtimeActions.submitThreadInput,

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -12,7 +12,10 @@ import { ChevronDown, GitFork, Monitor } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
-import { changeThreadConfig } from "@/renderer/actions/threadRuntimeActions";
+import {
+  changeThreadConfig,
+  clearThreadPendingSteer,
+} from "@/renderer/actions/threadRuntimeActions";
 import { BranchSelector, type BranchSelection } from "../common/BranchSelector/BranchSelector";
 import { modelVisibilityKey } from "@/renderer/components/common/ProviderModelMenu/parts/providerIdentity";
 import { AttachmentBar } from "../composer/AttachmentBar";
@@ -57,7 +60,7 @@ import {
 } from "./threadSlashCommands";
 import { useKeybindingStore } from "@/renderer/commands/keybindingStore";
 import { handleComposerControlShortcut } from "./threadComposerShortcuts";
-import { isAuthErrorMessage, type ThreadErrorDockState } from "./threadErrorState";
+import { resolveThreadAuthState, type ThreadErrorDockState } from "./threadErrorState";
 import type { ThreadGoalDockState } from "./threadGoalState";
 import type { ThreadTodoDockState } from "./threadTodoState";
 import type { TerminalPaneHandle } from "./TerminalPane";
@@ -100,10 +103,20 @@ type ThreadComposerSectionProps = {
    * Suppress the informational docks (subagents/crossagents/workflows, context,
    * goal, plan, errors) inside the composer. The mobile PWA sets this and surfaces
    * the same state as compact chips above the floating composer instead
-   * (ComposerInfoChips). Interactive docks — auth, pending steer, runtime
-   * requests, slash commands — always stay inline.
+   * (ComposerInfoChips). The action docks are gated separately — see
+   * {@link ThreadComposerSectionProps.hideActionDocks}.
    */
   hideInfoDocks?: boolean | undefined;
+  /**
+   * Suppress the action docks (auth required, pending steer, runtime requests)
+   * because the host renders them itself. The mobile PWA sets this: its compact
+   * composer clips to a single control line, so those docks are hoisted into the
+   * floating dock above the bubble (ComposerActionDocks). The slash-command
+   * panel stays inline — it only appears while the user is typing, i.e. with the
+   * composer already expanded. Deny-with-feedback from the input keeps working
+   * either way: this gates the panels, not the open request.
+   */
+  hideActionDocks?: boolean | undefined;
   onOpenProjectRelativePath?: ((path: string, lineNumber?: number) => void) | undefined;
   onTodoDockCollapsedChange: (collapsed: boolean) => void;
   onTodoDockPlacementChange: (placement: "composer" | "right") => void;
@@ -278,13 +291,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   );
   const filteredCommands = filterSlashCommands(availableCommands, slashQuery);
   const showCommandPanel = filteredCommands.length > 0;
-  // A stale runtime auth error (e.g. a 401 from before the user signed in)
-  // must not keep the auth dock visible once detection confirms the agent is
-  // authenticated again — otherwise the dock sticks until the user retries.
-  const isAgentAuthenticated = agentStatus?.authState === "authenticated";
-  const hasRuntimeAuthError =
-    !isAgentAuthenticated && errorDockStates.some((state) => isAuthErrorMessage(state.message));
-  const authRequired = agentStatus?.authState === "missing" || hasRuntimeAuthError;
+  const { authRequired, hasRuntimeAuthError } = resolveThreadAuthState({
+    authState: agentStatus?.authState,
+    errorDockStates,
+  });
   const canShowRuntimeChrome = !usesTerminalPresentation || isRemote;
   const isServerControlled =
     agentStatus?.capabilities.liveInputMode === "server" || !usesTerminalPresentation;
@@ -372,6 +382,13 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const approvalDenyOption = activeRuntimeRequest
     ? getApprovalDenyOption(activeRuntimeRequest)
     : undefined;
+  // Gate the inline docks only. `activeRuntimeRequest` still drives the
+  // composer's deny-with-feedback submit path, and `authRequired` still disables
+  // submit/voice, when a host renders these docks itself.
+  const hideActionDocks = props.hideActionDocks === true;
+  const composerRuntimeRequest = hideActionDocks ? undefined : activeRuntimeRequest;
+  const composerPendingSteer = hideActionDocks ? undefined : visiblePendingSteer;
+  const showAuthInComposer = authRequired && !hideActionDocks;
   const reportedContextUsage = useAppStore((s) =>
     canShowRuntimeChrome ? s.runtimeContextByThread[thread.id] : undefined,
   );
@@ -468,15 +485,6 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         setControlOpenRequest((prev) => ({ target, nonce: (prev?.nonce ?? 0) + 1 })),
       onSubmitInput: props.onSubmitInput,
     });
-  }
-
-  function handleCancelPendingSteer() {
-    void readBridge()
-      .clearPendingSteer({ threadId: thread.id })
-      .catch((error: unknown) => {
-        console.error("[thread] failed to clear pending steer", error);
-        toast.danger(friendlyError(error));
-      });
   }
 
   useEffect(() => {
@@ -637,9 +645,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                     showErrorInComposer ||
                     showGoalInComposer ||
                     showTodoInComposer ||
-                    authRequired ||
-                    visiblePendingSteer ||
-                    activeRuntimeRequest ||
+                    showAuthInComposer ||
+                    composerPendingSteer ||
+                    composerRuntimeRequest ||
                     showCommandPanel ? (
                       <ThreadComposerDocks
                         hasActiveSubAgent={hasActiveSubAgent}
@@ -647,7 +655,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         showErrorInComposer={showErrorInComposer}
                         showGoalInComposer={showGoalInComposer}
                         showTodoInComposer={showTodoInComposer}
-                        authRequired={authRequired}
+                        authRequired={showAuthInComposer}
                         showCommandPanel={showCommandPanel}
                         threadId={thread.id}
                         projectLocation={projectLocation}
@@ -662,8 +670,8 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         todoDockState={todoDockState}
                         todoDockCollapsed={todoDockCollapsed}
                         todoDockPlacement={todoDockPlacement}
-                        pendingSteer={visiblePendingSteer}
-                        activeRuntimeRequest={activeRuntimeRequest}
+                        pendingSteer={composerPendingSteer}
+                        activeRuntimeRequest={composerRuntimeRequest}
                         filteredCommands={filteredCommands}
                         slashActiveIndex={slashActiveIndex}
                         commandListId={commandListId}
@@ -675,7 +683,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
                         {...(props.onTodoDockRetire
                           ? { onTodoDockRetire: props.onTodoDockRetire }
                           : {})}
-                        onCancelPendingSteer={handleCancelPendingSteer}
+                        onCancelPendingSteer={() => clearThreadPendingSteer(thread.id)}
                         {...(props.onOpenProjectRelativePath
                           ? { onOpenProjectRelativePath: props.onOpenProjectRelativePath }
                           : {})}

--- a/src/renderer/components/thread/threadErrorState.ts
+++ b/src/renderer/components/thread/threadErrorState.ts
@@ -1,4 +1,4 @@
-import type { ErrorItemPayload } from "@/shared/contracts";
+import type { AuthState, ErrorItemPayload } from "@/shared/contracts";
 import type { AppStoreState } from "@/renderer/state/slices/shared";
 import {
   getRuntimeItemPayload,
@@ -91,4 +91,25 @@ export function isAuthErrorMessage(message: string): boolean {
     m.includes("oauth_org_not_allowed") ||
     /\bnot logged in\b/.test(m)
   );
+}
+
+/**
+ * Whether the auth-required dock applies, shared by every surface that hosts it
+ * (the desktop composer and the mobile PWA's action-dock card). A stale runtime
+ * auth error — e.g. a 401 from before the user signed in — must not keep the
+ * dock visible once detection confirms the agent is authenticated again;
+ * `hasRuntimeAuthError` is returned separately because the error dock hides
+ * itself for exactly those messages.
+ */
+export function resolveThreadAuthState(input: {
+  readonly authState: AuthState | undefined;
+  readonly errorDockStates: readonly ThreadErrorDockState[];
+}): { readonly authRequired: boolean; readonly hasRuntimeAuthError: boolean } {
+  const hasRuntimeAuthError =
+    input.authState !== "authenticated" &&
+    input.errorDockStates.some((state) => isAuthErrorMessage(state.message));
+  return {
+    authRequired: input.authState === "missing" || hasRuntimeAuthError,
+    hasRuntimeAuthError,
+  };
 }


### PR DESCRIPTION
- Classify this as a Bugfix for mobile composer behavior.
- Keep authentication, queued-steer, and runtime-request controls visible above the collapsed composer, including while the keyboard is open.
- Prevent blocking runtime requests from expanding the composer over their controls and preserve correct dock/pin layout.
- Share pending-steer cancellation and authentication-state handling across mobile and desktop composer surfaces, with coverage for the updated interactions.