### PR TITLE
fix(chat): preserve bottom pin on composer viewport resize

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.test.tsx
@@ -390,7 +390,7 @@ describe("ChatScrollControls", () => {
     expect(scrollTop).toBe(1025);
   });
 
-  it("keeps following the tail when composer growth shrinks the viewport", () => {
+  it("keeps following the tail when composer edits resize the viewport", () => {
     let now = 0;
     vi.spyOn(performance, "now").mockImplementation(() => now);
     let resizeCallback: ResizeObserverCallback | null = null;
@@ -459,6 +459,32 @@ describe("ChatScrollControls", () => {
     });
 
     expect(scrollTop).toBe(840);
+
+    while (animationFrames.size > 0) {
+      const callbacks = [...animationFrames.values()];
+      animationFrames.clear();
+      act(() => callbacks.forEach((callback) => callback(0)));
+    }
+
+    act(() => {
+      // Removing a line grows the chat viewport. LegendList can adjust its
+      // visible-content anchor before ResizeObserver reports that inverse
+      // composer resize, so the previous at-bottom cache must not suppress
+      // the corrective pin.
+      clientHeight = 200;
+      scrollTop = 760;
+      scrollEl.dispatchEvent(new Event("scroll"));
+      const callback = resizeCallback as ResizeObserverCallback | null;
+      callback?.([{ target: scrollEl } as unknown as ResizeObserverEntry], {} as ResizeObserver);
+    });
+
+    while (animationFrames.size > 0) {
+      const callbacks = [...animationFrames.values()];
+      animationFrames.clear();
+      act(() => callbacks.forEach((callback) => callback(0)));
+    }
+
+    expect(scrollTop).toBe(800);
   });
 
   it("keeps sticky while LegendList adjusts its anchor before scrollHeight changes", async () => {

--- a/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatScrollControls.tsx
@@ -108,6 +108,7 @@ export const ChatScrollControls = forwardRef<
   const threadOpenCoalesceUntilRef = useRef(0);
   const atBottomCachedUntilRef = useRef(0);
   const lastPinnedScrollHeightRef = useRef(0);
+  const lastPinnedClientHeightRef = useRef(0);
   const lastSeenScrollHeightRef = useRef(0);
   const lastSeenClientHeightRef = useRef(0);
   const previousInitialScrollSettledRef = useRef(initialScrollSettled);
@@ -165,6 +166,7 @@ export const ChatScrollControls = forwardRef<
     threadOpenCoalesceUntilRef.current = 0;
     atBottomCachedUntilRef.current = 0;
     lastPinnedScrollHeightRef.current = 0;
+    lastPinnedClientHeightRef.current = 0;
     stickToBottomRef.current = false;
     const el = scrollRef.current;
     setShowScrollDown(!el || !isElementAtBottom(el));
@@ -207,6 +209,7 @@ export const ChatScrollControls = forwardRef<
   function writeBottomPin(el: HTMLElement) {
     writeScrollTop(el, el.scrollHeight);
     lastPinnedScrollHeightRef.current = el.scrollHeight;
+    lastPinnedClientHeightRef.current = el.clientHeight;
     lastScrollTopRef.current = el.scrollTop;
     stickToBottomRef.current = true;
     setShowScrollDown(false);
@@ -236,6 +239,7 @@ export const ChatScrollControls = forwardRef<
       pinHoldoffUntilRef.current = 0;
     }
     const scrollHeight = el.scrollHeight;
+    const clientHeight = el.clientHeight;
     const reconcileVirtualizer = options.reconcileVirtualizer === true;
     // Stick-to-bottom storms (thread switch / row measure) call this many times
     // per frame. If we are already pinned at the same content height, skip
@@ -249,6 +253,8 @@ export const ChatScrollControls = forwardRef<
         cachedUntil: atBottomCachedUntilRef.current,
         scrollHeight,
         lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
+        clientHeight,
+        lastPinnedClientHeight: lastPinnedClientHeightRef.current,
         reconcileVirtualizer,
       })
     ) {
@@ -265,6 +271,8 @@ export const ChatScrollControls = forwardRef<
         coalesceUntil: threadOpenCoalesceUntilRef.current,
         scrollHeight,
         lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
+        clientHeight,
+        lastPinnedClientHeight: lastPinnedClientHeightRef.current,
       })
     ) {
       atBottomCachedUntilRef.current = nextAtBottomCacheUntil({
@@ -281,7 +289,7 @@ export const ChatScrollControls = forwardRef<
       shouldSkipScrollToBottomWrite({
         scrollHeight,
         scrollTop: el.scrollTop,
-        clientHeight: el.clientHeight,
+        clientHeight,
         lastPinnedScrollHeight: lastPinnedScrollHeightRef.current,
       })
     ) {
@@ -293,6 +301,7 @@ export const ChatScrollControls = forwardRef<
         coalesceUntil: threadOpenCoalesceUntilRef.current,
       });
       lastPinnedScrollHeightRef.current = scrollHeight;
+      lastPinnedClientHeightRef.current = clientHeight;
       lastScrollTopRef.current = el.scrollTop;
       stickToBottomRef.current = true;
       setShowScrollDown(false);
@@ -338,11 +347,14 @@ export const ChatScrollControls = forwardRef<
 
   const syncLayoutNowAndAfterPaint = useEffectEvent(() => {
     const el = scrollRef.current;
-    const contentHeightChanged = !!el && el.scrollHeight !== lastPinnedScrollHeightRef.current;
+    const layoutHeightChanged =
+      !!el &&
+      (el.scrollHeight !== lastPinnedScrollHeightRef.current ||
+        el.clientHeight !== lastPinnedClientHeightRef.current);
 
     // Height-driven sticky pins must run in this frame. Cancel any pending
     // coalesce so an earlier open-storm schedule cannot defer the write.
-    if (contentHeightChanged && stickToBottomRef.current) {
+    if (layoutHeightChanged && stickToBottomRef.current) {
       cancelScheduledLayoutSync();
       syncLayoutNow();
       return;
@@ -521,6 +533,7 @@ export const ChatScrollControls = forwardRef<
     threadOpenCoalesceUntilRef.current = performance.now() + THREAD_OPEN_COALESCE_MS;
     atBottomCachedUntilRef.current = 0;
     lastPinnedScrollHeightRef.current = 0;
+    lastPinnedClientHeightRef.current = 0;
     lastSeenScrollHeightRef.current = scrollRef.current?.scrollHeight ?? 0;
     lastSeenClientHeightRef.current = scrollRef.current?.clientHeight ?? 0;
     scrollToBottom({ reconcileVirtualizer: true });

--- a/src/renderer/components/thread/ChatPane/chatScrollGeometry.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatScrollGeometry.test.ts
@@ -331,6 +331,8 @@ describe("chatScrollGeometry", () => {
         cachedUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(true);
     expect(
@@ -339,6 +341,8 @@ describe("chatScrollGeometry", () => {
         cachedUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(false);
     expect(
@@ -347,6 +351,8 @@ describe("chatScrollGeometry", () => {
         cachedUntil: 400,
         scrollHeight: 1200,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(false);
     expect(
@@ -355,7 +361,19 @@ describe("chatScrollGeometry", () => {
         cachedUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
         reconcileVirtualizer: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTrustCachedAtBottom({
+        now: 100,
+        cachedUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+        clientHeight: 240,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(false);
   });
@@ -365,7 +383,7 @@ describe("chatScrollGeometry", () => {
     expect(nextAtBottomCacheUntil({ now: 100, frameCacheMs: 16, coalesceUntil: 50 })).toBe(116);
   });
 
-  it("only re-pins during open storm when scrollHeight grows", () => {
+  it("only re-pins during open storm when content or viewport height changes", () => {
     expect(
       shouldRepinForContentGrowth({
         stickToBottom: true,
@@ -373,6 +391,8 @@ describe("chatScrollGeometry", () => {
         coalesceUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(false);
     expect(
@@ -382,6 +402,19 @@ describe("chatScrollGeometry", () => {
         coalesceUntil: 400,
         scrollHeight: 1100,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRepinForContentGrowth({
+        stickToBottom: true,
+        now: 100,
+        coalesceUntil: 400,
+        scrollHeight: 1000,
+        lastPinnedScrollHeight: 1000,
+        clientHeight: 240,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(true);
     expect(
@@ -391,6 +424,8 @@ describe("chatScrollGeometry", () => {
         coalesceUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(true);
     expect(
@@ -400,6 +435,8 @@ describe("chatScrollGeometry", () => {
         coalesceUntil: 400,
         scrollHeight: 1000,
         lastPinnedScrollHeight: 1000,
+        clientHeight: 200,
+        lastPinnedClientHeight: 200,
       }),
     ).toBe(true);
   });

--- a/src/renderer/components/thread/ChatPane/chatScrollGeometry.ts
+++ b/src/renderer/components/thread/ChatPane/chatScrollGeometry.ts
@@ -47,8 +47,8 @@ export function shouldSkipScrollToBottomWrite(input: {
 /**
  * During a thread-open measurement storm, trust a recent "already at bottom"
  * result so we do not re-read scroll metrics on every ResizeObserver /
- * totalSize callback — but only while `scrollHeight` is unchanged. If content
- * grew (virtualizer measured taller rows), we must re-pin or the chat opens
+ * totalSize callback — but only while the content and viewport heights are
+ * unchanged. If either changes, we must re-pin or the chat can open or remain
  * mid-transcript.
  *
  * Never trust the cache when `reconcileVirtualizer` is requested: the initial
@@ -59,10 +59,13 @@ export function shouldTrustCachedAtBottom(input: {
   cachedUntil: number;
   scrollHeight: number;
   lastPinnedScrollHeight: number;
+  clientHeight: number;
+  lastPinnedClientHeight: number;
   reconcileVirtualizer?: boolean;
 }): boolean {
   if (input.reconcileVirtualizer) return false;
   if (input.scrollHeight !== input.lastPinnedScrollHeight) return false;
+  if (input.clientHeight !== input.lastPinnedClientHeight) return false;
   return input.now < input.cachedUntil;
 }
 
@@ -81,9 +84,9 @@ export function nextAtBottomCacheUntil(input: {
 
 /**
  * While sticky during a thread-open storm, only re-pin when the scrollable
- * content height changed. Re-reading distance-from-bottom on every callback is
- * wasted when `scrollHeight` is unchanged; grow or shrink both require a pin
- * (collapse must not leave the view stranded above the bottom).
+ * content or viewport height changed. Re-reading distance-from-bottom on every
+ * callback is wasted when both are unchanged; grow or shrink both require a
+ * pin (collapse and composer resize must not leave the view stranded).
  */
 export function shouldRepinForContentGrowth(input: {
   stickToBottom: boolean;
@@ -91,10 +94,15 @@ export function shouldRepinForContentGrowth(input: {
   coalesceUntil: number;
   scrollHeight: number;
   lastPinnedScrollHeight: number;
+  clientHeight: number;
+  lastPinnedClientHeight: number;
 }): boolean {
   if (!input.stickToBottom) return true;
   if (input.now >= input.coalesceUntil) return true;
-  return input.scrollHeight !== input.lastPinnedScrollHeight;
+  return (
+    input.scrollHeight !== input.lastPinnedScrollHeight ||
+    input.clientHeight !== input.lastPinnedClientHeight
+  );
 }
 
 /**


### PR DESCRIPTION
# Summary

What changed?

# Motivation

Why is this useful or needed?

# Testing

- [ ] `pnpm run typecheck`
- [ ] `pnpm run lint`
- [ ] `pnpm run fmt:check`
- [ ] `pnpm run test`
- [ ] Not run; reason:

# Screenshots

Add screenshots or screen recordings for UI changes.

# Linked issue

Closes #
