### PR TITLE
Remove MCP controls from active thread headers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -414,7 +414,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -95,11 +95,7 @@ describe("ThreadView", () => {
     });
   });
 
-  it("renders Browser MCP as a read-only header icon in active threads", () => {
-    // Mid-thread toggles can't re-attach an MCP server to a running session,
-    // so the active-thread chip is informational only. The toggle lives in
-    // the draft composer.
-
+  it("does not render MCP controls in active-thread headers", () => {
     renderThreadView({
       thread: {
         id: "thread-browser-mcp",
@@ -109,6 +105,7 @@ describe("ThreadView", () => {
         config: {
           model: "gpt-5.4",
           browserMcp: true,
+          computerUse: true,
         },
         status: "idle",
         attention: "none",
@@ -144,11 +141,14 @@ describe("ThreadView", () => {
       },
     });
 
-    const browserIcon = screen.getByLabelText("Browser MCP enabled for this thread");
-    expect(hasAncestorWithClassFragment(browserIcon, "poracode-overlay-header__controls")).toBe(
-      true,
-    );
+    expect(screen.queryByLabelText("Browser MCP enabled for this thread")).toBeNull();
+    expect(
+      screen.queryByLabelText(
+        "Computer Use enabled — interactive actions take over the desktop; don't use the machine while the agent is controlling it",
+      ),
+    ).toBeNull();
     expect(screen.queryByLabelText("Disable Browser MCP")).toBeNull();
+    expect(screen.queryByLabelText("Disable Computer Use")).toBeNull();
     expect(runtimeActions.changeThreadConfig).not.toHaveBeenCalled();
   });
 

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -15,9 +15,6 @@ import { DEFAULT_TERMINAL_SIZE as DEFAULT_HIDDEN_TERMINAL_SIZE } from "@/shared/
 
 import { useAppStore } from "@/renderer/state/appStore";
 import { TuxIcon } from "@/renderer/components/common/TuxIcon";
-import { ComputerUseChip, McpChip } from "@/renderer/components/composer/AttachmentBar";
-import { browserMcpServer } from "@/renderer/components/composer/composerMcpServers";
-import { readBridge } from "@/renderer/bridge";
 import { performInitialThreadLaunch } from "@/renderer/actions/threadLaunchActions";
 import { setRendererRuntimeDiagnosticContext } from "@/renderer/diagnostics/sentry";
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
@@ -69,8 +66,6 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.thread.done === next.thread.done &&
     prev.thread.canResumeWithConfig === next.thread.canResumeWithConfig &&
     prev.thread.sessionRef?.providerSessionId === next.thread.sessionRef?.providerSessionId &&
-    prev.thread.config.browserMcp === next.thread.config.browserMcp &&
-    prev.thread.config.computerUse === next.thread.config.computerUse &&
     (!configAffectsLaunch || prev.thread.config === next.thread.config) &&
     prev.agentStatus === next.agentStatus &&
     prev.projectLocation === next.projectLocation &&
@@ -179,15 +174,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     (thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal") ===
     "terminal";
   const launchTerminalSize = usesTerminalPresentation ? terminalSize : DEFAULT_HIDDEN_TERMINAL_SIZE;
-  // Browser MCP is bound at session-create time for every provider (Claude SDK
-  // `mcpServers` baked into `query()`, Codex `-c` overrides, ACP `newSession`).
-  // Toggling mid-thread can't re-attach the server, so the indicator in the
-  // active-thread header is informational only — disabling it would mislead
-  // the user into thinking the tool is no longer in scope. The toggle lives
-  // exclusively in the draft composer's ComposerAddMenu.
-  const showBrowserChip = thread.config.browserMcp === true;
-  const showComputerUseChip =
-    thread.config.computerUse === true && !isWsl && readBridge().platform !== "linux";
 
   useEffect(() => {
     const presentation =
@@ -308,16 +294,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                   {thread.title}
                 </Tooltip.Content>
               </Tooltip>
-              {showBrowserChip ? (
-                <McpChip
-                  descriptor={browserMcpServer}
-                  variant="header"
-                  {...(thread.agentKind === "opencode"
-                    ? { title: t`Browser MCP enabled for OpenCode` }
-                    : {})}
-                />
-              ) : null}
-              {showComputerUseChip ? <ComputerUseChip variant="header" /> : null}
               <div className="flex shrink-0 items-center">
                 {projectName ? (
                   <span className="px-1 text-sm leading-tight text-muted/60 @max-[560px]:text-xs @max-[360px]:text-[11px]">


### PR DESCRIPTION
- **Bugfix:** remove Browser MCP and Computer Use controls from active thread headers to avoid implying mid-thread configuration changes take effect.
- Keep MCP and Computer Use configuration scoped to the draft composer, where launch-time settings apply.
- Update thread view coverage for headers with either capability enabled.
- Align lockfile dependency resolution.