### PR TITLE
fix(git): harden GitHub polling and checkpoints

### DIFF
--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -2577,8 +2577,8 @@ describe("GitService worktree metadata", () => {
         }
         return { stdout: "main\n" };
       }
-      if (args[0] === "show-ref") {
-        return { stdout: "abc123 refs/heads/poracode/brave-heron\n" };
+      if (args[0] === "rev-parse" && args.includes("refs/heads/poracode/brave-heron")) {
+        return { stdout: `${"a".repeat(40)}\n` };
       }
       if (args[0] === "reflog") {
         return { stdout: "poracode experiment owner experiment-1:candidate-1\n" };

--- a/src/supervisor/git/checkpointService.argv.test.ts
+++ b/src/supervisor/git/checkpointService.argv.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { buildCheckpointCommitInput } from "./checkpointService";
+
+describe("buildCheckpointCommitInput", () => {
+  it("sends large checkpoint metadata over stdin instead of argv", () => {
+    const metadata = {
+      threadId: "thread-1",
+      checkpointItemId: "assistant-1",
+      changedFiles: Array.from({ length: 5_000 }, (_, index) => ({
+        path: `generated/${index.toString().padStart(5, "0")}-${"x".repeat(80)}.txt`,
+        status: "modified",
+      })),
+    };
+
+    const invocation = buildCheckpointCommitInput("tree", "parent", metadata);
+
+    expect(invocation.args).toEqual(["commit-tree", "tree", "-p", "parent", "-F", "-"]);
+    expect(invocation.args.join(" ").length).toBeLessThan(100);
+    expect(invocation.input.length).toBeGreaterThan(500_000);
+    expect(invocation.input).toContain('"changedFiles"');
+  });
+});

--- a/src/supervisor/git/checkpointService.ts
+++ b/src/supervisor/git/checkpointService.ts
@@ -16,6 +16,17 @@ const LEGACY_REF_ROOT = "refs/lightcode/checkpoints";
 
 type CheckpointMetadata = FileCheckpointRecord | FileCheckpointTurn;
 
+export function buildCheckpointCommitInput(
+  tree: string,
+  head: string | null,
+  metadata: unknown,
+): { args: string[]; input: string } {
+  return {
+    args: ["commit-tree", tree, ...(head ? ["-p", head] : []), "-F", "-"],
+    input: `Poracode checkpoint\n\n${JSON.stringify(metadata)}\n`,
+  };
+}
+
 export class GitCheckpointService {
   private wslClient: WslBridgeClient | undefined;
 
@@ -161,16 +172,10 @@ export class GitCheckpointService {
       await execGit(projectLocation, ["add", "-A", "--", "."], { env });
       const tree = (await execGit(projectLocation, ["write-tree"], { env })).trim();
       const head = await resolveHeadCommit(projectLocation);
-      const commitArgs = [
-        "commit-tree",
-        tree,
-        ...(head ? ["-p", head] : []),
-        "-m",
-        "Poracode checkpoint",
-        "-m",
-        JSON.stringify({ ...metadata, ref }),
-      ];
-      const commit = (await execGit(projectLocation, commitArgs, { env })).trim();
+      const commitInput = buildCheckpointCommitInput(tree, head, { ...metadata, ref });
+      const commit = (
+        await execGit(projectLocation, commitInput.args, { env, input: commitInput.input })
+      ).trim();
       await execGit(projectLocation, ["update-ref", ref, commit]);
       return {
         threadId: metadata.threadId,

--- a/src/supervisor/git/exec.input.test.ts
+++ b/src/supervisor/git/exec.input.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+import { execGit } from "./exec";
+
+const location: ProjectLocation = { kind: "posix", path: process.cwd() };
+
+describe("execGit stdin", () => {
+  it("reports an early child exit without leaking an unhandled stdin EPIPE", async () => {
+    await expect(
+      execGit(location, ["poracode-invalid-subcommand"], {
+        input: "x".repeat(1024 * 1024),
+      }),
+    ).rejects.toThrow(/git command/i);
+  });
+});

--- a/src/supervisor/git/exec.ts
+++ b/src/supervisor/git/exec.ts
@@ -20,17 +20,37 @@ function execFileWithInput(
   input: string,
 ): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    let stdinError: Error | undefined;
+    let settled = false;
+    const settle = (error: Error | null, result?: { stdout: string; stderr: string }): void => {
+      if (settled) return;
+      settled = true;
+      if (error) reject(error);
+      else resolve(result!);
+    };
     const child = execFile(command, args, options, (error, stdout, stderr) => {
       const stdoutText = typeof stdout === "string" ? stdout : stdout.toString("utf8");
       const stderrText = typeof stderr === "string" ? stderr : stderr.toString("utf8");
       if (error) {
         Object.assign(error, { stdout: stdoutText, stderr: stderrText });
-        reject(error);
+        settle(error);
         return;
       }
-      resolve({ stdout: stdoutText, stderr: stderrText });
+      settle(stdinError ?? null, { stdout: stdoutText, stderr: stderrText });
     });
-    child.stdin?.end(input);
+    if (!child.stdin) {
+      child.kill();
+      settle(new Error(`Unable to write stdin for ${command}.`));
+      return;
+    }
+    // A child may reject its argv and exit before consuming stdin. Without an
+    // error listener the resulting EPIPE becomes an uncaught supervisor error.
+    // Save it for the command callback, whose stderr remains the authoritative
+    // diagnostic when the child itself failed.
+    child.stdin.once("error", (error) => {
+      stdinError = error;
+    });
+    child.stdin.end(input);
   });
 }
 

--- a/src/supervisor/git/exec.ts
+++ b/src/supervisor/git/exec.ts
@@ -13,6 +13,27 @@ import { mkdir } from "node:fs/promises";
 
 const execFileAsync = promisify(execFile);
 
+function execFileWithInput(
+  command: string,
+  args: string[],
+  options: Parameters<typeof execFile>[2],
+  input: string,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(command, args, options, (error, stdout, stderr) => {
+      const stdoutText = typeof stdout === "string" ? stdout : stdout.toString("utf8");
+      const stderrText = typeof stderr === "string" ? stderr : stderr.toString("utf8");
+      if (error) {
+        Object.assign(error, { stdout: stdoutText, stderr: stderrText });
+        reject(error);
+        return;
+      }
+      resolve({ stdout: stdoutText, stderr: stderrText });
+    });
+    child.stdin?.end(input);
+  });
+}
+
 export const GIT_STATUS_TIMEOUT = 10_000;
 export const GIT_DIFF_TIMEOUT = 15_000;
 export const GIT_NETWORK_TIMEOUT = 30_000;
