### PR TITLE
Add resizable bottom terminal sidebar and scoped headers

### DIFF
--- a/src/renderer/hooks/useRightPanelThreadLock.test.tsx
+++ b/src/renderer/hooks/useRightPanelThreadLock.test.tsx
@@ -2,7 +2,9 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useRightPanelThreadLock } from "./useRightPanelThreadLock";
 
 function makeThread(input: Partial<Thread> = {}): Thread {
@@ -26,10 +28,11 @@ function makeThread(input: Partial<Thread> = {}): Thread {
 }
 
 const threadA = makeThread({ id: "thread-a", projectId: "project-a" });
+const threadBWorktreePath = "/repo-b/.poracode/worktrees/feature";
 const threadB = makeThread({
   id: "thread-b",
   projectId: "project-b",
-  worktreePath: "/repo-b/.poracode/worktrees/feature",
+  worktreePath: threadBWorktreePath,
 });
 
 function focusThread(threadId: string) {
@@ -51,6 +54,17 @@ describe("useRightPanelThreadLock", () => {
       filesPanelContext: null,
       rightPanelTab: "git",
     });
+    useDevTerminalStore.setState({
+      isOpen: false,
+      activeProjectId: null,
+      activeWorktreePath: null,
+      tabs: [],
+      activeTabId: null,
+      focusRequestId: 0,
+      tabActivity: {},
+      streamingTabs: {},
+    });
+    useSharedSettings.setState({ terminalPosition: "bottom" });
     focusThread("thread-a");
   });
 
@@ -97,5 +111,59 @@ describe("useRightPanelThreadLock", () => {
 
     expect(usePanelStore.getState().gitReviewContext).toBeNull();
     expect(usePanelStore.getState().filesPanelContext).toBeNull();
+  });
+
+  it("re-scopes the open bottom terminal to the focused thread", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: "project-a",
+      tabs: [
+        {
+          id: "terminal-a",
+          projectId: "project-a",
+          title: "Project A",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+        {
+          id: "terminal-b",
+          projectId: "project-b",
+          worktreePath: threadBWorktreePath,
+          title: "Feature",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      activeTabId: "terminal-a",
+    });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      activeProjectId: "project-b",
+      activeWorktreePath: threadBWorktreePath,
+      activeTabId: "terminal-b",
+    });
+  });
+
+  it("leaves a right-docked terminal on its existing scope", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useSharedSettings.setState({ terminalPosition: "right" });
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: "project-a",
+      activeWorktreePath: null,
+    });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      activeProjectId: "project-a",
+      activeWorktreePath: null,
+    });
   });
 });

