### PR TITLE
Fix root drop zones shrinking split panes

### DIFF
--- a/src/renderer/components/layout/SplitPaneContainer.test.ts
+++ b/src/renderer/components/layout/SplitPaneContainer.test.ts
@@ -174,6 +174,52 @@ describe("SplitPaneContainer", () => {
     HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 
+  it("does not render outer drop zones as resize handles or reserve space for them", () => {
+    const renderPane = (paneId: string) => React.createElement("div", { "data-pane-id": paneId });
+    const { container, rerender } = render(
+      React.createElement(SplitPaneContainer, {
+        layout: {
+          kind: "split",
+          axis: "vertical",
+          children: [
+            { kind: "leaf", paneId: "first" },
+            { kind: "leaf", paneId: "second" },
+          ],
+        },
+        renderPane,
+      }),
+    );
+    expect(
+      container.querySelectorAll('[class*="cursor-row-resize"], [class*="cursor-col-resize"]'),
+    ).toHaveLength(0);
+    expect(container.querySelectorAll('[role="separator"]')).toHaveLength(1);
+    const secondPane =
+      container.querySelector<HTMLElement>("[data-pane-id='second']")?.parentElement;
+    expect(secondPane?.style.top).toBe("0px");
+    expect(secondPane?.style.height).toBe("600px");
+    expect(Number(secondPane?.style.left.replace("px", ""))).toBe(504);
+    expect(
+      Number(secondPane?.style.left.replace("px", "")) +
+        Number(secondPane?.style.width.replace("px", "")),
+    ).toBe(1000);
+
+    rerender(
+      React.createElement(SplitPaneContainer, {
+        layout: { kind: "leaf", paneId: "only" },
+        renderPane,
+      }),
+    );
+
+    expect(
+      container.querySelectorAll('[class*="cursor-row-resize"], [class*="cursor-col-resize"]'),
+    ).toHaveLength(0);
+    const pane = container.querySelector<HTMLElement>("[data-pane-id='only']")?.parentElement;
+    expect(pane?.style.left).toBe("0px");
+    expect(pane?.style.top).toBe("0px");
+    expect(pane?.style.width).toBe("1000px");
+    expect(pane?.style.height).toBe("600px");
+  });
+
   it("updates an existing divider position when panes are added at the same container size", () => {
     const twoPanes: PaneLayout = {
       kind: "split",
@@ -201,12 +247,12 @@ describe("SplitPaneContainer", () => {
       '[role="separator"][aria-orientation="vertical"]',
     );
     expect(divider).not.toBeNull();
-    expect(parseFloat(divider!.style.left)).toBeCloseTo(492);
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(496);
 
     rerender(React.createElement(SplitPaneContainer, { layout: threePanes, renderPane }));
 
     expect(container.querySelector<HTMLElement>('[role="separator"]')).toBe(divider);
-    expect(parseFloat(divider!.style.left)).toBeCloseTo(976 / 3);
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(984 / 3);
   });
 
   it("keeps a pane shell mounted when its caller-provided DOM key stays stable", () => {
@@ -314,13 +360,13 @@ describe("SplitPaneContainer", () => {
       '[role="separator"][aria-orientation="vertical"]',
     );
     expect(divider).not.toBeNull();
-    expect(parseFloat(divider!.style.left)).toBeCloseTo(492);
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(496);
 
     rerender(React.createElement(SplitPaneContainer, { layout: twoPanes, renderPane }));
     writeStoredSizes(splitStorageKey(fourPanes, "vertical"), [35, 65]);
 
     rerender(React.createElement(SplitPaneContainer, { layout: fourPanes, renderPane }));
 
-    expect(parseFloat(divider!.style.left)).toBeCloseTo(344.4);
+    expect(parseFloat(divider!.style.left)).toBeCloseTo(347.2);
   });
 });

--- a/src/renderer/components/layout/SplitPaneContainer.tsx
+++ b/src/renderer/components/layout/SplitPaneContainer.tsx
@@ -15,7 +15,7 @@ import {
 } from "./paneSizeStorage";
 
 const DIVIDER_SIZE = 8;
-const ROOT_INSERT_ZONE_INSET = DIVIDER_SIZE / 2;
+const ROOT_INSERT_ZONE_SIZE = DIVIDER_SIZE / 2;
 // Step (in percent of the split's available space) used when a divider is
 // nudged via arrow keys instead of dragged.
 const KEY_RESIZE_STEP_PERCENT = 2;
@@ -56,8 +56,8 @@ function getContainerRect(size: ContainerSize): Rect {
   return {
     left: 0,
     top: 0,
-    width: Math.max(0, size.width - ROOT_INSERT_ZONE_INSET * 2),
-    height: Math.max(0, size.height - ROOT_INSERT_ZONE_INSET * 2),
+    width: Math.max(0, size.width),
+    height: Math.max(0, size.height),
   };
 }
 
@@ -241,17 +241,17 @@ const RootInsertZone = React.memo(function RootInsertZone(props: {
 
   const edgeClass =
     props.side === "top"
-      ? "top-0 right-0 left-0 cursor-row-resize"
+      ? "top-0 right-0 left-0"
       : props.side === "bottom"
-        ? "right-0 bottom-0 left-0 cursor-row-resize"
+        ? "right-0 bottom-0 left-0"
         : props.side === "left"
-          ? "top-0 bottom-0 left-0 cursor-col-resize"
-          : "top-0 right-0 bottom-0 cursor-col-resize";
+          ? "top-0 bottom-0 left-0"
+          : "top-0 right-0 bottom-0";
 
   const edgeStyle =
     props.side === "top" || props.side === "bottom"
-      ? { height: `${ROOT_INSERT_ZONE_INSET}px` }
-      : { width: `${ROOT_INSERT_ZONE_INSET}px` };
+      ? { height: `${ROOT_INSERT_ZONE_SIZE}px` }
+      : { width: `${ROOT_INSERT_ZONE_SIZE}px` };
 
   const lineClass =
     props.side === "top"
@@ -367,7 +367,6 @@ export function SplitPaneContainer(props: {
     transientSizesRef.current.clear();
   }
 
-  // Account for the inset padding around the layout.
   const containerRect = getContainerRect(containerSizeRef.current);
 
   const computed =
@@ -554,10 +553,7 @@ export function SplitPaneContainer(props: {
       <div
         className="absolute"
         style={{
-          left: ROOT_INSERT_ZONE_INSET,
-          top: ROOT_INSERT_ZONE_INSET,
-          right: ROOT_INSERT_ZONE_INSET,
-          bottom: ROOT_INSERT_ZONE_INSET,
+          inset: 0,
         }}
       >
         {/* Sort by DOM key so React keeps the same DOM slot per pane across


### PR DESCRIPTION
- **Bugfix:** Keep split-pane layouts sized to the full container while preserving root drop zones.
- Prevent root drop zones from appearing as resize handles.
- Update layout coverage for pane sizing, divider placement, and drop-zone behavior.