### PR TITLE
Move thread tools to the header in constrained split panes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -414,7 +414,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/renderer/components/thread/ThreadToolRail.tsx
+++ b/src/renderer/components/thread/ThreadToolRail.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { LucideIcon } from "lucide-react";
 import { FileDiff, FolderOpen, NotebookPen, PanelRightOpen, TerminalSquare } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
@@ -17,10 +18,6 @@ import { usePanelVisibility } from "@/renderer/views/MainView/parts/AppShell/par
 import { floatingChromeSurfaceClass } from "@/renderer/components/layout/sidebarChrome";
 import { useThreadToolRailDrag } from "./useThreadToolRailDrag";
 
-/**
- * Closed handle and open rail share both the surface (with the changes bubble
- * and scroll-to-bottom) and the pill geometry, so opening shifts nothing.
- */
 const railPillClass = "flex flex-col items-center gap-0.5 rounded-full p-1";
 
 /**
@@ -39,6 +36,8 @@ interface RailTool {
   activate: () => void;
 }
 
+type HeaderMenuPhase = "ready" | "suppressed" | "awaiting-reentry";
+
 /**
  * Per-pane launcher for the thread-scoped right-panel tools (git, files,
  * terminal, notes) pointed at *this* thread's project + worktree. Panel-wide
@@ -46,15 +45,12 @@ interface RailTool {
  * header only.
  *
  * Interaction mirrors the mobile PWA:
- * - Hidden entirely while the right panel is docked — the panel already exposes
- *   every tool in its header, and the rail would sit right against it.
+ * - The header launcher is omitted while the side rail is rendered, leaving no
+ *   duplicate icon or empty header space.
  * - Single pane wide enough that the rail lands beside the centered chat column
  *   instead of over it: permanently open and visible.
- * - Anything narrower (or split panes): only a handle, revealed on pane
- *   hover/focus, expanding into the rail on hover/focus of the rail itself. The
- *   hover target is deliberately larger than the handle so approaching the edge
- *   counts as intent to open, but stays short vertically so it does not swallow
- *   text selection or scrollbar drags down the whole right edge.
+ * - Anything narrower (or split panes): a header icon that expands downward
+ *   into the tool menu on hover/focus, keeping the conversation unobstructed.
  */
 export function ThreadToolRail(props: {
   projectId: string;
@@ -84,53 +80,56 @@ export function ThreadToolRail(props: {
       (s.activeWorktreePath ?? undefined) === worktreePath,
   );
   const terminalOnRight = useSharedSettings((s) => s.terminalPosition === "right");
-  const { rightPanelOpen, gitPanelOpen } = usePanelVisibility();
-  // Only the right-edge aside counts: with the terminal docked at the bottom,
-  // `rightPanelOpen` tracks that bottom dock and must not hide the rail.
-  const sidePanelOpen = gitPanelOpen || (terminalOnRight && rightPanelOpen);
+  const { sidePanelOpen } = usePanelVisibility();
 
-  const railRef = useRef<HTMLDivElement>(null);
+  const paneAnchorRef = useRef<HTMLSpanElement>(null);
   const pillRef = useRef<HTMLDivElement>(null);
+  const [paneElement, setPaneElement] = useState<HTMLElement | null>(null);
   const [paneWidth, setPaneWidth] = useState<number | null>(null);
   const [paneHeight, setPaneHeight] = useState<number | null>(null);
   const [railHeight, setRailHeight] = useState<number | null>(null);
+  const [headerMenuPhase, setHeaderMenuPhase] = useState<HeaderMenuPhase>("ready");
+  const alwaysOpen =
+    paneCount === 1 && paneWidth !== null && paneWidth >= ALWAYS_OPEN_MIN_PANE_WIDTH;
+  const sideRailVisible = alwaysOpen && paneElement !== null && !sidePanelOpen;
+
   useLayoutEffect(() => {
-    if (sidePanelOpen) return;
-    // The rail is absolutely positioned inside the thread pane, so its
-    // offsetParent *is* that pane. Its width decides whether an always-open rail
-    // lands beside the centered chat column or on top of it; its height, plus
-    // the pill's own, bounds how far the rail can be dragged.
-    const pane = railRef.current?.offsetParent;
+    if (paneCount !== 1 || sidePanelOpen) return;
+    // The pane width decides whether the rail clears the centered chat column;
+    // its height and the pill height bound rail dragging.
+    const pane = paneAnchorRef.current?.closest("[data-poracode-thread-pane]");
     if (!(pane instanceof HTMLElement)) return;
-    // `invisible` keeps layout, so the closed rail still reports its real height.
+    setPaneElement(pane);
     const pill = pillRef.current;
 
     const skipIfClose = (prev: number | null, next: number) =>
       prev !== null && Math.abs(prev - next) < 0.5 ? prev : next;
+
+    const paneRect = pane.getBoundingClientRect();
+    setPaneWidth((prev) => skipIfClose(prev, paneRect.width));
+    if (alwaysOpen) {
+      setPaneHeight((prev) => skipIfClose(prev, paneRect.height));
+    }
 
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         if (entry.target === pane) {
           const rect = entry.contentRect;
           setPaneWidth((prev) => skipIfClose(prev, rect.width));
-          setPaneHeight((prev) => skipIfClose(prev, rect.height));
+          if (alwaysOpen) {
+            setPaneHeight((prev) => skipIfClose(prev, rect.height));
+          }
         } else if (entry.target === pill) {
           setRailHeight((prev) => skipIfClose(prev, entry.contentRect.height));
         }
       }
     });
     observer.observe(pane);
-    if (pill) observer.observe(pill);
+    if (alwaysOpen && pill) observer.observe(pill);
     return () => observer.disconnect();
-  }, [sidePanelOpen]);
+  }, [alwaysOpen, paneCount, sidePanelOpen]);
 
