### PR TITLE
Add draggable thread tool rail and lockable right panel

### DIFF
--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -2,6 +2,7 @@ import type { ProjectLocation, Thread } from "@/shared/contracts";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -167,14 +168,15 @@ function applyFilesPanel(
 
   const fileEditor = useFileEditorStore.getState();
   const currentRoot = fileEditor.rootContext;
-  const hasDirtyBuffers = Object.values(fileEditor.buffers).some(
-    (buffer) => buffer.status === "ready" && buffer.isDirty,
-  );
   const isSameContext =
     currentRoot?.projectId === context.projectId &&
     currentRoot?.worktreePath === context.worktreePath;
 
-  if (!isSameContext && hasDirtyBuffers && !window.confirm("Discard unsaved editor changes?")) {
+  if (
+    !isSameContext &&
+    hasDirtyEditorBuffers() &&
+    !window.confirm("Discard unsaved editor changes?")
+  ) {
     return;
   }
 

--- a/src/renderer/components/layout/UnifiedRightPanel.tsx
+++ b/src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5,6 +5,8 @@ import {
   FolderOpen,
   Gauge,
   Globe,
+  Lock,
+  LockOpen,
   Maximize2,
   NotebookPen,
   PanelRightClose,
@@ -60,6 +62,9 @@ export function UnifiedRightPanel(props: {
   onOpenUsage?: () => void;
   onOpenNotes?: () => void;
   onOpenPorts?: () => void;
+  /** Whether the panel re-scopes itself to whichever thread is open. */
+  followsThread?: boolean;
+  onToggleFollowsThread?: () => void;
   onClose: () => void;
 }) {
   const {
@@ -97,6 +102,8 @@ export function UnifiedRightPanel(props: {
     onOpenUsage,
     onOpenNotes,
     onOpenPorts,
+    followsThread = false,
+    onToggleFollowsThread,
     onClose,
   } = props;
   const { t } = useLingui();
@@ -258,6 +265,21 @@ export function UnifiedRightPanel(props: {
             </button>
           );
         })}
+        {onToggleFollowsThread ? (
+          <button
+            type="button"
+            className={`${dragCtl} ${panelHeaderTabIconButtonClass(followsThread)}`}
+            title={
+              followsThread
+                ? t`Unlock panel from the open thread`
+                : t`Lock panel to the open thread`
+            }
+            aria-pressed={followsThread}
+            onClick={onToggleFollowsThread}
+          >
+            {followsThread ? <Lock className="size-3.5" /> : <LockOpen className="size-3.5" />}
+          </button>
+        ) : null}
         <button
           type="button"
           className={`${dragCtl} ${panelHeaderIconButtonClass}`}

--- a/src/renderer/components/layout/sidebarChrome.ts
+++ b/src/renderer/components/layout/sidebarChrome.ts
@@ -45,6 +45,15 @@ export const panelHeaderRowClass =
 export const panelHeaderTooltipTriggerResetClass =
   "min-w-0 shrink-0 justify-start rounded border-0 bg-transparent p-0 shadow-none outline-none";
 
+/**
+ * Floating chrome that hovers over a thread's conversation — the per-thread tool
+ * rail, the changes bubble above the composer, and the scroll-to-bottom button.
+ * One class so the three share a surface; the tint tracks `--sidebar-background`
+ * (see styles.css) so they read as app chrome in every theme.
+ */
+export const floatingChromeSurfaceClass =
+  "border border-border/15 bg-[var(--floating-chrome-surface)] shadow-lg backdrop-blur-md";
+
 /** Icon button in panel headers (tab toggles, close, expand). */
 export const panelHeaderIconButtonClass =
   "inline-flex items-center justify-center rounded p-0.5 text-muted hover:text-foreground";

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { ArrowDown } from "lucide-react";
+import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
 import { useAppStore } from "@/renderer/state/appStore";
 import { isPanelResizing, subscribePanelResize } from "@/renderer/state/panelResizeSignal";
 import {
@@ -745,7 +746,10 @@ export const ChatScrollControls = forwardRef<
       size="sm"
       aria-label={t`Scroll to bottom`}
       onPress={handleScrollButtonPress}
-      className={`absolute bottom-4 right-4 z-10 transition-opacity duration-200 ease-out ${
+      /* Centered via a negative margin, not `-translate-x-1/2`: HeroUI's pressed
+         state animates `transform`, which would fight a translate and snap the
+         button sideways on click. */
+      className={`${floatingChromeSurfaceClass} absolute bottom-4 left-1/2 z-10 -ml-3.5 size-7 min-w-0 rounded-full transition-opacity duration-200 ease-out ${
         showScrollDown ? "opacity-80 hover:opacity-100" : "pointer-events-none opacity-0"
       }`}
     >

--- a/src/renderer/components/thread/ThreadChangesBubble.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.tsx
@@ -1,0 +1,45 @@
+import { useShallow } from "zustand/shallow";
+import { useLingui } from "@lingui/react/macro";
+import { showGitReviewPanel } from "@/renderer/actions/panelActions";
+import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
+import { useGitStore } from "@/renderer/state/gitStore";
+
+/**
+ * Translucent working-tree diff stat that floats over the top-right corner of
+ * the composer. Renders nothing when the thread's scope has no changes, and
+ * opens the docked Git review panel for that scope on click.
+ */
+export function ThreadChangesBubble(props: {
+  projectId: string;
+  worktreePath?: string | undefined;
+}) {
+  const { t } = useLingui();
+  const { insertions, deletions } = useGitStore(
+    useShallow((s) => {
+      const status = props.worktreePath
+        ? s.worktreeStatuses[props.worktreePath]
+        : s.statuses[props.projectId];
+      return {
+        insertions: status?.totalInsertions ?? 0,
+        deletions: status?.totalDeletions ?? 0,
+      };
+    }),
+  );
+
+  if (insertions === 0 && deletions === 0) return null;
+
+  return (
+    <button
+      type="button"
+      title={t`Review changes`}
+      aria-label={t`Review changes`}
+      /* Sized to a 28px pill — same height as the scroll-to-bottom circle and the
+         rail's icon buttons, so the floating chrome shares one scale. */
+      className={`${floatingChromeSurfaceClass} absolute bottom-full right-2 z-10 mb-1.5 flex h-7 items-center gap-1.5 rounded-full px-3 text-xs font-medium transition-colors hover:border-border/30`}
+      onClick={() => showGitReviewPanel(props.projectId, props.worktreePath)}
+    >
+      {insertions > 0 && <span className="text-success">+{insertions}</span>}
+      {deletions > 0 && <span className="text-danger">-{deletions}</span>}
+    </button>
+  );
+}

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -43,6 +43,7 @@ import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { selectActiveSubAgentParentItemIds } from "@/renderer/state/subAgentSelectors";
 import { useThread } from "@/renderer/state/useThread";
+import { ThreadChangesBubble } from "./ThreadChangesBubble";
 import { ThreadComposer, type ComposerControl } from "./ThreadComposer";
 import { supportsUsableFastMode } from "./threadDraftViewHelpers";
 import { ThreadContextIndicator } from "./ThreadContextIndicator";
@@ -601,7 +602,11 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   return (
     <>
       {thread.status !== "launching" || !usesTerminalPresentation ? (
-        <div>
+        <div className="relative">
+          <ThreadChangesBubble
+            projectId={thread.projectId}
+            {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+          />
           <div
             className={`grid transition-[grid-template-rows] ease-[cubic-bezier(0.16,1,0.3,1)] ${isComposerCollapsed ? "duration-300" : "duration-200"}`}
             style={{ gridTemplateRows: isComposerCollapsed ? "0fr" : "1fr" }}

--- a/src/renderer/components/thread/ThreadToolRail.tsx
+++ b/src/renderer/components/thread/ThreadToolRail.tsx
@@ -1,0 +1,276 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { FileDiff, FolderOpen, NotebookPen, PanelRightOpen, TerminalSquare } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import { isHomeProjectId } from "@/shared/homeScope";
+import {
+  closeAllPanels,
+  openFilesPanel,
+  openNotesPanel,
+  showGitReviewPanel,
+} from "@/renderer/actions/panelActions";
+import { openTerminal, openWorktreeTerminal } from "@/renderer/actions/terminalActions";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { usePanelVisibility } from "@/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility";
+import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
+import { useThreadToolRailDrag } from "./useThreadToolRailDrag";
+
+/**
+ * Closed handle and open rail share both the surface (with the changes bubble
+ * and scroll-to-bottom) and the pill geometry, so opening shifts nothing.
+ */
+const railPillClass = "flex flex-col items-center gap-0.5 rounded-full p-1";
+
+/**
+ * Pane width from which an always-open rail clears the chat column instead of
+ * covering it: the column is centered and capped at 920px (inside a 1040px
+ * shell with 12px side padding), and the rail needs 36px plus an 8px gap on
+ * each side — 920 + 2 × 44.
+ */
+const ALWAYS_OPEN_MIN_PANE_WIDTH = 1008;
+
+interface RailTool {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  active: boolean;
+  activate: () => void;
+}
+
+/**
+ * Per-pane launcher for the thread-scoped right-panel tools (git, files,
+ * terminal, notes) pointed at *this* thread's project + worktree. Panel-wide
+ * tools that are not tied to a thread (usage, browser) stay in the right panel
+ * header only.
+ *
+ * Interaction mirrors the mobile PWA:
+ * - Hidden entirely while the right panel is docked — the panel already exposes
+ *   every tool in its header, and the rail would sit right against it.
+ * - Single pane wide enough that the rail lands beside the centered chat column
+ *   instead of over it: permanently open and visible.
+ * - Anything narrower (or split panes): only a handle, revealed on pane
+ *   hover/focus, expanding into the rail on hover/focus of the rail itself. The
+ *   hover target is deliberately larger than the handle so approaching the edge
+ *   counts as intent to open, but stays short vertically so it does not swallow
+ *   text selection or scrollbar drags down the whole right edge.
+ */
+export function ThreadToolRail(props: {
+  projectId: string;
+  worktreePath?: string | undefined;
+  paneCount: number;
+}) {
+  const { t } = useLingui();
+  const { projectId, worktreePath, paneCount } = props;
+
+  const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
+  const gitScoped = usePanelStore(
+    (s) =>
+      s.gitReviewAsPanel &&
+      s.gitReviewContext?.projectId === projectId &&
+      s.gitReviewContext?.worktreePath === worktreePath,
+  );
+  const filesScoped = usePanelStore(
+    (s) =>
+      s.filesPanelContext?.projectId === projectId &&
+      s.filesPanelContext?.worktreePath === worktreePath,
+  );
+  const notesPanelOpen = usePanelStore((s) => s.notesPanelOpen);
+  const terminalScoped = useDevTerminalStore(
+    (s) =>
+      s.isOpen &&
+      s.activeProjectId === projectId &&
+      (s.activeWorktreePath ?? undefined) === worktreePath,
+  );
+  const terminalOnRight = useSharedSettings((s) => s.terminalPosition === "right");
+  const { rightPanelOpen, gitPanelOpen } = usePanelVisibility();
+  // Only the right-edge aside counts: with the terminal docked at the bottom,
+  // `rightPanelOpen` tracks that bottom dock and must not hide the rail.
+  const sidePanelOpen = gitPanelOpen || (terminalOnRight && rightPanelOpen);
+
+  const railRef = useRef<HTMLDivElement>(null);
+  const pillRef = useRef<HTMLDivElement>(null);
+  const [paneWidth, setPaneWidth] = useState<number | null>(null);
+  const [paneHeight, setPaneHeight] = useState<number | null>(null);
+  const [railHeight, setRailHeight] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    if (sidePanelOpen) return;
+    // The rail is absolutely positioned inside the thread pane, so its
+    // offsetParent *is* that pane. Its width decides whether an always-open rail
+    // lands beside the centered chat column or on top of it; its height, plus
+    // the pill's own, bounds how far the rail can be dragged.
+    const pane = railRef.current?.offsetParent;
+    if (!(pane instanceof HTMLElement)) return;
+    // `invisible` keeps layout, so the closed rail still reports its real height.
+    const pill = pillRef.current;
+
+    const skipIfClose = (prev: number | null, next: number) =>
+      prev !== null && Math.abs(prev - next) < 0.5 ? prev : next;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === pane) {
+          const rect = entry.contentRect;
+          setPaneWidth((prev) => skipIfClose(prev, rect.width));
+          setPaneHeight((prev) => skipIfClose(prev, rect.height));
+        } else if (entry.target === pill) {
+          setRailHeight((prev) => skipIfClose(prev, entry.contentRect.height));
+        }
+      }
+    });
+    observer.observe(pane);
+    if (pill) observer.observe(pill);
+    return () => observer.disconnect();
+  }, [sidePanelOpen]);
+
+  const { offset, isDragging, dragHandlers } = useThreadToolRailDrag({ paneHeight, railHeight });
+
+  const alwaysOpen =
+    paneCount === 1 && paneWidth !== null && paneWidth >= ALWAYS_OPEN_MIN_PANE_WIDTH;
+  // A drag can travel outside the hover box, which would otherwise drop the
+  // CSS-driven open state mid-gesture.
+  const forceOpen = alwaysOpen || isDragging;
+
+  // Home-scope "projects" have no repository or file root, matching the tabs
+  // the right panel itself hides for that scope.
+  const isHomeScope = isHomeProjectId(projectId);
+  const gitActive = gitScoped && rightPanelTab === "git";
+  const terminalActive = terminalScoped && (!terminalOnRight || rightPanelTab === "terminal");
+
+  const tools: RailTool[] = [
+    ...(isHomeScope
+      ? []
+      : [
+          {
+            id: "git",
+            label: t`Git`,
+            icon: FileDiff,
+            active: gitActive,
+            activate: () => {
+              if (gitActive) {
+                closeAllPanels();
+                return;
+              }
+              showGitReviewPanel(projectId, worktreePath);
+            },
+          },
+          {
+            id: "files",
+            label: t`Files`,
+            icon: FolderOpen,
+            active: filesScoped && rightPanelTab === "files",
+            activate: () => openFilesPanel(projectId, worktreePath),
+          },
+        ]),
+    {
+      id: "terminal",
+      label: t`Terminal`,
+      icon: TerminalSquare,
+      active: terminalActive,
+      activate: () => {
+        if (worktreePath) {
+          openWorktreeTerminal(projectId, worktreePath);
+          return;
+        }
+        openTerminal(projectId);
+      },
+    },
+    {
+      id: "notes",
+      label: t`Notes`,
+      icon: NotebookPen,
+      active: notesPanelOpen && rightPanelTab === "notes",
+      activate: openNotesPanel,
+    },
+  ];
+
+  const primaryTool = tools[0];
+  if (!primaryTool) return null;
+  // The docked panel already exposes every tool in its header. Re-measuring is
+  // handled by the layout effect above, which re-attaches once this clears.
+  if (sidePanelOpen) return null;
+
+  // Top-anchored with a draggable offset rather than vertically centered, so the
+  // rail sits over the conversation body wherever the user parked it.
+  return (
+    <div
+      ref={railRef}
+      className="pointer-events-none absolute inset-y-0 right-0 z-20 flex items-start"
+    >
+      {/* When the rail has to overlap the chat column, padding — not size —
+          makes the open/intent area larger than the handle, while staying short
+          enough that it does not swallow scrollbar drags down the right edge.
+          Positioned with a transform, not layout: the pill carries a
+          `backdrop-blur` layer, and re-laying it out every drag frame makes the
+          compositor flash a stale copy of that backdrop. */}
+      <div
+        className={`group/rail pointer-events-auto flex items-start py-3 pr-1.5 ${
+          alwaysOpen ? "pl-1.5" : "pl-10"
+        }`}
+        style={{ transform: `translateY(${offset}px)` }}
+      >
+        <div className="relative flex items-start">
+          {/* Same pill geometry as the open rail, so opening shifts nothing.
+              Fades in with the pane, then out as the rail opens over it — the
+              open surface is translucent, so leaving it underneath would show
+              its glyph through. */}
+          {forceOpen ? null : (
+            <div className="opacity-0 transition-opacity duration-150 group-hover/pane:opacity-80">
+              <div className="transition-opacity duration-150 group-hover/rail:opacity-0 group-focus-within/rail:opacity-0">
+                <div className={`${floatingChromeSurfaceClass} ${railPillClass}`}>
+                  <button
+                    type="button"
+                    title={t`Show thread tools`}
+                    aria-label={t`Show thread tools`}
+                    className="flex size-7 items-center justify-center rounded-full text-muted transition-colors hover:text-foreground"
+                    onClick={primaryTool.activate}
+                  >
+                    <PanelRightOpen className="size-3.5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+          {/* `invisible` (not just opacity) keeps the closed rail out of the tab
+              order; focus-within on the handle reveals it before Tab moves in.
+              It grows downward from the handle instead of expanding around it,
+              which would push the rail up over the pane header. */}
+          <div
+            ref={pillRef}
+            data-poracode-thread-tool-rail=""
+            className={`${floatingChromeSurfaceClass} ${railPillClass} cursor-grab touch-none select-none transition-opacity duration-150 active:cursor-grabbing ${
+              alwaysOpen ? "" : "absolute right-0 top-0"
+            } ${
+              forceOpen
+                ? ""
+                : "invisible opacity-0 group-hover/rail:visible group-hover/rail:opacity-100 group-focus-within/rail:visible group-focus-within/rail:opacity-100"
+            }`}
+            {...dragHandlers}
+          >
+            {tools.map((tool) => {
+              const Icon = tool.icon;
+              return (
+                <button
+                  key={tool.id}
+                  type="button"
+                  title={tool.label}
+                  aria-label={tool.label}
+                  aria-pressed={tool.active}
+                  className={`flex size-7 items-center justify-center rounded-full transition-colors ${
+                    tool.active
+                      ? "bg-accent/15 text-accent"
+                      : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
+                  }`}
+                  onClick={tool.activate}
+                >
+                  <Icon className="size-3.5" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -26,6 +26,7 @@ import { ContinueInProviderDialog } from "./ContinueInProviderDialog";
 import { GuiThreadContent } from "./ThreadContent";
 import { TerminalThreadContent } from "./TerminalThreadContent";
 import { ThreadHeaderStatusButton } from "./ThreadHeaderStatus";
+import { ThreadToolRail } from "./ThreadToolRail";
 
 /**
  * Strip Electron's `Error invoking remote method '<channel>': Error: ` prefix
@@ -263,7 +264,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     <>
       <div
         ref={droppableRef}
-        className={`relative flex h-full min-h-0 flex-col ${isDragging ? "opacity-50" : ""}`}
+        className={`group/pane relative flex h-full min-h-0 flex-col ${isDragging ? "opacity-50" : ""}`}
       >
         {/* Header bar — provider icon outside pane drag handle; status tooltip uses HeroUI tooltip (anchored bottom start). */}
         <div className={`px-2 ${headerNeedsTrafficLightPad ? macosTrafficLightPadClass : ""}`}>
@@ -463,6 +464,12 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
             )}
           </div>
         </div>
+
+        <ThreadToolRail
+          projectId={thread.projectId}
+          paneCount={paneCount}
+          {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+        />
       </div>
       {onContinueInProvider && installedAgents && continueDialogOpen ? (
         <ContinueInProviderDialog

--- a/src/renderer/components/thread/useThreadToolRailDrag.ts
+++ b/src/renderer/components/thread/useThreadToolRailDrag.ts
@@ -1,0 +1,121 @@
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { usePanelStore } from "@/renderer/state/panelStore";
+
+/** Pointer travel before a press turns into a drag instead of a button click. */
+const DRAG_THRESHOLD_PX = 4;
+/** Keeps the rail off the pane's top and bottom edges. */
+const EDGE_INSET_PX = 8;
+
+interface RailDragState {
+  pointerId: number;
+  startY: number;
+  startOffset: number;
+  lastOffset: number;
+  moved: boolean;
+}
+
+interface ThreadToolRailDrag {
+  /** Clamped vertical offset to render at, live while dragging. */
+  offset: number;
+  isDragging: boolean;
+  /** Spread onto the rail pill — it is both the grab handle and the tool container. */
+  dragHandlers: {
+    onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+    onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+    onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+    onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
+    onClickCapture: (event: React.MouseEvent<HTMLElement>) => void;
+  };
+}
+
+/**
+ * Vertical-only drag for the thread tool rail. The offset lives in the panel
+ * store (persisted, shared by every pane) and is clamped to the pane on every
+ * render, so shrinking the window can never park the rail out of reach.
+ *
+ * The rail pill doubles as the grab handle, so a press only becomes a drag past
+ * {@link DRAG_THRESHOLD_PX}; below that it stays a plain button click. When it
+ * does become a drag, the click that follows `pointerup` is swallowed.
+ */
+export function useThreadToolRailDrag(params: {
+  paneHeight: number | null;
+  railHeight: number | null;
+}): ThreadToolRailDrag {
+  const { paneHeight, railHeight } = params;
+  const storedOffset = usePanelStore((s) => s.threadToolRailOffset);
+  const setStoredOffset = usePanelStore((s) => s.setThreadToolRailOffset);
+
+  const [dragOffset, setDragOffset] = useState<number | null>(null);
+  const dragStateRef = useRef<RailDragState | null>(null);
+  const justDraggedRef = useRef(false);
+
+  function clamp(value: number): number {
+    const maxOffset =
+      paneHeight !== null && railHeight !== null
+        ? Math.max(EDGE_INSET_PX, paneHeight - railHeight - EDGE_INSET_PX)
+        : null;
+    const lowerBounded = Math.max(value, EDGE_INSET_PX);
+    return maxOffset === null ? lowerBounded : Math.min(lowerBounded, maxOffset);
+  }
+
+  const offset = clamp(dragOffset ?? storedOffset);
+
+  function onPointerDown(event: ReactPointerEvent<HTMLElement>) {
+    if (event.button !== 0) return;
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startY: event.clientY,
+      startOffset: offset,
+      lastOffset: offset,
+      moved: false,
+    };
+  }
+
+  function onPointerMove(event: ReactPointerEvent<HTMLElement>) {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    const delta = event.clientY - state.startY;
+    if (!state.moved) {
+      if (Math.abs(delta) < DRAG_THRESHOLD_PX) return;
+      state.moved = true;
+      // Captured only once this is a real drag: capturing on `pointerdown`
+      // retargets `pointerup` and swallows clicks on the tool buttons.
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+    const next = clamp(state.startOffset + delta);
+    state.lastOffset = next;
+    setDragOffset(next);
+  }
+
+  function endDrag(event: ReactPointerEvent<HTMLElement>) {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) return;
+    dragStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setDragOffset(null);
+    if (!state.moved) return;
+    justDraggedRef.current = true;
+    setStoredOffset(state.lastOffset);
+  }
+
+  function onClickCapture(event: React.MouseEvent<HTMLElement>) {
+    if (!justDraggedRef.current) return;
+    justDraggedRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  return {
+    offset,
+    isDragging: dragOffset !== null,
+    dragHandlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+      onClickCapture,
+    },
+  };
+}

--- a/src/renderer/hooks/useRightPanelThreadLock.test.tsx
+++ b/src/renderer/hooks/useRightPanelThreadLock.test.tsx
@@ -1,0 +1,101 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Thread } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useRightPanelThreadLock } from "./useRightPanelThreadLock";
+
+function makeThread(input: Partial<Thread> = {}): Thread {
+  const now = "2026-03-22T00:00:00.000Z";
+  return {
+    id: "thread-a",
+    projectId: "project-a",
+    title: "Thread",
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: now,
+    updatedAt: now,
+    ...input,
+  };
+}
+
+const threadA = makeThread({ id: "thread-a", projectId: "project-a" });
+const threadB = makeThread({
+  id: "thread-b",
+  projectId: "project-b",
+  worktreePath: "/repo-b/.poracode/worktrees/feature",
+});
+
+function focusThread(threadId: string) {
+  useAppStore.setState((state) => ({
+    ...state,
+    threads: [threadA, threadB],
+    view: { kind: "thread", panes: [threadId] },
+    focusedPaneId: threadId,
+  }));
+}
+
+describe("useRightPanelThreadLock", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    usePanelStore.setState({
+      rightPanelFollowsThread: true,
+      gitReviewContext: { projectId: "project-a" },
+      gitReviewAsPanel: true,
+      filesPanelContext: null,
+      rightPanelTab: "git",
+    });
+    focusThread("thread-a");
+  });
+
+  it("re-scopes the open git panel to the focused thread", () => {
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(usePanelStore.getState().gitReviewContext).toEqual({
+      projectId: "project-b",
+      worktreePath: threadB.worktreePath,
+    });
+    expect(usePanelStore.getState().rightPanelTab).toBe("git");
+  });
+
+  it("keeps the active tab when re-scoping", () => {
+    usePanelStore.setState({ rightPanelTab: "usage" });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(usePanelStore.getState().gitReviewContext?.projectId).toBe("project-b");
+    expect(usePanelStore.getState().rightPanelTab).toBe("usage");
+  });
+
+  it("leaves the panel alone while unlocked", () => {
+    usePanelStore.setState({ rightPanelFollowsThread: false });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(usePanelStore.getState().gitReviewContext).toEqual({ projectId: "project-a" });
+  });
+
+  it("does not open panels the user has closed", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(usePanelStore.getState().gitReviewContext).toBeNull();
+    expect(usePanelStore.getState().filesPanelContext).toBeNull();
+  });
+});

--- a/src/renderer/hooks/useRightPanelThreadLock.ts
+++ b/src/renderer/hooks/useRightPanelThreadLock.ts
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { isHomeProjectId } from "@/shared/homeScope";
+import { resolveActivePaneId } from "@/renderer/actions/currentProject";
+import { showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
+import { useAppStore } from "@/renderer/state/appStore";
+import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
+import { usePanelStore } from "@/renderer/state/panelStore";
+
+/**
+ * Keeps the right panel pinned to the focused thread while
+ * `rightPanelFollowsThread` is on: whichever scope-bearing tools are already
+ * open (git, files) re-target that thread's project + worktree on every thread
+ * switch. Panels the user has closed stay closed — the lock re-scopes, it does
+ * not open anything.
+ *
+ * The dev terminal is deliberately left alone: re-targeting it would spawn a
+ * shell process for every thread visited.
+ */
+export function useRightPanelThreadLock(): void {
+  const enabled = usePanelStore((s) => s.rightPanelFollowsThread);
+  const projectId = useAppStore((state) => {
+    if (state.view.kind !== "thread") return null;
+    const paneId = resolveActivePaneId(state.view.panes, state.focusedPaneId);
+    const thread = state.threads.find((item) => item.id === paneId);
+    return thread?.projectId ?? null;
+  });
+  const worktreePath = useAppStore((state) => {
+    if (state.view.kind !== "thread") return null;
+    const paneId = resolveActivePaneId(state.view.panes, state.focusedPaneId);
+    const thread = state.threads.find((item) => item.id === paneId);
+    return thread?.worktreePath ?? null;
+  });
+
+  useEffect(() => {
+    if (!enabled || projectId === null || isHomeProjectId(projectId)) return;
+    const scopedWorktree = worktreePath ?? undefined;
+
+    const panel = usePanelStore.getState();
+    const gitPanelOpen = panel.gitReviewContext !== null && panel.gitReviewAsPanel;
+    const filesPanelOpen = panel.filesPanelContext !== null;
+    if (!gitPanelOpen && !filesPanelOpen) return;
+
+    // Both `show*Panel` helpers force their own tab; remember what the user was
+    // actually looking at and restore it after re-scoping.
+    const activeTab = panel.rightPanelTab;
+    if (gitPanelOpen) {
+      showGitReviewPanel(projectId, scopedWorktree);
+    }
+    if (filesPanelOpen) {
+      // `showFilesPanel` prompts before discarding dirty editor buffers — never
+      // surface that prompt as a side effect of plain thread navigation.
+      if (!hasDirtyEditorBuffers()) {
+        showFilesPanel(projectId, scopedWorktree);
+      }
+    }
+    if (usePanelStore.getState().rightPanelTab !== activeTab) {
+      panel.setRightPanelTab(activeTab);
+    }
+  }, [enabled, projectId, worktreePath]);
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Die Datei verwendet eine nicht unterstützte Codierung."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Dateien"
 
@@ -4426,6 +4427,7 @@ msgstr "Aufgabe abrufen"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} auf dem Desktop"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Standort"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Panel an den offenen Thread binden"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Nicht unterstützt"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notizen"
@@ -8201,6 +8208,10 @@ msgstr "Arbeit über Ihre GitHub-Konten hinweg prüfen und verfolgen."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Änderungen von Kandidat {0} ({label}) überprüfen"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Änderungen überprüfen"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Quelle anzeigen"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Zeigen Sie die Mikrofonschaltfläche im Composer an."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Thread-Werkzeuge anzeigen"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Sagen Sie dem Zielanbieter, was als nächstes zu tun ist ..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Inaktive Threads entladen nach (Minuten)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Thread entladen"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Panel vom offenen Thread lösen"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -4097,6 +4097,7 @@ msgstr "File uses an unsupported encoding."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Files"
 
@@ -4426,6 +4427,7 @@ msgstr "Get task"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} on desktop"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Location"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Lock panel to the open thread"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Not supported"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notes"
@@ -8201,6 +8208,10 @@ msgstr "Review and track work across your GitHub accounts."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Review candidate {0} ({label}) changes"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Review changes"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Show source"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Show the microphone button in the composer."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Show thread tools"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Tell the target provider what to do next..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Unload idle threads after (minutes)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Unload Thread"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Unlock panel from the open thread"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -4097,6 +4097,7 @@ msgstr "El archivo usa una codificación no compatible."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Archivos"
 
@@ -4426,6 +4427,7 @@ msgstr "Obtener tarea"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} en el escritorio"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Ubicación"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Fijar el panel al hilo abierto"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "No compatible"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notas"
@@ -8201,6 +8208,10 @@ msgstr "Revisa y haz seguimiento del trabajo en tus cuentas de GitHub."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Revisar los cambios del candidato {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Revisar cambios"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Mostrar fuente"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Mostrar el botón del micrófono en el redactor."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Mostrar herramientas del hilo"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Indica al proveedor de destino qué hacer a continuación..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Descargar los hilos inactivos tras (minutos)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Descargar hilo"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Liberar el panel del hilo abierto"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Le fichier utilise un encodage non pris en charge."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Fichiers"
 
@@ -4426,6 +4427,7 @@ msgstr "Obtenir la tâche"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} sur le bureau"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Emplacement"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Verrouiller le panneau sur le fil de discussion ouvert"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6497,6 +6503,7 @@ msgstr "Non pris en charge"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Remarques"
@@ -8200,6 +8207,10 @@ msgstr "Examinez et suivez le travail sur vos comptes GitHub."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Examiner les modifications du candidat {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Examiner les changements"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8925,6 +8936,10 @@ msgstr "Afficher la source"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Afficher le bouton du microphone dans le compositeur."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Afficher les outils du fil de discussion"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9689,6 +9704,7 @@ msgstr "Dites au fournisseur cible quoi faire ensuite..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10614,6 +10630,10 @@ msgstr "Décharger les fils de discussion inactifs après (minutes)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Décharger le fil de discussion"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Déverrouiller le panneau du fil de discussion ouvert"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -4096,6 +4096,7 @@ msgstr "ファイルはサポートされていないエンコーディングを
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "ファイル"
 
@@ -4425,6 +4426,7 @@ msgstr "タスクの取得"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5247,6 +5249,10 @@ msgstr "デスクトップの localhost:{0}"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "場所"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "パネルを開いているスレッドに固定する"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6496,6 +6502,7 @@ msgstr "サポートされていません"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "注意事項"
@@ -8199,6 +8206,10 @@ msgstr "GitHub アカウント全体の作業をレビュー・追跡します�
 msgid "Review candidate {0} ({label}) changes"
 msgstr "候補 {0}（{label}）の変更を確認"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "変更点をレビューする"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8924,6 +8935,10 @@ msgstr "ソースを表示"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "コンポーザーにマイクボタンを表示します。"
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "スレッドのツールを表示する"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9688,6 +9703,7 @@ msgstr "ターゲットプロバイダーに次に何をすべきかを伝えま
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10613,6 +10629,10 @@ msgstr "アイドル状態のスレッドをアンロードするまでの時間
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "スレッドをアンロード"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "パネルの固定を解除する"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -4097,6 +4097,7 @@ msgstr "파일이 지원되지 않는 인코딩을 사용합니다."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "파일"
 
@@ -4426,6 +4427,7 @@ msgstr "작업 가져오기"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "데스크톱의 localhost:{0}"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "위치"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "패널을 열린 스레드에 고정"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "지원되지 않음"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "메모"
@@ -8201,6 +8208,10 @@ msgstr "여러 GitHub 계정의 작업을 검토하고 추적하세요."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "후보 {0}({label})의 변경 사항 검토"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "변경 사항 검토"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "소스 표시"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "작성기에 마이크 버튼을 표시합니다."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "스레드 도구 표시"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "대상 공급자에게 다음에 무엇을 해야 할지 알려주세요
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "다음 시간 이후 유휴 스레드 언로드(분)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "스레드 언로드"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "열린 스레드에서 패널 고정 해제"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Plik używa nieobsługiwanego kodowania."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Pliki"
 
@@ -4426,6 +4427,7 @@ msgstr "Pobierz zadanie"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} na komputerze"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Lokalizacja"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Przypnij panel do otwartego wątku"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Nieobsługiwane"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notatki"
@@ -8201,6 +8208,10 @@ msgstr "Przeglądaj i śledź pracę na swoich kontach GitHub."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Przejrzyj zmiany kandydata {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Przejrzyj zmiany"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Pokaż źródło"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Pokaż przycisk mikrofonu w kompozytorze."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Pokaż narzędzia wątku"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Powiedz dostawcy docelowemu, co ma dalej robić..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Zwolnij bezczynne wątki po (minutach)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Zwolnij wątek"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Odepnij panel od otwartego wątku"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -4097,6 +4097,7 @@ msgstr "O arquivo usa uma codificação não suportada."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Arquivos"
 
@@ -4426,6 +4427,7 @@ msgstr "Obter tarefa"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} no desktop"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Localização"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Fixar o painel no tópico aberto"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Não compatível"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notas"
@@ -8201,6 +8208,10 @@ msgstr "Revise e acompanhe o trabalho nas suas contas do GitHub."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Revisar as alterações do candidato {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Revisar mudanças"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Mostrar fonte"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Mostre o botão do microfone no compositor."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Mostrar ferramentas do tópico"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Diga ao provedor alvo o que fazer a seguir..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Descarregar tópicos inativos após (minutos)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Descarregar tópico"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Desafixar o painel do tópico aberto"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Файл использует неподдерживаемую коди�
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Файлы"
 
@@ -4426,6 +4427,7 @@ msgstr "Получить задачу"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} на десктопе"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Расположение"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Закрепить панель за открытым тредом"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Не поддерживается"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Заметки"
@@ -8201,6 +8208,10 @@ msgstr "Просматривайте и отслеживайте работу в
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Просмотреть изменения кандидата {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Просмотреть изменения"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Показать источник"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Показывать кнопку микрофона в поле ввода."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Показать инструменты треда"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Укажите целевому провайдеру, что делат�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Выгружать неактивные треды через (мину�
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Выгрузить тред"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Открепить панель от открытого треда"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Dosya desteklenmeyen bir kodlama kullanıyor."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -4426,6 +4427,7 @@ msgstr "Görev al"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} masaüstünde"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Konum"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Paneli açık konuya sabitle"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Desteklenmiyor"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Notlar"
@@ -8201,6 +8208,10 @@ msgstr "GitHub hesaplarınızdaki çalışmaları inceleyin ve takip edin."
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Aday {0} ({label}) değişikliklerini incele"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Değişiklikleri incele"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Kaynağı göster"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Composer'da mikrofon düğmesini gösterin."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Konu araçlarını göster"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Hedef sağlayıcıya bundan sonra ne yapacağını söyleyin..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Boşta kalan konuları şu süreden sonra kaldır (dakika)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Konuyu Kaldır"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Panelin açık konuya sabitlemesini kaldır"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Файл використовує непідтримуване коду�
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Файли"
 
@@ -4426,6 +4427,7 @@ msgstr "Отримати завдання"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} на комп'ютері"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Розташування"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Закріпити панель за відкритим тредом"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Не підтримується"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Нотатки"
@@ -8201,6 +8208,10 @@ msgstr "Переглядайте й відстежуйте роботу у св�
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Переглянути зміни кандидата {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Переглянути зміни"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Показати джерело"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Показувати кнопку мікрофона в полі вводу."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Показати інструменти треда"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Укажіть цільовому провайдеру, що робит�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Вивантажувати неактивні треди через (х�
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Вивантажити тред"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Відкріпити панель від відкритого треда"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -4097,6 +4097,7 @@ msgstr "Tệp sử dụng mã hóa không được hỗ trợ."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Tập tin"
 
@@ -4426,6 +4427,7 @@ msgstr "Nhận nhiệm vụ"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "localhost:{0} trên máy tính"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "Vị trí"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "Ghim bảng vào luồng đang mở"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6498,6 +6504,7 @@ msgstr "Không được hỗ trợ"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "Ghi chú"
@@ -8201,6 +8208,10 @@ msgstr "Xem xét và theo dõi công việc trên các tài khoản GitHub của
 msgid "Review candidate {0} ({label}) changes"
 msgstr "Xem lại các thay đổi của ứng viên {0} ({label})"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "Xem xét thay đổi"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8926,6 +8937,10 @@ msgstr "Hiển thị nguồn"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "Hiển thị nút micrô trong trình soạn thảo."
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "Hiện công cụ luồng"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9690,6 +9705,7 @@ msgstr "Cho nhà cung cấp mục tiêu biết phải làm gì tiếp theo..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10615,6 +10631,10 @@ msgstr "Gỡ bỏ các chủ đề không hoạt động sau (phút)"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "Dỡ bỏ chủ đề"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "Bỏ ghim bảng khỏi luồng đang mở"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -4097,6 +4097,7 @@ msgstr "文件使用不受支持的编码。"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "文件"
 
@@ -4426,6 +4427,7 @@ msgstr "获取任务"
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -5248,6 +5250,10 @@ msgstr "桌面上的 localhost:{0}"
 #: src/renderer/views/MainView/parts/CreateProject/CreateProjectModal.tsx
 msgid "Location"
 msgstr "位置"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Lock panel to the open thread"
+msgstr "将面板锁定到打开的线程"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Log in to Tailscale to enable HTTPS access through MagicDNS."
@@ -6497,6 +6503,7 @@ msgstr "不支持"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
 msgstr "注释"
@@ -8200,6 +8207,10 @@ msgstr "在你的各个 GitHub 账户中审核和跟踪工作。"
 msgid "Review candidate {0} ({label}) changes"
 msgstr "查看候选 {0}（{label}）的更改"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Review changes"
+msgstr "查看更改"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
@@ -8925,6 +8936,10 @@ msgstr "显示来源"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Show the microphone button in the composer."
 msgstr "在编辑器中显示麦克风按钮。"
+
+#: src/renderer/components/thread/ThreadToolRail.tsx
+msgid "Show thread tools"
+msgstr "显示线程工具"
 
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -9689,6 +9704,7 @@ msgstr "告诉目标提供商下一步该做什么..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -10614,6 +10630,10 @@ msgstr "在以下分钟数后卸载空闲线程"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
 msgid "Unload Thread"
 msgstr "卸载线程"
+
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
+msgid "Unlock panel from the open thread"
+msgstr "解除面板与打开线程的锁定"
 
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx

--- a/src/renderer/state/fileEditorSelectors.ts
+++ b/src/renderer/state/fileEditorSelectors.ts
@@ -58,3 +58,10 @@ export function useIsActiveBufferDirty(): boolean {
 export function useIsPathOpenInTab(path: string): boolean {
   return useFileEditorStore((s) => s.tabs.includes(path));
 }
+
+/** Imperative check: any open buffer has unsaved changes. */
+export function hasDirtyEditorBuffers(): boolean {
+  return Object.values(useFileEditorStore.getState().buffers).some(
+    (buffer) => buffer.status === "ready" && buffer.isDirty,
+  );
+}

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -56,6 +56,14 @@ interface PanelState {
   subAgentPanelContext: SubAgentPanelContext | null;
   subAgentPanelOpen: boolean;
   rightPanelTab: RightPanelTab;
+  /**
+   * When true, the open right-panel tools re-scope to whichever thread is
+   * focused instead of staying on the project/worktree they were opened from.
+   * Persisted — single-thread users leave it on permanently.
+   */
+  rightPanelFollowsThread: boolean;
+  /** Vertical offset (px from the pane's top) of the per-thread tool rail. */
+  threadToolRailOffset: number;
   browserPanelOpen: boolean;
   usagePanelOpen: boolean;
   notesPanelOpen: boolean;
@@ -80,6 +88,8 @@ interface PanelState {
   setFilesPanelContext: (ctx: FilesPanelContext | null) => void;
   setSubAgentPanelContext: (ctx: SubAgentPanelContext | null) => void;
   setRightPanelTab: (tab: RightPanelTab) => void;
+  toggleRightPanelFollowsThread: () => void;
+  setThreadToolRailOffset: (offset: number) => void;
   setBrowserPanelOpen: (v: boolean) => void;
   setUsagePanelOpen: (v: boolean) => void;
   openUsagePanel: () => void;
@@ -156,7 +166,17 @@ function loadInitialDrawerWidth(): number {
 const initialPersisted = readPersistedSlice<{
   gitReviewContext: GitReviewContext | null;
   browserOverlayDrawerWidth: number;
+  rightPanelFollowsThread?: boolean;
+  threadToolRailOffset?: number;
 }>(PERSIST_KEY);
+
+/** Default rail offset: below the pane header, near the top of the conversation. */
+const DEFAULT_THREAD_TOOL_RAIL_OFFSET = 56;
+
+function sanitizeRailOffset(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_THREAD_TOOL_RAIL_OFFSET;
+  return Math.max(0, Math.round(value));
+}
 
 export const usePanelStore = create<PanelState>()((set) => ({
   gitReviewContext: initialPersisted
@@ -169,6 +189,10 @@ export const usePanelStore = create<PanelState>()((set) => ({
   subAgentPanelContext: null,
   subAgentPanelOpen: false,
   rightPanelTab: "git",
+  rightPanelFollowsThread: initialPersisted?.rightPanelFollowsThread ?? false,
+  threadToolRailOffset: sanitizeRailOffset(
+    initialPersisted?.threadToolRailOffset ?? DEFAULT_THREAD_TOOL_RAIL_OFFSET,
+  ),
   browserPanelOpen: false,
   usagePanelOpen: false,
   notesPanelOpen: false,
@@ -259,6 +283,15 @@ export const usePanelStore = create<PanelState>()((set) => ({
         rightPanelTab: tab,
         ...(reopenSubAgent ? { subAgentPanelOpen: true } : {}),
       };
+    }),
+  toggleRightPanelFollowsThread: () =>
+    set((state) => ({ rightPanelFollowsThread: !state.rightPanelFollowsThread })),
+  setThreadToolRailOffset: (offset) =>
+    set((state) => {
+      const clamped = sanitizeRailOffset(offset);
+      // Return `state` (not `{}`) so Zustand's Object.is bailout actually skips
+      // listener notification — this fires on every pointermove frame during drag.
+      return state.threadToolRailOffset === clamped ? state : { threadToolRailOffset: clamped };
     }),
   // Toggling the docked right-panel browser is independent of the floating
   // overlay (drawer/fullscreen): hiding the panel must NOT tear down an active
@@ -379,6 +412,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
 persistStoreSlice(usePanelStore, PERSIST_KEY, (state) => ({
   gitReviewContext: state.gitReviewContext,
   browserOverlayDrawerWidth: state.browserOverlayDrawerWidth,
+  rightPanelFollowsThread: state.rightPanelFollowsThread,
+  threadToolRailOffset: state.threadToolRailOffset,
 }));
 
 // Returns true when any full-window overlay (z-50) is currently rendered above

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -970,6 +970,11 @@
        wallpaper blur (more glassy, but tinted by whatever's on the desktop). */
     --sidebar-glass-tint: color-mix(in oklab, var(--content-background) 35%, transparent);
     --content-background: var(--background);
+    /* Floating chrome that hovers over the conversation — thread tool rail,
+       changes bubble, scroll-to-bottom. One shared surface so the three read as
+       a set, tinted like the sidebar (side chrome) rather than the pane beneath
+       it. Derived, so it follows --sidebar-background in every theme. */
+    --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 82%, transparent);
     --window-header-background: var(--sidebar-background);
     --window-overlay-background: rgba(0, 0, 0, 0);
     --composer-surface: var(--surface);

--- a/src/renderer/views/MainView/MainView.tsx
+++ b/src/renderer/views/MainView/MainView.tsx
@@ -15,6 +15,7 @@ import { AppDndProvider } from "@/renderer/dnd";
 
 import { useKeyboardShortcuts } from "@/renderer/hooks/useKeyboardShortcuts";
 import { useGitRefresh } from "@/renderer/hooks/useGitRefresh";
+import { useRightPanelThreadLock } from "@/renderer/hooks/useRightPanelThreadLock";
 import { useThreadLifecycle } from "@/renderer/hooks/useThreadLifecycle";
 import { useDndHandlers } from "@/renderer/hooks/useDndHandlers";
 import { useBrowserSync } from "@/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useBrowserSync";
@@ -45,6 +46,7 @@ export function MainView(props: { storeHydrated: boolean; loadT0: number }) {
   useThreadLifecycle(storeHydrated);
   useKeyboardShortcuts();
   useGitRefresh(storeHydrated);
+  useRightPanelThreadLock();
   useBrowserSync();
 
   const { handleSortEnd, handlePaneDrop, handleMainPanelDrop } = useDndHandlers();

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -82,6 +82,8 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
   const subAgentPanelContext = usePanelStore((s) => s.subAgentPanelContext);
   const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
   const setRightPanelTab = usePanelStore((s) => s.setRightPanelTab);
+  const rightPanelFollowsThread = usePanelStore((s) => s.rightPanelFollowsThread);
+  const toggleRightPanelFollowsThread = usePanelStore((s) => s.toggleRightPanelFollowsThread);
   const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
   const browserExtracted = useBrowserPanelStore((s) => s.extracted);
   const usagePanelOpen = usePanelStore((s) => s.usagePanelOpen);
@@ -359,6 +361,8 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
         setNotesPanelOpen(true);
         setRightPanelTab("notes");
       }}
+      followsThread={rightPanelFollowsThread}
+      onToggleFollowsThread={toggleRightPanelFollowsThread}
       onClose={handleClose}
     />
   );


### PR DESCRIPTION
- Feature: add a movable thread tool rail for quick access to files, git changes, notes, browser, and related panels.
- Let users lock the right panel to the current thread or keep it independent while navigating threads.
- Show thread change counts in the composer and refresh floating controls with shared chrome styling.
- Preserve panel and tool-rail preferences, guard against discarding unsaved editor buffers, and localize the new controls.