### PR TITLE
fix(updates): classify updater and remote delivery failures

### DIFF
--- a/src/main/remote/DesktopRemoteAccessController.test.ts
+++ b/src/main/remote/DesktopRemoteAccessController.test.ts
@@ -208,6 +208,9 @@ function createController(
   devServerUrl?: string,
   channel: DesktopRemoteAccessControllerOptions["channel"] = "stable",
   notifyRemoteAccessPairingChanged?: DesktopRemoteAccessControllerOptions["notifyRemoteAccessPairingChanged"],
+  reportError: DesktopRemoteAccessControllerOptions["reportError"] = vi.fn<
+    DesktopRemoteAccessControllerOptions["reportError"]
+  >(),
 ) {
   const callSupervisor = vi.fn<() => Promise<Record<string, never>>>(
     async () => ({}),
@@ -230,7 +233,7 @@ function createController(
     notifyRemoteAccessPairingChanged:
       notifyRemoteAccessPairingChanged ??
       vi.fn<DesktopRemoteAccessControllerOptions["notifyRemoteAccessPairingChanged"]>(),
-    reportError: vi.fn<DesktopRemoteAccessControllerOptions["reportError"]>(),
+    reportError,
     scheduleService: {} as never,
   });
 }
@@ -476,6 +479,53 @@ describe("DesktopRemoteAccessController", () => {
     expect(h.settings.remoteAccessEnabled).toBe(true);
     expect(h.forwardings[0]?.dispose).toHaveBeenCalledTimes(1);
     expect(controller.getServer()).toBeNull();
+  });
+
+  it("reports an exhausted port conflict without its address and with normalized tags", async () => {
+    const start = deferred<RemoteAccessServerInfo>();
+    h.serverPlans.push({ startPromise: start.promise });
+    const reportError = vi.fn<DesktopRemoteAccessControllerOptions["reportError"]>();
+    const controller = createController(undefined, "stable", undefined, reportError);
+    const serverCreated = waitForNextServerCreated();
+
+    const enabling = controller.setEnabled(true);
+    await serverCreated;
+    const conflict = Object.assign(new Error("listen EADDRINUSE 192.168.1.20:38987"), {
+      code: "EADDRINUSE",
+    });
+    start.reject(conflict);
+
+    await expect(enabling).rejects.toBe(conflict);
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError.mock.calls[0]?.[0]).toMatchObject({
+      name: "RemoteAccessPortConflictError",
+      message: "Remote access server port remained unavailable after retries.",
+    });
+    expect(reportError.mock.calls[0]?.[1]).toEqual({
+      "poracode.feature_area": "remote-access",
+      "poracode.channel": "stable",
+      "poracode.platform": process.platform,
+      "event.origin": "remote-access.listen.port-conflict",
+    });
+    expect((reportError.mock.calls[0]![0] as Error).message).not.toContain("192.168");
+  });
+
+  it("does not report a port bind failure from a superseded shutdown race", async () => {
+    const start = deferred<RemoteAccessServerInfo>();
+    h.serverPlans.push({ startPromise: start.promise });
+    const reportError = vi.fn<DesktopRemoteAccessControllerOptions["reportError"]>();
+    const controller = createController(undefined, "stable", undefined, reportError);
+    const serverCreated = waitForNextServerCreated();
+
+    const enabling = controller.setEnabled(true);
+    await serverCreated;
+    await controller.setEnabled(false);
+    start.reject(
+      Object.assign(new Error("listen EADDRINUSE private-address"), { code: "EADDRINUSE" }),
+    );
+
+    await expect(enabling).resolves.toEqual({ status: "disabled" });
+    expect(reportError).not.toHaveBeenCalled();
   });
 
   it("keeps forwarding alive until a full disable finishes closing the server", async () => {

--- a/src/main/remote/DesktopRemoteAccessController.ts
+++ b/src/main/remote/DesktopRemoteAccessController.ts
@@ -98,6 +98,35 @@ class RemoteAccessStartSupersededError extends Error {
   }
 }
 
+function remoteAccessStartupDiagnostic(
+  error: unknown,
+  channel: PoracodeChannel,
+): { error: unknown; tags: PoracodeDiagnosticTags } {
+  const code =
+    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? error.code
+      : null;
+  if (code === "EADDRINUSE") {
+    const diagnostic = new Error("Remote access server port remained unavailable after retries.");
+    diagnostic.name = "RemoteAccessPortConflictError";
+    return {
+      error: diagnostic,
+      tags: {
+        "poracode.feature_area": "remote-access",
+        "poracode.channel": channel,
+        "poracode.platform":
+          process.platform === "darwin" ||
+          process.platform === "linux" ||
+          process.platform === "win32"
+            ? process.platform
+            : "other",
+        "event.origin": "remote-access.listen.port-conflict",
+      },
+    };
+  }
+  return { error, tags: { "poracode.feature_area": "remote-access" } };
+}
+
 interface RemoteAccessStartAttempt {
   readonly generation: number;
   readonly promise: Promise<RemoteAccessServerInfo>;
@@ -384,7 +413,8 @@ export function createDesktopRemoteAccessController(
       const superseded = !isCurrentStartAttempt(attempt);
       if (!superseded) {
         console.error("[poracode] remote access failed to start:", toErrorMessage(error));
-        options.reportError(error, { "poracode.feature_area": "remote-access" });
+        const diagnostic = remoteAccessStartupDiagnostic(error, options.channel);
+        options.reportError(diagnostic.error, diagnostic.tags);
       }
       throw superseded ? new RemoteAccessStartSupersededError() : error;
     } finally {

--- a/src/main/remote/push/pushGateway.test.ts
+++ b/src/main/remote/push/pushGateway.test.ts
@@ -50,4 +50,99 @@ describe("push gateway client", () => {
 
     await expect(resolve()).resolves.toBe("vapid-key");
   });
+
+  it("aggregates transient 503 delivery failures as privacy-safe operational health", async () => {
+    const onError = vi.fn<(error: unknown) => void>();
+    const send = createPushGateway({
+      gatewayUrl: "https://gateway.example.test",
+      fetchImpl: vi.fn<GatewayFetch>(async () => ({ ok: false, status: 503 })),
+      onError,
+    });
+    const input = {
+      platform: "web",
+      pushType: "alert",
+      subscription: {
+        endpoint: "https://web.push.apple.com/private-subscription",
+        expirationTime: null,
+        keys: { p256dh: "private-key", auth: "private-auth" },
+      },
+      payload: { title: "Private", body: "Private", threadId: "secret", url: "/thread/secret" },
+    } as const;
+
+    await send(input);
+    await send(input);
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      name: "PushGatewayOperationalWarning",
+      message: "Remote push send warning: transient-response.",
+      operation: "send",
+      outcome: "transient-response",
+      platform: "web",
+      status: 503,
+    });
+    expect(JSON.stringify(onError.mock.calls[0]?.[0])).not.toContain("private");
+    expect(JSON.stringify(onError.mock.calls[0]?.[0])).not.toContain("subscription");
+  });
+
+  it("does not forward raw network errors and permits one report per bounded window", async () => {
+    let now = 1_000;
+    const onError = vi.fn<(error: unknown) => void>();
+    const rawFailure = Object.assign(
+      new Error("request to https://gateway.example.test?token=secret failed"),
+      { code: "ETIMEDOUT" },
+    );
+    const send = createPushGateway({
+      gatewayUrl: "https://gateway.example.test",
+      fetchImpl: vi.fn<GatewayFetch>(async () => {
+        throw rawFailure;
+      }),
+      onError,
+      now: () => now,
+      operationalReportIntervalMs: 100,
+    });
+    const input = {
+      platform: "ios",
+      pushType: "alert",
+      token: "secret-token",
+      payload: {},
+    } as const;
+
+    await expect(send(input)).resolves.toMatchObject({
+      status: 0,
+      reason: "Gateway request timed out.",
+    });
+    await send(input);
+    now += 100;
+    await send(input);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    for (const [reported] of onError.mock.calls) {
+      expect((reported as Error).message).toBe("Remote push send warning: timeout.");
+      expect((reported as Error).message).not.toContain("secret");
+      expect(reported).not.toBe(rawFailure);
+    }
+  });
+
+  it("bounds repeated Web Push key 503 reports while allowing request retries", async () => {
+    const onError = vi.fn<(error: unknown) => void>();
+    const fetchImpl = vi.fn<GatewayFetch>(async () => ({ ok: false, status: 503 }));
+    const resolve = createWebPushPublicKeyResolver({
+      gatewayUrl: "https://gateway.example.test",
+      fetchImpl,
+      onError,
+    });
+
+    await expect(resolve()).rejects.toThrow("status 503");
+    await expect(resolve()).rejects.toThrow("status 503");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      operation: "resolve-web-key",
+      outcome: "transient-response",
+      platform: "web",
+      status: 503,
+    });
+  });
 });

