### PR TITLE
Simplify thread context indicator ring

### DIFF
--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -676,7 +676,7 @@ export function ThreadComposer(props: {
               style={{ position: "absolute", inset: 0 }}
             >
               {leadingControls && (
-                <div className="flex shrink-0 items-end gap-2">
+                <div className="flex shrink-0 items-end gap-1">
                   {typeof leadingControls === "function" ? leadingControls(level) : leadingControls}
                 </div>
               )}
@@ -686,7 +686,7 @@ export function ThreadComposer(props: {
               >
                 {renderProbeControlsList(level)}
               </div>
-              <div className="flex shrink-0 items-end gap-2">
+              <div className="flex shrink-0 items-end gap-1">
                 {typeof afterControls === "function" ? afterControls(level) : afterControls}
                 {!hideSubmitButton && <div className="size-8 shrink-0" />}
               </div>
@@ -838,12 +838,12 @@ export function ThreadComposer(props: {
   const toolbar = (
     <div ref={toolbarRef} className={toolbarClassName} data-wrap-level={wrapLevelRef.current}>
       {leadingControls && (
-        <div className="flex shrink-0 items-end gap-2">
+        <div className="flex shrink-0 items-end gap-1">
           {typeof leadingControls === "function" ? leadingControls(0) : leadingControls}
         </div>
       )}
       {renderControls()}
-      <div className="flex shrink-0 items-end gap-2">
+      <div className="flex shrink-0 items-end gap-1">
         {typeof afterControls === "function" ? afterControls(0) : afterControls}
         {renderSendButton()}
       </div>

--- a/src/renderer/components/thread/ThreadContextIndicator.test.tsx
+++ b/src/renderer/components/thread/ThreadContextIndicator.test.tsx
@@ -20,7 +20,7 @@ const summary: ThreadContextUsageSummary = {
 };
 
 describe("ThreadContextIndicator", () => {
-  it("renders the context ring with the percent number inside and toggles the dock", () => {
+  it("renders the context ring without any number and toggles the dock", () => {
     const onToggle = vi.fn<() => void>();
     const { container } = render(
       <ThreadContextIndicator summary={summary} isOpen={false} onToggle={onToggle} />,
@@ -31,9 +31,10 @@ describe("ThreadContextIndicator", () => {
     fireEvent.click(trigger);
 
     expect(trigger).toHaveAttribute("data-tone", "normal");
-    expect(container.querySelector(".poracode-context-indicator__ring-number")).toHaveTextContent(
-      "36",
-    );
+    expect(
+      container.querySelector(".poracode-context-indicator__ring-progress"),
+    ).toBeInTheDocument();
+    expect(container.querySelector(".poracode-context-indicator svg text")).not.toBeInTheDocument();
     expect(container.querySelector(".poracode-context-indicator__percent")).not.toBeInTheDocument();
     expect(onToggle).toHaveBeenCalledTimes(1);
   });

--- a/src/renderer/components/thread/ThreadContextIndicator.tsx
+++ b/src/renderer/components/thread/ThreadContextIndicator.tsx
@@ -38,32 +38,20 @@ export function ThreadContextIndicator({
               cy="8"
               r={ringRadius}
               fill="none"
-              strokeWidth="1.75"
+              strokeWidth="1.5"
             />
             {percent !== undefined ? (
-              <>
-                <circle
-                  className="poracode-context-indicator__ring-progress"
-                  cx="8"
-                  cy="8"
-                  r={ringRadius}
-                  fill="none"
-                  strokeWidth="1.75"
-                  strokeLinecap="round"
-                  strokeDasharray={`${ringProgress} ${ringCircumference}`}
-                  transform="rotate(-90 8 8)"
-                />
-                <text
-                  className="poracode-context-indicator__ring-number"
-                  x="8"
-                  y="8"
-                  textAnchor="middle"
-                  dominantBaseline="central"
-                  alignmentBaseline="central"
-                >
-                  {percent}
-                </text>
-              </>
+              <circle
+                className="poracode-context-indicator__ring-progress"
+                cx="8"
+                cy="8"
+                r={ringRadius}
+                fill="none"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeDasharray={`${ringProgress} ${ringCircumference}`}
+                transform="rotate(-90 8 8)"
+              />
             ) : null}
           </svg>
           <span className="sr-only">{label}</span>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2387,8 +2387,8 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
 .poracode-context-indicator__ring {
   --lc-context-ring: color-mix(in oklab, var(--foreground) 65%, transparent);
 
-  width: 1.4rem;
-  height: 1.4rem;
+  width: 1rem;
+  height: 1rem;
   flex-shrink: 0;
 }
 
@@ -2403,16 +2403,6 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
     stroke-dasharray 0.2s ease;
 }
 
-.poracode-context-indicator__ring-number {
-  fill: currentColor;
-  font-size: 0.375rem;
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-  text-anchor: middle;
-  dominant-baseline: central;
-  pointer-events: none;
-}
-
 .poracode-context-indicator[data-tone="unknown"] .poracode-context-indicator__ring {
   --lc-context-ring: color-mix(in oklab, var(--muted) 50%, transparent);
 }
@@ -2421,16 +2411,8 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
   --lc-context-ring: oklch(0.86 0.16 86);
 }
 
-.poracode-context-indicator[data-tone="warning"] .poracode-context-indicator__ring-number {
-  color: oklch(0.86 0.16 86);
-}
-
 .poracode-context-indicator[data-tone="danger"] .poracode-context-indicator__ring {
   --lc-context-ring: oklch(0.62 0.22 28);
-}
-
-.poracode-context-indicator[data-tone="danger"] .poracode-context-indicator__ring-number {
-  color: oklch(0.62 0.22 28);
 }
 
 .poracode-context-dock__bar {


### PR DESCRIPTION
- Refactor the thread context indicator into a compact progress-only ring, removing the inline percentage.
- Tighten composer toolbar control spacing to better fit the smaller indicator.
- Update indicator styling and coverage for the streamlined context usage display.