### PR TITLE
Add explicit MCP automation session controls

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -414,7 +414,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/main/browser/BrowserMcpIngress.test.ts
+++ b/src/main/browser/BrowserMcpIngress.test.ts
@@ -37,6 +37,8 @@ describe("BrowserMcpIngress", () => {
 
     expect(body.result.serverInfo.name).toBe("browser");
     expect(body.result.instructions).toContain("Use the browser MCP server");
+    expect(body.result.instructions).toContain("browser.enable");
+    expect(body.result.instructions).toContain("browser.disable");
     expect(body.result.instructions).toContain("browser.api");
     expect(body.result.instructions).toContain("@e refs");
   });
@@ -88,6 +90,7 @@ describe("BrowserMcpIngress", () => {
           getTab: () => tab,
           ensureTabReady: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
           createTab: vi.fn<() => Promise<unknown>>().mockResolvedValue({ tabId: "tab-1" }),
+          setAutomationSession: vi.fn<() => boolean>().mockReturnValue(true),
           reload: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
         }) as unknown as BrowserPanelManager,
     );

--- a/src/main/browser/BrowserPanelManager.test.ts
+++ b/src/main/browser/BrowserPanelManager.test.ts
@@ -137,6 +137,26 @@ describe("BrowserPanelManager", () => {
     expect(tab.attach).toHaveBeenCalledWith(guestWebContents);
   });
 