--- a/src/renderer/hooks/useRightPanelThreadLock.ts
+++ b/src/renderer/hooks/useRightPanelThreadLock.ts
@@ -3,21 +3,26 @@ import { isHomeProjectId } from "@/shared/homeScope";
 import { resolveActivePaneId } from "@/renderer/actions/currentProject";
 import { showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 
 /**
  * Keeps the right panel pinned to the focused thread while
  * `rightPanelFollowsThread` is on: whichever scope-bearing tools are already
- * open (git, files) re-target that thread's project + worktree on every thread
- * switch. Panels the user has closed stay closed — the lock re-scopes, it does
- * not open anything.
+ * open (git, files, bottom terminal) re-target that thread's project +
+ * worktree on every thread switch. Panels the user has closed stay closed —
+ * the lock re-scopes, it does not open anything or spawn a new shell.
  *
- * The dev terminal is deliberately left alone: re-targeting it would spawn a
- * shell process for every thread visited.
+ * A right-docked terminal is deliberately left alone. It shares the right
+ * panel itself, while the bottom terminal is a separate surface that should
+ * follow the panel lock.
  */
 export function useRightPanelThreadLock(): void {
   const enabled = usePanelStore((s) => s.rightPanelFollowsThread);
+  const terminalOpen = useDevTerminalStore((s) => s.isOpen);
+  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   const projectId = useAppStore((state) => {
     if (state.view.kind !== "thread") return null;
     const paneId = resolveActivePaneId(state.view.panes, state.focusedPaneId);
@@ -38,7 +43,8 @@ export function useRightPanelThreadLock(): void {
     const panel = usePanelStore.getState();
     const gitPanelOpen = panel.gitReviewContext !== null && panel.gitReviewAsPanel;
     const filesPanelOpen = panel.filesPanelContext !== null;
-    if (!gitPanelOpen && !filesPanelOpen) return;
+    const bottomTerminalOpen = terminalOpen && terminalPosition === "bottom";
+    if (!gitPanelOpen && !filesPanelOpen && !bottomTerminalOpen) return;
 
     // Both `show*Panel` helpers force their own tab; remember what the user was
     // actually looking at and restore it after re-scoping.
@@ -53,8 +59,12 @@ export function useRightPanelThreadLock(): void {
         showFilesPanel(projectId, scopedWorktree);
       }
     }
+    if (bottomTerminalOpen) {
+      const terminal = useDevTerminalStore.getState();
+      terminal.setPanelScope(projectId, scopedWorktree);
+    }
     if (usePanelStore.getState().rightPanelTab !== activeTab) {
       panel.setRightPanelTab(activeTab);
     }
-  }, [enabled, projectId, worktreePath]);
+  }, [enabled, projectId, terminalOpen, terminalPosition, worktreePath]);
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Größe der Zeile ändern"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Größe der Seitenleiste ändern"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Resize row"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Resize sidebar"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Redimensionar fila"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8553,6 +8553,7 @@ msgstr "Redimensionner la ligne"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionner la barre latérale"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8552,6 +8552,7 @@ msgstr "行のサイズを変更する"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "サイドバーのサイズを変更する"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8554,6 +8554,7 @@ msgstr "행 크기 조정"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "사이드바 크기 조정"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Zmień rozmiar wiersza"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Zmień rozmiar paska bocznego"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Redimensionar linha"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Изменить размер строки"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Изменить размер боковой панели"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Satırı yeniden boyutlandır"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Kenar çubuğunu yeniden boyutlandır"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Змінити розмір рядка"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Змінити розмір бічної панелі"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8554,6 +8554,7 @@ msgstr "Thay đổi kích thước hàng"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "Thay đổi kích thước thanh bên"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8553,6 +8553,7 @@ msgstr "调整行大小"
 
 #: src/mobile/WideShell.tsx
 #: src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
 msgid "Resize sidebar"
 msgstr "调整侧边栏大小"
 

--- a/src/renderer/state/devTerminalStore.ts
+++ b/src/renderer/state/devTerminalStore.ts
@@ -33,6 +33,8 @@ interface DevTerminalActions {
   openWorktreePanel: (projectId: string, worktreePath: string) => void;
   closePanel: () => void;
   setActiveProject: (projectId: string) => void;
+  /** Re-scope an open panel without opening it or spawning a shell. */
+  setPanelScope: (projectId: string, worktreePath?: string) => void;
   addTab: (projectId: string, projectName: string, worktreePath?: string) => DevTerminalTab;
   removeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
@@ -104,6 +106,24 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       activeTabId: tabs[0]?.id ?? null,
     });
   },
