### PR TITLE
Fix analytics timers and select option padding

### DIFF
--- a/src/renderer/analytics/posthog.ts
+++ b/src/renderer/analytics/posthog.ts
@@ -100,9 +100,11 @@ function installStoreSubscriptions(): () => void {
   const disposers: Array<() => void> = [];
   const appViewTracker = createProductViewTracker({
     capture: captureProductEvent,
-    clearTimeout,
+    // Wrap window's timer methods — called detached from `window` they throw
+    // "Illegal invocation" in the browser (Node's timers don't, so tests miss it).
+    clearTimeout: (timer) => clearTimeout(timer),
     now: Date.now,
-    setTimeout,
+    setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
   });
   const syncAppView = () => {
     appViewTracker.setView(appViewDefinition(useAppStore.getState().view));

--- a/src/renderer/analytics/useProductViewTracking.ts
+++ b/src/renderer/analytics/useProductViewTracking.ts
@@ -94,9 +94,11 @@ export function useProductViewTracking(
   if (!trackerRef.current) {
     trackerRef.current = createProductViewTracker({
       capture: captureProductEvent,
-      clearTimeout,
+      // Wrap window's timer methods — called detached from `window` they throw
+      // "Illegal invocation" in the browser (Node's timers don't, so tests miss it).
+      clearTimeout: (timer) => clearTimeout(timer),
       now: Date.now,
-      setTimeout,
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
     });
   }
 
@@ -132,9 +134,11 @@ export function useStandaloneWindowViewTracking(surface: string, active = true):
   if (!trackerRef.current) {
     trackerRef.current = createProductViewTracker({
       capture: captureProductEvent,
-      clearTimeout,
+      // Wrap window's timer methods — called detached from `window` they throw
+      // "Illegal invocation" in the browser (Node's timers don't, so tests miss it).
+      clearTimeout: (timer) => clearTimeout(timer),
       now: Date.now,
-      setTimeout,
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
     });
   }
 

--- a/src/renderer/components/common/Select.tsx
+++ b/src/renderer/components/common/Select.tsx
@@ -98,7 +98,12 @@ export function Select(props: SelectProps) {
   const listBox = (
     <ListBox {...(isVirtualized ? { className: "max-h-60 overflow-y-auto" } : {})}>
       {options.map((option) => (
-        <ListBox.Item key={option.id} id={option.id} textValue={option.label}>
+        // HeroUI's select popover sets `px-2.5` on items with the same
+        // specificity as the base `:has(.list-box-item__indicator) { pe-7 }`
+        // rule but later in import order, collapsing the end padding that
+        // reserves room for the checkmark so it overlaps long labels. The
+        // `pe-7` utility (utilities layer) restores it.
+        <ListBox.Item key={option.id} id={option.id} textValue={option.label} className="pe-7">
           {option.label}
           <ListBox.ItemIndicator />
         </ListBox.Item>


### PR DESCRIPTION
- **Bugfix**
- Prevent browser timer binding errors from disrupting product view tracking.
- Preserve end padding in select options so checkmarks do not overlap long labels.