### PR TITLE
Fix active sidebar tab icon color

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -414,7 +414,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/renderer/components/layout/sidebarChrome.ts
+++ b/src/renderer/components/layout/sidebarChrome.ts
@@ -69,10 +69,10 @@ export const floatingChromeActiveClass = "ring-1 ring-accent/50";
 export const panelHeaderIconButtonClass =
   "inline-flex items-center justify-center rounded p-0.5 text-muted hover:text-foreground";
 
-/** Tab-style icon button: accents when active, muted+hover otherwise. */
+/** Tab-style icon button: foreground when active, muted+hover otherwise. */
 export function panelHeaderTabIconButtonClass(active: boolean) {
   return `inline-flex items-center justify-center rounded p-0.5 transition-colors ${
-    active ? "text-accent" : "text-muted hover:text-foreground"
+    active ? "text-foreground" : "text-muted hover:text-foreground"
   }`;
 }
 


### PR DESCRIPTION
- **Bugfix:** use the foreground color for active sidebar tab icons to improve visual consistency.
- Refresh the lockfile's HeroUI style dependency resolution.