-  const { offset, isDragging, dragHandlers } = useThreadToolRailDrag({ paneHeight, railHeight });
-
-  const alwaysOpen =
-    paneCount === 1 && paneWidth !== null && paneWidth >= ALWAYS_OPEN_MIN_PANE_WIDTH;
-  // A drag can travel outside the hover box, which would otherwise drop the
-  // CSS-driven open state mid-gesture.
-  const forceOpen = alwaysOpen || isDragging;
+  const { offset, dragHandlers } = useThreadToolRailDrag({ paneHeight, railHeight });
 
   // Home-scope "projects" have no repository or file root, matching the tabs
   // the right panel itself hides for that scope.
@@ -187,90 +186,105 @@ export function ThreadToolRail(props: {
 
   const primaryTool = tools[0];
   if (!primaryTool) return null;
-  // The docked panel already exposes every tool in its header. Re-measuring is
-  // handled by the layout effect above, which re-attaches once this clears.
-  if (sidePanelOpen) return null;
 
-  // Top-anchored with a draggable offset rather than vertically centered, so the
-  // rail sits over the conversation body wherever the user parked it.
-  return (
-    <div
-      ref={railRef}
-      className="pointer-events-none absolute inset-y-0 right-0 z-20 flex items-start"
-    >
-      {/* When the rail has to overlap the chat column, padding — not size —
-          makes the open/intent area larger than the handle, while staying short
-          enough that it does not swallow scrollbar drags down the right edge.
-          Positioned with a transform, not layout: the pill carries a
-          `backdrop-blur` layer, and re-laying it out every drag frame makes the
-          compositor flash a stale copy of that backdrop. */}
-      <div
-        className={`group/rail pointer-events-auto flex items-start py-3 pr-1.5 ${
-          alwaysOpen ? "pl-1.5" : "pl-10"
+  const suppressHeaderMenu = () => {
+    setHeaderMenuPhase("suppressed");
+  };
+
+  const toolButtons = tools.map((tool) => {
+    const Icon = tool.icon;
+    return (
+      <button
+        key={tool.id}
+        type="button"
+        title={tool.label}
+        aria-label={tool.label}
+        aria-pressed={tool.active}
+        className={`flex size-7 items-center justify-center rounded-full transition-colors ${
+          tool.active
+            ? "bg-accent/15 text-accent"
+            : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
         }`}
-        style={{ transform: `translateY(${offset}px)` }}
+        onClick={() => {
+          suppressHeaderMenu();
+          tool.activate();
+        }}
       >
-        <div className="relative flex items-start">
-          {/* Same pill geometry as the open rail, so opening shifts nothing.
-              Fades in with the pane, then out as the rail opens over it — the
-              open surface is translucent, so leaving it underneath would show
-              its glyph through. */}
-          {forceOpen ? null : (
-            <div className="opacity-0 transition-opacity duration-150 group-hover/pane:opacity-80">
-              <div className="transition-opacity duration-150 group-hover/rail:opacity-0 group-focus-within/rail:opacity-0">
-                <div className={`${floatingChromeSurfaceClass} ${railPillClass}`}>
-                  <button
-                    type="button"
-                    title={t`Show thread tools`}
-                    aria-label={t`Show thread tools`}
-                    className="flex size-7 items-center justify-center rounded-full text-muted transition-colors hover:text-foreground"
-                    onClick={primaryTool.activate}
-                  >
-                    <PanelRightOpen className="size-3.5" />
-                  </button>
+        <Icon className="size-3.5" />
+      </button>
+    );
+  });
+
+  return (
+    <>
+      {sideRailVisible && paneElement
+        ? createPortal(
+            <div className="poracode-overlay-header__controls pointer-events-none absolute inset-y-0 right-0 z-20 flex items-start">
+              {/* Positioned with a transform, not layout: the pill carries a
+                `backdrop-blur` layer, and re-laying it out every drag frame
+                makes the compositor flash a stale copy of that backdrop. */}
+              <div
+                className="pointer-events-auto flex items-start py-3 pl-1.5 pr-1.5"
+                style={{ transform: `translateY(${offset}px)` }}
+              >
+                <div
+                  ref={pillRef}
+                  data-poracode-thread-tool-rail=""
+                  data-placement="side"
+                  className={`${floatingChromeSurfaceClass} ${railPillClass} cursor-grab touch-none select-none active:cursor-grabbing`}
+                  {...dragHandlers}
+                >
+                  {toolButtons}
                 </div>
               </div>
-            </div>
-          )}
-          {/* `invisible` (not just opacity) keeps the closed rail out of the tab
-              order; focus-within on the handle reveals it before Tab moves in.
-              It grows downward from the handle instead of expanding around it,
-              which would push the rail up over the pane header. */}
-          <div
-            ref={pillRef}
-            data-poracode-thread-tool-rail=""
-            className={`${floatingChromeSurfaceClass} ${railPillClass} cursor-grab touch-none select-none transition-opacity duration-150 active:cursor-grabbing ${
-              alwaysOpen ? "" : "absolute right-0 top-0"
-            } ${
-              forceOpen
-                ? ""
-                : "invisible opacity-0 group-hover/rail:visible group-hover/rail:opacity-100 group-focus-within/rail:visible group-focus-within/rail:opacity-100"
-            }`}
-            {...dragHandlers}
+            </div>,
+            paneElement,
+          )
+        : null}
+      {sideRailVisible ? null : (
+        <div
+          data-poracode-thread-tool-rail=""
+          data-placement="header"
+          className="poracode-overlay-header__controls group/thread-tools relative shrink-0"
+          onPointerLeave={() => {
+            setHeaderMenuPhase((phase) => (phase === "suppressed" ? "awaiting-reentry" : phase));
+          }}
+          onPointerEnter={() => {
+            setHeaderMenuPhase((phase) => (phase === "awaiting-reentry" ? "ready" : phase));
+          }}
+          onFocusCapture={() => setHeaderMenuPhase("ready")}
+        >
+          <button
+            type="button"
+            title={t`Show thread tools`}
+            aria-label={t`Show thread tools`}
+            className="flex size-6 items-center justify-center rounded text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground"
+            onClick={() => {
+              suppressHeaderMenu();
+              primaryTool.activate();
+            }}
           >
-            {tools.map((tool) => {
-              const Icon = tool.icon;
-              return (
-                <button
-                  key={tool.id}
-                  type="button"
-                  title={tool.label}
-                  aria-label={tool.label}
-                  aria-pressed={tool.active}
-                  className={`flex size-7 items-center justify-center rounded-full transition-colors ${
-                    tool.active
-                      ? "bg-accent/15 text-accent"
-                      : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground"
-                  }`}
-                  onClick={tool.activate}
-                >
-                  <Icon className="size-3.5" />
-                </button>
-              );
-            })}
+            <PanelRightOpen className="size-3.5" />
+          </button>
+          <div
+            data-poracode-thread-tool-menu=""
+            className={`pointer-events-none invisible absolute left-1/2 top-full z-30 grid w-9 -translate-x-1/2 grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-150 ${
+              headerMenuPhase !== "ready"
+                ? ""
+                : "group-hover/thread-tools:pointer-events-auto group-hover/thread-tools:visible group-hover/thread-tools:grid-rows-[1fr] group-hover/thread-tools:opacity-100 group-focus-within/thread-tools:pointer-events-auto group-focus-within/thread-tools:visible group-focus-within/thread-tools:grid-rows-[1fr] group-focus-within/thread-tools:opacity-100"
+            }`}
+          >
+            <div className="min-h-0 overflow-hidden pt-1">
+              <div className={`${floatingChromeSurfaceClass} ${railPillClass}`}>{toolButtons}</div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      )}
+      <span
+        ref={paneAnchorRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute left-0 top-0 size-0"
+      />
+    </>
   );
 }

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1628,6 +1628,59 @@ describe("ThreadView", () => {
     expect(hasAncestorWithClassFragment(terminalPane.parentElement, "max-w-[1040px]")).toBe(true);
   });
 
+  it("moves thread tools into the header when the pane cannot clear a side rail", () => {
+    renderThreadView({
+      thread: {
+        id: "thread-split-tool-menu",
+        projectId: "project-1",
+        title: "Split pane thread",
+        agentKind: "codex",
+        config: {
+          model: "gpt-5.4",
+        },
+        status: "idle",
+        attention: "none",
+        canResumeWithConfig: true,
+        archived: false,
+        done: false,
+        starred: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      agentStatus: undefined,
+      projectLocation: {
+        kind: "windows",
+        path: "C:\\repo",
+      },
+      paneCount: 2,
+      onMarkDone: () => undefined,
+    });
+
+    const headerTrigger = screen.getByRole("button", { name: "Show thread tools" });
+    const headerMenu = headerTrigger.closest("[data-poracode-thread-tool-rail]");
+    const toolMenu = headerMenu?.querySelector("[data-poracode-thread-tool-menu]");
+    const doneButton = screen.getByRole("button", { name: "Mark done" });
+
+    expect(headerMenu).toHaveAttribute("data-placement", "header");
+    expect(headerMenu).not.toHaveClass("invisible");
+    expect(toolMenu).toHaveClass("left-1/2", "w-9", "-translate-x-1/2");
+    expect(toolMenu).toHaveClass("group-hover/thread-tools:visible");
+    expect(doneButton.nextElementSibling).toBe(headerMenu);
+    expect(hasAncestorWithClassFragment(headerMenu as HTMLElement, "@container")).toBe(true);
+    expect(headerMenu?.querySelector('[aria-label="Git"]')).not.toBeNull();
+    expect(headerMenu?.querySelector('[aria-label="Files"]')).not.toBeNull();
+    expect(headerMenu?.querySelector('[aria-label="Terminal"]')).not.toBeNull();
+    expect(headerMenu?.querySelector('[aria-label="Notes"]')).not.toBeNull();
+
+    fireEvent.click(headerTrigger);
+    expect(toolMenu).not.toHaveClass("group-hover/thread-tools:visible");
+    fireEvent.pointerLeave(headerMenu as HTMLElement);
+    expect(toolMenu).not.toHaveClass("group-hover/thread-tools:visible");
+    fireEvent.pointerEnter(headerMenu as HTMLElement);
+    expect(toolMenu).toHaveClass("group-hover/thread-tools:visible");
+    fireEvent.click(headerTrigger);
+  });
+
   it("allows queued follow-ups and stop while a GUI ACP thread is running", async () => {
     renderThreadView({
       thread: {

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -264,6 +264,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     <>
       <div
         ref={droppableRef}
+        data-poracode-thread-pane=""
         className={`group/pane relative flex h-full min-h-0 flex-col ${isDragging ? "opacity-50" : ""}`}
       >
         {/* Header bar — provider icon outside pane drag handle; status tooltip uses HeroUI tooltip (anchored bottom start). */}
@@ -390,6 +391,11 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                     <CircleCheck className="size-3.5" />
                   </button>
                 ) : null}
+                <ThreadToolRail
+                  projectId={thread.projectId}
+                  paneCount={paneCount}
+                  {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+                />
                 {showCloseButton ? (
                   <button
                     type="button"
@@ -464,12 +470,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
             )}
           </div>
         </div>
-
-        <ThreadToolRail
-          projectId={thread.projectId}
-          paneCount={paneCount}
-          {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
-        />
       </div>
       {onContinueInProvider && installedAgents && continueDialogOpen ? (
         <ContinueInProviderDialog

--- a/src/renderer/components/thread/useThreadToolRailDrag.ts
+++ b/src/renderer/components/thread/useThreadToolRailDrag.ts
@@ -17,7 +17,6 @@ interface RailDragState {
 interface ThreadToolRailDrag {
   /** Clamped vertical offset to render at, live while dragging. */
   offset: number;
-  isDragging: boolean;
   /** Spread onto the rail pill — it is both the grab handle and the tool container. */
   dragHandlers: {
     onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
@@ -109,7 +108,6 @@ export function useThreadToolRailDrag(params: {
 
   return {
     offset,
-    isDragging: dragOffset !== null,
     dragHandlers: {
       onPointerDown,
       onPointerMove,

--- a/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
@@ -441,7 +441,7 @@ export function AppShell(props: {
   }, []);
   const layoutMetricsReady = shellWidth > 0;
 
-  const { rightPanelOpen, gitPanelOpen } = usePanelVisibility();
+  const { rightPanelOpen, gitPanelOpen, sidePanelOpen } = usePanelVisibility();
   const isBottom = terminalPosition === "bottom";
   const hasHeaders = sidebarHeader != null || contentHeader != null;
   const hasContentHeader = contentHeader != null;
@@ -450,7 +450,7 @@ export function AppShell(props: {
   // CONTENT_MIN_WIDTH, render them as a fixed overlay anchored to the right
   // edge (mirroring the sidebar's narrow overlay).
   const dockedRightPanelOpen = !isBottom && rightPanelOpen;
-  const wantsRightOverlay = dockedRightPanelOpen || gitPanelOpen;
+  const wantsRightOverlay = sidePanelOpen;
   // Compute the docked main width even when panels are currently overlaid, so
   // the transition between modes is driven by a stable signal.
   const wouldBeMainWidth = layoutMetricsReady

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -51,6 +51,7 @@ export function usePanelVisibility() {
       browserPanelOpen ||
       usagePanelOpen ||
       notesPanelOpen);
+  const sidePanelOpen = isTerminalRight ? rightPanelOpen : sideGitPanelOpen;
 
-  return { rightPanelOpen, gitPanelOpen: sideGitPanelOpen };
+  return { rightPanelOpen, gitPanelOpen: sideGitPanelOpen, sidePanelOpen };
 }


### PR DESCRIPTION
- **Bugfix:** keep thread-scoped Git, Files, Terminal, and Notes tools accessible when split-pane width cannot accommodate the side rail.
- Preserve tool access and hover behavior in a header-mounted menu without shifting the thread layout.
- Treat all active side panels consistently when deciding whether to overlay constrained content.
- Add split-pane coverage and align lockfile dependency resolution.