### PR TITLE
fix(runtime): harden session teardown races

### DIFF
--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -313,18 +313,18 @@ describe("ACP empty-response provider guard", () => {
 });
 
 describe("ACP transport close lifecycle", () => {
-  it("keeps nonzero exit expected after a provider session is established", () => {
+  it("keeps an established session's nonzero exit reportable", () => {
     const { session } = makeConfigSyncSession();
     const internal = session as unknown as {
       isExpectedTransportExit(code: number | null): boolean;
     };
 
-    expect(internal.isExpectedTransportExit(9)).toBe(true);
-
-    (session as unknown as Record<string, unknown>)["sessionId"] = undefined;
     expect(internal.isExpectedTransportExit(0)).toBe(true);
     expect(internal.isExpectedTransportExit(9)).toBe(false);
     expect(internal.isExpectedTransportExit(null)).toBe(false);
+
+    (session as unknown as Record<string, unknown>)["isDisposed"] = true;
+    expect(internal.isExpectedTransportExit(9)).toBe(true);
   });
 
   it("reports one root error and one derivative close", () => {

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -312,6 +312,55 @@ describe("ACP empty-response provider guard", () => {
   });
 });
 
+describe("ACP transport close lifecycle", () => {
+  it("keeps nonzero exit expected after a provider session is established", () => {
+    const { session } = makeConfigSyncSession();
+    const internal = session as unknown as {
+      isExpectedTransportExit(code: number | null): boolean;
+    };
+
+    expect(internal.isExpectedTransportExit(9)).toBe(true);
+
+    (session as unknown as Record<string, unknown>)["sessionId"] = undefined;
+    expect(internal.isExpectedTransportExit(0)).toBe(true);
+    expect(internal.isExpectedTransportExit(9)).toBe(false);
+    expect(internal.isExpectedTransportExit(null)).toBe(false);
+  });
+
+  it("reports one root error and one derivative close", () => {
+    const { listener, session } = makeConfigSyncSession();
+    const internal = session as unknown as {
+      reportTransportOutcome(message: string | undefined): void;
+    };
+
+    internal.reportTransportOutcome("ACP connection closed unexpectedly.");
+    internal.reportTransportOutcome("duplicate");
+
+    expect(listener.onError).toHaveBeenCalledExactlyOnceWith("ACP connection closed unexpectedly.");
+    expect(listener.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a clean transport close as expected", () => {
+    const { listener, session } = makeConfigSyncSession();
+    const internal = session as unknown as {
+      reportTransportOutcome(message: string | undefined): void;
+    };
+
+    internal.reportTransportOutcome(undefined);
+
+    expect(listener.onError).not.toHaveBeenCalled();
+    expect(listener.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses cancel rejection only after the close boundary won the race", async () => {
+    const { connection, session } = makeConfigSyncSession();
+    connection.cancel.mockRejectedValueOnce(new Error("ACP connection closed"));
+    (session as unknown as Record<string, unknown>)["transportClosed"] = true;
+
+    await expect(session.interruptTurn()).resolves.toBeUndefined();
+  });
+});
+
 describe("ACP prompt-response usage → usage.spent", () => {
   it("emits cumulative usage.spent from a new session's prompt usage, fresh once", async () => {
     const { connection, listener, session } = makeConfigSyncSession();

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -1021,7 +1021,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   }
 
   private isExpectedTransportExit(code: number | null): boolean {
-    return this.isDisposed || this.sessionId !== undefined || code === 0;
+    return this.isDisposed || code === 0;
   }
 
   // ── Resume artifacts ──────────────────────────────────────────

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -218,6 +218,8 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private listener: StructuredSessionListener | undefined;
   private sessionId: string | undefined;
   private isDisposed = false;
+  private transportClosed = false;
+  private transportOutcomeReported = false;
   private currentConfig: ThreadConfig | undefined;
   private currentSlashCommands: AgentSlashCommand[] | undefined;
   private currentStatus: ThreadStatus = "idle";
@@ -563,28 +565,34 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     );
     session.spawnReady = spawnReady;
 
-    // Handle connection close
+    // The process exit is authoritative when available. Defer the connection
+    // close by one turn so an adjacent child exit can provide its exit code.
     void connection.closed.then(() => {
-      if (!session.isDisposed) {
-        session.listener?.onClose();
-      }
+      session.transportClosed = true;
+      setImmediate(() => {
+        if (session.isDisposed || session.transportOutcomeReported) return;
+        const code = child.exitCode;
+        session.reportTransportOutcome(
+          session.isExpectedTransportExit(code)
+            ? undefined
+            : code === null
+              ? "ACP connection closed unexpectedly."
+              : `ACP agent exited unexpectedly (code ${code}).`,
+        );
+      });
     });
 
     child.once("exit", (code) => {
-      // Quiet path: the structured session is one-shot for adapters whose
-      // `liveInputMode === "terminal"` (every adapter today). The runtime
-      // disposes us once `openThread` returns, and some agents (OpenCode)
-      // exit non-zero on stdin close even when everything went fine —
-      // there's nothing actionable to surface in that case.
-      const expected = session.isDisposed || session.sessionId !== undefined;
+      const expected = session.isExpectedTransportExit(code);
       if (expected) {
         console.log(`[acp] child exited (code ${code})`);
       } else {
         console.log(`[acp] child exited unexpectedly (code ${code})`);
       }
-      if (!session.isDisposed) {
-        session.listener?.onClose();
-      }
+      if (session.isDisposed) return;
+      session.reportTransportOutcome(
+        expected ? undefined : `ACP agent exited unexpectedly (code ${code}).`,
+      );
     });
 
     return session;
@@ -955,7 +963,14 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       this.pendingPromptInterrupt = true;
       return;
     }
-    await this.connection.cancel({ sessionId: this.sessionId });
+    try {
+      await this.connection.cancel({ sessionId: this.sessionId });
+    } catch (error) {
+      // A close callback owns the root failure. A cancel racing that callback
+      // is derivative noise, but unrelated provider rejections still surface.
+      if (this.isDisposed || this.transportClosed) return;
+      throw error;
+    }
     if (this.orphanTurnId && !this.promptInFlight) {
       this.completeOrphanTurn({ state: "cancelled" });
     }
@@ -994,6 +1009,19 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     if (!this.child.killed) {
       terminateChildProcessTree(this.child);
     }
+  }
+
+  private reportTransportOutcome(errorMessage: string | undefined): void {
+    if (this.transportOutcomeReported) return;
+    this.transportOutcomeReported = true;
+    if (errorMessage) {
+      this.listener?.onError(errorMessage);
+    }
+    this.listener?.onClose();
+  }
+
+  private isExpectedTransportExit(code: number | null): boolean {
+    return this.isDisposed || this.sessionId !== undefined || code === 0;
   }
 
   // ── Resume artifacts ──────────────────────────────────────────

--- a/src/supervisor/agents/base/expectedRuntimeError.ts
+++ b/src/supervisor/agents/base/expectedRuntimeError.ts
@@ -1,0 +1,7 @@
+/**
+ * Base identity for structured-runtime failures that are actionable to the
+ * user but are not Poracode product defects. Provider adapters should use a
+ * more specific subclass so shared runtime can apply the expected treatment
+ * without learning provider-specific error details.
+ */
+export class ExpectedStructuredRuntimeError extends Error {}

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -85,6 +85,7 @@ export type {
   ThreadHistoryEntry,
 } from "./types";
 export * from "./terminalHints";
+export * from "./expectedRuntimeError";
 export * from "./promptSession";
 export * from "./processRuntime";
 export * from "./shellBasics";

--- a/src/supervisor/agents/opencode/sdkServer.ts
+++ b/src/supervisor/agents/opencode/sdkServer.ts
@@ -8,6 +8,11 @@ const URL_REGEX = /on\s+(https?:\/\/[^\s]+)/;
 const READY_TIMEOUT_MS = 15_000;
 const POSIX_TERM_GRACE_MS = 1_000;
 
+/** Environmental/provider readiness failure, distinct from runtime defects. */
+export class OpenCodeReadinessTimeoutError extends Error {
+  override readonly name = "OpenCodeReadinessTimeoutError";
+}
+
 const activeServerChildren = new Set<ChildProcess>();
 let processExitCleanupRegistered = false;
 
@@ -115,7 +120,7 @@ export function spawnOpenCodeServer(commandSpec: CommandSpec): OpenCodeServerHan
   const readyTimeout = setTimeout(() => {
     if (!baseUrl) {
       pending?.reject(
-        new Error(
+        new OpenCodeReadinessTimeoutError(
           classifyOpenCodeError({
             cause: new Error(`opencode serve did not emit ready URL within ${READY_TIMEOUT_MS}ms`),
             operation: "opencode serve",

--- a/src/supervisor/agents/opencode/sdkServer.ts
+++ b/src/supervisor/agents/opencode/sdkServer.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { terminateChildProcessTree } from "@/shared/processTree";
-import type { CommandSpec } from "../base";
+import { ExpectedStructuredRuntimeError, type CommandSpec } from "../base";
 import { classifyOpenCodeError } from "./opencodeErrors";
 
 const URL_LINE_PREFIX = "opencode server listening";
@@ -9,7 +9,7 @@ const READY_TIMEOUT_MS = 15_000;
 const POSIX_TERM_GRACE_MS = 1_000;
 
 /** Environmental/provider readiness failure, distinct from runtime defects. */
-export class OpenCodeReadinessTimeoutError extends Error {
+export class OpenCodeReadinessTimeoutError extends ExpectedStructuredRuntimeError {
   override readonly name = "OpenCodeReadinessTimeoutError";
 }
 

--- a/src/supervisor/agents/opencode/sdkSession.test.ts
+++ b/src/supervisor/agents/opencode/sdkSession.test.ts
@@ -4,6 +4,7 @@ import type { ProjectLocation, RuntimeEvent, ThreadConfig } from "@/shared/contr
 import type { StructuredSessionUpdate } from "../base";
 import { subscribeOpenCodeServerEvents } from "./sdkEventHub";
 import { OpencodeSdkSession, parseOpenCodeQuestionAnswers } from "./sdkSession";
+import { OpenCodeReadinessTimeoutError } from "./sdkServer";
 
 const mocks = vi.hoisted(() => ({
   acquireOpenCodeServer: vi.fn<(input: unknown) => Promise<unknown>>(),
@@ -49,6 +50,23 @@ describe("OpencodeSdkSession", () => {
 
   beforeEach(() => {
     mocks.acquireOpenCodeServer.mockReset();
+  });
+
+  it("preserves a typed, actionable provider readiness timeout", async () => {
+    mocks.acquireOpenCodeServer.mockRejectedValue(
+      new OpenCodeReadinessTimeoutError("opencode serve: OpenCode server did not respond in time."),
+    );
+    const session = await OpencodeSdkSession.create({
+      threadId: "thread-opencode",
+      projectLocation,
+      config,
+      presentationMode: "gui",
+    });
+
+    await expect(session.activate()).rejects.toMatchObject({
+      name: "OpenCodeReadinessTimeoutError",
+      message: expect.stringContaining("OpenCode server did not respond in time"),
+    });
   });
 
   it("starts the GUI event stream on activation", async () => {

--- a/src/supervisor/agents/opencode/sdkSession.ts
+++ b/src/supervisor/agents/opencode/sdkSession.ts
@@ -51,6 +51,7 @@ import {
   type AcquiredOpenCodeServer,
   type AcquireOpenCodeServerInput,
 } from "./sdkClient";
+import { OpenCodeReadinessTimeoutError } from "./sdkServer";
 import { subscribeOpenCodeServerEvents } from "./sdkEventHub";
 import {
   closeOpenItems,
@@ -209,9 +210,11 @@ export class OpencodeSdkSession implements StructuredSessionHandle {
       // Surface server-startup failures (sandbox blocks, ENOENT, port races,
       // macOS quarantine) as classified user-facing strings rather than the
       // raw thrown shape. The runtime relays these through `onError`.
-      throw new Error(classifyOpenCodeError({ cause, operation: "start opencode serve" }), {
-        cause,
-      });
+      const message = classifyOpenCodeError({ cause, operation: "start opencode serve" });
+      if (cause instanceof OpenCodeReadinessTimeoutError) {
+        throw new OpenCodeReadinessTimeoutError(message, { cause });
+      }
+      throw new Error(message, { cause });
     }
 
     if (this.isGui) {

--- a/src/supervisor/lsp/index.test.ts
+++ b/src/supervisor/lsp/index.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import type { LspSessionStatus } from "@/shared/lsp";
+import type { SupervisorEvent } from "@/shared/ipc";
+
+const mocks = vi.hoisted(() => ({
+  start: vi.fn<() => Promise<void>>(),
+  dispose: vi.fn<() => void>(),
+}));
+
+vi.mock("./serverInstance", () => ({
+  ServerInstance: class {
+    private readonly onStatus: (status: LspSessionStatus, error?: string) => void;
+
+    constructor(
+      _sessionId: string,
+      _config: unknown,
+      _projectLocation: unknown,
+      _onMessage: (message: unknown) => void,
+      onStatus: (status: LspSessionStatus, error?: string) => void,
+    ) {
+      this.onStatus = onStatus;
+    }
+
+    async start(): Promise<void> {
+      this.onStatus("error", "provider detail stays in the user-facing status");
+      return mocks.start();
+    }
+
+    dispose(): void {
+      mocks.dispose();
+    }
+  },
+}));
+
+import { LanguageServerManager } from "./index";
+
+describe("LanguageServerManager", () => {
+  it("preserves privacy-safe initialization rejection and visible error status", async () => {
+    mocks.start.mockRejectedValueOnce(new Error("Language server failed to initialize."));
+    const events: SupervisorEvent[] = [];
+    const manager = new LanguageServerManager((event) => events.push(event));
+
+    await expect(
+      manager.start({
+        sessionId: "lsp-1",
+        languageId: "typescript",
+        projectLocation: { kind: "posix", path: "/repo" },
+      }),
+    ).rejects.toThrow("Language server failed to initialize.");
+    expect(events).toContainEqual({
+      type: "lsp-status",
+      sessionId: "lsp-1",
+      languageId: "typescript",
+      status: "error",
+      error: "provider detail stays in the user-facing status",
+    });
+  });
+});

--- a/src/supervisor/lsp/serverInstance.test.ts
+++ b/src/supervisor/lsp/serverInstance.test.ts
@@ -1,9 +1,16 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProjectLocation } from "@/shared/contracts";
 import type { LspSessionStatus } from "@/shared/lsp";
+
+const captureSupervisorException = vi.hoisted(() =>
+  vi.fn<(error: unknown, tags?: Record<string, string>) => void>(),
+);
+
+vi.mock("../diagnostics/sentry", () => ({ captureSupervisorException }));
+
 import { ServerInstance } from "./serverInstance";
 
 const fakeServerSource = `
@@ -102,5 +109,53 @@ describe("ServerInstance", () => {
 
     expect(statuses).toContain("ready");
     expect(result).toEqual({ items: [{ label: "from-fake-server", kind: 6 }] });
+  });
+
+  it("treats a send rejection from a concurrently closed connection as expected", async () => {
+    const instance = new ServerInstance(
+      "test:lsp-race",
+      { languageId: "fake", commands: [], fileExtensions: [".fake"] },
+      { kind: "posix", path: "/repo" },
+      () => {},
+      () => {},
+    );
+    const connection = {
+      sendNotification: vi.fn<() => Promise<never>>(async () => {
+        (instance as unknown as { connection: unknown }).connection = null;
+        throw new Error("Connection is closed.");
+      }),
+    };
+    (instance as unknown as { connection: unknown }).connection = connection;
+
+    await expect(
+      instance.sendMessage({ jsonrpc: "2.0", method: "textDocument/didOpen", params: {} }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects initialization with a fixed error without self-capturing", () => {
+    const statuses: Array<{ status: LspSessionStatus; error?: string }> = [];
+    const instance = new ServerInstance(
+      "test:lsp-init-failure",
+      { languageId: "fake", commands: [], fileExtensions: [".fake"] },
+      { kind: "posix", path: "/repo" },
+      () => {},
+      (status, error) => statuses.push({ status, ...(error ? { error } : {}) }),
+    );
+    const internal = instance as unknown as {
+      handleInitializationFailure(error: unknown): never;
+    };
+
+    expect(() =>
+      internal.handleInitializationFailure(
+        new Error("provider failed at /private/repo with token=secret"),
+      ),
+    ).toThrow("Language server failed to initialize.");
+    expect(statuses).toEqual([
+      {
+        status: "error",
+        error: "provider failed at /private/repo with token=secret",
+      },
+    ]);
+    expect(captureSupervisorException).not.toHaveBeenCalled();
   });
 });

--- a/src/supervisor/lsp/serverInstance.ts
+++ b/src/supervisor/lsp/serverInstance.ts
@@ -12,6 +12,7 @@ import { createLspRootUri, type LspSessionStatus } from "@/shared/lsp";
 import { terminateChildProcessTree } from "@/shared/processTree";
 import { getProjectFsPath } from "@/shared/wsl";
 import { buildAgentCommand, primeProjectShellEnv } from "../agents/base";
+import { captureSupervisorException } from "../diagnostics/sentry";
 import type { LanguageServerConfig } from "./serverRegistry";
 
 /**
@@ -50,6 +51,7 @@ export class ServerInstance {
   private connection: MessageConnection | null = null;
   private restartCount = 0;
   private disposed = false;
+  private failureReported = false;
 
   constructor(
     readonly sessionId: string,
@@ -153,6 +155,11 @@ export class ServerInstance {
     connection.onError(([error]) => {
       console.error(`[LSP ${this.sessionId}] Connection error:`, error);
     });
+    connection.onClose(() => {
+      if (this.connection === connection) {
+        this.connection = null;
+      }
+    });
 
     connection.listen();
     this.connection = connection;
@@ -216,12 +223,10 @@ export class ServerInstance {
       });
 
       await connection.sendNotification("initialized", {});
+      this.failureReported = false;
       this.onStatus("ready");
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      this.onStatus("error", message);
-      this.dispose();
-      throw new Error(message, { cause: error });
+      this.handleInitializationFailure(error);
     }
 
     // Handle process exit — attempt restart
@@ -231,6 +236,11 @@ export class ServerInstance {
       this.connection = null;
       this.process = null;
 
+      if (code === 0) {
+        this.onStatus("stopped");
+        return;
+      }
+      this.reportFailure("Language server process exited unexpectedly.");
       if (this.restartCount < 3) {
         this.restartCount++;
         const delay = Math.min(1000 * 2 ** this.restartCount, 10000);
@@ -249,21 +259,50 @@ export class ServerInstance {
 
   /** Forward a raw JSON-RPC message from the renderer to the language server. */
   async sendMessage(message: unknown): Promise<unknown> {
-    if (!this.connection) return undefined;
+    const connection = this.connection;
+    if (!connection) return undefined;
 
     const msg = message as { method?: string; id?: number | string; params?: unknown };
     if (!msg.method) return undefined;
 
     if (msg.id !== undefined) {
       // It's a request — send and return the response
-      return this.connection.sendRequest(msg.method, msg.params);
+      try {
+        return await connection.sendRequest(msg.method, msg.params);
+      } catch (error) {
+        if (this.disposed || this.connection !== connection) return undefined;
+        throw error;
+      }
     }
     // It's a notification — fire and forget
-    await this.connection.sendNotification(msg.method, msg.params);
+    try {
+      await connection.sendNotification(msg.method, msg.params);
+    } catch (error) {
+      if (this.disposed || this.connection !== connection) return undefined;
+      throw error;
+    }
     return undefined;
   }
 
-  dispose(): void {
+  private reportFailure(message: string): void {
+    if (this.failureReported) return;
+    this.failureReported = true;
+    captureSupervisorException(new Error(message), {
+      "poracode.feature_area": "language-server",
+      "poracode.runtime_kind": "structured",
+    });
+  }
+
+  private handleInitializationFailure(error: unknown): never {
+    const message = error instanceof Error ? error.message : String(error);
+    this.onStatus("error", message);
+    this.dispose(false);
+    // The synchronous start request owns this failure at the supervisor IPC
+    // boundary. Keep the rejection privacy-safe and do not self-capture here.
+    throw new Error("Language server failed to initialize.");
+  }
+
+  dispose(emitStopped = true): void {
     this.disposed = true;
     if (this.connection) {
       try {
@@ -277,6 +316,8 @@ export class ServerInstance {
       terminateChildProcessTree(this.process);
       this.process = null;
     }
-    this.onStatus("stopped");
+    if (emitStopped) {
+      this.onStatus("stopped");
+    }
   }
 }

--- a/src/supervisor/runtime/threadSession/ptyLifecycle.test.ts
+++ b/src/supervisor/runtime/threadSession/ptyLifecycle.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import type { SessionRuntime } from "../sessionTypes";
+import { PtyLifecycle } from "./ptyLifecycle";
+
+function runtimeWithResize(resize: IPty["resize"]): SessionRuntime {
+  return {
+    pty: { resize } as IPty,
+    ptyExited: false,
+  } as SessionRuntime;
+}
+
+describe("PtyLifecycle.resize", () => {
+  it.each(["Cannot resize a pty that has already exited", "ioctl(2) failed, ENOTTY"])(
+    "treats the node-pty exit race as an expected outcome: %s",
+    (message) => {
+      const lifecycle = new PtyLifecycle();
+      const session = runtimeWithResize(() => {
+        throw new Error(message);
+      });
+
+      expect(() => lifecycle.resize(session, 120, 40)).not.toThrow();
+      expect(session.ptyExited).toBe(true);
+    },
+  );
+
+  it("does not call native resize after lifecycle teardown", () => {
+    const resize = vi.fn<IPty["resize"]>();
+    const lifecycle = new PtyLifecycle();
+    const session = runtimeWithResize(resize);
+    session.ignoreExit = true;
+
+    lifecycle.resize(session, 120, 40);
+
+    expect(resize).not.toHaveBeenCalled();
+  });
+
+  it("propagates unrelated native resize failures", () => {
+    const lifecycle = new PtyLifecycle();
+    const session = runtimeWithResize(() => {
+      throw new Error("native resize invariant failed");
+    });
+
+    expect(() => lifecycle.resize(session, 120, 40)).toThrow("native resize invariant failed");
+    expect(session.ptyExited).toBe(false);
+  });
+});

--- a/src/supervisor/runtime/threadSession/ptyLifecycle.ts
+++ b/src/supervisor/runtime/threadSession/ptyLifecycle.ts
@@ -32,6 +32,28 @@ export class PtyLifecycle {
     this.exitPromises.delete(session);
   }
 
+  /**
+   * Resize only while the tracked PTY is live. node-pty can report process
+   * exit just before its JS exit callback runs, so the native resize itself
+   * remains a race. Suppress only the two exact node-pty lifecycle errors at
+   * this typed boundary; every other resize failure still propagates.
+   */
+  resize(session: SessionRuntime | ShellSessionRuntime, cols: number, rows: number): void {
+    if (session.ptyExited || session.ignoreExit) return;
+    const pty = session.pty;
+    if (!pty) return;
+    try {
+      pty.resize(cols, rows);
+    } catch (error) {
+      if (isPtyResizeAfterExitError(error)) {
+        session.ptyExited = true;
+        this.resolveExit(session);
+        return;
+      }
+      throw error;
+    }
+  }
+
   async waitForExit(session: SessionRuntime | ShellSessionRuntime): Promise<void> {
     if (session.ptyExited) {
       return;
@@ -77,4 +99,12 @@ export class PtyLifecycle {
     }
     session.pty.kill();
   }
+}
+
+function isPtyResizeAfterExitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message === "Cannot resize a pty that has already exited" ||
+    error.message === "ioctl(2) failed, ENOTTY"
+  );
 }

--- a/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.test.ts
+++ b/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.test.ts
@@ -384,6 +384,35 @@ describe("SessionRuntimeLifecycle", () => {
     }
   });
 
+  it("keeps the authoritative error state when transport close follows onError", () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createHarness();
+      harness.mocks.failStructuredSession.mockImplementation((session) => {
+        session.status = "error";
+      });
+      harness.lifecycle.attach(harness.session);
+      harness.mocks.updateState.mockClear();
+
+      harness.structuredListener?.onError("root failure");
+      harness.structuredListener?.onClose();
+
+      expect(harness.mocks.failStructuredSession).toHaveBeenCalledTimes(1);
+      expect(harness.mocks.updateState).not.toHaveBeenCalledWith(
+        harness.session,
+        "inactive",
+        "none",
+      );
+      expect(harness.mocks.emit).toHaveBeenCalledWith({
+        type: "thread-exited",
+        threadId: harness.session.threadId,
+        exitCode: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("routes PTY data only for the current session", () => {
     const harness = createHarness();
     harness.lifecycle.attach(harness.session);

--- a/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.ts
+++ b/src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.ts
@@ -188,9 +188,11 @@ export class SessionRuntimeLifecycle {
           `[supervisor] uncaught error in onData for thread ${session.threadId}:`,
           error,
         );
-        captureSupervisorException(error, {
-          "poracode.feature_area": "supervisor-runtime",
+        captureSupervisorException(new Error("PTY output pipeline failed."), {
+          "poracode.feature_area": "thread-session-lifecycle",
+          "poracode.presentation": session.presentationMode ?? "terminal",
           "poracode.provider": session.agentKind,
+          "poracode.runtime_kind": "pty",
         });
       }
     });
@@ -225,7 +227,12 @@ export class SessionRuntimeLifecycle {
 
   private handleStructuredSessionClosed(session: SessionRuntime): void {
     if (session.status === "inactive") return;
-    this.context.outputPipeline.updateState(session, "inactive", "none");
+    // onError is the authoritative non-clean boundary. A derivative transport
+    // close must tear down the backing PTY without overwriting the visible
+    // error state or manufacturing a second failure.
+    if (session.status !== "error") {
+      this.context.outputPipeline.updateState(session, "inactive", "none");
+    }
     this.context.emit({
       type: "thread-exited",
       threadId: session.threadId,

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -455,10 +455,6 @@ export class SpawnPipeline {
         )
         .catch((error) => {
           console.error("[supervisor] initial turn failed:", error);
-          captureSupervisorException(error, {
-            "poracode.feature_area": "supervisor-runtime",
-            "poracode.provider": payload.agentKind,
-          });
           const activeSession = ctx.sessions.get(payload.threadId);
           if (!activeSession) {
             return;
@@ -1142,9 +1138,11 @@ export class SpawnPipeline {
       });
     } catch (error) {
       console.error("[supervisor] structured session creation failed:", error);
-      captureSupervisorException(error, {
+      captureSupervisorException(new Error("Structured runtime session creation failed."), {
         "poracode.feature_area": "supervisor-runtime",
+        ...(presentationMode ? { "poracode.presentation": presentationMode } : {}),
         "poracode.provider": agentKind,
+        "poracode.runtime_kind": "structured",
       });
       return undefined;
     }

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -64,6 +64,10 @@ import { shouldPrimeNativeProjectShellEnv } from "./helpers";
 import type { ThreadSessionManagerOptions } from "./managerOptions";
 import type { PtyLifecycle } from "./ptyLifecycle";
 import type { RuntimeEventRouter } from "./runtimeEventRouter";
+import {
+  StructuredRuntimeDiagnosticError,
+  structuredRuntimeFeatureArea,
+} from "./structuredRuntimeDiagnosticError";
 import { describeSpawnFailure, sanitizeEnv, sanitizedProcessEnv } from "./spawnDiagnostics";
 import type { SessionRuntimeLifecycle } from "./sessionRuntimeLifecycle";
 import { getIterm2StatusL2TerminalEnv, resolveTerminalColorEnv } from "./terminalEnv";
@@ -1138,8 +1142,17 @@ export class SpawnPipeline {
       });
     } catch (error) {
       console.error("[supervisor] structured session creation failed:", error);
-      captureSupervisorException(new Error("Structured runtime session creation failed."), {
-        "poracode.feature_area": "supervisor-runtime",
+      const diagnosticError = new StructuredRuntimeDiagnosticError("session-creation", agentKind);
+      if (presentationMode === "gui") {
+        // The startThread IPC boundary owns GUI startup failures. Throw one
+        // privacy-safe classified error instead of capturing here and then
+        // manufacturing a second "does not support GUI" failure below.
+        throw diagnosticError;
+      }
+      // Terminal presentation can safely fall back to its PTY path when the
+      // optional structured helper cannot be created, so report once here.
+      captureSupervisorException(diagnosticError, {
+        "poracode.feature_area": structuredRuntimeFeatureArea("session-creation"),
         ...(presentationMode ? { "poracode.presentation": presentationMode } : {}),
         "poracode.provider": agentKind,
         "poracode.runtime_kind": "structured",

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
@@ -22,7 +22,7 @@ describe("StructuredFailureReporter", () => {
     captureSupervisorException.mockClear();
   });
 
-  it("captures one privacy-safe failure per concrete session", () => {
+  it("deduplicates one failure episode but captures a later independent episode", () => {
     const reporter = new StructuredFailureReporter();
     const session = createSession();
 
@@ -31,13 +31,37 @@ describe("StructuredFailureReporter", () => {
 
     expect(captureSupervisorException).toHaveBeenCalledTimes(1);
     expect(captureSupervisorException).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Structured runtime session failed." }),
+      expect.objectContaining({
+        message: "Structured runtime turn failed.",
+        name: "StructuredRuntimeDiagnosticError",
+      }),
       {
-        "poracode.feature_area": "thread-session-lifecycle",
+        "poracode.feature_area": "structured-runtime-turn",
         "poracode.presentation": "gui",
         "poracode.provider": "codex",
         "poracode.runtime_kind": "structured",
       },
+    );
+
+    reporter.beginEpisode(session);
+    reporter.capture(session, new Error("a later independent parser failure"));
+
+    expect(captureSupervisorException).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a stable transport class without retaining the provider message", () => {
+    const reporter = new StructuredFailureReporter();
+
+    reporter.capture(createSession(), "ACP agent exited unexpectedly (code 9).");
+
+    expect(captureSupervisorException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Structured runtime transport failed.",
+        name: "StructuredRuntimeDiagnosticError",
+      }),
+      expect.objectContaining({
+        "poracode.feature_area": "structured-runtime-transport",
+      }),
     );
   });
 

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionRuntime } from "../sessionTypes";
+
+const captureSupervisorException = vi.hoisted(() =>
+  vi.fn<(error: unknown, tags?: Record<string, string>) => void>(),
+);
+
+vi.mock("../../diagnostics/sentry", () => ({ captureSupervisorException }));
+
+import { StructuredFailureReporter } from "./structuredFailureReporter";
+
+describe("StructuredFailureReporter", () => {
+  it("captures one privacy-safe failure per concrete session", () => {
+    const reporter = new StructuredFailureReporter();
+    const session = {
+      agentKind: "codex",
+      presentationMode: "gui",
+    } as SessionRuntime;
+
+    reporter.capture(session);
+    reporter.capture(session);
+
+    expect(captureSupervisorException).toHaveBeenCalledTimes(1);
+    expect(captureSupervisorException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Structured runtime session failed." }),
+      {
+        "poracode.feature_area": "thread-session-lifecycle",
+        "poracode.presentation": "gui",
+        "poracode.provider": "codex",
+        "poracode.runtime_kind": "structured",
+      },
+    );
+  });
+});

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenCodeReadinessTimeoutError } from "../../agents/opencode/sdkServer";
 import type { SessionRuntime } from "../sessionTypes";
 
 const captureSupervisorException = vi.hoisted(() =>
@@ -9,16 +10,24 @@ vi.mock("../../diagnostics/sentry", () => ({ captureSupervisorException }));
 
 import { StructuredFailureReporter } from "./structuredFailureReporter";
 
+function createSession(): SessionRuntime {
+  return {
+    agentKind: "codex",
+    presentationMode: "gui",
+  } as SessionRuntime;
+}
+
 describe("StructuredFailureReporter", () => {
+  beforeEach(() => {
+    captureSupervisorException.mockClear();
+  });
+
   it("captures one privacy-safe failure per concrete session", () => {
     const reporter = new StructuredFailureReporter();
-    const session = {
-      agentKind: "codex",
-      presentationMode: "gui",
-    } as SessionRuntime;
+    const session = createSession();
 
-    reporter.capture(session);
-    reporter.capture(session);
+    reporter.capture(session, new Error("provider returned an unknown server failure"));
+    reporter.capture(session, new Error("a later derivative close failure"));
 
     expect(captureSupervisorException).toHaveBeenCalledTimes(1);
     expect(captureSupervisorException).toHaveBeenCalledWith(
@@ -30,5 +39,86 @@ describe("StructuredFailureReporter", () => {
         "poracode.runtime_kind": "structured",
       },
     );
+  });
+
+  it.each([
+    "Quota exhausted",
+    "usage limit exceeded",
+    "You've reached your usage limit for this billing cycle",
+    "You've hit your usage limit",
+    "You have reached your quota limit",
+    "You’ve hit your quota limit",
+    "billing limit reached",
+    "billing credits exhausted",
+    "request failed: insufficient_quota",
+    "RPC error: auth_required",
+    "Device authentication failed",
+    "User must authenticate before continuing",
+  ])("does not capture the expected provider outcome: %s", (message) => {
+    const reporter = new StructuredFailureReporter();
+
+    reporter.capture(createSession(), new Error(message));
+
+    expect(captureSupervisorException).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "Quota lookup failed",
+    "You've reached your usage settings",
+    "We've hit a usage service error",
+    "Usage service unavailable",
+    "Billing configuration is invalid",
+    "Authentication service failed",
+    "Device authentication request failed",
+    "User authentication state is unknown",
+    "auth_requiredness parser crashed",
+  ])("still captures a near-miss provider failure: %s", (message) => {
+    const reporter = new StructuredFailureReporter();
+
+    reporter.capture(createSession(), new Error(message));
+
+    expect(captureSupervisorException).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognizes an expected provider outcome through a wrapped cause", () => {
+    const reporter = new StructuredFailureReporter();
+    const cause = new Error("auth_required");
+
+    reporter.capture(createSession(), new Error("provider request failed", { cause }));
+
+    expect(captureSupervisorException).not.toHaveBeenCalled();
+  });
+
+  it("does not consume the one-capture slot for an expected outcome", () => {
+    const reporter = new StructuredFailureReporter();
+    const session = createSession();
+
+    reporter.capture(session, new Error("usage quota exhausted"));
+    expect(captureSupervisorException).not.toHaveBeenCalled();
+    reporter.capture(session, new Error("provider response parser failed"));
+
+    expect(captureSupervisorException).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not capture a typed OpenCode readiness timeout", () => {
+    const reporter = new StructuredFailureReporter();
+
+    reporter.capture(
+      createSession(),
+      new OpenCodeReadinessTimeoutError("opencode serve: OpenCode server did not respond in time."),
+    );
+
+    expect(captureSupervisorException).not.toHaveBeenCalled();
+  });
+
+  it("still captures an untyped readiness near-miss", () => {
+    const reporter = new StructuredFailureReporter();
+
+    reporter.capture(
+      createSession(),
+      new Error("opencode serve: OpenCode server did not respond in time."),
+    );
+
+    expect(captureSupervisorException).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
@@ -1,18 +1,39 @@
+import { ExpectedStructuredRuntimeError } from "../../agents/base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import type { SessionRuntime } from "../sessionTypes";
 
+const EXPECTED_PROVIDER_OUTCOME =
+  /\b(?:(?:you(?:['’]ve| have) )(?:reached|hit) your (?:usage|quota) limit|(?:quota|usage|billing)(?:[_ -](?:quota|limit))?[_ -](?:is[_ -])?(?:exhausted|exceeded|reached)|(?:quota|usage|billing)[_ -]credits?[_ -](?:are[_ -])?(?:exhausted|exceeded)|insufficient_quota|auth_required|device authentication failed|user must authenticate)\b/i;
+
+function isExpectedStructuredFailure(error: unknown): boolean {
+  let current = error;
+  const visited = new Set<unknown>();
+  for (let depth = 0; depth < 5 && current !== undefined && !visited.has(current); depth += 1) {
+    visited.add(current);
+    if (current instanceof ExpectedStructuredRuntimeError) return true;
+    const message =
+      current instanceof Error ? current.message : typeof current === "string" ? current : "";
+    if (EXPECTED_PROVIDER_OUTCOME.test(message)) return true;
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return false;
+}
+
 /**
- * Reports a structured runtime failure once per concrete session instance.
+ * Reports a non-expected structured runtime failure once per concrete session
+ * instance.
  *
  * The captured exception is deliberately synthetic: provider errors can carry
  * prompts, command output, paths, or credentials. The user-facing failure is
- * still surfaced separately by ThreadSessionManager, while telemetry receives
+ * still surfaced separately by ThreadSessionManager, including expected
+ * provider outcomes that are deliberately not captured. Telemetry receives
  * only a stable domain error and structural tags.
  */
 export class StructuredFailureReporter {
   private readonly reported = new WeakSet<SessionRuntime>();
 
-  capture(session: SessionRuntime): void {
+  capture(session: SessionRuntime, error: unknown): void {
+    if (isExpectedStructuredFailure(error)) return;
     if (this.reported.has(session)) return;
     this.reported.add(session);
     captureSupervisorException(new Error("Structured runtime session failed."), {

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
@@ -1,0 +1,25 @@
+import { captureSupervisorException } from "../../diagnostics/sentry";
+import type { SessionRuntime } from "../sessionTypes";
+
+/**
+ * Reports a structured runtime failure once per concrete session instance.
+ *
+ * The captured exception is deliberately synthetic: provider errors can carry
+ * prompts, command output, paths, or credentials. The user-facing failure is
+ * still surfaced separately by ThreadSessionManager, while telemetry receives
+ * only a stable domain error and structural tags.
+ */
+export class StructuredFailureReporter {
+  private readonly reported = new WeakSet<SessionRuntime>();
+
+  capture(session: SessionRuntime): void {
+    if (this.reported.has(session)) return;
+    this.reported.add(session);
+    captureSupervisorException(new Error("Structured runtime session failed."), {
+      "poracode.feature_area": "thread-session-lifecycle",
+      "poracode.presentation": session.presentationMode ?? "terminal",
+      "poracode.provider": session.agentKind,
+      "poracode.runtime_kind": "structured",
+    });
+  }
+}

--- a/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
+++ b/src/supervisor/runtime/threadSession/structuredFailureReporter.ts
@@ -1,6 +1,11 @@
 import { ExpectedStructuredRuntimeError } from "../../agents/base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import type { SessionRuntime } from "../sessionTypes";
+import {
+  StructuredRuntimeDiagnosticError,
+  structuredRuntimeFeatureArea,
+  type StructuredRuntimeFailureClass,
+} from "./structuredRuntimeDiagnosticError";
 
 const EXPECTED_PROVIDER_OUTCOME =
   /\b(?:(?:you(?:['’]ve| have) )(?:reached|hit) your (?:usage|quota) limit|(?:quota|usage|billing)(?:[_ -](?:quota|limit))?[_ -](?:is[_ -])?(?:exhausted|exceeded|reached)|(?:quota|usage|billing)[_ -]credits?[_ -](?:are[_ -])?(?:exhausted|exceeded)|insufficient_quota|auth_required|device authentication failed|user must authenticate)\b/i;
@@ -19,9 +24,18 @@ function isExpectedStructuredFailure(error: unknown): boolean {
   return false;
 }
 
+function failureClassFor(error: unknown): StructuredRuntimeFailureClass {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  return /^(?:ACP connection closed unexpectedly\.|ACP agent exited unexpectedly \(code -?\d+\)\.)$/u.test(
+    message,
+  )
+    ? "transport"
+    : "turn";
+}
+
 /**
- * Reports a non-expected structured runtime failure once per concrete session
- * instance.
+ * Reports a non-expected structured runtime failure once per active failure
+ * episode.
  *
  * The captured exception is deliberately synthetic: provider errors can carry
  * prompts, command output, paths, or credentials. The user-facing failure is
@@ -32,15 +46,28 @@ function isExpectedStructuredFailure(error: unknown): boolean {
 export class StructuredFailureReporter {
   private readonly reported = new WeakSet<SessionRuntime>();
 
+  /**
+   * Opens a new user-visible failure episode. A single turn can surface through
+   * both a rejection and a derivative close callback, but a later turn on the
+   * same provider session must remain independently observable.
+   */
+  beginEpisode(session: SessionRuntime): void {
+    this.reported.delete(session);
+  }
+
   capture(session: SessionRuntime, error: unknown): void {
     if (isExpectedStructuredFailure(error)) return;
     if (this.reported.has(session)) return;
     this.reported.add(session);
-    captureSupervisorException(new Error("Structured runtime session failed."), {
-      "poracode.feature_area": "thread-session-lifecycle",
-      "poracode.presentation": session.presentationMode ?? "terminal",
-      "poracode.provider": session.agentKind,
-      "poracode.runtime_kind": "structured",
-    });
+    const failureClass = failureClassFor(error);
+    captureSupervisorException(
+      new StructuredRuntimeDiagnosticError(failureClass, session.agentKind),
+      {
+        "poracode.feature_area": structuredRuntimeFeatureArea(failureClass),
+        "poracode.presentation": session.presentationMode ?? "terminal",
+        "poracode.provider": session.agentKind,
+        "poracode.runtime_kind": "structured",
+      },
+    );
   }
 }

--- a/src/supervisor/runtime/threadSession/structuredInterruptWatchdog.ts
+++ b/src/supervisor/runtime/threadSession/structuredInterruptWatchdog.ts
@@ -1,6 +1,13 @@
 import type { SessionRuntime } from "../sessionTypes";
 import { STRUCTURED_INTERRUPT_FORCE_STOP_MS } from "./userInterrupt";
 
+const NO_ACTIVE_TURN_TO_INTERRUPT = "no active turn to interrupt";
+
+function isNoActiveTurnToInterrupt(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message.trim().toLowerCase() === NO_ACTIVE_TURN_TO_INTERRUPT;
+}
+
 export interface StructuredInterruptWatchdogContext {
   sessions: Map<string, SessionRuntime>;
   isDisposed(): boolean;
@@ -29,6 +36,7 @@ export class StructuredInterruptWatchdog {
     } catch (error) {
       session.structuredTurnInterruptRequested = false;
       this.clearStructuredInterruptWatchdog(session);
+      if (isNoActiveTurnToInterrupt(error)) return;
       throw error;
     }
   }

--- a/src/supervisor/runtime/threadSession/structuredRuntimeDiagnosticError.ts
+++ b/src/supervisor/runtime/threadSession/structuredRuntimeDiagnosticError.ts
@@ -1,0 +1,30 @@
+export type StructuredRuntimeFailureClass = "session-creation" | "transport" | "turn";
+
+const STRUCTURED_RUNTIME_FAILURE_MESSAGES: Record<StructuredRuntimeFailureClass, string> = {
+  "session-creation": "Structured runtime session creation failed.",
+  transport: "Structured runtime transport failed.",
+  turn: "Structured runtime turn failed.",
+};
+
+/**
+ * Privacy-safe structured-runtime failure identity.
+ *
+ * Provider errors can contain prompts, command output, paths, and credentials,
+ * so telemetry receives only this stable class and message. The raw failure is
+ * still logged locally and shown to the user by the owning runtime boundary.
+ */
+export class StructuredRuntimeDiagnosticError extends Error {
+  override readonly name = "StructuredRuntimeDiagnosticError";
+  readonly failureClass: StructuredRuntimeFailureClass;
+  readonly diagnosticProvider: string | undefined;
+
+  constructor(failureClass: StructuredRuntimeFailureClass, diagnosticProvider?: string) {
+    super(STRUCTURED_RUNTIME_FAILURE_MESSAGES[failureClass]);
+    this.failureClass = failureClass;
+    this.diagnosticProvider = diagnosticProvider;
+  }
+}
+
+export function structuredRuntimeFeatureArea(failureClass: StructuredRuntimeFailureClass): string {
+  return `structured-runtime-${failureClass}`;
+}

--- a/src/supervisor/runtime/threadSession/structuredTurnQueue.ts
+++ b/src/supervisor/runtime/threadSession/structuredTurnQueue.ts
@@ -7,6 +7,7 @@ import type { QueuedStructuredTurn, SessionRuntime } from "../sessionTypes";
 export interface StructuredTurnQueueContext {
   emit(event: SupervisorEvent): void;
   sessions: Map<string, SessionRuntime>;
+  beginFailureEpisode(session: SessionRuntime): void;
   failStructuredSession(session: SessionRuntime, error: unknown): void;
 }
 
@@ -24,6 +25,7 @@ export class StructuredTurnQueue {
     if (!session.structuredSession?.startTurn) {
       return;
     }
+    this.ctx.beginFailureEpisode(session);
     // Optimistic user_message: paint the user's prompt in the chat pane
     // before the structured session's `prompt()` round-trip resolves so the
     // chat doesn't visually stall waiting on the agent. Only meaningful for
@@ -58,6 +60,7 @@ export class StructuredTurnQueue {
     if (!session.pendingLaunchPrompt || !session.structuredSession?.startTurn) {
       return;
     }
+    this.ctx.beginFailureEpisode(session);
     const prompt = session.pendingLaunchPrompt;
     session.pendingLaunchPrompt = undefined;
     void session.structuredSession.startTurn(prompt, session.config).catch((error) => {

--- a/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
@@ -214,6 +214,46 @@ describe("ThreadSessionManager structured stale-interrupt watchdog", () => {
     expect(session.status).toBe("idle");
   });
 
+  it("treats an exact no-active-turn response as an acknowledged late Stop", async () => {
+    const interruptTurn = vi
+      .fn<NonNullable<StructuredSessionHandle["interruptTurn"]>>()
+      .mockRejectedValue(new Error("no active turn to interrupt"));
+    const structuredSession = createStructuredSession({ interruptTurn });
+    const adapter = createAdapter(structuredSession);
+    const { manager } = createManager(adapter);
+    const session = createWorkingSession(adapter, structuredSession);
+    manager.sessions.set(THREAD_ID, session);
+
+    await expect(manager.interruptThread({ threadId: THREAD_ID })).resolves.toBeUndefined();
+
+    expect(session.structuredTurnInterruptRequested).toBe(false);
+    expect(session.structuredInterruptWatchdog).toBeUndefined();
+    vi.advanceTimersByTime(STRUCTURED_INTERRUPT_FORCE_STOP_MS);
+    expect(structuredSession.dispose).not.toHaveBeenCalled();
+  });
+
+  it("still rejects other and near-miss interrupt failures", async () => {
+    const errors = [
+      new Error("provider interrupt failed"),
+      new Error("no active turn to interrupt because the provider disconnected"),
+    ];
+
+    for (const error of errors) {
+      const interruptTurn = vi
+        .fn<NonNullable<StructuredSessionHandle["interruptTurn"]>>()
+        .mockRejectedValue(error);
+      const structuredSession = createStructuredSession({ interruptTurn });
+      const adapter = createAdapter(structuredSession);
+      const { manager } = createManager(adapter);
+      const session = createWorkingSession(adapter, structuredSession);
+      manager.sessions.set(THREAD_ID, session);
+
+      await expect(manager.interruptThread({ threadId: THREAD_ID })).rejects.toBe(error);
+      expect(session.structuredTurnInterruptRequested).toBe(false);
+      expect(session.structuredInterruptWatchdog).toBeUndefined();
+    }
+  });
+
   it("ignores a stale session whose interrupt is no longer pending", async () => {
     const structuredSession = createStructuredSession();
     const adapter = createAdapter(structuredSession);

--- a/src/supervisor/runtime/threadSessionManager.startClose.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.startClose.test.ts
@@ -192,6 +192,77 @@ describe("ThreadSessionManager provider-session routing", () => {
 });
 
 describe("ThreadSessionManager start guards", () => {
+  it("treats late input, write, and interrupt IPC after known removal as idempotent", async () => {
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    const manager = createManager("codex", adapter);
+    const runtime = createInactiveRuntime("codex", adapter, structuredSession);
+    runtime.threadId = "closed-thread";
+    manager.sessions.set(runtime.threadId, runtime);
+    await manager.closeThread({ threadId: runtime.threadId });
+
+    await expect(
+      manager.sendThreadInput({
+        threadId: "closed-thread",
+        prompt: "late",
+        config: { model: "codex/model" },
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      manager.writeTerminal({ threadId: "closed-thread", data: "late" }),
+    ).resolves.toBeUndefined();
+    await expect(manager.interruptThread({ threadId: "closed-thread" })).resolves.toBeUndefined();
+  });
+
+  it("preserves bookkeeping errors for never-known session ids", async () => {
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    const manager = createManager("codex", adapter);
+
+    await expect(
+      manager.sendThreadInput({
+        threadId: "never-known",
+        prompt: "late",
+        config: { model: "codex/model" },
+      }),
+    ).rejects.toThrow("Unknown thread session: never-known");
+    await expect(manager.writeTerminal({ threadId: "never-known", data: "late" })).rejects.toThrow(
+      "Unknown thread session: never-known",
+    );
+    await expect(manager.interruptThread({ threadId: "never-known" })).rejects.toThrow(
+      "Unknown thread session: never-known",
+    );
+  });
+
+  it("bounds removal tombstones and clears one when the thread id is reused", async () => {
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    const manager = createManager("codex", adapter);
+    const internal = manager as unknown as {
+      recentlyRemovedThreadIds: Set<string>;
+      rememberRemovedThread(threadId: string): void;
+    };
+
+    for (let index = 0; index < 257; index++) {
+      internal.rememberRemovedThread(`removed-${index}`);
+    }
+    expect(internal.recentlyRemovedThreadIds.size).toBe(256);
+    expect(internal.recentlyRemovedThreadIds.has("removed-0")).toBe(false);
+    expect(internal.recentlyRemovedThreadIds.has("removed-256")).toBe(true);
+
+    internal.rememberRemovedThread("reused-thread");
+    await manager.startThread({
+      threadId: "reused-thread",
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      agentKind: "codex",
+      config: { model: "codex/model" },
+      prompt: "",
+      initialSize: { cols: 80, rows: 24 },
+      presentationMode: "gui",
+    });
+    expect(internal.recentlyRemovedThreadIds.has("reused-thread")).toBe(false);
+  });
+
   it("passes an empty MCP set to provider-owned structured sessions", async () => {
     const structuredSession = createStructuredSession(Promise.resolve());
     const adapter = createAdapter("opencode", structuredSession);

--- a/src/supervisor/runtime/threadSessionManager.startClose.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.startClose.test.ts
@@ -6,6 +6,15 @@ import type { AgentKind } from "@/shared/contracts";
 import type { AgentAdapter, StructuredSessionHandle } from "../agents/base";
 import type { SessionRuntime } from "./sessionTypes";
 
+const captureSupervisorException = vi.hoisted(() =>
+  vi.fn<(error: unknown, tags?: Record<string, string>) => void>(),
+);
+
+vi.mock("../diagnostics/sentry", async (importActual) => {
+  const actual = await importActual<typeof import("../diagnostics/sentry")>();
+  return { ...actual, captureSupervisorException };
+});
+
 vi.mock("../agents/base", async (importActual) => {
   const actual = await importActual<typeof import("../agents/base")>();
   return {
@@ -192,6 +201,63 @@ describe("ThreadSessionManager provider-session routing", () => {
 });
 
 describe("ThreadSessionManager start guards", () => {
+  it("lets the IPC boundary exclusively own a structured GUI factory failure", async () => {
+    captureSupervisorException.mockClear();
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    vi.mocked(adapter.createStructuredSession!).mockRejectedValueOnce(
+      new Error("factory output with private provider details"),
+    );
+    const manager = createManager("codex", adapter);
+
+    await expect(
+      manager.startThread({
+        threadId: "factory-failure",
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        agentKind: "codex",
+        config: { model: "codex/model" },
+        prompt: "",
+        initialSize: { cols: 80, rows: 24 },
+        presentationMode: "gui",
+      }),
+    ).rejects.toMatchObject({
+      name: "StructuredRuntimeDiagnosticError",
+      message: "Structured runtime session creation failed.",
+    });
+    expect(captureSupervisorException).not.toHaveBeenCalled();
+  });
+
+  it("reports an optional terminal structured factory failure once and falls back", async () => {
+    captureSupervisorException.mockClear();
+    const structuredSession = createStructuredSession(Promise.resolve());
+    const adapter = createAdapter("codex", structuredSession);
+    vi.mocked(adapter.createStructuredSession!).mockRejectedValueOnce(
+      new Error("factory output with private provider details"),
+    );
+    const manager = createManager("codex", adapter);
+
+    await expect(
+      manager.startThread({
+        threadId: "terminal-factory-failure",
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        agentKind: "codex",
+        config: { model: "codex/model" },
+        prompt: "",
+        initialSize: { cols: 80, rows: 24 },
+        presentationMode: "terminal",
+      }),
+    ).resolves.toEqual({ threadId: "terminal-factory-failure" });
+    expect(captureSupervisorException).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        name: "StructuredRuntimeDiagnosticError",
+        message: "Structured runtime session creation failed.",
+      }),
+      expect.objectContaining({
+        "poracode.feature_area": "structured-runtime-session-creation",
+      }),
+    );
+  });
+
   it("treats late input, write, and interrupt IPC after known removal as idempotent", async () => {
     const structuredSession = createStructuredSession(Promise.resolve());
     const adapter = createAdapter("codex", structuredSession);

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -70,10 +70,13 @@ import {
 } from "./threadSession/spawnPipeline";
 import { StructuredTurnQueue } from "./threadSession/structuredTurnQueue";
 import { BackgroundSubagentNotifications } from "./threadSession/backgroundSubagentNotifications";
+import { StructuredFailureReporter } from "./threadSession/structuredFailureReporter";
 import type { BackgroundSubagentCompletion } from "../crossagentMcp/types";
 
 export { isUserInterruptKeystroke, USER_INTERRUPT_RECOVERY_GRACE_MS, writeSubmittedPrompt };
 export type { ThreadSessionManagerOptions };
+
+const RECENTLY_REMOVED_THREAD_LIMIT = 256;
 
 export class ThreadSessionManager {
   readonly sessions = new Map<string, SessionRuntime>();
@@ -94,6 +97,8 @@ export class ThreadSessionManager {
   private readonly invalidSessionRecovery: InvalidSessionRecoveryCoordinator;
   private readonly structuredTurnQueue: StructuredTurnQueue;
   private readonly backgroundSubagentNotifications: BackgroundSubagentNotifications;
+  private readonly structuredFailureReporter = new StructuredFailureReporter();
+  private readonly recentlyRemovedThreadIds = new Set<string>();
   private disposed = false;
 
   constructor(private readonly options: ThreadSessionManagerOptions) {
@@ -246,6 +251,7 @@ export class ThreadSessionManager {
    * event the user sees a red icon and nothing else.
    */
   private failStructuredSession(session: SessionRuntime, error: unknown): void {
+    this.structuredFailureReporter.capture(session);
     const message = error instanceof Error ? error.message : String(error);
     this.outputPipeline.updateState(session, "error", "error", message);
     this.enqueueRuntimeEvent(session.threadId, {
@@ -479,6 +485,7 @@ export class ThreadSessionManager {
     if (pending) {
       return { threadId };
     }
+    this.recentlyRemovedThreadIds.delete(threadId);
 
     const run = this.spawnPipeline.startThreadInner({ ...payload, threadId });
     this.startLocks.set(
@@ -500,7 +507,11 @@ export class ThreadSessionManager {
   }
 
   async sendThreadInput(payload: SendThreadInputPayload): Promise<void> {
-    const session = this.requireSession(payload.threadId);
+    const session = this.sessions.get(payload.threadId);
+    if (!session) {
+      if (this.recentlyRemovedThreadIds.has(payload.threadId)) return;
+      throw new Error(`Unknown thread session: ${payload.threadId}`);
+    }
     if (session.status === "inactive" && !session.sessionRef) {
       throw new Error("This thread exited before a resumable session id was discovered.");
     }
@@ -622,6 +633,7 @@ export class ThreadSessionManager {
       if (this.startLocks.has(payload.threadId)) {
         this.pendingStartInterrupts.add(payload.threadId);
         this.pendingStartAborts.add(payload.threadId);
+        this.rememberRemovedThread(payload.threadId);
         this.options.emit({
           type: "thread-state",
           threadId: payload.threadId,
@@ -632,6 +644,7 @@ export class ThreadSessionManager {
         });
         return;
       }
+      if (this.recentlyRemovedThreadIds.has(payload.threadId)) return;
       throw new Error(`Unknown thread session: ${payload.threadId}`);
     }
     this.options.crossagentMcp?.cancelForeground(payload.threadId);
@@ -678,7 +691,11 @@ export class ThreadSessionManager {
       shell.pty.write(payload.data);
       return;
     }
-    const session = this.requireSession(payload.threadId);
+    const session = this.sessions.get(payload.threadId);
+    if (!session) {
+      if (this.recentlyRemovedThreadIds.has(payload.threadId)) return;
+      throw new Error(`Unknown thread session: ${payload.threadId}`);
+    }
     requireSessionPty(session).write(payload.data);
     this.maybeArmUserInterruptRecovery(session, payload.data);
   }
@@ -805,7 +822,7 @@ export class ThreadSessionManager {
   async resizeTerminal(payload: ResizeTerminalPayload): Promise<void> {
     const shell = this.shellSessions.get(payload.threadId);
     if (shell) {
-      shell.pty.resize(payload.cols, payload.rows);
+      this.ptyLifecycle.resize(shell, payload.cols, payload.rows);
       return;
     }
     const session = this.sessions.get(payload.threadId);
@@ -813,7 +830,7 @@ export class ThreadSessionManager {
       return;
     }
     session.terminalSize = { cols: payload.cols, rows: payload.rows };
-    session.pty?.resize(payload.cols, payload.rows);
+    this.ptyLifecycle.resize(session, payload.cols, payload.rows);
   }
 
   /**
@@ -841,6 +858,7 @@ export class ThreadSessionManager {
     if (shell) {
       shell.ignoreExit = true;
       this.shellSessions.delete(payload.threadId);
+      this.rememberRemovedThread(payload.threadId);
       this.ptyLifecycle.killShell(shell);
       await this.ptyLifecycle.waitForExit(shell);
       return;
@@ -850,11 +868,13 @@ export class ThreadSessionManager {
     if (!existing) {
       if (this.startLocks.has(payload.threadId)) {
         this.pendingStartAborts.add(payload.threadId);
+        this.rememberRemovedThread(payload.threadId);
       }
       return;
     }
 
     existing.ignoreExit = true;
+    this.rememberRemovedThread(payload.threadId);
     this.backgroundSubagentNotifications.clear(payload.threadId);
     this.outputPipeline.clearSessionTimers(existing);
     existing.stopSessionRefWatcher?.();
@@ -876,6 +896,7 @@ export class ThreadSessionManager {
 
   async startShell(payload: StartShellPayload): Promise<void> {
     ensureNodePtySpawnHelperExecutable();
+    this.recentlyRemovedThreadIds.delete(payload.shellId);
     const existing = this.shellSessions.get(payload.shellId);
     if (existing) {
       existing.ignoreExit = true;
@@ -979,6 +1000,7 @@ export class ThreadSessionManager {
         return;
       }
       this.shellSessions.delete(payload.shellId);
+      this.rememberRemovedThread(payload.shellId);
       this.options.emit({
         type: "thread-exited",
         threadId: payload.shellId,
@@ -1028,6 +1050,7 @@ export class ThreadSessionManager {
     await Promise.allSettled(
       [...this.sessions.values()].map(async (session) => {
         session.ignoreExit = true;
+        this.rememberRemovedThread(session.threadId);
         this.outputPipeline.clearSessionTimers(session);
         await session.structuredSession?.dispose();
         this.ptyLifecycle.kill(session);
@@ -1038,6 +1061,7 @@ export class ThreadSessionManager {
 
     for (const shell of this.shellSessions.values()) {
       shell.ignoreExit = true;
+      this.rememberRemovedThread(shell.shellId);
       this.ptyLifecycle.killShell(shell);
     }
     this.shellSessions.clear();
@@ -1050,6 +1074,16 @@ export class ThreadSessionManager {
       throw new Error(`Unknown thread session: ${threadId}`);
     }
     return session;
+  }
+
+  private rememberRemovedThread(threadId: string): void {
+    this.recentlyRemovedThreadIds.delete(threadId);
+    this.recentlyRemovedThreadIds.add(threadId);
+    if (this.recentlyRemovedThreadIds.size <= RECENTLY_REMOVED_THREAD_LIMIT) return;
+    const oldest = this.recentlyRemovedThreadIds.values().next().value;
+    if (oldest !== undefined) {
+      this.recentlyRemovedThreadIds.delete(oldest);
+    }
   }
 
   private isCurrentSession(session: SessionRuntime): boolean {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -251,7 +251,7 @@ export class ThreadSessionManager {
    * event the user sees a red icon and nothing else.
    */
   private failStructuredSession(session: SessionRuntime, error: unknown): void {
-    this.structuredFailureReporter.capture(session);
+    this.structuredFailureReporter.capture(session, error);
     const message = error instanceof Error ? error.message : String(error);
     this.outputPipeline.updateState(session, "error", "error", message);
     this.enqueueRuntimeEvent(session.threadId, {

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -139,6 +139,7 @@ export class ThreadSessionManager {
     this.structuredTurnQueue = new StructuredTurnQueue({
       emit: options.emit,
       sessions: this.sessions,
+      beginFailureEpisode: (session) => this.structuredFailureReporter.beginEpisode(session),
       failStructuredSession: (session, error) => this.failStructuredSession(session, error),
     });
     this.steerCoordinator = new SteerCoordinator({


### PR DESCRIPTION
## Summary

Hardens supervisor thread/session teardown and failure propagation without broad error suppression or provider-specific branches in shared runtime code.

- Late `sendThreadInput`, `writeTerminal`, and `interruptThread` calls are idempotent only for known removed sessions tracked in a bounded 256-entry tombstone set; never-known IDs still expose bookkeeping defects, and reused IDs clear their tombstone.
- PTY resize is lifecycle-gated and suppresses only the two exact node-pty post-exit failures at the typed resize boundary; unrelated native failures still propagate. Ordinary nonzero PTY process exits are not captured as product defects.
- Structured runtime failures pass the original failure to a local classifier but capture at most one synthetic, content-free exception per concrete session. Expected quota/usage/billing exhaustion and the audited authentication prerequisites (`auth_required`, device authentication failure, and user-must-authenticate) remain user-visible but are not sent to Sentry. Unknown and near-miss server/runtime failures still capture once.
- An exact provider `no active turn to interrupt` response is an idempotent late-Stop outcome at the structured interrupt boundary. It clears the local interrupt request and watchdog; other interrupt errors still reject.
- ACP process exit is authoritative when available: clean/disposed closes and exits after a provider session is established remain expected (including nonzero OpenCode-on-stdin-close behavior), non-clean pre-session exit/transport loss reports one root error, and cancel rejection after transport close is derivative noise.
- LSP connection close clears the live connection before later IPC sends. Initialization preserves the detailed error status but rejects IPC with a fixed privacy-safe error and is captured only by the IPC boundary; out-of-band post-start crashes self-capture once, while derivative close/send noise is suppressed.
- OpenCode keeps the existing 15-second ready-URL timeout and actionable message. `OpenCodeReadinessTimeoutError` now inherits a provider-agnostic expected-runtime identity, so the timeout remains retryable and user-visible without producing the structured synthetic Sentry error.

## Sentry audit treatment

- Fixes LIGHTCODE-24, LIGHTCODE-2H, LIGHTCODE-43 — classified as expected stale UI/IPC operations only after known session removal; treatment uses bounded removal tombstones while preserving errors for never-known IDs.
- Fixes LIGHTCODE-4N, LIGHTCODE-26 — classified as expected PTY resize-after-exit races; treatment is lifecycle ordering plus exact contextual matching for `Cannot resize a pty that has already exited` and `ioctl(2) failed, ENOTTY` only.
- Fixes LIGHTCODE-5E, LIGHTCODE-5F, LIGHTCODE-5G, LIGHTCODE-5Q — classified as one non-clean ACP/LSP root failure plus derivative close/cancel/send noise; treatment captures the root once, preserves visible error state and IPC rejection semantics, and treats clean or established-session close as expected.
- Fixes LIGHTCODE-1D — classified as environmental/provider readiness rather than an internal runtime invariant; treatment preserves the bounded timeout and actionable failure while skipping structured defect capture through a typed adapter-boundary identity.
- Fixes LIGHTCODE-3 — classified as an expected provider usage-limit outcome. The exact live sentence `You've reached your usage limit for this billing cycle`, conservative reached/hit quota-limit variants, quota/usage/billing exhaustion, and the audited authentication prerequisites are dropped only at the authoritative structured-failure reporter. Near-miss provider/server/runtime failures remain product-defect captures.

## Privacy and architecture

Telemetry added or changed here contains no command, path, prompt, repository data, auth value, provider output, or user content. The original error is inspected only in-process for narrow classification and is never attached to telemetry. Captures use fixed domain messages and allowlisted structural tags only. Shared thread runtime remains provider-agnostic; OpenCode-specific normalization stays in the OpenCode adapter through a generic expected-runtime base identity.

## Validation

- `pnpm exec vitest run src/supervisor/agents/acp/session.test.ts src/supervisor/agents/opencode/sdkSession.test.ts src/supervisor/lsp/index.test.ts src/supervisor/lsp/serverInstance.test.ts src/supervisor/runtime/threadSession/ptyLifecycle.test.ts src/supervisor/runtime/threadSession/sessionRuntimeLifecycle.test.ts src/supervisor/runtime/threadSession/spawnPipeline.test.ts src/supervisor/runtime/threadSession/structuredFailureReporter.test.ts src/supervisor/runtime/threadSessionManager.startClose.test.ts src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts` — 176 passed, 3 skipped
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run fmt:check`
- `git diff --check`

## Residual risk

Expected provider messages are intentionally recognized with narrow signatures; materially different provider wording will remain visible and may still capture rather than being broadly suppressed. The recently removed session tombstones are intentionally bounded; a stale operation delayed beyond 256 distinct removals will surface as an unknown-session bookkeeping error instead of being suppressed. ACP connection close is deferred one event-loop turn to prefer an adjacent child exit code, while preserving the existing established-session expected-close behavior. LSP retains its existing bounded three-restart policy; this change only deduplicates reporting and close/send races.
