### PR TITLE
fix(diagnostics): enforce supervisor failure policy

### DIFF
--- a/src/shared/diagnostics/sentryPolicy.test.ts
+++ b/src/shared/diagnostics/sentryPolicy.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDiagnosticBreadcrumb,
+  classifyDiagnosticFailure,
+  DiagnosticError,
+} from "./sentryPolicy";
+
+describe("sentryPolicy", () => {
+  it.each([
+    ["expected-operational", "drop", null, true],
+    ["transient-service", "metric", "warning", true],
+    ["product-defect", "capture", "error", false],
+  ] as const)(
+    "maps %s failures to their enforced treatment",
+    (failureClass, treatment, level, operational) => {
+      const error = new DiagnosticError("caller-visible detail", {
+        failureClass,
+        domain: "provider.service",
+        errorClass: "service-unavailable",
+      });
+
+      expect(
+        classifyDiagnosticFailure(error, {
+          domain: "fallback",
+          operation: "refresh-usage",
+        }),
+      ).toMatchObject({
+        failureClass,
+        treatment,
+        level,
+        operational,
+        domain: "provider.service",
+        operation: "refresh-usage",
+        errorClass: "service-unavailable",
+      });
+    },
+  );
+
+  it("preserves unknown failures as captured errors", () => {
+    const error = new TypeError("private prompt and /private/path");
+
+    expect(
+      classifyDiagnosticFailure(error, {
+        domain: "supervisor.ipc",
+        operation: "start-thread",
+      }),
+    ).toEqual({
+      failureClass: "unknown",
+      treatment: "capture",
+      level: "error",
+      operational: false,
+      domain: "supervisor.ipc",
+      operation: "start-thread",
+      errorClass: "type-error",
+      fingerprint: null,
+    });
+  });
+
+  it("builds typed fingerprints independently of raw messages and paths", () => {
+    const metadata = {
+      failureClass: "product-defect",
+      domain: "supervisor.ipc",
+      errorClass: "invalid-state",
+    } as const;
+    const first = classifyDiagnosticFailure(
+      new DiagnosticError("failed in /Users/alice/repo", metadata),
+      {
+        domain: "fallback",
+        operation: "start-thread",
+      },
+    );
+    const second = classifyDiagnosticFailure(
+      new DiagnosticError("different command and prompt", metadata),
+      {
+        domain: "fallback",
+        operation: "start-thread",
+      },
+    );
+
+    expect(first.fingerprint).toEqual(second.fingerprint);
+    expect(first.fingerprint?.join(":")).not.toContain("alice");
+    expect(first.fingerprint?.join(":")).not.toContain("command");
+  });
+
+  it("leaves unknown failures at different stack sites to Sentry default grouping", () => {
+    function firstSite(): Error {
+      return new Error("same message");
+    }
+    function secondSite(): Error {
+      return new Error("same message");
+    }
+
+    const first = firstSite();
+    const second = secondSite();
+    const context = { domain: "supervisor.ipc", operation: "start-thread" };
+
+    expect(first.stack).not.toEqual(second.stack);
+    expect(classifyDiagnosticFailure(first, context).fingerprint).toBeNull();
+    expect(classifyDiagnosticFailure(second, context).fingerprint).toBeNull();
+  });
+
+  it("rejects unsafe metadata tokens instead of normalizing private values", () => {
+    const error = new DiagnosticError("caller-visible detail", {
+      failureClass: "product-defect",
+      domain: "/Users/alice/private-repo",
+      errorClass: "prompt text with spaces",
+    });
+
+    expect(
+      classifyDiagnosticFailure(error, {
+        domain: "fallback",
+        operation: "run-command",
+      }),
+    ).toMatchObject({
+      domain: "unknown",
+      errorClass: "unknown-error",
+      fingerprint: ["poracode", "unknown", "run-command", "unknown-error"],
+    });
+  });
+
+  it("creates a payload-free diagnostic transition breadcrumb", () => {
+    expect(
+      buildDiagnosticBreadcrumb({
+        domain: "supervisor.ipc",
+        operation: "write-terminal",
+        state: "failed",
+        transition: "expected-operational",
+        level: "warning",
+      }),
+    ).toEqual({
+      category: "poracode.diagnostic.transition",
+      type: "info",
+      level: "warning",
+      data: {
+        domain: "supervisor.ipc",
+        operation: "write-terminal",
+        state: "failed",
+        transition: "expected-operational",
+      },
+    });
+  });
+});

--- a/src/shared/diagnostics/sentryPolicy.ts
+++ b/src/shared/diagnostics/sentryPolicy.ts
@@ -1,0 +1,146 @@
+export const DIAGNOSTIC_BREADCRUMB_CATEGORY = "poracode.diagnostic.transition";
+
+export type DiagnosticFailureClass =
+  | "expected-operational"
+  | "transient-service"
+  | "product-defect"
+  | "unknown";
+
+export type DiagnosticTreatment = "drop" | "metric" | "capture";
+export type DiagnosticLevel = "warning" | "error";
+
+export type DiagnosticFailureMetadata = {
+  failureClass: Exclude<DiagnosticFailureClass, "unknown">;
+  domain: string;
+  errorClass: string;
+};
+
+export type DiagnosticFailureContext = {
+  domain: string;
+  operation: string;
+};
+
+export type DiagnosticFailureDecision = {
+  failureClass: DiagnosticFailureClass;
+  treatment: DiagnosticTreatment;
+  level: DiagnosticLevel | null;
+  operational: boolean;
+  domain: string;
+  operation: string;
+  errorClass: string;
+  fingerprint: string[] | null;
+};
+
+export type DiagnosticBreadcrumb = {
+  category: typeof DIAGNOSTIC_BREADCRUMB_CATEGORY;
+  type: "info";
+  level: "info" | "warning" | "error";
+  data: {
+    domain: string;
+    operation: string;
+    state: string;
+    transition: string;
+  };
+};
+
+const DIAGNOSTIC_TOKEN_PATTERN = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/u;
+const MAX_DIAGNOSTIC_TOKEN_LENGTH = 64;
+
+const TREATMENTS: Record<
+  DiagnosticFailureClass,
+  { treatment: DiagnosticTreatment; level: DiagnosticLevel | null; operational: boolean }
+> = {
+  "expected-operational": { treatment: "drop", level: null, operational: true },
+  "transient-service": { treatment: "metric", level: "warning", operational: true },
+  "product-defect": { treatment: "capture", level: "error", operational: false },
+  unknown: { treatment: "capture", level: "error", operational: false },
+};
+
+function stableToken(value: string, fallback: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_DIAGNOSTIC_TOKEN_LENGTH ||
+    !DIAGNOSTIC_TOKEN_PATTERN.test(normalized)
+  ) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function builtInErrorClass(error: unknown): string {
+  if (error instanceof AggregateError) return "aggregate-error";
+  if (error instanceof EvalError) return "eval-error";
+  if (error instanceof RangeError) return "range-error";
+  if (error instanceof ReferenceError) return "reference-error";
+  if (error instanceof SyntaxError) return "syntax-error";
+  if (error instanceof TypeError) return "type-error";
+  if (error instanceof URIError) return "uri-error";
+  if (error instanceof Error) return "error";
+  return "non-error";
+}
+
+export class DiagnosticError extends Error {
+  readonly diagnostic: DiagnosticFailureMetadata;
+
+  constructor(
+    message: string,
+    diagnostic: DiagnosticFailureMetadata,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = "DiagnosticError";
+    this.diagnostic = diagnostic;
+  }
+}
+
+export function isStableDiagnosticToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_DIAGNOSTIC_TOKEN_LENGTH &&
+    DIAGNOSTIC_TOKEN_PATTERN.test(value)
+  );
+}
+
+export function classifyDiagnosticFailure(
+  error: unknown,
+  context: DiagnosticFailureContext,
+  knownClassification?: DiagnosticFailureMetadata,
+): DiagnosticFailureDecision {
+  const metadata =
+    knownClassification ?? (error instanceof DiagnosticError ? error.diagnostic : undefined);
+  const failureClass = metadata?.failureClass ?? "unknown";
+  const treatment = TREATMENTS[failureClass];
+  const domain = stableToken(metadata?.domain ?? context.domain, "unknown");
+  const operation = stableToken(context.operation, "unknown");
+  const errorClass = stableToken(metadata?.errorClass ?? builtInErrorClass(error), "unknown-error");
+
+  return {
+    failureClass,
+    ...treatment,
+    domain,
+    operation,
+    errorClass,
+    fingerprint: failureClass === "unknown" ? null : ["poracode", domain, operation, errorClass],
+  };
+}
+
+export function buildDiagnosticBreadcrumb(
+  input: Omit<DiagnosticBreadcrumb["data"], "domain" | "operation"> &
+    Pick<DiagnosticFailureDecision, "domain" | "operation"> & {
+      level?: DiagnosticBreadcrumb["level"];
+    },
+): DiagnosticBreadcrumb {
+  return {
+    category: DIAGNOSTIC_BREADCRUMB_CATEGORY,
+    type: "info",
+    level: input.level ?? "info",
+    data: {
+      domain: stableToken(input.domain, "unknown"),
+      operation: stableToken(input.operation, "unknown"),
+      state: stableToken(input.state, "unknown"),
+      transition: stableToken(input.transition, "unknown"),
+    },
+  };
+}