@@ -102,6 +123,7 @@ export async function execGit(
     allowNonZeroExit?: boolean;
     acceptedExitCodes?: readonly number[];
     env?: Record<string, string>;
+    input?: string;
     maxBuffer?: number;
   },
 ): Promise<string> {
@@ -121,13 +143,17 @@ export async function execGit(
     }
 
     const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0", ...(options?.env ?? {}) };
-    const { stdout } = await execFileAsync("git", withQuotePathDisabled(args), {
+    const execOptions = {
       cwd: location.path,
       env,
       timeout,
       maxBuffer,
       windowsHide: true,
-    });
+    };
+    const { stdout } =
+      options?.input !== undefined
+        ? await execFileWithInput("git", withQuotePathDisabled(args), execOptions, options.input)
+        : await execFileAsync("git", withQuotePathDisabled(args), execOptions);
     return stdout;
   } catch (error: unknown) {
     if (

--- a/src/supervisor/git/experimentService.test.ts
+++ b/src/supervisor/git/experimentService.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+
+const execGitMock = vi.hoisted(() =>
+  vi.fn<(location: ProjectLocation, args: string[], options?: unknown) => Promise<string>>(),
+);
+
+vi.mock("./exec", async () => {
+  const actual = await vi.importActual<typeof import("./exec")>("./exec");
+  return { ...actual, execGit: execGitMock };
+});
+
+import { GitExperimentService } from "./experimentService";
+import { GitStatusService } from "./statusService";
+
+const location: ProjectLocation = { kind: "posix", path: "/repo" };
+const commit = "a".repeat(40);
+
+describe("GitExperimentService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses concrete untracked files instead of collapsed directory status rows", async () => {
+    const statusService = new GitStatusService();
+    const statusSpy = vi.spyOn(statusService, "getStatusSummary").mockResolvedValue({
+      isRepo: true,
+      branch: "main",
+      tracking: "",
+      hasRemote: false,
+      remoteInfo: null,
+      ahead: 0,
+      behind: 0,
+      staged: [],
+      unstaged: [
+        {
+          path: ".venv",
+          status: "?",
+          staged: false,
+          insertions: 0,
+          deletions: 0,
+        },
+      ],
+      totalInsertions: 0,
+      totalDeletions: 0,
+    });
+    execGitMock.mockImplementation(async (_location, args) => {
+      if (args[0] === "rev-parse") return `${commit}\n`;
+      if (args[0] === "ls-files") return ".venv/bin/python\0";
+      if (args[0] === "diff" && args.includes("--no-index")) {
+        return "2\t0\t.venv/bin/python\n";
+      }
+      return "";
+    });
+
+    await expect(
+      new GitExperimentService(statusService).getCandidateStats(location, commit),
+    ).resolves.toEqual({ insertions: 2, deletions: 0, files: 1 });
+
+    expect(statusSpy).not.toHaveBeenCalled();
+    const untrackedDiffCalls = execGitMock.mock.calls.filter(([, args]) =>
+      args.includes("--no-index"),
+    );
+    expect(untrackedDiffCalls).toHaveLength(2);
+    expect(untrackedDiffCalls.every(([, args]) => args.at(-1) === ".venv/bin/python")).toBe(true);
+  });
+});

--- a/src/supervisor/git/experimentService.ts
+++ b/src/supervisor/git/experimentService.ts
@@ -8,8 +8,8 @@ import {
   type ProjectLocation,
 } from "@/shared/contracts";
 import { msg } from "@/shared/messages";
-import { execGit, GIT_DIFF_TIMEOUT } from "./exec";
-import { parseDiffNumstat } from "./statusParsing";
+import { execGit, GIT_DIFF_TIMEOUT, toForwardSlash } from "./exec";
+import { LS_FILES_UNTRACKED_ARGS, parseDiffNumstat } from "./statusParsing";
 import { GitStatusService } from "./statusService";
 
 const EXPERIMENT_GIT_READ_CONCURRENCY = 4;
