### PR TITLE
Add responsive provider usage rails and per-provider settings

### DIFF
--- a/src/renderer/components/providers/ProviderUsageRail.tsx
+++ b/src/renderer/components/providers/ProviderUsageRail.tsx
@@ -1,4 +1,5 @@
-import { startTransition, useEffect } from "react";
+import { startTransition, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useShallow } from "zustand/shallow";
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import { DragDropProvider, type DragEndEvent, KeyboardSensor, PointerSensor } from "@dnd-kit/react";
 import { isSortable, useSortable } from "@dnd-kit/react/sortable";
@@ -15,6 +16,7 @@ import { ContextMenu, type ContextMenuEntry } from "@/renderer/components/common
 import { useProviderUsage, useProviderUsageStore } from "@/renderer/state/providerUsageStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { ProviderUsageCircle } from "./ProviderUsageCircle";
+import { UsageOverflowChip } from "./UsageOverflowChip";
 import { PaceLine } from "./UsageWindowBars";
 import {
   formatWindowPace,
@@ -23,11 +25,40 @@ import {
   sharedWindowResetLabel,
 } from "./usageFormat";
 import {
+  hasRailUsage,
   isClaudeUsageProvider,
   resolveDisplayedProviders,
   usageRingGroups,
   usesSharedWindowReset,
+  type UsageProvider,
 } from "./usageProviders";
+import {
+  fitUsageRail,
+  RAIL_CIRCLE_SIZE,
+  RAIL_COLUMN_GAP,
+  RAIL_COLUMN_MAX,
+  RAIL_ROW_GAP,
+  railSlots,
+} from "./usageRailFit";
+
+// A 5px activation distance lets a plain click open the panel while a drag
+// reorders — mirrors the app's global pointer sensor. `configure` returns a
+// plugin descriptor, not a live sensor, so one module-level array is safe to
+// share and keeps a stable identity across renders.
+const RAIL_SENSORS = [
+  PointerSensor.configure({
+    activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
+  }),
+  KeyboardSensor,
+];
+
+const STRIP = {
+  row: { className: "flex flex-row items-center overflow-hidden", gap: RAIL_ROW_GAP },
+  column: {
+    className: "mb-1 flex w-full flex-col items-center border-b border-[var(--hairline)] pb-2",
+    gap: RAIL_COLUMN_GAP,
+  },
+} as const;
 
 function statusText(
   providerId: string,
@@ -146,6 +177,7 @@ function ProviderUsageRailItem(props: { id: string; label: string; index: number
             <ProviderUsageCircle
               kind={id}
               windows={snapshot?.windows}
+              size={RAIL_CIRCLE_SIZE}
               ringGroup={selectedRingGroup}
             />
           </button>
@@ -181,6 +213,100 @@ function ProviderUsageRailItem(props: { id: string; label: string; index: number
   );
 }
 
+type ReorderHandler = (orderedRenderedIds: readonly string[]) => void;
+
+/**
+ * The sortable strip, shared by both orientations: the first `shownCount`
+ * circles, then the "+N" chip for the rest. Only the circles are sortable, so a
+ * drag always reorders within what the user can see.
+ */
+function UsageRailStrip(props: {
+  providers: readonly UsageProvider[];
+  shownCount: number;
+  orientation: "row" | "column";
+  onReorder: ReorderHandler;
+}) {
+  const { providers, shownCount, orientation, onReorder } = props;
+  const shown = providers.slice(0, shownCount);
+  // Namespace the sortable group per orientation so the row + column instances
+  // (one of which may be mounted but hidden) never share registrations.
+  const group = `usage-rail-${orientation}`;
+
+  function handleDragEnd(event: DragEndEvent) {
+    if (event.canceled) return;
+    const src = event.operation.source;
+    if (!src || !isSortable(src)) return;
+    const fromIndex = src.initialIndex;
+    const toIndex = src.index;
+    if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return;
+    const ids = shown.map((p) => p.id);
+    const [moved] = ids.splice(fromIndex, 1);
+    if (!moved) return;
+    ids.splice(toIndex, 0, moved);
+    onReorder(ids);
+  }
+
+  return (
+    <DragDropProvider sensors={RAIL_SENSORS} onDragEnd={handleDragEnd}>
+      <div className={STRIP[orientation].className} style={{ gap: STRIP[orientation].gap }}>
+        {shown.map((p, index) => (
+          <ProviderUsageRailItem key={p.id} id={p.id} label={p.label} index={index} group={group} />
+        ))}
+        <UsageOverflowChip providers={providers.slice(shownCount)} />
+      </div>
+    </DragDropProvider>
+  );
+}
+
+/**
+ * Expanded sidebar rail: as many circles as fit one row, then a "+N" chip whose
+ * tooltip carries the rest. The row is measured rather than wrapped so the rail
+ * keeps a fixed height as the sidebar is resized.
+ */
+function UsageRailRow(props: { providers: readonly UsageProvider[]; onReorder: ReorderHandler }) {
+  const { providers, onReorder } = props;
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const [slots, setSlots] = useState(0);
+
+  // Measured before paint so the first frame is already fitted. Storing the
+  // derived slot count rather than the raw width means a resize drag only
+  // re-renders when a circle actually gains or loses its place. The measured div
+  // is block-level, so its width follows the sidebar and never the circles
+  // inside it — no measure/relayout feedback loop.
+  useLayoutEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    const measure = (width: number) => setSlots(railSlots(width));
+    measure(el.getBoundingClientRect().width);
+    const ro = new ResizeObserver((entries) => {
+      const cr = entries[0]?.contentRect;
+      if (cr) measure(cr.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // A labeled "Usage" section that sits between the thread list and the footer
+  // nav. The column's gap above and the footer's top border below provide the
+  // separation, so no extra dividers here — that avoids the cramped boxed strip.
+  // `px-2` aligns the circles with the footer button icons.
+  return (
+    <div className="px-2">
+      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
+        <Trans>Usage</Trans>
+      </p>
+      <div ref={rowRef}>
+        <UsageRailStrip
+          providers={providers}
+          shownCount={fitUsageRail(slots, providers.length)}
+          orientation="row"
+          onReorder={onReorder}
+        />
+      </div>
+    </div>
+  );
+}
+
 /**
  * A compact rail of per-provider usage rings for the sidebar footer. Hidden when
  * the user turns off `usage.showInSidebar`. On mount it hydrates the store from
@@ -212,75 +338,44 @@ export function ProviderUsageRail(props: { orientation?: "row" | "column" }) {
     };
   }, []);
 
-  // A 5px activation distance lets a plain click open the panel while a drag
-  // reorders — mirrors the app's global pointer sensor.
-  const sensors = [
-    PointerSensor.configure({
-      activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
-    }),
-    KeyboardSensor,
-  ];
-
-  // Full set drives the persisted order; the rail only renders the providers
-  // whose circle the user hasn't individually hidden. Hidden providers still
-  // hold their slot in `providerOrder` (the docked panel can still reorder them).
+  // Full set drives the persisted order; the rail only offers the providers the
+  // user hasn't individually hidden and that have usage worth a ring — a
+  // signed-out provider belongs in Settings, not in the rail. Skipped providers
+  // still hold their slot in `providerOrder` (the docked panel can reorder them).
   const allProviders = resolveDisplayedProviders(providerOrder, disabledProviders, agentInstances);
-  const providers = allProviders.filter((p) => !sidebarHiddenProviders.includes(p.id));
+  // Subscribe to rail *eligibility* only. The snapshot map gets a new identity on
+  // every refresh tick, so selecting it whole would re-render the rail (and every
+  // circle) whenever any provider's percentages moved; each circle already reads
+  // its own snapshot through a narrow selector.
+  const eligible = useProviderUsageStore(
+    useShallow((s) => allProviders.map((p) => hasRailUsage(s.snapshots[p.id]))),
+  );
+  const providers = allProviders.filter(
+    (p, i) => !sidebarHiddenProviders.includes(p.id) && eligible[i],
+  );
 
   if (!showInSidebar || providers.length === 0) return null;
 
-  // Namespace the sortable group per orientation so the row + column instances
-  // (one of which may be mounted but hidden) never share registrations.
-  const group = `usage-rail-${orientation}`;
-
-  function handleDragEnd(event: DragEndEvent) {
-    if (event.canceled) return;
-    const src = event.operation.source;
-    if (!src || !isSortable(src)) return;
-    const fromIndex = src.initialIndex;
-    const toIndex = src.index;
-    if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0) return;
-    // Reorder only the visible ids, then splice the result back into the full
-    // order so hidden providers keep their absolute positions.
-    const visibleIds = providers.map((p) => p.id);
-    const [moved] = visibleIds.splice(fromIndex, 1);
-    if (!moved) return;
-    visibleIds.splice(toIndex, 0, moved);
-    const hidden = new Set(sidebarHiddenProviders);
+  function handleReorder(orderedRenderedIds: readonly string[]) {
+    // Splice the strip's new order back into the full order so hidden and
+    // overflowed providers keep their absolute positions.
+    const rendered = new Set(orderedRenderedIds);
     let v = 0;
-    const next = allProviders.map((p) => (hidden.has(p.id) ? p.id : visibleIds[v++]!));
+    const next = allProviders.map((p) => (rendered.has(p.id) ? orderedRenderedIds[v++]! : p.id));
     startTransition(() => setUsageSetting("providerOrder", next));
   }
 
-  const items = providers
-    .slice(0, 4)
-    .map((p, index) => (
-      <ProviderUsageRailItem key={p.id} id={p.id} label={p.label} index={index} group={group} />
-    ));
-
-  // Collapsed icon rail: a centered column of circles.
+  // The collapsed rail is a fixed cap rather than a measured fit — it is one
+  // narrow column sharing vertical space with the footer nav.
   if (orientation === "column") {
     return (
-      <DragDropProvider sensors={sensors} onDragEnd={handleDragEnd}>
-        <div className="mb-1 flex w-full flex-col items-center gap-1.5 border-b border-[var(--hairline)] pb-2">
-          {items}
-        </div>
-      </DragDropProvider>
+      <UsageRailStrip
+        providers={providers}
+        shownCount={RAIL_COLUMN_MAX}
+        orientation="column"
+        onReorder={handleReorder}
+      />
     );
   }
-
-  // Expanded sidebar: a labeled "Usage" section that sits between the thread
-  // list and the footer nav. The column's gap above and the footer's top border
-  // below provide the separation, so no extra dividers here — that avoids the
-  // cramped boxed strip. `px-2` aligns the circles with the footer button icons.
-  return (
-    <div className="px-2">
-      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted/70">
-        <Trans>Usage</Trans>
-      </p>
-      <DragDropProvider sensors={sensors} onDragEnd={handleDragEnd}>
-        <div className="flex flex-row flex-wrap items-center gap-2.5">{items}</div>
-      </DragDropProvider>
-    </div>
-  );
+  return <UsageRailRow providers={providers} onReorder={handleReorder} />;
 }

--- a/src/renderer/components/providers/UsageOverflowChip.tsx
+++ b/src/renderer/components/providers/UsageOverflowChip.tsx
@@ -1,0 +1,81 @@
+import { Tooltip } from "@heroui/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { UsageWindow } from "@poracode/agents-usage/types";
+import { openUsagePanel } from "@/renderer/actions/panelActions";
+import { useProviderUsage } from "@/renderer/state/providerUsageStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { ProviderUsageCircle } from "./ProviderUsageCircle";
+import { formatWindowValue, usageStatusText } from "./usageFormat";
+import { pickUsageRings, usageRingGroups, type UsageProvider } from "./usageProviders";
+import { RAIL_CIRCLE_SIZE } from "./usageRailFit";
+
+/** One compact line per overflowed provider: mini rings, label, ring values. */
+function OverflowRow(props: { id: string; label: string }) {
+  const { id, label } = props;
+  const snapshot = useProviderUsage(id);
+  const selectedRingGroups = useSharedSettings((s) => s.usage.selectedRingGroups);
+  const ringGroup = selectedRingGroups[id] ?? usageRingGroups(id)[0]?.key;
+  const rings = pickUsageRings(id, snapshot?.windows, ringGroup);
+  // The same windows the circle draws — the tooltip stays a readout of the ring,
+  // not a second, differently-sourced number.
+  const shownWindows = [rings.outer, rings.inner].filter((w): w is UsageWindow => w !== undefined);
+  return (
+    <div className="flex items-center justify-between gap-3 whitespace-nowrap">
+      <span className="flex items-center gap-1.5">
+        <ProviderUsageCircle
+          kind={id}
+          windows={snapshot?.windows}
+          size={16}
+          ringGroup={ringGroup}
+        />
+        <span className="text-muted">{label}</span>
+      </span>
+      {shownWindows.length > 0 ? (
+        <span className="font-medium text-foreground">
+          {shownWindows.map(formatWindowValue).join(" · ")}
+        </span>
+      ) : (
+        <span className="text-muted">{usageStatusText(snapshot, label, id)}</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Overflow affordance for the usage rail: a "+N" circle standing in for the
+ * providers that did not fit. Hovering lists every one of them in a single
+ * compact line each, so a narrow sidebar hides circles but never information.
+ * Clicking opens the docked usage panel, matching the circles it replaces.
+ */
+export function UsageOverflowChip(props: { providers: readonly UsageProvider[] }) {
+  const { providers } = props;
+  const { t } = useLingui();
+  if (providers.length === 0) return null;
+  return (
+    <Tooltip delay={150}>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          aria-label={t`More usage providers — open usage panel`}
+          onClick={openUsagePanel}
+          className="flex shrink-0 items-center justify-center rounded-full border border-[var(--hairline)] text-[10px] font-semibold text-muted outline-none hover:text-foreground focus-visible:focus-ring"
+          style={{ width: RAIL_CIRCLE_SIZE, height: RAIL_CIRCLE_SIZE }}
+        >
+          +{providers.length}
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content placement="top" offset={8} className="px-2 py-1.5 text-xs">
+        <div className="min-w-[160px] space-y-1">
+          <p className="font-semibold text-foreground">
+            <Trans>More providers</Trans>
+          </p>
+          <div className="space-y-0.5">
+            {providers.map((p) => (
+              <OverflowRow key={p.id} id={p.id} label={p.label} />
+            ))}
+          </div>
+        </div>
+      </Tooltip.Content>
+    </Tooltip>
+  );
+}

--- a/src/renderer/components/providers/usageProviders.test.ts
+++ b/src/renderer/components/providers/usageProviders.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import type { UsageWindow } from "@poracode/agents-usage";
+import type { UsageSnapshot, UsageStatus, UsageWindow } from "@poracode/agents-usage";
 import type { AgentInstanceConfigMap } from "@/shared/contracts";
 import {
+  hasRailUsage,
   isClaudeUsageProvider,
   pickUsageRings,
   resolveDisplayedProviders,
@@ -164,5 +165,30 @@ describe("usageProviders", () => {
       expect(rings.outer?.id).toBe("antigravity:claude:session-5h");
       expect(rings.inner).toBeUndefined();
     });
+  });
+});
+
+describe("hasRailUsage", () => {
+  const snapshot = (status: UsageStatus): UsageSnapshot => ({
+    providerId: "kimi",
+    status,
+    windows: [],
+    fetchedAt: 0,
+  });
+
+  // Signed-out and usage-less providers belong in Settings, not the rail;
+  // everything else is readable now or recovers on its own. `undefined` keeps a
+  // cold start from painting an empty rail.
+  it.each<[UsageStatus | "pending", boolean]>([
+    ["ok", true],
+    ["app-not-running", true],
+    ["rate-limited", true],
+    ["quota-hit", true],
+    ["error", true],
+    ["pending", true],
+    ["auth-missing", false],
+    ["unsupported", false],
+  ])("keeps %s in the rail: %s", (status, expected) => {
+    expect(hasRailUsage(status === "pending" ? undefined : snapshot(status))).toBe(expected);
   });
 });

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -1,6 +1,6 @@
 import { antigravityWindowId } from "@poracode/agents-usage/antigravity";
 import { allUsageProviderDescriptors } from "@poracode/agents-usage/providers";
-import type { UsageWindow } from "@poracode/agents-usage/types";
+import type { UsageSnapshot, UsageWindow } from "@poracode/agents-usage/types";
 import {
   baseAgentKind,
   claudeProfileKind,
@@ -258,6 +258,31 @@ export function pickUsageRings(
   }
   const worst = [...windows].sort((a, b) => b.usedPercent - a.usedPercent)[0];
   return worst ? { outer: worst } : {};
+}
+
+/**
+ * Whether a provider earns a circle in the sidebar rail. A signed-out provider
+ * (`auth-missing`) or one with no usage API (`unsupported`) has nothing a ring
+ * can show, so the rail leaves it out — Settings → Usage still lists it with its
+ * status and login action. Everything else stays: snapshots that haven't arrived
+ * yet (so a cold start isn't an empty rail) and signed-in-but-unreadable states
+ * like `app-not-running` or `rate-limited`, which do recover on their own.
+ */
+export function hasRailUsage(snapshot: UsageSnapshot | undefined): boolean {
+  if (!snapshot) return true;
+  // Exhaustive on purpose: a status added upstream should fail the typecheck
+  // here rather than silently defaulting into (or out of) the rail.
+  switch (snapshot.status) {
+    case "auth-missing":
+    case "unsupported":
+      return false;
+    case "ok":
+    case "app-not-running":
+    case "rate-limited":
+    case "quota-hit":
+    case "error":
+      return true;
+  }
 }
 
 /**

--- a/src/renderer/components/providers/usageRailFit.test.ts
+++ b/src/renderer/components/providers/usageRailFit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { fitUsageRail, railSlots } from "./usageRailFit";
+
+describe("railSlots", () => {
+  // Literal widths so the expectations pin observable behaviour rather than
+  // restating the formula: circles are 28px, laid out with a 10px row gap.
+  it.each([
+    [0, 0],
+    [27, 0],
+    [28, 1],
+    [65, 1],
+    [66, 2],
+    [180, 5],
+  ])("fits %i px into %i slots", (width, expected) => {
+    expect(railSlots(width)).toBe(expected);
+  });
+});
+
+describe("fitUsageRail", () => {
+  it.each([
+    // [slots, total, shown] — one slot pays for the "+N" chip when short.
+    [6, 6, 6],
+    [5, 6, 4],
+    [1, 3, 0],
+    [0, 5, 5], // unmeasured row: draw everything
+    [4, 0, 0],
+  ])("draws %i slots of %i providers as %i circles", (slots, total, shown) => {
+    expect(fitUsageRail(slots, total)).toBe(shown);
+  });
+});

--- a/src/renderer/components/providers/usageRailFit.ts
+++ b/src/renderer/components/providers/usageRailFit.ts
@@ -1,0 +1,43 @@
+/**
+ * Circle diameter for both rails. Passed explicitly to `ProviderUsageCircle`
+ * rather than relying on its default `size`, so the measured and the rendered
+ * diameter are one value.
+ */
+export const RAIL_CIRCLE_SIZE = 28;
+/**
+ * Gaps between circles, applied inline (`style={{ gap }}`) instead of a Tailwind
+ * class so no class edit can silently drift from the fit math.
+ */
+export const RAIL_ROW_GAP = 10;
+export const RAIL_COLUMN_GAP = 6;
+/**
+ * Collapsed icon rail cap. The column is a single narrow strip competing with
+ * the footer nav for vertical space, so it stops at four circles regardless of
+ * how many providers are enabled.
+ */
+export const RAIL_COLUMN_MAX = 4;
+
+/**
+ * How many circles fit a row `width` px wide. Returns 0 for an unmeasured row,
+ * which {@link fitUsageRail} reads as "no limit yet".
+ *
+ * Split from {@link fitUsageRail} so the rail can store this derived count
+ * instead of the raw width: a resize drag then re-renders only when a circle
+ * gains or loses its place, and the measuring effect stays independent of how
+ * many providers there are.
+ */
+export function railSlots(width: number): number {
+  if (width <= 0) return 0;
+  return Math.floor((width + RAIL_ROW_GAP) / (RAIL_CIRCLE_SIZE + RAIL_ROW_GAP));
+}
+
+/**
+ * How many circles to draw given `slots` of capacity. Everything, when it fits
+ * — or when the row hasn't been measured yet, so the first paint is the full
+ * rail rather than an empty strip. Otherwise one slot goes to the "+N" chip, so
+ * every provider is either drawn or reachable through the chip.
+ */
+export function fitUsageRail(slots: number, total: number): number {
+  if (slots <= 0 || slots >= total) return total;
+  return slots - 1;
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} Threads"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0}-Token"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# Agent bereit} other {# Agenten bereit}}"
 #~ msgstr "{judgingLabel} überprüft die Änderungen jedes Kandidaten, um einen Gewinner zu empfehlen."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} API-Schlüssel"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Automatisches Aktualisierungsintervall für {label} in Minuten"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> von {0} Prüfungen bestanden"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · geschätzt"
 
@@ -1261,8 +1259,8 @@ msgstr "Automatisch generieren"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Auto-Aktualisierung"
+#~ msgid "Auto-refresh"
+#~ msgstr "Auto-Aktualisierung"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Browser-Auswahlziel für CLI-Threads"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Browser-Anmeldung"
 
@@ -2922,7 +2920,6 @@ msgstr "Anmeldeinformationen sind konfiguriert."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Credits"
 
@@ -4595,7 +4592,7 @@ msgstr "Versteckte fortsetzbare Threads werden alle 5 Minuten durchsucht und nac
 msgid "Hide"
 msgstr "Verstecken"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "{label}-Ring in der Seitenleiste ausblenden"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Mikrofontests sind in dieser Umgebung nicht verfügbar."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5767,6 +5764,10 @@ msgstr "Weitere PR-Aktionen"
 msgid "More PR options"
 msgstr "Mehr PR-Optionen"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Weitere Anbieter"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Weitere Pull-Request-Optionen"
@@ -5778,6 +5779,10 @@ msgstr "Weitere Zeitplanoptionen"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Weitere Synchronisierungsoptionen"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Weitere Nutzungsanbieter – Nutzungsbereich öffnen"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Einfügen"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "{label} API-Schlüssel einfügen"
 
@@ -7692,7 +7697,6 @@ msgstr "Rekonstruiert aus lokalen Protokollen zu öffentlichen API-Tarifen – e
 msgid "Redact notification content"
 msgstr "Benachrichtigungsinhalt verbergen"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Tastenkürzel"
 msgid "Show {0}"
 msgstr "{0} anzeigen"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "{label}-Ring in der Seitenleiste anzeigen"
 
@@ -8943,10 +8947,10 @@ msgstr "Es werden die ersten 4.000 Einträge angezeigt."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Seitenleiste"
+#~ msgid "Sidebar"
+#~ msgstr "Seitenleiste"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Seitenleisten-Ringe sind oben global deaktiviert"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Mattierung der Seitenleiste"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Anmelden"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Mit der Agent-CLI anmelden."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Abmelden"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "{label} abmelden"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Anmelden"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Anmelden…"
 
@@ -10246,7 +10251,7 @@ msgstr "Tokens im Zeitraum"
 msgid "Total tokens"
 msgstr "Tokens im Zeitraum"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Verfolgen Sie die Nutzung von {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Tracking und Anzeige"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Verfolgung aus"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} threads"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} tokens"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# agent ready} other {# agents ready}}"
 #~ msgstr "{judgingLabel} is reviewing each candidate's changes to recommend a winner."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} API key"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "{label} auto-refresh interval in minutes"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> of {0} checks passed"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · est."
 
@@ -1261,8 +1259,8 @@ msgstr "Auto-generate"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Auto-refresh"
+#~ msgid "Auto-refresh"
+#~ msgstr "Auto-refresh"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Browser pick target for CLI threads"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Browser sign-in"
 
@@ -2922,7 +2920,6 @@ msgstr "Credentials are configured."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Credits"
 
@@ -4595,7 +4592,7 @@ msgstr "Hidden resumable threads are swept every 5 minutes and unloaded after th
 msgid "Hide"
 msgstr "Hide"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Hide {label} circle in sidebar"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Microphone testing is not available in this environment."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5767,6 +5764,10 @@ msgstr "More PR actions"
 msgid "More PR options"
 msgstr "More PR options"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "More providers"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "More pull request options"
@@ -5778,6 +5779,10 @@ msgstr "More schedule options"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "More sync options"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "More usage providers — open usage panel"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Paste"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Paste {label} API key"
 
@@ -7692,7 +7697,6 @@ msgstr "Reconstructed from local logs at public API rates — it does not reflec
 msgid "Redact notification content"
 msgstr "Redact notification content"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Shortcuts"
 msgid "Show {0}"
 msgstr "Show {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Show {label} circle in sidebar"
 
@@ -8943,10 +8947,10 @@ msgstr "Showing the first 4,000 entries."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Sidebar"
+#~ msgid "Sidebar"
+#~ msgstr "Sidebar"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Sidebar circles are turned off globally above"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Sidebar frosting"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Sign in with the agent CLI."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Sign out"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Sign out {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Signing in"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Signing in…"
 
@@ -10246,7 +10251,7 @@ msgstr "total tokens"
 msgid "Total tokens"
 msgstr "Total tokens"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Track {label} usage"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Tracking and display"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Tracking off"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} hilos"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} tokens"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# agente listo} other {# agentes listos}}"
 #~ msgstr "{judgingLabel} está revisando los cambios de cada candidato para recomendar un ganador."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "Clave API de {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Intervalo de actualización automática de {label} en minutos"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> de {0} comprobaciones superadas"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · est."
 
@@ -1261,8 +1259,8 @@ msgstr "Autogenerar"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Actualización automática"
+#~ msgid "Auto-refresh"
+#~ msgstr "Actualización automática"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Destino de selección del navegador para los hilos de CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Inicio de sesión en el navegador"
 
@@ -2922,7 +2920,6 @@ msgstr "Las credenciales están configuradas."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Créditos"
 
@@ -4595,7 +4592,7 @@ msgstr "Los hilos ocultos reanudables se revisan cada 5 minutos y se descargan t
 msgid "Hide"
 msgstr "Ocultar"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Ocultar el círculo de {label} en la barra lateral"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "La prueba del micrófono no está disponible en este entorno."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5767,6 +5764,10 @@ msgstr "Más acciones de PR"
 msgid "More PR options"
 msgstr "Más opciones de PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Más proveedores"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Más opciones de pull request"
@@ -5778,6 +5779,10 @@ msgstr "Más opciones de programación"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Más opciones de sincronización"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Más proveedores de uso — abrir panel de uso"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Pegar"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Pega la clave API de {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Reconstruido a partir de los registros locales según las tarifas públi
 msgid "Redact notification content"
 msgstr "Ocultar el contenido de las notificaciones"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Atajos"
 msgid "Show {0}"
 msgstr "Mostrar {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Mostrar el círculo de {label} en la barra lateral"
 
@@ -8943,10 +8947,10 @@ msgstr "Mostrando las primeras 4000 entradas."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Barra lateral"
+#~ msgid "Sidebar"
+#~ msgstr "Barra lateral"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Los círculos de la barra lateral están desactivados globalmente arriba"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Esmerilado del panel lateral"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Inicia sesión con la CLI del agente."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Cerrar sesión {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Iniciando sesión"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Iniciando sesión…"
 
@@ -10246,7 +10251,7 @@ msgstr "tokens del periodo"
 msgid "Total tokens"
 msgstr "Tokens del periodo"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Hacer seguimiento del uso de {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Seguimiento y visualización"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Seguimiento desactivado"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} fils"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} jetons"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# agent prêt} other {# agents prêts}}"
 #~ msgstr "{judgingLabel} examine les modifications de chaque candidat pour recommander un gagnant."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "Clé API {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Intervalle de rafraîchissement automatique de {label} en minutes"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> sur {0} contrôles réussis"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · est."
 
@@ -1261,8 +1259,8 @@ msgstr "Générer automatiquement"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Rafraîchissement automatique"
+#~ msgid "Auto-refresh"
+#~ msgstr "Rafraîchissement automatique"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Cible de sélection du navigateur pour les fils CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Connexion via le navigateur"
 
@@ -2922,7 +2920,6 @@ msgstr "Les informations d'identification sont configurées."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Crédits"
 
@@ -4595,7 +4592,7 @@ msgstr "Les fils de discussion masqués pouvant être repris sont nettoyés tout
 msgid "Hide"
 msgstr "Masquer"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Masquer le cercle de {label} dans la barre latérale"
 
@@ -5659,7 +5656,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Les tests de microphone ne sont pas disponibles dans cet environnement."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5766,6 +5763,10 @@ msgstr "Plus d'actions PR"
 msgid "More PR options"
 msgstr "Plus d'options PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Autres fournisseurs"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Plus d'options de pull request"
@@ -5777,6 +5778,10 @@ msgstr "Plus d'options de planification"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Plus d'options de synchronisation"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Autres fournisseurs d'utilisation — ouvrir le panneau d'utilisation"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7048,7 +7053,7 @@ msgid "Paste"
 msgstr "Coller"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Collez la clé API {label}"
 
@@ -7691,7 +7696,6 @@ msgstr "Reconstruit à partir de journaux locaux aux tarifs de l'API publique, i
 msgid "Redact notification content"
 msgstr "Masquer le contenu des notifications"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8807,7 +8811,7 @@ msgstr "Raccourcis"
 msgid "Show {0}"
 msgstr "Afficher {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Afficher le cercle de {label} dans la barre latérale"
 
@@ -8942,10 +8946,10 @@ msgstr "Affichage des 4 000 premières entrées."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Barre latérale"
+#~ msgid "Sidebar"
+#~ msgstr "Barre latérale"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Les cercles de la barre latérale sont désactivés globalement ci-dessus"
 
@@ -8955,7 +8959,7 @@ msgid "Sidebar frosting"
 msgstr "Givrage de la barre latérale"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Connectez-vous"
 
@@ -8977,11 +8981,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Connectez-vous avec l’agent CLI."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Se déconnecter"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Déconnexion {label}"
 
@@ -9015,7 +9020,7 @@ msgid "Signing in"
 msgstr "Connexion"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Connexion…"
 
@@ -10245,7 +10250,7 @@ msgstr "total des tokens"
 msgid "Total tokens"
 msgstr "Total des tokens"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Suivre l'utilisation de {label}"
 
@@ -10258,7 +10263,7 @@ msgid "Tracking and display"
 msgstr "Suivi et affichage"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Suivi désactivé"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} 件のスレッド"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0}トークン"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {#エージェントの準備ができて�
 #~ msgstr "{judgingLabel} が各候補の変更を確認して勝者を推薦します。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} APIキー"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "{label} の自動更新間隔 (分単位)"
 
@@ -532,7 +531,6 @@ msgstr "<0>{passed}</0> 件の{0}チェックに合格しました"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens}·{0}· 推定。"
 
@@ -1260,8 +1258,8 @@ msgstr "自動生成"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "自動更新"
+#~ msgid "Auto-refresh"
+#~ msgstr "自動更新"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1524,7 +1522,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "ブラウザによる CLI スレッドのターゲットの選択"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "ブラウザーでサインイン"
 
@@ -2921,7 +2919,6 @@ msgstr "資格情報が設定されています。"
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "クレジット"
 
@@ -4594,7 +4591,7 @@ msgstr "非表示の再開可能なスレッドは 5 分ごとにスイープさ
 msgid "Hide"
 msgstr "隠す"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "サイドバーで {label} のリングを非表示にする"
 
@@ -5658,7 +5655,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "この環境ではマイクテストは利用できません。"
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "分"
 
@@ -5765,6 +5762,10 @@ msgstr "その他の PR 操作"
 msgid "More PR options"
 msgstr "その他の PR オプション"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "その他のプロバイダー"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "その他のプルリクエストオプション"
@@ -5776,6 +5777,10 @@ msgstr "その他のスケジュールオプション"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "その他の同期オプション"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "その他の使用量プロバイダー — 使用量パネルを開く"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7047,7 +7052,7 @@ msgid "Paste"
 msgstr "ペースト"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "{label} APIキーを貼り付け"
 
@@ -7690,7 +7695,6 @@ msgstr "パブリック API レートでローカル ログから再構築され
 msgid "Redact notification content"
 msgstr "通知内容を伏せる"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8806,7 +8810,7 @@ msgstr "ショートカット"
 msgid "Show {0}"
 msgstr "{0}を表示"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "サイドバーで {label} のリングを表示する"
 
@@ -8941,10 +8945,10 @@ msgstr "最初の4,000件を表示しています。"
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "サイドバー"
+#~ msgid "Sidebar"
+#~ msgstr "サイドバー"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "サイドバーのリングは上で全体的にオフになっています"
 
@@ -8954,7 +8958,7 @@ msgid "Sidebar frosting"
 msgstr "サイドバーのすりガラス効果"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "サインイン"
 
@@ -8976,11 +8980,12 @@ msgid "Sign in with the agent CLI."
 msgstr "エージェント CLI を使用してサインインします。"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "サインアウト"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "サインアウト{label}"
 
@@ -9014,7 +9019,7 @@ msgid "Signing in"
 msgstr "サインインしています"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "サインイン中…"
 
@@ -10244,7 +10249,7 @@ msgstr "合計トークン"
 msgid "Total tokens"
 msgstr "合計トークン"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "{label}の使用状況を追跡する"
 
@@ -10257,7 +10262,7 @@ msgid "Tracking and display"
 msgstr "トラッキングと表示"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "追跡オフ"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -243,7 +243,6 @@ msgstr "스레드 {0}개"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} 토큰"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# 에이전트 준비됨} other {# 에이�
 #~ msgstr "{judgingLabel}이(가) 각 후보의 변경 사항을 검토하여 우승자를 추천합니다."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} API 키"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "{label} 자동 새로고침 간격(분)"
 
@@ -533,7 +532,6 @@ msgstr "{0}개 검사 중 <0>{passed}</0>개 통과"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · 예상"
 
@@ -1261,8 +1259,8 @@ msgstr "자동 생성"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "자동 새로고침"
+#~ msgid "Auto-refresh"
+#~ msgstr "자동 새로고침"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "CLI 스레드에 대한 브라우저 선택 대상"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "브라우저로 로그인"
 
@@ -2922,7 +2920,6 @@ msgstr "자격 증명이 구성되었습니다."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "크레딧"
 
@@ -4595,7 +4592,7 @@ msgstr "숨겨진 재개 가능 스레드는 5분마다 청소되고 이 유휴 
 msgid "Hide"
 msgstr "숨기기"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "사이드바에서 {label} 원 숨기기"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "이 환경에서는 마이크 테스트를 사용할 수 없습니다."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "분"
 
@@ -5767,6 +5764,10 @@ msgstr "추가 PR 작업"
 msgid "More PR options"
 msgstr "더 많은 PR 옵션"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "추가 공급자"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "추가 풀 요청 옵션"
@@ -5778,6 +5779,10 @@ msgstr "추가 일정 옵션"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "더 많은 동기화 옵션"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "추가 사용량 공급자 — 사용량 패널 열기"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "붙여넣기"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "{label} API 키 붙여넣기"
 
@@ -7692,7 +7697,6 @@ msgstr "공개 API 요금으로 로컬 로그에서 재구성되며 구독 계�
 msgid "Redact notification content"
 msgstr "알림 내용 가리기"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "단축키"
 msgid "Show {0}"
 msgstr "{0} 표시"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "사이드바에 {label} 원 표시"
 
@@ -8943,10 +8947,10 @@ msgstr "처음 4,000개 항목을 표시합니다."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "사이드바"
+#~ msgid "Sidebar"
+#~ msgstr "사이드바"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "위에서 사이드바 원이 전체적으로 꺼져 있습니다"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "사이드바 프로스트"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "로그인"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "에이전트 CLI로 로그인합니다."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "로그아웃"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "{label} 로그아웃"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "로그인 중"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "로그인 중…"
 
@@ -10246,7 +10251,7 @@ msgstr "전체 토큰"
 msgid "Total tokens"
 msgstr "전체 토큰"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "{label} 사용량 추적"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "추적 및 표시"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "추적 꺼짐"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} wątków"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} tokenów"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# agent gotowy} few {# agenci gotowi} many
 #~ msgstr "{judgingLabel} przegląda zmiany każdego kandydata, aby polecić zwycięzcę."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "Klucz API {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Interwał automatycznego odświeżania {label} w minutach"
 
@@ -533,7 +532,6 @@ msgstr "Zaliczono <0>{passed}</0> z {0} kontroli"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · szac."
 
@@ -1261,8 +1259,8 @@ msgstr "Generuj automatycznie"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Automatyczne odświeżanie"
+#~ msgid "Auto-refresh"
+#~ msgstr "Automatyczne odświeżanie"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Cel wyboru przeglądarki dla wątków CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Logowanie przez przeglądarkę"
 
@@ -2922,7 +2920,6 @@ msgstr "Poświadczenia są skonfigurowane."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Kredyty"
 
@@ -4595,7 +4592,7 @@ msgstr "Ukryte wątki, które można wznowić, są czyszczone co 5 minut i rozł
 msgid "Hide"
 msgstr "Ukryj"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Ukryj krąg {label} na pasku bocznym"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Testowanie mikrofonu nie jest dostępne w tym środowisku."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5767,6 +5764,10 @@ msgstr "Więcej działań PR"
 msgid "More PR options"
 msgstr "Więcej opcji PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Więcej dostawców"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Więcej opcji żądania ściągnięcia"
@@ -5778,6 +5779,10 @@ msgstr "Więcej opcji harmonogramu"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Więcej opcji synchronizacji"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Więcej dostawców użycia — otwórz panel użycia"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Wklej"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Wklej klucz API {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Zrekonstruowane z lokalnych dzienników po stawkach publicznego API — 
 msgid "Redact notification content"
 msgstr "Ukryj treść powiadomień"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Skróty klawiszowe"
 msgid "Show {0}"
 msgstr "Pokaż {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Pokaż krąg {label} na pasku bocznym"
 
@@ -8943,10 +8947,10 @@ msgstr "Wyświetlanie pierwszych 4000 wpisów."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Pasek boczny"
+#~ msgid "Sidebar"
+#~ msgstr "Pasek boczny"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Kręgi na pasku bocznym są wyłączone globalnie powyżej"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Zmatowienie paska bocznego"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Zaloguj się"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Zaloguj się za pomocą interfejsu CLI agenta."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Wyloguj się"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Wyloguj się z {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Logowanie"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Logowanie…"
 
@@ -10246,7 +10251,7 @@ msgstr "łączna liczba tokenów"
 msgid "Total tokens"
 msgstr "Łączna liczba tokenów"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Śledź wykorzystanie {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Śledzenie i wyświetlanie"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Śledzenie wyłączone"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} threads"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} tokens"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# agente pronto} other {# agentes prontos}
 #~ msgstr "{judgingLabel} está revisando as alterações de cada candidato para recomendar um vencedor."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "Chave de API do {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Intervalo de atualização automática de {label} em minutos"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> de {0} verificações aprovadas"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · est."
 
@@ -1261,8 +1259,8 @@ msgstr "Gerar automaticamente"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Atualização automática"
+#~ msgid "Auto-refresh"
+#~ msgstr "Atualização automática"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Destino escolhido pelo navegador para threads CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Login pelo navegador"
 
@@ -2922,7 +2920,6 @@ msgstr "As credenciais estão configuradas."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Créditos"
 
@@ -4595,7 +4592,7 @@ msgstr "Tópicos recuperáveis ocultos são varridos a cada 5 minutos e descarre
 msgid "Hide"
 msgstr "Esconder"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Ocultar círculo de {label} na barra lateral"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "O teste de microfone não está disponível neste ambiente."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "min"
 
@@ -5767,6 +5764,10 @@ msgstr "Mais ações de PR"
 msgid "More PR options"
 msgstr "Mais opções de PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Mais provedores"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Mais opções de solicitação pull"
@@ -5778,6 +5779,10 @@ msgstr "Mais opções de agendamento"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Mais opções de sincronização"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Mais provedores de uso — abrir o painel de uso"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Colar"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Cole a chave de API do {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Reconstruído a partir de registros locais com taxas de API públicas �
 msgid "Redact notification content"
 msgstr "Ocultar o conteúdo das notificações"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Atalhos"
 msgid "Show {0}"
 msgstr "Mostrar {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Mostrar círculo de {label} na barra lateral"
 
@@ -8943,10 +8947,10 @@ msgstr "Exibindo as primeiras 4.000 entradas."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Barra lateral"
+#~ msgid "Sidebar"
+#~ msgstr "Barra lateral"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Os círculos da barra lateral estão desativados globalmente acima"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Efeito fosco da barra lateral"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Faça login"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Faça login com a CLI do agente."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Sair"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Sair de {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Fazendo login"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Fazendo login…"
 
@@ -10246,7 +10251,7 @@ msgstr "total de tokens"
 msgid "Total tokens"
 msgstr "Total de tokens"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Rastrear o uso de {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Rastreamento e exibição"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Rastreamento desativado"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} потоков"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} токенов"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# агент готов} few {# агент
 #~ msgstr "{judgingLabel} просматривает изменения каждого кандидата, чтобы порекомендовать победителя."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "API-ключ {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Интервал автообновления {label} в минутах"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> из {0} проверок пройдено"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · прибл."
 
@@ -1261,8 +1259,8 @@ msgstr "Создавать автоматически"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Автообновление"
+#~ msgid "Auto-refresh"
+#~ msgstr "Автообновление"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Цель выбора из браузера для CLI-тредов"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Вход через браузер"
 
@@ -2922,7 +2920,6 @@ msgstr "Учётные данные настроены."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Кредиты"
 
@@ -4595,7 +4592,7 @@ msgstr "Скрытые возобновляемые треды проверяю�
 msgid "Hide"
 msgstr "Скрыть"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Скрыть кружок {label} на боковой панели"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Проверка микрофона недоступна в этой среде."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "мин"
 
@@ -5767,6 +5764,10 @@ msgstr "Больше действий с PR"
 msgid "More PR options"
 msgstr "Больше параметров PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Другие провайдеры"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Больше параметров pull request"
@@ -5778,6 +5779,10 @@ msgstr "Дополнительные параметры расписания"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Больше параметров синхронизации"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Другие провайдеры использования — открыть панель использования"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Вставить"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Вставьте API-ключ {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Реконструировано из локальных логов по
 msgid "Redact notification content"
 msgstr "Скрывать содержимое уведомлений"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Сочетания клавиш"
 msgid "Show {0}"
 msgstr "Показать {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Показать кружок {label} на боковой панели"
 
@@ -8943,10 +8947,10 @@ msgstr "Показаны первые 4 000 записей."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Боковая панель"
+#~ msgid "Sidebar"
+#~ msgstr "Боковая панель"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Кружки на боковой панели отключены глобально выше"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Матовость боковой панели"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Войти"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Войдите через CLI агента."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Выйти"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Выйти {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Выполняется вход"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Выполняется вход…"
 
@@ -10246,7 +10251,7 @@ msgstr "токенов всего"
 msgid "Total tokens"
 msgstr "Токенов всего"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Отслеживать использование {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Отслеживание и отображение"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Отслеживание выключено"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} iş parçacığı"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} jeton"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# aracı hazır} other {# aracı hazır}}"
 #~ msgstr "{judgingLabel}, bir kazanan önermek için her adayın değişikliklerini inceliyor."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} API anahtarı"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "{label} otomatik yenileme aralığı (dakika)"
 
@@ -533,7 +532,6 @@ msgstr "{0} kontrolden <0>{passed}</0> tanesi başarılı oldu"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · tahmini"
 
@@ -1261,8 +1259,8 @@ msgstr "Otomatik oluştur"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Otomatik yenileme"
+#~ msgid "Auto-refresh"
+#~ msgstr "Otomatik yenileme"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "CLI konuları için tarayıcı seçim hedefi"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Tarayıcıyla oturum aç"
 
@@ -2922,7 +2920,6 @@ msgstr "Kimlik bilgileri yapılandırıldı."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Krediler"
 
@@ -4595,7 +4592,7 @@ msgstr "Gizli devam ettirilebilir konular her 5 dakikada bir taranır ve bu boş
 msgid "Hide"
 msgstr "Gizle"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "{label} dairesini kenar çubuğunda gizle"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Bu ortamda mikrofon testi yapılamaz."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "dk"
 
@@ -5767,6 +5764,10 @@ msgstr "Daha fazla PR eylemi"
 msgid "More PR options"
 msgstr "Daha fazla PR seçeneği"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Diğer sağlayıcılar"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Daha fazla çekme isteği seçeneği"
@@ -5778,6 +5779,10 @@ msgstr "Diğer zamanlama seçenekleri"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Daha fazla senkronizasyon seçeneği"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Diğer kullanım sağlayıcıları — kullanım panelini aç"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Yapıştır"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "{label} API anahtarını yapıştır"
 
@@ -7692,7 +7697,6 @@ msgstr "Yerel günlüklerden genel API oranlarıyla yeniden oluşturulmuştur; a
 msgid "Redact notification content"
 msgstr "Bildirim içeriğini gizle"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Kısayollar"
 msgid "Show {0}"
 msgstr "{0} öğesini göster"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "{label} dairesini kenar çubuğunda göster"
 
@@ -8943,10 +8947,10 @@ msgstr "İlk 4.000 giriş gösteriliyor."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Kenar çubuğu"
+#~ msgid "Sidebar"
+#~ msgstr "Kenar çubuğu"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Kenar çubuğu daireleri yukarıda genel olarak kapatılmış"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Kenar çubuğu buzlu cam efekti"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Oturum aç"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Aracı CLI ile oturum açın."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Oturumu kapat"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "{label} oturumunu kapat"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Oturum açılıyor"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Oturum açılıyor…"
 
@@ -10246,7 +10251,7 @@ msgstr "token toplamı"
 msgid "Total tokens"
 msgstr "Token toplamı"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "{label} kullanımını takip edin"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "İzleme ve görüntüleme"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Takip kapalı"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} потоків"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} токенів"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# агент готовий} few {# аге
 #~ msgstr "{judgingLabel} переглядає зміни кожного кандидата, щоб порекомендувати переможця."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "API-ключ {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Інтервал автооновлення {label} у хвилинах"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> із {0} перевірок пройдено"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · прибл."
 
@@ -1261,8 +1259,8 @@ msgstr "Генерувати автоматично"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Автооновлення"
+#~ msgid "Auto-refresh"
+#~ msgstr "Автооновлення"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Ціль вибору в браузері для тредів CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Вхід через браузер"
 
@@ -2922,7 +2920,6 @@ msgstr "Облікові дані налаштовано."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Кредити"
 
@@ -4595,7 +4592,7 @@ msgstr "Приховані відновлювані треди перевіря�
 msgid "Hide"
 msgstr "Сховати"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Сховати коло {label} на бічній панелі"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Перевірка мікрофона недоступна в цьому середовищі."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "хв"
 
@@ -5767,6 +5764,10 @@ msgstr "Більше дій із PR"
 msgid "More PR options"
 msgstr "Більше параметрів PR"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Інші постачальники"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Більше параметрів pull request"
@@ -5778,6 +5779,10 @@ msgstr "Додаткові параметри розкладу"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Більше параметрів синхронізації"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Інші постачальники використання — відкрити панель використання"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Вставити"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Вставте API-ключ {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Відтворено з локальних журналів за пуб�
 msgid "Redact notification content"
 msgstr "Приховувати вміст сповіщень"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Комбінації клавіш"
 msgid "Show {0}"
 msgstr "Показати {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Показати коло {label} на бічній панелі"
 
@@ -8943,10 +8947,10 @@ msgstr "Показано перші 4 000 записів."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Бічна панель"
+#~ msgid "Sidebar"
+#~ msgstr "Бічна панель"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Кола на бічній панелі вимкнено глобально вище"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Матовість бічної панелі"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Увійти"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Увійдіть через CLI агента."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Вийти"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Вийти {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Виконується вхід"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Виконується вхід…"
 
@@ -10246,7 +10251,7 @@ msgstr "усього токенів"
 msgid "Total tokens"
 msgstr "Усього токенів"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Відстежувати використання {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Отслеживание и отображение"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Відстеження вимкнено"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} luồng"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} mã thông báo"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# tác nhân đã sẵn sàng} other {# t�
 #~ msgstr "{judgingLabel} đang xem xét các thay đổi của từng ứng viên để đề xuất ứng viên thắng."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "Khóa API {label}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "Khoảng thời gian tự động làm mới {label} tính bằng phút"
 
@@ -533,7 +532,6 @@ msgstr "<0>{passed}</0> trong số {0} kiểm tra đã được thông qua"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · ước tính."
 
@@ -1261,8 +1259,8 @@ msgstr "Tự động tạo"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "Tự động làm mới"
+#~ msgid "Auto-refresh"
+#~ msgstr "Tự động làm mới"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "Mục tiêu chọn trình duyệt cho các chủ đề CLI"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "Đăng nhập bằng trình duyệt"
 
@@ -2922,7 +2920,6 @@ msgstr "Thông tin xác thực được cấu hình."
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "Số dư tín dụng"
 
@@ -4595,7 +4592,7 @@ msgstr "Các chủ đề tiếp tục ẩn sẽ được quét 5 phút một l�
 msgid "Hide"
 msgstr "Ẩn"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "Ẩn vòng tròn {label} ở thanh bên"
 
@@ -5660,7 +5657,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "Kiểm tra micrô không có sẵn trong môi trường này."
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "phút"
 
@@ -5767,6 +5764,10 @@ msgstr "Thêm thao tác PR"
 msgid "More PR options"
 msgstr "Nhiều lựa chọn PR hơn"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "Nhà cung cấp khác"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "Nhiều tùy chọn pull request hơn"
@@ -5778,6 +5779,10 @@ msgstr "Thêm tùy chọn lịch"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "Nhiều tùy chọn đồng bộ hơn"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "Nhà cung cấp mức sử dụng khác — mở bảng sử dụng"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7049,7 +7054,7 @@ msgid "Paste"
 msgstr "Dán"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "Dán khóa API {label}"
 
@@ -7692,7 +7697,6 @@ msgstr "Được xây dựng lại từ nhật ký cục bộ ở mức API côn
 msgid "Redact notification content"
 msgstr "Ẩn nội dung thông báo"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8808,7 +8812,7 @@ msgstr "Phím tắt"
 msgid "Show {0}"
 msgstr "Hiển thị {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "Hiển thị vòng tròn {label} ở thanh bên"
 
@@ -8943,10 +8947,10 @@ msgstr "Đang hiển thị 4.000 mục đầu tiên."
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "Thanh bên"
+#~ msgid "Sidebar"
+#~ msgstr "Thanh bên"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "Vòng tròn thanh bên đã bị tắt toàn cục ở trên"
 
@@ -8956,7 +8960,7 @@ msgid "Sidebar frosting"
 msgstr "Độ mờ thanh bên"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "Đăng nhập"
 
@@ -8978,11 +8982,12 @@ msgid "Sign in with the agent CLI."
 msgstr "Đăng nhập bằng CLI tác nhân."
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "Đăng xuất"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "Đăng xuất {label}"
 
@@ -9016,7 +9021,7 @@ msgid "Signing in"
 msgstr "Đăng nhập"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "Đang đăng nhập…"
 
@@ -10246,7 +10251,7 @@ msgstr "tổng số tokens"
 msgid "Total tokens"
 msgstr "Tổng số tokens"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "Theo dõi mức sử dụng {label}"
 
@@ -10259,7 +10264,7 @@ msgid "Tracking and display"
 msgstr "Theo dõi và hiển thị"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "Tắt theo dõi"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -243,7 +243,6 @@ msgstr "{0} 个线程"
 
 #. placeholder {0}: formatTokens(snapshot.tokens.total)
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "{0} tokens"
 msgstr "{0} 令牌"
 
@@ -383,11 +382,11 @@ msgstr "{installedCount, plural, one {# 个代理准备就绪} other {# 个代�
 #~ msgstr "{judgingLabel} 正在查看每个候选的更改以推荐优胜者。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} API key"
 msgstr "{label} API 密钥"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "{label} auto-refresh interval in minutes"
 msgstr "{label} 自动刷新间隔（分钟）"
 
@@ -533,7 +532,6 @@ msgstr "{0} 项检查中 <0>{passed}</0> 项已通过"
 
 #. placeholder {0}: snapshot.cost.period
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "~{money}{tokens} · {0} · est."
 msgstr "~{money}{tokens} · {0} · 预计"
 
@@ -1261,8 +1259,8 @@ msgstr "自动生成"
 
 #. Label for the per-provider auto-refresh cadence field
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Auto-refresh"
-msgstr "自动刷新"
+#~ msgid "Auto-refresh"
+#~ msgstr "自动刷新"
 
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Auto-refresh interval in minutes, 0 to turn off"
@@ -1525,7 +1523,7 @@ msgid "Browser pick target for CLI threads"
 msgstr "为 CLI 线程在浏览器中选取目标"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Browser sign-in"
 msgstr "浏览器登录"
 
@@ -2922,7 +2920,6 @@ msgstr "凭证已配置。"
 
 #: src/renderer/components/providers/usageFormat.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
 msgid "Credits"
 msgstr "鸣谢"
 
@@ -4595,7 +4592,7 @@ msgstr "隐藏的可恢复线程每 5 分钟清理一次，并在此空闲期限
 msgid "Hide"
 msgstr "隐藏"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Hide {label} circle in sidebar"
 msgstr "在侧边栏中隐藏 {label} 圆环"
 
@@ -5659,7 +5656,7 @@ msgid "Microphone testing is not available in this environment."
 msgstr "在此环境中无法进行麦克风测试。"
 
 #. Unit suffix: minutes
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "min"
 msgstr "分钟"
 
@@ -5766,6 +5763,10 @@ msgstr "更多 PR 操作"
 msgid "More PR options"
 msgstr "更多 PR 选项"
 
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More providers"
+msgstr "更多提供商"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
 msgid "More pull request options"
 msgstr "更多拉取请求选项"
@@ -5777,6 +5778,10 @@ msgstr "更多计划选项"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
 msgid "More sync options"
 msgstr "更多同步选项"
+
+#: src/renderer/components/providers/UsageOverflowChip.tsx
+msgid "More usage providers — open usage panel"
+msgstr "更多用量提供商 — 打开用法面板"
 
 #: src/renderer/views/ProfileOverlay/parts/ActivityInsights.tsx
 msgid "Most active hour"
@@ -7048,7 +7053,7 @@ msgid "Paste"
 msgstr "粘贴"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Paste {label} API key"
 msgstr "粘贴 {label} API 密钥"
 
@@ -7691,7 +7696,6 @@ msgstr "以公共 API 费率从本地日志重建 — 它不反映您订阅计�
 msgid "Redact notification content"
 msgstr "隐藏通知内容"
 
-#. Button: re-fetch one provider's usage now
 #. Button: re-fetch provider usage now
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/PortsView.tsx
@@ -8807,7 +8811,7 @@ msgstr "快捷键"
 msgid "Show {0}"
 msgstr "显示 {0}"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Show {label} circle in sidebar"
 msgstr "在侧边栏中显示 {label} 圆环"
 
@@ -8942,10 +8946,10 @@ msgstr "仅显示前 4,000 个条目。"
 
 #. Toggle: show this provider's usage ring in the sidebar
 #: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
-msgid "Sidebar"
-msgstr "侧边栏"
+#~ msgid "Sidebar"
+#~ msgstr "侧边栏"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sidebar circles are turned off globally above"
 msgstr "侧边栏圆环已在上方全局关闭"
 
@@ -8955,7 +8959,7 @@ msgid "Sidebar frosting"
 msgstr "侧边栏磨砂效果"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign in"
 msgstr "登录"
 
@@ -8977,11 +8981,12 @@ msgid "Sign in with the agent CLI."
 msgstr "使用代理 CLI 登录。"
 
 #: src/renderer/components/mcp/McpServersManager.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out"
 msgstr "退出登录"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Sign out {label}"
 msgstr "退出{label}"
 
@@ -9015,7 +9020,7 @@ msgid "Signing in"
 msgstr "正在登录"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/UsagePanel/parts/UsageProviderCard.tsx
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Signing in…"
 msgstr "正在登录..."
 
@@ -10245,7 +10250,7 @@ msgstr "token总数"
 msgid "Total tokens"
 msgstr "token总数"
 
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Track {label} usage"
 msgstr "跟踪{label}使用情况"
 
@@ -10258,7 +10263,7 @@ msgid "Tracking and display"
 msgstr "跟踪和显示"
 
 #. Usage status when provider tracking is disabled
-#: src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
 msgid "Tracking off"
 msgstr "追踪关闭"
 

--- a/src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageProviderRow.tsx
@@ -1,0 +1,268 @@
+import { startTransition, useState, type FormEvent } from "react";
+import { Tooltip } from "@heroui/react";
+import { Eye, EyeOff, LogOut } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Button, ToggleSwitch } from "@/renderer/components/common";
+import { ProviderUsageCircle } from "@/renderer/components/providers/ProviderUsageCircle";
+import { usageStatusText } from "@/renderer/components/providers/usageFormat";
+import { useUsageProviderLogin } from "@/renderer/components/providers/useUsageProviderLogin";
+import { useProviderUsage } from "@/renderer/state/providerUsageStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { clampRefreshMinutes, MIN_REFRESH_MINUTES } from "./usageRefreshBounds";
+
+/**
+ * Per-provider auto-refresh cadence as bare inline text: no border, no fill, no
+ * stepper — just the number, editable in place. Empty inherits the global
+ * default, which the dimmer placeholder shows. Typing is buffered so a
+ * half-typed value never round-trips through settings; the draft commits on
+ * blur or Enter and reverts on Escape.
+ */
+function UsageCadenceField(props: { id: string; label: string }) {
+  const { id, label } = props;
+  const { t } = useLingui();
+  const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
+  const providerRefreshIntervals = useSharedSettings((s) => s.usage.providerRefreshIntervals);
+  const defaultIntervalMinutes = useSharedSettings((s) => s.usage.refreshIntervalMinutes);
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const override = providerRefreshIntervals[id];
+  const text = draft ?? String(override ?? "");
+
+  const commit = () => {
+    if (draft === null) return;
+    setDraft(null);
+    // `draft` only ever holds digits (the change handler strips the rest), so
+    // empty is the only non-numeric case to handle.
+    const next = { ...providerRefreshIntervals };
+    if (draft === "") delete next[id];
+    else next[id] = clampRefreshMinutes(Number(draft), MIN_REFRESH_MINUTES);
+    startTransition(() => setUsageSetting("providerRefreshIntervals", next));
+  };
+
+  return (
+    // The ring lives on the wrapper: `input:focus-visible` is stripped of
+    // box-shadow app-wide (styles.css), so a ring utility on the input itself
+    // would render nothing and leave this borderless field with no focus state.
+    <span className="flex shrink-0 items-baseline gap-1 rounded-md py-1 text-xs text-muted focus-within:focus-ring">
+      <input
+        type="text"
+        inputMode="numeric"
+        aria-label={t`${label} auto-refresh interval in minutes`}
+        value={text}
+        placeholder={String(defaultIntervalMinutes)}
+        onChange={(e) => setDraft(e.target.value.replace(/[^\d]/g, ""))}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+          else if (e.key === "Escape") setDraft(null);
+        }}
+        className="w-[28px] shrink-0 bg-transparent p-0 text-right text-xs tabular-nums text-muted outline-none transition-colors hover:text-foreground focus:text-foreground placeholder:text-muted/40"
+      />
+      <Trans comment="Unit suffix: minutes">min</Trans>
+    </span>
+  );
+}
+
+/**
+ * Controls for a tracked provider. This is a component rather than inline JSX
+ * because it owns `useUsageProviderLogin`, and the row mounts it only while
+ * tracking is on — a hook can't be called conditionally.
+ */
+function UsageProviderControls(props: { id: string; label: string }) {
+  const { id, label } = props;
+  const { t } = useLingui();
+  const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
+  const sidebarHiddenProviders = useSharedSettings((s) => s.usage.sidebarHiddenProviders);
+  const showInSidebar = useSharedSettings((s) => s.usage.showInSidebar);
+
+  const {
+    canBrowserSignIn,
+    canApiKeySignIn,
+    canSignOut,
+    signingIn,
+    signingOut,
+    apiKey,
+    setApiKey,
+    handleSignIn,
+    handleSubmitApiKey,
+    handleSignOut,
+  } = useUsageProviderLogin(id);
+
+  const circleHidden = sidebarHiddenProviders.includes(id);
+  const circleAction = circleHidden
+    ? t`Show ${label} circle in sidebar`
+    : t`Hide ${label} circle in sidebar`;
+  const toggleCircle = () => {
+    const next = circleHidden
+      ? sidebarHiddenProviders.filter((x) => x !== id)
+      : [...new Set([...sidebarHiddenProviders, id])];
+    startTransition(() => setUsageSetting("sidebarHiddenProviders", next));
+  };
+
+  const onSubmitApiKey = (event: FormEvent) => {
+    event.preventDefault();
+    void handleSubmitApiKey();
+  };
+
+  // Sign-in is the widest thing in a row, so rather than squeezing the provider
+  // name to an ellipsis it drops below: the key form always (it needs a text
+  // field), the button only while the container is too narrow to seat it.
+  const browserSignIn = canBrowserSignIn ? (
+    <div className="order-last flex basis-full items-center @xl:order-none @xl:basis-auto">
+      <Button
+        size="sm"
+        variant="ghost"
+        className="shrink-0 text-foreground"
+        isDisabled={signingIn}
+        onPress={() => void handleSignIn()}
+      >
+        {signingIn ? <Trans>Signing in…</Trans> : <Trans>Browser sign-in</Trans>}
+      </Button>
+    </div>
+  ) : null;
+
+  const apiKeySignIn = canApiKeySignIn ? (
+    <form
+      onSubmit={onSubmitApiKey}
+      className="order-last flex min-w-0 basis-full items-center gap-1.5"
+    >
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        placeholder={t`Paste ${label} API key`}
+        aria-label={t`${label} API key`}
+        autoComplete="off"
+        spellCheck={false}
+        className="min-w-0 flex-1 rounded-lg border border-[color:var(--separator)] bg-background px-2 py-1 text-xs text-foreground outline-none focus-visible:focus-ring @xl:max-w-[240px]"
+      />
+      <Button
+        size="sm"
+        variant="ghost"
+        type="submit"
+        className="shrink-0 text-foreground"
+        isDisabled={signingIn || apiKey.trim().length === 0}
+      >
+        {signingIn ? <Trans>Signing in…</Trans> : <Trans>Sign in</Trans>}
+      </Button>
+    </form>
+  ) : null;
+
+  return (
+    <>
+      {browserSignIn}
+      {apiKeySignIn}
+      {/* Pinned to the right of the first line; the sign-in block above wraps
+          below them when the container is narrow. */}
+      <span className="ml-auto flex shrink-0 items-center gap-1">
+        <Tooltip>
+          <Tooltip.Trigger>
+            <Button
+              isIconOnly
+              size="sm"
+              variant="ghost"
+              aria-pressed={!circleHidden}
+              aria-label={circleAction}
+              className={`shrink-0 ${circleHidden ? "text-muted/50" : "text-foreground"}`}
+              onPress={toggleCircle}
+            >
+              {circleHidden ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            {showInSidebar ? circleAction : t`Sidebar circles are turned off globally above`}
+          </Tooltip.Content>
+        </Tooltip>
+        {canSignOut ? (
+          <Tooltip>
+            <Tooltip.Trigger>
+              <Button
+                isIconOnly
+                size="sm"
+                variant="ghost"
+                aria-label={t`Sign out ${label}`}
+                className="shrink-0 text-muted"
+                isDisabled={signingOut}
+                onPress={() => void handleSignOut()}
+              >
+                <LogOut className="size-4" />
+              </Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <Trans>Sign out</Trans>
+            </Tooltip.Content>
+          </Tooltip>
+        ) : null}
+        <UsageCadenceField id={id} label={label} />
+      </span>
+    </>
+  );
+}
+
+/**
+ * One provider, one line: the usage ring in the title carries the numbers — this
+ * page draws no bars, those live in the docked usage panel — followed by that
+ * provider's settings and the tracking switch. Everything is on the surface, so
+ * there is nothing to expand.
+ *
+ * Carries the shared `settings-row` classes so the phone shell reflows it with
+ * every other settings row (see src/mobile/styles.css).
+ */
+export function UsageProviderRow(props: { id: string; label: string }) {
+  const { id, label } = props;
+  const { t } = useLingui();
+  const snapshot = useProviderUsage(id);
+  const disabledProviders = useSharedSettings((s) => s.usage.disabledProviders);
+  const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
+  const enabled = !disabledProviders.includes(id);
+  const hasWindows = enabled && snapshot?.status === "ok" && snapshot.windows.length > 0;
+
+  return (
+    // A container (not viewport) query: the settings page is also rendered in
+    // narrow hosts — a resized window, the docked overlay, the phone shell — so
+    // the row collapses against its own width. `min-h` keeps it a finger-sized
+    // target on the phone.
+    <div className="settings-row @container flex min-h-[44px] flex-wrap items-center gap-x-2 gap-y-1.5 border-t border-[color:var(--separator)] py-2 first:border-t-0">
+      <ProviderUsageCircle kind={id} windows={enabled ? snapshot?.windows : undefined} size={22} />
+      {/* Floors the name/status at a readable width so the controls wrap away
+          instead of crushing it to an ellipsis. */}
+      <div className="settings-row__text flex min-w-[8rem] flex-1 items-baseline gap-2">
+        {/* The name is the row's identity, so the plan/status gives up its
+            characters first: capped at 60% it keeps a long name readable
+            without ever pushing the controls off the line. */}
+        <p className="max-w-[60%] shrink-0 truncate text-sm font-medium text-foreground">{label}</p>
+        {snapshot?.plan ? (
+          <span className="truncate text-xs text-muted">{snapshot.plan}</span>
+        ) : null}
+        {/* With windows present the ring says it all; otherwise the row needs
+            words — "Not signed in", "Tracking off", or a credits balance that
+            usageStatusText folds in. */}
+        {hasWindows ? null : (
+          <span className="truncate text-xs text-muted">
+            {enabled
+              ? usageStatusText(snapshot, label, id)
+              : t({
+                  message: "Tracking off",
+                  comment: "Usage status when provider tracking is disabled",
+                })}
+          </span>
+        )}
+      </div>
+      {enabled ? <UsageProviderControls id={id} label={label} /> : null}
+      <span className={enabled ? "shrink-0" : "ml-auto shrink-0"}>
+        <ToggleSwitch
+          aria-label={t`Track ${label} usage`}
+          isSelected={enabled}
+          onChange={(selected) => {
+            const next = selected
+              ? disabledProviders.filter((x) => x !== id)
+              : [...new Set([...disabledProviders, id])];
+            startTransition(() => {
+              setUsageSetting("disabledProviders", next);
+            });
+          }}
+        />
+      </span>
+    </div>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/UsageSettings.tsx
@@ -1,269 +1,15 @@
-import { startTransition, useEffect, useState, type FormEvent } from "react";
-import { Eye, EyeOff, LogOut, RefreshCw } from "lucide-react";
-import { NumberField } from "@heroui/react";
+import { startTransition, useEffect, useState } from "react";
+import { NumberField, Tooltip } from "@heroui/react";
+import { RefreshCw } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { isRemoteSession, readBridge } from "@/renderer/bridge";
 import { Button, ToggleSwitch } from "@/renderer/components/common";
-import { ProviderIcon } from "@/renderer/components/providers/ProviderIcon";
-import {
-  formatMoney,
-  formatTokens,
-  usageStatusText,
-} from "@/renderer/components/providers/usageFormat";
-import { UsageWindowBars } from "@/renderer/components/providers/UsageWindowBars";
 import { usageProvidersForAgentInstances } from "@/renderer/components/providers/usageProviders";
-import { useProviderUsageRefresh } from "@/renderer/components/providers/useProviderUsageRefresh";
-import { useUsageProviderLogin } from "@/renderer/components/providers/useUsageProviderLogin";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { useProviderUsage, useProviderUsageStore } from "@/renderer/state/providerUsageStore";
+import { useProviderUsageStore } from "@/renderer/state/providerUsageStore";
 import { SettingRow, SettingsPage } from "./SettingsForm";
-
-/**
- * Per-provider controls beneath each provider row: sign in / out, a manual
- * single-provider refresh, a sidebar-circle visibility toggle, and a
- * per-provider auto-refresh cadence override. Only rendered while the provider
- * is tracked (the master Switch is on).
- */
-function UsageProviderControls(props: { id: string; label: string }) {
-  const { id, label } = props;
-  const { t } = useLingui();
-  const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
-  const sidebarHiddenProviders = useSharedSettings((s) => s.usage.sidebarHiddenProviders);
-  const providerRefreshIntervals = useSharedSettings((s) => s.usage.providerRefreshIntervals);
-  const defaultIntervalMinutes = useSharedSettings((s) => s.usage.refreshIntervalMinutes);
-  const showInSidebar = useSharedSettings((s) => s.usage.showInSidebar);
-
-  const {
-    canBrowserSignIn,
-    canApiKeySignIn,
-    canSignOut,
-    signingIn,
-    signingOut,
-    apiKey,
-    setApiKey,
-    handleSignIn,
-    handleSubmitApiKey,
-    handleSignOut,
-  } = useUsageProviderLogin(id);
-  const { refreshing, refresh } = useProviderUsageRefresh(id);
-
-  const circleHidden = sidebarHiddenProviders.includes(id);
-  const toggleCircle = () => {
-    const next = circleHidden
-      ? sidebarHiddenProviders.filter((x) => x !== id)
-      : [...new Set([...sidebarHiddenProviders, id])];
-    startTransition(() => setUsageSetting("sidebarHiddenProviders", next));
-  };
-
-  // The field shows the effective cadence (override or the global default).
-  // Setting it back to the default value removes the override so the provider
-  // follows the global cadence again.
-  const intervalValue = providerRefreshIntervals[id] ?? defaultIntervalMinutes;
-  const setIntervalMinutes = (minutes: number) => {
-    const clamped = Math.min(120, Math.max(2, Math.floor(minutes)));
-    const next = { ...providerRefreshIntervals };
-    if (clamped === defaultIntervalMinutes) delete next[id];
-    else next[id] = clamped;
-    startTransition(() => setUsageSetting("providerRefreshIntervals", next));
-  };
-
-  const onSubmitApiKey = (event: FormEvent) => {
-    event.preventDefault();
-    void handleSubmitApiKey();
-  };
-
-  const signInForm =
-    canBrowserSignIn || canApiKeySignIn ? (
-      <>
-        {canBrowserSignIn ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="text-foreground"
-            isDisabled={signingIn}
-            onPress={() => void handleSignIn()}
-          >
-            {signingIn ? <Trans>Signing in…</Trans> : <Trans>Browser sign-in</Trans>}
-          </Button>
-        ) : null}
-        {canApiKeySignIn ? (
-          <form onSubmit={onSubmitApiKey} className="flex items-center gap-1.5">
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder={t`Paste ${label} API key`}
-              aria-label={t`${label} API key`}
-              autoComplete="off"
-              spellCheck={false}
-              className="min-w-0 flex-1 rounded-lg border border-[color:var(--separator)] bg-background px-2 py-1 text-xs text-foreground outline-none focus-visible:focus-ring sm:w-[200px] sm:flex-none"
-            />
-            <Button
-              size="sm"
-              variant="ghost"
-              type="submit"
-              className="text-foreground"
-              isDisabled={signingIn || apiKey.trim().length === 0}
-            >
-              {signingIn ? <Trans>Signing in…</Trans> : <Trans>Sign in</Trans>}
-            </Button>
-          </form>
-        ) : null}
-      </>
-    ) : canSignOut ? (
-      <Button
-        size="sm"
-        variant="ghost"
-        className="text-foreground"
-        isDisabled={signingOut}
-        onPress={() => void handleSignOut()}
-      >
-        <LogOut className="size-3.5" />
-        <Trans>Sign out</Trans>
-      </Button>
-    ) : null;
-
-  return (
-    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
-      {signInForm}
-      <Button
-        size="sm"
-        variant="ghost"
-        className="text-foreground"
-        isDisabled={refreshing}
-        onPress={() => void refresh()}
-      >
-        <RefreshCw className={`size-3.5 ${refreshing ? "animate-spin" : ""}`} />
-        <Trans comment="Button: re-fetch one provider's usage now">Refresh</Trans>
-      </Button>
-      <button
-        type="button"
-        onClick={toggleCircle}
-        aria-pressed={!circleHidden}
-        aria-label={
-          circleHidden ? t`Show ${label} circle in sidebar` : t`Hide ${label} circle in sidebar`
-        }
-        title={showInSidebar ? undefined : t`Sidebar circles are turned off globally above`}
-        className={`flex items-center gap-1.5 rounded-lg border border-[color:var(--separator)] px-2 py-1 text-xs transition-colors hover:bg-muted/10 ${
-          circleHidden ? "text-muted/60" : "text-foreground"
-        }`}
-      >
-        {circleHidden ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
-        <Trans comment="Toggle: show this provider's usage ring in the sidebar">Sidebar</Trans>
-      </button>
-      <div className="flex items-center gap-1.5 text-xs text-muted">
-        <span aria-hidden="true">
-          <Trans comment="Label for the per-provider auto-refresh cadence field">
-            Auto-refresh
-          </Trans>
-        </span>
-        <NumberField
-          aria-label={t`${label} auto-refresh interval in minutes`}
-          className="w-[116px] shrink-0"
-          minValue={2}
-          maxValue={120}
-          step={1}
-          value={intervalValue}
-          onChange={(value) => {
-            if (value === undefined || Number.isNaN(value)) return;
-            setIntervalMinutes(value);
-          }}
-        >
-          <NumberField.Group>
-            <NumberField.DecrementButton />
-            <NumberField.Input />
-            <NumberField.IncrementButton />
-          </NumberField.Group>
-        </NumberField>
-        <span aria-hidden="true">
-          <Trans comment="Unit suffix: minutes">min</Trans>
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function UsageProviderRow(props: { id: string; label: string }) {
-  const { id, label } = props;
-  const { t } = useLingui();
-  const snapshot = useProviderUsage(id);
-  const disabledProviders = useSharedSettings((s) => s.usage.disabledProviders);
-  const setUsageSetting = useSharedSettings((s) => s.setUsageSetting);
-  const enabled = !disabledProviders.includes(id);
-  const showBars = enabled && snapshot?.status === "ok" && snapshot.windows.length > 0;
-  const reserveBars = !enabled && snapshot?.status === "ok" && snapshot.windows.length > 0;
-  const message = enabled
-    ? usageStatusText(snapshot, label, id)
-    : t({ message: "Tracking off", comment: "Usage status when provider tracking is disabled" });
-  // The credits line below already shows the balance, and usageStatusText folds
-  // it into the status string for a windowless "ok" snapshot — so skip the
-  // standalone message there to avoid rendering "Zen balance: $X" twice.
-  const messageDuplicatesCredits =
-    enabled &&
-    snapshot?.status === "ok" &&
-    snapshot.windows.length === 0 &&
-    !!snapshot.credits &&
-    !snapshot.credits.unlimited;
-  const tokens =
-    snapshot?.cost && snapshot.tokens?.total
-      ? ` · ${t`${formatTokens(snapshot.tokens.total)} tokens`}`
-      : "";
-  const money = snapshot?.cost ? formatMoney(snapshot.cost.amount, snapshot.cost.currency) : "";
-
-  return (
-    <div className="border-t border-[color:var(--separator)] py-3 first:border-t-0">
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 flex-1 items-start gap-2.5">
-          <ProviderIcon kind={id} fallbackLabel={label} className="mt-0.5 size-4 shrink-0" />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <p className="truncate text-sm font-medium text-foreground">{label}</p>
-              {snapshot?.plan ? (
-                <span className="truncate text-xs text-muted">{snapshot.plan}</span>
-              ) : null}
-            </div>
-            {showBars && snapshot ? (
-              <UsageWindowBars windows={snapshot.windows} className="mt-1.5 max-w-[360px]" />
-            ) : reserveBars && snapshot ? (
-              <div className="relative mt-1.5 max-w-[360px]">
-                <div className="invisible" aria-hidden="true">
-                  <UsageWindowBars windows={snapshot.windows} />
-                </div>
-                <p className="absolute inset-0 text-xs text-muted">{message}</p>
-              </div>
-            ) : messageDuplicatesCredits ? null : (
-              <p className="mt-0.5 text-xs text-muted">{message}</p>
-            )}
-            {snapshot?.cost ? (
-              <p className="mt-1.5 text-xs text-muted">
-                {t`~${money}${tokens} · ${snapshot.cost.period} · est.`}
-              </p>
-            ) : null}
-            {snapshot?.credits && !snapshot.credits.unlimited ? (
-              <p className="mt-1.5 text-xs text-muted">
-                {snapshot.credits.label ?? t`Credits`}:{" "}
-                {formatMoney(snapshot.credits.balance, snapshot.credits.currency)}
-              </p>
-            ) : null}
-          </div>
-        </div>
-        <ToggleSwitch
-          aria-label={t`Track ${label} usage`}
-          isSelected={enabled}
-          onChange={(selected) => {
-            const next = selected
-              ? disabledProviders.filter((x) => x !== id)
-              : [...new Set([...disabledProviders, id])];
-            startTransition(() => {
-              setUsageSetting("disabledProviders", next);
-            });
-          }}
-        />
-      </div>
-      {enabled ? <UsageProviderControls id={id} label={label} /> : null}
-    </div>
-  );
-}
+import { UsageProviderRow } from "./UsageProviderRow";
+import { clampRefreshMinutes, MAX_REFRESH_MINUTES } from "./usageRefreshBounds";
 
 export function UsageSettings() {
   const { t } = useLingui();
@@ -307,16 +53,24 @@ export function UsageSettings() {
       title={t`Provider Usage`}
       description={t`Track per-provider session, weekly, and monthly usage. Windows are reported by each provider; estimated cost is reconstructed from local logs.`}
       actions={
-        <Button
-          size="sm"
-          variant="ghost"
-          className="text-foreground"
-          isDisabled={isRefreshing}
-          onPress={refreshNow}
-        >
-          <RefreshCw className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
-          <Trans comment="Button: re-fetch provider usage now">Refresh</Trans>
-        </Button>
+        <Tooltip>
+          <Tooltip.Trigger>
+            <Button
+              isIconOnly
+              size="sm"
+              variant="ghost"
+              aria-label={t`Refresh`}
+              className="text-muted"
+              isDisabled={isRefreshing}
+              onPress={refreshNow}
+            >
+              <RefreshCw className={`size-4 ${isRefreshing ? "animate-spin" : ""}`} />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <Trans comment="Button: re-fetch provider usage now">Refresh</Trans>
+          </Tooltip.Content>
+        </Tooltip>
       }
     >
       {/* The background refresher runs on the desktop; a remote session's
@@ -337,7 +91,7 @@ export function UsageSettings() {
             aria-label={t`Auto-refresh interval in minutes, 0 to turn off`}
             className="w-[140px] shrink-0"
             minValue={0}
-            maxValue={120}
+            maxValue={MAX_REFRESH_MINUTES}
             step={1}
             value={autoRefresh ? refreshIntervalMinutes : 0}
             onChange={(value) => {
@@ -349,7 +103,7 @@ export function UsageSettings() {
                   return;
                 }
                 setUsageSetting("autoRefresh", true);
-                setUsageSetting("refreshIntervalMinutes", Math.min(120, Math.max(2, minutes)));
+                setUsageSetting("refreshIntervalMinutes", clampRefreshMinutes(minutes));
               });
             }}
           >

--- a/src/renderer/views/SettingsOverlay/parts/usageRefreshBounds.ts
+++ b/src/renderer/views/SettingsOverlay/parts/usageRefreshBounds.ts
@@ -1,0 +1,12 @@
+/**
+ * Bounds for every auto-refresh cadence field — the global default and each
+ * provider's override. The floor respects provider rate limits; 0 is accepted
+ * only by the global field, where it means "manual only".
+ */
+export const MIN_REFRESH_MINUTES = 2;
+export const MAX_REFRESH_MINUTES = 120;
+
+/** Clamp a cadence to the shared bounds; `min` lets the global field allow 0. */
+export function clampRefreshMinutes(minutes: number, min: number = MIN_REFRESH_MINUTES): number {
+  return Math.min(MAX_REFRESH_MINUTES, Math.max(min, Math.floor(minutes)));
+}


### PR DESCRIPTION
- Feature: make sidebar usage rails adapt to available space, with an overflow chip that keeps additional providers accessible.
- Refine provider eligibility so recoverable usage states remain visible in the rail.
- Add per-provider usage tracking and refresh controls, with shared refresh interval bounds.
- Add coverage for rail fitting and provider visibility, and update localized usage settings strings.