### PR TITLE
fix(sentry): attribute renderer and native crashes

### DIFF
--- a/src/main/diagnostics/mainEvent.test.ts
+++ b/src/main/diagnostics/mainEvent.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import type { SentryEventLike } from "@/shared/diagnostics/sentryPrivacy";
+import { prepareMainSentryEvent } from "./mainEvent";
+
+describe("main Sentry event preparation", () => {
+  it.each([
+    {
+      message: "net::ERR_NETWORK_CHANGED",
+    },
+    {
+      exception: {
+        values: [{ value: "net::ERR_NETWORK_CHANGED" }],
+      },
+    },
+  ] satisfies SentryEventLike[])("drops the exact transient network-change error", (event) => {
+    expect(prepareMainSentryEvent(event, "darwin")).toBeNull();
+  });
+
+  it.each([
+    {
+      message: "net::ERR_INTERNET_DISCONNECTED",
+    },
+    {
+      exception: {
+        values: [{ value: "Navigation failed: net::ERR_NETWORK_CHANGED" }],
+      },
+    },
+    {
+      exception: {
+        values: [{ value: "net::ERR_NETWORK_CHANGED " }],
+      },
+    },
+  ] satisfies SentryEventLike[])("keeps nearby Electron network failures", (event) => {
+    expect(prepareMainSentryEvent(event, "darwin")).toEqual(event);
+  });
+});

--- a/src/main/diagnostics/mainEvent.ts
+++ b/src/main/diagnostics/mainEvent.ts
@@ -1,0 +1,29 @@
+import { sanitizeSentryEvent, type SentryEventLike } from "@/shared/diagnostics/sentryPrivacy";
+import { classifyNativeCrashEvent } from "./nativeCrash";
+
+const TRANSIENT_NETWORK_CHANGED_ERROR = "net::ERR_NETWORK_CHANGED";
+
+function isTransientNetworkChangedEvent(event: SentryEventLike): boolean {
+  if (event.message === TRANSIENT_NETWORK_CHANGED_ERROR) return true;
+  return (
+    event.exception?.values?.some(
+      (exception) => exception.value === TRANSIENT_NETWORK_CHANGED_ERROR,
+    ) ?? false
+  );
+}
+
+export function prepareMainSentryEvent<T extends SentryEventLike>(
+  event: T,
+  platform: NodeJS.Platform,
+): T | null {
+  if (isTransientNetworkChangedEvent(event)) {
+    return null;
+  }
+
+  const treatment = classifyNativeCrashEvent(event, platform);
+  if (treatment.drop) return null;
+  const classified = treatment.fingerprint
+    ? ({ ...event, fingerprint: treatment.fingerprint } as T)
+    : event;
+  return sanitizeSentryEvent(classified);
+}

--- a/src/main/diagnostics/nativeCrash.test.ts
+++ b/src/main/diagnostics/nativeCrash.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { SentryEventLike } from "@/shared/diagnostics/sentryPrivacy";
+import { classifyNativeCrashEvent } from "./nativeCrash";
+
+describe("native crash diagnostics", () => {
+  it("drops only an unknown native process proven to be Xcode swift-frontend", () => {
+    const event = {
+      platform: "native",
+      tags: { "event.process": "unknown" },
+      contexts: {
+        electron: {
+          "crashpad.Stack dump":
+            "0.\tProgram arguments: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -interpret /private/tmp/main.swift\n1.\tApple Swift version 6.3",
+        },
+      },
+    } satisfies SentryEventLike;
+
+    expect(classifyNativeCrashEvent(event, "darwin")).toEqual({ drop: true });
+  });
+
+  it("keeps unknown Swift and macOS native crashes without executable ownership proof", () => {
+    const event = {
+      platform: "native",
+      tags: { "event.process": "unknown" },
+      exception: { values: [{ value: "closure in _assertionFailure" }] },
+      contexts: {
+        electron: {
+          "crashpad.Stack dump":
+            "0.\tProgram arguments: /Applications/Poracode.app/Contents/MacOS/Poracode",
+        },
+      },
+    } satisfies SentryEventLike;
+
+    expect(classifyNativeCrashEvent(event, "darwin")).toEqual({ drop: false });
+  });
+
+  it("keeps and groups Electron browser GPU fatals by OS and reason class", () => {
+    const event = {
+      platform: "native",
+      tags: { "event.process": "browser" },
+      contexts: {
+        electron: {
+          "crashpad.LOG_FATAL":
+            "gpu_data_manager_impl_private.cc:416: GPU process isn't usable. Goodbye.",
+        },
+      },
+    } satisfies SentryEventLike;
+
+    expect(classifyNativeCrashEvent(event, "linux")).toEqual({
+      drop: false,
+      fingerprint: ["poracode-native-crash", "linux", "gpu-fatal"],
+    });
+  });
+
+  it("keeps and groups native out-of-memory crashes", () => {
+    const event = {
+      platform: "native",
+      tags: { "event.process": "renderer", "exit.reason": "oom" },
+    } satisfies SentryEventLike;
+
+    expect(classifyNativeCrashEvent(event, "win32")).toEqual({
+      drop: false,
+      fingerprint: ["poracode-native-crash", "win32", "out-of-memory"],
+    });
+  });
+});

