### PR TITLE
Fix worktree setup serialization and dependency isolation

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -37,6 +37,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Release runners are disposable single checkouts; use pnpm's standard local
+  # virtual store so postinstall native rebuilds operate on this checkout.
+  PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: "false"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # CI checkouts do not benefit from the worktree-oriented global virtual
+  # store, and targeted pnpm rebuilds must operate on checkout-local packages.
+  PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: "false"
+
 jobs:
   typecheck:
     name: Typecheck

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -22,6 +22,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Mobile release runners are disposable single checkouts and do not benefit
+  # from the developer worktree global virtual store.
+  PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: "false"
+
 concurrency:
   group: release-mobile-${{ github.ref }}
   cancel-in-progress: false

--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -1,4 +1,25 @@
-// pnpm's ESM resolver bridge is inherited by nested pnpm commands. Keeping an
-// explicit ESM pnpmfile prevents pnpm 11 from probing a missing optional file
-// through that loader, which would otherwise turn the probe into a hard error.
-export const hooks = {};
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const workspaceRoot = dirname(fileURLToPath(import.meta.url));
+const loaderUrl = pathToFileURL(
+  resolve(workspaceRoot, "scripts/pnpm-esm-node-path-loader.mjs"),
+).href;
+
+export const hooks = {
+  updateConfig(config) {
+    if (!config.enableGlobalVirtualStore) return config;
+
+    const registrationCode =
+      `import{register}from'node:module';` +
+      `register('${loaderUrl}','${pathToFileURL(workspaceRoot).href}');`;
+    const importFlag = `--import=data:text/javascript,${encodeURIComponent(registrationCode)}`;
+    const currentNodeOptions = process.env.NODE_OPTIONS?.trim() ?? "";
+
+    config.extraEnv ??= {};
+    config.extraEnv.NODE_OPTIONS = currentNodeOptions.includes(loaderUrl)
+      ? currentNodeOptions
+      : [currentNodeOptions, importFlag].filter(Boolean).join(" ");
+    return config;
+  },
+};

--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -1,0 +1,4 @@
+// pnpm's ESM resolver bridge is inherited by nested pnpm commands. Keeping an
+// explicit ESM pnpmfile prevents pnpm 11 from probing a missing optional file
+// through that loader, which would otherwise turn the probe into a hard error.
+export const hooks = {};

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "oxlint-tsgolint": "^0.24.0",
     "postcss": "^8.5.16",
     "react-devtools": "^7.0.1",
+    "sharp": "0.35.3",
     "tsdown": "^0.22.4",
     "typescript": "^7.0.2",
     "vite": "8.0.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,8 @@ overrides:
   brace-expansion@<1.1.16: ^1.1.16
   brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
 
+packageExtensionsChecksum: sha256-poYlOieRMgHR4WCooGnRe9Jg6+ydgS+c86SN2RV6EzQ=
+
 importers:
 
   .:
