### PR TITLE
Show thread plans in the right panel

### DIFF
--- a/src/mobile/ComposerInfoChips.test.tsx
+++ b/src/mobile/ComposerInfoChips.test.tsx
@@ -25,7 +25,6 @@ const dockState: ThreadDockState = {
   errorDockStates: [],
   showTodoDock: false,
   showGoalDock: true,
-  showTodoInRightRail: false,
   hiddenRuntimeItemId: undefined,
   dockLayoutToken: "goal:goal-1",
   onGoalDockDismiss: vi.fn<ThreadDockState["onGoalDockDismiss"]>(),

--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -6,8 +6,13 @@ import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import {
+  useThreadTodoDockStore,
+  type ThreadTodoDockPlacement,
+} from "@/renderer/state/threadTodoDockStore";
 import { buildFileEditorContext, resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads } from "@/renderer/utils/shellUtils";
+import { resolveActivePaneId } from "./currentProject";
 
 function panelContextMatchesThread(
   projectId: string,
@@ -126,8 +131,22 @@ export function openProjectSettings(projectId: string): void {
   usePanelStore.getState().openProjectSettings(projectId);
 }
 
-/** Closes git/files side and right-panel content only. Does not hide the dev terminal (bottom or right). */
+export function moveThreadTodoDock(threadId: string, placement: ThreadTodoDockPlacement): void {
+  useThreadTodoDockStore.getState().setPlacement(threadId, placement);
+  if (placement === "right") {
+    usePanelStore.getState().setRightPanelTab("plan");
+  }
+}
+
+/** Close right-panel content and return its focused Plan to the composer. */
 export function closeAllPanels(): void {
+  const appState = useAppStore.getState();
+  if (appState.view.kind === "thread") {
+    moveThreadTodoDock(
+      resolveActivePaneId(appState.view.panes, appState.focusedPaneId),
+      "composer",
+    );
+  }
   usePanelStore.getState().closeAllPanels();
 }
 
@@ -148,7 +167,7 @@ export function showSubAgentPanel(
 
 /** Dismiss every panel that can occupy the right edge — used by the overlay backdrop. */
 export function dismissRightOverlay(): void {
-  usePanelStore.getState().closeAllPanels();
+  closeAllPanels();
   useDevTerminalStore.getState().closePanel();
 }
 

--- a/src/renderer/components/layout/UnifiedRightPanel.tsx
+++ b/src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   Gauge,
   Globe,
+  ListChecks,
   Lock,
   LockOpen,
   Maximize2,
@@ -36,6 +37,7 @@ export function UnifiedRightPanel(props: {
   usageContent?: ReactNode;
   notesContent?: ReactNode;
   portsContent?: ReactNode;
+  planContent?: ReactNode;
   subagentContent?: ReactNode;
   subagentModel?: ReactNode;
   subagentTitle?: ReactNode;
@@ -47,6 +49,7 @@ export function UnifiedRightPanel(props: {
   showUsageTab?: boolean;
   showNotesTab?: boolean;
   showPortsTab?: boolean;
+  showPlanTab?: boolean;
   showSubagentTab?: boolean;
   showBrowserTab?: boolean;
   onCloseSubagent?: () => void;
@@ -77,6 +80,7 @@ export function UnifiedRightPanel(props: {
     usageContent,
     notesContent,
     portsContent,
+    planContent,
     subagentContent,
     subagentModel,
     subagentTitle,
@@ -87,6 +91,7 @@ export function UnifiedRightPanel(props: {
     showUsageTab = true,
     showNotesTab = true,
     showPortsTab = false,
+    showPlanTab = false,
     showSubagentTab = false,
     showBrowserTab = true,
     onCloseSubagent,
@@ -123,6 +128,14 @@ export function UnifiedRightPanel(props: {
 
   const dragCtl = "poracode-overlay-header__controls";
   const tabs = [
+    {
+      id: "plan",
+      label: t`Plan`,
+      icon: ListChecks,
+      content: planContent,
+      visible: showPlanTab,
+      onOpen: undefined,
+    },
     {
       id: "subagent",
       label: t`Subagent`,

--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -9,7 +9,6 @@ import { guiChatFontCssVars } from "./ChatPane/chatFontVars";
 import { clearUserMessageCollapsedHeightCache } from "./ChatPane/parts/items/userMessageOverflow";
 import type { TerminalPaneHandle } from "./TerminalPane";
 import { ThreadComposerSection } from "./ThreadComposerSection";
-import { ThreadTodoDock } from "./ThreadTodoDock";
 import { useThreadDockState, type ThreadDockState } from "./useThreadDockState";
 
 export type ThreadContentCommonProps = {
@@ -49,9 +48,6 @@ export function GuiThreadContent(
   }, [guiChatFontSize]);
   const ownDockState = useThreadDockState(thread.id);
   const dockState = props.dockState ?? ownDockState;
-  const { todoDockState } = dockState;
-  const showTodoInRightRail = dockState.showTodoInRightRail;
-  const showThreadSideRail = runtimeDebugOpen || showTodoInRightRail;
 
   return (
     <>
@@ -84,34 +80,14 @@ export function GuiThreadContent(
                 : {})}
             />
           </div>
-          {showThreadSideRail ? (
+          {runtimeDebugOpen ? (
             <div className="flex h-full min-h-0 w-[min(44%,24rem)] shrink-0 flex-col gap-2 border-l border-[color:var(--border)] pl-2">
-              {showTodoInRightRail ? (
-                <div
-                  className={
-                    runtimeDebugOpen && !dockState.todoDockCollapsed
-                      ? "min-h-0 max-h-[45%] shrink-0"
-                      : "min-h-0 flex-1"
-                  }
-                >
-                  <ThreadTodoDock
-                    collapsed={dockState.todoDockCollapsed}
-                    placement={dockState.todoDockPlacement}
-                    state={todoDockState!}
-                    onCollapsedChange={dockState.onTodoDockCollapsedChange}
-                    onPlacementChange={dockState.onTodoDockPlacementChange}
-                    onRetire={dockState.onTodoDockRetire}
-                  />
-                </div>
-              ) : null}
-              {runtimeDebugOpen ? (
-                <div className="flex min-h-0 flex-1 flex-col gap-1.5">
-                  <p className="shrink-0 text-xs font-medium text-foreground">
-                    <Trans>Runtime debug</Trans>
-                  </p>
-                  <ChatRuntimeDebugPanel threadId={thread.id} />
-                </div>
-              ) : null}
+              <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+                <p className="shrink-0 text-xs font-medium text-foreground">
+                  <Trans>Runtime debug</Trans>
+                </p>
+                <ChatRuntimeDebugPanel threadId={thread.id} />
+              </div>
             </div>
           ) : null}
         </div>

--- a/src/renderer/components/thread/ThreadTodoDock.tsx
+++ b/src/renderer/components/thread/ThreadTodoDock.tsx
@@ -59,7 +59,14 @@ export function ThreadTodoDock(props: ThreadTodoDockProps) {
   const countLabel = `${completedCount}/${state.steps.length}`;
 
   return (
-    <ThreadDockSection ariaLabel={t`Thread todo dock`} placement={placement} collapsed={collapsed}>
+    <ThreadDockSection
+      ariaLabel={t`Thread todo dock`}
+      placement={placement}
+      collapsed={collapsed}
+      className={
+        placement === "right" ? "rounded-none border-0 bg-[var(--content-background)]" : ""
+      }
+    >
       <ThreadDockHeader
         icon={ListChecks}
         title={t`Plan`}

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/renderer/components/providers/bootstrap";
 import type { Thread } from "@/shared/contracts";
+import { closeAllPanels } from "@/renderer/actions/panelActions";
 import { AppProvider } from "@/renderer/components/ui/provider";
 import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { ThreadView } from "./ThreadView";
@@ -88,6 +90,7 @@ describe("ThreadView", () => {
       defaultCollapsed: false,
       byThreadId: {},
     });
+    usePanelStore.setState({ rightPanelTab: "git" });
     useAppStore.setState({
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
@@ -1232,8 +1235,9 @@ describe("ThreadView", () => {
     expect(screen.getByText("Complete · 120 tokens")).toBeInTheDocument();
   });
 
-  it("moves the pinned todo dock to the right rail and supports collapse", () => {
+  it("moves the pinned todo dock into the unified right panel", () => {
     useAppStore.setState({
+      view: { kind: "thread", panes: ["thread-gui-plan"] },
       runtimeItemIdsByThread: {
         "thread-gui-plan": ["plan-1"],
       },
@@ -1304,11 +1308,14 @@ describe("ThreadView", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Move todo dock to right panel" }));
-    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-placement", "right");
+    expect(screen.queryByLabelText("Thread todo dock")).not.toBeInTheDocument();
+    expect(useThreadTodoDockStore.getState().byThreadId["thread-gui-plan"]?.placement).toBe(
+      "right",
+    );
+    expect(usePanelStore.getState().rightPanelTab).toBe("plan");
 
-    fireEvent.click(screen.getByRole("button", { name: "Collapse todo dock" }));
-    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-collapsed", "true");
-    expect(screen.queryByText("Wire ACP todo placement")).not.toBeInTheDocument();
+    act(() => closeAllPanels());
+    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-placement", "composer");
   });
 
   it("keeps todo dock placement and collapse scoped to each thread", () => {
@@ -1398,10 +1405,12 @@ describe("ThreadView", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Move todo dock to right panel" }));
-    fireEvent.click(screen.getByRole("button", { name: "Collapse todo dock" }));
+    useThreadTodoDockStore.getState().setCollapsed("thread-gui-plan-a", true);
 
-    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-placement", "right");
-    expect(screen.getByLabelText("Thread todo dock")).toHaveAttribute("data-collapsed", "true");
+    expect(useThreadTodoDockStore.getState().byThreadId["thread-gui-plan-a"]).toMatchObject({
+      placement: "right",
+      collapsed: true,
+    });
 
     rerender(
       <AppProvider>

--- a/src/renderer/components/thread/useThreadDockState.ts
+++ b/src/renderer/components/thread/useThreadDockState.ts
@@ -5,6 +5,7 @@ import {
   useThreadTodoDockStore,
   type ThreadTodoDockPlacement,
 } from "@/renderer/state/threadTodoDockStore";
+import { moveThreadTodoDock } from "@/renderer/actions/panelActions";
 import { selectThreadErrorDockStates, type ThreadErrorDockState } from "./threadErrorState";
 import {
   selectThreadGoalDockItem,
@@ -27,7 +28,6 @@ export interface ThreadDockState {
   errorDockStates: ThreadErrorDockState[];
   showTodoDock: boolean;
   showGoalDock: boolean;
-  showTodoInRightRail: boolean;
   hiddenRuntimeItemId: string | undefined;
   dockLayoutToken: string | null;
   onGoalDockDismiss: () => void;
@@ -47,7 +47,6 @@ export function useThreadDockState(threadId: string): ThreadDockState {
   const retiredSourceItemId = useThreadTodoDockStore(
     (s) => s.byThreadId[threadId]?.retiredSourceItemId,
   );
-  const setTodoDockPlacement = useThreadTodoDockStore((s) => s.setPlacement);
   const setTodoDockCollapsed = useThreadTodoDockStore((s) => s.setCollapsed);
   const retireTodoDock = useThreadTodoDockStore((s) => s.retire);
   const todoDockState = useAppStore((s) => selectThreadTodoDockState(s, threadId));
@@ -111,7 +110,6 @@ export function useThreadDockState(threadId: string): ThreadDockState {
     (dismissedGoal?.threadId !== threadId || goalDockState.sourceItemId !== dismissedGoal.itemId);
   const visibleTodoDockState = showTodoDock ? todoDockState : null;
   const visibleGoalDockState = showGoalDock ? goalDockState : null;
-  const showTodoInRightRail = showTodoDock && todoDockPlacement === "right";
   const hiddenRuntimeItemId = visibleTodoDockState?.sourceItemId;
   const dockLayoutToken =
     [
@@ -131,7 +129,6 @@ export function useThreadDockState(threadId: string): ThreadDockState {
     errorDockStates,
     showTodoDock,
     showGoalDock,
-    showTodoInRightRail,
     hiddenRuntimeItemId,
     dockLayoutToken,
     onGoalDockDismiss: () => {
@@ -145,7 +142,7 @@ export function useThreadDockState(threadId: string): ThreadDockState {
         itemIds: new Set([...(prev.threadId === threadId ? prev.itemIds : []), sourceItemId]),
       })),
     onTodoDockCollapsedChange: (collapsed) => setTodoDockCollapsed(threadId, collapsed),
-    onTodoDockPlacementChange: (placement) => setTodoDockPlacement(threadId, placement),
+    onTodoDockPlacementChange: (placement) => moveThreadTodoDock(threadId, placement),
     onTodoDockRetire: () => {
       if (visibleTodoDockState) retireTodoDock(threadId, visibleTodoDockState.sourceItemId);
     },

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -45,6 +45,7 @@ export type RightPanelTab =
   | "usage"
   | "notes"
   | "ports"
+  | "plan"
   | "subagent";
 
 interface PanelState {

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -2,6 +2,9 @@ import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
+import { resolveActivePaneId } from "@/renderer/actions/currentProject";
 
 export function usePanelVisibility() {
   const devTerminalOpen = useDevTerminalStore((s) => s.isOpen);
@@ -14,30 +17,50 @@ export function usePanelVisibility() {
   const usagePanelOpen = usePanelStore((s) => s.usagePanelOpen);
   const notesPanelOpen = usePanelStore((s) => s.notesPanelOpen);
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
+  const currentThreadId = useAppStore((state) => {
+    if (state.view.kind !== "thread") return null;
+    return resolveActivePaneId(state.view.panes, state.focusedPaneId);
+  });
+  const todoDockPlacement = useThreadTodoDockStore((state) =>
+    currentThreadId
+      ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)
+      : "composer",
+  );
+  const retiredTodoSourceItemId = useThreadTodoDockStore((state) =>
+    currentThreadId ? state.byThreadId[currentThreadId]?.retiredSourceItemId : undefined,
+  );
+  const todoDockState = useAppStore((state) =>
+    currentThreadId && todoDockPlacement === "right"
+      ? selectThreadTodoDockState(state, currentThreadId)
+      : null,
+  );
 
   const isTerminalRight = terminalPosition === "right";
   const gitPanelOpen = !!gitReviewContext && gitReviewAsPanel;
   const filesPanelOpen = filesPanelContext !== null;
-  const subAgentInCurrentThread = useAppStore((state) => {
-    if (!subAgentPanelContext || state.view.kind !== "thread") return false;
-    const activeThreadId =
-      state.focusedPaneId && state.view.panes.includes(state.focusedPaneId)
-        ? state.focusedPaneId
-        : state.view.panes[0];
-    return (
-      activeThreadId === subAgentPanelContext.threadId &&
-      state.runtimeItemsByIdByThread[subAgentPanelContext.threadId]?.[
-        subAgentPanelContext.parentItemId
-      ] !== undefined
-    );
-  });
+  const subAgentItemExists = useAppStore((state) =>
+    subAgentPanelContext
+      ? state.runtimeItemsByIdByThread[subAgentPanelContext.threadId]?.[
+          subAgentPanelContext.parentItemId
+        ] !== undefined
+      : false,
+  );
+  const subAgentInCurrentThread =
+    subAgentPanelContext !== null &&
+    subAgentPanelContext.threadId === currentThreadId &&
+    subAgentItemExists;
   const scopedSubAgentPanelOpen =
     subAgentPanelOpen && subAgentPanelContext !== null && subAgentInCurrentThread;
+  const planPanelOpen =
+    todoDockPlacement === "right" &&
+    todoDockState !== null &&
+    todoDockState.sourceItemId !== retiredTodoSourceItemId;
 
   const rightPanelOpen = isTerminalRight
     ? devTerminalOpen ||
       gitPanelOpen ||
       filesPanelOpen ||
+      planPanelOpen ||
       scopedSubAgentPanelOpen ||
       browserPanelOpen ||
       usagePanelOpen ||
@@ -47,6 +70,7 @@ export function usePanelVisibility() {
     !isTerminalRight &&
     (gitPanelOpen ||
       filesPanelOpen ||
+      planPanelOpen ||
       scopedSubAgentPanelOpen ||
       browserPanelOpen ||
       usagePanelOpen ||

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -20,6 +20,8 @@ import {
   SubAgentContent,
   SubAgentHeaderText,
 } from "@/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay";
+import { ThreadTodoDock } from "@/renderer/components/thread/ThreadTodoDock";
+import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
@@ -29,13 +31,15 @@ import {
   type FilesPanelContext,
   type GitReviewContext,
 } from "@/renderer/state/panelStore";
+import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import {
   closeAllPanels,
+  moveThreadTodoDock,
   showFilesPanel,
   showGitReviewPanel,
 } from "@/renderer/actions/panelActions";
 import { showTerminalPanel } from "@/renderer/actions/terminalActions";
-import { getCurrentProjectId } from "@/renderer/actions/currentProject";
+import { getCurrentProjectId, resolveActivePaneId } from "@/renderer/actions/currentProject";
 import { buildFileEditorContext } from "@/renderer/utils/gitHelpers";
 import { GitReviewPanelContent } from "./RightPanel/parts/GitReviewPanelContent";
 
@@ -104,10 +108,26 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
   const terminalWorktreePath = useDevTerminalStore((s) => s.activeWorktreePath);
   const currentThreadId = useAppStore((state) => {
     if (state.view.kind !== "thread") return null;
-    return state.focusedPaneId && state.view.panes.includes(state.focusedPaneId)
-      ? state.focusedPaneId
-      : state.view.panes[0];
+    return resolveActivePaneId(state.view.panes, state.focusedPaneId);
   });
+  const todoDockPlacement = useThreadTodoDockStore((state) =>
+    currentThreadId
+      ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)
+      : "composer",
+  );
+  const todoDockCollapsed = useThreadTodoDockStore((state) =>
+    currentThreadId
+      ? (state.byThreadId[currentThreadId]?.collapsed ?? state.defaultCollapsed)
+      : false,
+  );
+  const retiredTodoSourceItemId = useThreadTodoDockStore((state) =>
+    currentThreadId ? state.byThreadId[currentThreadId]?.retiredSourceItemId : undefined,
+  );
+  const todoDockState = useAppStore((state) =>
+    currentThreadId && todoDockPlacement === "right"
+      ? selectThreadTodoDockState(state, currentThreadId)
+      : null,
+  );
 
   const gitPanelOpen = !!gitReviewContext && gitReviewAsPanel;
   const filesPanelOpen = filesPanelContext !== null;
@@ -122,6 +142,11 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
     subAgentPanelContext !== null &&
     subAgentPanelContext.threadId === currentThreadId &&
     subAgentItemExists;
+  const planInCurrentThread =
+    currentThreadId !== null &&
+    todoDockPlacement === "right" &&
+    todoDockState !== null &&
+    todoDockState.sourceItemId !== retiredTodoSourceItemId;
 
   const lastGitPanelContextRef = useRef(gitReviewContext);
   if (gitReviewContext && gitReviewAsPanel) {
@@ -146,25 +171,36 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
         rightPanelTab === "browser" ||
         rightPanelTab === "usage" ||
         rightPanelTab === "notes" ||
+        rightPanelTab === "plan" ||
         rightPanelTab === "subagent"
       ? rightPanelTab
       : "git";
-  const activeTab: RightPanelTab =
-    requestedTab !== "subagent" || subAgentInCurrentThread
-      ? requestedTab
-      : filesPanelOpen
-        ? "files"
-        : gitPanelOpen
-          ? "git"
-          : browserPanelOpen
-            ? "browser"
-            : usagePanelOpen
-              ? "usage"
-              : notesPanelOpen
-                ? "notes"
-                : props.includeTerminal && terminalOpen
-                  ? "terminal"
-                  : "git";
+
+  function requestedTabIsAvailable(): boolean {
+    if (requestedTab === "subagent") return subAgentInCurrentThread;
+    if (requestedTab === "plan") return planInCurrentThread;
+    if (!planInCurrentThread) return true;
+    if (requestedTab === "terminal") return terminalOpen;
+    if (requestedTab === "files") return filesPanelOpen;
+    if (requestedTab === "git") return gitPanelOpen;
+    if (requestedTab === "browser") return browserPanelOpen;
+    if (requestedTab === "usage") return usagePanelOpen;
+    return requestedTab === "notes" && notesPanelOpen;
+  }
+
+  function fallbackActiveTab(): RightPanelTab {
+    if (planInCurrentThread) return "plan";
+    if (subAgentInCurrentThread) return "subagent";
+    if (filesPanelOpen) return "files";
+    if (gitPanelOpen) return "git";
+    if (browserPanelOpen) return "browser";
+    if (usagePanelOpen) return "usage";
+    if (notesPanelOpen) return "notes";
+    if (props.includeTerminal && terminalOpen) return "terminal";
+    return "git";
+  }
+
+  const activeTab = requestedTabIsAvailable() ? requestedTab : fallbackActiveTab();
 
   const gitScope = scopeFromGitContext(gitPanelContext);
   const filesScope = scopeFromFilesContext(resolvedFilesPanelContext);
@@ -203,6 +239,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
       case "notes":
         return notesProjectId ? projectNameForScope({ projectId: notesProjectId }) : t`Notes`;
       case "subagent":
+      case "plan":
         return undefined;
       case "files":
         return resolvedFilesPanelContext?.rootLabel ?? projectNameForScope(activeProjectScope());
@@ -253,6 +290,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
   const renderBrowserContent = browserPanelOpen;
   const renderUsageContent = usagePanelOpen;
   const renderNotesContent = notesPanelOpen && notesProjectId !== undefined;
+  const renderPlanContent = planInCurrentThread;
   const renderSubAgentContent = subAgentInCurrentThread;
 
   return (
@@ -260,6 +298,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
       activeTab={activeTab}
       onTabChange={(tab) => {
         if (tab === "subagent" && !renderSubAgentContent) return;
+        if (tab === "plan" && !renderPlanContent) return;
         setRightPanelTab(tab);
       }}
       {...(renderTerminalContent ? { terminalContent: <DevTerminalPanel hideHeader /> } : {})}
@@ -292,6 +331,26 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
           <NotesPanel key={notesProjectId} projectId={notesProjectId} />
         ) : undefined
       }
+      {...(renderPlanContent && currentThreadId && todoDockState
+        ? {
+            planContent: (
+              <ThreadTodoDock
+                collapsed={todoDockCollapsed}
+                placement="right"
+                state={todoDockState}
+                onCollapsedChange={(collapsed) =>
+                  useThreadTodoDockStore.getState().setCollapsed(currentThreadId, collapsed)
+                }
+                onPlacementChange={(placement) => moveThreadTodoDock(currentThreadId, placement)}
+                onRetire={() =>
+                  useThreadTodoDockStore
+                    .getState()
+                    .retire(currentThreadId, todoDockState.sourceItemId)
+                }
+              />
+            ),
+          }
+        : {})}
       subagentContent={
         renderSubAgentContent ? (
           <SubAgentContent
@@ -312,6 +371,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean }) {
       showFilesTab={!isHomeScope}
       showGitTab={!isHomeScope}
       showNotesTab={notesProjectId !== undefined}
+      showPlanTab={renderPlanContent}
       showSubagentTab={renderSubAgentContent}
       {...(renderSubAgentContent
         ? {


### PR DESCRIPTION
- **Feature:** Add a Plan tab that displays each thread’s todo plan in the right panel.
- Keep plan placement, panel visibility, close behavior, styling, and thread-scoped state consistent across desktop and mobile coverage.