--- a/src/main/remote/push/pushGateway.test.ts
+++ b/src/main/remote/push/pushGateway.test.ts
@@ -51,8 +51,9 @@ describe("push gateway client", () => {
     await expect(resolve()).resolves.toBe("vapid-key");
   });
 
-  it("aggregates transient 503 delivery failures as privacy-safe operational health", async () => {
+  it("aggregates transient 503 delivery failures without using the error sink", async () => {
     const onError = vi.fn<(error: unknown) => void>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const send = createPushGateway({
       gatewayUrl: "https://gateway.example.test",
       fetchImpl: vi.fn<GatewayFetch>(async () => ({ ok: false, status: 503 })),
@@ -72,22 +73,18 @@ describe("push gateway client", () => {
     await send(input);
     await send(input);
 
-    expect(onError).toHaveBeenCalledOnce();
-    expect(onError.mock.calls[0]?.[0]).toMatchObject({
-      name: "PushGatewayOperationalWarning",
-      message: "Remote push send warning: transient-response.",
-      operation: "send",
-      outcome: "transient-response",
-      platform: "web",
-      status: 503,
-    });
-    expect(JSON.stringify(onError.mock.calls[0]?.[0])).not.toContain("private");
-    expect(JSON.stringify(onError.mock.calls[0]?.[0])).not.toContain("subscription");
+    expect(onError).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("[poracode] Remote push send warning: transient-response.");
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("private");
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("subscription");
+    warn.mockRestore();
   });
 
   it("does not forward raw network errors and permits one report per bounded window", async () => {
     let now = 1_000;
     const onError = vi.fn<(error: unknown) => void>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const rawFailure = Object.assign(
       new Error("request to https://gateway.example.test?token=secret failed"),
       { code: "ETIMEDOUT" },
@@ -116,16 +113,19 @@ describe("push gateway client", () => {
     now += 100;
     await send(input);
 
-    expect(onError).toHaveBeenCalledTimes(2);
-    for (const [reported] of onError.mock.calls) {
-      expect((reported as Error).message).toBe("Remote push send warning: timeout.");
-      expect((reported as Error).message).not.toContain("secret");
+    expect(onError).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(2);
+    for (const [reported] of warn.mock.calls) {
+      expect(reported).toBe("[poracode] Remote push send warning: timeout.");
+      expect(reported).not.toContain("secret");
       expect(reported).not.toBe(rawFailure);
     }
+    warn.mockRestore();
   });
 
   it("bounds repeated Web Push key 503 reports while allowing request retries", async () => {
     const onError = vi.fn<(error: unknown) => void>();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fetchImpl = vi.fn<GatewayFetch>(async () => ({ ok: false, status: 503 }));
     const resolve = createWebPushPublicKeyResolver({
       gatewayUrl: "https://gateway.example.test",
@@ -137,12 +137,38 @@ describe("push gateway client", () => {
     await expect(resolve()).rejects.toThrow("status 503");
 
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "[poracode] Remote push resolve-web-key warning: transient-response.",
+    );
+    warn.mockRestore();
+  });
+
+  it("reports malformed non-transient responses as sanitized real errors", async () => {
+    const onError = vi.fn<(error: unknown) => void>();
+    const send = createPushGateway({
+      gatewayUrl: "https://gateway.example.test",
+      fetchImpl: vi.fn<GatewayFetch>(async () => ({ ok: false, status: 400 })),
+      onError,
+    });
+
+    await send({
+      platform: "ios",
+      pushType: "alert",
+      token: "private-token",
+      payload: { private: "request-body" },
+    });
+
     expect(onError).toHaveBeenCalledOnce();
     expect(onError.mock.calls[0]?.[0]).toMatchObject({
-      operation: "resolve-web-key",
-      outcome: "transient-response",
-      platform: "web",
-      status: 503,
+      name: "PushGatewayDiagnosticError",
+      message: "Remote push send failed: invalid-response.",
+      operation: "send",
+      outcome: "invalid-response",
+      platform: "ios",
+      status: 400,
     });
+    expect(JSON.stringify(onError.mock.calls[0]?.[0])).not.toContain("private");
   });
 });

--- a/src/main/remote/push/pushGateway.ts
+++ b/src/main/remote/push/pushGateway.ts
@@ -81,9 +81,9 @@ export interface CreatePushGatewayOptions {
   /** Per-request timeout; defaults to 10s. */
   readonly timeoutMs?: number;
   /**
-   * Operational-health sink. Receives only bounded, privacy-safe failures with
-   * operation/outcome metadata; raw transport errors and request data are never
-   * forwarded.
+   * Non-transient diagnostic sink. Receives only bounded, privacy-safe
+   * malformed-response failures; raw transport errors, transient operational
+   * outcomes, and request data are never forwarded.
    */
   readonly onError?: (error: unknown) => void;
   /** Injectable clock and reporting window for deterministic tests. */
@@ -105,8 +105,9 @@ class PushGatewayOperationalError extends Error {
     readonly platform: SendPushInput["platform"] | "none",
     readonly status: number,
   ) {
-    super(`Remote push ${operation} warning: ${outcome}.`);
-    this.name = "PushGatewayOperationalWarning";
+    const transient = outcome !== "invalid-response";
+    super(`Remote push ${operation} ${transient ? "warning" : "failed"}: ${outcome}.`);
+    this.name = transient ? "PushGatewayOperationalWarning" : "PushGatewayDiagnosticError";
   }
 }
 
@@ -134,13 +135,17 @@ function createOperationalReporter(options: CreatePushGatewayOptions) {
     platform: SendPushInput["platform"] | "none",
     status: number,
   ): void => {
-    if (!options.onError) return;
     const key = `${operation}:${outcome}:${platform}:${status}`;
     const timestamp = now();
     const lastReport = lastReports.get(key);
     if (lastReport !== undefined && timestamp - lastReport < interval) return;
     lastReports.set(key, timestamp);
-    options.onError(new PushGatewayOperationalError(operation, outcome, platform, status));
+    const diagnostic = new PushGatewayOperationalError(operation, outcome, platform, status);
+    if (outcome === "invalid-response") {
+      options.onError?.(diagnostic);
+      return;
+    }
+    console.warn(`[poracode] ${diagnostic.message}`);
   };
 }
 
@@ -208,6 +213,8 @@ export function createPushGateway(options: CreatePushGatewayOptions = {}): SendP
       });
       if (TRANSIENT_GATEWAY_STATUSES.has(response.status)) {
         reportOperationalIssue("send", "transient-response", input.platform, response.status);
+      } else if (!response.ok && response.status !== 404 && response.status !== 410) {
+        reportOperationalIssue("send", "invalid-response", input.platform, response.status);
       }
       return {
         ok: response.ok,

--- a/src/main/remote/push/pushGateway.ts
+++ b/src/main/remote/push/pushGateway.ts
@@ -80,11 +80,69 @@ export interface CreatePushGatewayOptions {
   readonly fetchImpl?: FetchLike;
   /** Per-request timeout; defaults to 10s. */
   readonly timeoutMs?: number;
-  /** Structured-log sink for gateway failures. */
+  /**
+   * Operational-health sink. Receives only bounded, privacy-safe failures with
+   * operation/outcome metadata; raw transport errors and request data are never
+   * forwarded.
+   */
   readonly onError?: (error: unknown) => void;
+  /** Injectable clock and reporting window for deterministic tests. */
+  readonly now?: () => number;
+  readonly operationalReportIntervalMs?: number;
 }
 
 const DEFAULT_GATEWAY_TIMEOUT_MS = 10_000;
+const DEFAULT_OPERATIONAL_REPORT_INTERVAL_MS = 15 * 60 * 1_000;
+const TRANSIENT_GATEWAY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+type PushGatewayOperation = "send" | "resolve-web-key";
+type PushGatewayOutcome = "network-error" | "timeout" | "transient-response" | "invalid-response";
+
+class PushGatewayOperationalError extends Error {
+  constructor(
+    readonly operation: PushGatewayOperation,
+    readonly outcome: PushGatewayOutcome,
+    readonly platform: SendPushInput["platform"] | "none",
+    readonly status: number,
+  ) {
+    super(`Remote push ${operation} warning: ${outcome}.`);
+    this.name = "PushGatewayOperationalWarning";
+  }
+}
+
+function classifyTransportOutcome(error: unknown): PushGatewayOutcome {
+  const code =
+    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? error.code.toUpperCase()
+      : null;
+  if (
+    (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) ||
+    code === "ETIMEDOUT"
+  ) {
+    return "timeout";
+  }
+  return "network-error";
+}
+
+function createOperationalReporter(options: CreatePushGatewayOptions) {
+  const lastReports = new Map<string, number>();
+  const now = options.now ?? Date.now;
+  const interval = options.operationalReportIntervalMs ?? DEFAULT_OPERATIONAL_REPORT_INTERVAL_MS;
+  return (
+    operation: PushGatewayOperation,
+    outcome: PushGatewayOutcome,
+    platform: SendPushInput["platform"] | "none",
+    status: number,
+  ): void => {
+    if (!options.onError) return;
+    const key = `${operation}:${outcome}:${platform}:${status}`;
+    const timestamp = now();
+    const lastReport = lastReports.get(key);
+    if (lastReport !== undefined && timestamp - lastReport < interval) return;
+    lastReports.set(key, timestamp);
+    options.onError(new PushGatewayOperationalError(operation, outcome, platform, status));
+  };
+}
 
 interface GatewayTransport {
   /** Absolute `/api/push` URL on the resolved gateway origin. */
@@ -130,6 +188,7 @@ function createGatewayTransport(options: CreatePushGatewayOptions): GatewayTrans
  */
 export function createPushGateway(options: CreatePushGatewayOptions = {}): SendPush {
   const transport = createGatewayTransport(options);
+  const reportOperationalIssue = createOperationalReporter(options);
   return async (input: SendPushInput): Promise<SendPushResult> => {
     try {
       const response = await transport.request({
@@ -147,6 +206,9 @@ export function createPushGateway(options: CreatePushGatewayOptions = {}): SendP
           ...(input.expiration !== undefined ? { expiration: input.expiration } : {}),
         }),
       });
+      if (TRANSIENT_GATEWAY_STATUSES.has(response.status)) {
+        reportOperationalIssue("send", "transient-response", input.platform, response.status);
+      }
       return {
         ok: response.ok,
         status: response.status,
@@ -154,12 +216,13 @@ export function createPushGateway(options: CreatePushGatewayOptions = {}): SendP
           response.status === 410 || (input.platform === "web" && response.status === 404),
       };
     } catch (error) {
-      options.onError?.(error);
+      const outcome = classifyTransportOutcome(error);
+      reportOperationalIssue("send", outcome, input.platform, 0);
       return {
         ok: false,
         status: 0,
         unregistered: false,
-        reason: error instanceof Error ? error.message : String(error),
+        reason: outcome === "timeout" ? "Gateway request timed out." : "Gateway request failed.",
       };
     }
   };
@@ -176,19 +239,35 @@ export function createWebPushPublicKeyResolver(
   options: CreatePushGatewayOptions = {},
 ): ResolveWebPushPublicKey {
   const transport = createGatewayTransport(options);
+  const reportOperationalIssue = createOperationalReporter(options);
   const fetchPublicKey = async (): Promise<string> => {
     try {
       const response = await transport.request({ method: "GET" });
       if (!response.ok || !response.json) {
+        reportOperationalIssue(
+          "resolve-web-key",
+          TRANSIENT_GATEWAY_STATUSES.has(response.status)
+            ? "transient-response"
+            : "invalid-response",
+          "web",
+          response.status,
+        );
         throw new Error(`Web Push config request failed with status ${response.status}.`);
       }
       const body = (await response.json()) as { publicKey?: unknown };
       if (typeof body.publicKey !== "string" || body.publicKey.length === 0) {
+        reportOperationalIssue("resolve-web-key", "invalid-response", "web", response.status);
         throw new Error("Web Push config response did not include a public key.");
       }
       return body.publicKey;
     } catch (error) {
-      options.onError?.(error);
+      if (
+        !(error instanceof Error) ||
+        (!error.message.startsWith("Web Push config request failed") &&
+          error.message !== "Web Push config response did not include a public key.")
+      ) {
+        reportOperationalIssue("resolve-web-key", classifyTransportOutcome(error), "web", 0);
+      }
       throw error;
     }
   };

--- a/src/main/updates/autoUpdater.test.ts
+++ b/src/main/updates/autoUpdater.test.ts
@@ -38,6 +38,7 @@ describe("createAutoUpdaterController", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     autoUpdaterMock.checkForUpdates.mockResolvedValue(undefined);
+    autoUpdaterMock.downloadUpdate.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -62,36 +63,142 @@ describe("createAutoUpdaterController", () => {
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(process.platform === "win32", true);
   });
 
-  it("installs a downloaded update when the user quits a stuck app", () => {
+  it("keeps automatic delivery controller-owned and installs on app quit", () => {
     autoUpdaterMock.autoInstallOnAppQuit = false;
     const controller = createAutoUpdaterController(vi.fn(), "stable", false);
 
     controller.initialize();
 
-    expect(autoUpdaterMock.autoDownload).toBe(true);
+    expect(autoUpdaterMock.autoDownload).toBe(false);
     expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true);
   });
 
-  it("does not reject from a manual check when checkForUpdates() fails", async () => {
-    // A freshly-published release whose channel manifest hasn't finished
-    // uploading 404s, so electron-updater emits "error" and then rejects.
-    // The renderer invokes checkForUpdate() fire-and-forget, so a rejection
-    // here would escalate into a fatal unhandled-rejection crash screen.
+  it("starts the controller-owned download when a check finds an update", async () => {
+    const controller = createAutoUpdaterController(vi.fn(), "stable", false);
+    controller.initialize();
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("update-available", { version: "1.2.3" });
+    });
+
+    await controller.checkForUpdate();
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("treats a missing nightly manifest as an optional probe", async () => {
     const sendStatus = vi.fn<(status: { type: string; message?: string }) => void>();
     const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
     const controller = createAutoUpdaterController(sendStatus, "nightly", false, reportError);
     controller.initialize();
 
-    const failure = new Error("Cannot find latest-mac.yml in the latest release artifacts");
-    autoUpdaterMock.checkForUpdates.mockRejectedValueOnce(failure);
+    const failure = Object.assign(
+      new Error("Cannot find nightly-mac.yml in the latest release artifacts (404)"),
+      { statusCode: 404 },
+    );
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("error", failure);
+      throw failure;
+    });
 
     await expect(controller.checkForUpdate()).resolves.toBeUndefined();
 
-    // The user still sees the failure: electron-updater's "error" event drives
-    // the toast + Sentry report, independent of the swallowed rejection.
-    autoUpdaterMock.emit("error", failure);
-    expect(sendStatus).toHaveBeenCalledWith({ type: "error", message: failure.message });
-    expect(reportError).toHaveBeenCalledWith(failure, { "poracode.feature_area": "updates" });
+    expect(sendStatus).toHaveBeenCalledWith({ type: "update-not-available" });
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("keeps a missing stable manifest observable with normalized tags", async () => {
+    const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
+    const controller = createAutoUpdaterController(vi.fn(), "stable", false, reportError);
+    controller.initialize();
+    const failure = Object.assign(new Error("latest-mac.yml returned 404"), { statusCode: 404 });
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("error", failure);
+      throw failure;
+    });
+
+    await controller.checkForUpdate();
+
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError.mock.calls[0]?.[0]).toMatchObject({
+      name: "UpdateDiagnosticError",
+      message: "Updater check failed: required-manifest-missing.",
+    });
+    expect(reportError.mock.calls[0]?.[1]).toEqual({
+      "poracode.feature_area": "updates",
+      "poracode.channel": "stable",
+      "poracode.platform": process.platform,
+      "event.origin": "updater.check.required-manifest-missing",
+    });
+  });
+
+  it("does not report transient check failures when a retry succeeds", async () => {
+    const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
+    const controller = createAutoUpdaterController(vi.fn(), "stable", false, reportError);
+    controller.initialize();
+    const transient = Object.assign(new Error("socket closed"), { code: "ECONNRESET" });
+    autoUpdaterMock.checkForUpdates
+      .mockImplementationOnce(async () => {
+        autoUpdaterMock.emit("error", transient);
+        throw transient;
+      })
+      .mockImplementationOnce(async () => {
+        autoUpdaterMock.emit("error", transient);
+        throw transient;
+      })
+      .mockResolvedValueOnce(undefined);
+
+    const checking = controller.checkForUpdate();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await checking;
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(3);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("captures one bounded warning after transient check retries are exhausted", async () => {
+    const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
+    const controller = createAutoUpdaterController(vi.fn(), "stable", false, reportError);
+    controller.initialize();
+    const transient = Object.assign(new Error("socket closed"), { code: "EPIPE" });
+    autoUpdaterMock.checkForUpdates.mockImplementation(async () => {
+      autoUpdaterMock.emit("error", transient);
+      throw transient;
+    });
+
+    const first = controller.checkForUpdate();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await first;
+    const second = controller.checkForUpdate();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await second;
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(6);
+    expect(reportError).toHaveBeenCalledOnce();
+    expect(reportError.mock.calls[0]?.[0]).toMatchObject({
+      name: "UpdateOperationalWarning",
+      message: "Updater check failed: transient-network.",
+    });
+  });
+
+  it("keeps signature failures observable without sending the raw error", async () => {
+    const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
+    const controller = createAutoUpdaterController(vi.fn(), "stable", false, reportError);
+    controller.initialize();
+    const failure = new Error(
+      "Code signature invalid for /Users/person/private/Poracode.zip from https://example.test",
+    );
+    autoUpdaterMock.downloadUpdate.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("error", failure);
+      throw failure;
+    });
+
+    await expect(controller.startUpdateDownload()).rejects.toBe(failure);
+
+    expect(reportError).toHaveBeenCalledOnce();
+    const reported = reportError.mock.calls[0]?.[0] as Error;
+    expect(reported.message).toBe("Updater download failed: artifact-integrity.");
+    expect(reported.message).not.toContain("/Users/");
+    expect(reported.message).not.toContain("https://");
   });
 
   it("runs an initial check after launch and then keeps checking on the hourly interval", async () => {

--- a/src/main/updates/autoUpdater.test.ts
+++ b/src/main/updates/autoUpdater.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateStatus } from "@/shared/ipc";
 
 const autoUpdaterMock = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => void>();
@@ -155,9 +156,11 @@ describe("createAutoUpdaterController", () => {
     expect(reportError).not.toHaveBeenCalled();
   });
 
-  it("captures one bounded warning after transient check retries are exhausted", async () => {
+  it("logs one bounded warning without capturing exhausted transient retries as errors", async () => {
     const reportError = vi.fn<(error: unknown, tags?: Record<string, string>) => void>();
-    const controller = createAutoUpdaterController(vi.fn(), "stable", false, reportError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sendStatus = vi.fn<(status: UpdateStatus) => void>();
+    const controller = createAutoUpdaterController(sendStatus, "stable", false, reportError);
     controller.initialize();
     const transient = Object.assign(new Error("socket closed"), { code: "EPIPE" });
     autoUpdaterMock.checkForUpdates.mockImplementation(async () => {
@@ -173,10 +176,25 @@ describe("createAutoUpdaterController", () => {
     await second;
 
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(6);
-    expect(reportError).toHaveBeenCalledOnce();
-    expect(reportError.mock.calls[0]?.[0]).toMatchObject({
-      name: "UpdateOperationalWarning",
-      message: "Updater check failed: transient-network.",
+    expect(reportError).not.toHaveBeenCalled();
+    expect(sendStatus).toHaveBeenLastCalledWith({
+      type: "error",
+      messageKey: "update.serviceUnavailable",
+    });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("[poracode] updater check transient failure after retries.");
+    warn.mockRestore();
+  });
+
+  it("uses a localized message key when update checks are unavailable in development", async () => {
+    const sendStatus = vi.fn<(status: UpdateStatus) => void>();
+    const controller = createAutoUpdaterController(sendStatus, "stable", true);
+
+    await controller.checkForUpdate();
+
+    expect(sendStatus).toHaveBeenCalledWith({
+      type: "error",
+      messageKey: "update.devUnavailable",
     });
   });
 

--- a/src/main/updates/autoUpdater.ts
+++ b/src/main/updates/autoUpdater.ts
@@ -2,6 +2,13 @@ import { autoUpdater } from "electron-updater";
 import type { PoracodeChannel } from "@/shared/channel";
 import type { UpdateStatus } from "@/shared/ipc";
 import type { PoracodeDiagnosticTags } from "@/shared/diagnostics/sentryPrivacy";
+import {
+  buildUpdateDiagnosticTags,
+  classifyUpdateFailure,
+  UpdateDiagnosticError,
+  type UpdateFailureKind,
+  type UpdateOperation,
+} from "./updateErrorPolicy";
 
 /**
  * Delay before the first update check once the app is ready. Matches VS Code's
@@ -15,6 +22,8 @@ const INITIAL_CHECK_DELAY_MS = 30_000;
  * long-lived window still discovers releases without ever being restarted.
  */
 const PERIODIC_CHECK_INTERVAL_MS = 60 * 60 * 1_000;
+const TRANSIENT_RETRY_DELAYS_MS = [500, 1_000] as const;
+const TRANSIENT_REPORT_COOLDOWN_MS = 6 * 60 * 60 * 1_000;
 
 export interface AutoUpdaterController {
   initialize(): void;
@@ -38,6 +47,106 @@ export function createAutoUpdaterController(
   // until the user restarts to apply it.
   let updateReady = false;
   let periodicTimer: ReturnType<typeof setInterval> | null = null;
+  let checkPromise: Promise<void> | null = null;
+  let downloadPromise: Promise<void> | null = null;
+  let updateAvailable = false;
+  let activeAttempt: { operation: UpdateOperation; eventError: unknown | null } | null = null;
+  const transientReportTimes = new Map<string, number>();
+
+  function reportClassifiedFailure(operation: UpdateOperation, outcome: UpdateFailureKind): void {
+    if (outcome === "optional-manifest-missing") {
+      console.warn("[poracode] optional nightly update manifest is not available.");
+      return;
+    }
+    if (outcome === "transient-network") {
+      const key = `${operation}:${outcome}`;
+      const now = Date.now();
+      const lastReportAt = transientReportTimes.get(key);
+      if (lastReportAt !== undefined && now - lastReportAt < TRANSIENT_REPORT_COOLDOWN_MS) {
+        return;
+      }
+      transientReportTimes.set(key, now);
+    }
+    reportError(
+      new UpdateDiagnosticError(operation, outcome),
+      buildUpdateDiagnosticTags(channel, operation, outcome),
+    );
+  }
+
+  async function runOperation(
+    operation: UpdateOperation,
+    invoke: () => Promise<unknown>,
+  ): Promise<void> {
+    for (let attempt = 0; ; attempt += 1) {
+      const attemptState = { operation, eventError: null as unknown | null };
+      activeAttempt = attemptState;
+      try {
+        await invoke();
+        if (attemptState.eventError) {
+          throw attemptState.eventError instanceof Error
+            ? attemptState.eventError
+            : new Error("Updater emitted a non-Error failure.");
+        }
+        return;
+      } catch (error) {
+        const failure = classifyUpdateFailure(attemptState.eventError ?? error, operation, channel);
+        const retryDelay = TRANSIENT_RETRY_DELAYS_MS[attempt];
+        if (failure.retryable && retryDelay !== undefined) {
+          if (activeAttempt === attemptState) activeAttempt = null;
+          await new Promise((resolve) => setTimeout(resolve, retryDelay));
+          continue;
+        }
+        reportClassifiedFailure(operation, failure.kind);
+        if (failure.kind === "optional-manifest-missing") {
+          sendStatus({ type: "update-not-available" });
+          return;
+        }
+        sendStatus({
+          type: "error",
+          message:
+            failure.kind === "transient-network"
+              ? "The update service is temporarily unavailable."
+              : "The update operation failed.",
+        });
+        throw error;
+      } finally {
+        if (activeAttempt === attemptState) {
+          activeAttempt = null;
+        }
+      }
+    }
+  }
+
+  function beginDownload(): Promise<void> {
+    if (downloadPromise) return downloadPromise;
+    checkInFlight = true;
+    downloadPromise = runOperation("download", () => autoUpdater.downloadUpdate()).finally(() => {
+      downloadPromise = null;
+      if (!updateReady) checkInFlight = false;
+    });
+    return downloadPromise;
+  }
+
+  function beginCheck(): Promise<void> {
+    if (checkPromise) return checkPromise;
+    checkInFlight = true;
+    updateAvailable = false;
+    checkPromise = runOperation("check", () => autoUpdater.checkForUpdates())
+      .then(() => {
+        if (updateAvailable && !updateReady) {
+          void beginDownload().catch(() => {});
+        } else {
+          checkInFlight = false;
+        }
+      })
+      .catch(() => {
+        checkInFlight = false;
+      })
+      .finally(() => {
+        checkPromise = null;
+      });
+    return checkPromise;
+  }
 
   // Fire a background check, but only when the updater is otherwise idle. Used
   // by both the initial launch check and the recurring interval.
@@ -45,11 +154,7 @@ export function createAutoUpdaterController(
     if (checkInFlight || updateReady) {
       return;
     }
-    checkInFlight = true;
-    void autoUpdater.checkForUpdates().catch((error: unknown) => {
-      checkInFlight = false;
-      reportError(error, { "poracode.feature_area": "updates" });
-    });
+    void beginCheck();
   }
 
   function initialize(): void {
@@ -58,7 +163,10 @@ export function createAutoUpdaterController(
     }
     initialized = true;
 
-    autoUpdater.autoDownload = true;
+    // Keep downloads automatic from the user's perspective, while invoking
+    // downloadUpdate ourselves so transient retries and final reporting belong
+    // to one typed operation instead of the updater's global error event.
+    autoUpdater.autoDownload = false;
     // A renderer stuck during hydration cannot reach the normal install
     // button. Once an update is downloaded, Cmd/Ctrl+Q still provides a
     // main-process-owned recovery path that applies it on quit.
@@ -82,7 +190,7 @@ export function createAutoUpdaterController(
       sendStatus({ type: "checking" });
     });
     autoUpdater.on("update-available", (info) => {
-      // A download starts automatically (autoDownload), so stay "in flight".
+      updateAvailable = true;
       checkInFlight = true;
       sendStatus({ type: "update-available", version: info.version });
     });
@@ -106,9 +214,19 @@ export function createAutoUpdaterController(
       sendStatus({ type: "downloaded", version: info.version });
     });
     autoUpdater.on("error", (error) => {
+      if (activeAttempt) {
+        activeAttempt.eventError = error;
+        return;
+      }
+      const operation: UpdateOperation = downloadPromise ? "download" : "check";
+      const failure = classifyUpdateFailure(error, operation, channel);
+      reportClassifiedFailure(operation, failure.kind);
       checkInFlight = false;
-      reportError(error, { "poracode.feature_area": "updates" });
-      sendStatus({ type: "error", message: error.message });
+      if (failure.kind === "optional-manifest-missing") {
+        sendStatus({ type: "update-not-available" });
+      } else {
+        sendStatus({ type: "error", message: "The update operation failed." });
+      }
     });
 
     // First check ~30s after launch, then keep checking hourly so an app that
@@ -126,31 +244,15 @@ export function createAutoUpdaterController(
       return;
     }
     try {
-      await autoUpdater.checkForUpdates();
+      await beginCheck();
     } catch {
-      // checkForUpdates() rejects on any check failure — most commonly a
-      // freshly-published release whose channel manifest (e.g. nightly-mac.yml)
-      // hasn't finished uploading yet, which 404s and then falls back to a
-      // 404 on latest-mac.yml. electron-updater emits an "error" event before
-      // this promise rejects, and the listener registered in initialize()
-      // already reports it (reportError) and surfaces it to the UI (sendStatus
-      // error → toast). Swallow the rejection here so this IPC never rejects:
-      // the renderer invokes it fire-and-forget, where an unhandled rejection
-      // is escalated into a fatal full-screen crash. This mirrors the
-      // .catch() guard on the background runScheduledCheck path.
+      // beginCheck owns classification, reporting, and UI status. Keep this IPC
+      // resolved because the renderer invokes it fire-and-forget.
     }
   }
 
   async function startUpdateDownload(): Promise<void> {
-    try {
-      await autoUpdater.downloadUpdate();
-    } catch (error: unknown) {
-      if ((error as NodeJS.ErrnoException).code === "EPIPE") {
-        return;
-      }
-      reportError(error, { "poracode.feature_area": "updates" });
-      throw error;
-    }
+    await beginDownload();
   }
 
   function installUpdate(): void {

--- a/src/main/updates/autoUpdater.ts
+++ b/src/main/updates/autoUpdater.ts
@@ -66,6 +66,8 @@ export function createAutoUpdaterController(
         return;
       }
       transientReportTimes.set(key, now);
+      console.warn(`[poracode] updater ${operation} transient failure after retries.`);
+      return;
     }
     reportError(
       new UpdateDiagnosticError(operation, outcome),
@@ -103,10 +105,10 @@ export function createAutoUpdaterController(
         }
         sendStatus({
           type: "error",
-          message:
+          messageKey:
             failure.kind === "transient-network"
-              ? "The update service is temporarily unavailable."
-              : "The update operation failed.",
+              ? "update.serviceUnavailable"
+              : "update.operationFailed",
         });
         throw error;
       } finally {
@@ -225,7 +227,13 @@ export function createAutoUpdaterController(
       if (failure.kind === "optional-manifest-missing") {
         sendStatus({ type: "update-not-available" });
       } else {
-        sendStatus({ type: "error", message: "The update operation failed." });
+        sendStatus({
+          type: "error",
+          messageKey:
+            failure.kind === "transient-network"
+              ? "update.serviceUnavailable"
+              : "update.operationFailed",
+        });
       }
     });
 
@@ -240,7 +248,7 @@ export function createAutoUpdaterController(
 
   async function checkForUpdate(): Promise<void> {
     if (isDev && !process.env.UPDATE_SERVER_URL) {
-      sendStatus({ type: "error", message: "Update check is not available in dev mode." });
+      sendStatus({ type: "error", messageKey: "update.devUnavailable" });
       return;
     }
     try {

--- a/src/main/updates/updateErrorPolicy.ts
+++ b/src/main/updates/updateErrorPolicy.ts
@@ -113,8 +113,7 @@ export class UpdateDiagnosticError extends Error {
     readonly outcome: UpdateFailureKind,
   ) {
     super(`Updater ${operation} failed: ${outcome}.`);
-    this.name =
-      outcome === "transient-network" ? "UpdateOperationalWarning" : "UpdateDiagnosticError";
+    this.name = "UpdateDiagnosticError";
   }
 }
 

--- a/src/main/updates/updateErrorPolicy.ts
+++ b/src/main/updates/updateErrorPolicy.ts
@@ -1,0 +1,144 @@
+import type { PoracodeChannel } from "@/shared/channel";
+import type { PoracodeDiagnosticTags } from "@/shared/diagnostics/sentryPrivacy";
+
+export type UpdateOperation = "check" | "download";
+
+export type UpdateFailureKind =
+  | "transient-network"
+  | "optional-manifest-missing"
+  | "required-manifest-missing"
+  | "artifact-integrity"
+  | "disk"
+  | "unexpected";
+
+export interface ClassifiedUpdateFailure {
+  readonly kind: UpdateFailureKind;
+  readonly retryable: boolean;
+}
+
+const TRANSIENT_NETWORK_CODES = new Set([
+  "EPIPE",
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+]);
+const DISK_ERROR_CODES = new Set(["ENOSPC", "EACCES", "EPERM", "EROFS"]);
+const UPDATE_MANIFEST_PATTERN = /(?:latest|nightly)(?:-[a-z0-9]+)?\.ya?ml/i;
+const INTEGRITY_PATTERN =
+  /(?:artifact[^.]*\b(?:corrupt|invalid|missing)|checksum|code signature|hash mismatch|integrity|sha512|signature)/i;
+
+function errorChain(error: unknown): unknown[] {
+  const chain: unknown[] = [];
+  let current = error;
+  for (let depth = 0; depth < 4 && current !== undefined && current !== null; depth += 1) {
+    chain.push(current);
+    if (typeof current !== "object" || !("cause" in current)) break;
+    current = current.cause;
+  }
+  return chain;
+}
+
+function errorCode(error: unknown): string | null {
+  for (const item of errorChain(error)) {
+    if (typeof item !== "object" || item === null || !("code" in item)) continue;
+    if (typeof item.code === "string") return item.code.toUpperCase();
+  }
+  return null;
+}
+
+function hasTimeoutName(error: unknown): boolean {
+  for (const item of errorChain(error)) {
+    if (item instanceof Error && (item.name === "AbortError" || item.name === "TimeoutError")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function errorMessage(error: unknown): string {
+  return errorChain(error)
+    .map((item) => (item instanceof Error ? item.message : ""))
+    .filter(Boolean)
+    .join(" ");
+}
+
+function errorStatus(error: unknown): number | null {
+  for (const item of errorChain(error)) {
+    if (typeof item !== "object" || item === null || !("statusCode" in item)) continue;
+    if (typeof item.statusCode === "number") return item.statusCode;
+  }
+  return null;
+}
+
+function isManifest404(error: unknown, operation: UpdateOperation): boolean {
+  if (operation !== "check") return false;
+  const message = errorMessage(error);
+  const is404 = errorStatus(error) === 404 || /\b404\b/.test(message);
+  return is404 && UPDATE_MANIFEST_PATTERN.test(message);
+}
+
+export function classifyUpdateFailure(
+  error: unknown,
+  operation: UpdateOperation,
+  channel: PoracodeChannel,
+): ClassifiedUpdateFailure {
+  const code = errorCode(error);
+  const message = errorMessage(error);
+
+  if (code && TRANSIENT_NETWORK_CODES.has(code)) {
+    return { kind: "transient-network", retryable: true };
+  }
+  if (hasTimeoutName(error)) {
+    return { kind: "transient-network", retryable: true };
+  }
+  if (isManifest404(error, operation)) {
+    return {
+      kind: channel === "nightly" ? "optional-manifest-missing" : "required-manifest-missing",
+      retryable: false,
+    };
+  }
+  if (code && DISK_ERROR_CODES.has(code)) {
+    return { kind: "disk", retryable: false };
+  }
+  if (INTEGRITY_PATTERN.test(message)) {
+    return { kind: "artifact-integrity", retryable: false };
+  }
+  return { kind: "unexpected", retryable: false };
+}
+
+export class UpdateDiagnosticError extends Error {
+  constructor(
+    readonly operation: UpdateOperation,
+    readonly outcome: UpdateFailureKind,
+  ) {
+    super(`Updater ${operation} failed: ${outcome}.`);
+    this.name =
+      outcome === "transient-network" ? "UpdateOperationalWarning" : "UpdateDiagnosticError";
+  }
+}
+
+function normalizePlatform(platform: NodeJS.Platform): string {
+  switch (platform) {
+    case "darwin":
+    case "linux":
+    case "win32":
+      return platform;
+    default:
+      return "other";
+  }
+}
+
+export function buildUpdateDiagnosticTags(
+  channel: PoracodeChannel,
+  operation: UpdateOperation,
+  outcome: UpdateFailureKind,
+  platform: NodeJS.Platform = process.platform,
+): PoracodeDiagnosticTags {
+  return {
+    "poracode.feature_area": "updates",
+    "poracode.channel": channel,
+    "poracode.platform": normalizePlatform(platform),
+    "event.origin": `updater.${operation}.${outcome}`,
+  };
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -274,10 +274,12 @@ function handleUpdateStatus(status: UpdateStatus): void {
     case "downloaded":
       store.setDownloaded(status.version);
       break;
-    case "error":
-      store.setError(status.message);
-      toast.danger(msg("update.error", { detail: status.message }));
+    case "error": {
+      const detail = status.messageKey ? msg(status.messageKey) : status.message;
+      store.setError(detail);
+      toast.danger(msg("update.error", { detail }));
       break;
+    }
   }
 }
 

--- a/src/renderer/i18n/sharedMessages.test.ts
+++ b/src/renderer/i18n/sharedMessages.test.ts
@@ -28,6 +28,9 @@ describe("shared message i18n integration", () => {
     // interpolates the `{detail}` value.
     expect(translated).not.toBe("Commit failed: boom");
     expect(translated).toContain("boom");
+    expect(msg("update.serviceUnavailable")).toBe(
+      "El servicio de actualizaciones no está disponible temporalmente.",
+    );
   });
 
   it("preserves a leading placeholder + newline through translation", async () => {

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -180,6 +180,13 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
       "Kimi Code ended the turn without returning a response. Restart the thread and try again.",
   }),
   "update.error": msg({ message: "Update error: {detail}" }),
+  "update.serviceUnavailable": msg({
+    message: "The update service is temporarily unavailable.",
+  }),
+  "update.operationFailed": msg({ message: "The update operation failed." }),
+  "update.devUnavailable": msg({
+    message: "Update checks are not available in development mode.",
+  }),
 };
 
 /**

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Der Skill-Marketplace konnte nicht geladen werden."
 msgid "the target provider"
 msgstr "der Zielanbieter"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Der Update-Vorgang ist fehlgeschlagen."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Der Update-Dienst ist vorübergehend nicht verfügbar."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "den Windows-Benutzer"
@@ -10981,6 +10989,10 @@ msgstr "Update verfügbar"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Branch aktualisieren"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Im Entwicklungsmodus kann nicht nach Updates gesucht werden."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -10183,6 +10183,14 @@ msgstr "The skills marketplace couldn't be loaded."
 msgid "the target provider"
 msgstr "the target provider"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "The update operation failed."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "The update service is temporarily unavailable."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "the Windows user"
@@ -10981,6 +10989,10 @@ msgstr "Update available"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Update branch"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Update checks are not available in development mode."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -10183,6 +10183,14 @@ msgstr "No se pudo cargar el marketplace de skills."
 msgid "the target provider"
 msgstr "el proveedor de destino"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "La operación de actualización falló."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "El servicio de actualizaciones no está disponible temporalmente."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "el usuario de Windows"
@@ -10981,6 +10989,10 @@ msgstr "Actualización disponible"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Actualizar rama"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Las comprobaciones de actualizaciones no están disponibles en el modo de desarrollo."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -10182,6 +10182,14 @@ msgstr "Impossible de charger la place de marché des compétences."
 msgid "the target provider"
 msgstr "le fournisseur cible"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "L’opération de mise à jour a échoué."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Le service de mise à jour est temporairement indisponible."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "l’utilisateur Windows"
@@ -10980,6 +10988,10 @@ msgstr "Mise à jour disponible"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Mettre à jour la branche"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "La recherche de mises à jour n’est pas disponible en mode développement."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -10181,6 +10181,14 @@ msgstr "スキルマーケットプレイスを読み込めませんでした。
 msgid "the target provider"
 msgstr "対象プロバイダー"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "アップデート操作に失敗しました。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "アップデートサービスは一時的に利用できません。"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "Windows ユーザー"
@@ -10979,6 +10987,10 @@ msgstr "利用可能なアップデート"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "ブランチを更新する"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "開発モードではアップデートを確認できません。"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -10183,6 +10183,14 @@ msgstr "스킬 마켓플레이스를 로드할 수 없습니다."
 msgid "the target provider"
 msgstr "대상 공급자"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "업데이트 작업에 실패했습니다."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "업데이트 서비스를 일시적으로 사용할 수 없습니다."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "Windows 사용자"
@@ -10981,6 +10989,10 @@ msgstr "업데이트 가능"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "브랜치 업데이트"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "개발 모드에서는 업데이트를 확인할 수 없습니다."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Nie udało się załadować marketplace umiejętności."
 msgid "the target provider"
 msgstr "docelowego dostawcy"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Operacja aktualizacji nie powiodła się."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Usługa aktualizacji jest tymczasowo niedostępna."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "użytkownika Windows"
@@ -10981,6 +10989,10 @@ msgstr "Dostępna aktualizacja"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Zaktualizuj gałąź"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Sprawdzanie aktualizacji nie jest dostępne w trybie programistycznym."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Não foi possível carregar o marketplace de skills."
 msgid "the target provider"
 msgstr "o provedor alvo"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "A operação de atualização falhou."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "O serviço de atualização está temporariamente indisponível."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "o usuário do Windows"
@@ -10981,6 +10989,10 @@ msgstr "Atualização disponível"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Atualizar branch"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "As verificações de atualização não estão disponíveis no modo de desenvolvimento."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Не удалось загрузить маркетплейс навык
 msgid "the target provider"
 msgstr "целевой провайдер"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Не удалось выполнить операцию обновления."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Служба обновлений временно недоступна."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "пользователя Windows"
@@ -10981,6 +10989,10 @@ msgstr "Доступно обновление"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Обновить ветку"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Проверка обновлений недоступна в режиме разработки."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Beceri marketplace'i yüklenemedi."
 msgid "the target provider"
 msgstr "hedef sağlayıcı"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Güncelleme işlemi başarısız oldu."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Güncelleme hizmeti geçici olarak kullanılamıyor."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "Windows kullanıcısı"
@@ -10981,6 +10989,10 @@ msgstr "Güncelleme mevcut"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Şubeyi güncelle"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Geliştirme modunda güncelleme denetimi kullanılamaz."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Не вдалося завантажити маркетплейс нав
 msgid "the target provider"
 msgstr "цільовий провайдер"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Не вдалося виконати операцію оновлення."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Служба оновлень тимчасово недоступна."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "користувача Windows"
@@ -10981,6 +10989,10 @@ msgstr "Доступне оновлення"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Оновити гілку"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Перевірка оновлень недоступна в режимі розробки."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -10183,6 +10183,14 @@ msgstr "Không thể tải marketplace skill."
 msgid "the target provider"
 msgstr "nhà cung cấp mục tiêu"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "Thao tác cập nhật không thành công."
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "Dịch vụ cập nhật tạm thời không khả dụng."
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "người dùng Windows"
@@ -10981,6 +10989,10 @@ msgstr "Đã có bản cập nhật"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "Cập nhật nhánh"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "Không thể kiểm tra bản cập nhật trong chế độ phát triển."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -10182,6 +10182,14 @@ msgstr "无法加载技能市场。"
 msgid "the target provider"
 msgstr "目标提供商"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update operation failed."
+msgstr "更新操作失败。"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "The update service is temporarily unavailable."
+msgstr "更新服务暂时不可用。"
+
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "the Windows user"
 msgstr "Windows 用户"
@@ -10980,6 +10988,10 @@ msgstr "可用更新"
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 msgid "Update branch"
 msgstr "更新分支"
+
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Update checks are not available in development mode."
+msgstr "开发模式下无法检查更新。"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Update error: {detail}"

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -17,6 +17,7 @@ import type {
 import type { BrowserState, BrowserTabInfo } from "./procedures/browser";
 import type { BrowserLinkPresentationMode } from "../settings";
 import type { IpcProcedurePayload, SupervisorProcedureName } from "./procedureMap";
+import type { MessageKey } from "../messages";
 
 export type SupervisorRequest = {
   [Name in SupervisorProcedureName]: {
@@ -155,4 +156,5 @@ export type UpdateStatus =
       total: number;
     }
   | { type: "downloaded"; version: string }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string; messageKey?: never }
+  | { type: "error"; messageKey: MessageKey; message?: never };

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -124,6 +124,9 @@ const messages = {
 
   // ── App update ────────────────────────────────────────────
   "update.error": "Update error: {detail}",
+  "update.serviceUnavailable": "The update service is temporarily unavailable.",
+  "update.operationFailed": "The update operation failed.",
+  "update.devUnavailable": "Update checks are not available in development mode.",
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Move updater checks and downloads behind operation-owned transient retries so recovered `EPIPE`, `ECONNRESET`, `ENOTFOUND`, `ECONNREFUSED`, and timeout failures do not reach Sentry.
- Make missing update-manifest treatment channel-aware: nightly manifest 404s become an expected local warning/no-update result, while stable manifest absence remains observable.
- Keep signature, artifact-integrity, disk, required-manifest, malformed-response, and unexpected updater failures as real errors, reported through fixed privacy-safe diagnostics with normalized channel/platform and operation/outcome tags.
- Aggregate push gateway 408/425/429/5xx responses and network/timeouts into bounded local warnings that never call the exception sink; malformed non-transient responses remain sanitized real errors.
- Preserve the existing same-port startup retry behavior and distinguish superseded shutdown/restart races from a genuine exhausted `EADDRINUSE` conflict.
- Route updater UI failures through stable shared message keys, translated in all 12 non-English renderer catalogs.

## Sentry issues and treatment

| Issue IDs | Classification | Treatment |
| --- | --- | --- |
| LIGHTCODE-5X, LIGHTCODE-2G, LIGHTCODE-4F | Updater download/signature/artifact or disk failure | Real error. Retry only typed transient network failures; report integrity/disk/final non-transient failures with privacy-safe synthetic diagnostics and normalized `poracode.channel`, `poracode.platform`, and `event.origin` tags. |
| LIGHTCODE-2F | Missing release manifest | A nightly manifest 404 is an optional probe absence and produces a fixed local warning plus `update-not-available`; a required stable manifest 404 remains a captured error. |
| Updater EPIPE/ECONNRESET/ENOTFOUND/ECONNREFUSED/timeout | Transient updater transport failure | Two bounded retries (three total attempts). Success emits nothing. Exhaustion logs at most one fixed local warning per operation every six hours and never calls `reportError`/Sentry exception capture. |
| LIGHTCODE-5P, LIGHTCODE-5W | Web Push/provider/gateway transient failure | 408/425/429/500/502/503/504 and transport timeouts/network errors log at most one fixed warning per operation/outcome/platform/status every 15 minutes and never call `onError`/Sentry exception capture. Raw errors, URLs, subscriptions, tokens, payloads, and response bodies are never forwarded. Malformed non-transient responses still call the error sink with a synthetic diagnostic. |
| LIGHTCODE-4W | Local `EADDRINUSE` | Master already retries the assigned port to absorb short listener overlap. This PR adds regression coverage, suppresses superseded shutdown/restart races, and reports only a fixed privacy-safe diagnostic after a genuine conflict exhausts retries. |

No metrics dependency was added because the installed reporting seam exposes exception capture only. Transient operational health therefore stays local and bounded instead of being mislabeled as a Sentry error.

## Localization

Updater errors emitted by main now carry stable `MessageKey` values. The renderer resolves those keys through the existing shared Lingui bridge before updating UI state or showing a toast. `pnpm i18n:extract` reports zero missing translations for `de`, `es`, `fr`, `ja`, `ko`, `pl`, `pt-BR`, `ru`, `tr`, `uk`, `vi`, and `zh-CN`.

## Validation

- `pnpm exec vitest run src/main/updates/autoUpdater.test.ts src/main/remote/push/pushGateway.test.ts src/main/remote/DesktopRemoteAccessController.test.ts src/main/remote/RemoteAccessServer.test.ts src/renderer/i18n/sharedMessages.test.ts src/shared/ipc.test.ts` — 6 files, 115 tests passed
- `pnpm i18n:extract` — zero missing translations in every catalog
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run fmt:check`
- `git diff --check`

## Privacy and architecture review

- Error telemetry receives only fixed synthetic errors and safe operation/outcome/channel/platform/status metadata.
- Transient updater and push outcomes do not invoke exception capture.
- No commands, paths, prompts, repository data, request bodies, URLs, addresses, auth values, device tokens, subscriptions, payload content, or user identifiers are captured.
- Classification stays at the updater, push gateway, and remote-listener boundaries; no central Sentry privacy/classification file or unrelated provider/runtime module changed.
- The changes remain provider-agnostic and pass strict `exactOptionalPropertyTypes` typechecking.

## Residual risk

- Retry/warning bounds are process-local and reset after an app restart.
- Automatic download ownership uses `autoUpdater.autoDownload = false` and invokes `downloadUpdate()` after the normal `update-available` event; focused tests cover the event ordering and automatic handoff, but release-provider integration remains the main runtime-sensitive surface.