### PR TITLE
Fix floating thread controls across chat and terminal views

### DIFF
--- a/src/renderer/components/layout/sidebarChrome.ts
+++ b/src/renderer/components/layout/sidebarChrome.ts
@@ -49,10 +49,21 @@ export const panelHeaderTooltipTriggerResetClass =
  * Floating chrome that hovers over a thread's conversation — the per-thread tool
  * rail, the changes bubble above the composer, and the scroll-to-bottom button.
  * One class so the three share a surface; the tint tracks `--sidebar-background`
- * (see styles.css) so they read as app chrome in every theme.
+ * (see styles.css) so they read as app chrome in every theme. The
+ * `poracode-floating-chrome` marker lets styles.css push the blur further on
+ * Windows, which has no OS vibrancy behind these pills.
  */
 export const floatingChromeSurfaceClass =
-  "border border-border/15 bg-[var(--floating-chrome-surface)] shadow-lg backdrop-blur-md";
+  "poracode-floating-chrome border border-border/15 bg-[var(--floating-chrome-surface)] shadow-lg backdrop-blur-md";
+
+/**
+ * Pressed/open state for a floating-chrome pill that toggles a panel. A ring
+ * rather than a border or background so it composes with
+ * {@link floatingChromeSurfaceClass} without fighting its own utilities; matches
+ * the accent ring the sidebar `GitBadge` uses for the same "this panel is open"
+ * signal.
+ */
+export const floatingChromeActiveClass = "ring-1 ring-accent/50";
 
 /** Icon button in panel headers (tab toggles, close, expand). */
 export const panelHeaderIconButtonClass =

--- a/src/renderer/components/terminal/XTermSurface.tsx
+++ b/src/renderer/components/terminal/XTermSurface.tsx
@@ -30,6 +30,7 @@ import {
   clearActiveTerminalFind,
   setActiveTerminalFind,
 } from "@/renderer/components/find/terminalFindBridge";
+import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
 
 /** Decoration colors for in-terminal find matches (kept in sync with the CSS
  * highlight colors used elsewhere: amber for matches, orange for the active). */
@@ -1003,7 +1004,10 @@ export const XTermSurface = forwardRef<
           size="sm"
           aria-label={t`Scroll to bottom`}
           onPress={() => terminalRef.current?.scrollToBottom()}
