### PR TITLE
Fix PR automation default display while loading

### DIFF
--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.test.tsx
@@ -41,6 +41,20 @@ const bridge = vi.hoisted(() => ({
   deletePrWatch: vi.fn<() => Promise<void>>(),
 }));
 
+const settings = vi.hoisted(() => ({
+  prAutomationDefault: "merge" as const,
+  conflictResolverProvider: "codex",
+  conflictResolverModel: "gpt-5.7",
+  conflictResolverEffort: "high",
+  conflictResolverFast: false,
+  conflictResolverPresentationMode: "gui" as const,
+  wslConflictResolverProvider: "auto",
+  wslConflictResolverModel: "",
+  wslConflictResolverEffort: "",
+  wslConflictResolverFast: false,
+  wslConflictResolverPresentationMode: "gui" as const,
+}));
+
 vi.mock("@/renderer/bridge", () => ({
   readBridge: () => bridge,
 }));
@@ -51,7 +65,12 @@ vi.mock("@/renderer/state/appStore", () => ({
 }));
 
 vi.mock("@/renderer/state/agentStatusesStore", () => {
-  const getState = () => ({ agentStatuses: [agent], wslAgentStatuses: [] });
+  let state: { agentStatuses: AgentStatus[]; wslAgentStatuses: AgentStatus[] } | undefined;
+  const getState = () =>
+    (state ??= {
+      agentStatuses: [agent],
+      wslAgentStatuses: [],
+    });
   const useAgentStatusesStore = Object.assign(
     (selector: (state: ReturnType<typeof getState>) => unknown) => selector(getState()),
     { getState },
@@ -60,18 +79,7 @@ vi.mock("@/renderer/state/agentStatusesStore", () => {
 });
 
 vi.mock("@/renderer/state/sharedSettingsStore", () => {
-  const getState = () => ({
-    conflictResolverProvider: "codex",
-    conflictResolverModel: "gpt-5.7",
-    conflictResolverEffort: "high",
-    conflictResolverFast: false,
-    conflictResolverPresentationMode: "gui" as const,
-    wslConflictResolverProvider: "auto",
-    wslConflictResolverModel: "",
-    wslConflictResolverEffort: "",
-    wslConflictResolverFast: false,
-    wslConflictResolverPresentationMode: "gui" as const,
-  });
+  const getState = () => settings;
   const useSharedSettings = Object.assign(
     (selector: (state: ReturnType<typeof getState>) => unknown) => selector(getState()),
     { getState },
@@ -103,6 +111,17 @@ describe("PrWatchControls", () => {
       lastError: null,
     }));
     bridge.deletePrWatch.mockResolvedValue(undefined);
+  });
+
+  it("shows the configured default while the initial automation state loads", () => {
+    bridge.getPrWatch.mockReturnValue(new Promise(() => undefined));
+
+    render(<PrWatchControls projectId={project.id} prNumber={42} headBranch="feature/pr-watch" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "PR automation" }));
+    const slider = screen.getByRole("slider", { name: "PR automation" });
+    expect(slider).toHaveValue("2");
+    expect(slider).toBeDisabled();
   });
 
   it("enables watching with the AI Helpers conflict resolver model", async () => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
@@ -13,7 +13,11 @@ import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 
-function automationMode(watch: PrWatch | null): PrAutomationMode {
+function automationMode(
+  watch: PrWatch | null | undefined,
+  loadingMode: PrAutomationMode,
+): PrAutomationMode {
+  if (watch === undefined) return loadingMode;
   if (watch?.autoMerge) return "merge";
   return watch?.watchEnabled ? "fix" : "off";
 }
@@ -31,11 +35,12 @@ export function PrWatchControls(props: {
   );
   const windowsAgents = useAgentStatusesStore((state) => state.agentStatuses);
   const wslAgents = useAgentStatusesStore((state) => state.wslAgentStatuses);
-  const [watch, setWatch] = useState<PrWatch | null>(null);
+  const defaultMode = useSharedSettings((state) => state.prAutomationDefault);
+  const [watch, setWatch] = useState<PrWatch | null | undefined>(undefined);
   const [busy, setBusy] = useState(false);
   const watchPresentRef = useRef(false);
   const refreshPrRef = useRef(props.onRefreshPr);
-  const mode = automationMode(watch);
+  const mode = automationMode(watch, defaultMode);
   const enabled = mode !== "off";
 
   useEffect(() => {
@@ -167,7 +172,7 @@ export function PrWatchControls(props: {
             <PrAutomationSlider
               ariaLabel={t`PR automation`}
               className="mx-auto w-[200px] px-2"
-              isDisabled={busy}
+              isDisabled={busy || watch === undefined}
               value={mode}
               onChange={update}
             />


### PR DESCRIPTION
- **Bugfix:** Show the configured default PR automation mode before watch state loads.
- Keep the automation control disabled until its current watch state is available.
- Add coverage for the loading-state default and disabled control.