@@ -303,7 +305,7 @@ importers:
         version: 4.3.2(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
-        version: 6.9.1
+        version: 6.9.1(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7994,6 +7996,7 @@ snapshots:
   '@heroui/react@3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)':
     dependencies:
       '@heroui/styles': 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+      '@internationalized/date': 3.12.2
       '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@react-aria/i18n': 3.13.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@react-aria/ssr': 3.10.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -8042,6 +8045,7 @@ snapshots:
     dependencies:
       '@huggingface/jinja': 0.5.9
       '@huggingface/tokenizers': 0.1.3
+      onnxruntime-common: 1.24.3
       onnxruntime-node: 1.24.3
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.35.3(@types/node@25.9.5)
@@ -9392,7 +9396,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.9.1':
+  '@testing-library/jest-dom@6.9.1(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@adobe/css-tools': 4.5.0
       aria-query: 5.3.2
@@ -9400,6 +9404,21 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@types/node'
+      - '@vitest/browser-playwright'
+      - '@vitest/browser-preview'
+      - '@vitest/browser-webdriverio'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - msw
+      - vite
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -13061,6 +13080,7 @@ snapshots:
   react-aria-components@1.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@internationalized/date': 3.12.2
+      '@internationalized/string': 3.2.9
       '@react-types/shared': 3.36.0(react@19.2.7)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1
@@ -13072,6 +13092,7 @@ snapshots:
   react-aria-components@1.19.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@internationalized/date': 3.12.2
+      '@internationalized/string': 3.2.9
       '@react-types/shared': 3.36.0(react@19.2.7)
       '@swc/helpers': 0.5.23
       client-only: 0.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,24 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies:
-      '@pnpm/plugin-esm-node-path':
-        specifier: 0.1.2
-        version: 0.1.2
-
-packages:
-
-  '@pnpm/plugin-esm-node-path@0.1.2':
-    resolution: {integrity: sha512-KzcFbJpNJHRZ60GpXmc6CoBX/zjy+fKEf/OOYdRbAlxV/Kf/f6pDNUDIVTQU8a5DHt6ODXq5mndwJPlryqMj1A==}
-
-snapshots:
-
-  '@pnpm/plugin-esm-node-path@0.1.2': {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -58,7 +37,7 @@ overrides:
 
 packageExtensionsChecksum: sha256-poYlOieRMgHR4WCooGnRe9Jg6+ydgS+c86SN2RV6EzQ=
 
-pnpmfileChecksum: sha256-HLcFzMEMFrJQT+DTQqNFod0StiZ4dz2U7EFPf6hAaQQ=
+pnpmfileChecksum: sha256-BIchYFv0KpVI2Fu9YSi3hK+ZN/ZSz3O0ksJFvqhaUHI=
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,24 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies:
+      '@pnpm/plugin-esm-node-path':
+        specifier: 0.1.2
+        version: 0.1.2
+
+packages:
+
+  '@pnpm/plugin-esm-node-path@0.1.2':
+    resolution: {integrity: sha512-KzcFbJpNJHRZ60GpXmc6CoBX/zjy+fKEf/OOYdRbAlxV/Kf/f6pDNUDIVTQU8a5DHt6ODXq5mndwJPlryqMj1A==}
+
+snapshots:
+
+  '@pnpm/plugin-esm-node-path@0.1.2': {}
+
+---
 lockfileVersion: '9.0'
 
 settings:
@@ -36,6 +57,8 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
 
 packageExtensionsChecksum: sha256-poYlOieRMgHR4WCooGnRe9Jg6+ydgS+c86SN2RV6EzQ=
+
+pnpmfileChecksum: sha256-HLcFzMEMFrJQT+DTQqNFod0StiZ4dz2U7EFPf6hAaQQ=
 
 importers:
 
@@ -384,6 +407,9 @@ importers:
       react-devtools:
         specifier: ^7.0.1
         version: 7.0.1
+      sharp:
+        specifier: 0.35.3
+        version: 0.35.3(@types/node@25.9.5)
       tsdown:
         specifier: ^0.22.4
         version: 0.22.4(typescript@7.0.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,14 @@ packages:
 
 # Share the virtual store across worktrees/checkouts via symlinks instead of
 # hardlinking every package into each node_modules/.pnpm (see pnpm.io/git-worktrees).
+# Native build outputs are shared too; worktrees intentionally testing a
+# different Electron ABI should set PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false.
 enableGlobalVirtualStore: true
+
+# Node's ESM resolver ignores NODE_PATH, so load pnpm's official resolver bridge
+# when development dependencies live in the shared global virtual store.
+configDependencies:
+  "@pnpm/plugin-esm-node-path": 0.1.2
 
 allowBuilds:
   "@google/genai": false
@@ -27,21 +34,12 @@ onlyBuiltDependencies:
   - esbuild
   - node-pty
 
-# @sentry/electron's main-process bundle eagerly requires @sentry/node, which
-# requires @opentelemetry/* via bare paths. Keep these packages public-hoisted
-# so that development and tests work with pnpm's isolated linker.
+# TypeScript does not use Node's ESM resolver bridge, so keep a root-level
+# compatibility facade for external declaration files and tooling. This masks
+# undeclared transitive imports at the root; first-party imports must still be
+# declared. Entries are symlinks, not duplicate package contents.
 publicHoistPattern:
-  - "@opentelemetry/*"
-  - "@sentry/*"
-  - "@sentry-internal/*"
-  - "@fastify/otel"
-  - "@prisma/instrumentation"
-  - "import-in-the-middle"
-  - "require-in-the-middle"
-  - "acorn"
-  - "acorn-import-attributes"
-  - "cjs-module-lexer"
-  - "module-details-from-path"
+  - "*"
 
 # Declare published packages' direct imports at their package boundaries so
 # resolution still works when the dependency graph lives in pnpm's global

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,11 +10,6 @@ packages:
 # different Electron ABI should set PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE=false.
 enableGlobalVirtualStore: true
 
-# Node's ESM resolver ignores NODE_PATH, so load pnpm's official resolver bridge
-# when development dependencies live in the shared global virtual store.
-configDependencies:
-  "@pnpm/plugin-esm-node-path": 0.1.2
-
 allowBuilds:
   "@google/genai": false
   "@sentry/cli": true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,10 +28,8 @@ onlyBuiltDependencies:
   - node-pty
 
 # @sentry/electron's main-process bundle eagerly requires @sentry/node, which
-# requires @opentelemetry/* via bare paths. Under pnpm's nested layout
-# electron-builder does not traverse those into the asar. Public-hoisting
-# pins them to top-level node_modules so the default packaging traversal
-# picks them up.
+# requires @opentelemetry/* via bare paths. Keep these packages public-hoisted
+# so that development and tests work with pnpm's isolated linker.
 publicHoistPattern:
   - "@opentelemetry/*"
   - "@sentry/*"
@@ -45,10 +43,33 @@ publicHoistPattern:
   - "cjs-module-lexer"
   - "module-details-from-path"
 
-# Force electron-builder to traverse symlinked transitive deps under pnpm's
-# nested layout. Without this, deep deps like @opentelemetry/* are not copied
-# into the asar even when listed in `files`.
-nodeLinker: hoisted
+# Declare published packages' direct imports at their package boundaries so
+# resolution still works when the dependency graph lives in pnpm's global
+# virtual store.
+packageExtensions:
+  "@testing-library/jest-dom@6.9.1":
+    dependencies:
+      vitest: 4.1.9
+  "@huggingface/transformers@4.2.0":
+    dependencies:
+      onnxruntime-common: 1.24.3
+  "@heroui/react@3.2.2":
+    dependencies:
+      "@internationalized/date": 3.12.2
+  "react-aria-components@1.17.0":
+    dependencies:
+      "@internationalized/string": 3.2.9
+  "react-aria-components@1.19.0":
+    dependencies:
+      "@internationalized/string": 3.2.9
+
+# Keep development installs lightweight across Git worktrees. The global
+# virtual store above shares package graphs between checkouts, while each
+# worktree keeps only the symlinks needed for its own dependency graph.
+#
+# Production packaging is intentionally independent: build-desktop-artifact.mjs
+# installs the curated runtime dependency set into a clean, flat npm stage.
+nodeLinker: isolated
 
 minimumReleaseAgeExclude:
   # Claude steering relies on the current official SDK lifecycle controls.

--- a/scripts/build-desktop-artifact.mjs
+++ b/scripts/build-desktop-artifact.mjs
@@ -7,7 +7,7 @@
 // by glob is a moving target. Instead we copy the build artifacts into a clean
 // staging directory, write a fresh package.json that lists ONLY the runtime
 // externals reported by `scripts/scan-runtime-externals.mjs`, run a flat
-// `pnpm install` (node-linker=hoisted), and run electron-builder there.
+// `npm install`, and run electron-builder there.
 
 import { spawnSync } from "node:child_process";
 import {
@@ -357,14 +357,11 @@ async function main() {
       buildElectronBuilderConfig(initialMacArtifactKind),
     );
 
-    // 6. Install prod + stage devdeps with a flat layout.
-    //    node-linker=hoisted makes pnpm produce an npm-style flat node_modules,
-    //    which electron-builder's file walker (and our asar globs) expect.
-    //    dangerously-allow-all-builds bypasses pnpm 10+'s build-script gating
-    //    (electron's postinstall must run to download the binary; better-sqlite3
-    //    and node-pty compile native bindings). The stage's deps are pinned to
-    //    versions the root project already trusts, so this is no riskier than
-    //    `pnpm install` on the root.
+    // 6. Install prod + stage devdeps with a genuinely flat npm layout.
+    //    electron-builder's file walker (and our asar globs) expect this.
+    //    npm runs electron's postinstall and the native dependency build
+    //    scripts by default. The stage's deps are pinned to versions the root
+    //    project already trusts.
     //    We DON'T disable optionals because electron-builder's dmg-builder
     //    requires the `dmg-license` optionalDependency unconditionally at
     //    import time. Instead we install optionals normally, then surgically

--- a/scripts/pnpm-esm-node-path-loader.mjs
+++ b/scripts/pnpm-esm-node-path-loader.mjs
@@ -1,0 +1,30 @@
+// Mirrors @pnpm/plugin-esm-node-path for pnpm's global virtual store without a
+// configDependency, whose multi-document lockfile is not yet accepted by
+// Vercel's project-config parser.
+import { createRequire } from "node:module";
+import { delimiter } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const extraNodePaths = (process.env.NODE_PATH ?? "").split(delimiter).filter(Boolean);
+
+export async function resolve(specifier, context, defaultResolve) {
+  try {
+    return await defaultResolve(specifier, context, defaultResolve);
+  } catch (originalError) {
+    if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("node:")) {
+      throw originalError;
+    }
+
+    for (const basePath of extraNodePaths) {
+      const require = createRequire(pathToFileURL(basePath).href);
+      try {
+        const resolved = require.resolve(specifier);
+        return { url: pathToFileURL(resolved).href };
+      } catch {
+        // Try the next pnpm-provided NODE_PATH entry.
+      }
+    }
+
+    throw originalError;
+  }
+}

--- a/scripts/runtime-externals.mjs
+++ b/scripts/runtime-externals.mjs
@@ -7,6 +7,11 @@ import { tokenizer } from "acorn";
 // into the packaged app's node_modules tree.
 const HOST_PROVIDED_PACKAGES = new Set(["electron"]);
 
+// Optional feature probes that are guarded by their caller. These must not
+// force a production dependency into the clean packaging stage merely because
+// a bundled dependency retains its literal `require()` inside a try/catch.
+const OPTIONAL_RUNTIME_PACKAGES = new Set(["supports-color"]);
+
 function packageNameFor(id) {
   const parts = id.split("/");
   return id.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
@@ -99,7 +104,12 @@ export function scanRuntimeExternals(repoRoot) {
     for (const id of scanModuleIds(readFileSync(path, "utf8"))) {
       if (id.startsWith(".") || id.startsWith("/") || isBuiltin(id)) continue;
       const packageName = packageNameFor(id);
-      if (!packageName || isBuiltin(packageName) || HOST_PROVIDED_PACKAGES.has(packageName)) {
+      if (
+        !packageName ||
+        isBuiltin(packageName) ||
+        HOST_PROVIDED_PACKAGES.has(packageName) ||
+        OPTIONAL_RUNTIME_PACKAGES.has(packageName)
+      ) {
         continue;
       }
       externals.add(packageName);

--- a/src/renderer/actions/worktreeActions.ts
+++ b/src/renderer/actions/worktreeActions.ts
@@ -14,6 +14,7 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads, runShellScriptToCompletion } from "@/renderer/utils/shellUtils";
+import { cancelQueuedWorktreeSetup } from "./worktreeLaunchActions";
 
 export async function performWorktreeRemoval(
   project: Project,
@@ -88,6 +89,8 @@ export async function prepareWorktreeRemoval(
   project: Project,
   worktreePath: string,
 ): Promise<void> {
+  cancelQueuedWorktreeSetup(project, worktreePath);
+
   const cleanupScript = project.scripts?.cleanupScript;
   if (cleanupScript) {
     const wtLocation = buildWorktreeLocation(project.location, worktreePath);

--- a/src/renderer/actions/worktreeLaunchActions.test.ts
+++ b/src/renderer/actions/worktreeLaunchActions.test.ts
@@ -57,4 +57,25 @@ describe("runWorktreeSetupScript", () => {
     useDevTerminalStore.getState().removeTab(tab!.id);
     await setup;
   });
+
+  it("starts only one setup shell at a time", async () => {
+    const first = runWorktreeSetupScript(project, "C:\\first", "pnpm install", {
+      openTerminalPanel: false,
+    });
+    const second = runWorktreeSetupScript(project, "C:\\second", "pnpm install", {
+      openTerminalPanel: false,
+    });
+
+    await vi.waitFor(() => expect(bridge.startShell).toHaveBeenCalledOnce());
+    const [firstTab] = useDevTerminalStore.getState().tabs;
+    expect(firstTab?.worktreePath).toBe("C:\\first");
+
+    useDevTerminalStore.getState().removeTab(firstTab!.id);
+    await vi.waitFor(() => expect(bridge.startShell).toHaveBeenCalledTimes(2));
+    const [secondTab] = useDevTerminalStore.getState().tabs;
+    expect(secondTab?.worktreePath).toBe("C:\\second");
+
+    useDevTerminalStore.getState().removeTab(secondTab!.id);
+    await Promise.all([first, second]);
+  });
 });

--- a/src/renderer/actions/worktreeLaunchActions.ts
+++ b/src/renderer/actions/worktreeLaunchActions.ts
@@ -11,6 +11,7 @@ import {
   startShellWithToast,
   writeScriptToShellThenExitOnSuccess,
 } from "@/renderer/utils/shellUtils";
+import { cancelPendingWorktreeSetup, enqueueWorktreeSetup } from "./worktreeSetupQueue";
 
 export async function primeWorktreeGitState(project: Project, worktreePath: string): Promise<void> {
   const worktreePaths = [
@@ -37,6 +38,28 @@ export function runWorktreeSetupScript(
   // entirely rather than leaving an idle "setup" shell behind.
   if (!normalizeShellScript(setupScript)) return Promise.resolve();
 
+  return enqueueWorktreeSetup(worktreeSetupKey(project, worktreePath), () =>
+    startWorktreeSetupScript(project, worktreePath, setupScript, options),
+  );
+}
+
+export function cancelQueuedWorktreeSetup(project: Project, worktreePath: string): void {
+  cancelPendingWorktreeSetup(worktreeSetupKey(project, worktreePath));
+}
+
+function worktreeSetupKey(project: Project, worktreePath: string): string {
+  const normalizedPath = worktreePath.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  const comparablePath =
+    project.location.kind === "windows" ? normalizedPath.toLowerCase() : normalizedPath;
+  return `${project.id}:${comparablePath}`;
+}
+
+function startWorktreeSetupScript(
+  project: Project,
+  worktreePath: string,
+  setupScript: string,
+  options: { openTerminalPanel?: boolean },
+): Promise<void> {
   const wtLocation = buildWorktreeLocation(project.location, worktreePath);
   const store = useDevTerminalStore.getState();
   const tab = store.addTab(project.id, "setup", worktreePath);
@@ -63,10 +86,16 @@ export function runWorktreeSetupScript(
       finished = true;
       resolve();
     };
-    const detach = writeScriptToShellThenExitOnSuccess(tab.id, setupScript, wtLocation.kind, () => {
-      finish();
-      removeWorktreeSetupTab(tab);
-    });
+    const detach = writeScriptToShellThenExitOnSuccess(
+      tab.id,
+      setupScript,
+      wtLocation.kind,
+      () => {
+        finish();
+        removeWorktreeSetupTab(tab);
+      },
+      finish,
+    );
     const unsubscribeTabs = useDevTerminalStore.subscribe((state, prev) => {
       if (state.tabs === prev.tabs) return;
       if (state.tabs.some((item) => item.id === tab.id)) return;

--- a/src/renderer/actions/worktreeSetupQueue.test.ts
+++ b/src/renderer/actions/worktreeSetupQueue.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { WorktreeSetupQueue } from "./worktreeSetupQueue";
+
+describe("WorktreeSetupQueue", () => {
+  it("runs setup jobs serially", async () => {
+    const queue = new WorktreeSetupQueue();
+    const started: string[] = [];
+    let finishFirst!: () => void;
+    const first = queue.enqueue(
+      "first",
+      () =>
+        new Promise<void>((resolve) => {
+          started.push("first");
+          finishFirst = resolve;
+        }),
+    );
+    const second = queue.enqueue("second", async () => {
+      started.push("second");
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(["first"]));
+    finishFirst();
+    await Promise.all([first, second]);
+
+    expect(started).toEqual(["first", "second"]);
+  });
+
+  it("cancels queued work for a removed worktree", async () => {
+    const queue = new WorktreeSetupQueue();
+    let finishActive!: () => void;
+    const active = queue.enqueue(
+      "active",
+      () =>
+        new Promise<void>((resolve) => {
+          finishActive = resolve;
+        }),
+    );
+    const canceledRun = vi.fn<() => Promise<void>>(async () => undefined);
+    const canceled = queue.enqueue("removed", canceledRun);
+
+    await vi.waitFor(() => expect(finishActive).toBeTypeOf("function"));
+    queue.cancelPending("removed");
+    await canceled;
+    expect(canceledRun).not.toHaveBeenCalled();
+
+    finishActive();
+    await active;
+  });
+
+  it("continues after an unexpected setup error", async () => {
+    const queue = new WorktreeSetupQueue();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const nextRun = vi.fn<() => Promise<void>>(async () => undefined);
+
+    await Promise.all([
+      queue.enqueue("failed", async () => {
+        throw new Error("failed");
+      }),
+      queue.enqueue("next", nextRun),
+    ]);
+
+    expect(nextRun).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("[renderer] worktree setup failed:", "failed");
+    warn.mockRestore();
+  });
+});

--- a/src/renderer/actions/worktreeSetupQueue.ts
+++ b/src/renderer/actions/worktreeSetupQueue.ts
@@ -1,0 +1,65 @@
+interface WorktreeSetupJob {
+  key: string;
+  run: () => Promise<void>;
+  resolve: () => void;
+}
+
+/**
+ * Runs resource-heavy worktree setup scripts one at a time. Package managers
+ * already parallelize internally; running several installs together mostly
+ * multiplies CPU, filesystem metadata churn, and native rebuild contention.
+ */
+export class WorktreeSetupQueue {
+  private active = false;
+  private pending: WorktreeSetupJob[] = [];
+
+  enqueue(key: string, run: () => Promise<void>): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.pending.push({ key, run, resolve });
+      this.drain();
+    });
+  }
+
+  cancelPending(key: string): void {
+    const kept: WorktreeSetupJob[] = [];
+    for (const job of this.pending) {
+      if (job.key === key) {
+        job.resolve();
+      } else {
+        kept.push(job);
+      }
+    }
+    this.pending = kept;
+  }
+
+  private drain(): void {
+    if (this.active) return;
+    const job = this.pending.shift();
+    if (!job) return;
+
+    this.active = true;
+    void Promise.resolve()
+      .then(job.run)
+      .catch((error) => {
+        console.warn(
+          "[renderer] worktree setup failed:",
+          error instanceof Error ? error.message : error,
+        );
+      })
+      .finally(() => {
+        this.active = false;
+        job.resolve();
+        this.drain();
+      });
+  }
+}
+
+const worktreeSetupQueue = new WorktreeSetupQueue();
+
+export function enqueueWorktreeSetup(key: string, run: () => Promise<void>): Promise<void> {
+  return worktreeSetupQueue.enqueue(key, run);
+}
+
+export function cancelPendingWorktreeSetup(key: string): void {
+  worktreeSetupQueue.cancelPending(key);
+}

--- a/src/renderer/utils/shellUtils.test.ts
+++ b/src/renderer/utils/shellUtils.test.ts
@@ -242,6 +242,53 @@ describe("writeScriptToShellThenExitOnSuccess", () => {
     expect(supervisorHandlers).toHaveLength(0);
   });
 
+  it("reports a failed command without closing its shell", () => {
+    const onExit = vi.fn<(exitCode: number | null) => void>();
+    const onCommandComplete = vi.fn<(exitCode: number) => void>();
+    writeScriptToShellThenExitOnSuccess(
+      "shell:1",
+      "npm install\nnpm run setup",
+      "posix",
+      onExit,
+      onCommandComplete,
+    );
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "$ ", outputLength: 2 });
+    const token = /poracode-shell-complete=([^:]+):/u.exec(lastWrite())?.[1];
+    expect(token).toBeTruthy();
+    expect(lastWrite()).toContain('if [ "$__poracode_setup_exit" -eq 0 ]; then exit; fi');
+
+    const marker = `\u001B]777;poracode-shell-complete=${token}:1\u0007`;
+    emit({ type: "thread-output", threadId: "shell:1", data: marker, outputLength: marker.length });
+
+    expect(onCommandComplete).toHaveBeenCalledWith(1);
+    expect(onExit).not.toHaveBeenCalled();
+    expect(supervisorHandlers).toHaveLength(1);
+  });
+
+  it("reports command completion only once when a successful shell exits", () => {
+    const onExit = vi.fn<(exitCode: number | null) => void>();
+    const onCommandComplete = vi.fn<(exitCode: number) => void>();
+    writeScriptToShellThenExitOnSuccess(
+      "shell:1",
+      "npm install",
+      "windows",
+      onExit,
+      onCommandComplete,
+    );
+
+    emit({ type: "thread-output", threadId: "shell:1", data: "PS> ", outputLength: 4 });
+    const token = /poracode-shell-complete=([^:]+):/u.exec(lastWrite())?.[1];
+    const marker = `\u001B]777;poracode-shell-complete=${token}:0\u0007`;
+    emit({ type: "thread-output", threadId: "shell:1", data: marker, outputLength: marker.length });
+    emit({ type: "thread-exited", threadId: "shell:1", exitCode: 0 });
+
+    expect(onCommandComplete).toHaveBeenCalledTimes(1);
+    expect(onCommandComplete).toHaveBeenCalledWith(0);
+    expect(onExit).toHaveBeenCalledWith(0);
+    expect(supervisorHandlers).toHaveLength(0);
+  });
+
   it("ignores events for other shells", () => {
     const onExit = vi.fn<(exitCode: number | null) => void>();
     writeScriptToShellThenExitOnSuccess("shell:1", "echo hi", "posix", onExit);

--- a/src/renderer/utils/shellUtils.ts
+++ b/src/renderer/utils/shellUtils.ts
@@ -51,6 +51,47 @@ function buildPowerShellExitOnSuccess(lines: string[]): string {
   return lines.reduceRight((tail, line) => `${line}; if ($?) { ${tail} }`, "exit");
 }
 
+function createShellCompletionToken(): string {
+  return `pc_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
+}
+
+function shellCompletionMarker(token: string): string {
+  return `\u001B]777;poracode-shell-complete=${token}:`;
+}
+
+function buildScriptWithCompletion(
+  script: string,
+  locationKind: ProjectLocation["kind"],
+  token: string,
+): string {
+  const lines = normalizeShellScriptLines(script);
+  if (lines.length === 0) return "";
+
+  if (locationKind === "windows") {
+    const succeeded = "$poracodeSetupSucceeded";
+    const exitCode = "$poracodeSetupExitCode";
+    const guarded = lines.reduceRight(
+      (tail, line) => `${line}; if ($?) { ${tail} }`,
+      `${succeeded} = $true`,
+    );
+    return [
+      `${succeeded} = $false`,
+      guarded,
+      `${exitCode} = if (${succeeded}) { 0 } elseif ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }`,
+      `Write-Host "$([char]27)]777;poracode-shell-complete=${token}:${exitCode}$([char]7)" -NoNewline`,
+      `if (${succeeded}) { exit }`,
+    ].join("; ");
+  }
+
+  const exitCode = "__poracode_setup_exit";
+  return [
+    lines.join(" && "),
+    `${exitCode}=$?`,
+    `printf '\\033]777;poracode-shell-complete=${token}:%s\\007' "$${exitCode}"`,
+    `if [ "$${exitCode}" -eq 0 ]; then exit; fi`,
+  ].join("; ");
+}
+
 export function buildScriptWithExitOnSuccess(
   script: string,
   locationKind: ProjectLocation["kind"],
@@ -120,27 +161,42 @@ export function appendExitOnSuccess(
  * surviving PTY when the shell respawns (e.g. a panel-driven, viewport-sized
  * respawn).
  *
- * `onExit` fires once the shell's PTY exits — success, or a manual `exit` — and
- * the listener detaches itself first. Returns a detach fn so callers can stop
- * listening if the shell is torn down before it finishes (a manual close kills
- * the PTY with `ignoreExit`, suppressing `thread-exited`), avoiding a dangling
- * subscription. Unlike {@link runShellScriptToCompletion} this keeps the shell
- * visible and never times out, so long installs are not cut short.
+ * `onExit` fires once the shell's PTY exits — success, or a manual `exit`.
+ * `onCommandComplete` additionally fires when the script finishes, including
+ * failures that deliberately leave the shell open for inspection. Returns a
+ * detach fn so callers can stop listening if the shell is torn down before it
+ * finishes (a manual close kills the PTY with `ignoreExit`, suppressing
+ * `thread-exited`), avoiding a dangling subscription. Unlike
+ * {@link runShellScriptToCompletion} this keeps the shell visible and never
+ * times out, so long installs are not cut short.
  */
 export function writeScriptToShellThenExitOnSuccess(
   shellId: string,
   script: string,
   locationKind: ProjectLocation["kind"],
   onExit: (exitCode: number | null) => void,
+  onCommandComplete?: (exitCode: number) => void,
 ): () => void {
   const command = normalizeShellScript(script);
   // Nothing meaningful to run — leave the (caller-guarded) shell untouched.
   if (!command) return () => undefined;
-  const data = `${buildScriptWithExitOnSuccess(script, locationKind)}\r`;
+  const completionToken = onCommandComplete ? createShellCompletionToken() : undefined;
+  const data = `${
+    completionToken
+      ? buildScriptWithCompletion(script, locationKind, completionToken)
+      : buildScriptWithExitOnSuccess(script, locationKind)
+  }\r`;
 
   let armed = true;
   let detached = false;
+  let commandCompleted = false;
+  let outputBuffer = "";
   let unsubscribe: () => void = () => undefined;
+  const reportCommandComplete = (exitCode: number) => {
+    if (commandCompleted) return;
+    commandCompleted = true;
+    onCommandComplete?.(exitCode);
+  };
   const detach = () => {
     if (detached) return;
     detached = true;
@@ -152,6 +208,7 @@ export function writeScriptToShellThenExitOnSuccess(
       // A fresh PTY spawned; re-send on its first output so the command runs
       // in the survivor rather than a PTY that is about to be replaced.
       armed = true;
+      outputBuffer = "";
       return;
     }
     if (event.type === "thread-output" && armed) {
@@ -163,10 +220,21 @@ export function writeScriptToShellThenExitOnSuccess(
             `[shellUtils] Unable to write command to shell ${shellId}:`,
             error instanceof Error ? error.message : error,
           );
+          reportCommandComplete(-1);
         });
       return;
     }
+    if (event.type === "thread-output" && completionToken) {
+      outputBuffer = `${outputBuffer}${event.data}`.slice(-1024);
+      const marker = shellCompletionMarker(completionToken);
+      const markerStart = outputBuffer.indexOf(marker);
+      if (markerStart < 0) return;
+      const match = /^(\d+)/u.exec(outputBuffer.slice(markerStart + marker.length));
+      if (match) reportCommandComplete(Number(match[1]));
+      return;
+    }
     if (event.type === "thread-exited") {
+      reportCommandComplete(event.exitCode ?? -1);
       detach();
       onExit(event.exitCode);
     }

--- a/src/shared/runtimeExternals.test.ts
+++ b/src/shared/runtimeExternals.test.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { scanModuleIds } from "../../scripts/runtime-externals.mjs";
+import { scanModuleIds, scanRuntimeExternals } from "../../scripts/runtime-externals.mjs";
 
 describe("scanModuleIds", () => {
   it("finds CommonJS, dynamic, static, and minified-template module specifiers", () => {
@@ -34,5 +37,21 @@ describe("scanModuleIds", () => {
     `;
 
     expect(scanModuleIds(code)).toEqual([]);
+  });
+
+  it("does not stage debug's optional supports-color feature probe", () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), "poracode-runtime-externals-"));
+    try {
+      const outputDir = join(repoRoot, "dist", "main");
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(
+        join(outputDir, "main.cjs"),
+        'try { require("supports-color"); } catch {} require("required-runtime");',
+      );
+
+      expect(scanRuntimeExternals(repoRoot)).toEqual(["required-runtime"]);
+    } finally {
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/supervisor/git/copyIgnoredFiles.test.ts
+++ b/src/supervisor/git/copyIgnoredFiles.test.ts
@@ -62,13 +62,15 @@ describe("copyIgnoredFilesIntoWorktree", () => {
     worktreeDir = await mkdtemp(join(tmpdir(), "poracode-copy-dest-"));
 
     await execFileAsync("git", ["init"], { cwd: repoDir });
-    await writeFile(join(repoDir, ".gitignore"), ".env*\nsecrets/\n");
+    await writeFile(join(repoDir, ".gitignore"), ".env*\nsecrets/\nnode_modules/\n");
     await writeFile(join(repoDir, ".env"), "ROOT=1\n");
     await writeFile(join(repoDir, ".env.local"), "LOCAL=1\n");
     await mkdir(join(repoDir, "packages", "app"), { recursive: true });
     await writeFile(join(repoDir, "packages", "app", ".env"), "NESTED=1\n");
     await mkdir(join(repoDir, "secrets"), { recursive: true });
     await writeFile(join(repoDir, "secrets", "key.pem"), "KEY\n");
+    await mkdir(join(repoDir, "node_modules", "example"), { recursive: true });
+    await writeFile(join(repoDir, "node_modules", "example", "index.js"), "module.exports = 1;\n");
     await writeFile(join(repoDir, "tracked.ts"), "export {};\n");
   });
 
@@ -111,5 +113,11 @@ describe("copyIgnoredFilesIntoWorktree", () => {
     await copyIgnoredFilesIntoWorktree(location(), worktreeDir, []);
 
     await expect(stat(join(worktreeDir, ".env"))).rejects.toThrow(/ENOENT/);
+  });
+
+  it("never copies dependency installations", async () => {
+    await copyIgnoredFilesIntoWorktree(location(), worktreeDir, ["node_modules"]);
+
+    await expect(stat(join(worktreeDir, "node_modules"))).rejects.toThrow(/ENOENT/);
   });
 });

--- a/src/supervisor/git/copyIgnoredFiles.ts
+++ b/src/supervisor/git/copyIgnoredFiles.ts
@@ -48,12 +48,19 @@ export async function copyIgnoredFilesIntoWorktree(
   ]);
   const entries = raw.split("\0").filter(Boolean);
   const matched = matchIgnoredCopyEntries(entries, patterns);
+  const safeMatches = matched.filter((entry) => {
+    const segments = entry.replace(/\\/gu, "/").replace(/\/+$/u, "").split("/");
+    return !segments.includes("node_modules");
+  });
+  if (safeMatches.length !== matched.length) {
+    console.warn("[supervisor] skipped copying node_modules into a worktree");
+  }
 
   const sourceRoot = getProjectFsPath(location);
   const destRoot = getProjectFsPath(buildWorktreeLocation(location, worktreePath));
 
   await Promise.all(
-    matched.map(async (entry) => {
+    safeMatches.map(async (entry) => {
       const relative = entry.replace(/\/+$/, "");
       const source = join(sourceRoot, relative);
       const dest = join(destRoot, relative);

--- a/src/supervisor/projectWatcher.test.ts
+++ b/src/supervisor/projectWatcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ProjectWatcher } from "./projectWatcher";
+import { isIgnoredWorkTreeFile, ProjectWatcher } from "./projectWatcher";
 import type { WslBridgeClient, WslLocation } from "./wsl/bridge/client";
 
 function makeLocation(linuxPath: string): WslLocation {
@@ -54,6 +54,20 @@ function createWatchHarness(subscriptionIdForCall: (callNumber: number) => strin
     watch,
   };
 }
+
+describe("isIgnoredWorkTreeFile", () => {
+  it("ignores project-relative managed worktrees and their dependency churn", () => {
+    expect(isIgnoredWorkTreeFile(".poracode/worktrees/feature/node_modules/react/index.js")).toBe(
+      true,
+    );
+    expect(isIgnoredWorkTreeFile(".poracode/worktrees/feature/src/app.ts")).toBe(true);
+  });
+
+  it("does not hide unrelated project files", () => {
+    expect(isIgnoredWorkTreeFile(".poracode/settings.json")).toBe(false);
+    expect(isIgnoredWorkTreeFile("src/worktrees/create.ts")).toBe(false);
+  });
+});
 
 describe("ProjectWatcher WSL worktrees", () => {
   afterEach(() => {
@@ -132,6 +146,37 @@ describe("ProjectWatcher WSL worktrees", () => {
 
     await vi.advanceTimersByTimeAsync(300);
     expect(onTreeChanged).toHaveBeenCalledWith("project-1");
+    await watcher.dispose();
+  });
+
+  it("ignores project-relative managed worktree churn", async () => {
+    vi.useFakeTimers();
+    const { watch, waitForSubscription } = createWatchHarness();
+    const client = {
+      readFile: vi.fn<WslBridgeClient["readFile"]>(async () => {
+        throw new Error("missing");
+      }),
+      stat: vi.fn<WslBridgeClient["stat"]>(async () => ({ stats: [] })),
+      watch,
+    } as unknown as WslBridgeClient;
+    const onTreeChanged = vi.fn<(projectId: string) => void>();
+    const watcher = new ProjectWatcher({
+      onGitChanged: vi.fn<(projectId: string) => void>(),
+      onTreeChanged,
+    });
+    watcher.setWslClient(client);
+    watcher.watch("project-1", makeLocation("/home/demo/work/repo"));
+
+    await waitForSubscription(1);
+    const onEvent = watch.mock.calls[0]![2];
+    onEvent({
+      subscriptionId: "sub",
+      scope: "worktree",
+      paths: [".poracode/worktrees/feature/node_modules/react/index.js"],
+    });
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onTreeChanged).not.toHaveBeenCalled();
     await watcher.dispose();
   });
 

--- a/src/supervisor/projectWatcher.ts
+++ b/src/supervisor/projectWatcher.ts
@@ -40,6 +40,7 @@ interface WorktreeWatcherEntry {
 
 const IGNORED_PREFIXES = [
   "node_modules/",
+  ".poracode/worktrees/",
   ".next/",
   "dist/",
   "build/",
@@ -48,7 +49,7 @@ const IGNORED_PREFIXES = [
   ".venv/",
 ];
 
-function isIgnoredWorkTreeFile(name: string): boolean {
+export function isIgnoredWorkTreeFile(name: string): boolean {
   if (name === ".git" || name.startsWith(".git/")) return true;
   return IGNORED_PREFIXES.some((p) => name.startsWith(p));
 }
@@ -500,7 +501,9 @@ export class ProjectWatcher {
             // worktree path is the parent of `.git`. Those are already covered
             // by the dedicated git-scope subscription with noise filtering, so
             // drop them here to avoid a refresh→lock-write→refresh loop.
-            const treePaths = event.paths.filter((p) => p !== ".git" && !p.startsWith(".git/"));
+            const treePaths = event.paths.filter(
+              (p) => p !== ".git" && !p.startsWith(".git/") && !isIgnoredWorkTreeFile(p),
+            );
             if (treePaths.length === 0) return;
             schedule.onTree();
             return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "preserveSymlinks": true,
     "jsx": "react-jsx",
     "allowJs": false,
     "resolveJsonModule": true,

--- a/website/.pnpmfile.mjs
+++ b/website/.pnpmfile.mjs
@@ -1,0 +1,4 @@
+// Root workspace scripts pass pnpm's ESM resolver bridge to nested website
+// commands. An explicit pnpmfile keeps pnpm 11's optional-file probe from
+// becoming a hard error under that inherited loader.
+export const hooks = {};

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   postcss@<8.5.12: 8.5.12
   sharp@<0.35.3: 0.35.3
 
+pnpmfileChecksum: sha256-cMVwtnrRwJb4xi1TroJLPLe/pzOePOx3qxj8TTiMh8c=
+
 importers:
 
   .:


### PR DESCRIPTION
- **Bugfix:** serialize worktree setup scripts and cancel pending setup when a worktree is removed, preventing concurrent install contention.
- Detect setup command failures without prematurely closing their terminal sessions.
- Keep dependency installs isolated per worktree by excluding `node_modules` from copied ignored files and watcher refreshes.
- Preserve reliable desktop packaging with flat staged runtime dependencies and optional-runtime dependency filtering.