+  it("keeps automation active until every explicit session ends", async () => {
+    const { BrowserPanelManager } = await import("./BrowserPanelManager");
+    const manager = new BrowserPanelManager(
+      { settingsPath: "settings.json" } as never,
+      "Mozilla/5.0 Chrome/141.0.0.0 Safari/537.36",
+    );
+    const activity: boolean[] = [];
+    manager.addEventListener((event) => {
+      if (event.type === "automation-active") activity.push(event.active);
+    });
+
+    expect(manager.setAutomationSession("thread-1", true)).toBe(false);
+    expect(manager.setAutomationSession("thread-2", true)).toBe(false);
+    expect(manager.setAutomationSession("thread-1", false)).toBe(false);
+    expect(activity).toEqual([true]);
+
+    expect(manager.setAutomationSession("thread-2", false)).toBe(true);
+    expect(activity).toEqual([true, false]);
+  });
+
   it("moves ungrouped tabs into the target tab's group", async () => {
     const { BrowserPanelManager } = await import("./BrowserPanelManager");
     const manager = new BrowserPanelManager(

--- a/src/main/browser/BrowserPanelManager.ts
+++ b/src/main/browser/BrowserPanelManager.ts
@@ -74,6 +74,7 @@ export class BrowserPanelManager {
   private readonly bookmarks = new BrowserBookmarkStore();
   private restored = false;
   private automationActive = false;
+  private readonly automationSessions = new Set<string>();
   private automationTimer: ReturnType<typeof setTimeout> | null = null;
   private pickerKeyCleanup: (() => void) | null = null;
   private readonly loginCoordinator = new BrowserLoginCaptureCoordinator({
@@ -177,6 +178,8 @@ export class BrowserPanelManager {
       clearTimeout(this.automationTimer);
       this.automationTimer = null;
     }
+    this.automationSessions.clear();
+    this.automationActive = false;
     this.clearPickerShortcut();
     this.loginCoordinator.cancelLoginConfirmations();
     for (const t of this.tabs) {
@@ -271,11 +274,34 @@ export class BrowserPanelManager {
       this.emit({ type: "automation-active", active: true });
     }
     if (this.automationTimer) clearTimeout(this.automationTimer);
+    if (this.automationSessions.size > 0) {
+      this.automationTimer = null;
+      return;
+    }
     this.automationTimer = setTimeout(() => {
       this.automationTimer = null;
       this.automationActive = false;
       this.emit({ type: "automation-active", active: false });
     }, AUTOMATION_GRACE_MS);
+  }
+
+  setAutomationSession(sessionId: string, active: boolean): boolean {
+    if (active) {
+      this.automationSessions.add(sessionId);
+      this.markAutomationActivity();
+      return false;
+    }
+
+    this.automationSessions.delete(sessionId);
+    if (this.automationSessions.size > 0) return false;
+    if (!this.automationActive) return true;
+    if (this.automationTimer) {
+      clearTimeout(this.automationTimer);
+      this.automationTimer = null;
+    }
+    this.automationActive = false;
+    this.emit({ type: "automation-active", active: false });
+    return true;
   }
 
   /**

--- a/src/main/browser/cursorOverlay.test.ts
+++ b/src/main/browser/cursorOverlay.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CdpSession } from "./cdp/cdpClient";
-import { withCursorOverlayHidden } from "./cursorOverlay";
+import { setCursorOverlayVisible, withCursorOverlayHidden } from "./cursorOverlay";
 
 type RuntimeEvaluateResponse = { result: { type: string; value: boolean } };
 type Send = (method: string, params?: Record<string, unknown>) => Promise<RuntimeEvaluateResponse>;
@@ -104,5 +104,20 @@ describe("withCursorOverlayHidden", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await expect(result).resolves.toBe("image");
+  });
+});
+
+describe("setCursorOverlayVisible", () => {
+  it("adds and removes the persistent session visibility style", async () => {
+    const expressions: string[] = [];
+    const cdp = createCdp([], expressions);
+
+    await setCursorOverlayVisible(cdp, false);
+    await setCursorOverlayVisible(cdp, true);
+
+    expect(expressions[0]).toContain("__poracode_session_overlay_hide__");
+    expect(expressions[0]).toContain("visibility:hidden");
+    expect(expressions[1]).toContain("__poracode_session_overlay_hide__");
+    expect(expressions[1]).toContain("?.remove()");
   });
 });

--- a/src/main/browser/cursorOverlay.ts
+++ b/src/main/browser/cursorOverlay.ts
@@ -50,6 +50,9 @@ function __pcRipple(x,y){
 }`;
 
 const SCREENSHOT_OVERLAY_STYLE_ID = "__poracode_screenshot_overlay_hide__";
+const SESSION_OVERLAY_STYLE_ID = "__poracode_session_overlay_hide__";
+const CURSOR_OVERLAY_HIDDEN_CSS =
+  "#__poracode_cursor__,[data-poracode-cursor-ripple]{visibility:hidden!important}";
 const SCREENSHOT_OVERLAY_EVAL_CAP_MS = 250;
 
 const HIDE_OVERLAY_FOR_SCREENSHOT = `(async () => {
@@ -58,7 +61,7 @@ const HIDE_OVERLAY_FOR_SCREENSHOT = `(async () => {
   if(!style){
     style=document.createElement("style");
     style.id=ID;
-    style.textContent="#__poracode_cursor__,[data-poracode-cursor-ripple]{visibility:hidden!important}";
+    style.textContent=${JSON.stringify(CURSOR_OVERLAY_HIDDEN_CSS)};
     (document.head||document.documentElement).appendChild(style);
   }
   const depth=Number(style.dataset.depth||"0");
@@ -110,6 +113,25 @@ async function settleBounded<T>(promise: Promise<T>): Promise<BoundedResult<T>> 
 
 function restoreCursorOverlay(cdp: CdpSession): Promise<unknown> {
   return evalJs(cdp, RESTORE_OVERLAY_AFTER_SCREENSHOT);
+}
+
+/** Show or hide the page-level agent presence visuals for an explicit MCP
+ * session. Best-effort so presence bookkeeping never blocks browser work. */
+export async function setCursorOverlayVisible(cdp: CdpSession, visible: boolean): Promise<void> {
+  const expression = visible
+    ? `(() => { document.getElementById(${JSON.stringify(SESSION_OVERLAY_STYLE_ID)})?.remove(); return true; })()`
+    : `(() => {
+        const ID=${JSON.stringify(SESSION_OVERLAY_STYLE_ID)};
+        let style=document.getElementById(ID);
+        if(!style){
+          style=document.createElement("style");
+          style.id=ID;
+          style.textContent=${JSON.stringify(CURSOR_OVERLAY_HIDDEN_CSS)};
+          (document.head||document.documentElement).appendChild(style);
+        }
+        return true;
+      })()`;
+  await settleBounded(evalJs(cdp, expression));
 }
 
 /** Hide the agent-presence cursor and click ripples for the duration of a page

--- a/src/main/browser/external/ChromeMcpIngress.test.ts
+++ b/src/main/browser/external/ChromeMcpIngress.test.ts
@@ -40,16 +40,16 @@ describe("ChromeMcpIngress", () => {
     };
     expect(initializeBody.result.serverInfo.name).toBe("chrome");
     expect(initializeBody.result.instructions).toContain("USER'S OWN Chrome");
-    expect(initializeBody.result.instructions).toContain("chrome_enable");
-    expect(initializeBody.result.instructions).toContain("chrome_disable");
+    expect(initializeBody.result.instructions).toContain("chrome.enable");
+    expect(initializeBody.result.instructions).toContain("chrome.disable");
 
     const list = await postMcp(info, { jsonrpc: "2.0", id: 2, method: "tools/list" });
     const listBody = (await list.json()) as {
       result: { tools: Array<{ name: string }> };
     };
     expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_status");
-    expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_enable");
-    expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_disable");
+    expect(listBody.result.tools.map((tool) => tool.name)).toContain("enable");
+    expect(listBody.result.tools.map((tool) => tool.name)).toContain("disable");
   });
 
   it("routes Chrome tool calls and formats their result", async () => {

--- a/src/main/browser/external/ChromeMcpIngress.test.ts
+++ b/src/main/browser/external/ChromeMcpIngress.test.ts
@@ -40,12 +40,16 @@ describe("ChromeMcpIngress", () => {
     };
     expect(initializeBody.result.serverInfo.name).toBe("chrome");
     expect(initializeBody.result.instructions).toContain("USER'S OWN Chrome");
+    expect(initializeBody.result.instructions).toContain("chrome_enable");
+    expect(initializeBody.result.instructions).toContain("chrome_disable");
 
     const list = await postMcp(info, { jsonrpc: "2.0", id: 2, method: "tools/list" });
     const listBody = (await list.json()) as {
       result: { tools: Array<{ name: string }> };
     };
     expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_status");
+    expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_enable");
+    expect(listBody.result.tools.map((tool) => tool.name)).toContain("chrome_disable");
   });
 
   it("routes Chrome tool calls and formats their result", async () => {

--- a/src/main/browser/external/ChromeMcpIngress.ts
+++ b/src/main/browser/external/ChromeMcpIngress.ts
@@ -23,6 +23,7 @@ export type ChromeMcpIngressInfo = StreamableHttpMcpIngressInfo;
 export class ChromeMcpIngress {
   private allowEval = false;
   private allowDataAccess = false;
+  private readonly activeSessions = new Set<string>();
   private getConnection: (() => ExternalChromeConnection | null) | null = null;
   private readonly ingress = new StreamableHttpMcpIngress<ChromeToolContext>({
     // Chrome MCP is intentionally unavailable to WSL agents, so exposing this
@@ -58,14 +59,21 @@ export class ChromeMcpIngress {
   }
 
   dispose(): void {
+    this.activeSessions.clear();
     this.ingress.dispose();
   }
 
   private buildContext(identity: McpThreadIdentity): ChromeToolContext {
+    const sessionId = identity.threadId ?? "unscoped";
     return {
       connection: this.getConnection?.() ?? null,
       allowEval: this.allowEval,
       allowDataAccess: this.allowDataAccess,
+      setSessionActive: (active) => {
+        if (active) this.activeSessions.add(sessionId);
+        else this.activeSessions.delete(sessionId);
+        return this.activeSessions.size === 0;
+      },
       ...(identity.threadId ? { threadId: identity.threadId } : {}),
       ...(identity.title ? { threadTitle: identity.title } : {}),
     };

--- a/src/main/browser/external/ExternalChromeConnection.test.ts
+++ b/src/main/browser/external/ExternalChromeConnection.test.ts
@@ -113,6 +113,21 @@ describe("ExternalChromeConnection", () => {
     expect(conn.isAttached()).toBe(false);
   });
 
+  it("detaches the current tab when an MCP session ends", async () => {
+    const { conn, ws } = makeConn();
+    const attach = conn.attach(5);
+    ws.inbound({ id: ws.last().id, type: "result", ok: true, tab: { tabId: 5, url: "https://b" } });
+    await attach;
+
+    const detach = conn.detach();
+    const req = ws.last();
+    expect(req).toMatchObject({ type: "detach", tabId: 5 });
+    ws.inbound({ id: req.id, type: "result", ok: true });
+    await detach;
+
+    expect(conn.isAttached()).toBe(false);
+  });
+
   it("ignores events from a stale attached tab", async () => {
     const { conn, ws } = makeConn();
     const seen: unknown[] = [];

--- a/src/main/browser/external/ExternalChromeConnection.ts
+++ b/src/main/browser/external/ExternalChromeConnection.ts
@@ -57,7 +57,7 @@ type RequestPayload =
       groupTitle?: string;
       groupColor?: string;
     }
-  | { type: "detach" }
+  | { type: "detach"; tabId: number }
   | { type: "cdp"; tabId: number; method: string; params?: Record<string, unknown> };
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
@@ -148,6 +148,16 @@ export class ExternalChromeConnection {
     if (this.attachedTabId !== null) return this.attachedTabId;
     const tab = await this.openTab();
     return tab.tabId;
+  }
+
+  async detach(): Promise<void> {
+    if (this.attachedTabId === null) return;
+    const tabId = this.attachedTabId;
+    await this.request({ type: "detach", tabId });
+    if (this.attachedTabId !== tabId) return;
+    this.attachedTabId = null;
+    this.attachedUrl = undefined;
+    this.attachedTitle = undefined;
   }
 
   /** Run a CDP command against the attached tab. Opens a workspace on first use. */

--- a/src/main/browser/external/chromeTools.test.ts
+++ b/src/main/browser/external/chromeTools.test.ts
@@ -4,6 +4,69 @@ import type { ExternalChromeConnection } from "./ExternalChromeConnection";
 import { dispatchChromeTool } from "./chromeTools";
 
 describe("dispatchChromeTool", () => {
+  it("attaches for an enabled session and detaches when it is disabled", async () => {
+    const cdp = {
+      send: vi.fn<() => Promise<unknown>>().mockResolvedValue({
+        result: { type: "boolean", value: true },
+      }),
+    } as unknown as CdpSession;
+    const connection = {
+      cdpSession: () => cdp,
+      ensureWorkspace: vi.fn<() => Promise<number>>().mockResolvedValue(7),
+      isAttached: () => true,
+      detach: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      status: () => ({ connected: true, extensionVersion: "1", attachedTabId: 7 }),
+    } as unknown as ExternalChromeConnection;
+    const setSessionActive = vi.fn<(active: boolean) => boolean>().mockReturnValue(true);
+    const ctx = {
+      connection,
+      allowEval: false,
+      allowDataAccess: false,
+      setSessionActive,
+    };
+
+    await expect(dispatchChromeTool("chrome_enable", {}, ctx)).resolves.toMatchObject({
+      enabled: true,
+    });
+    await expect(dispatchChromeTool("chrome_disable", {}, ctx)).resolves.toEqual({
+      enabled: false,
+    });
+
+    expect(connection.ensureWorkspace).toHaveBeenCalledOnce();
+    expect(setSessionActive).toHaveBeenNthCalledWith(1, true);
+    expect(setSessionActive).toHaveBeenNthCalledWith(2, false);
+    expect(connection.detach).toHaveBeenCalledOnce();
+  });
+
+  it("does not hide or detach while another Chrome session remains active", async () => {
+    const cdp = {
+      send: vi.fn<() => Promise<unknown>>().mockResolvedValue({
+        result: { type: "boolean", value: true },
+      }),
+    } as unknown as CdpSession;
+    const connection = {
+      cdpSession: () => cdp,
+      isAttached: () => true,
+      detach: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    } as unknown as ExternalChromeConnection;
+
+    await expect(
+      dispatchChromeTool(
+        "chrome_disable",
+        {},
+        {
+          connection,
+          allowEval: false,
+          allowDataAccess: false,
+          setSessionActive: () => false,
+        },
+      ),
+    ).resolves.toEqual({ enabled: false });
+
+    expect(cdp.send).not.toHaveBeenCalled();
+    expect(connection.detach).not.toHaveBeenCalled();
+  });
+
   it("hides and restores the presence cursor around external Chrome screenshots", async () => {
     const events: string[] = [];
     const cdp = {

--- a/src/main/browser/external/chromeTools.test.ts
+++ b/src/main/browser/external/chromeTools.test.ts
@@ -25,10 +25,10 @@ describe("dispatchChromeTool", () => {
       setSessionActive,
     };
 
-    await expect(dispatchChromeTool("chrome_enable", {}, ctx)).resolves.toMatchObject({
+    await expect(dispatchChromeTool("enable", {}, ctx)).resolves.toMatchObject({
       enabled: true,
     });
-    await expect(dispatchChromeTool("chrome_disable", {}, ctx)).resolves.toEqual({
+    await expect(dispatchChromeTool("disable", {}, ctx)).resolves.toEqual({
       enabled: false,
     });
 
@@ -52,7 +52,7 @@ describe("dispatchChromeTool", () => {
 
     await expect(
       dispatchChromeTool(
-        "chrome_disable",
+        "disable",
         {},
         {
           connection,

--- a/src/main/browser/external/chromeTools.ts
+++ b/src/main/browser/external/chromeTools.ts
@@ -13,7 +13,11 @@ import {
   waitForSelector,
   waitForText,
 } from "../cdp/tools";
-import { glideCursorToSelector, withCursorOverlayHidden } from "../cursorOverlay";
+import {
+  glideCursorToSelector,
+  setCursorOverlayVisible,
+  withCursorOverlayHidden,
+} from "../cursorOverlay";
 import { clampInteger } from "../mcp/tools/helpers";
 import type { McpContent, McpToolResult, ToolSpec } from "../mcp/tools/types";
 import { clickSelector, fillSelector, resolveRefToSelector, typeIntoSelector } from "../pageDriver";
@@ -35,6 +39,7 @@ export interface ChromeToolContext {
    *  per-thread tab group named after the task. */
   threadId?: string;
   threadTitle?: string;
+  setSessionActive?: (active: boolean) => boolean;
 }
 
 export const CHROME_MCP_INSTRUCTIONS = [
@@ -45,7 +50,9 @@ export const CHROME_MCP_INSTRUCTIONS = [
   "there; tabs are never auto-closed. Pass newTab:true only when you truly need a second tab. Use chrome_attach",
   "(with a tabId from chrome_list_tabs) only when the user asks you to act on a specific tab they already have open.",
   "Prefer chrome_snapshot / chrome_find to discover elements (they return @e refs) before chrome_click / chrome_fill.",
-  "Use chrome_status first to confirm the extension is connected and which tab is attached.",
+  "Use chrome_status first to confirm the extension is connected, then call chrome_enable once before the first browser action.",
+  "Keep Chrome enabled across the whole uninterrupted session so agent presence stays consistent between calls.",
+  "Always call chrome_disable before pausing to ask for user input, waiting for an external event, or finishing, and call chrome_enable again when you resume.",
   "Destructive or account-affecting actions (purchases, deletions, messages) should be confirmed with the user first.",
 ].join(" ");
 
@@ -111,6 +118,15 @@ export async function dispatchChromeTool(
     return conn.status();
   }
 
+  if (name === "chrome_disable") {
+    const shouldDetach = ctx.setSessionActive?.(false) ?? true;
+    if (shouldDetach && conn?.isAttached()) {
+      await setCursorOverlayVisible(conn.cdpSession(), false);
+      await conn.detach();
+    }
+    return { enabled: false };
+  }
+
   if (!conn) {
     return {
       error:
@@ -121,6 +137,11 @@ export async function dispatchChromeTool(
   const cdp = conn.cdpSession();
 
   switch (name) {
+    case "chrome_enable":
+      await conn.ensureWorkspace();
+      ctx.setSessionActive?.(true);
+      await setCursorOverlayVisible(cdp, true);
+      return { enabled: true, status: conn.status() };
     case "chrome_list_tabs":
       return { tabs: await conn.listTabs() };
     case "chrome_open": {
@@ -329,6 +350,18 @@ export const CHROME_TOOLS: ToolSpec[] = [
     name: "chrome_status",
     description:
       "Report whether the companion Chrome extension is connected and which of the user's tabs is attached. Call this first.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "chrome_enable",
+    description:
+      "Begin one uninterrupted Chrome MCP session, attach the background workspace, and keep agent presence active between calls.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "chrome_disable",
+    description:
+      "End the current Chrome MCP session, hide agent presence, and detach when no other session is active. Always call before pausing for user input or finishing.",
     inputSchema: { type: "object", properties: {} },
   },
   {

--- a/src/main/browser/external/chromeTools.ts
+++ b/src/main/browser/external/chromeTools.ts
@@ -50,9 +50,9 @@ export const CHROME_MCP_INSTRUCTIONS = [
   "there; tabs are never auto-closed. Pass newTab:true only when you truly need a second tab. Use chrome_attach",
   "(with a tabId from chrome_list_tabs) only when the user asks you to act on a specific tab they already have open.",
   "Prefer chrome_snapshot / chrome_find to discover elements (they return @e refs) before chrome_click / chrome_fill.",
-  "Use chrome_status first to confirm the extension is connected, then call chrome_enable once before the first browser action.",
+  "Use chrome_status first to confirm the extension is connected, then call chrome.enable once before the first browser action.",
   "Keep Chrome enabled across the whole uninterrupted session so agent presence stays consistent between calls.",
-  "Always call chrome_disable before pausing to ask for user input, waiting for an external event, or finishing, and call chrome_enable again when you resume.",
+  "Always call chrome.disable before pausing to ask for user input, waiting for an external event, or finishing, and call chrome.enable again when you resume.",
   "Destructive or account-affecting actions (purchases, deletions, messages) should be confirmed with the user first.",
 ].join(" ");
 
@@ -118,7 +118,7 @@ export async function dispatchChromeTool(
     return conn.status();
   }
 
-  if (name === "chrome_disable") {
+  if (name === "disable") {
     const shouldDetach = ctx.setSessionActive?.(false) ?? true;
     if (shouldDetach && conn?.isAttached()) {
       await setCursorOverlayVisible(conn.cdpSession(), false);
@@ -137,7 +137,7 @@ export async function dispatchChromeTool(
   const cdp = conn.cdpSession();
 
   switch (name) {
-    case "chrome_enable":
+    case "enable":
       await conn.ensureWorkspace();
       ctx.setSessionActive?.(true);
       await setCursorOverlayVisible(cdp, true);
@@ -353,13 +353,13 @@ export const CHROME_TOOLS: ToolSpec[] = [
     inputSchema: { type: "object", properties: {} },
   },
   {
-    name: "chrome_enable",
+    name: "enable",
     description:
       "Begin one uninterrupted Chrome MCP session, attach the background workspace, and keep agent presence active between calls.",
     inputSchema: { type: "object", properties: {} },
   },
   {
-    name: "chrome_disable",
+    name: "disable",
     description:
       "End the current Chrome MCP session, hide agent presence, and detach when no other session is active. Always call before pausing for user input or finishing.",
     inputSchema: { type: "object", properties: {} },

--- a/src/main/browser/mcp/toolRegistry.test.ts
+++ b/src/main/browser/mcp/toolRegistry.test.ts
@@ -101,6 +101,7 @@ function createDispatchContext(send: ReturnType<typeof vi.fn>): ToolContext {
       getTab: () => tab,
       ensureTabReady: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       createTab: vi.fn<() => Promise<unknown>>().mockResolvedValue({ tabId: "tab-1" }),
+      setAutomationSession: vi.fn<() => boolean>().mockReturnValue(true),
       setActiveTab: vi.fn<() => void>(),
       closeTab: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       navigate: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
@@ -154,6 +155,8 @@ function createRoutingSend(): ReturnType<typeof vi.fn> {
 
 const ROUTING_ARGS: Record<string, Record<string, unknown>> = {
   api: {},
+  enable: {},
+  disable: {},
   list_tabs: {},
   new_tab: { url: "https://example.test/", activate: true },
   open: { url: "https://example.test/open" },
@@ -227,6 +230,8 @@ describe("browser MCP tool registry", () => {
     const formatted = formatToolResult("api", result);
 
     expect(BROWSER_MCP_INSTRUCTIONS).toContain("call browser.api");
+    expect(BROWSER_MCP_INSTRUCTIONS).toContain("browser.enable");
+    expect(BROWSER_MCP_INSTRUCTIONS).toContain("browser.disable");
     expect(formatted.content[0]?.type).toBe("text");
     expect(formatted.content[0]?.text).toContain('"workflows"');
     expect(formatted.content[0]?.text).toContain('"args"');
@@ -285,6 +290,16 @@ describe("browser MCP tool registry", () => {
     ).toBe(true);
     expect(activeTab.cdp.attach).not.toHaveBeenCalled();
     expect(activeTab.webContents.focus).not.toHaveBeenCalled();
+  });
+
+  it("keeps browser automation presence active between enable and disable", async () => {
+    const ctx = createDispatchContext(createRoutingSend());
+
+    await expect(dispatchTool("enable", {}, ctx)).resolves.toEqual({ enabled: true });
+    await expect(dispatchTool("disable", {}, ctx)).resolves.toEqual({ enabled: false });
+
+    expect(ctx.manager.setAutomationSession).toHaveBeenNthCalledWith(1, "unscoped", true);
+    expect(ctx.manager.setAutomationSession).toHaveBeenNthCalledWith(2, "unscoped", false);
   });
 
   it("dispatches every advertised browser tool through the browser context", async () => {

--- a/src/main/browser/mcp/tools/dispatch.ts
+++ b/src/main/browser/mcp/tools/dispatch.ts
@@ -37,7 +37,7 @@ import {
   setCheckedSelector,
   typeIntoSelector,
 } from "../../pageDriver";
-import { glideCursorToSelector } from "../../cursorOverlay";
+import { glideCursorToSelector, setCursorOverlayVisible } from "../../cursorOverlay";
 import {
   agentTabOpts,
   clampInteger,
@@ -66,6 +66,7 @@ export async function dispatchTool(
           "Controls the Poracode in-app browser panel through tabs, navigation, inspection, input, screenshots, console, network, dialogs, cookies, and storage.",
         guidance: [
           "Prefer this MCP server over shell-driven browser automation when a page is visible in Poracode.",
+          "Call enable before a browsing session and disable before pausing for user input or finishing.",
           "Start with snapshot or find to identify @e refs before click, fill, type, hover, get, is, or scroll.",
           "Use fill for form fields when replacing text; use type only when appending text to the current value.",
           "Use wait after navigation or mutations instead of fixed sleeps unless a plain ms delay is intentional.",
@@ -107,6 +108,28 @@ export async function dispatchTool(
         tools: TOOLS.filter((tool) => tool.name !== "api").map(compactToolSpec),
         tabs: ctx.manager.snapshot(),
       };
+    case "enable": {
+      ctx.manager.setAutomationSession(ctx.threadId ?? "unscoped", true);
+      const tab = ctx.manager.getActiveTab();
+      if (tab) {
+        await ctx.manager.ensureTabReady(tab.tabId);
+        await tab.cdp.attach();
+        await setCursorOverlayVisible(tab.cdp, true);
+      }
+      return { enabled: true };
+    }
+    case "disable": {
+      const shouldHidePresence = ctx.manager.setAutomationSession(
+        ctx.threadId ?? "unscoped",
+        false,
+      );
+      const tab = ctx.manager.getActiveTab();
+      if (shouldHidePresence && tab) {
+        await tab.cdp.attach();
+        await setCursorOverlayVisible(tab.cdp, false);
+      }
+      return { enabled: false };
+    }
     case "list_tabs":
       return ctx.manager.snapshot();
     case "new_tab": {

--- a/src/main/browser/mcp/tools/specs.ts
+++ b/src/main/browser/mcp/tools/specs.ts
@@ -1,13 +1,25 @@
 import type { ToolSpec } from "./types";
 
 export const BROWSER_MCP_INSTRUCTIONS =
-  "Use the browser MCP server for browsing, inspecting, clicking, typing, screenshots, network/console checks, and local web app verification inside Poracode. Prefer browser.snapshot or browser.find before browser.click/fill/type, use @e refs from snapshots when possible, and call browser.api when you need the complete API map.";
+  "Use the browser MCP server for browsing, inspecting, clicking, typing, screenshots, network/console checks, and local web app verification inside Poracode. Before the first browsing action, call browser.enable once and keep it enabled across the whole uninterrupted browser session so agent presence stays consistent between calls. Always call browser.disable before pausing to ask for user input, waiting for an external event, or finishing, and enable again when you resume. Prefer browser.snapshot or browser.find before browser.click/fill/type, use @e refs from snapshots when possible, and call browser.api when you need the complete API map.";
 
 export const TOOLS: ToolSpec[] = [
   {
     name: "api",
     description:
       "Return the complete Browser MCP API, recommended workflows, and current tabs. Call this first if you need to browse, inspect, click, type, screenshot, or verify a web page.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "enable",
+    description:
+      "Begin one uninterrupted Browser MCP session and keep its automation host and presence state active between calls.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "disable",
+    description:
+      "End the current Browser MCP session and release its automation presence state. Always call before pausing for user input or finishing.",
     inputSchema: { type: "object", properties: {} },
   },
   {

--- a/src/main/computer-use/ComputerUseDesktopOverlay.test.ts
+++ b/src/main/computer-use/ComputerUseDesktopOverlay.test.ts
@@ -93,7 +93,12 @@ describe("ComputerUseDesktopOverlay", () => {
       onExit: vi.fn<(threadIds: string[]) => void>(),
     });
 
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: true,
+    });
     await Promise.resolve();
 
     expect(electronMock.BrowserWindow.instances).toHaveLength(2);
@@ -103,7 +108,8 @@ describe("ComputerUseDesktopOverlay", () => {
       expect(window.setAlwaysOnTop).toHaveBeenCalledWith(true, "screen-saver");
       expect(window.showInactive).toHaveBeenCalled();
       const overlayHtml = decodeURIComponent(window.loadURL.mock.calls[0]![0].split(",", 2)[1]!);
-      expect(overlayHtml).toContain("inset 0 0 0 3px");
+      expect(overlayHtml).toContain("inset 0 0 0 2px rgba(92, 167, 255, 0.6)");
+      expect(overlayHtml).toContain("inset 0 0 48px rgba(92, 167, 255, 0.08)");
       expect(overlayHtml).toContain("Poracode using your computer | Esc to Exit");
       expect(overlayHtml).not.toContain("<button");
     }
@@ -119,11 +125,21 @@ describe("ComputerUseDesktopOverlay", () => {
     const overlay = new ComputerUseDesktopOverlay({
       onExit: vi.fn<(threadIds: string[]) => void>(),
     });
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: true,
+    });
     await Promise.resolve();
     const windows = [...electronMock.BrowserWindow.instances];
 
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: false });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: false,
+    });
     vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS - 1);
     expect(windows.every((window) => window.visible)).toBe(true);
 
@@ -133,10 +149,44 @@ describe("ComputerUseDesktopOverlay", () => {
     overlay.dispose();
   });
 
+  it("keeps the border visible for an enabled session until it is disabled", async () => {
+    const overlay = new ComputerUseDesktopOverlay({
+      onExit: vi.fn<(threadIds: string[]) => void>(),
+    });
+    overlay.setActivity({ kind: "session", threadId: "thread-1", active: true });
+    await Promise.resolve();
+    const windows = [...electronMock.BrowserWindow.instances];
+
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: true,
+    });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: false,
+    });
+    vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS);
+    expect(windows.every((window) => window.visible)).toBe(true);
+
+    overlay.setActivity({ kind: "session", threadId: "thread-1", active: false });
+    expect(windows.every((window) => !window.visible)).toBe(true);
+
+    overlay.dispose();
+  });
+
   it("interrupts active threads when Escape returns control to the user", async () => {
     const onExit = vi.fn<(threadIds: string[]) => void>();
     const overlay = new ComputerUseDesktopOverlay({ onExit });
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: true,
+    });
     await Promise.resolve();
 
     electronMock.shortcuts.get("Escape")?.();
@@ -152,12 +202,22 @@ describe("ComputerUseDesktopOverlay", () => {
     const overlay = new ComputerUseDesktopOverlay({
       onExit: vi.fn<(threadIds: string[]) => void>(),
     });
-    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: true });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "press_key",
+      active: true,
+    });
     await Promise.resolve();
 
     expect(electronMock.shortcuts.has("Escape")).toBe(false);
 
-    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: false });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "press_key",
+      active: false,
+    });
     expect(electronMock.shortcuts.has("Escape")).toBe(true);
 
     overlay.dispose();
@@ -167,17 +227,37 @@ describe("ComputerUseDesktopOverlay", () => {
     const overlay = new ComputerUseDesktopOverlay({
       onExit: vi.fn<(threadIds: string[]) => void>(),
     });
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: true });
-    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: true });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: true,
+    });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "press_key",
+      active: true,
+    });
     await Promise.resolve();
     const windows = [...electronMock.BrowserWindow.instances];
 
-    overlay.setActivity({ threadId: "thread-1", toolName: "click", active: false });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "click",
+      active: false,
+    });
     vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS);
     expect(windows.every((window) => window.visible)).toBe(true);
     expect(electronMock.shortcuts.has("Escape")).toBe(false);
 
-    overlay.setActivity({ threadId: "thread-1", toolName: "press_key", active: false });
+    overlay.setActivity({
+      kind: "action",
+      threadId: "thread-1",
+      toolName: "press_key",
+      active: false,
+    });
     expect(electronMock.shortcuts.has("Escape")).toBe(true);
     vi.advanceTimersByTime(COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS);
     expect(windows.every((window) => !window.visible)).toBe(true);

--- a/src/main/computer-use/ComputerUseDesktopOverlay.ts
+++ b/src/main/computer-use/ComputerUseDesktopOverlay.ts
@@ -2,7 +2,9 @@ import { BrowserWindow, globalShortcut, screen, type Display } from "electron";
 import type { ComputerUseActivityEvent } from "./ComputerUseMcpIngress";
 import { isKeyChordToolName } from "./mcp/toolRegistry";
 
-export const COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS = 500;
+// Fallback for agents that have not adopted explicit enable/disable sessions.
+// Long enough to bridge normal reasoning gaps between consecutive actions.
+export const COMPUTER_USE_OVERLAY_RELEASE_DELAY_MS = 5_000;
 
 const ESCAPE_ACCELERATOR = "Escape";
 const OVERLAY_HTML = `<!doctype html>
@@ -15,10 +17,10 @@ const OVERLAY_HTML = `<!doctype html>
       * { box-sizing: border-box; }
       html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }
       body {
-        background: rgba(8, 12, 20, 0.08);
+        background: rgba(8, 12, 20, 0.03);
         box-shadow:
-          inset 0 0 0 3px rgba(92, 167, 255, 0.95),
-          inset 0 0 24px rgba(92, 167, 255, 0.2);
+          inset 0 0 0 2px rgba(92, 167, 255, 0.6),
+          inset 0 0 48px rgba(92, 167, 255, 0.08);
       }
       .badge {
         position: fixed;
@@ -54,6 +56,7 @@ export interface ComputerUseDesktopOverlayOptions {
 
 export class ComputerUseDesktopOverlay {
   private readonly activeThreads = new Set<string>();
+  private readonly activeSessions = new Set<string>();
   private readonly activeCalls = new Map<string, number>();
   private escapeSuppressedCalls = 0;
   private readonly releaseTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -72,6 +75,22 @@ export class ComputerUseDesktopOverlay {
       this.releaseTimers.delete(event.threadId);
     }
 
+    if (event.kind === "session") {
+      if (event.active) {
+        this.activeSessions.add(event.threadId);
+        this.activeThreads.add(event.threadId);
+        this.show();
+      } else {
+        this.activeSessions.delete(event.threadId);
+        if (!this.activeCalls.has(event.threadId)) {
+          this.activeThreads.delete(event.threadId);
+          if (this.activeThreads.size === 0) this.hide();
+        }
+      }
+      this.syncEscapeShortcut();
+      return;
+    }
+
     if (event.active) {
       this.activeCalls.set(event.threadId, (this.activeCalls.get(event.threadId) ?? 0) + 1);
       this.activeThreads.add(event.threadId);
@@ -88,7 +107,13 @@ export class ComputerUseDesktopOverlay {
       this.escapeSuppressedCalls = Math.max(0, this.escapeSuppressedCalls - 1);
     }
     this.syncEscapeShortcut();
-    if (!this.activeThreads.has(event.threadId) || activeCalls > 0) return;
+    if (
+      !this.activeThreads.has(event.threadId) ||
+      this.activeSessions.has(event.threadId) ||
+      activeCalls > 0
+    ) {
+      return;
+    }
     this.releaseTimers.set(
       event.threadId,
       setTimeout(() => {
@@ -200,6 +225,7 @@ export class ComputerUseDesktopOverlay {
     for (const releaseTimer of this.releaseTimers.values()) clearTimeout(releaseTimer);
     this.releaseTimers.clear();
     this.activeThreads.clear();
+    this.activeSessions.clear();
     this.activeCalls.clear();
     this.escapeSuppressedCalls = 0;
     this.hide();

--- a/src/main/computer-use/ComputerUseMcpIngress.test.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.test.ts
@@ -76,6 +76,8 @@ describe("ComputerUseMcpIngress", () => {
 
     expect(body.result.serverInfo.name).toBe("computer_use");
     expect(body.result.instructions).toContain("computer_use.api");
+    expect(body.result.instructions).toContain("computer_use.enable");
+    expect(body.result.instructions).toContain("computer_use.disable");
     expect(body.result.instructions).toContain("switch to interactive mode");
   });
 
@@ -123,6 +125,7 @@ describe("ComputerUseMcpIngress", () => {
     });
     await vi.waitFor(() => {
       expect(onActivity).toHaveBeenCalledWith({
+        kind: "action",
         threadId: "thread-1",
         toolName: "click",
         active: true,
@@ -133,6 +136,19 @@ describe("ComputerUseMcpIngress", () => {
     resolveClick?.({ ok: true, mode: "interactive" });
     expect((await response).status).toBe(200);
     expect(onActivity.mock.calls.map(([event]) => event.active)).toEqual([true, false]);
+  });
+
+  it("holds takeover activity between explicit enable and disable calls", async () => {
+    const onActivity = vi.fn<NonNullable<ComputerUseMcpIngressOptions["onActivity"]>>();
+    ingress = new ComputerUseMcpIngress({ driver: createDriver(), onActivity });
+    const info = await ingress.start();
+
+    expect((await callTool(info, "enable", {})).status).toBe(200);
+    expect((await callTool(info, "disable", {})).status).toBe(200);
+    expect(onActivity.mock.calls.map(([event]) => event)).toEqual([
+      { kind: "session", threadId: "thread-1", active: true },
+      { kind: "session", threadId: "thread-1", active: false },
+    ]);
   });
 
   it("does not emit takeover activity for passive tools", async () => {
@@ -161,9 +177,8 @@ describe("ComputerUseMcpIngress", () => {
     expect(
       (await callTool(info, "key", { window: { app: "calc", id: 1 }, key: "Escape" })).status,
     ).toBe(200);
-    expect(onActivity.mock.calls.map(([event]) => event.toolName)).toEqual([
-      "press_key",
-      "press_key",
-    ]);
+    expect(
+      onActivity.mock.calls.map(([event]) => (event.kind === "action" ? event.toolName : null)),
+    ).toEqual(["press_key", "press_key"]);
   });
 });

--- a/src/main/computer-use/ComputerUseMcpIngress.ts
+++ b/src/main/computer-use/ComputerUseMcpIngress.ts
@@ -18,11 +18,9 @@ import {
 
 export type ComputerUseMcpIngressInfo = StreamableHttpMcpIngressInfo;
 
-export interface ComputerUseActivityEvent {
-  threadId: string;
-  active: boolean;
-  toolName: string;
-}
+export type ComputerUseActivityEvent =
+  | { kind: "session"; threadId: string; active: boolean }
+  | { kind: "action"; threadId: string; active: boolean; toolName: string };
 
 export interface ComputerUseMcpIngressOptions {
   driver?: ComputerUseDriver;
@@ -70,9 +68,20 @@ export class ComputerUseMcpIngress {
   }
 
   private buildContext(identity: McpThreadIdentity): ToolContext {
+    const { threadId } = identity;
     return {
       driver: this.driver,
-      ...(identity.threadId ? { threadId: identity.threadId } : {}),
+      ...(threadId
+        ? {
+            threadId,
+            setSessionActive: (active: boolean) =>
+              this.options.onActivity?.({
+                kind: "session",
+                threadId,
+                active,
+              }),
+          }
+        : {}),
     };
   }
 
@@ -85,11 +94,11 @@ export class ComputerUseMcpIngress {
       return await dispatchTool(name, args, ctx);
     }
     const event = { threadId: ctx.threadId, toolName: normalizeToolName(name) };
-    this.options.onActivity?.({ ...event, active: true });
+    this.options.onActivity?.({ kind: "action", ...event, active: true });
     try {
       return await dispatchTool(name, args, ctx);
     } finally {
-      this.options.onActivity?.({ ...event, active: false });
+      this.options.onActivity?.({ kind: "action", ...event, active: false });
     }
   }
 }

--- a/src/main/computer-use/mcp/toolRegistry.ts
+++ b/src/main/computer-use/mcp/toolRegistry.ts
@@ -3,6 +3,7 @@ import { readNumber, readString, readWindow } from "../drivers/common";
 
 export interface ToolContext {
   driver: ComputerUseDriver;
+  setSessionActive?: (active: boolean) => void;
   threadId?: string;
 }
 
@@ -27,13 +28,25 @@ const WINDOW_SCHEMA = {
 };
 
 export const COMPUTER_USE_MCP_INSTRUCTIONS =
-  "Use the computer_use MCP server to inspect and control native macOS or Windows apps on the host desktop (including when the user is driving from a paired phone/remote client — agents still run on that desktop). Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. Prefer ordinary Win32 desktop apps when you have a choice — some Store/WinUI apps recreate window handles during activation, so always prefer the `window` object returned by interactive tools (or re-call list_windows/get_window) before the next click/type. list/get/screenshot operations are passive and do not steal focus; click, drag, scroll, type_text, press_key, activate_window, and launch_app switch to interactive mode, bring the target app to the FOREGROUND, and take exclusive control of the real mouse/keyboard — nobody should use the host machine while interactive computer-use is running. Coordinates (x/y) are window-relative with the origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the most recent get_window_state screenshot for that window; if the window may have moved or resized, call get_window_state again before sending coordinates. If a tool reports that the window is no longer available (windows are re-identified after they move/resize), call computer_use.list_windows or computer_use.get_window to obtain a fresh window id and retry. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
+  "Use the computer_use MCP server to inspect and control native macOS or Windows apps on the host desktop (including when the user is driving from a paired phone/remote client — agents still run on that desktop). Start with computer_use.api or computer_use.list_apps, choose a returned window, then call computer_use.get_window_state before coordinate input. Immediately before the first interactive action, call computer_use.enable once; it keeps the Computer Use overlay visible across the whole uninterrupted control session. Keep it enabled between related actions, including passive inspection calls. Always call computer_use.disable before you pause to ask for user input, wait for an external event, or finish; call enable again when you resume. Prefer ordinary Win32 desktop apps when you have a choice — some Store/WinUI apps recreate window handles during activation, so always prefer the `window` object returned by interactive tools (or re-call list_windows/get_window) before the next click/type. list/get/screenshot operations are passive and do not steal focus; click, drag, scroll, type_text, press_key, activate_window, and launch_app switch to interactive mode, bring the target app to the FOREGROUND, and take exclusive control of the real mouse/keyboard — nobody should use the host machine while interactive computer-use is running. Coordinates (x/y) are window-relative with the origin at the TOP-LEFT of the window frame (including the title bar), matching the top-left pixel of the most recent get_window_state screenshot for that window; if the window may have moved or resized, call get_window_state again before sending coordinates. If a tool reports that the window is no longer available (windows are re-identified after they move/resize), call computer_use.list_windows or computer_use.get_window to obtain a fresh window id and retry. Prefer the browser MCP server for web pages. Locked desktops, secure prompts, OS permission prompts, and password/authentication surfaces require the user.";
 
 export const TOOLS: ToolSpec[] = [
   {
     name: "api",
     description:
       "Return the complete Computer Use API and guidance. Call first when controlling a native app.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "enable",
+    description:
+      "Begin one uninterrupted interactive Computer Use session and keep its desktop overlay visible between actions. Call once before the first interactive action.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "disable",
+    description:
+      "End the current Computer Use session and hide its desktop overlay. Always call before pausing for user input or finishing.",
     inputSchema: { type: "object", properties: {} },
   },
   {
@@ -237,6 +250,14 @@ export async function dispatchTool(
           description: entry.description,
         })),
       };
+    case "enable":
+      if (!ctx.setSessionActive) throw new Error("computer_use.enable requires a thread context");
+      ctx.setSessionActive(true);
+      return { enabled: true };
+    case "disable":
+      if (!ctx.setSessionActive) throw new Error("computer_use.disable requires a thread context");
+      ctx.setSessionActive(false);
+      return { enabled: false };
     case "list_apps":
       return await ctx.driver.listApps();
     case "list_windows":

--- a/src/renderer/components/mcp/McpServersManager.test.tsx
+++ b/src/renderer/components/mcp/McpServersManager.test.tsx
@@ -138,7 +138,7 @@ describe("McpServersManager", () => {
     expect(screen.getByRole("button", { name: "Edit memory" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete memory" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delete Browser" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "44 tools" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "46 tools" })).toBeInTheDocument();
   });
 
   it("shows the built-in tool list from its tool count", () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
@@ -34,7 +34,12 @@ describe("QuestionAnswer", () => {
     expect(screen.getByText("Allow this command?")).toBeInTheDocument();
     expect(screen.getByText("Allow once")).toBeInTheDocument();
     expect(screen.getByText("Only for this run")).toBeInTheDocument();
-    expect(await screen.findByText("Use README.md instead.")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        (_, element) =>
+          element?.tagName === "P" && element.textContent === "Use README.md instead.",
+      ),
+    ).toBeInTheDocument();
     const revertButton = screen.getByRole("button", { name: "Revert to this checkpoint" });
     expect(revertButton).toBeInTheDocument();
     expect(revertButton.closest(".poracode-message-action-strip")).not.toBeNull();

--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
@@ -5,7 +5,7 @@ import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice"
 import { QuestionAnswer } from "./QuestionAnswer";
 
 describe("QuestionAnswer", () => {
-  it("renders selected options, descriptions, custom answers, and checkpoint controls", () => {
+  it("renders selected options, descriptions, custom answers, and checkpoint controls", async () => {
     const item: RuntimeChatItem = {
       id: "qa-1",
       type: "question_answer",
@@ -34,7 +34,7 @@ describe("QuestionAnswer", () => {
     expect(screen.getByText("Allow this command?")).toBeInTheDocument();
     expect(screen.getByText("Allow once")).toBeInTheDocument();
     expect(screen.getByText("Only for this run")).toBeInTheDocument();
-    expect(screen.getByText("Use README.md instead.")).toBeInTheDocument();
+    expect(await screen.findByText("Use README.md instead.")).toBeInTheDocument();
     const revertButton = screen.getByRole("button", { name: "Revert to this checkpoint" });
     expect(revertButton).toBeInTheDocument();
     expect(revertButton.closest(".poracode-message-action-strip")).not.toBeNull();

--- a/src/shared/contracts/mcpServer.ts
+++ b/src/shared/contracts/mcpServer.ts
@@ -26,6 +26,8 @@ export const BUILT_IN_MCP_SERVER_NAMES: Record<BuiltInMcpServerId, string> = {
 export const BUILT_IN_MCP_SERVER_TOOL_NAMES = {
   browser: [
     "api",
+    "enable",
+    "disable",
     "list_tabs",
     "new_tab",
     "open",
@@ -81,6 +83,8 @@ export const BUILT_IN_MCP_SERVER_TOOL_NAMES = {
   ],
   chrome: [
     "chrome_status",
+    "enable",
+    "disable",
     "chrome_list_tabs",
     "chrome_open",
     "chrome_attach",
@@ -103,6 +107,8 @@ export const BUILT_IN_MCP_SERVER_TOOL_NAMES = {
   ],
   "computer-use": [
     "api",
+    "enable",
+    "disable",
     "list_apps",
     "list_windows",
     "launch_app",


### PR DESCRIPTION
- **Feature:** add enable/disable controls for Browser, external Chrome, and Computer Use MCP sessions.
- Keep automation presence active across a session and release it only after the final active session ends.
- Detach external Chrome and hide cursor/desktop overlays when sessions finish, preserving action-level safeguards.
- Expand MCP ingress, tool registry, connection, overlay, and lifecycle test coverage.