### PR TITLE
Categorize MCP tool calls separately in chat groups

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -589,6 +589,38 @@ describe("ToolCallGroup", () => {
     expect(screen.getByText("Tool search · deploy")).toBeInTheDocument();
   });
 
+  it("summarizes MCP calls separately from generic tools", () => {
+    const threadId = "thread-1";
+    const items = [
+      makeSemanticToolItem("mcp-1", "mcp_tool_call", {
+        name: "wait_for_agent",
+        serverId: "crossagents",
+        status: "success",
+      }),
+      makeSemanticToolItem("mcp-2", "mcp_tool_call", {
+        name: "wait_for_agent",
+        serverId: "crossagents",
+        status: "success",
+      }),
+      makeSemanticToolItem("mcp-3", "mcp_tool_call", {
+        name: "wait_for_agent",
+        serverId: "crossagents",
+        status: "success",
+      }),
+      makeReasoningItem("reasoning-1", "Testing website build and pnpm config"),
+    ];
+    seedThread(threadId, items);
+
+    renderToolCallGroup(
+      threadId,
+      items.map((item) => item.id),
+    );
+
+    expect(screen.getByText("3 MCPs")).toBeInTheDocument();
+    expect(screen.getByText("1 thought")).toBeInTheDocument();
+    expect(screen.queryByText("3 tools")).not.toBeInTheDocument();
+  });
+
   it("keeps web searches visible when Codex omits the query", () => {
     const threadId = "thread-1";
     const item = makeWebSearchItem("web-search-1", {

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -180,7 +180,12 @@ export const ToolCallGroup = memo(function ToolCallGroup({
                       <span className="flex shrink-0 items-center gap-1">
                         <section.Icon className="size-3" />
                         <code className="font-mono tabular-nums !text-[color:var(--muted)]">
-                          {section.count} {section.label}
+                          {section.count}{" "}
+                          {section.category === "mcp" ? (
+                            <Plural value={section.count} one="MCP" other="MCPs" />
+                          ) : (
+                            section.label
+                          )}
                         </code>
                         {diffLabel ? (
                           <span className="shrink-0 tabular-nums font-medium">{diffLabel}</span>

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.test.ts
@@ -24,6 +24,17 @@ describe("categorizeItem", () => {
     // Thoughts are group members like any other tool row.
     expect(isToolGroupItem(item)).toBe(true);
   });
+
+  it("maps MCP tool calls to their own category", () => {
+    const encodedName = makeTool("mcp-encoded", "mcp__crossagents__wait_for_agent");
+    const explicitServer = {
+      ...makeTool("mcp-server", "wait_for_agent"),
+      payload: { name: "wait_for_agent", serverId: "crossagents", status: "success" },
+    } as RuntimeChatItem;
+
+    expect(categorizeItem(encodedName)).toBe("mcp");
+    expect(categorizeItem(explicitServer)).toBe("mcp");
+  });
 });
 
 describe("segmentToolGroupRows", () => {
@@ -140,6 +151,8 @@ describe("categoryFromSummaryLabel", () => {
     expect(categoryFromSummaryLabel("edits")).toBe("edited");
     expect(categoryFromSummaryLabel("command")).toBe("executed");
     expect(categoryFromSummaryLabel("commands")).toBe("executed");
+    expect(categoryFromSummaryLabel("MCP")).toBe("mcp");
+    expect(categoryFromSummaryLabel("MCPs")).toBe("mcp");
     expect(categoryFromSummaryLabel("tool")).toBe("other");
     expect(categoryFromSummaryLabel("tools")).toBe("other");
   });

--- a/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolCallCategorization.ts
@@ -1,4 +1,13 @@
-import { Brain, Eye, Pencil, SearchCode, Terminal, Wrench, type LucideIcon } from "lucide-react";
+import {
+  Brain,
+  Eye,
+  Pencil,
+  Plug,
+  SearchCode,
+  Terminal,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
 import type {
   CommandExecutionPayload,
   FileChangePayload,
@@ -8,13 +17,21 @@ import {
   getRuntimeItemPayload,
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
+import { parseMcpName } from "@/shared/toolCallClassification";
 import { extractAcpDiffSummary, readAcpStringField } from "./acpToolPayload";
 import { commandIntentDisplay } from "./commandSummary";
 import { isContextCompactionToolCall } from "./ContextCompaction";
 import { isPlanProposalToolCall } from "./PlanProposal";
 import { deriveToolDisplay, isDelegatedAgentTool } from "./toolDisplay";
 
-export type GroupCategory = "thought" | "viewed" | "searched" | "edited" | "executed" | "other";
+export type GroupCategory =
+  | "thought"
+  | "viewed"
+  | "searched"
+  | "edited"
+  | "executed"
+  | "mcp"
+  | "other";
 
 export interface CategoryMeta {
   Icon: LucideIcon;
@@ -25,12 +42,13 @@ export interface CategoryMeta {
 }
 
 export const CATEGORY_META: Record<GroupCategory, CategoryMeta> = {
-  thought: { Icon: Brain, singular: "thought", plural: "thoughts", priority: 5 },
+  thought: { Icon: Brain, singular: "thought", plural: "thoughts", priority: 6 },
   viewed: { Icon: Eye, singular: "view", plural: "views", priority: 0 },
   searched: { Icon: SearchCode, singular: "search", plural: "searches", priority: 1 },
   edited: { Icon: Pencil, singular: "edit", plural: "edits", priority: 2 },
   executed: { Icon: Terminal, singular: "command", plural: "commands", priority: 3 },
-  other: { Icon: Wrench, singular: "tool", plural: "tools", priority: 4 },
+  mcp: { Icon: Plug, singular: "MCP", plural: "MCPs", priority: 4 },
+  other: { Icon: Wrench, singular: "tool", plural: "tools", priority: 5 },
 };
 
 export interface GroupSection {
@@ -313,6 +331,7 @@ export function categorizeItem(item: RuntimeChatItem): GroupCategory {
   const payload = getToolLikePayload(item);
   if (!payload) return "other";
   if (isDelegatedAgentTool(payload)) return "executed";
+  if (parseMcpName(payload)) return "mcp";
 
   switch (payload.kind) {
     case "read":
@@ -443,7 +462,7 @@ export function categoryFromSummaryLabel(label: string): GroupCategory | null {
   for (const [category, labels] of Object.entries(SUMMARY_CATEGORY_LABELS) as Array<
     [GroupCategory, readonly string[]]
   >) {
-    if (labels.includes(normalized)) return category;
+    if (labels.some((candidate) => candidate.toLowerCase() === normalized)) return category;
   }
   return null;
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# Tool} other {# Tools}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Kandidat (#)} other {Kandidaten (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCPs}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Angepinnt"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# tool} other {# tools}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCPs}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Pinned"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# herramienta} other {# herramientas}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Candidato (#)} other {Candidatos (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Fijado"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# outil} other {# outils}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Candidat (#)} other {Candidats (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7225,6 +7230,7 @@ msgid "Pinned"
 msgstr "Épinglé"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# 個のツール} other {# 個のツール}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {候補（# 件）} other {候補（# 件）}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7224,6 +7229,7 @@ msgid "Pinned"
 msgstr "固定された"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {도구 #개} other {도구 #개}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {후보(#개)} other {후보(#개)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "고정됨"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# narzędzie} few {# narzędzia} many {# narzędzi} oth
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Kandydat (#)} few {Kandydaci (#)} many {Kandydaci (#)} other {Kandydaci (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} few {MCP} many {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Przypięty"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# ferramenta} other {# ferramentas}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Candidato (#)} other {Candidatos (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCPs}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Fixado"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# инструмент} few {# инструмента} 
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Кандидат (#)} few {Кандидаты (#)} many {Кандидаты (#)} other {Кандидаты (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} few {MCP} many {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Закреплено"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# araç} other {# araç}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Aday (#)} other {Adaylar (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Sabitlendi"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# інструмент} few {# інструменти} 
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Кандидат (#)} few {Кандидати (#)} many {Кандидати (#)} other {Кандидати (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} few {MCP} many {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Закріплено"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# công cụ} other {# công cụ}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {Ứng viên (#)} other {Ứng viên (#)}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7226,6 +7231,7 @@ msgid "Pinned"
 msgstr "Đã ghim"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -99,6 +99,11 @@ msgstr "{0, plural, one {# 个工具} other {# 个工具}}"
 #~ msgid "{0, plural, one {Candidate (#)} other {Candidates (#)}}"
 #~ msgstr "{0, plural, one {候选项（# 个）} other {候选项（# 个）}}"
 
+#. placeholder {0}: section.count
+#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+msgid "{0, plural, one {MCP} other {MCPs}}"
+msgstr "{0, plural, one {MCP} other {MCP}}"
+
 #. placeholder {0}: details.patterns.length
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/parts/PermissionDetailsLine.tsx
 msgid "{0, plural, one {target} other {targets}}"
@@ -7225,6 +7230,7 @@ msgid "Pinned"
 msgstr "已固定"
 
 #: src/mobile/ComposerInfoChips.tsx
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Plan"


### PR DESCRIPTION
- **Bugfix:** group MCP tool calls independently from generic tools so chat summaries accurately reflect their type.
- Display localized singular and plural MCP labels across all supported renderer locales.
- Add categorization and UI coverage for explicit and encoded MCP tool calls.