### PR TITLE
Fix cross-agent MCP union schema validation

### DIFF
--- a/src/supervisor/crossagentMcp/toolRegistry.test.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.test.ts
@@ -472,7 +472,10 @@ describe("subagent tool registration", () => {
   it("declares required fields on the subagent tool schemas", () => {
     const byName = new Map(TOOLS.map((tool) => [tool.name, tool]));
     expect(byName.get("spawn_agent")!.inputSchema).toMatchObject({
-      oneOf: [{ required: ["prompt"] }, { required: ["tasks"] }],
+      oneOf: [
+        { type: "object", required: ["prompt"] },
+        { type: "object", required: ["tasks"] },
+      ],
     });
     expect(byName.get("get_agent")!.inputSchema).toMatchObject({ required: ["id"] });
     expect(byName.get("set_routing_preference")!.inputSchema).toMatchObject({
@@ -482,7 +485,10 @@ describe("subagent tool registration", () => {
       required: ["tags"],
     });
     expect(byName.get("wait_for_agent")!.inputSchema).toMatchObject({
-      oneOf: [{ required: ["run_id"] }, { required: ["run_ids"] }],
+      oneOf: [
+        { type: "object", required: ["run_id"] },
+        { type: "object", required: ["run_ids"] },
+      ],
     });
     expect(byName.get("get_status")!.inputSchema).toMatchObject({ required: ["run_id"] });
     expect(byName.get("cancel")!.inputSchema).toMatchObject({ required: ["run_id"] });

--- a/src/supervisor/crossagentMcp/toolRegistry.ts
+++ b/src/supervisor/crossagentMcp/toolRegistry.ts
@@ -189,7 +189,12 @@ const BASE_TOOLS: ToolSpec[] = [
           description: TIMEOUT_S_DESCRIPTION,
         },
       },
-      oneOf: [{ required: ["prompt"] }, { required: ["tasks"] }],
+      // Keep every root union branch explicitly object-typed. Some OpenAI-compatible
+      // providers reject `required`-only branches because they also match non-objects.
+      oneOf: [
+        { type: "object", required: ["prompt"] },
+        { type: "object", required: ["tasks"] },
+      ],
     },
   },
   {
@@ -243,7 +248,11 @@ const BASE_TOOLS: ToolSpec[] = [
           description: TIMEOUT_S_DESCRIPTION,
         },
       },
-      oneOf: [{ required: ["run_id"] }, { required: ["run_ids"] }],
+      // See the spawn_agent schema above for why these branches repeat the root type.
+      oneOf: [
+        { type: "object", required: ["run_id"] },
+        { type: "object", required: ["run_ids"] },
+      ],
     },
   },
   {


### PR DESCRIPTION
- Classify `spawn_agent` and `wait_for_agent` union branches as objects.
- Ensure OpenAI-compatible providers accept required-field schema alternatives.
- Extend registry tests to enforce object-typed union branches.