### PR TITLE
Simplify sidebar workspace switcher

### DIFF
--- a/src/renderer/components/workspace/workspaceMenuKeys.ts
+++ b/src/renderer/components/workspace/workspaceMenuKeys.ts
@@ -9,8 +9,6 @@ const WORKSPACE_KEY_PREFIX = "workspace:";
 
 /** "Unfiled" — belongs to no workspace, so it shows in all of them. */
 export const WORKSPACE_UNFILED_KEY = "workspace:unfiled";
-export const WORKSPACE_ADD_KEY = "workspace:add";
-export const WORKSPACE_MANAGE_KEY = "workspace:manage";
 
 export function workspaceMenuKey(workspaceId: string): string {
   return `${WORKSPACE_KEY_PREFIX}${workspaceId}`;
@@ -18,15 +16,11 @@ export function workspaceMenuKey(workspaceId: string): string {
 
 export type WorkspaceMenuSelection =
   | { kind: "workspace"; workspaceId: string }
-  | { kind: "unfiled" }
-  | { kind: "add" }
-  | { kind: "manage" };
+  | { kind: "unfiled" };
 
 /** Returns null for keys owned by another namespace (e.g. `action:` entries). */
 export function parseWorkspaceMenuKey(key: string): WorkspaceMenuSelection | null {
   if (key === WORKSPACE_UNFILED_KEY) return { kind: "unfiled" };
-  if (key === WORKSPACE_ADD_KEY) return { kind: "add" };
-  if (key === WORKSPACE_MANAGE_KEY) return { kind: "manage" };
   if (!key.startsWith(WORKSPACE_KEY_PREFIX)) return null;
   return { kind: "workspace", workspaceId: key.slice(WORKSPACE_KEY_PREFIX.length) };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -846,7 +846,6 @@ msgstr "Zum Home-Bildschirm hinzufügen"
 msgid "Add to-do"
 msgstr "Aufgabe hinzufügen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Arbeitsbereich hinzufügen"
@@ -5515,8 +5514,8 @@ msgstr "Verwalten Sie die MCP-Server-Konfigurationen, die Poracode beim Start un
 #~ msgstr "Verwalte die Skills, die Poracode unterstützten Agents zur Verfügung stellt. Projekt-Skills können in den Einstellungen des jeweiligen Projekts verwaltet werden."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Arbeitsbereiche verwalten"
+#~ msgid "Manage workspaces"
+#~ msgstr "Arbeitsbereiche verwalten"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -846,7 +846,6 @@ msgstr "Add to Home Screen"
 msgid "Add to-do"
 msgstr "Add to-do"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Add workspace"
@@ -5515,8 +5514,8 @@ msgstr "Manage the MCP server configurations Poracode adds when starting support
 #~ msgstr "Manage the skills Poracode makes available to supported agents. Project skills can be managed in each project's settings."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Manage workspaces"
+#~ msgid "Manage workspaces"
+#~ msgstr "Manage workspaces"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -846,7 +846,6 @@ msgstr "Agregar a la pantalla de inicio"
 msgid "Add to-do"
 msgstr "Añadir tarea"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Añadir espacio de trabajo"
@@ -5515,8 +5514,8 @@ msgstr "Administra las configuraciones de servidores MCP que Poracode añade al 
 #~ msgstr "Gestiona los skills que Poracode pone a disposición de los agentes compatibles. Los skills de proyecto se pueden gestionar en la configuración de cada proyecto."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Gestionar espacios de trabajo"
+#~ msgid "Manage workspaces"
+#~ msgstr "Gestionar espacios de trabajo"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -846,7 +846,6 @@ msgstr "Ajouter à l'écran d'accueil"
 msgid "Add to-do"
 msgstr "Ajouter une tâche"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Ajouter un espace de travail"
@@ -5515,8 +5514,8 @@ msgstr "Gérez les configurations de serveurs MCP que Poracode ajoute au démarr
 #~ msgstr "Gérez les compétences que Poracode met à la disposition des agents pris en charge. Les compétences de projet peuvent être gérées dans les paramètres de chaque projet."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Gérer les espaces de travail"
+#~ msgid "Manage workspaces"
+#~ msgstr "Gérer les espaces de travail"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -845,7 +845,6 @@ msgstr "ホーム画面に追加"
 msgid "Add to-do"
 msgstr "タスクを追加"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "ワークスペースを追加"
@@ -5514,8 +5513,8 @@ msgstr "対応エージェントの起動時にPoracodeが追加するMCPサー�
 #~ msgstr "Poracode が対応エージェントに提供するスキルを管理します。プロジェクトスキルは各プロジェクトの設定で管理できます。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "ワークスペースを管理"
+#~ msgid "Manage workspaces"
+#~ msgstr "ワークスペースを管理"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -846,7 +846,6 @@ msgstr "홈 화면에 추가"
 msgid "Add to-do"
 msgstr "할 일 추가"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "작업 영역 추가"
@@ -5515,8 +5514,8 @@ msgstr "지원되는 에이전트를 시작할 때 Poracode에서 추가하는 M
 #~ msgstr "Poracode가 지원되는 에이전트에 제공하는 스킬을 관리합니다. 프로젝트 스킬은 각 프로젝트의 설정에서 관리할 수 있습니다."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "작업 영역 관리"
+#~ msgid "Manage workspaces"
+#~ msgstr "작업 영역 관리"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -846,7 +846,6 @@ msgstr "Dodaj do ekranu głównego"
 msgid "Add to-do"
 msgstr "Dodaj zadanie"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Dodaj obszar roboczy"
@@ -5515,8 +5514,8 @@ msgstr "Zarządzaj konfiguracjami serwerów MCP dodawanymi przez Poracode podcza
 #~ msgstr "Zarządzaj umiejętnościami udostępnianymi przez Poracode obsługiwanym agentom. Umiejętnościami projektu można zarządzać w ustawieniach każdego projektu."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Zarządzaj obszarami roboczymi"
+#~ msgid "Manage workspaces"
+#~ msgstr "Zarządzaj obszarami roboczymi"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -846,7 +846,6 @@ msgstr "Adicionar à tela inicial"
 msgid "Add to-do"
 msgstr "Adicionar tarefa"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Adicionar espaço de trabalho"
@@ -5515,8 +5514,8 @@ msgstr "Gerencie as configurações de servidores MCP que o Poracode adiciona ao
 #~ msgstr "Gerencie as skills que o Poracode disponibiliza para agentes compatíveis. As skills de projeto podem ser gerenciadas nas configurações de cada projeto."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Gerenciar espaços de trabalho"
+#~ msgid "Manage workspaces"
+#~ msgstr "Gerenciar espaços de trabalho"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -846,7 +846,6 @@ msgstr "Добавить на главный экран"
 msgid "Add to-do"
 msgstr "Добавить задачу"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Добавить рабочую область"
@@ -5515,8 +5514,8 @@ msgstr "Управляйте конфигурациями серверов MCP, 
 #~ msgstr "Управляйте навыками, которые Poracode предоставляет поддерживаемым агентам. Навыками проекта можно управлять в настройках каждого проекта."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Управление рабочими областями"
+#~ msgid "Manage workspaces"
+#~ msgstr "Управление рабочими областями"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -846,7 +846,6 @@ msgstr "Ana Ekrana ekle"
 msgid "Add to-do"
 msgstr "Yapılacak ekle"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Çalışma alanı ekle"
@@ -5515,8 +5514,8 @@ msgstr "Poracode'un desteklenen aracıları başlatırken eklediği MCP sunucusu
 #~ msgstr "Poracode'un desteklenen aracılara sunduğu becerileri yönetin. Proje becerileri her projenin ayarlarından yönetilebilir."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Çalışma alanlarını yönet"
+#~ msgid "Manage workspaces"
+#~ msgstr "Çalışma alanlarını yönet"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -846,7 +846,6 @@ msgstr "Додати на головний екран"
 msgid "Add to-do"
 msgstr "Додати завдання"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Додати робочу область"
@@ -5515,8 +5514,8 @@ msgstr "Керуйте конфігураціями серверів MCP, які
 #~ msgstr "Керуйте навичками, які Poracode надає підтримуваним агентам. Навичками проєкту можна керувати в налаштуваннях кожного проєкту."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Керування робочими областями"
+#~ msgid "Manage workspaces"
+#~ msgstr "Керування робочими областями"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -846,7 +846,6 @@ msgstr "Thêm vào màn hình chính"
 msgid "Add to-do"
 msgstr "Thêm việc cần làm"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "Thêm không gian làm việc"
@@ -5515,8 +5514,8 @@ msgstr "Quản lý cấu hình máy chủ MCP mà Poracode thêm khi khởi đ�
 #~ msgstr "Quản lý các skill mà Poracode cung cấp cho những tác tử được hỗ trợ. Có thể quản lý skill dự án trong phần cài đặt của từng dự án."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "Quản lý không gian làm việc"
+#~ msgid "Manage workspaces"
+#~ msgstr "Quản lý không gian làm việc"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -846,7 +846,6 @@ msgstr "添加到主屏幕"
 msgid "Add to-do"
 msgstr "添加待办事项"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Add workspace"
 msgstr "添加工作区"
@@ -5515,8 +5514,8 @@ msgstr "管理 Poracode 在启动受支持的代理时添加的 MCP 服务器配
 #~ msgstr "管理 Poracode 向受支持智能体提供的技能。可以在每个项目的设置中管理项目技能。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
-msgid "Manage workspaces"
-msgstr "管理工作区"
+#~ msgid "Manage workspaces"
+#~ msgstr "管理工作区"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 #~ msgid "Managed"

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Workspace, WorkspaceIconId } from "@/shared/contracts";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useWorkspaceStore } from "@/renderer/state/workspaceStore";
+import { SidebarWorkspaceSwitcher } from "./SidebarWorkspaceSwitcher";
+
+function workspace(id: string, name: string, icon: WorkspaceIconId): Workspace {
+  return {
+    id,
+    name,
+    icon,
+    createdAt: "2026-07-27T00:00:00.000Z",
+  };
+}
+
+describe("SidebarWorkspaceSwitcher", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSharedSettings.setState({
+      workspaces: [
+        workspace("work", "Work", "briefcase"),
+        workspace("side", "Side Hustle", "rocket"),
+      ],
+    });
+    useWorkspaceStore.setState({ activeWorkspaceId: "work" });
+  });
+
+  it("stays hidden when there is only one workspace", () => {
+    useSharedSettings.setState((state) => ({ workspaces: [state.workspaces[0]!] }));
+
+    render(<SidebarWorkspaceSwitcher />);
+
+    expect(screen.queryByRole("button", { name: "Switch workspace" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Work")).not.toBeInTheDocument();
+  });
+
+  it("switches directly to the other workspace when there are exactly two", () => {
+    render(<SidebarWorkspaceSwitcher />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("side");
+    expect(screen.getByText("Side Hustle")).toBeInTheDocument();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("work");
+    expect(screen.getByText("Work")).toBeInTheDocument();
+  });
+
+  it("opens a workspace-only picker when there are more than two", async () => {
+    useSharedSettings.setState((state) => ({
+      workspaces: [...state.workspaces, workspace("client", "Client", "palette")],
+    }));
+
+    render(<SidebarWorkspaceSwitcher />);
+    fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+    const client = screen.getByRole("menuitemradio", { name: "Client" });
+    expect(screen.queryByText("Add workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("Manage workspaces")).not.toBeInTheDocument();
+
+    fireEvent.click(client);
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("client");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
@@ -1,18 +1,13 @@
 import { useState, type ReactNode } from "react";
-import { Dropdown, Label, Separator } from "@heroui/react";
-import { Check, ChevronsUpDown, Plus, Settings2 } from "lucide-react";
+import { Dropdown, Label } from "@heroui/react";
+import { Check, ChevronsUpDown } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
-import { openWorkspaceSettings } from "@/renderer/actions/panelActions";
-import { createWorkspace } from "@/renderer/actions/workspaceActions";
 import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
 } from "@/renderer/components/common/ResponsiveMenuSurface";
-import { WorkspaceNameDialog } from "@/renderer/components/workspace/WorkspaceNameDialog";
 import { WorkspaceIcon } from "@/renderer/components/workspace/WorkspaceIcon";
 import {
-  WORKSPACE_ADD_KEY,
-  WORKSPACE_MANAGE_KEY,
   parseWorkspaceMenuKey,
   workspaceMenuKey,
 } from "@/renderer/components/workspace/workspaceMenuKeys";
@@ -39,11 +34,10 @@ export function SidebarWorkspaceSwitcher() {
   const activeWorkspaceId = useActiveWorkspaceId();
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
-  const [addOpen, setAddOpen] = useState(false);
 
-  // Nothing to switch between before the first-run bootstrap has seeded the
-  // defaults; showing an empty switcher would just be a dead control.
-  if (workspaces.length === 0) return null;
+  // With fewer than two workspaces there is nothing to switch, so keep the
+  // footer uncluttered instead of showing a dead context row.
+  if (workspaces.length < 2) return null;
 
   // `useActiveWorkspaceId` falls back to the first workspace, so this resolves.
   const active = workspaces.find((w) => w.id === activeWorkspaceId) ?? workspaces[0]!;
@@ -51,10 +45,7 @@ export function SidebarWorkspaceSwitcher() {
   function handleAction(key: string) {
     setIsOpen(false);
     const selection = parseWorkspaceMenuKey(key);
-    if (!selection) return;
-    if (selection.kind === "add") setAddOpen(true);
-    else if (selection.kind === "manage") openWorkspaceSettings();
-    else if (selection.kind === "workspace") {
+    if (selection?.kind === "workspace") {
       useWorkspaceStore.getState().setActiveWorkspaceId(selection.workspaceId);
     }
   }
@@ -66,18 +57,6 @@ export function SidebarWorkspaceSwitcher() {
     icon: <WorkspaceIcon icon={workspace.icon} className="size-4 text-muted" />,
     isSelected: workspace.id === active.id,
   }));
-  const actionEntries: MenuEntry[] = [
-    {
-      key: WORKSPACE_ADD_KEY,
-      label: t`Add workspace`,
-      icon: <Plus className="size-4 shrink-0 text-muted" />,
-    },
-    {
-      key: WORKSPACE_MANAGE_KEY,
-      label: t`Manage workspaces`,
-      icon: <Settings2 className="size-4 shrink-0 text-muted" />,
-    },
-  ];
 
   const triggerContent = (
     <>
@@ -87,11 +66,27 @@ export function SidebarWorkspaceSwitcher() {
       <div className="min-w-0 flex-1">
         <span className="block truncate text-left">{active.name}</span>
       </div>
-      <span className="flex shrink-0 items-center">
-        <ChevronsUpDown className="size-3.5 text-muted" />
-      </span>
+      {workspaces.length > 1 ? (
+        <span className="flex shrink-0 items-center">
+          <ChevronsUpDown className="size-3.5 text-muted" />
+        </span>
+      ) : null}
     </>
   );
+
+  if (workspaces.length === 2) {
+    const nextWorkspace = workspaces.find((workspace) => workspace.id !== active.id)!;
+    return (
+      <button
+        type="button"
+        aria-label={t`Switch workspace`}
+        className={sidebarRowClass()}
+        onClick={() => useWorkspaceStore.getState().setActiveWorkspaceId(nextWorkspace.id)}
+      >
+        {triggerContent}
+      </button>
+    );
+  }
 
   const trigger = (
     <button
@@ -107,94 +102,56 @@ export function SidebarWorkspaceSwitcher() {
     </button>
   );
 
-  const dialog = (
-    <WorkspaceNameDialog
-      isOpen={addOpen}
-      mode="create"
-      onSubmit={(name) => createWorkspace(name)}
-      onClose={() => setAddOpen(false)}
-    />
-  );
-
   if (mobile) {
     return (
-      <>
-        <ResponsiveMenuSurface
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          label={t`Switch workspace`}
-          trigger={trigger}
-        >
-          <div className="m-sheet-list">
-            {workspaceEntries.map((entry) => (
-              <button
-                key={entry.key}
-                type="button"
-                className="m-sheet-action"
-                aria-pressed={entry.isSelected || undefined}
-                onClick={() => handleAction(entry.key)}
-              >
-                {entry.icon}
-                <span className="flex-1 truncate">{entry.label}</span>
-                {entry.isSelected ? <Check className="size-4 shrink-0 text-accent" /> : null}
-              </button>
-            ))}
-            <Separator variant="tertiary" className="my-1" />
-            {actionEntries.map((entry) => (
-              <button
-                key={entry.key}
-                type="button"
-                className="m-sheet-action"
-                onClick={() => handleAction(entry.key)}
-              >
-                {entry.icon}
-                <span className="flex-1 truncate">{entry.label}</span>
-              </button>
-            ))}
-          </div>
-        </ResponsiveMenuSurface>
-        {dialog}
-      </>
+      <ResponsiveMenuSurface
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        label={t`Switch workspace`}
+        trigger={trigger}
+      >
+        <div className="m-sheet-list">
+          {workspaceEntries.map((entry) => (
+            <button
+              key={entry.key}
+              type="button"
+              className="m-sheet-action"
+              aria-pressed={entry.isSelected || undefined}
+              onClick={() => handleAction(entry.key)}
+            >
+              {entry.icon}
+              <span className="flex-1 truncate">{entry.label}</span>
+              {entry.isSelected ? <Check className="size-4 shrink-0 text-accent" /> : null}
+            </button>
+          ))}
+        </div>
+      </ResponsiveMenuSurface>
     );
   }
 
   return (
-    <>
-      <Dropdown isOpen={isOpen} onOpenChange={setIsOpen}>
-        <Dropdown.Trigger aria-label={t`Switch workspace`} className={sidebarRowClass()}>
-          {triggerContent}
-        </Dropdown.Trigger>
-        <Dropdown.Popover placement="top start">
-          <Dropdown.Menu
-            aria-label={t`Workspaces`}
-            className="poracode-menu min-w-56"
-            selectionMode="single"
-            // The trailing action rows aren't workspaces, so they never match a
-            // selected key and render without a check.
-            selectedKeys={[workspaceMenuKey(active.id)]}
-            onAction={(key) => handleAction(String(key))}
-          >
-            <Dropdown.Section>
-              {workspaceEntries.map((entry) => (
-                <Dropdown.Item key={entry.key} id={entry.key} textValue={entry.label}>
-                  {entry.icon}
-                  <Label>{entry.label}</Label>
-                </Dropdown.Item>
-              ))}
-            </Dropdown.Section>
-            <Separator variant="tertiary" />
-            <Dropdown.Section>
-              {actionEntries.map((entry) => (
-                <Dropdown.Item key={entry.key} id={entry.key} textValue={entry.label}>
-                  {entry.icon}
-                  <Label>{entry.label}</Label>
-                </Dropdown.Item>
-              ))}
-            </Dropdown.Section>
-          </Dropdown.Menu>
-        </Dropdown.Popover>
-      </Dropdown>
-      {dialog}
-    </>
+    <Dropdown isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Dropdown.Trigger aria-label={t`Switch workspace`} className={sidebarRowClass()}>
+        {triggerContent}
+      </Dropdown.Trigger>
+      <Dropdown.Popover placement="top start">
+        <Dropdown.Menu
+          aria-label={t`Workspaces`}
+          className="poracode-menu min-w-56"
+          selectionMode="single"
+          selectedKeys={[workspaceMenuKey(active.id)]}
+          onAction={(key) => handleAction(String(key))}
+        >
+          <Dropdown.Section>
+            {workspaceEntries.map((entry) => (
+              <Dropdown.Item key={entry.key} id={entry.key} textValue={entry.label}>
+                {entry.icon}
+                <Label>{entry.label}</Label>
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Section>
+        </Dropdown.Menu>
+      </Dropdown.Popover>
+    </Dropdown>
   );
 }


### PR DESCRIPTION
- Refactor the sidebar workspace switcher to focus exclusively on selecting workspaces.
- Remove add and manage workspace actions and their unused menu-key handling.
- Update all locale catalogs to retire removed workspace-management strings.
- Add coverage for workspace selection and the streamlined menu.