### PR TITLE
Fix hidden models appearing in favorites and recents

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
@@ -121,6 +121,7 @@ describe("ProviderModelMenu", () => {
     useSharedSettings.setState({
       favoriteModels: [],
       recentModels: [],
+      hiddenModels: {},
     });
   });
 
@@ -524,6 +525,41 @@ describe("ProviderModelMenu", () => {
     expect(within(listbox).getByText("Gui Recent")).toBeInTheDocument();
     expect(within(listbox).queryByText("Terminal Fav")).not.toBeInTheDocument();
     expect(within(listbox).queryByText("Terminal Recent")).not.toBeInTheDocument();
+  });
+
+  it("keeps hidden models out of the favorites and recents sections", async () => {
+    useSharedSettings.setState({
+      favoriteModels: [{ agentKind: "codex", modelId: "model-2", presentationMode: "gui" }],
+      recentModels: [
+        { agentKind: "codex", modelId: "model-4[1m]", presentationMode: "gui" },
+        { agentKind: "codex", modelId: "model-3", presentationMode: "gui" },
+      ],
+      hiddenModels: { codex: ["model-2", "model-4"] },
+    });
+
+    // Callers strip hidden models from the capabilities they pass in, so the
+    // visible catalog only carries model-1 and model-3.
+    const codex = makeNamedProvider("codex", "Codex", 3);
+    codex.capabilities.models = codex.capabilities.models.filter((m) => m.id !== "model-2");
+
+    render(
+      <ProviderModelMenu
+        providers={[codex, makeNamedProvider("claude", "Claude", 1)]}
+        currentAgentKind="codex"
+        currentModel="model-1"
+        presentationMode="gui"
+        onChange={vi.fn<(next: { agentKind: string; model: string }) => void>()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const listbox = await screen.findByRole("listbox", { name: "Models" });
+    expect(within(listbox).getByText("Recent")).toBeInTheDocument();
+    expect(within(listbox).getAllByText("Model 3").length).toBeGreaterThan(0);
+    expect(within(listbox).queryAllByText("Favorites")).toHaveLength(0);
+    expect(within(listbox).queryAllByText("Model 2")).toHaveLength(0);
+    expect(within(listbox).queryAllByText(/Model 4/u)).toHaveLength(0);
   });
 
   it("does not duplicate favorites into a separate section when only one provider is visible", async () => {

--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -283,6 +283,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
   const favorites = useSharedSettings((s) => s.favoriteModels);
   const recents = useSharedSettings((s) => s.recentModels);
   const providerOrder = useSharedSettings((s) => s.providerOrder);
+  const hiddenModels = useSharedSettings((s) => s.hiddenModels);
   const toggleFavoriteModel = useSharedSettings((s) => s.toggleFavoriteModel);
   const latestFavoritesRef = useRef(favorites);
   const latestRecentsRef = useRef(recents);
@@ -356,6 +357,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
         favorites: sectionFavorites,
         favoriteStateRefs: activeFavorites,
         recents: sectionRecents,
+        hiddenModels,
         providerOrder,
       })
     : [];

--- a/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
+++ b/src/renderer/components/common/ProviderModelMenu/parts/buildItems.ts
@@ -65,6 +65,12 @@ export interface BuildProviderModelItemsInput {
   /** Display cap for recents (default 5). */
   recentsLimit?: number;
   /**
+   * Hidden model ids keyed by provider visibility key. Callers already strip
+   * these from `providers[*].capabilities.models`; this keeps them out of the
+   * favorites/recents sections too, which resolve from persisted refs.
+   */
+  hiddenModels?: Readonly<Record<string, readonly string[] | undefined>>;
+  /**
    * User-defined provider display order. Kinds in this list win over the built-in
    * provider-manifest default; anything missing falls to the tail.
    */
@@ -308,20 +314,50 @@ function findVisibleProvider(
   );
 }
 
+const EMPTY_HIDDEN_ALIASES: ReadonlySet<string> = new Set();
+const hiddenAliasCache = new WeakMap<readonly string[], ReadonlySet<string>>();
+
+// Expand a provider's hidden ids into every alias form once and cache it against
+// the settings array identity, so repeated builds (each keystroke re-runs this
+// while the menu is open) reuse the same set instead of re-deriving aliases.
+function getHiddenAliases(hiddenIds: readonly string[] | undefined): ReadonlySet<string> {
+  if (!hiddenIds || hiddenIds.length === 0) return EMPTY_HIDDEN_ALIASES;
+  const cached = hiddenAliasCache.get(hiddenIds);
+  if (cached) return cached;
+  const aliases = new Set<string>();
+  for (const id of hiddenIds) {
+    for (const alias of modelLookupAliases(id)) aliases.add(alias);
+  }
+  hiddenAliasCache.set(hiddenIds, aliases);
+  return aliases;
+}
+
 function resolveModelRef(
   ref: ModelRef,
   providersByKind: ReadonlyMap<string, VisibleProvider[]>,
+  hiddenModels: BuildProviderModelItemsInput["hiddenModels"],
 ): ResolvedModelRef | undefined {
   const visibleProvider = findVisibleProvider(providersByKind, ref.agentKind, ref.presentationMode);
   if (!visibleProvider) return undefined;
   const { provider, cache } = visibleProvider;
-  const model =
-    findModelEntry(cache, ref.modelId) ??
-    makeModelEntry(
+  let model = findModelEntry(cache, ref.modelId);
+  if (!model) {
+    // Missing from the visible catalog means the caller either hid this model or
+    // never offered it. Hidden ones drop out of the section; genuinely unknown
+    // ids (stale recents, custom models) still get a synthesized row. Only this
+    // miss path pays for the hidden lookup — a resolvable id can't be hidden.
+    const hidden = getHiddenAliases(hiddenModels?.[visibleProvider.visibilityKey]);
+    if (hidden.size > 0) {
+      for (const alias of modelLookupAliases(ref.modelId)) {
+        if (hidden.has(alias)) return undefined;
+      }
+    }
+    model = makeModelEntry(
       ref.modelId,
       formatShortcutFallbackLabel(ref.agentKind, ref.modelId),
       provider.capabilities,
     );
+  }
   const resolved: ResolvedModelRef = {
     ref,
     label: formatShortcutModelLabel(ref.agentKind, ref.modelId, model.label),
@@ -347,6 +383,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     favoriteStateRefs,
     recents,
     recentsLimit = 5,
+    hiddenModels,
     providerOrder,
   } = input;
   const providerSortKey = makeProviderSortKey(providerOrder);
@@ -411,7 +448,7 @@ export function buildProviderModelItems(input: BuildProviderModelItemsInput): Pr
     });
     const items = dedupedRefs
       .filter((ref) => visibleKinds.has(ref.agentKind))
-      .map((ref) => resolveModelRef(ref, visibleProvidersByKind))
+      .map((ref) => resolveModelRef(ref, visibleProvidersByKind, hiddenModels))
       .filter((m): m is ResolvedModelRef => m !== undefined)
       .filter((m) => {
         if (!isSearching) return true;


### PR DESCRIPTION
- **Bugfix:** prevent hidden provider models from resurfacing in Favorites and Recent sections.
- Apply hidden-model filtering to persisted model references, including alias forms and stale entries.
- Add coverage confirming hidden models remain absent while visible recents continue to display.