-          className={`absolute bottom-4 right-4 z-10 transition-opacity duration-200 ease-out ${
+          /* Same floating chrome as the chat pane's scroll-to-bottom and the
+             thread tool rail, so the two scroll buttons match across the
+             terminal/chat presentations. */
+          className={`${floatingChromeSurfaceClass} absolute bottom-4 right-4 z-10 size-7 min-w-0 rounded-full transition-opacity duration-200 ease-out ${
             showScrollDown ? "opacity-80 hover:opacity-100" : "pointer-events-none opacity-0"
           }`}
         >

--- a/src/renderer/components/thread/ThreadChangesBubble.tsx
+++ b/src/renderer/components/thread/ThreadChangesBubble.tsx
@@ -1,13 +1,19 @@
 import { useShallow } from "zustand/shallow";
 import { useLingui } from "@lingui/react/macro";
-import { showGitReviewPanel } from "@/renderer/actions/panelActions";
-import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
+import { closeAllPanels, showGitReviewPanel } from "@/renderer/actions/panelActions";
+import {
+  floatingChromeActiveClass,
+  floatingChromeSurfaceClass,
+} from "@/renderer/components/layout/sidebarChrome";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 
 /**
  * Translucent working-tree diff stat that floats over the top-right corner of
  * the composer. Renders nothing when the thread's scope has no changes, and
- * opens the docked Git review panel for that scope on click.
+ * toggles the docked Git review panel for that scope on click — the same
+ * open/close behaviour as the thread tool rail's Git button, so the two entry
+ * points to the panel stay in lockstep.
  */
 export function ThreadChangesBubble(props: {
   projectId: string;
@@ -25,18 +31,35 @@ export function ThreadChangesBubble(props: {
       };
     }),
   );
+  // Active only when the docked Git panel is showing *this* thread's scope.
+  const isOpen = usePanelStore(
+    (s) =>
+      s.rightPanelTab === "git" &&
+      s.gitReviewAsPanel &&
+      s.gitReviewContext?.projectId === props.projectId &&
+      s.gitReviewContext?.worktreePath === props.worktreePath,
+  );
 
   if (insertions === 0 && deletions === 0) return null;
 
   return (
     <button
       type="button"
-      title={t`Review changes`}
-      aria-label={t`Review changes`}
+      title={isOpen ? t`Close changes` : t`Review changes`}
+      aria-label={isOpen ? t`Close changes` : t`Review changes`}
+      aria-pressed={isOpen}
       /* Sized to a 28px pill — same height as the scroll-to-bottom circle and the
          rail's icon buttons, so the floating chrome shares one scale. */
-      className={`${floatingChromeSurfaceClass} absolute bottom-full right-2 z-10 mb-1.5 flex h-7 items-center gap-1.5 rounded-full px-3 text-xs font-medium transition-colors hover:border-border/30`}
-      onClick={() => showGitReviewPanel(props.projectId, props.worktreePath)}
+      className={`${floatingChromeSurfaceClass} absolute bottom-full right-2 z-10 mb-1.5 flex h-7 items-center gap-1.5 rounded-full px-3 text-xs font-medium transition-colors ${
+        isOpen ? floatingChromeActiveClass : "hover:border-border/30"
+      }`}
+      onClick={() => {
+        if (isOpen) {
+          closeAllPanels();
+          return;
+        }
+        showGitReviewPanel(props.projectId, props.worktreePath);
+      }}
     >
       {insertions > 0 && <span className="text-success">+{insertions}</span>}
       {deletions > 0 && <span className="text-danger">-{deletions}</span>}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Projekt hinzufügen schließen"
 msgid "Close browser"
 msgstr "Browser schließen"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Änderungen schließen"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Close add project"
 msgid "Close browser"
 msgstr "Close browser"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Close changes"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Cerrar agregar proyecto"
 msgid "Close browser"
 msgstr "Cerrar navegador"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Cerrar cambios"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Fermer l'ajout de projet"
 msgid "Close browser"
 msgstr "Fermer le navigateur"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Fermer les changements"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2001,6 +2001,10 @@ msgstr "プロジェクトの追加を閉じる"
 msgid "Close browser"
 msgstr "ブラウザを閉じる"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "変更点を閉じる"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2002,6 +2002,10 @@ msgstr "프로젝트 추가 닫기"
 msgid "Close browser"
 msgstr "브라우저 닫기"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "변경 사항 닫기"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Zamknij dodawanie projektu"
 msgid "Close browser"
 msgstr "Zamknij przeglądarkę"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Zamknij zmiany"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Fechar adicionar projeto"
 msgid "Close browser"
 msgstr "Fechar navegador"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Fechar mudanças"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Закрыть добавление проекта"
 msgid "Close browser"
 msgstr "Закрыть браузер"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Закрыть изменения"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Proje eklemeyi kapat"
 msgid "Close browser"
 msgstr "Tarayıcıyı kapat"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Değişiklikleri kapat"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Закрити додавання проєкту"
 msgid "Close browser"
 msgstr "Закрити браузер"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Закрити зміни"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2002,6 +2002,10 @@ msgstr "Đóng thêm dự án"
 msgid "Close browser"
 msgstr "Đóng trình duyệt"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "Đóng thay đổi"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2002,6 +2002,10 @@ msgstr "关闭添加项目"
 msgid "Close browser"
 msgstr "关闭浏览器"
 
+#: src/renderer/components/thread/ThreadChangesBubble.tsx
+msgid "Close changes"
+msgstr "关闭更改"
+
 #: src/mobile/views/QuickCompose.tsx
 #: src/mobile/views/ThreadView.tsx
 msgid "Close composer"

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1450,6 +1450,38 @@ html[data-platform="win32"][data-native-material="on"][data-theme="dark"] {
   --sidebar-glass-tint: color-mix(in oklab, var(--content-background) 85%, transparent);
 }
 
+/* Windows frosting for the *floating chrome* (thread tool rail, changes bubble,
+   chat + terminal scroll-to-bottom). These pills sit over the opaque
+   conversation pane, not over the OS material, so their glass is entirely ours
+   to author — and on Windows, where there is no vibrancy softening them, the
+   shared 82% tint reads as a flat plate stamped on the chat.
+
+   Thinning the tint alone does not fix it: --sidebar-background and
+   --content-background are close in value (dark: #0e0e14 over #070709), so the
+   pill's *fill* composites to nearly the same color either way. What sells the
+   glass is the backdrop — hence a `brightness()` lift alongside the blur, so
+   the sampled conversation reads as lit frosting rather than a faded patch.
+   Dark leans on brightness (it has room to lift); light instead settles the
+   backdrop slightly, where a lift would blow out to white.
+
+   macOS keeps the base token — vibrancy already carries this. Unlayered so both
+   the token and `backdrop-filter` beat Tailwind's utilities, but deliberately
+   *not* `box-shadow`, which carries the pill's `shadow-lg` and its accent
+   `ring-1` open-state indicator. */
+html[data-platform="win32"] {
+  --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 55%, transparent);
+  --floating-chrome-backdrop: blur(20px) saturate(150%) brightness(0.97);
+}
+html[data-platform="win32"].dark,
+html[data-platform="win32"][data-theme="dark"] {
+  --floating-chrome-surface: color-mix(in oklab, var(--sidebar-background) 45%, transparent);
+  --floating-chrome-backdrop: blur(20px) saturate(160%) brightness(1.35);
+}
+html[data-platform="win32"] .poracode-floating-chrome {
+  backdrop-filter: var(--floating-chrome-backdrop);
+  -webkit-backdrop-filter: var(--floating-chrome-backdrop);
+}
+
 /* 2. In-app fallback: opaque window, faux-translucent gradient sidebar. */
 html[data-sidebar-glass="on"]:not([data-native-material="on"]) .poracode-sidebar-aside {
   background: linear-gradient(
@@ -1518,6 +1550,16 @@ html[data-native-material="on"]
     background: transparent;
     backdrop-filter: none;
     box-shadow: none;
+  }
+  /* The Windows floating chrome leans hard on backdrop blur (see the win32 block
+     above), so it needs its own opt-out: paint the pills solid and drop the
+     filter so the diff counts and rail icons keep full contrast. Set on the
+     element rather than the token — the dark-theme token override carries more
+     specificity than a bare html[data-platform] rule would here. */
+  html[data-platform="win32"] .poracode-floating-chrome {
+    background: var(--sidebar-background);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
- Bugfix: align the shared floating chrome treatment for thread controls, changes, and scroll-to-bottom actions.
- Let the changes bubble reflect its open state and close the review panel when toggled again.
- Improve Windows floating-control contrast and honor reduced-transparency preferences.
- Localize the new “Close changes” accessibility label across all supported languages.