--- a/src/main/diagnostics/nativeCrash.ts
+++ b/src/main/diagnostics/nativeCrash.ts
@@ -1,0 +1,69 @@
+import type { SentryEventLike } from "@/shared/diagnostics/sentryPrivacy";
+
+export type NativeCrashTreatment = {
+  drop: boolean;
+  fingerprint?: string[];
+};
+
+function stringField(record: unknown, key: string): string | undefined {
+  if (!record || typeof record !== "object") return undefined;
+  const value = (record as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function crashpadStackDump(event: SentryEventLike): string | undefined {
+  return (
+    stringField(event.contexts?.electron, "crashpad.Stack dump") ??
+    stringField(event.contexts?.["swift-frontend"], "Stack dump")
+  );
+}
+
+function isProvenExternalSwiftFrontend(event: SentryEventLike): boolean {
+  if (event.platform !== "native" || event.tags?.["event.process"] !== "unknown") return false;
+  const stackDump = crashpadStackDump(event);
+  if (!stackDump) return false;
+  const firstLine = stackDump.split(/\r?\n/, 1)[0] ?? "";
+  return /^0\.\s*Program arguments:\s+\/Applications\/Xcode\.app\/Contents\/Developer\/Toolchains\/\S+\/usr\/bin\/swift-frontend(?:\s|$)/.test(
+    firstLine,
+  );
+}
+
+function isGpuFatal(event: SentryEventLike): boolean {
+  if (event.platform !== "native" || event.tags?.["event.process"] !== "browser") return false;
+  for (const context of Object.values(event.contexts ?? {})) {
+    const fatal = stringField(context, "crashpad.LOG_FATAL") ?? stringField(context, "LOG_FATAL");
+    if (fatal?.includes("GPU process isn't usable")) return true;
+  }
+  return false;
+}
+
+function isNativeOutOfMemory(event: SentryEventLike): boolean {
+  if (event.platform !== "native") return false;
+  if (event.tags?.["exit.reason"] === "oom") return true;
+  const values = event.exception?.values as
+    | Array<{ type?: unknown; value?: string; mechanism?: Record<string, unknown> }>
+    | undefined;
+  return values?.some((value) => value.type === "OutOfMemoryError") ?? false;
+}
+
+export function classifyNativeCrashEvent(
+  event: SentryEventLike,
+  platform: NodeJS.Platform,
+): NativeCrashTreatment {
+  if (isProvenExternalSwiftFrontend(event)) {
+    return { drop: true };
+  }
+  if (isGpuFatal(event)) {
+    return {
+      drop: false,
+      fingerprint: ["poracode-native-crash", platform, "gpu-fatal"],
+    };
+  }
+  if (isNativeOutOfMemory(event)) {
+    return {
+      drop: false,
+      fingerprint: ["poracode-native-crash", platform, "out-of-memory"],
+    };
+  }
+  return { drop: false };
+}

--- a/src/main/diagnostics/processGone.test.ts
+++ b/src/main/diagnostics/processGone.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { classifyRendererProcessGone } from "./processGone";
+
+describe("renderer process-gone diagnostics", () => {
+  it("does not report clean exits or explicit user lifecycle terminations", () => {
+    expect(classifyRendererProcessGone({ reason: "clean-exit" }, "darwin")).toBeNull();
+    expect(classifyRendererProcessGone({ reason: "killed" }, "darwin", "app-shutdown")).toBeNull();
+    expect(classifyRendererProcessGone({ reason: "killed" }, "win32", "reload")).toBeNull();
+    expect(classifyRendererProcessGone({ reason: "killed" }, "linux", "window-close")).toBeNull();
+  });
+
+  it.each([
+    ["crashed", "crash"],
+    ["oom", "memory-pressure"],
+    ["memory-eviction", "memory-pressure"],
+    ["abnormal-exit", "abnormal-exit"],
+    ["launch-failed", "launch-failure"],
+    ["integrity-failure", "integrity-failure"],
+    ["killed", "unexpected-kill"],
+  ] as const)("normalizes %s into a stable %s bucket", (reason, bucket) => {
+    expect(classifyRendererProcessGone({ reason }, "linux")).toEqual({
+      bucket,
+      fingerprint: ["poracode-renderer-process-gone", "linux", bucket],
+    });
+  });
+});

--- a/src/main/diagnostics/processGone.ts
+++ b/src/main/diagnostics/processGone.ts
@@ -1,0 +1,49 @@
+import type { RenderProcessGoneDetails } from "electron";
+
+export type RendererProcessGoneIntent = "app-shutdown" | "reload" | "window-close";
+
+export type RendererProcessGoneDiagnostic = {
+  bucket:
+    | "abnormal-exit"
+    | "crash"
+    | "integrity-failure"
+    | "launch-failure"
+    | "memory-pressure"
+    | "unexpected-kill"
+    | "unknown";
+  fingerprint: string[];
+};
+
+export function classifyRendererProcessGone(
+  details: Pick<RenderProcessGoneDetails, "reason">,
+  platform: NodeJS.Platform,
+  intent?: RendererProcessGoneIntent,
+): RendererProcessGoneDiagnostic | null {
+  if (details.reason === "clean-exit") return null;
+  if (details.reason === "killed" && intent) return null;
+
+  const bucket = (() => {
+    switch (details.reason) {
+      case "abnormal-exit":
+        return "abnormal-exit";
+      case "crashed":
+        return "crash";
+      case "integrity-failure":
+        return "integrity-failure";
+      case "launch-failed":
+        return "launch-failure";
+      case "memory-eviction":
+      case "oom":
+        return "memory-pressure";
+      case "killed":
+        return "unexpected-kill";
+      default:
+        return "unknown";
+    }
+  })();
+
+  return {
+    bucket,
+    fingerprint: ["poracode-renderer-process-gone", platform, bucket],
+  };
+}

--- a/src/main/diagnostics/sentry.ts
+++ b/src/main/diagnostics/sentry.ts
@@ -1,14 +1,11 @@
 import { app } from "electron";
 import type { PoracodeChannel } from "@/shared/channel";
-import {
-  sanitizeSentryEvent,
-  type PoracodeDiagnosticTags,
-  type SentryEventLike,
-} from "@/shared/diagnostics/sentryPrivacy";
+import type { PoracodeDiagnosticTags, SentryEventLike } from "@/shared/diagnostics/sentryPrivacy";
 import {
   readBuildSentryDsn,
   readBuildSentryEnvironment,
 } from "@/shared/diagnostics/sentryBuildConfig";
+import { prepareMainSentryEvent } from "./mainEvent";
 
 const DISABLED_INTEGRATIONS = new Set([
   "ChildProcess",
@@ -112,7 +109,10 @@ export function initializeMainSentry(options: MainSentryOptions): boolean {
       return null;
     },
     beforeSend(event) {
-      return sanitizeSentryEvent(event as unknown as SentryEventLike) as unknown as typeof event;
+      return prepareMainSentryEvent(
+        event as unknown as SentryEventLike,
+        process.platform,
+      ) as unknown as typeof event | null;
     },
     integrations(defaultIntegrations) {
       return defaultIntegrations.filter(
@@ -131,13 +131,20 @@ export function initializeMainSentry(options: MainSentryOptions): boolean {
   return true;
 }
 
-export function captureMainException(error: unknown, tags?: PoracodeDiagnosticTags): void {
+export function captureMainException(
+  error: unknown,
+  tags?: PoracodeDiagnosticTags,
+  fingerprint?: string[],
+): void {
   const Sentry = loadMainSentry();
   if (!Sentry) return;
   if (!Sentry.isEnabled()) return;
   Sentry.withScope((scope) => {
     if (tags) {
       scope.setTags(tags);
+    }
+    if (fingerprint) {
+      scope.setFingerprint(fingerprint);
     }
     Sentry.captureException(error);
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,6 +9,7 @@ import {
   Menu,
   nativeTheme,
   session as electronSession,
+  type RenderProcessGoneDetails,
 } from "electron";
 import { resolveThemeMode } from "@/shared/themeMode";
 import { isThreadTurnActive, type RemoteThreadCommand } from "@/shared/contracts";
@@ -53,6 +54,7 @@ import { SupervisorClient } from "./supervisor/SupervisorClient";
 import { createAutoUpdaterController } from "./updates/autoUpdater";
 import { showOsNotification } from "./osNotifications";
 import { createMainWindow } from "./window/createMainWindow";
+import { requestTrackedRendererReload } from "./window/windowHardening";
 import {
   createQuickComposerWindow,
   showQuickComposerWindow,
@@ -79,6 +81,10 @@ import { readSharedSettingsFile, writeSharedSettingsFile } from "./sharedSetting
 import { remoteProjectCommandResultSchema } from "@/shared/remote";
 import { WindowsJobObjectManager } from "./windowsJobObject";
 import { captureMainException, initializeMainSentry } from "./diagnostics/sentry";
+import {
+  classifyRendererProcessGone,
+  type RendererProcessGoneIntent,
+} from "./diagnostics/processGone";
 import { configureSecretStorageKey } from "@/shared/secretStorage";
 import { readOrCreateSafeStorageSecretKey } from "./secretStorageKey";
 import { createDesktopRemoteAccessController, type DesktopRemoteAccessController } from "./remote";
@@ -210,6 +216,27 @@ let browserExtractWindow: BrowserWindow | null = null;
 let tray: TrayHandle | null = null;
 let quickComposerShortcutManager: QuickComposerShortcutManager | null = null;
 let isQuitting = false;
+
+function captureRendererProcessGone(
+  details: RenderProcessGoneDetails,
+  featureArea: "browser" | "quick-composer" | "renderer",
+  intent?: RendererProcessGoneIntent,
+): void {
+  const diagnostic = classifyRendererProcessGone(
+    details,
+    process.platform,
+    isQuitting ? "app-shutdown" : intent,
+  );
+  if (!diagnostic) return;
+  captureMainException(
+    new Error(`Electron renderer process gone (${diagnostic.bucket})`),
+    {
+      "poracode.feature_area": featureArea,
+      "poracode.process": "renderer",
+    },
+    diagnostic.fingerprint,
+  );
+}
 
 function isCloseToTrayEnabled(): boolean {
   if (!poracodePaths) return false;
@@ -377,11 +404,8 @@ function createQuickComposerAppWindow(): BrowserWindow {
     onClosed: () => {
       if (quickComposerWindow === window) quickComposerWindow = null;
     },
-    onRendererProcessGone: (details) => {
-      captureMainException(new Error(`Quick composer renderer gone: ${details.reason}`), {
-        "poracode.feature_area": "quick-composer",
-        "poracode.process": "renderer",
-      });
+    onRendererProcessGone: (details, intent) => {
+      captureRendererProcessGone(details, "quick-composer", intent);
     },
   });
   window.on("blur", () => {
@@ -442,12 +466,9 @@ function createMainAppWindow(showOnReady = true): BrowserWindow {
       mainRendererReady = false;
     },
     onClose: handleMainWindowClose,
-    onRendererProcessGone: (details) => {
+    onRendererProcessGone: (details, intent) => {
       mainRendererReady = false;
-      captureMainException(new Error(`Renderer process gone: ${details.reason}`), {
-        "poracode.feature_area": "renderer",
-        "poracode.process": "renderer",
-      });
+      captureRendererProcessGone(details, "renderer", intent);
     },
   });
   window.webContents.on("did-start-loading", () => {
@@ -504,11 +525,8 @@ function createBrowserExtractWindow(): BrowserWindow {
         revealBrowserInMainWindow();
       }
     },
-    onRendererProcessGone: (details) => {
-      captureMainException(new Error(`Browser renderer process gone: ${details.reason}`), {
-        "poracode.feature_area": "browser",
-        "poracode.process": "renderer",
-      });
+    onRendererProcessGone: (details, intent) => {
+      captureRendererProcessGone(details, "browser", intent);
     },
   });
   return window;
@@ -1030,6 +1048,10 @@ if (!hasSingleInstanceLock) {
         mainRendererReady = true;
         flushQuickComposerSubmissions();
         flushTrayThreadOpen();
+      });
+      ipcMain.handle(IPC_WINDOW_CHANNELS.rendererReload, (event) => {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        if (window) requestTrackedRendererReload(window);
       });
 
       const initialMainWindow = ensureMainWindow(showMainWindowOnReady);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -210,6 +210,9 @@ const bridge: PoracodeBridge = {
   notifyQuickComposerMainReady() {
     return ipcRenderer.invoke(IPC_WINDOW_CHANNELS.quickComposerMainReady);
   },
+  reloadRenderer() {
+    return ipcRenderer.invoke(IPC_WINDOW_CHANNELS.rendererReload);
+  },
   onQuickComposerSubmit(listener) {
     const handler = (_event: Electron.IpcRendererEvent, payload: QuickComposerSubmission) => {
       listener(payload);

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -7,6 +7,7 @@ const setUserAgent = vi.hoisted(() => vi.fn<(userAgent: string) => void>());
 
 let browserWindowOptions: Record<string, unknown> | null = null;
 let webContentsHandlers: Record<string, (...args: never[]) => void> = {};
+let windowHandlers: Record<string, (...args: never[]) => void> = {};
 
 vi.mock("electron", () => ({
   BrowserWindow: class BrowserWindow {
@@ -26,7 +27,9 @@ vi.mock("electron", () => ({
     }
 
     once = vi.fn<() => void>();
-    on = vi.fn<() => void>();
+    on = vi.fn<(event: string, handler: (...args: never[]) => void) => void>((event, handler) => {
+      windowHandlers[event] = handler;
+    });
     isMaximized = vi.fn<() => boolean>(() => false);
     isDestroyed = vi.fn<() => boolean>(() => false);
     getNormalBounds = vi.fn<() => { x: number; y: number; width: number; height: number }>(() => ({
@@ -63,6 +66,7 @@ describe("createMainWindow", () => {
     vi.clearAllMocks();
     browserWindowOptions = null;
     webContentsHandlers = {};
+    windowHandlers = {};
   });
 
   it("applies the browser user agent to the window and sanitizes attached webviews", async () => {
@@ -104,5 +108,61 @@ describe("createMainWindow", () => {
     expect(webPreferences.preload).toBeUndefined();
     expect(webPreferences.nodeIntegration).toBe(false);
     expect(webPreferences.contextIsolation).toBe(true);
+  });
+
+  it("supplies window-close intent only when the app does not prevent the close", async () => {
+    const { createMainWindow } = await import("./createMainWindow");
+    let preventClose = true;
+    const onRendererProcessGone =
+      vi.fn<
+        (
+          details: Electron.RenderProcessGoneDetails,
+          intent: "app-shutdown" | "reload" | "window-close" | undefined,
+        ) => void
+      >();
+    createMainWindow({
+      title: "Poracode",
+      isDev: false,
+      channel: "stable",
+      preloadPath: "/tmp/preload.cjs",
+      rendererHtmlPath: "/tmp/index.html",
+      appVersion: "1.2.1",
+      posthogEnableDev: false,
+      posthogEnabled: false,
+      posthogHost: "",
+      posthogKey: "",
+      sentryEnabled: false,
+      windowChromeHeight: 32,
+      browserUserAgent: "Poracode",
+      appearance: "dark",
+      sidebarTranslucency: false,
+      onClosed: vi.fn<() => void>(),
+      onClose(event) {
+        if (preventClose) event.preventDefault();
+      },
+      onRendererProcessGone,
+    });
+    const killed = {
+      reason: "killed",
+      exitCode: 9,
+    } satisfies Electron.RenderProcessGoneDetails;
+    const closeEvent = {
+      defaultPrevented: false,
+      preventDefault() {
+        this.defaultPrevented = true;
+      },
+    };
+
+    windowHandlers.close?.(closeEvent as never);
+    webContentsHandlers["render-process-gone"]?.({} as never, killed as never);
+    preventClose = false;
+    closeEvent.defaultPrevented = false;
+    windowHandlers.close?.(closeEvent as never);
+    webContentsHandlers["render-process-gone"]?.({} as never, killed as never);
+
+    expect(onRendererProcessGone.mock.calls).toEqual([
+      [killed, undefined],
+      [killed, "window-close"],
+    ]);
   });
 });

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -2,12 +2,14 @@ import { dbGetState, dbSetState } from "../db";
 import { BrowserWindow, screen, type RenderProcessGoneDetails } from "electron";
 import type { PoracodeChannel } from "@/shared/channel";
 import type { PoracodeWindowKind } from "@/shared/ipc";
+import type { RendererProcessGoneIntent } from "@/main/diagnostics/processGone";
 import { installSessionPermissions } from "../browser/permissions";
 import { supportsNativeWindowMaterial, syncNativeThemeForMaterial } from "./windowMaterial";
 import {
   buildRendererAdditionalArguments,
   installAppNavigationGuards,
   installRendererReloadGuard,
+  noteRendererWindowClose,
 } from "./windowHardening";
 import { rectOverlapsWorkArea } from "./windowGeometry";
 
@@ -78,7 +80,10 @@ export interface CreateMainWindowOptions {
   sidebarTranslucency: boolean;
   onClosed(): void;
   onClose?: (event: Electron.Event) => void;
-  onRendererProcessGone?: (details: RenderProcessGoneDetails) => void;
+  onRendererProcessGone?: (
+    details: RenderProcessGoneDetails,
+    intent: RendererProcessGoneIntent | undefined,
+  ) => void;
   devServerUrl?: string;
   openDevTools?: boolean;
   showOnReady?: boolean;
@@ -217,6 +222,7 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
       saveWindowBounds(window, boundsStateKey);
     }
     options.onClose?.(event);
+    noteRendererWindowClose(window, event);
   });
   window.on("closed", options.onClosed);
 

--- a/src/main/window/createQuickComposerWindow.ts
+++ b/src/main/window/createQuickComposerWindow.ts
@@ -1,11 +1,13 @@
 import { BrowserWindow, screen, type Rectangle, type RenderProcessGoneDetails } from "electron";
 import type { PoracodeChannel } from "@/shared/channel";
+import type { RendererProcessGoneIntent } from "@/main/diagnostics/processGone";
 import { installSessionPermissions } from "../browser/permissions";
 import { showAndFocusWindow } from "./showAndFocusWindow";
 import {
   buildRendererAdditionalArguments,
   installAppNavigationGuards,
   installRendererReloadGuard,
+  noteRendererWindowClose,
 } from "./windowHardening";
 import { rectOverlapsWorkArea } from "./windowGeometry";
 
@@ -28,7 +30,10 @@ export interface CreateQuickComposerWindowOptions {
   sentryEnabled: boolean;
   browserUserAgent: string;
   onClosed(): void;
-  onRendererProcessGone?: (details: RenderProcessGoneDetails) => void;
+  onRendererProcessGone?: (
+    details: RenderProcessGoneDetails,
+    intent: RendererProcessGoneIntent | undefined,
+  ) => void;
   devServerUrl?: string;
 }
 
@@ -140,6 +145,7 @@ export function createQuickComposerWindow(
       : {}),
   });
 
+  window.on("close", (event) => noteRendererWindowClose(window, event));
   window.on("closed", options.onClosed);
   return window;
 }

--- a/src/main/window/windowHardening.test.ts
+++ b/src/main/window/windowHardening.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserWindow, RenderProcessGoneDetails } from "electron";
+import {
+  classifyRendererProcessGone,
+  type RendererProcessGoneIntent,
+} from "@/main/diagnostics/processGone";
+import {
+  installRendererReloadGuard,
+  noteRendererWindowClose,
+  requestTrackedRendererReload,
+} from "./windowHardening";
+
+type Handler = (...args: unknown[]) => void;
+
+function createWindowHarness() {
+  const handlers = new Map<string, Handler>();
+  const onceHandlers = new Map<string, Handler>();
+  const reload = vi.fn<() => void>();
+  const window = {
+    isDestroyed: vi.fn<() => boolean>(() => false),
+    webContents: {
+      on: vi.fn<(event: string, handler: Handler) => void>((event, handler) => {
+        handlers.set(event, handler);
+      }),
+      once: vi.fn<(event: string, handler: Handler) => void>((event, handler) => {
+        onceHandlers.set(event, handler);
+      }),
+      removeListener: vi.fn<(event: string, handler: Handler) => void>((event, handler) => {
+        if (onceHandlers.get(event) === handler) onceHandlers.delete(event);
+      }),
+      reload,
+    },
+  } as unknown as BrowserWindow;
+  return { handlers, onceHandlers, reload, window };
+}
+
+const killed = { reason: "killed", exitCode: 9 } satisfies RenderProcessGoneDetails;
+
+describe("renderer termination intent wiring", () => {
+  it("supplies reload once, then keeps an unproven killed event observable", () => {
+    const harness = createWindowHarness();
+    const treatments: Array<ReturnType<typeof classifyRendererProcessGone>> = [];
+    installRendererReloadGuard(harness.window, {
+      loadRenderer: vi.fn<() => void>(),
+      onRendererProcessGone(details, intent) {
+        treatments.push(classifyRendererProcessGone(details, "darwin", intent));
+      },
+    });
+
+    expect(requestTrackedRendererReload(harness.window)).toBe(true);
+    expect(harness.reload).toHaveBeenCalledOnce();
+    harness.handlers.get("render-process-gone")?.({}, killed);
+    harness.handlers.get("render-process-gone")?.({}, killed);
+
+    expect(treatments).toEqual([
+      null,
+      {
+        bucket: "unexpected-kill",
+        fingerprint: ["poracode-renderer-process-gone", "darwin", "unexpected-kill"],
+      },
+    ]);
+  });
+
+  it("clears reload intent after a successful lifecycle transition", () => {
+    const harness = createWindowHarness();
+    const onRendererProcessGone =
+      vi.fn<
+        (details: RenderProcessGoneDetails, intent: RendererProcessGoneIntent | undefined) => void
+      >();
+    installRendererReloadGuard(harness.window, {
+      loadRenderer: vi.fn<() => void>(),
+      onRendererProcessGone,
+    });
+
+    requestTrackedRendererReload(harness.window);
+    harness.onceHandlers.get("did-finish-load")?.();
+    harness.handlers.get("render-process-gone")?.({}, killed);
+
+    expect(onRendererProcessGone).toHaveBeenCalledWith(killed, undefined);
+  });
+
+  it("does not turn a prevented close-to-tray event into window-close intent", () => {
+    const harness = createWindowHarness();
+    const onRendererProcessGone =
+      vi.fn<
+        (details: RenderProcessGoneDetails, intent: RendererProcessGoneIntent | undefined) => void
+      >();
+    installRendererReloadGuard(harness.window, {
+      loadRenderer: vi.fn<() => void>(),
+      onRendererProcessGone,
+    });
+
+    noteRendererWindowClose(harness.window, { defaultPrevented: true } as Electron.Event);
+    harness.handlers.get("render-process-gone")?.({}, killed);
+    noteRendererWindowClose(harness.window, { defaultPrevented: false } as Electron.Event);
+    harness.handlers.get("render-process-gone")?.({}, killed);
+
+    expect(onRendererProcessGone.mock.calls).toEqual([
+      [killed, undefined],
+      [killed, "window-close"],
+    ]);
+  });
+});

--- a/src/main/window/windowHardening.ts
+++ b/src/main/window/windowHardening.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow, RenderProcessGoneDetails } from "electron";
 import type { PoracodeChannel } from "@/shared/channel";
 import type { PoracodeWindowKind } from "@/shared/ipc";
+import type { RendererProcessGoneIntent } from "@/main/diagnostics/processGone";
 
 interface AppNavigationGuardOptions {
   isDev: boolean;
@@ -46,9 +47,85 @@ export function installAppNavigationGuards(
 
 interface RendererReloadGuardOptions {
   loadRenderer: () => void;
-  onRendererProcessGone?: (details: RenderProcessGoneDetails) => void;
+  onRendererProcessGone?: (
+    details: RenderProcessGoneDetails,
+    intent: RendererProcessGoneIntent | undefined,
+  ) => void;
   /** Log-only surface label (e.g. "quick composer") to distinguish messages. */
   label?: string;
+}
+
+type RendererTerminationState = {
+  intent?: RendererProcessGoneIntent;
+  reloadCleanup?: () => void;
+  reloadToken?: object;
+};
+
+const rendererTerminationStates = new WeakMap<BrowserWindow, RendererTerminationState>();
+
+function terminationStateFor(window: BrowserWindow): RendererTerminationState {
+  const existing = rendererTerminationStates.get(window);
+  if (existing) return existing;
+  const state: RendererTerminationState = {};
+  rendererTerminationStates.set(window, state);
+  return state;
+}
+
+function consumeRendererTerminationIntent(
+  window: BrowserWindow,
+): RendererProcessGoneIntent | undefined {
+  const state = rendererTerminationStates.get(window);
+  if (!state) return undefined;
+  const intent = state.intent;
+  state.reloadCleanup?.();
+  delete state.intent;
+  delete state.reloadCleanup;
+  delete state.reloadToken;
+  return intent;
+}
+
+export function noteRendererWindowClose(window: BrowserWindow, event: Electron.Event): void {
+  const state = terminationStateFor(window);
+  if (event.defaultPrevented) {
+    if (state.intent === "window-close") delete state.intent;
+    return;
+  }
+  state.reloadCleanup?.();
+  delete state.reloadCleanup;
+  delete state.reloadToken;
+  state.intent = "window-close";
+}
+
+export function requestTrackedRendererReload(window: BrowserWindow): boolean {
+  if (window.isDestroyed()) return false;
+  const state = rendererTerminationStates.get(window);
+  if (!state) return false;
+  state.reloadCleanup?.();
+  const reloadToken = {};
+  state.intent = "reload";
+  state.reloadToken = reloadToken;
+
+  const removeReloadListeners = () => {
+    window.webContents.removeListener("did-finish-load", clearReloadIntent);
+    window.webContents.removeListener("did-fail-load", clearReloadIntent);
+  };
+  const clearReloadIntent = () => {
+    removeReloadListeners();
+    if (state.reloadToken !== reloadToken) return;
+    delete state.intent;
+    delete state.reloadCleanup;
+    delete state.reloadToken;
+  };
+  state.reloadCleanup = removeReloadListeners;
+  window.webContents.once("did-finish-load", clearReloadIntent);
+  window.webContents.once("did-fail-load", clearReloadIntent);
+  try {
+    window.webContents.reload();
+    return true;
+  } catch {
+    clearReloadIntent();
+    return false;
+  }
 }
 
 /**
@@ -59,15 +136,17 @@ export function installRendererReloadGuard(
   window: BrowserWindow,
   options: RendererReloadGuardOptions,
 ): void {
+  terminationStateFor(window);
   const prefix = options.label ? `${options.label} ` : "";
   let lastReloadAt = 0;
   let reloadCount = 0;
   window.webContents.on("render-process-gone", (_event, details) => {
+    const intent = consumeRendererTerminationIntent(window);
     if (details.reason === "clean-exit" || window.isDestroyed()) return;
     console.error(
       `[poracode] ${prefix}renderer gone: reason=${details.reason} exitCode=${details.exitCode}`,
     );
-    options.onRendererProcessGone?.(details);
+    options.onRendererProcessGone?.(details, intent);
     const now = Date.now();
     reloadCount = now - lastReloadAt < 5_000 ? reloadCount + 1 : 1;
     lastReloadAt = now;

--- a/src/renderer/RendererCrashScreen.test.tsx
+++ b/src/renderer/RendererCrashScreen.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createRendererCrashReport,
   formatRendererCrashReport,
+  RendererCrashScreen,
   RendererErrorBoundary,
 } from "./RendererCrashScreen";
 
@@ -56,5 +57,30 @@ describe("RendererCrashScreen", () => {
     expect(screen.getByText("Renderer crashed")).toBeInTheDocument();
     expect(screen.getByText("Renderer hit a React error")).toBeInTheDocument();
     expect(screen.getByText(/Message: render failed/)).toBeInTheDocument();
+  });
+
+  it("requests a tracked desktop renderer reload", () => {
+    const reloadRenderer = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    Object.assign(window, {
+      poracode: {
+        appVersion: "1.5.4",
+        electronVersion: "43.1.0",
+        platform: "darwin",
+        isDev: false,
+        reloadRenderer,
+      },
+    });
+    render(
+      <RendererCrashScreen
+        report={createRendererCrashReport({
+          kind: "bootstrap",
+          error: new Error("startup failed"),
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+
+    expect(reloadRenderer).toHaveBeenCalledOnce();
   });
 });

--- a/src/renderer/RendererCrashScreen.test.tsx
+++ b/src/renderer/RendererCrashScreen.test.tsx
@@ -1,12 +1,40 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentry = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn<(name: string, value: Record<string, unknown>) => void>(),
+    setTags: vi.fn<(tags: Record<string, unknown>) => void>(),
+  };
+  return {
+    captureException: vi.fn<(error: unknown) => void>(),
+    isEnabled: vi.fn<() => boolean>(() => true),
+    scope,
+    withScope: vi.fn<(callback: (value: typeof scope) => void) => void>((callback) =>
+      callback(scope),
+    ),
+  };
+});
+
+vi.mock("@sentry/electron/renderer", () => ({
+  captureException: sentry.captureException,
+  isEnabled: sentry.isEnabled,
+  withScope: sentry.withScope,
+}));
+
 import {
   createRendererCrashReport,
   formatRendererCrashReport,
   RendererCrashScreen,
   RendererErrorBoundary,
 } from "./RendererCrashScreen";
+import { captureRendererException } from "./diagnostics/sentry";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sentry.isEnabled.mockReturnValue(true);
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -57,6 +85,39 @@ describe("RendererCrashScreen", () => {
     expect(screen.getByText("Renderer crashed")).toBeInTheDocument();
     expect(screen.getByText("Renderer hit a React error")).toBeInTheDocument();
     expect(screen.getByText(/Message: render failed/)).toBeInTheDocument();
+    expect(sentry.captureException).toHaveBeenCalledOnce();
+  });
+
+  it("lets the desktop root capture a boundary failure exactly once with safe component context", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    function PrivateProjectPanel(): ReactNode {
+      throw new Error("render failed");
+    }
+
+    render(
+      <RendererErrorBoundary captureCaughtErrors={false}>
+        <PrivateProjectPanel />
+      </RendererErrorBoundary>,
+      {
+        onCaughtError(error, errorInfo) {
+          captureRendererException(
+            error,
+            { featureArea: "react" },
+            errorInfo.componentStack?.trim(),
+          );
+        },
+      },
+    );
+
+    expect(sentry.captureException).toHaveBeenCalledOnce();
+    expect(sentry.scope.setContext).toHaveBeenCalledOnce();
+    const componentContext = sentry.scope.setContext.mock.calls[0];
+    expect(componentContext?.[0]).toBe("poracode");
+    expect(componentContext?.[1]).toEqual({
+      react_components: expect.arrayContaining(["PrivateProjectPanel", "RendererErrorBoundary"]),
+    });
+    expect(JSON.stringify(componentContext)).not.toMatch(/[\\/](?:Users|home|private|tmp)[\\/]/i);
   });
 
   it("requests a tracked desktop renderer reload", () => {

--- a/src/renderer/RendererCrashScreen.tsx
+++ b/src/renderer/RendererCrashScreen.tsx
@@ -196,6 +196,12 @@ export function RendererCrashScreen(props: RendererCrashScreenProps) {
 
 type RendererErrorBoundaryProps = {
   children: ReactNode;
+  /**
+   * The desktop root owns caught-error reporting through React's
+   * `onCaughtError` callback so it can attach the complete component stack
+   * exactly once. Standalone/mobile roots keep this fallback enabled.
+   */
+  captureCaughtErrors?: boolean;
 };
 
 type RendererErrorBoundaryState = {
@@ -220,7 +226,9 @@ export class RendererErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
-    captureRendererException(error, { featureArea: "react" });
+    if (this.props.captureCaughtErrors ?? true) {
+      captureRendererException(error, { featureArea: "react" }, errorInfo.componentStack?.trim());
+    }
     this.setState({
       report: createRendererCrashReport({
         kind: "react",

--- a/src/renderer/RendererCrashScreen.tsx
+++ b/src/renderer/RendererCrashScreen.tsx
@@ -3,6 +3,7 @@ import { Copy, RefreshCw } from "lucide-react";
 import { msg } from "@lingui/core/macro";
 import type { MessageDescriptor } from "@lingui/core";
 import { Button } from "./components/common/Button";
+import { readBridge } from "./bridge";
 import { captureRendererException } from "./diagnostics/sentry";
 import { i18n } from "./i18n/i18n";
 
@@ -165,7 +166,11 @@ export function RendererCrashScreen(props: RendererCrashScreenProps) {
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <Button size="sm" variant="secondary" onPress={() => window.location.reload()}>
+            <Button
+              size="sm"
+              variant="secondary"
+              onPress={() => void readBridge().reloadRenderer()}
+            >
               <RefreshCw className="size-3.5" />
               {i18n._(msg`Reload`)}
             </Button>

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -16,7 +16,6 @@ import { DEFAULT_TERMINAL_SIZE as DEFAULT_HIDDEN_TERMINAL_SIZE } from "@/shared/
 import { useAppStore } from "@/renderer/state/appStore";
 import { TuxIcon } from "@/renderer/components/common/TuxIcon";
 import { performInitialThreadLaunch } from "@/renderer/actions/threadLaunchActions";
-import { setRendererRuntimeDiagnosticContext } from "@/renderer/diagnostics/sentry";
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
 import type { TerminalPaneHandle } from "./TerminalPane";
 import { ContinueInProviderDialog } from "./ContinueInProviderDialog";
@@ -174,17 +173,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     (thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal") ===
     "terminal";
   const launchTerminalSize = usesTerminalPresentation ? terminalSize : DEFAULT_HIDDEN_TERMINAL_SIZE;
-
-  useEffect(() => {
-    const presentation =
-      thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal";
-    setRendererRuntimeDiagnosticContext({
-      provider: thread.agentKind,
-      presentation,
-      runtimeKind: presentation === "terminal" ? "pty" : "structured",
-      featureArea: "thread",
-    });
-  }, [agentStatus?.capabilities.presentationMode, thread.agentKind, thread.presentationMode]);
 
   useLayoutEffect(() => {
     setContinueDialogOpen(false);

--- a/src/renderer/diagnostics/runtimeContext.test.ts
+++ b/src/renderer/diagnostics/runtimeContext.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { Thread } from "@/shared/contracts";
+import { resolveRendererRuntimeDiagnosticContext } from "./runtimeContext";
+
+function makeThread(input: Partial<Thread> = {}): Thread {
+  const now = "2026-07-27T00:00:00.000Z";
+  return {
+    id: "thread-a",
+    projectId: "project-a",
+    title: "Thread",
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: now,
+    updatedAt: now,
+    ...input,
+  };
+}
+
+describe("renderer runtime diagnostic context", () => {
+  it("uses the focused visible thread instead of mounted pane order", () => {
+    const context = resolveRendererRuntimeDiagnosticContext({
+      view: { kind: "thread", panes: ["thread-a", "thread-b"] },
+      focusedPaneId: "thread-b",
+      threads: [
+        makeThread(),
+        makeThread({
+          id: "thread-b",
+          agentKind: "claude",
+          presentationMode: "gui",
+        }),
+      ],
+    });
+
+    expect(context).toEqual({
+      provider: "claude",
+      presentation: "gui",
+      runtimeKind: "structured",
+      featureArea: "thread",
+    });
+    expect(context).not.toHaveProperty("threadId");
+    expect(context).not.toHaveProperty("projectId");
+  });
+
+  it("falls back to the first pane and terminal PTY semantics", () => {
+    expect(
+      resolveRendererRuntimeDiagnosticContext({
+        view: { kind: "thread", panes: ["thread-a"] },
+        focusedPaneId: "stale-thread",
+        threads: [makeThread()],
+      }),
+    ).toEqual({
+      provider: "codex",
+      presentation: "terminal",
+      runtimeKind: "pty",
+      featureArea: "thread",
+    });
+  });
+
+  it("matches the provider presentation default for legacy rows without a thread override", () => {
+    expect(
+      resolveRendererRuntimeDiagnosticContext(
+        {
+          view: { kind: "thread", panes: ["thread-a"] },
+          focusedPaneId: "thread-a",
+          threads: [makeThread()],
+        },
+        "gui",
+      ),
+    ).toEqual({
+      provider: "codex",
+      presentation: "gui",
+      runtimeKind: "structured",
+      featureArea: "thread",
+    });
+  });
+
+  it("clears context outside a real thread pane", () => {
+    expect(
+      resolveRendererRuntimeDiagnosticContext({
+        view: { kind: "home" },
+        focusedPaneId: null,
+        threads: [makeThread()],
+      }),
+    ).toBeNull();
+    expect(
+      resolveRendererRuntimeDiagnosticContext({
+        view: { kind: "thread", panes: ["draft:project-a"] },
+        focusedPaneId: "draft:project-a",
+        threads: [makeThread()],
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/renderer/diagnostics/runtimeContext.tsx
+++ b/src/renderer/diagnostics/runtimeContext.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import type { AppView, ProjectLocation, Thread, ThreadPresentationMode } from "@/shared/contracts";
+import type { PoracodeRuntimeDiagnosticContext } from "@/shared/diagnostics/sentryPrivacy";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useProjectAgentStatuses } from "@/renderer/hooks/uiSelectors";
+import { setRendererRuntimeDiagnosticContext } from "./sentry";
+
+type RuntimeContextState = {
+  view: AppView;
+  focusedPaneId: string | null;
+  threads: readonly Thread[];
+};
+
+export function resolveRendererRuntimeDiagnosticContext(
+  state: RuntimeContextState,
+  defaultPresentation?: ThreadPresentationMode,
+): PoracodeRuntimeDiagnosticContext | null {
+  if (state.view.kind !== "thread") return null;
+  const activePaneId =
+    state.focusedPaneId && state.view.panes.includes(state.focusedPaneId)
+      ? state.focusedPaneId
+      : state.view.panes[0];
+  const thread = state.threads.find((candidate) => candidate.id === activePaneId);
+  if (!thread) return null;
+
+  const presentation = thread.presentationMode ?? defaultPresentation ?? "terminal";
+  return {
+    provider: thread.agentKind,
+    presentation,
+    runtimeKind: presentation === "terminal" ? "pty" : "structured",
+    featureArea: "thread",
+  };
+}
+
+export function RendererRuntimeDiagnosticContextSync() {
+  const view = useAppStore((state) => state.view);
+  const focusedPaneId = useAppStore((state) => state.focusedPaneId);
+  const threads = useAppStore((state) => state.threads);
+  const activeThread =
+    view.kind === "thread"
+      ? threads.find(
+          (thread) =>
+            thread.id ===
+            (focusedPaneId && view.panes.includes(focusedPaneId) ? focusedPaneId : view.panes[0]),
+        )
+      : undefined;
+  const projectLocation = useAppStore((state): ProjectLocation | undefined =>
+    activeThread
+      ? state.projects.find((project) => project.id === activeThread.projectId)?.location
+      : undefined,
+  );
+  const agentStatuses = useProjectAgentStatuses(projectLocation);
+  const defaultPresentation = agentStatuses.find(
+    (status) => status.kind === activeThread?.agentKind,
+  )?.capabilities.presentationMode;
+  const context = resolveRendererRuntimeDiagnosticContext(
+    { view, focusedPaneId, threads },
+    defaultPresentation,
+  );
+  const presentation = context?.presentation;
+  const provider = context?.provider;
+  const runtimeKind = context?.runtimeKind;
+
+  useEffect(() => {
+    setRendererRuntimeDiagnosticContext(
+      provider && presentation && runtimeKind
+        ? { provider, presentation, runtimeKind, featureArea: "thread" }
+        : null,
+    );
+    return () => setRendererRuntimeDiagnosticContext(null);
+  }, [presentation, provider, runtimeKind]);
+
+  return null;
+}

--- a/src/renderer/diagnostics/sentry.test.ts
+++ b/src/renderer/diagnostics/sentry.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentry = vi.hoisted(() => {
+  const scope = {
+    setContext: vi.fn<(name: string, value: Record<string, unknown>) => void>(),
+    setTag: vi.fn<(key: string, value: unknown) => void>(),
+    setTags: vi.fn<(tags: Record<string, unknown>) => void>(),
+  };
+  return {
+    captureException: vi.fn<(error: unknown) => void>(),
+    getCurrentScope: vi.fn<() => typeof scope>(() => scope),
+    isEnabled: vi.fn<() => boolean>(() => true),
+    scope,
+    withScope: vi.fn<(callback: (value: typeof scope) => void) => void>((callback) =>
+      callback(scope),
+    ),
+  };
+});
+
+vi.mock("@sentry/electron/renderer", () => ({
+  captureException: sentry.captureException,
+  getCurrentScope: sentry.getCurrentScope,
+  isEnabled: sentry.isEnabled,
+  withScope: sentry.withScope,
+}));
+
+import {
+  captureRendererException,
+  extractSafeReactComponentTree,
+  prepareRendererSentryEvent,
+  setRendererRuntimeDiagnosticContext,
+} from "./sentry";
+
+describe("renderer Sentry diagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sentry.isEnabled.mockReturnValue(true);
+  });
+
+  it("extracts only structural component names from a React component stack", () => {
+    const stack = `
+      at AccountPanel (/Users/alice/private/repo/AccountPanel.tsx:42:9)
+      at div (<anonymous>)
+      at Customer_alice@example.com (file:///Users/alice/private.tsx:3:1)
+      at PromptView ({"prompt":"private user content"})
+      private user content
+    `;
+
+    expect(extractSafeReactComponentTree(stack)).toEqual(["AccountPanel", "div", "PromptView"]);
+    expect(extractSafeReactComponentTree(stack).join(" ")).not.toMatch(
+      /alice|private|Users|repo|[(/{}]/i,
+    );
+  });
+
+  it("captures the scrubbed component tree through the allowed poracode context", () => {
+    captureRendererException(
+      new Error("render failed"),
+      { featureArea: "react" },
+      "at SettingsPanel (/Users/alice/work/repo/SettingsPanel.tsx:1:2)\nat App",
+    );
+
+    expect(sentry.scope.setContext).toHaveBeenCalledWith("poracode", {
+      react_components: ["SettingsPanel", "App"],
+    });
+    expect(sentry.scope.setContext).not.toHaveBeenCalledWith(
+      "poracode",
+      expect.objectContaining({ path: expect.anything() }),
+    );
+  });
+
+  it("explicitly clears every runtime tag on a non-thread transition", () => {
+    setRendererRuntimeDiagnosticContext(null);
+
+    expect(sentry.scope.setTag.mock.calls).toEqual([
+      ["poracode.provider", undefined],
+      ["poracode.presentation", undefined],
+      ["poracode.runtime_kind", undefined],
+      ["poracode.feature_area", undefined],
+    ]);
+  });
+
+  it("drops only the audited unfocused clipboard write race before sanitization", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "NotAllowedError",
+            value: "Failed to execute 'writeText' on 'Clipboard': Document is not focused.",
+          },
+        ],
+      },
+    };
+
+    expect(prepareRendererSentryEvent(event)).toBeNull();
+  });
+
+  it.each([
+    {
+      type: "SecurityError",
+      value: "Failed to execute 'writeText' on 'Clipboard': Document is not focused.",
+    },
+    {
+      type: "NotAllowedError",
+      value: "Failed to execute 'writeText' on 'Clipboard': Write permission denied.",
+    },
+    {
+      type: "NotAllowedError",
+      value: "Document is not focused.",
+    },
+  ])("keeps nearby clipboard and NotAllowedError failures: $type / $value", (exception) => {
+    const event = { exception: { values: [exception] } };
+
+    expect(prepareRendererSentryEvent(event)).toEqual(event);
+  });
+
+  it("drops a handled stale-file outcome from the file editor", () => {
+    const event = {
+      tags: { "poracode.feature_area": "file-editor" },
+      exception: {
+        values: [
+          {
+            value: "File not found: src/removed.ts",
+            mechanism: { handled: true },
+          },
+        ],
+      },
+    };
+
+    expect(prepareRendererSentryEvent(event)).toBeNull();
+  });
+
+  it.each([
+    {
+      tags: { "poracode.feature_area": "git" },
+      exception: {
+        values: [
+          {
+            value: "File not found: src/removed.ts",
+            mechanism: { handled: true },
+          },
+        ],
+      },
+    },
+    {
+      tags: { "poracode.feature_area": "file-editor" },
+      exception: {
+        values: [
+          {
+            value: "File not found: src/removed.ts",
+            mechanism: { handled: false },
+          },
+        ],
+      },
+    },
+    {
+      tags: { "poracode.feature_area": "file-editor" },
+      exception: {
+        values: [
+          {
+            value: "ENOENT: no such file or directory",
+            mechanism: { handled: true },
+          },
+        ],
+      },
+    },
+    {
+      tags: { "poracode.feature_area": "file-editor" },
+      exception: {
+        values: [
+          {
+            value: "File not found:",
+            mechanism: { handled: true },
+          },
+        ],
+      },
+    },
+  ])("keeps nearby file errors: %#", (event) => {
+    expect(prepareRendererSentryEvent(event)).toEqual(event);
+  });
+});

--- a/src/renderer/diagnostics/sentry.ts
+++ b/src/renderer/diagnostics/sentry.ts
@@ -16,6 +16,70 @@ const DISABLED_INTEGRATIONS = new Set([
   "ReportingObserver",
 ]);
 
+const RUNTIME_TAG_KEYS = [
+  "poracode.provider",
+  "poracode.presentation",
+  "poracode.runtime_kind",
+  "poracode.feature_area",
+] as const;
+
+const MAX_REACT_COMPONENTS = 32;
+const SAFE_COMPONENT_NAME = /^[A-Za-z_$][A-Za-z0-9_$.-]{0,79}$/;
+const UNFOCUSED_CLIPBOARD_WRITE_MESSAGE =
+  "Failed to execute 'writeText' on 'Clipboard': Document is not focused.";
+const EXPECTED_FILE_NOT_FOUND_MESSAGE = /^File not found: .+$/;
+
+type RendererExceptionValue = NonNullable<
+  NonNullable<SentryEventLike["exception"]>["values"]
+>[number] & {
+  type?: string;
+};
+
+function isUnfocusedClipboardWriteRace(event: SentryEventLike): boolean {
+  return (
+    event.exception?.values?.some((value) => {
+      const exception = value as RendererExceptionValue;
+      return (
+        exception.type === "NotAllowedError" &&
+        exception.value === UNFOCUSED_CLIPBOARD_WRITE_MESSAGE
+      );
+    }) ?? false
+  );
+}
+
+function isHandledStaleFileEditorEvent(event: SentryEventLike): boolean {
+  if (event.tags?.["poracode.feature_area"] !== "file-editor") return false;
+  return (
+    event.exception?.values?.some((value) => {
+      const exception = value as RendererExceptionValue;
+      return (
+        exception.mechanism?.handled === true &&
+        typeof exception.value === "string" &&
+        EXPECTED_FILE_NOT_FOUND_MESSAGE.test(exception.value)
+      );
+    }) ?? false
+  );
+}
+
+export function prepareRendererSentryEvent<T extends SentryEventLike>(event: T): T | null {
+  if (isUnfocusedClipboardWriteRace(event) || isHandledStaleFileEditorEvent(event)) {
+    return null;
+  }
+  return sanitizeSentryEvent(event);
+}
+
+export function extractSafeReactComponentTree(componentStack: string): string[] {
+  const components: string[] = [];
+  for (const line of componentStack.split(/\r?\n/)) {
+    const match = line.match(/^\s*at\s+([^\s(]+)/);
+    const component = match?.[1];
+    if (!component || !SAFE_COMPONENT_NAME.test(component)) continue;
+    components.push(component);
+    if (components.length >= MAX_REACT_COMPONENTS) break;
+  }
+  return components;
+}
+
 function buildBaseTags(): PoracodeDiagnosticTags {
   const bridge = readBridge();
   return {
@@ -45,7 +109,9 @@ export function initializeRendererSentry(): boolean {
       return null;
     },
     beforeSend(event) {
-      return sanitizeSentryEvent(event as unknown as SentryEventLike) as unknown as typeof event;
+      return prepareRendererSentryEvent(event as unknown as SentryEventLike) as unknown as
+        | typeof event
+        | null;
     },
     integrations(defaultIntegrations) {
       return defaultIntegrations.filter(
@@ -65,20 +131,31 @@ export function initializeRendererSentry(): boolean {
 }
 
 export function setRendererRuntimeDiagnosticContext(
-  context: PoracodeRuntimeDiagnosticContext,
+  context: PoracodeRuntimeDiagnosticContext | null,
 ): void {
   if (!Sentry.isEnabled()) return;
-  Sentry.getCurrentScope().setTags(buildRuntimeDiagnosticTags(context));
+  const scope = Sentry.getCurrentScope();
+  const tags = context ? buildRuntimeDiagnosticTags(context) : {};
+  for (const key of RUNTIME_TAG_KEYS) {
+    scope.setTag(key, tags[key]);
+  }
 }
 
 export function captureRendererException(
   error: unknown,
   context?: PoracodeRuntimeDiagnosticContext,
+  componentStack?: string,
 ): void {
   if (!Sentry.isEnabled()) return;
   Sentry.withScope((scope) => {
     if (context) {
       scope.setTags(buildRuntimeDiagnosticTags(context));
+    }
+    if (componentStack) {
+      const reactComponents = extractSafeReactComponentTree(componentStack);
+      if (reactComponents.length > 0) {
+        scope.setContext("poracode", { react_components: reactComponents });
+      }
     }
     Sentry.captureException(error);
   });

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -199,7 +199,7 @@ void Promise.all([appModulePromise, providerBootstrapPromise, localeBootstrapPro
   .then(([{ App }]) => {
     logRendererBootstrap("rendering React app");
     reactRoot?.render(
-      <RendererErrorBoundary>
+      <RendererErrorBoundary captureCaughtErrors={false}>
         <App />
       </RendererErrorBoundary>,
     );

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -86,12 +86,12 @@ function reportRootError(
 
   if (kind === "recoverable") {
     console.warn(prefix, error, componentStack ?? "");
-    captureRendererException(error, { featureArea: "react" });
+    captureRendererException(error, { featureArea: "react" }, componentStack);
     return;
   }
 
   console.error(prefix, error, componentStack ?? "");
-  captureRendererException(error, { featureArea: "react" });
+  captureRendererException(error, { featureArea: "react" }, componentStack);
 }
 
 function renderCrashScreen(report: RendererCrashReport): void {

--- a/src/renderer/views/MainView/MainView.tsx
+++ b/src/renderer/views/MainView/MainView.tsx
@@ -26,6 +26,7 @@ import { PullFromSourceDialog } from "@/renderer/views/MainView/parts/PullFromSo
 import { MainPageLayout, StalePanelCleanup } from "@/renderer/views/MainView/parts/MainPageLayout";
 import { ThreadSearchOverlayHost } from "@/renderer/views/ThreadSearchOverlay/ThreadSearchOverlay";
 import { ThreadLiveWorkflowTracker } from "@/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile";
+import { RendererRuntimeDiagnosticContextSync } from "@/renderer/diagnostics/runtimeContext";
 
 function findMissingWslDistro(distros: readonly string[], statuses: readonly AgentStatus[]) {
   const cachedDistros = new Set(
@@ -105,6 +106,7 @@ export function MainView(props: { storeHydrated: boolean; loadT0: number }) {
   console.log(`[renderer] +${Date.now() - loadT0}ms: rendering main UI`);
   return (
     <>
+      <RendererRuntimeDiagnosticContextSync />
       <AppDndProvider
         onSidebarSortEnd={handleSortEnd}
         onPaneDrop={handlePaneDrop}

--- a/src/shared/ipc/bridge.ts
+++ b/src/shared/ipc/bridge.ts
@@ -67,6 +67,7 @@ export type PoracodeBridge = PoracodeInvokeBridge & {
   dismissQuickComposer(): Promise<void>;
   pickQuickComposerFiles(): Promise<string[] | null>;
   notifyQuickComposerMainReady(): Promise<void>;
+  reloadRenderer(): Promise<void>;
   onQuickComposerSubmit(listener: (submission: QuickComposerSubmission) => void): () => void;
   onQuickComposerDismissRequested(listener: () => void): () => void;
 };
@@ -134,4 +135,5 @@ export const IPC_WINDOW_CHANNELS = {
   quickComposerDismiss: createChannel("quickComposerWindowDismiss"),
   quickComposerPickFiles: createChannel("quickComposerWindowPickFiles"),
   quickComposerMainReady: createChannel("quickComposerMainReady"),
+  rendererReload: createChannel("rendererReload"),
 } as const;


### PR DESCRIPTION
## Summary

- Sync renderer Sentry runtime tags from the focused visible thread, including provider, presentation, and runtime kind, and explicitly clear stale tags on home/draft/unmount transitions.
- Preserve React crash structure as a privacy-safe `poracode` context containing only validated component names; file paths, props, prompts, and user text are never attached.
- Normalize main, quick-composer, and browser renderer process-gone events into stable OS/reason fingerprints. Per-window close/reload intent is supplied at the capture sites, prevented close-to-tray events do not count as closes, reload intent is one-shot, and unproven kills remain visible.
- Classify native GPU fatals and OOMs into stable OS/reason fingerprints while narrowly dropping only minidumps whose native/unknown process plus Crashpad stack annotation proves the executable is Xcode's external `swift-frontend`.
- Drop the audited xterm clipboard focus race only when the raw renderer exception has both type `NotAllowedError` and the exact unfocused-document `Clipboard.writeText` message; other clipboard, security, and `NotAllowedError` failures remain reportable.
- Drop the exact main-process `net::ERR_NETWORK_CHANGED` transient and handled `file-editor` stale-file outcomes at their raw-event boundaries. Other network errors, generic ENOENT failures, other feature areas, and unhandled file errors remain reportable.

## Sentry issues and treatment

- **LIGHTCODE-59 / LIGHTCODE-4G — real Electron GPU/native fatals.** Preserved as fatal errors and grouped by OS plus `gpu-fatal`; no macOS/native or GPU suppression was added.
- **LIGHTCODE-5T — external child-process pollution.** Filtered only when the minidump is native, `event.process` is `unknown`, and the Crashpad `Program arguments` line identifies `/Applications/Xcode.app/.../usr/bin/swift-frontend`. Generic Swift assertion failures and unknown macOS native crashes remain reportable.
- **LIGHTCODE-49 — expected xterm clipboard focus race.** Dropped in renderer `beforeSend`, before sanitization, only for the audited exception type/message pair. Nearby permission, security, and clipboard failures remain captured.
- **LIGHTCODE-1R — transient Electron network transition.** Dropped in main `beforeSend` only when the raw event message or exception value is exactly `net::ERR_NETWORK_CHANGED`; related and prefixed network failures remain captured.
- **LIGHTCODE-5J — expected stale external file.** Dropped in renderer `beforeSend` only when `poracode.feature_area=file-editor`, the exception mechanism is explicitly handled, and the value matches `^File not found: .+$`. The UI error path is unchanged.
- Renderer process-gone noise is treated contextually: `clean-exit` is ignored, `killed` is ignored only with explicit app-shutdown/reload/window-close intent, and crashed/OOM/integrity/launch/abnormal/unknown paths stay reportable with stable fingerprints.

## Privacy and architecture

- No project, thread, user, command, path, prompt, repository, auth, or content values are added to telemetry.
- React component context admits only bounded structural component identifiers.
- Existing zero-PII, zero-screenshot, and breadcrumb restrictions are unchanged.
- Provider behavior remains data-driven; shared Sentry privacy/classification code and tag allowlists were not edited, so this PR builds independently against `master`.

## Validation

- `pnpm exec vitest run src/main/diagnostics/mainEvent.test.ts src/main/diagnostics/nativeCrash.test.ts src/main/diagnostics/processGone.test.ts src/main/window/windowHardening.test.ts src/main/window/createMainWindow.test.ts src/main/window/createQuickComposerWindow.test.ts src/renderer/diagnostics/sentry.test.ts src/renderer/diagnostics/runtimeContext.test.ts src/renderer/RendererCrashScreen.test.tsx` — 9 files / 45 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run lint` — passed.
- `pnpm run fmt:check` — passed.
- `pnpm run test` — 631 files / 6,605 tests passed; two native DB fixture suites raced while concurrently rebuilding the same ignored `dist/server-native` directory. Both were rerun sequentially and passed (`projectsThreads`: 10, `tokenStats`: 4).

## Residual risk

- The external-child filter intentionally recognizes only the audited canonical Xcode executable path. Other toolchain/install layouts remain visible rather than risking a false-positive suppression.
- Renderer `killed` events without an explicit lifecycle intent remain visible as `unexpected-kill`, favoring detection over noise suppression.
