### PR TITLE
fix(thread): make thread tool menu interactive

### DIFF
--- a/src/renderer/components/thread/ThreadToolRail.tsx
+++ b/src/renderer/components/thread/ThreadToolRail.tsx
@@ -316,8 +316,10 @@ export function ThreadToolRail(props: {
           </button>
           <div
             data-poracode-thread-tool-menu=""
-            className={`pointer-events-none invisible absolute left-1/2 top-full z-30 w-9 -translate-x-1/2 opacity-0 transition-opacity duration-150 ${
-              headerMenuOpen ? "pointer-events-auto visible opacity-100" : ""
+            className={`absolute left-1/2 top-full z-30 w-9 -translate-x-1/2 transition-opacity duration-150 ${
+              headerMenuOpen
+                ? "pointer-events-auto visible opacity-100"
+                : "pointer-events-none invisible opacity-0"
             }`}
           >
             <div className="pt-1">

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -1690,7 +1690,8 @@ describe("ThreadView", () => {
       expect(headerMenu?.querySelector('[aria-label="Notes"]')).not.toBeNull();
 
       fireEvent.pointerEnter(headerMenu as HTMLElement);
-      expect(toolMenu).toHaveClass("visible");
+      expect(toolMenu).toHaveClass("pointer-events-auto", "visible", "opacity-100");
+      expect(toolMenu).not.toHaveClass("pointer-events-none", "invisible", "opacity-0");
 
       fireEvent.pointerLeave(headerMenu as HTMLElement);
       expect(toolMenu).toHaveClass("visible");


### PR DESCRIPTION
## Summary

- apply mutually exclusive pointer-event, visibility, and opacity classes to the header thread-tool menu
- keep the visible menu available to real mouse hit-testing
- strengthen the regression test so the open state cannot retain inactive interaction classes

## Root cause

The open menu retained both `pointer-events-none` and `pointer-events-auto`. Tailwind's generated rule order made `pointer-events: none` win, so the menu was visible but could not receive hover or click events. Because the pointer never entered the menu, the leave timer then hid it.

## User impact

The floating thread-tool menu now stays open while the pointer enters it, shows row hover feedback, and responds to clicks.

## Validation

- `pnpm exec vitest run src/renderer/components/thread/ThreadView.test.tsx` (25 tests)
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec oxfmt --check src/renderer/components/thread/ThreadToolRail.tsx src/renderer/components/thread/ThreadView.test.tsx`
- real Electron mouse verification: menu computed `pointer-events: auto`, the hovered row received `:hover`, and clicking Files switched the right panel from Git to Files