@@ -145,20 +145,33 @@ export class GitExperimentService {
   }
 
   private async getUntrackedFiles(location: ProjectLocation): Promise<GitFileChange[]> {
-    const status = await this.statusService.getStatusSummary(location);
-    if (!status.isRepo) {
-      throw new Error(msg("experiment.candidate.statusFailed"));
-    }
-    const untrackedFiles = status.unstaged.filter((file) => file.status === "?");
-    if (untrackedFiles.length > MAX_EXPERIMENT_UNTRACKED_FILES) {
+    // Porcelain status may collapse an untracked directory to one row when its
+    // companion `ls-files` call fails. Passing that directory to
+    // `git diff --no-index /dev/null <path>` makes Git reinterpret `/dev/null`
+    // beneath the directory (for example `.venv/null`). Resolve actual files at
+    // this boundary instead.
+    const output = await execGit(location, LS_FILES_UNTRACKED_ARGS, {
+      timeout: GIT_DIFF_TIMEOUT,
+    });
+    const paths = output
+      .split("\0")
+      .filter((path) => path.length > 0)
+      .map(toForwardSlash);
+    if (paths.length > MAX_EXPERIMENT_UNTRACKED_FILES) {
       throw new Error(
         msg("experiment.candidate.tooManyUntracked", {
-          count: untrackedFiles.length,
+          count: paths.length,
           maximum: MAX_EXPERIMENT_UNTRACKED_FILES,
         }),
       );
     }
-    return untrackedFiles;
+    return paths.map((path) => ({
+      path,
+      status: "?",
+      staged: false,
+      insertions: 0,
+      deletions: 0,
+    }));
   }
 
   private async getHeadCommit(location: ProjectLocation): Promise<string> {

--- a/src/supervisor/git/worktreeService.test.ts
+++ b/src/supervisor/git/worktreeService.test.ts
@@ -18,7 +18,7 @@ vi.mock("./exec", async () => {
 });
 
 import { GIT_NETWORK_TIMEOUT } from "./exec";
-import { GitWorktreeService } from "./worktreeService";
+import { GitWorktreeService, isValidGitBranchName } from "./worktreeService";
 
 const location: ProjectLocation = {
   kind: "posix",
@@ -51,6 +51,51 @@ describe("GitWorktreeService pull", () => {
     });
   });
 });