--- a/src/shared/diagnostics/sentryPrivacy.test.ts
+++ b/src/shared/diagnostics/sentryPrivacy.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRuntimeDiagnosticTags,
+  prepareSentryEvent,
   sanitizeSentryEvent,
   type SentryEventLike,
 } from "./sentryPrivacy";
+import { buildDiagnosticBreadcrumb } from "./sentryPolicy";
 
 describe("sentryPrivacy", () => {
   it("keeps only allowlisted diagnostic tags", () => {
     const event = sanitizeSentryEvent({
       tags: {
+        "poracode.error_class": "/Users/alice/private-repo",
+        "poracode.failure_domain": "supervisor.ipc",
+        "poracode.operational": "true",
         "poracode.provider": "codex",
         "poracode.presentation": "terminal",
         repo: "secret-repo",
@@ -17,12 +22,14 @@ describe("sentryPrivacy", () => {
     });
 
     expect(event.tags).toEqual({
+      "poracode.failure_domain": "supervisor.ipc",
+      "poracode.operational": "true",
       "poracode.provider": "codex",
       "poracode.presentation": "terminal",
     });
   });
 
-  it("drops user, request, extra, modules, and breadcrumbs", () => {
+  it("drops user, request, extra, modules, and automatic breadcrumbs", () => {
     const event = sanitizeSentryEvent({
       breadcrumbs: [{ message: "terminal output" }],
       extra: { prompt: "write code", token: "secret" },
@@ -40,13 +47,16 @@ describe("sentryPrivacy", () => {
     expect(event.user).toBeUndefined();
   });
 
-  it("scrubs paths, tokens, and frame locals while preserving stack frame shape", () => {
+  it("scrubs messages and exception values while preserving privacy-safe stack shape", () => {
     const event = sanitizeSentryEvent({
-      message: "Failed in /Users/alice/work/private-repo/src/app.ts token=abc123",
+      message:
+        'Git push failed: Command failed: git push https://github.example/private/repo.git private-branch --force\nfatal: unable to access "https://github.example/private/repo.git": Could not resolve host: github.example',
       exception: {
         values: [
           {
-            value: "Cannot open C:\\Users\\alice\\repo\\secret.ts",
+            type: "Error",
+            value:
+              'Git commit failed: Command failed: git commit -m "private commit message" private-branch\nhusky - pre-commit script failed (code 1)',
             stacktrace: {
               frames: [
                 {
@@ -63,13 +73,149 @@ describe("sentryPrivacy", () => {
       },
     } satisfies SentryEventLike);
 
-    expect(event.message).toBe("Failed in [path] token=[redacted]");
-    expect(event.exception?.values?.[0]?.value).toBe("Cannot open [path]");
+    expect(event.message).toBe(
+      'Git push failed: Command failed: [redacted]\nfatal: unable to access "[url]": Could not resolve host: github.example',
+    );
+    expect(event.exception?.values?.[0]?.type).toBe("Error");
+    expect(event.exception?.values?.[0]?.value).toBe(
+      "Git commit failed: Command failed: [redacted]\nhusky - pre-commit script failed (code 1)",
+    );
     expect(event.exception?.values?.[0]?.stacktrace?.frames?.[0]).toEqual({
-      filename: "[path]",
-      abs_path: "[path]",
+      filename: "[app-file]/app.ts",
+      abs_path: "[app-file]/app.ts",
       function: "runThread",
     });
+  });
+
+  it("retains path and credential redaction for ordinary diagnostic reasons", () => {
+    const event = sanitizeSentryEvent({
+      message: "Failed in /Users/alice/work/private-repo/src/app.ts token=abc123",
+      exception: {
+        values: [{ value: "Cannot open C:\\Users\\alice\\repo\\secret.ts" }],
+      },
+    } satisfies SentryEventLike);
+
+    expect(event.message).toBe("Failed in [path] token=[redacted]");
+    expect(event.exception?.values?.[0]?.value).toBe("Cannot open [path]");
+  });
+
+  it("keeps only curated payload-free diagnostic breadcrumbs", () => {
+    const event = sanitizeSentryEvent({
+      breadcrumbs: [
+        buildDiagnosticBreadcrumb({
+          domain: "supervisor.ipc",
+          operation: "start-thread",
+          state: "running",
+          transition: "failed",
+        }),
+        {
+          category: "poracode.diagnostic.transition",
+          type: "info",
+          message: "private prompt",
+          data: {
+            domain: "supervisor.ipc",
+            operation: "/Users/alice/repo",
+            state: "running",
+            transition: "failed",
+          },
+        },
+        { category: "console", type: "info", message: "terminal output" },
+      ],
+    } satisfies SentryEventLike);
+
+    expect(event.breadcrumbs).toEqual([
+      {
+        category: "poracode.diagnostic.transition",
+        type: "info",
+        level: "info",
+        data: {
+          domain: "supervisor.ipc",
+          operation: "start-thread",
+          state: "running",
+          transition: "failed",
+        },
+      },
+    ]);
+  });
+
+  it("keeps only stable privacy-safe fingerprints", () => {
+    expect(
+      sanitizeSentryEvent({
+        fingerprint: ["poracode", "supervisor.ipc", "write-terminal", "error"],
+      }).fingerprint,
+    ).toEqual(["poracode", "supervisor.ipc", "write-terminal", "error"]);
+    expect(
+      sanitizeSentryEvent({
+        fingerprint: ["poracode", "/Users/alice/private-repo"],
+      }).fingerprint,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ["Cannot resize a pty that has already exited", "resizeterminal"],
+    ["ioctl(2) failed, ENOTTY", "resizeterminal"],
+  ])("drops the audited expected signature as a beforeSend backstop: %s", (value, operation) => {
+    expect(
+      prepareSentryEvent({
+        tags: {
+          "poracode.feature_area": "supervisor-ipc",
+          "poracode.operation": operation,
+        },
+        exception: { values: [{ value }] },
+      }),
+    ).toBeNull();
+  });
+
+  it.each(["interruptthread", "sendthreadinput", "writeterminal"])(
+    "does not drop a missing-session invariant from %s",
+    (operation) => {
+      const value = "Unknown thread session: 945a852b-4a68-42c2-ad9d-7671014abc71";
+      const event = prepareSentryEvent({
+        tags: {
+          "poracode.feature_area": "supervisor-ipc",
+          "poracode.operation": operation,
+        },
+        exception: { values: [{ value }] },
+      });
+
+      expect(event?.exception?.values?.[0]?.value).toBe(value);
+    },
+  );
+
+  it("does not drop a resize signature outside resizeTerminal", () => {
+    const event = prepareSentryEvent({
+      tags: {
+        "poracode.feature_area": "supervisor-ipc",
+        "poracode.operation": "startthread",
+      },
+      exception: {
+        values: [{ value: "Cannot resize a pty that has already exited" }],
+      },
+    });
+
+    expect(event?.exception?.values?.[0]?.value).toBe(
+      "Cannot resize a pty that has already exited",
+    );
+  });
+
+  it("does not drop unknown errors at the beforeSend backstop", () => {
+    const event = prepareSentryEvent({
+      tags: { "poracode.feature_area": "supervisor-ipc" },
+      exception: {
+        values: [
+          {
+            value: "ENOENT: /Users/alice/private-repo",
+            stacktrace: { frames: [{ function: "readProjectFile" }] },
+          },
+        ],
+      },
+    });
+
+    expect(event).not.toBeNull();
+    expect(event?.exception?.values?.[0]?.value).toBe("ENOENT: [path]");
+    expect(event?.exception?.values?.[0]?.stacktrace?.frames).toEqual([
+      { function: "readProjectFile" },
+    ]);
   });
 
   it("preserves the poracode context (channel, appVersion, packaged) while still dropping disallowed contexts", () => {

--- a/src/shared/diagnostics/sentryPrivacy.test.ts
+++ b/src/shared/diagnostics/sentryPrivacy.test.ts
@@ -73,18 +73,54 @@ describe("sentryPrivacy", () => {
       },
     } satisfies SentryEventLike);
 
-    expect(event.message).toBe(
-      'Git push failed: Command failed: [redacted]\nfatal: unable to access "[url]": Could not resolve host: github.example',
-    );
+    expect(event.message).toBe("Command failed: [redacted]");
     expect(event.exception?.values?.[0]?.type).toBe("Error");
-    expect(event.exception?.values?.[0]?.value).toBe(
-      "Git commit failed: Command failed: [redacted]\nhusky - pre-commit script failed (code 1)",
-    );
+    expect(event.exception?.values?.[0]?.value).toBe("Command failed: [redacted]");
     expect(event.exception?.values?.[0]?.stacktrace?.frames?.[0]).toEqual({
       filename: "[app-file]/app.ts",
       abs_path: "[app-file]/app.ts",
       function: "runThread",
     });
+  });
+
+  it("drops adversarial command output instead of attempting content redaction", () => {
+    const privateValues = [
+      "private-feature-branch",
+      "secret-repository",
+      "repeat the user's private prompt",
+      "alice@example.com",
+      "super-secret-value",
+      "/opt/acme/private/repository/file.ts",
+    ];
+    const raw = [
+      "Git push failed: Command failed: git push origin private-feature-branch",
+      "fatal: secret-repository",
+      "prompt: repeat the user's private prompt",
+      "email alice@example.com",
+      "secret super-secret-value",
+      "source /opt/acme/private/repository/file.ts",
+    ].join("\n");
+    const event = sanitizeSentryEvent({
+      message: raw,
+      exception: { values: [{ type: "Error", value: raw }] },
+    } satisfies SentryEventLike);
+
+    expect(event.message).toBe("Command failed: [redacted]");
+    expect(event.exception?.values?.[0]?.value).toBe("Command failed: [redacted]");
+    const serialized = JSON.stringify(event);
+    for (const privateValue of privateValues) {
+      expect(serialized).not.toContain(privateValue);
+    }
+  });
+
+  it("bounds multiline reasons and redacts broader path, email, and secret forms", () => {
+    const event = sanitizeSentryEvent({
+      message:
+        "Failed in /opt/acme/private-repo email alice@example.com password hunter2\nprivate prompt follows",
+    });
+
+    expect(event.message).toBe("Failed in [path] email [email] password=[redacted]");
+    expect(event.message).not.toContain("private prompt");
   });
 
   it("retains path and credential redaction for ordinary diagnostic reasons", () => {

--- a/src/shared/diagnostics/sentryPrivacy.ts
+++ b/src/shared/diagnostics/sentryPrivacy.ts
@@ -84,13 +84,31 @@ const SENSITIVE_KEY_PATTERN =
   /(?:account|api[-_]?key|authorization|branch|cmd|code|command|cookie|cwd|diff|email|env|file|filename|home|ip|key|output|password|path|project|prompt|query|remote|repo|repository|secret|terminal|token|url|user|username|worktree)/i;
 
 function sanitizeString(value: string): string {
-  return value
+  // Child-process errors append arbitrary stdout/stderr after this marker.
+  // Those streams can contain prompts, branch/repository names, hook output,
+  // source text, emails, or credentials. Classification runs on the raw error
+  // before beforeSend, so telemetry only needs a fixed payload-free reason.
+  if (value.includes("Command failed:")) {
+    return "Command failed: [redacted]";
+  }
+
+  // Exception messages are not a safe transport for multiline process output.
+  // Retain only the bounded summary line; stable tags/fingerprints carry the
+  // diagnostic class selected from the raw error.
+  const [summary = ""] = value.split(/\r?\n/u, 1);
+  return summary
     .replace(/https?:\/\/[^\s"'<>)]*/giu, "[url]")
-    .replace(/Command failed:[^\r\n]*/gu, "Command failed: [redacted]")
-    .replace(/(?:file:\/\/)?\/(?:Users|home|private|tmp|var)\/[^\s"'<>)]*/g, "[path]")
+    .replace(
+      /(?:file:\/\/)?\/(?:Users|home|private|tmp|var|opt|srv|mnt|Volumes)\/[^\s"'<>)]*/g,
+      "[path]",
+    )
     .replace(/[A-Za-z]:\\[^\s"'<>)]*/g, "[path]")
-    .replace(/(token|secret|password|api[-_]?key|authorization)=([^&\s]+)/gi, "$1=[redacted]")
-    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]");
+    .replace(
+      /(token|secret|password|api[-_ ]?key|authorization)(?:\s*[:=]\s*|\s+)([^&\s]+)/gi,
+      "$1=[redacted]",
+    )
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/giu, "[email]");
 }
 
 function sanitizeFramePath(value: unknown): unknown {

--- a/src/shared/diagnostics/sentryPrivacy.ts
+++ b/src/shared/diagnostics/sentryPrivacy.ts
@@ -1,11 +1,17 @@
+import { DIAGNOSTIC_BREADCRUMB_CATEGORY, isStableDiagnosticToken } from "./sentryPolicy";
+
 export const PORACODE_DIAGNOSTIC_TAG_KEYS = [
   "poracode.app_version",
   "poracode.arch",
   "poracode.channel",
   "poracode.chrome",
+  "poracode.error_class",
   "poracode.electron",
+  "poracode.failure_domain",
   "poracode.feature_area",
   "poracode.node",
+  "poracode.operation",
+  "poracode.operational",
   "poracode.platform",
   "poracode.presentation",
   "poracode.process",
@@ -28,16 +34,25 @@ export type PoracodeRuntimeDiagnosticContext = {
 };
 
 export type SentryEventLike = Record<string, unknown> & {
-  breadcrumbs?: unknown[];
+  breadcrumbs?: Array<{
+    category?: string;
+    data?: Record<string, unknown>;
+    level?: string;
+    message?: string;
+    type?: string;
+  }>;
   contexts?: Record<string, unknown>;
   exception?: {
     values?: Array<{
       mechanism?: Record<string, unknown>;
       stacktrace?: { frames?: Array<Record<string, unknown>> };
+      type?: string;
       value?: string;
     }>;
   };
   extra?: Record<string, unknown>;
+  fingerprint?: unknown[];
+  level?: string;
   message?: string;
   modules?: Record<string, unknown>;
   request?: Record<string, unknown>;
@@ -48,6 +63,12 @@ export type SentryEventLike = Record<string, unknown> & {
 };
 
 const ALLOWED_TAG_KEYS = new Set<string>(PORACODE_DIAGNOSTIC_TAG_KEYS);
+const STABLE_TOKEN_TAG_KEYS = new Set([
+  "poracode.error_class",
+  "poracode.failure_domain",
+  "poracode.operation",
+  "poracode.operational",
+]);
 const ALLOWED_CONTEXT_KEYS = new Set([
   "app",
   "browser",
@@ -64,6 +85,8 @@ const SENSITIVE_KEY_PATTERN =
 
 function sanitizeString(value: string): string {
   return value
+    .replace(/https?:\/\/[^\s"'<>)]*/giu, "[url]")
+    .replace(/Command failed:[^\r\n]*/gu, "Command failed: [redacted]")
     .replace(/(?:file:\/\/)?\/(?:Users|home|private|tmp|var)\/[^\s"'<>)]*/g, "[path]")
     .replace(/[A-Za-z]:\\[^\s"'<>)]*/g, "[path]")
     .replace(/(token|secret|password|api[-_]?key|authorization)=([^&\s]+)/gi, "$1=[redacted]")
@@ -72,9 +95,11 @@ function sanitizeString(value: string): string {
 
 function sanitizeFramePath(value: unknown): unknown {
   if (typeof value !== "string") return value;
-  const sanitized = sanitizeString(value);
-  const pathMatch = sanitized.match(/\[path\][\\/]+([^\\/]+)$/);
-  return pathMatch?.[1] ? `[app-file]/${pathMatch[1]}` : sanitized;
+  if (/^(?:file:\/\/)?\//u.test(value) || /^[A-Za-z]:\\/u.test(value)) {
+    const filename = value.split(/[\\/]/u).at(-1);
+    return filename ? `[app-file]/${sanitizeString(filename)}` : "[app-file]";
+  }
+  return sanitizeString(value);
 }
 
 function sanitizeRecord(
@@ -114,10 +139,53 @@ function sanitizeTags(
   for (const [key, value] of Object.entries(tags)) {
     if (!ALLOWED_TAG_KEYS.has(key)) continue;
     if (typeof value === "string" && value.trim().length > 0) {
+      if (STABLE_TOKEN_TAG_KEYS.has(key) && !isStableDiagnosticToken(value)) continue;
       output[key] = sanitizeString(value);
     }
   }
   return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function sanitizeBreadcrumbs(
+  breadcrumbs: SentryEventLike["breadcrumbs"],
+): SentryEventLike["breadcrumbs"] | undefined {
+  if (!breadcrumbs) return undefined;
+  const output = breadcrumbs.flatMap((breadcrumb) => {
+    if (
+      breadcrumb.category !== DIAGNOSTIC_BREADCRUMB_CATEGORY ||
+      breadcrumb.type !== "info" ||
+      !breadcrumb.data
+    ) {
+      return [];
+    }
+    const { domain, operation, state, transition } = breadcrumb.data;
+    if (
+      !isStableDiagnosticToken(domain) ||
+      !isStableDiagnosticToken(operation) ||
+      !isStableDiagnosticToken(state) ||
+      !isStableDiagnosticToken(transition)
+    ) {
+      return [];
+    }
+    return [
+      {
+        category: DIAGNOSTIC_BREADCRUMB_CATEGORY,
+        type: "info",
+        level:
+          breadcrumb.level === "warning" || breadcrumb.level === "error"
+            ? breadcrumb.level
+            : "info",
+        data: { domain, operation, state, transition },
+      },
+    ];
+  });
+  return output.length > 0 ? output : undefined;
+}
+
+function sanitizeFingerprint(fingerprint: unknown[] | undefined): string[] | undefined {
+  if (!fingerprint || fingerprint.length === 0 || fingerprint.length > 6) return undefined;
+  if (!fingerprint.every(isStableDiagnosticToken)) return undefined;
+  return fingerprint;
 }
 
 function sanitizeContexts(
@@ -141,24 +209,48 @@ function sanitizeException(exception: SentryEventLike["exception"]): SentryEvent
   if (!exception?.values) return exception;
   return {
     values: exception.values.map((entry) => {
-      const next = sanitizeRecord(entry as Record<string, unknown>, { allowSensitiveKeys: true });
+      const next: Record<string, unknown> = {};
+      if (typeof entry.type === "string" && /^[A-Za-z_$][A-Za-z0-9_$]{0,63}$/u.test(entry.type)) {
+        next.type = entry.type;
+      }
       if (entry.value) {
         next.value = sanitizeString(entry.value);
       }
       if (entry.mechanism) {
-        next.mechanism = sanitizeRecord(entry.mechanism);
+        const mechanism: Record<string, unknown> = {};
+        if (isStableDiagnosticToken(entry.mechanism.type)) {
+          mechanism.type = entry.mechanism.type;
+        }
+        if (typeof entry.mechanism.handled === "boolean") {
+          mechanism.handled = entry.mechanism.handled;
+        }
+        if (typeof entry.mechanism.synthetic === "boolean") {
+          mechanism.synthetic = entry.mechanism.synthetic;
+        }
+        if (Object.keys(mechanism).length > 0) {
+          next.mechanism = mechanism;
+        }
       }
       const frames = entry.stacktrace?.frames;
       if (frames) {
         next.stacktrace = {
           frames: frames.map((frame) => {
-            const sanitizedFrame = sanitizeRecord(frame, { allowSensitiveKeys: true });
-            sanitizedFrame.filename = sanitizeFramePath(frame.filename);
-            sanitizedFrame.abs_path = sanitizeFramePath(frame.abs_path);
-            delete sanitizedFrame.vars;
-            delete sanitizedFrame.context_line;
-            delete sanitizedFrame.pre_context;
-            delete sanitizedFrame.post_context;
+            const sanitizedFrame: Record<string, unknown> = {};
+            if (
+              typeof frame.function === "string" &&
+              /^[A-Za-z_$<][A-Za-z0-9_$<>.[\] ]{0,159}$/u.test(frame.function)
+            ) {
+              sanitizedFrame.function = frame.function;
+            }
+            if (typeof frame.filename === "string") {
+              sanitizedFrame.filename = sanitizeFramePath(frame.filename);
+            }
+            if (typeof frame.abs_path === "string") {
+              sanitizedFrame.abs_path = sanitizeFramePath(frame.abs_path);
+            }
+            if (typeof frame.lineno === "number") sanitizedFrame.lineno = frame.lineno;
+            if (typeof frame.colno === "number") sanitizedFrame.colno = frame.colno;
+            if (typeof frame.in_app === "boolean") sanitizedFrame.in_app = frame.in_app;
             return sanitizedFrame;
           }),
         };
@@ -181,7 +273,6 @@ export function buildRuntimeDiagnosticTags(
 
 export function sanitizeSentryEvent<T extends SentryEventLike>(event: T): T {
   const sanitized: SentryEventLike = { ...event };
-  delete sanitized.breadcrumbs;
   delete sanitized.extra;
   delete sanitized.modules;
   delete sanitized.request;
@@ -190,6 +281,20 @@ export function sanitizeSentryEvent<T extends SentryEventLike>(event: T): T {
 
   if (event.message) sanitized.message = sanitizeString(event.message);
   if (event.transaction) sanitized.transaction = sanitizeString(event.transaction);
+
+  const breadcrumbs = sanitizeBreadcrumbs(event.breadcrumbs);
+  if (breadcrumbs) {
+    sanitized.breadcrumbs = breadcrumbs;
+  } else {
+    delete sanitized.breadcrumbs;
+  }
+
+  const fingerprint = sanitizeFingerprint(event.fingerprint);
+  if (fingerprint) {
+    sanitized.fingerprint = fingerprint;
+  } else {
+    delete sanitized.fingerprint;
+  }
 
   const tags = sanitizeTags(event.tags);
   if (tags) {
@@ -213,4 +318,29 @@ export function sanitizeSentryEvent<T extends SentryEventLike>(event: T): T {
   }
 
   return sanitized as T;
+}
+
+const TERMINAL_EXPECTED_SIGNATURES = new Set([
+  "Cannot resize a pty that has already exited",
+  "ioctl(2) failed, ENOTTY",
+]);
+
+function isKnownExpectedEvent(event: SentryEventLike): boolean {
+  const domain = event.tags?.["poracode.failure_domain"];
+  const featureArea = event.tags?.["poracode.feature_area"];
+  if (domain !== "supervisor.ipc" && featureArea !== "supervisor-ipc") return false;
+  const operation = event.tags?.["poracode.operation"];
+
+  const values = [
+    event.message,
+    ...(event.exception?.values?.map((entry) => entry.value) ?? []),
+  ].filter((value): value is string => typeof value === "string");
+  return values.some(
+    (value) => operation === "resizeterminal" && TERMINAL_EXPECTED_SIGNATURES.has(value),
+  );
+}
+
+export function prepareSentryEvent<T extends SentryEventLike>(event: T): T | null {
+  if (isKnownExpectedEvent(event)) return null;
+  return sanitizeSentryEvent(event);
 }

--- a/src/supervisor/diagnostics/sentry.test.ts
+++ b/src/supervisor/diagnostics/sentry.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "vitest";
+import { classifySupervisorFailure, classifySupervisorIpcFailure } from "./sentry";
+
+type ClassificationCase = {
+  operation: string;
+  message: string;
+  errorClass: string;
+  operationScoped?: boolean;
+};
+
+const EXPECTED_OPERATIONAL_CASES: ClassificationCase[] = [
+  {
+    operation: "resizeTerminal",
+    message: "Cannot resize a pty that has already exited",
+    errorClass: "terminal-already-exited",
+  },
+  {
+    operation: "resizeTerminal",
+    message: "ioctl(2) failed, ENOTTY",
+    errorClass: "terminal-not-attached",
+  },
+  {
+    operation: "ghListPrs",
+    message: 'GitHub CLI is not authenticated. Run "gh auth login" in the terminal.',
+    errorClass: "github-cli-unauthenticated",
+  },
+  {
+    operation: "interruptThread",
+    message: "NO ACTIVE TURN TO INTERRUPT",
+    errorClass: "no-active-turn",
+  },
+  {
+    operation: "rollbackThreadConversation",
+    message: "pi ACP does not support checkpoint rollback.",
+    errorClass: "checkpoint-rollback-unsupported",
+  },
+  {
+    operation: "extractContext",
+    message: "Cannot extract context from OpenCode: no session resume or scrollback available",
+    errorClass: "context-extraction-unavailable",
+  },
+  {
+    operation: "generateTitle",
+    message: "No default one-shot model configured for GitHub Copilot",
+    errorClass: "one-shot-model-unconfigured",
+  },
+  {
+    operation: "generatePrSummary",
+    message: "No commits found between branches",
+    errorClass: "no-commits-between-branches",
+  },
+  {
+    operation: "ghCreatePr",
+    message:
+      'gh pr create failed\na pull request for branch "feature" into branch "master" already exists:\nhttps://github.example/pull/1\n',
+    errorClass: "github-pull-request-exists",
+  },
+  {
+    operation: "startThread",
+    message:
+      "error: failed to run prompt: provider.api_error: 403 You've reached your usage limit for this billing cycle. Your quota will be refreshed in the next cycle.\nSee log: /private/path",
+    errorClass: "provider-quota-exhausted",
+  },
+  {
+    operation: "sendThreadInput",
+    message:
+      "Payment or usage limit reached (HTTP 402). Check your Factory account billing or usage.",
+    errorClass: "provider-quota-exhausted",
+  },
+  {
+    operation: "startThread",
+    message: "Internal error: Device authentication failed",
+    errorClass: "provider-authentication-required",
+  },
+  {
+    operation: "authenticateAcpAgent",
+    message: "User authentication required",
+    errorClass: "provider-authentication-required",
+  },
+  {
+    operation: "createFileCheckpoint",
+    message:
+      "Git rev-parse failed: Command failed: git rev-parse --is-inside-work-tree\nfatal: not a git repository (or any of the parent directories): .git\n",
+    errorClass: "git-not-a-repository",
+    operationScoped: false,
+  },
+  {
+    operation: "gitCommit",
+    message:
+      "Git commit failed: Command failed: git commit\nhusky - pre-commit hook exited with code 127 (error)\n",
+    errorClass: "git-commit-hook-rejected",
+  },
+  {
+    operation: "gitPush",
+    message:
+      "Git push failed\n ! [rejected] main -> main (non-fast-forward)\nhint: Updates were rejected because the tip of your current branch is behind\n",
+    errorClass: "git-non-fast-forward",
+  },
+  {
+    operation: "gitPush",
+    message:
+      "Git push failed\nhint: Updates were rejected because the tip of your current branch is behind its remote counterpart\n",
+    errorClass: "git-non-fast-forward",
+  },
+  {
+    operation: "gitCommit",
+    message:
+      "Git commit failed: Command failed: git commit\nhusky - pre-commit script failed (code 1)\n",
+    errorClass: "git-commit-hook-rejected",
+  },
+];
+
+const NEAR_MISS_CASES: ClassificationCase[] = [
+  {
+    operation: "ghListPrs",
+    message: 'GitHub CLI is not authenticated. Run "gh auth login" in the terminal!',
+    errorClass: "github-cli-unauthenticated",
+  },
+  {
+    operation: "interruptThread",
+    message: "no active turns to interrupt",
+    errorClass: "no-active-turn",
+  },
+  {
+    operation: "rollbackThreadConversation",
+    message: "pi ACP does not support checkpoint rollback",
+    errorClass: "checkpoint-rollback-unsupported",
+  },
+  {
+    operation: "extractContext",
+    message: "Cannot extract context from OpenCode: scrollback read failed",
+    errorClass: "context-extraction-unavailable",
+  },
+  {
+    operation: "generateTitle",
+    message: "No default model configured for GitHub Copilot",
+    errorClass: "one-shot-model-unconfigured",
+  },
+  {
+    operation: "generatePrSummary",
+    message: "No commits found between branches.",
+    errorClass: "no-commits-between-branches",
+  },
+  {
+    operation: "ghCreatePr",
+    message: 'GraphQL: Field "mergeStateStatus" doesn\'t exist on type "PullRequest"',
+    errorClass: "github-pull-request-exists",
+  },
+  {
+    operation: "ghCreatePr",
+    message:
+      'a pull request for branch "feature" into branch "master" already exists\nhttps://github.example/pull/1',
+    errorClass: "github-pull-request-exists",
+  },
+  {
+    operation: "generateTitle",
+    message: "error: failed to run prompt: provider.api_error: 403 Forbidden",
+    errorClass: "provider-quota-exhausted",
+  },
+  {
+    operation: "startThread",
+    message: "Internal error: Authentication failed",
+    errorClass: "provider-authentication-required",
+  },
+  {
+    operation: "createFileCheckpoint",
+    message: "fatal: this operation must be run in a work tree",
+    errorClass: "git-not-a-repository",
+  },
+  {
+    operation: "gitCommit",
+    message: "Git commit failed: Command failed: git commit",
+    errorClass: "git-commit-hook-rejected",
+  },
+  {
+    operation: "gitCommit",
+    message:
+      "Git commit failed: Command failed: git commit\nhusky - pre-commit script failed unexpectedly (code 1)\n",
+    errorClass: "git-commit-hook-rejected",
+  },
+  {
+    operation: "gitPush",
+    message: "Git push failed: Updates were rejected by the remote.",
+    errorClass: "git-non-fast-forward",
+  },
+];
+
+function expectUnknown(operation: string, message: string): void {
+  expect(classifySupervisorIpcFailure(new Error(message), operation)).toMatchObject({
+    failureClass: "unknown",
+    treatment: "capture",
+    level: "error",
+    operational: false,
+    errorClass: "error",
+    fingerprint: null,
+  });
+}
+
+function expectTransient(operation: string, error: Error, errorClass: string): void {
+  expect(classifySupervisorIpcFailure(error, operation)).toEqual({
+    failureClass: "transient-service",
+    treatment: "metric",
+    level: "warning",
+    operational: true,
+    domain: "supervisor.ipc",
+    operation: operation.toLowerCase(),
+    errorClass,
+    fingerprint: ["poracode", "supervisor.ipc", operation.toLowerCase(), errorClass],
+  });
+}
+
+describe("supervisor Sentry policy", () => {
+  it.each(EXPECTED_OPERATIONAL_CASES)(
+    "drops $errorClass only for $operation",
+    ({ operation, message, errorClass }) => {
+      expect(classifySupervisorIpcFailure(new Error(message), operation)).toEqual({
+        failureClass: "expected-operational",
+        treatment: "drop",
+        level: null,
+        operational: true,
+        domain: "supervisor.ipc",
+        operation: operation.toLowerCase(),
+        errorClass,
+        fingerprint: ["poracode", "supervisor.ipc", operation.toLowerCase(), errorClass],
+      });
+    },
+  );
+
+  it("routes the exact generateTitle server failure to a warning metric", () => {
+    expect.hasAssertions();
+    expectTransient(
+      "generateTitle",
+      new Error("session.prompt: Unexpected server error. Check server logs for details."),
+      "provider-service-unavailable",
+    );
+  });
+
+  it.each(["gitFetch", "gitPull", "gitPullRebase", "gitPush", "gitSync", "gitSyncRebase"])(
+    "routes an audited network failure from %s to a warning metric",
+    (operation) => {
+      expect.hasAssertions();
+      expectTransient(
+        operation,
+        new Error(
+          "Git remote operation failed: Command failed: git remote-operation\nfatal: Failed to connect to proxy: Could not connect to server",
+        ),
+        "git-network-unavailable",
+      );
+    },
+  );
+
+  it("routes only an exact fetch TypeError to a warning metric", () => {
+    expectTransient("getProviderUsage", new TypeError("fetch failed"), "fetch-failed");
+    expectUnknown("getProviderUsage", "fetch failed");
+    expect(
+      classifySupervisorIpcFailure(
+        new TypeError("fetch failed with status 500"),
+        "getProviderUsage",
+      ),
+    ).toMatchObject({
+      failureClass: "unknown",
+      treatment: "capture",
+      errorClass: "type-error",
+      fingerprint: null,
+    });
+  });
+
+  it.each(NEAR_MISS_CASES)(
+    "keeps the $errorClass near miss as an unknown error",
+    ({ operation, message }) => {
+      expect.hasAssertions();
+      expectUnknown(operation, message);
+    },
+  );
+
+  it.each(EXPECTED_OPERATIONAL_CASES.filter((testCase) => testCase.operationScoped !== false))(
+    "keeps $errorClass unknown outside its scoped operation",
+    ({ message }) => {
+      expect.hasAssertions();
+      expectUnknown("readProjectFile", message);
+    },
+  );
+
+  it("keeps the transient signature unknown outside generateTitle", () => {
+    expect.hasAssertions();
+    expectUnknown(
+      "generatePrSummary",
+      "session.prompt: Unexpected server error. Check server logs for details.",
+    );
+  });
+
+  it("keeps ambiguous Git transport and push failures captured", () => {
+    expect.hasAssertions();
+    expectUnknown("gitPull", "Git pull failed: Command failed: git pull origin");
+    expectUnknown(
+      "gitPush",
+      "Git push failed\n ! [rejected] main -> main (fetch first)\nerror: failed to push some refs",
+    );
+    expectUnknown(
+      "gitCommit",
+      "Git commit failed: Command failed: git commit\nlint failed with code 1",
+    );
+  });
+
+  it.each(["interruptThread", "sendThreadInput", "writeTerminal"])(
+    "preserves a never-known thread invariant failure from %s",
+    (operation) => {
+      expect.hasAssertions();
+      expectUnknown(operation, "Unknown thread session: 945a852b-4a68-42c2-ad9d-7671014abc71");
+    },
+  );
+
+  it("preserves generic filesystem failures as unknown errors", () => {
+    expect.hasAssertions();
+    expectUnknown("readProjectFile", "ENOENT: /Users/alice/private-repo");
+  });
+
+  it("routes exact unhandled write EPIPE through the generic supervisor metric policy", () => {
+    expect(classifySupervisorFailure(new Error("write EPIPE"), "supervisor")).toEqual({
+      failureClass: "transient-service",
+      treatment: "metric",
+      level: "warning",
+      operational: true,
+      domain: "supervisor.runtime",
+      operation: "supervisor",
+      errorClass: "broken-pipe",
+      fingerprint: ["poracode", "supervisor.runtime", "supervisor", "broken-pipe"],
+    });
+  });
+
+  it("keeps other generic supervisor failures captured with default grouping", () => {
+    expect(classifySupervisorFailure(new Error("read EPIPE"), "supervisor")).toMatchObject({
+      failureClass: "unknown",
+      treatment: "capture",
+      errorClass: "error",
+      fingerprint: null,
+    });
+    expect(classifySupervisorFailure(new TypeError("write EPIPE"), "supervisor")).toMatchObject({
+      failureClass: "unknown",
+      treatment: "capture",
+      errorClass: "type-error",
+      fingerprint: null,
+    });
+  });
+});

--- a/src/supervisor/diagnostics/sentry.test.ts
+++ b/src/supervisor/diagnostics/sentry.test.ts
@@ -210,6 +210,49 @@ function expectTransient(operation: string, error: Error, errorClass: string): v
 }
 
 describe("supervisor Sentry policy", () => {
+  it.each([
+    ["Structured runtime session creation failed.", "session-creation-failed"],
+    ["Structured runtime transport failed.", "transport-failed"],
+    ["Structured runtime turn failed.", "turn-failed"],
+  ])("classifies the stable structured-runtime identity: %s", (message, errorClass) => {
+    const error = new Error(message) as Error & { diagnosticProvider?: string };
+    error.name = "StructuredRuntimeDiagnosticError";
+    error.diagnosticProvider = "codex";
+
+    expect(classifySupervisorIpcFailure(error, "startThread")).toEqual({
+      failureClass: "product-defect",
+      treatment: "capture",
+      level: "error",
+      operational: false,
+      domain: "structured-runtime",
+      operation: "startthread",
+      errorClass,
+      fingerprint: ["poracode", "structured-runtime", "startthread", errorClass],
+    });
+    expect(classifySupervisorFailure(error, "structured-runtime-turn")).toEqual({
+      failureClass: "product-defect",
+      treatment: "capture",
+      level: "error",
+      operational: false,
+      domain: "structured-runtime",
+      operation: "structured-runtime-turn",
+      errorClass,
+      fingerprint: ["poracode", "structured-runtime", "structured-runtime-turn", errorClass],
+    });
+  });
+
+  it("keeps a structured-runtime name/message near miss unknown", () => {
+    const error = new Error("Structured runtime provider output failed.");
+    error.name = "StructuredRuntimeDiagnosticError";
+
+    expect(classifySupervisorIpcFailure(error, "startThread")).toMatchObject({
+      failureClass: "unknown",
+      treatment: "capture",
+      domain: "supervisor.ipc",
+      fingerprint: null,
+    });
+  });
+
   it.each(EXPECTED_OPERATIONAL_CASES)(
     "drops $errorClass only for $operation",
     ({ operation, message, errorClass }) => {

--- a/src/supervisor/diagnostics/sentry.ts
+++ b/src/supervisor/diagnostics/sentry.ts
@@ -1,8 +1,14 @@
 import {
-  sanitizeSentryEvent,
+  prepareSentryEvent,
   type PoracodeDiagnosticTags,
   type SentryEventLike,
 } from "@/shared/diagnostics/sentryPrivacy";
+import {
+  buildDiagnosticBreadcrumb,
+  classifyDiagnosticFailure,
+  type DiagnosticFailureDecision,
+  type DiagnosticFailureMetadata,
+} from "@/shared/diagnostics/sentryPolicy";
 import {
   readBuildSentryDsn,
   readBuildSentryEnvironment,
@@ -11,6 +17,154 @@ import {
 type SupervisorSentryModule = typeof import("@sentry/node");
 
 let supervisorSentry: SupervisorSentryModule | null | undefined;
+
+type SupervisorIpcFailureRule = {
+  operations: readonly string[] | null;
+  signature: string | RegExp;
+  failureClass: DiagnosticFailureMetadata["failureClass"];
+  errorClass: string;
+  errorType?: "type-error";
+};
+
+const PROVIDER_GENERATION_OPERATIONS = [
+  "extractContext",
+  "generateCommitMessage",
+  "generatePrSummary",
+  "generateTitle",
+] as const;
+const PROVIDER_PROMPT_OPERATIONS = [
+  ...PROVIDER_GENERATION_OPERATIONS,
+  "sendThreadInput",
+  "startThread",
+] as const;
+const PROVIDER_AUTH_OPERATIONS = ["authenticateAcpAgent", ...PROVIDER_PROMPT_OPERATIONS] as const;
+const GIT_NETWORK_OPERATIONS = [
+  "gitFetch",
+  "gitPull",
+  "gitPullRebase",
+  "gitPush",
+  "gitSync",
+  "gitSyncRebase",
+] as const;
+
+const SUPERVISOR_IPC_FAILURE_RULES: readonly SupervisorIpcFailureRule[] = [
+  {
+    operations: ["resizeTerminal"],
+    signature: "Cannot resize a pty that has already exited",
+    failureClass: "expected-operational",
+    errorClass: "terminal-already-exited",
+  },
+  {
+    operations: ["resizeTerminal"],
+    signature: "ioctl(2) failed, ENOTTY",
+    failureClass: "expected-operational",
+    errorClass: "terminal-not-attached",
+  },
+  {
+    operations: ["ghListPrs"],
+    signature: 'GitHub CLI is not authenticated. Run "gh auth login" in the terminal.',
+    failureClass: "expected-operational",
+    errorClass: "github-cli-unauthenticated",
+  },
+  {
+    operations: ["interruptThread"],
+    signature: /^no active turn to interrupt$/iu,
+    failureClass: "expected-operational",
+    errorClass: "no-active-turn",
+  },
+  {
+    operations: ["rollbackThreadConversation"],
+    signature: /^.+ does not support checkpoint rollback\.$/u,
+    failureClass: "expected-operational",
+    errorClass: "checkpoint-rollback-unsupported",
+  },
+  {
+    operations: ["extractContext"],
+    signature: /^Cannot extract context from .+: no session resume or scrollback available$/u,
+    failureClass: "expected-operational",
+    errorClass: "context-extraction-unavailable",
+  },
+  {
+    operations: ["generateTitle"],
+    signature: /^No default one-shot model configured for .+$/u,
+    failureClass: "expected-operational",
+    errorClass: "one-shot-model-unconfigured",
+  },
+  {
+    operations: ["generatePrSummary"],
+    signature: "No commits found between branches",
+    failureClass: "expected-operational",
+    errorClass: "no-commits-between-branches",
+  },
+  {
+    operations: ["ghCreatePr"],
+    signature:
+      /(?:^|\r?\n)a pull request for branch "[^"\r\n]+" into branch "[^"\r\n]+" already exists:(?:\r?\n|$)/u,
+    failureClass: "expected-operational",
+    errorClass: "github-pull-request-exists",
+  },
+  {
+    operations: PROVIDER_PROMPT_OPERATIONS,
+    signature:
+      /^error: failed to run prompt: provider\.api_error: (?:402|403) [^\r\n]*(?:usage limit|quota|billing (?:cycle|limit)|payment required)[\s\S]*$/iu,
+    failureClass: "expected-operational",
+    errorClass: "provider-quota-exhausted",
+  },
+  {
+    operations: PROVIDER_PROMPT_OPERATIONS,
+    signature:
+      /^Payment or usage limit reached \(HTTP 402\)\. Check your [A-Za-z0-9][A-Za-z0-9 ._-]* account billing or usage\.$/u,
+    failureClass: "expected-operational",
+    errorClass: "provider-quota-exhausted",
+  },
+  {
+    operations: PROVIDER_AUTH_OPERATIONS,
+    signature: /^(?:Internal error: )?(?:Device|User) authentication (?:failed|required)$/u,
+    failureClass: "expected-operational",
+    errorClass: "provider-authentication-required",
+  },
+  {
+    operations: ["generateTitle"],
+    signature: "session.prompt: Unexpected server error. Check server logs for details.",
+    failureClass: "transient-service",
+    errorClass: "provider-service-unavailable",
+  },
+  {
+    operations: null,
+    signature:
+      /(?:^|\r?\n)fatal: not a git repository \(or any of the parent directories\): \.git(?:\r?\n|\p{Cc}|$)/u,
+    failureClass: "expected-operational",
+    errorClass: "git-not-a-repository",
+  },
+  {
+    operations: GIT_NETWORK_OPERATIONS,
+    signature:
+      /(?=[\s\S]*(?:Command failed: git|fatal:|error:))[\s\S]*(?:failed to connect|could not connect|could not resolve host|connection (?:reset|timed out)|operation timed out)/iu,
+    failureClass: "transient-service",
+    errorClass: "git-network-unavailable",
+  },
+  {
+    operations: ["gitPush"],
+    signature:
+      /(?:\[rejected\][^\r\n]*\(non-fast-forward\)|Updates were rejected because the tip[^\r\n]* is behind)/u,
+    failureClass: "expected-operational",
+    errorClass: "git-non-fast-forward",
+  },
+  {
+    operations: ["gitCommit"],
+    signature:
+      /(?:^|\r?\n)(?:husky - )?(?:(?:pre-commit|commit-msg|prepare-commit-msg|post-commit) hook (?:declined|exited with code \d+(?: \(error\))?|failed|rejected)|pre-commit script failed \(code \d+\))(?:\r?\n|\p{Cc}|$)/iu,
+    failureClass: "expected-operational",
+    errorClass: "git-commit-hook-rejected",
+  },
+  {
+    operations: null,
+    signature: "fetch failed",
+    failureClass: "transient-service",
+    errorClass: "fetch-failed",
+    errorType: "type-error",
+  },
+];
 
 export type SupervisorSentryOptions = {
   appVersion: string;
@@ -75,7 +229,7 @@ export function initializeSupervisorSentry(options: SupervisorSentryOptions): bo
     environment: readSentryEnvironment(options),
     sendDefaultPii: false,
     defaultIntegrations: false,
-    maxBreadcrumbs: 0,
+    maxBreadcrumbs: 20,
     normalizeDepth: 4,
     tracesSampleRate: 0,
     debug: process.env.SENTRY_DEBUG === "1",
@@ -83,7 +237,7 @@ export function initializeSupervisorSentry(options: SupervisorSentryOptions): bo
       tags: buildBaseTags(options),
     },
     beforeSend(event) {
-      return sanitizeSentryEvent(event as unknown as SentryEventLike) as unknown as typeof event;
+      return prepareSentryEvent(event as unknown as SentryEventLike) as unknown as typeof event;
     },
   });
 
@@ -95,16 +249,128 @@ export function initializeSupervisorSentry(options: SupervisorSentryOptions): bo
   return true;
 }
 
-export function captureSupervisorException(error: unknown, tags?: PoracodeDiagnosticTags): void {
+function errorMessage(error: unknown): string | null {
+  return error instanceof Error ? error.message : null;
+}
+
+function matchesFailureRule(
+  rule: SupervisorIpcFailureRule,
+  error: unknown,
+  operation: string,
+  message: string,
+) {
+  if (rule.operations && !rule.operations.includes(operation)) return false;
+  if (rule.errorType === "type-error" && !(error instanceof TypeError)) return false;
+  return typeof rule.signature === "string"
+    ? message === rule.signature
+    : rule.signature.test(message);
+}
+
+function knownSupervisorIpcClassification(
+  error: unknown,
+  operation: string,
+): DiagnosticFailureMetadata | undefined {
+  const message = errorMessage(error);
+  if (!message) return undefined;
+  const rule = SUPERVISOR_IPC_FAILURE_RULES.find((candidate) =>
+    matchesFailureRule(candidate, error, operation, message),
+  );
+  return rule
+    ? {
+        failureClass: rule.failureClass,
+        domain: "supervisor.ipc",
+        errorClass: rule.errorClass,
+      }
+    : undefined;
+}
+
+export function classifySupervisorIpcFailure(
+  error: unknown,
+  operation: string,
+): DiagnosticFailureDecision {
+  return classifyDiagnosticFailure(
+    error,
+    { domain: "supervisor.ipc", operation },
+    knownSupervisorIpcClassification(error, operation),
+  );
+}
+
+export function classifySupervisorFailure(
+  error: unknown,
+  operation: string,
+): DiagnosticFailureDecision {
+  const knownClassification: DiagnosticFailureMetadata | undefined =
+    error instanceof Error && error.name === "Error" && error.message === "write EPIPE"
+      ? {
+          failureClass: "transient-service",
+          domain: "supervisor.runtime",
+          errorClass: "broken-pipe",
+        }
+      : undefined;
+  return classifyDiagnosticFailure(error, { domain: "supervisor", operation }, knownClassification);
+}
+
+function captureSupervisorFailure(
+  error: unknown,
+  decision: DiagnosticFailureDecision,
+  tags?: PoracodeDiagnosticTags,
+): void {
+  if (decision.treatment === "drop") return;
   const Sentry = loadSupervisorSentry();
   if (!Sentry) return;
   if (!Sentry.isEnabled()) return;
+
+  const diagnosticTags: PoracodeDiagnosticTags = {
+    ...tags,
+    "poracode.error_class": decision.errorClass,
+    "poracode.failure_domain": decision.domain,
+    "poracode.operation": decision.operation,
+    "poracode.operational": String(decision.operational),
+    "poracode.process": "supervisor",
+  };
+  if (decision.treatment === "metric") {
+    Sentry.metrics.count("poracode.diagnostic.failure", 1, {
+      attributes: {
+        domain: decision.domain,
+        error_class: decision.errorClass,
+        level: decision.level ?? "warning",
+        operation: decision.operation,
+        operational: decision.operational,
+        process: "supervisor",
+      },
+    });
+    return;
+  }
+
   Sentry.withScope((scope) => {
-    if (tags) {
-      scope.setTags(tags);
+    scope.setTags(diagnosticTags);
+    if (decision.fingerprint) {
+      scope.setFingerprint(decision.fingerprint);
     }
+    scope.setLevel(decision.level ?? "error");
+    scope.addBreadcrumb(
+      buildDiagnosticBreadcrumb({
+        domain: decision.domain,
+        operation: decision.operation,
+        state: "failed",
+        transition: decision.failureClass,
+        level: decision.level ?? "error",
+      }),
+      20,
+    );
     Sentry.captureException(error);
   });
+}
+
+export function captureSupervisorIpcFailure(error: unknown, operation: string): void {
+  captureSupervisorFailure(error, classifySupervisorIpcFailure(error, operation), {
+    "poracode.feature_area": "supervisor-ipc",
+  });
+}
+
+export function captureSupervisorException(error: unknown, tags?: PoracodeDiagnosticTags): void {
+  const operation = tags?.["poracode.feature_area"] ?? "unhandled";
+  captureSupervisorFailure(error, classifySupervisorFailure(error, operation), tags);
 }
 
 export async function flushSupervisorSentry(timeoutMs = 2000): Promise<void> {

--- a/src/supervisor/diagnostics/sentry.ts
+++ b/src/supervisor/diagnostics/sentry.ts
@@ -6,6 +6,7 @@ import {
 import {
   buildDiagnosticBreadcrumb,
   classifyDiagnosticFailure,
+  isStableDiagnosticToken,
   type DiagnosticFailureDecision,
   type DiagnosticFailureMetadata,
 } from "@/shared/diagnostics/sentryPolicy";
@@ -46,6 +47,12 @@ const GIT_NETWORK_OPERATIONS = [
   "gitSync",
   "gitSyncRebase",
 ] as const;
+
+const STRUCTURED_RUNTIME_FAILURES = new Map<string, string>([
+  ["Structured runtime session creation failed.", "session-creation-failed"],
+  ["Structured runtime transport failed.", "transport-failed"],
+  ["Structured runtime turn failed.", "turn-failed"],
+]);
 
 const SUPERVISOR_IPC_FAILURE_RULES: readonly SupervisorIpcFailureRule[] = [
   {
@@ -253,6 +260,28 @@ function errorMessage(error: unknown): string | null {
   return error instanceof Error ? error.message : null;
 }
 
+function structuredRuntimeClassification(error: unknown): DiagnosticFailureMetadata | undefined {
+  if (!(error instanceof Error) || error.name !== "StructuredRuntimeDiagnosticError") {
+    return undefined;
+  }
+  const errorClass = STRUCTURED_RUNTIME_FAILURES.get(error.message);
+  return errorClass
+    ? {
+        failureClass: "product-defect",
+        domain: "structured-runtime",
+        errorClass,
+      }
+    : undefined;
+}
+
+function structuredRuntimeProvider(error: unknown): string | undefined {
+  if (!(error instanceof Error) || error.name !== "StructuredRuntimeDiagnosticError") {
+    return undefined;
+  }
+  const provider = (error as Error & { diagnosticProvider?: unknown }).diagnosticProvider;
+  return isStableDiagnosticToken(provider) ? provider : undefined;
+}
+
 function matchesFailureRule(
   rule: SupervisorIpcFailureRule,
   error: unknown,
@@ -270,6 +299,8 @@ function knownSupervisorIpcClassification(
   error: unknown,
   operation: string,
 ): DiagnosticFailureMetadata | undefined {
+  const structuredClassification = structuredRuntimeClassification(error);
+  if (structuredClassification) return structuredClassification;
   const message = errorMessage(error);
   if (!message) return undefined;
   const rule = SUPERVISOR_IPC_FAILURE_RULES.find((candidate) =>
@@ -300,13 +331,14 @@ export function classifySupervisorFailure(
   operation: string,
 ): DiagnosticFailureDecision {
   const knownClassification: DiagnosticFailureMetadata | undefined =
-    error instanceof Error && error.name === "Error" && error.message === "write EPIPE"
+    structuredRuntimeClassification(error) ??
+    (error instanceof Error && error.name === "Error" && error.message === "write EPIPE"
       ? {
           failureClass: "transient-service",
           domain: "supervisor.runtime",
           errorClass: "broken-pipe",
         }
-      : undefined;
+      : undefined);
   return classifyDiagnosticFailure(error, { domain: "supervisor", operation }, knownClassification);
 }
 
@@ -363,14 +395,20 @@ function captureSupervisorFailure(
 }
 
 export function captureSupervisorIpcFailure(error: unknown, operation: string): void {
+  const provider = structuredRuntimeProvider(error);
   captureSupervisorFailure(error, classifySupervisorIpcFailure(error, operation), {
     "poracode.feature_area": "supervisor-ipc",
+    ...(provider ? { "poracode.provider": provider } : {}),
   });
 }
 
 export function captureSupervisorException(error: unknown, tags?: PoracodeDiagnosticTags): void {
   const operation = tags?.["poracode.feature_area"] ?? "unhandled";
-  captureSupervisorFailure(error, classifySupervisorFailure(error, operation), tags);
+  const provider = tags?.["poracode.provider"] ?? structuredRuntimeProvider(error);
+  captureSupervisorFailure(error, classifySupervisorFailure(error, operation), {
+    ...tags,
+    ...(provider ? { "poracode.provider": provider } : {}),
+  });
 }
 
 export async function flushSupervisorSentry(timeoutMs = 2000): Promise<void> {

--- a/src/supervisor/index.ts
+++ b/src/supervisor/index.ts
@@ -4,6 +4,7 @@ import {
   flushSupervisorSentry,
   initializeSupervisorSentry,
 } from "./diagnostics/sentry";
+import { handleSupervisorIpcFailure } from "./ipcFailure";
 import { createSupervisorIpcHandlers } from "./ipcHandlers";
 import { SupervisorRuntime } from "./supervisorRuntime";
 import { configureSecretStorageKey } from "./secretStorage";
@@ -54,12 +55,7 @@ process.on("message", (message: SupervisorRequest) => {
       }),
     )
     .catch((error: unknown): SupervisorReply => {
-      captureSupervisorException(error, { "poracode.feature_area": "supervisor-ipc" });
-      return {
-        replyTo: message.id,
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      };
+      return handleSupervisorIpcFailure(error, message.type, message.id);
     })
     .then((reply) => process.send?.(reply));
 });

--- a/src/supervisor/ipcFailure.test.ts
+++ b/src/supervisor/ipcFailure.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSupervisorIpcFailure } from "./ipcFailure";
+
+describe("handleSupervisorIpcFailure", () => {
+  it("preserves the caller rejection while reporting the original failure for classification", () => {
+    const error = new Error("Unknown thread session: caller-visible-id");
+    const capture = vi.fn<(error: unknown, operation: string) => void>();
+
+    expect(handleSupervisorIpcFailure(error, "writeTerminal", "request-1", capture)).toEqual({
+      replyTo: "request-1",
+      ok: false,
+      error: "Unknown thread session: caller-visible-id",
+    });
+    expect(capture).toHaveBeenCalledExactlyOnceWith(error, "writeTerminal");
+  });
+
+  it("keeps non-Error rejection text unchanged for the caller", () => {
+    expect(
+      handleSupervisorIpcFailure(
+        "rejected",
+        "startThread",
+        "request-2",
+        vi.fn<(error: unknown, operation: string) => void>(),
+      ),
+    ).toEqual({
+      replyTo: "request-2",
+      ok: false,
+      error: "rejected",
+    });
+  });
+});

--- a/src/supervisor/ipcFailure.ts
+++ b/src/supervisor/ipcFailure.ts
@@ -1,0 +1,18 @@
+import type { SupervisorReply } from "@/shared/ipc";
+import { captureSupervisorIpcFailure } from "./diagnostics/sentry";
+
+type CaptureSupervisorIpcFailure = (error: unknown, operation: string) => void;
+
+export function handleSupervisorIpcFailure(
+  error: unknown,
+  operation: string,
+  replyTo: string,
+  capture: CaptureSupervisorIpcFailure = captureSupervisorIpcFailure,
+): SupervisorReply {
+  capture(error, operation);
+  return {
+    replyTo,
+    ok: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds the shared Sentry failure-policy foundation and applies it at the supervisor IPC capture boundary without changing caller-visible IPC rejection behavior.

### Behavior and treatment

- Defines enforceable failure classes:
  - `expected-operational` → no Sentry error event
  - `transient-service` → warning metric, where supported
  - `product-defect` → error event
  - `unknown` → error event
- Replaces unconditional supervisor IPC exception capture with classification-aware handling while returning the original rejection text to the caller.
- Drops only conservative audited outcomes:
  - PTY resize-after-exit / ENOTTY (LIGHTCODE-26, LIGHTCODE-4N)
  - unauthenticated `ghListPrs` (LIGHTCODE-4K)
  - no active turn for `interruptThread` (LIGHTCODE-51)
  - unsupported checkpoint rollback (LIGHTCODE-5K)
  - unavailable context extraction (LIGHTCODE-31, LIGHTCODE-32)
  - missing one-shot title model (LIGHTCODE-20)
  - no commits for PR summary (LIGHTCODE-2W)
  - provider quota/billing and authentication-required outcomes (LIGHTCODE-3, LIGHTCODE-4Y)
  - exact Git no-repository outcomes (LIGHTCODE-J, LIGHTCODE-H, LIGHTCODE-3P)
  - explicit commit/pre-commit hook rejection, including the live Husky fixtures (LIGHTCODE-5V, LIGHTCODE-5Z)
  - existing GitHub pull request (LIGHTCODE-5N)
  - explicit non-fast-forward push rejection (LIGHTCODE-4T)
- Routes audited transient failures to warning metrics instead of error issues:
  - title-generation provider server failure (LIGHTCODE-3M, LIGHTCODE-4P)
  - scoped Git network/connectivity failures (including LIGHTCODE-5C)
  - exact `TypeError("fetch failed")` (LIGHTCODE-4)
  - exact unhandled `Error("write EPIPE")` (LIGHTCODE-5M)
- Keeps never-known thread-session invariant failures, generic Git/GitHub/schema failures, unrelated 403s, arbitrary hook/commit failures, and other unknown exceptions captured as errors. PR #401 owns removed-session races; PR #400 owns the invalid gh JSON field.

### Grouping, tags, and privacy

- Adds stable tags for failure domain, normalized error class, operation, operational status, and available process/provider/runtime context.
- Uses deterministic payload-free fingerprints for explicitly classified failures. Unknown failures omit a custom fingerprint so Sentry keeps default stack-based grouping.
- Adds a curated payload-free diagnostic transition breadcrumb; automatic console/network/HTTP breadcrumbs remain disabled.
- Keeps sanitized diagnostic messages, exception type/value, and stack shape for unknown failures while removing sensitive structured fields.
- Redacts full HTTP(S) URLs and the argument-bearing portion of audited `Command failed: ...` lines, while retaining subsequent stderr/reason text.
- Keeps the `beforeSend` backstop narrow: only the two exact PTY resize signatures in the exact supervisor IPC operation.

### Tests run

- `pnpm exec vitest run src/shared/diagnostics/sentryPolicy.test.ts src/shared/diagnostics/sentryPrivacy.test.ts src/supervisor/diagnostics/sentry.test.ts src/supervisor/ipcFailure.test.ts` — 4 files, 90 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec oxfmt --check` for all 9 touched files
- `git diff --check`

Coverage includes classifications and treatments, stable tags/fingerprints, unknown default grouping from distinct stack sites, privacy sanitization, exact operation boundaries, live fixtures, near-miss non-suppression, and preserved IPC replies.

### Residual risk

The message rules intentionally cover only audited signatures and operations. Provider or CLI wording changes will remain unknown/captured rather than being silently suppressed until a typed boundary or another exact fixture is added. Main/renderer Sentry integration is intentionally excluded from this lane to avoid conflicts with the active renderer/native diagnostics work.