+
+  setPanelScope: (projectId, worktreePath) =>
+    set((state) => {
+      if (
+        state.activeProjectId === projectId &&
+        (state.activeWorktreePath ?? undefined) === worktreePath
+      ) {
+        return {};
+      }
+      const scopedTab = state.tabs.find(
+        (tab) => tab.projectId === projectId && (tab.worktreePath ?? undefined) === worktreePath,
+      );
+      return {
+        activeProjectId: projectId,
+        activeWorktreePath: worktreePath ?? null,
+        activeTabId: scopedTab?.id ?? null,
+      };
+    }),
 
   addTab: (projectId, projectName, worktreePath?) => {
     const tab: DevTerminalTab = {

--- a/src/renderer/utils/projectScopeLabel.ts
+++ b/src/renderer/utils/projectScopeLabel.ts
@@ -1,0 +1,8 @@
+import { getBasename } from "@/shared/pathUtils";
+
+/** Compact project/worktree scope label for docked panel headers. */
+export function formatProjectScopeLabel(projectName: string, worktreePath?: string): string {
+  if (!worktreePath) return projectName;
+  const worktreeName = getBasename(worktreePath);
+  return worktreeName ? `${projectName} / ${worktreeName}` : projectName;
+}

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -45,6 +45,7 @@ import {
 import { showTerminalPanel } from "@/renderer/actions/terminalActions";
 import { getCurrentProjectId, resolveActivePaneId } from "@/renderer/actions/currentProject";
 import { buildFileEditorContext } from "@/renderer/utils/gitHelpers";
+import { formatProjectScopeLabel } from "@/renderer/utils/projectScopeLabel";
 import { GitReviewPanelContent } from "./RightPanel/parts/GitReviewPanelContent";
 
 interface PanelProjectScope {
@@ -246,6 +247,12 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
         return t`Usage`;
       case "notes":
         return notesProjectId ? projectNameForScope({ projectId: notesProjectId }) : t`Notes`;
+      case "terminal": {
+        const terminalProjectName = projectNameForScope(terminalScope);
+        return terminalProjectName
+          ? formatProjectScopeLabel(terminalProjectName, terminalWorktreePath ?? undefined)
+          : undefined;
+      }
       case "subagent":
       case "plan":
         return undefined;

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.test.tsx
@@ -22,22 +22,30 @@ vi.mock("@/renderer/bridge", () => ({
 vi.mock("./parts/RightTerminalLayout", () => ({
   RightTerminalLayout: (props: {
     projectTabs: DevTerminalTab[];
+    activeScopeLabel: string | undefined;
     handleCloseTab: (tab: DevTerminalTab) => void;
   }) => (
-    <button type="button" onClick={() => props.handleCloseTab(props.projectTabs[0]!)}>
-      close right tab
-    </button>
+    <>
+      <span>{props.activeScopeLabel}</span>
+      <button type="button" onClick={() => props.handleCloseTab(props.projectTabs[0]!)}>
+        close right tab
+      </button>
+    </>
   ),
 }));
 
 vi.mock("./parts/BottomTerminalLayout", () => ({
   BottomTerminalLayout: (props: {
     projectTabs: DevTerminalTab[];
+    activeScopeLabel: string | undefined;
     handleCloseTab: (tab: DevTerminalTab) => void;
   }) => (
-    <button type="button" onClick={() => props.handleCloseTab(props.projectTabs[0]!)}>
-      close bottom tab
-    </button>
+    <>
+      <span>{props.activeScopeLabel}</span>
+      <button type="button" onClick={() => props.handleCloseTab(props.projectTabs[0]!)}>
+        close bottom tab
+      </button>
+    </>
   ),
 }));
 
@@ -107,6 +115,19 @@ describe("DevTerminalPanel", () => {
     expect(useDevTerminalStore.getState().isOpen).toBe(false);
     expect(usePanelStore.getState().gitReviewContext).toEqual({ projectId: project.id });
     expect(usePanelStore.getState().filesPanelContext?.projectId).toBe(project.id);
+  });
+
+  it("shows the project and worktree in the terminal scope label", () => {
+    const worktreePath = "/repo/.poracode/worktrees/feature";
+    useSharedSettings.setState({ terminalPosition: "bottom" });
+    useDevTerminalStore.setState({
+      activeWorktreePath: worktreePath,
+      tabs: [{ ...tab, worktreePath }],
+    });
+
+    render(<DevTerminalPanel hideHeader />);
+
+    expect(screen.getByText("Poracode / feature")).toBeInTheDocument();
   });
 
   it("can force the right layout for an embedded host without changing saved settings", () => {

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
@@ -11,6 +11,7 @@ import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTe
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { closeAllPanels } from "@/renderer/actions/panelActions";
 import { clearEagerShellStart, wasShellStartedEagerly } from "@/renderer/utils/shellUtils";
+import { formatProjectScopeLabel } from "@/renderer/utils/projectScopeLabel";
 import type { TerminalSize } from "@/shared/contracts";
 import type { TerminalFeedListener } from "@/shared/remote/terminalFeed";
 import { buildWorktreeLocation } from "@/shared/worktree";
@@ -48,6 +49,9 @@ export function DevTerminalPanel(props: {
     return !tab.worktreePath;
   });
   const activeProject = projects.find((p) => p.id === activeProjectId);
+  const activeScopeLabel = activeProject
+    ? formatProjectScopeLabel(activeProject.name, activeWorktreePath ?? undefined)
+    : undefined;
   const selectedTabId =
     projectTabs.find((tab) => tab.id === activeTabId)?.id ?? projectTabs.at(-1)?.id ?? "__add__";
   const activeTab = projectTabs.find((tab) => tab.id === selectedTabId);
@@ -207,7 +211,7 @@ export function DevTerminalPanel(props: {
       <BottomTerminalLayout
         tabs={tabs}
         projectTabs={projectTabs}
-        activeProject={activeProject}
+        activeScopeLabel={activeScopeLabel}
         selectedTabId={selectedTabId}
         activeTab={activeTab}
         focusRequestId={focusRequestId}
@@ -230,7 +234,7 @@ export function DevTerminalPanel(props: {
     <RightTerminalLayout
       tabs={tabs}
       projectTabs={projectTabs}
-      activeProject={activeProject}
+      activeScopeLabel={activeScopeLabel}
       selectedTabId={selectedTabId}
       activeTab={activeTab}
       focusRequestId={focusRequestId}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { BottomTerminalLayout } from "./BottomTerminalLayout";
+
+vi.mock("./TerminalSurfaces", () => ({
+  TerminalSurfaces: () => <div data-testid="terminal-surfaces" />,
+}));
+
+function renderLayout() {
+  return render(
+    <BottomTerminalLayout
+      tabs={[]}
+      projectTabs={[]}
+      activeScopeLabel="Poracode / feature"
+      selectedTabId="__add__"
+      activeTab={undefined}
+      focusRequestId={0}
+      markTabActive={vi.fn<() => void>()}
+      updateTabTitle={vi.fn<() => void>()}
+      fadeStyle={{ opacity: 1, transition: "none" }}
+      emptyState={null}
+      handleCloseTab={vi.fn<() => void>()}
+      handleCloseSplit={vi.fn<() => void>()}
+      handleSelectionChange={vi.fn<() => void>()}
+      getTabContextItems={() => []}
+      handleTabContextAction={vi.fn<() => void>()}
+    />,
+  );
+}
+
+describe("BottomTerminalLayout", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the project and worktree scope in the header", () => {
+    renderLayout();
+
+    expect(screen.getByText("Poracode / feature")).toBeInTheDocument();
+  });
+
+  it("resizes and persists the terminal sidebar with the keyboard", () => {
+    renderLayout();
+    const separator = screen.getByRole("separator", { name: "Resize sidebar" });
+    const sidebar = separator.previousElementSibling;
+    expect(sidebar).toHaveStyle({ width: "140px" });
+
+    fireEvent.keyDown(separator, { key: "ArrowRight" });
+
+    expect(sidebar).toHaveStyle({ width: "164px" });
+    expect(localStorage.getItem("poracode-bottom-terminal-sidebar-width")).toBe("164");
+  });
+
+  it("resizes and persists the terminal sidebar by dragging", () => {
+    renderLayout();
+    const separator = screen.getByRole("separator", { name: "Resize sidebar" });
+    const sidebar = separator.previousElementSibling;
+
+    fireEvent.pointerDown(separator, { clientX: 100 });
+    fireEvent.pointerMove(window, { clientX: 170 });
+    fireEvent.pointerUp(window);
+
+    expect(sidebar).toHaveStyle({ width: "210px" });
+    expect(localStorage.getItem("poracode-bottom-terminal-sidebar-width")).toBe("210");
+  });
+});

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
@@ -1,7 +1,7 @@
 import { Columns2, PanelBottomClose, Plus, Trash2 } from "lucide-react";
 import { Tabs } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
-import type { Project, TerminalSize } from "@/shared/contracts";
+import type { TerminalSize } from "@/shared/contracts";
 import type { TerminalFeedListener } from "@/shared/remote/terminalFeed";
 import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTerminalStore";
 import { ContextMenu } from "@/renderer/components/common/ContextMenu";
@@ -11,11 +11,16 @@ import {
   panelHeaderRowClass,
 } from "@/renderer/components/layout/sidebarChrome";
 import { TerminalSurfaces } from "./TerminalSurfaces";
+import {
+  BOTTOM_TERMINAL_SIDEBAR_MAX_WIDTH,
+  BOTTOM_TERMINAL_SIDEBAR_MIN_WIDTH,
+  useBottomTerminalSidebarResize,
+} from "./useBottomTerminalSidebarResize";
 
 export function BottomTerminalLayout(props: {
   tabs: DevTerminalTab[];
   projectTabs: DevTerminalTab[];
-  activeProject: Project | undefined;
+  activeScopeLabel: string | undefined;
   selectedTabId: string;
   activeTab: DevTerminalTab | undefined;
   focusRequestId: number;
@@ -37,7 +42,7 @@ export function BottomTerminalLayout(props: {
   const {
     tabs,
     projectTabs,
-    activeProject,
+    activeScopeLabel,
     selectedTabId,
     activeTab,
     focusRequestId,
@@ -53,6 +58,8 @@ export function BottomTerminalLayout(props: {
     onTerminalResize,
     watchTerminal,
   } = props;
+  const { sidebarRef, sidebarWidth, handleResizeStart, handleResizeKeyDown } =
+    useBottomTerminalSidebarResize();
 
   // Build flat entries: primary tabs + their split children
   type TabRow = { id: string; tab: DevTerminalTab; isSplit: boolean };
@@ -64,10 +71,17 @@ export function BottomTerminalLayout(props: {
 
   return (
     <div className="flex h-full min-h-0 bg-[var(--content-background)]" style={fadeStyle}>
-      <div className="flex w-[140px] shrink-0 flex-col overflow-hidden border-r border-[color:var(--border)]">
-        {activeProject && (
+      <div
+        ref={sidebarRef}
+        className="flex shrink-0 flex-col overflow-hidden"
+        style={{ width: sidebarWidth, minWidth: sidebarWidth }}
+      >
+        {activeScopeLabel && (
           <div className={panelHeaderRowClass}>
-            <PanelHeaderProjectName name={activeProject.name} maxWidthClass="max-w-[80px]" />
+            <PanelHeaderProjectName
+              name={activeScopeLabel}
+              maxWidthClass="max-w-[calc(100%-1.75rem)]"
+            />
             <div className="flex-1" />
             <button
               type="button"
@@ -138,6 +152,19 @@ export function BottomTerminalLayout(props: {
           </Tabs>
         </div>
       </div>
+
+      <div
+        className="poracode-pane-divider"
+        onPointerDown={handleResizeStart}
+        onKeyDown={handleResizeKeyDown}
+        role="separator"
+        tabIndex={0}
+        aria-label={t`Resize sidebar`}
+        aria-orientation="vertical"
+        aria-valuemin={BOTTOM_TERMINAL_SIDEBAR_MIN_WIDTH}
+        aria-valuemax={BOTTOM_TERMINAL_SIDEBAR_MAX_WIDTH}
+        aria-valuenow={sidebarWidth}
+      />
 
       <div className="relative min-h-0 min-w-0 flex-1 px-2 pt-2">
         <TerminalSurfaces

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
@@ -1,7 +1,7 @@
 import { PanelRightClose, Plus, Trash2 } from "lucide-react";
 import { Tabs } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
-import type { Project, TerminalSize } from "@/shared/contracts";
+import type { TerminalSize } from "@/shared/contracts";
 import type { TerminalFeedListener } from "@/shared/remote/terminalFeed";
 import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTerminalStore";
 import { PanelHeaderProjectName } from "@/renderer/components/layout/PanelHeaderProjectName";
@@ -14,7 +14,7 @@ import { TerminalSurfaces } from "./TerminalSurfaces";
 export function RightTerminalLayout(props: {
   tabs: DevTerminalTab[];
   projectTabs: DevTerminalTab[];
-  activeProject: Project | undefined;
+  activeScopeLabel: string | undefined;
   selectedTabId: string;
   activeTab: DevTerminalTab | undefined;
   focusRequestId: number;
@@ -32,7 +32,7 @@ export function RightTerminalLayout(props: {
   const {
     tabs,
     projectTabs,
-    activeProject,
+    activeScopeLabel,
     selectedTabId,
     activeTab,
     focusRequestId,
@@ -49,9 +49,9 @@ export function RightTerminalLayout(props: {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[var(--content-background)]" style={fadeStyle}>
-      {!hideHeader && activeProject && (
+      {!hideHeader && activeScopeLabel && (
         <div className={panelHeaderRowClass}>
-          <PanelHeaderProjectName name={activeProject.name} maxWidthClass="max-w-[100px]" />
+          <PanelHeaderProjectName name={activeScopeLabel} maxWidthClass="max-w-[100px]" />
           <div className="flex-1" />
           <button
             type="button"

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/useBottomTerminalSidebarResize.ts
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/useBottomTerminalSidebarResize.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import { readStoredNumber, writeStoredNumber } from "@/renderer/utils/localStorage";
+
+const WIDTH_STORAGE_KEY = "poracode-bottom-terminal-sidebar-width";
+export const BOTTOM_TERMINAL_SIDEBAR_MIN_WIDTH = 100;
+export const BOTTOM_TERMINAL_SIDEBAR_MAX_WIDTH = 360;
+const BOTTOM_TERMINAL_SIDEBAR_DEFAULT_WIDTH = 140;
+const KEY_RESIZE_STEP_PX = 24;
+
+function clampWidth(width: number): number {
+  return Math.min(
+    BOTTOM_TERMINAL_SIDEBAR_MAX_WIDTH,
+    Math.max(BOTTOM_TERMINAL_SIDEBAR_MIN_WIDTH, Math.round(width)),
+  );
+}
+
+export function useBottomTerminalSidebarResize() {
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    clampWidth(readStoredNumber(WIDTH_STORAGE_KEY, BOTTOM_TERMINAL_SIDEBAR_DEFAULT_WIDTH)),
+  );
+  const widthRef = useRef(sidebarWidth);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => cleanupRef.current?.();
+  }, []);
+
+  function applyWidth(width: number): number {
+    const next = clampWidth(width);
+    widthRef.current = next;
+    if (sidebarRef.current) {
+      sidebarRef.current.style.width = `${next}px`;
+      sidebarRef.current.style.minWidth = `${next}px`;
+    }
+    return next;
+  }
+
+  function commitWidth(width: number) {
+    const next = applyWidth(width);
+    setSidebarWidth(next);
+    writeStoredNumber(WIDTH_STORAGE_KEY, next);
+  }
+
+  function handleResizeStart(event: ReactPointerEvent<HTMLDivElement>) {
+    event.preventDefault();
+    cleanupRef.current?.();
+
+    const startX = event.clientX;
+    const startWidth = widthRef.current;
+
+    function onPointerMove(pointerEvent: PointerEvent) {
+      applyWidth(startWidth + pointerEvent.clientX - startX);
+    }
+
+    function cleanup() {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      cleanupRef.current = null;
+    }
+
+    function onPointerUp() {
+      cleanup();
+      commitWidth(widthRef.current);
+    }
+
+    cleanupRef.current = cleanup;
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+  }
+
+  function handleResizeKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    let next: number;
+    switch (event.key) {
+      case "ArrowLeft":
+        next = widthRef.current - KEY_RESIZE_STEP_PX;
+        break;
+      case "ArrowRight":
+        next = widthRef.current + KEY_RESIZE_STEP_PX;
+        break;
+      case "Home":
+        next = BOTTOM_TERMINAL_SIDEBAR_MIN_WIDTH;
+        break;
+      case "End":
+        next = BOTTOM_TERMINAL_SIDEBAR_MAX_WIDTH;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    commitWidth(next);
+  }
+
+  return {
+    sidebarRef,
+    sidebarWidth,
+    handleResizeStart,
+    handleResizeKeyDown,
+  };
+}


### PR DESCRIPTION
- Add a resizable, keyboard-accessible bottom terminal sidebar with persisted width preferences.
- Show project and worktree scope labels in docked terminal headers and auxiliary panels for clearer context.
- Keep bottom-positioned terminal panels synchronized with the active project/worktree without reopening or spawning shells.
- Add coverage for resizing, scoped labels, and terminal thread-lock behavior.