+
+describe("GitWorktreeService branch validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each(["feature/valid", "poracode/candidate-1", "release/v1.2.3"])(
+    "accepts a valid branch name: %s",
+    (branch) => {
+      expect(isValidGitBranchName(branch)).toBe(true);
+    },
+  );
+
+  it.each(["", "HEAD", "-candidate", "candidate..one", "candidate.lock", "bad\u0000ref"])(
+    "rejects an invalid branch name locally: %s",
+    (branch) => {
+      expect(isValidGitBranchName(branch)).toBe(false);
+    },
+  );
+
+  it("does not invoke Git while resolving an invalid stale branch owner", async () => {
+    const service = new GitWorktreeService();
+
+    await expect(service.getWorktreeOwner(location, "candidate..invalid")).resolves.toEqual({
+      ownerToken: null,
+    });
+    expect(mocks.execGit).not.toHaveBeenCalled();
+  });
+
+  it("probes a missing valid branch without Git's fatal show-ref diagnostic", async () => {
+    mocks.execGit.mockResolvedValue("");
+
+    await expect(serviceOwner("candidate/missing")).resolves.toBeNull();
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      location,
+      ["show-ref", "--verify", "--quiet", "refs/heads/candidate/missing"],
+      { acceptedExitCodes: [1] },
+    );
+  });
+});
+
+async function serviceOwner(branch: string): Promise<string | null> {
+  const result = await new GitWorktreeService().getWorktreeOwner(location, branch);
+  return result.ownerToken;
+}
 
 describe("GitWorktreeService experiment batches", () => {
   const baseCommit = "a".repeat(40);

--- a/src/supervisor/git/worktreeService.test.ts
+++ b/src/supervisor/git/worktreeService.test.ts
@@ -64,7 +64,7 @@ describe("GitWorktreeService branch validation", () => {
     },
   );
 
-  it.each(["", "HEAD", "-candidate", "candidate..one", "candidate.lock", "bad\u0000ref"])(
+  it.each(["", "@", "HEAD", "-candidate", "candidate..one", "candidate.lock", "bad\u0000ref"])(
     "rejects an invalid branch name locally: %s",
     (branch) => {
       expect(isValidGitBranchName(branch)).toBe(false);
@@ -86,7 +86,22 @@ describe("GitWorktreeService branch validation", () => {
     await expect(serviceOwner("candidate/missing")).resolves.toBeNull();
     expect(mocks.execGit).toHaveBeenCalledWith(
       location,
-      ["show-ref", "--verify", "--quiet", "refs/heads/candidate/missing"],
+      ["rev-parse", "--verify", "--quiet", "refs/heads/candidate/missing"],
+      { acceptedExitCodes: [1] },
+    );
+  });
+
+  it("recognizes an existing branch while probing without diagnostics", async () => {
+    mocks.execGit.mockImplementation(async (_location, args) => {
+      if (args[0] === "rev-parse") return `${"a".repeat(40)}\n`;
+      if (args[0] === "reflog") return "poracode experiment owner experiment-1\n";
+      return "";
+    });
+
+    await expect(serviceOwner("candidate/existing")).resolves.toBe("experiment-1");
+    expect(mocks.execGit).toHaveBeenCalledWith(
+      location,
+      ["rev-parse", "--verify", "--quiet", "refs/heads/candidate/existing"],
       { acceptedExitCodes: [1] },
     );
   });

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -36,6 +36,22 @@ import { parseStatusPorcelainV2 } from "./statusParsing";
 const WORKTREE_OWNER_REFLOG_PREFIX = "poracode experiment owner ";
 const EXPERIMENT_WORKTREE_CREATE_CONCURRENCY = 2;
 
+export function isValidGitBranchName(branch: string): boolean {
+  if (!branch || branch === "HEAD" || branch.startsWith("-")) return false;
+  if (branch.startsWith("/") || branch.endsWith("/") || branch.endsWith(".")) return false;
+  if (branch.includes("//") || branch.includes("..") || branch.includes("@{")) return false;
+  for (let index = 0; index < branch.length; index += 1) {
+    const code = branch.charCodeAt(index);
+    if (code <= 32 || code === 127) return false;
+  }
+  if (/[~^:?*\x5b\\]/u.test(branch)) return false;
+  return branch
+    .split("/")
+    .every(
+      (segment) => segment.length > 0 && !segment.startsWith(".") && !segment.endsWith(".lock"),
+    );
+}
+
 function trimTrailingSeparators(path: string): string {
   const trimmed = path.replace(/[\\/]+$/, "");
   return trimmed || path;
@@ -1053,6 +1069,7 @@ export class GitWorktreeService {
     location: ProjectLocation,
     branch: string,
   ): Promise<string | null> {
+    if (!isValidGitBranchName(branch)) return null;
     const configuredOwner = await execGit(
       location,
       ["config", "--get", `branch.${branch}.poracodeOwner`],
@@ -1085,9 +1102,14 @@ export class GitWorktreeService {
   }
 
   private async branchExists(location: ProjectLocation, branch: string): Promise<boolean> {
-    const output = await execGit(location, ["show-ref", "--verify", `refs/heads/${branch}`], {
-      acceptedExitCodes: [1],
-    });
+    if (!isValidGitBranchName(branch)) return false;
+    const output = await execGit(
+      location,
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      {
+        acceptedExitCodes: [1],
+      },
+    );
     return output.trim().length > 0;
   }
 

--- a/src/supervisor/git/worktreeService.ts
+++ b/src/supervisor/git/worktreeService.ts
@@ -37,7 +37,7 @@ const WORKTREE_OWNER_REFLOG_PREFIX = "poracode experiment owner ";
 const EXPERIMENT_WORKTREE_CREATE_CONCURRENCY = 2;
 
 export function isValidGitBranchName(branch: string): boolean {
-  if (!branch || branch === "HEAD" || branch.startsWith("-")) return false;
+  if (!branch || branch === "@" || branch === "HEAD" || branch.startsWith("-")) return false;
   if (branch.startsWith("/") || branch.endsWith("/") || branch.endsWith(".")) return false;
   if (branch.includes("//") || branch.includes("..") || branch.includes("@{")) return false;
   for (let index = 0; index < branch.length; index += 1) {
@@ -1105,7 +1105,7 @@ export class GitWorktreeService {
     if (!isValidGitBranchName(branch)) return false;
     const output = await execGit(
       location,
-      ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+      ["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`],
       {
         acceptedExitCodes: [1],
       },

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -1198,19 +1198,79 @@ describe("GitHubService", () => {
   });
 
   describe("getPrChecks", () => {
-    it("returns parsed check results", async () => {
+    it("maps gh check buckets into canonical pass, fail, and pending results", async () => {
       const checksJson = JSON.stringify([
-        { name: "CI", state: "completed", conclusion: "success" },
-        { name: "Lint", state: "completed", conclusion: "failure" },
+        {
+          name: "CI",
+          state: "SUCCESS",
+          bucket: "pass",
+          link: "https://github.com/owner/repo/actions/runs/1",
+          workflow: "CI",
+          startedAt: "2026-07-27T10:00:00Z",
+          completedAt: "2026-07-27T10:01:00Z",
+        },
+        { name: "Lint", state: "FAILURE", bucket: "fail" },
+        { name: "Build", state: "IN_PROGRESS", bucket: "pending" },
+        { name: "Queued", state: "QUEUED", bucket: "pending" },
       ]);
       execFileAsyncMock.mockResolvedValue({ stdout: checksJson });
 
       const result = await new GitHubService().getPrChecks(location, "feature/x");
 
       expect(result.checks).toEqual([
-        { name: "CI", state: "completed", conclusion: "success" },
-        { name: "Lint", state: "completed", conclusion: "failure" },
+        {
+          name: "CI",
+          state: "COMPLETED",
+          conclusion: "SUCCESS",
+          url: "https://github.com/owner/repo/actions/runs/1",
+          workflowName: "CI",
+          startedAt: "2026-07-27T10:00:00Z",
+          completedAt: "2026-07-27T10:01:00Z",
+        },
+        { name: "Lint", state: "COMPLETED", conclusion: "FAILURE" },
+        { name: "Build", state: "IN_PROGRESS", conclusion: "" },
+        { name: "Queued", state: "QUEUED", conclusion: "" },
       ]);
+
+      const args = execFileAsyncMock.mock.calls[0]?.[1] as string[];
+      expect(args).toEqual([
+        "pr",
+        "checks",
+        "feature/x",
+        "--json",
+        "name,state,bucket,link,startedAt,completedAt,workflow",
+      ]);
+      expect(args.join(",")).not.toContain("conclusion");
+    });
+
+    it("maps cancelled and skipped buckets to completed outcomes", async () => {
+      execFileAsyncMock.mockResolvedValue({
+        stdout: JSON.stringify([
+          { name: "Cancelled", state: "CANCELLED", bucket: "cancel" },
+          { name: "Skipped", state: "SKIPPED", bucket: "skipping" },
+        ]),
+      });
+
+      const result = await new GitHubService().getPrChecks(location, "feature/x");
+
+      expect(result.checks).toEqual([
+        { name: "Cancelled", state: "COMPLETED", conclusion: "CANCELLED" },
+        { name: "Skipped", state: "COMPLETED", conclusion: "SKIPPED" },
+      ]);
+    });
+
+    it("parses pending check JSON returned with gh exit code 8", async () => {
+      const pendingJson = JSON.stringify([{ name: "Build", state: "PENDING", bucket: "pending" }]);
+      execFileAsyncMock.mockRejectedValue(
+        Object.assign(new Error("Command failed with exit code 8"), {
+          code: 8,
+          stdout: pendingJson,
+        }),
+      );
+
+      const result = await new GitHubService().getPrChecks(location, "feature/x");
+
+      expect(result.checks).toEqual([{ name: "Build", state: "PENDING", conclusion: "" }]);
     });
 
     it("returns empty checks when gh returns empty array", async () => {
@@ -1219,6 +1279,14 @@ describe("GitHubService", () => {
       const result = await new GitHubService().getPrChecks(location, "feature/x");
 
       expect(result.checks).toEqual([]);
+    });
+
+    it("keeps unsupported gh field failures observable", async () => {
+      execFileAsyncMock.mockRejectedValue(new Error("Unknown JSON field: futureField"));
+
+      await expect(new GitHubService().getPrChecks(location, "feature/x")).rejects.toThrow(
+        "gh pr checks failed: Unknown JSON field: futureField",
+      );
     });
   });
 

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -12,6 +12,9 @@ const buildAgentCommandMock = vi.hoisted(() =>
     ) => { command: string; args: string[] }
   >(),
 );
+const primeProjectShellEnvMock = vi.hoisted(() =>
+  vi.fn<(cwd: string) => Promise<Record<string, string> | undefined>>(),
+);
 const mkdtempMock = vi.hoisted(() => vi.fn<(prefix: string) => Promise<string>>());
 const rmMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
 const writeFileMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
@@ -42,6 +45,7 @@ vi.mock("node:fs/promises", () => ({
 
 vi.mock("./agents/base", () => ({
   buildAgentCommand: buildAgentCommandMock,
+  primeProjectShellEnv: primeProjectShellEnvMock,
 }));
 
 import {
@@ -54,6 +58,7 @@ import { mapStatusCheck } from "./githubMappers";
 import { resolveClonedProjectPath } from "./git/exec";
 
 const location = { kind: "windows" as const, path: "C:\\Users\\demo\\repo" };
+const posixLocation = { kind: "posix" as const, path: "/Users/demo/repo" };
 const wslLocation = {
   kind: "wsl" as const,
   distro: "Ubuntu",
@@ -71,6 +76,7 @@ describe("GitHubService", () => {
     mkdtempMock.mockImplementation(async (prefix) => `${prefix}abc123`);
     rmMock.mockResolvedValue(undefined);
     writeFileMock.mockResolvedValue(undefined);
+    primeProjectShellEnvMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -437,6 +443,31 @@ describe("GitHubService", () => {
       expect(execFileAsyncMock.mock.calls[0]?.[0]).toBe("gh");
       expect(execFileAsyncMock.mock.calls[0]?.[1]).toEqual(
         expect.arrayContaining(["pr", "list", "--json"]),
+      );
+    });
+
+    it("captures the login-shell PATH before directly running machine-readable gh", async () => {
+      let primed = false;
+      primeProjectShellEnvMock.mockImplementation(async () => {
+        primed = true;
+        return { PATH: "/opt/homebrew/bin:/usr/bin:/bin" };
+      });
+      buildAgentCommandMock.mockImplementation((_location, command, args) => ({
+        command: "/bin/zsh",
+        args: ["-l", "-i", "-c", command, ...args],
+        ...(primed ? { env: { PATH: "/opt/homebrew/bin:/usr/bin:/bin" } } : {}),
+      }));
+      execFileAsyncMock.mockResolvedValue({ stdout: "[]" });
+
+      await new GitHubService().listPrs(posixLocation);
+
+      expect(primeProjectShellEnvMock).toHaveBeenCalledWith(posixLocation.path);
+      expect(execFileAsyncMock).toHaveBeenCalledWith(
+        "gh",
+        expect.arrayContaining(["pr", "list", "--json"]),
+        expect.objectContaining({
+          env: expect.objectContaining({ PATH: "/opt/homebrew/bin:/usr/bin:/bin" }),
+        }),
       );
     });
   });

--- a/src/supervisor/github.test.ts
+++ b/src/supervisor/github.test.ts
@@ -407,6 +407,38 @@ describe("GitHubService", () => {
 
       expect(result).toEqual({});
     });
+
+    it.each([
+      "failed to run git: fatal: not a git repository (or any parent): .git",
+      "no repository configured for this command",
+    ])("returns an empty map for a non-repository project: %s", async (message) => {
+      execFileAsyncMock.mockRejectedValue(new Error(message));
+
+      await expect(new GitHubService().listPrs(location)).resolves.toEqual({});
+    });
+
+    it("does not hide unrelated gh failures", async () => {
+      execFileAsyncMock.mockRejectedValue(new Error("GraphQL: API rate limit exceeded"));
+
+      await expect(new GitHubService().listPrs(location)).rejects.toThrow(
+        "gh pr list failed: GraphQL: API rate limit exceeded",
+      );
+    });
+
+    it("bypasses login shells so OSC 1337 startup output cannot contaminate JSON", async () => {
+      buildAgentCommandMock.mockReturnValue({
+        command: "/bin/zsh",
+        args: ["-l", "-i", "-c", "\u001b]1337;RemoteHost=test\u0007"],
+      });
+      execFileAsyncMock.mockResolvedValue({ stdout: "[]" });
+
+      await new GitHubService().listPrs(location);
+
+      expect(execFileAsyncMock.mock.calls[0]?.[0]).toBe("gh");
+      expect(execFileAsyncMock.mock.calls[0]?.[1]).toEqual(
+        expect.arrayContaining(["pr", "list", "--json"]),
+      );
+    });
   });
 
   describe("listPullRequests", () => {
@@ -976,6 +1008,9 @@ describe("GitHubService", () => {
 
       expect(buildAgentCommandMock.mock.calls[0]![2]).toEqual(["pr", "diff", "42"]);
       expect(result.diff).toBe("diff --git a/x b/x\n");
+      expect(execFileAsyncMock.mock.calls[0]?.[2]).toMatchObject({
+        maxBuffer: 50 * 1024 * 1024,
+      });
     });
   });
 

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -35,7 +35,7 @@ import { parsePrReviewThreads, PR_REVIEW_THREADS_QUERY } from "./githubReviewThr
 // Re-export the pure mappers previously defined inline here so the module's
 // public surface stays identical for github.test.ts and bridge consumers.
 export { aggregateChecksStatus, mapGitHubApiRepo, parseGhAuthAccounts } from "./githubMappers";
-import { buildAgentCommand } from "./agents/base";
+import { buildAgentCommand, primeProjectShellEnv } from "./agents/base";
 import { resolveClonedProjectPath } from "./git/exec";
 import type { WslBridgeClient, WslProcessExecResult } from "./wsl/bridge/client";
 
@@ -237,6 +237,13 @@ async function runGh(
     throw processResultToError(result);
   }
 
+  // Native desktop launches frequently inherit a minimal PATH that does not
+  // include Homebrew or other user-managed binary directories. Machine-readable
+  // commands must run directly so login-shell startup output cannot corrupt JSON,
+  // but they still need the PATH captured from that shell first.
+  if (machineReadable && location.kind === "posix") {
+    await primeProjectShellEnv(location.path);
+  }
   const spec = buildAgentCommand(location, "gh", args, undefined, options?.env);
   const cwd = spec.cwd ?? location.path;
   const { stdout } = await execFileAsync(

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -59,6 +59,15 @@ const PR_VIEW_FIELDS =
 const PR_LIST_FIELDS =
   "number,headRefName,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus";
 const PULL_REQUEST_LIST_FIELDS = `${PR_LIST_FIELDS},author,additions,deletions,reviewRequests`;
+const PR_CHECK_FIELDS = "name,state,bucket,link,startedAt,completedAt,workflow";
+const PR_CHECK_PENDING_STATES = new Set([
+  "EXPECTED",
+  "IN_PROGRESS",
+  "PENDING",
+  "QUEUED",
+  "REQUESTED",
+  "WAITING",
+]);
 
 function selectLatestPr(items: unknown[]): Record<string, unknown> | null {
   return items.reduce<Record<string, unknown> | null>((latest, item) => {
@@ -68,6 +77,52 @@ function selectLatestPr(items: unknown[]): Record<string, unknown> | null {
     const latestNumber = typeof latest?.number === "number" ? latest.number : 0;
     return number > latestNumber ? pr : latest;
   }, null);
+}
+
+function mapGhPrCheck(item: unknown): PrCheck {
+  const check = item !== null && typeof item === "object" ? (item as Record<string, unknown>) : {};
+  const field = (name: string): string =>
+    typeof check[name] === "string" ? (check[name] as string) : "";
+  const bucket = field("bucket").toLowerCase();
+  const rawState = field("state").toUpperCase();
+
+  let state = rawState;
+  let conclusion = "";
+  switch (bucket) {
+    case "pass":
+      state = "COMPLETED";
+      conclusion = "SUCCESS";
+      break;
+    case "fail":
+      state = "COMPLETED";
+      conclusion = "FAILURE";
+      break;
+    case "pending":
+      state = PR_CHECK_PENDING_STATES.has(rawState) ? rawState : "PENDING";
+      break;
+    case "cancel":
+      state = "COMPLETED";
+      conclusion = "CANCELLED";
+      break;
+    case "skipping":
+      state = "COMPLETED";
+      conclusion = "SKIPPED";
+      break;
+  }
+
+  const url = field("link");
+  const workflowName = field("workflow");
+  const startedAt = field("startedAt");
+  const completedAt = field("completedAt");
+  return {
+    name: field("name"),
+    state,
+    conclusion,
+    ...(url ? { url } : {}),
+    ...(workflowName ? { workflowName } : {}),
+    ...(startedAt ? { startedAt } : {}),
+    ...(completedAt ? { completedAt } : {}),
+  };
 }
 
 function delay(ms: number): Promise<void> {
@@ -278,6 +333,11 @@ function extractStdout(error: unknown): string {
     if (typeof value === "string") return value;
   }
   return "";
+}
+
+function isPendingPrChecksResult(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) return false;
+  return (error as { code?: unknown }).code === 8 && extractStdout(error).trim().startsWith("[");
 }
 
 /** Stable cache key for {@link GitHubService.viewerLoginCache}. */
@@ -705,21 +765,15 @@ export class GitHubService {
 
   async getPrChecks(location: ProjectLocation, branch: string): Promise<GhGetPrChecksResult> {
     try {
-      const stdout = await this.runGh(location, [
-        "pr",
-        "checks",
-        branch,
-        "--json",
-        "name,state,conclusion",
-      ]);
+      let stdout: string;
+      try {
+        stdout = await this.runGh(location, ["pr", "checks", branch, "--json", PR_CHECK_FIELDS]);
+      } catch (err) {
+        if (!isPendingPrChecksResult(err)) throw err;
+        stdout = extractStdout(err);
+      }
       const items = JSON.parse(stdout);
-      const checks: PrCheck[] = Array.isArray(items)
-        ? items.map((c: Record<string, string>) => ({
-            name: c.name ?? "",
-            state: c.state ?? "",
-            conclusion: c.conclusion ?? "",
-          }))
-        : [];
+      const checks = Array.isArray(items) ? items.map(mapGhPrCheck) : [];
       return { checks };
     } catch (err) {
       throw classifyError(err, "pr checks");

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -49,6 +49,7 @@ const GH_CLONE_TIMEOUT = 600_000;
 const GH_REPO_PAGE_SIZE = 100;
 const GH_REPO_MAX_PAGES = 5;
 const PULL_REQUEST_LIST_LIMIT = 1_000;
+const PR_DIFF_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const CREATE_PR_STATUS_WAIT_MS = 15_000;
 const CREATE_PR_STATUS_POLL_MS = 5_000;
 const PR_VIEW_FIELDS =
@@ -95,6 +96,7 @@ function isNoGitHubRepositoryError(error: unknown): boolean {
   const lower = msg.toLowerCase();
   return (
     lower.includes("not a git repository") ||
+    lower.includes("no repository configured") ||
     lower.includes("no git remotes") ||
     lower.includes("none of the git remotes") ||
     lower.includes("unable to determine current repository")
@@ -130,7 +132,17 @@ function classifyError(error: unknown, operation: string): Error {
 interface RunGhOptions {
   /** Extra env (e.g. `GH_TOKEN`) merged into the gh invocation. */
   env?: Record<string, string>;
+  maxBufferBytes?: number;
   timeoutMs?: number;
+}
+
+function isMachineReadableGhCommand(args: readonly string[]): boolean {
+  return (
+    args.includes("--json") ||
+    args.includes("--jq") ||
+    args[0] === "api" ||
+    (args[0] === "auth" && (args[1] === "status" || args[1] === "token"))
+  );
 }
 
 /**
@@ -151,6 +163,7 @@ async function runGh(
   options?: RunGhOptions,
 ): Promise<string> {
   const timeoutMs = options?.timeoutMs ?? GH_TIMEOUT;
+  const machineReadable = isMachineReadableGhCommand(args);
   if (location.kind === "wsl") {
     if (!wslClient) {
       throw new Error(`WSL bridge unavailable for GitHub CLI in distro "${location.distro}"`);
@@ -171,12 +184,17 @@ async function runGh(
 
   const spec = buildAgentCommand(location, "gh", args, undefined, options?.env);
   const cwd = spec.cwd ?? location.path;
-  const { stdout } = await execFileAsync(spec.command, spec.args, {
-    windowsHide: true,
-    timeout: timeoutMs,
-    ...(cwd ? { cwd } : {}),
-    env: projectGhEnvironment({ ...spec.env, ...options?.env }),
-  });
+  const { stdout } = await execFileAsync(
+    machineReadable ? "gh" : spec.command,
+    machineReadable ? args : spec.args,
+    {
+      windowsHide: true,
+      timeout: timeoutMs,
+      ...(cwd ? { cwd } : {}),
+      ...(options?.maxBufferBytes ? { maxBuffer: options.maxBufferBytes } : {}),
+      env: projectGhEnvironment({ ...spec.env, ...options?.env }),
+    },
+  );
   return stdout;
 }
 
@@ -580,7 +598,7 @@ export class GitHubService {
       }
       return result;
     } catch (err) {
-      if (isRepoNotFoundError(err)) return {};
+      if (isNoGitHubRepositoryError(err)) return {};
       throw classifyError(err, "pr list");
     }
   }
@@ -735,7 +753,9 @@ export class GitHubService {
 
   async getPrDiff(location: ProjectLocation, prNumber: number): Promise<GhGetPrDiffResult> {
     try {
-      const stdout = await this.runGh(location, ["pr", "diff", String(prNumber)]);
+      const stdout = await this.runGh(location, ["pr", "diff", String(prNumber)], {
+        maxBufferBytes: PR_DIFF_MAX_BUFFER_BYTES,
+      });
       return { diff: stdout };
     } catch (err) {
       throw classifyError(err, "pr diff");

--- a/src/supervisor/wsl/bridge/bridge.mjs
+++ b/src/supervisor/wsl/bridge/bridge.mjs
@@ -580,11 +580,12 @@ function writeNewFileHandler(req, body) {
   return { status: 200, data: { mtimeMs: st.mtimeMs, size: st.size } };
 }
 
-function git(args, cwd, env) {
+function git(args, cwd, env, input) {
   return execFileSync("git", args, {
     cwd,
     env: { ...sanitizeGitEnv(process.env), GIT_OPTIONAL_LOCKS: "0", ...(env ?? {}) },
     encoding: "utf8",
+    ...(input !== undefined ? { input } : {}),
     maxBuffer: 50 * 1024 * 1024,
   });
 }
@@ -857,16 +858,9 @@ function gitCheckpointSnapshotHandler(req, body) {
       git(["add", "-A", "--", "."], projectRoot, env);
       const tree = git(["write-tree"], projectRoot, env).trim();
       const head = gitMaybe(["rev-parse", "--verify", "HEAD"], projectRoot);
-      const commitArgs = [
-        "commit-tree",
-        tree,
-        ...(head ? ["-p", head] : []),
-        "-m",
-        "Poracode checkpoint",
-        "-m",
-        JSON.stringify(body.metadata),
-      ];
-      const commit = git(commitArgs, projectRoot, env).trim();
+      const commitArgs = ["commit-tree", tree, ...(head ? ["-p", head] : []), "-F", "-"];
+      const message = `Poracode checkpoint\n\n${JSON.stringify(body.metadata)}\n`;
+      const commit = git(commitArgs, projectRoot, env, message).trim();
       git(["update-ref", body.ref, commit], projectRoot);
       return { status: 200, data: { commit } };
     } finally {

--- a/src/supervisor/wsl/bridge/bridge.test.ts
+++ b/src/supervisor/wsl/bridge/bridge.test.ts
@@ -354,6 +354,9 @@ describeOnPosix("bridge.mjs fs endpoints", () => {
       checkpointItemId: "user-1",
       capturedAt: "2026-05-16T00:00:00.000Z",
       ref: "refs/poracode/checkpoints/dGhyZWFkLTE/dXNlci0x",
+      // Finalized checkpoints can carry a large changed-file manifest. Keep it
+      // above common argv limits to prove commit-tree receives it over stdin.
+      changedFiles: [{ path: `generated/${"x".repeat(300_000)}.txt` }],
     };
     const { status, body } = await post(`${bridge.baseUrl}/v1/git/checkpoint-snapshot`, {
       projectRoot,


### PR DESCRIPTION
## Summary

- Treat GitHub PR polling from non-repositories as an expected empty state using the existing narrow repository classifier.
- Run machine-readable native `gh` commands directly instead of through interactive login shells, while preserving WSL's bridge-isolated login environment.
- Request only supported `gh pr checks` JSON fields and map `bucket` outcomes into the provider-neutral `PrCheck` lifecycle/conclusion model.
- Give PR diff retrieval an operation-specific bounded 50 MiB buffer.
- Send checkpoint commit metadata to `git commit-tree` over stdin on native and WSL paths instead of encoding large changed-file manifests in argv.
- Resolve experiment untracked stats from concrete `git ls-files` entries, validate stale branch names locally, and probe missing refs without fatal diagnostics while preserving an existing-ref success signal.

## Sentry issues and treatment

- **LIGHTCODE-54 / LIGHTCODE-1Y** — expected environment state. `listPrs` now returns `{}` for the audited `not a git repository` and `no repository configured` signatures (plus the existing narrow no-remote signatures), preventing repeated IPC error capture. Unrelated `gh` failures still reject and remain observable.
- **LIGHTCODE-1Q** — product defect. Structured JSON/JQ/API output bypasses interactive native shell startup, preventing OSC `]1337` prompt sequences from contaminating JSON. WSL continues using its bridge-isolated environment capture.
- **LIGHTCODE-48** — product defect. Checkpoint metadata is delivered through stdin with `commit-tree -F -`, so large changed-file manifests no longer exceed argv limits.
- **LIGHTCODE-44** — bounded capacity defect. PR diff reads use a per-operation 50 MiB buffer rather than Node's small default; the operation remains bounded and oversized/runtime failures are not swallowed.
- **LIGHTCODE-5A** — product defect. Experiment stats use concrete NUL-separated untracked file paths instead of collapsed directory rows such as `.venv`, avoiding invalid `/dev/null` directory comparisons.
- **LIGHTCODE-57 / LIGHTCODE-56** — expected stale/user-actionable state at the Git boundary. Invalid branch names (including Git's special invalid `@`) return no owner without invoking Git. Missing valid refs use `rev-parse --verify --quiet` with exit 1 accepted, while existing refs retain their object-ID success signal. Genuine Git command/runtime failures still propagate to the UI.
- **LIGHTCODE-60** — product defect. `getPrChecks` no longer requests unsupported `conclusion` JSON. It requests `name,state,bucket` plus supported link/timestamp/workflow metadata, maps pass/fail/pending/cancel/skipping buckets into the existing `PrCheck` contract, and narrowly accepts `gh` exit code 8 only when it carries JSON pending-check output. Unsupported-field and other runtime failures still reject and remain observable.

No central Sentry privacy/classification files were changed, and no command, path, prompt, repository data, auth value, or user content was added to telemetry.

## Validation

- `pnpm exec vitest run src/supervisor/github.test.ts` — 71 passed
- Prior focused Git/GitHub/checkpoint/WSL suite — 94 passed, 12 platform-skipped
- `pnpm run typecheck`
- `pnpm run lint`
- touched-file `pnpm exec oxfmt --check ...`
- commit hooks: type-aware lint, formatting, and typecheck passed

## Residual risk

PR diffs larger than 50 MiB still fail explicitly instead of exhausting an unbounded buffer. Pending `gh pr checks` results are accepted only for documented exit code 8 with JSON array stdout; malformed output and every other CLI failure remain visible. Machine-readable native `gh` execution depends on the project/primed environment PATH already assembled by the existing command builder; non-machine commands retain the existing shell behavior.