### PR TITLE
Fix batched sed view command summaries

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -472,6 +472,29 @@ describe("ToolCallGroup", () => {
     expect(screen.getByText("Install packages · pnpm install")).toBeInTheDocument();
   });
 
+  it("cleans and syntax-highlights batched Codex sed views", async () => {
+    const threadId = "thread-1";
+    const item: RuntimeChatItem = {
+      ...makeCommandItem(
+        "cmd-batched-view",
+        `/bin/zsh -lc "sed -n '1,80p' src/shared/settings.ts; sed -n '570,630p' src/shared/settings.ts"`,
+      ),
+      streams: {
+        command_output: 'import { z } from "zod";\nexport const setting = true;\n',
+      },
+    };
+    seedThread(threadId, [item]);
+
+    const view = renderToolCallGroup(threadId, [item.id]);
+
+    expect(screen.queryByText(";src/shared/settings.ts")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText("src/shared/settings.ts"));
+
+    await waitFor(() => {
+      expect(view.container.querySelector(".lc-shiki")).toBeInTheDocument();
+    });
+  });
+
   it("categorizes persisted compacted tool summaries by their labels", () => {
     const threadId = "thread-1";
     const items = [

--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.test.ts
@@ -121,6 +121,17 @@ describe("humanIntentTitle", () => {
     });
   });
 
+  it("does not include a statement separator in a batched sed view path", () => {
+    const full = `/bin/zsh -lc "sed -n '1,80p' src/shared/settings.ts; sed -n '570,630p' src/shared/settings.ts"`;
+    const display = commandIntentDisplay(full);
+
+    expect(display.title).toBe("View 1:80: src/shared/settings.ts");
+    expect(display.parts).toEqual({
+      prefix: "View 1:80: ",
+      path: "src/shared/settings.ts",
+    });
+  });
+
   it("describes ripgrep commands as searches", () => {
     const full = `/bin/zsh -lc 'rg -n "agent status|AgentStatus" src/main src/supervisor src/shared -S'`;
     expect(humanIntentTitle(full)).toBe('Search: "agent status|AgentStatus"');

--- a/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
@@ -353,7 +353,11 @@ interface FindSearch {
 }
 
 function parseSedView(command: string): SedView | null {
-  const words = splitShellWords(command);
+  // Codex commonly batches several reads into one shell invocation:
+  // `sed ... first.ts; sed ... second.ts`. Parse only the first statement so
+  // its `;` separator does not become part of the displayed path (and turn a
+  // highlightable `.ts` extension into the unknown `.ts;` extension).
+  const words = splitShellWords(firstShellStatement(command));
   if (words.length < 3) return null;
   const executable = words[0]!.split(/[/\\]/).pop()?.toLowerCase();
   if (executable !== "sed" && executable !== "gsed") return null;
@@ -382,6 +386,34 @@ function parseSedView(command: string): SedView | null {
   const start = range[1]!;
   const end = range[2];
   return { path, lines: end ? `${start}-${end}` : start };
+}
+
+function firstShellStatement(input: string): string {
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (ch === ";") return input.slice(0, i).trim();
+  }
+
+  return input;
 }
 
 function formatLineRange(lines: string): string {


### PR DESCRIPTION
- Fix command summaries for batched `sed` views so statement separators are not shown as part of file paths.
- Preserve syntax highlighting when opening Codex-generated batched file views.
- Add coverage for command parsing and rendered tool-call behavior.