### PR TITLE
Fix independent agent update state across environments

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -427,7 +427,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.test.tsx
@@ -1550,6 +1550,89 @@ describe("SingleAgentSettings", () => {
     platformSpy.mockRestore();
   });
 
+  it("keeps Windows and WSL update loaders independent", async () => {
+    const platformSpy = vi.spyOn(navigator, "platform", "get").mockReturnValue("Win32");
+    statusesState.agentStatuses = [
+      makeStatus("cursor", {
+        label: "Cursor",
+        version: "1.0.0",
+        envKind: "windows",
+        update: { builtIn: { binary: "cursor-agent", args: ["update"] } },
+      }),
+    ];
+    statusesState.wslAgentStatuses = [
+      makeStatus("cursor", {
+        label: "Cursor",
+        version: "1.0.0",
+        envKind: "wsl",
+        envDistro: "Ubuntu",
+        update: { builtIn: { binary: "cursor-agent", args: ["update"] } },
+      }),
+    ];
+    getLatestAgentVersionMock.mockResolvedValue({
+      version: "1.1.0",
+      source: "npm",
+    });
+    let resolveWindowsUpdate!: (result: { ok: boolean }) => void;
+    let resolveWslUpdate!: (result: { ok: boolean }) => void;
+    const windowsUpdate = new Promise<{ ok: boolean }>((resolve) => {
+      resolveWindowsUpdate = resolve;
+    });
+    const wslUpdate = new Promise<{ ok: boolean }>((resolve) => {
+      resolveWslUpdate = resolve;
+    });
+    updateAgentBinaryMock.mockImplementation((payload) =>
+      payload.envKind === "wsl" ? wslUpdate : windowsUpdate,
+    );
+
+    render(<SingleAgentSettings agentKind="cursor" />);
+
+    const windowsRow = envRow("Windows");
+    const wslRow = envRow("WSL (Ubuntu)");
+    fireEvent.click(
+      await within(windowsRow).findByRole("button", {
+        name: /Update to v1\.1\.0/i,
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        within(windowsRow).getByRole("status", { name: "Updating Cursor (Windows)" }),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(
+      within(wslRow).getByRole("button", {
+        name: /Update to v1\.1\.0/i,
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        within(windowsRow).getByRole("status", { name: "Updating Cursor (Windows)" }),
+      ).toBeInTheDocument();
+      expect(
+        within(wslRow).getByRole("status", { name: "Updating Cursor (WSL (Ubuntu))" }),
+      ).toBeInTheDocument();
+    });
+
+    resolveWslUpdate({ ok: false });
+    await waitFor(() =>
+      expect(
+        within(wslRow).queryByRole("status", { name: "Updating Cursor (WSL (Ubuntu))" }),
+      ).toBeNull(),
+    );
+    expect(
+      within(windowsRow).getByRole("status", { name: "Updating Cursor (Windows)" }),
+    ).toBeInTheDocument();
+
+    resolveWindowsUpdate({ ok: false });
+    await waitFor(() =>
+      expect(
+        within(windowsRow).queryByRole("status", { name: "Updating Cursor (Windows)" }),
+      ).toBeNull(),
+    );
+    platformSpy.mockRestore();
+  });
+
   it("reports the new version in the toast after a successful update", async () => {
     statusesState.agentStatuses = [
       makeStatus("claude", { label: "Claude Code", version: "1.0.0" }),

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
@@ -87,12 +87,16 @@ export function SingleAgentSettings(props: {
   // lazily via the registry entry's `accountResolver` when this page opens;
   // undefined for agents without a resolver.
   const [providerAccount, setProviderAccount] = useState<AgentProviderMetadata | undefined>();
-  const [binaryUpdatePendingEnvKey, setBinaryUpdatePendingEnvKey] = useState<string | undefined>();
+  const [binaryUpdatePendingEnvKeys, setBinaryUpdatePendingEnvKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   // After a successful update we hide the stale version and show a loader on
   // that row until `refreshAgentStatuses` returns with the freshly-detected
   // version. Without this the user sees "vOld" alongside the success toast and
   // assumes the update silently failed.
-  const [redetectingEnvKey, setRedetectingEnvKey] = useState<string | undefined>();
+  const [redetectingEnvKeys, setRedetectingEnvKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const agentStatuses = useAgentStatusesStore((s) => s.agentStatuses);
   const wslAgentStatuses = useAgentStatusesStore((s) => s.wslAgentStatuses);
   // Live quota read for this provider. Its plan supersedes the detected one,
@@ -511,7 +515,7 @@ export function SingleAgentSettings(props: {
     const envKey = statusEnvKey(status);
     const envName = envLabelForStatus(status);
     const previousVersion = status.version;
-    setBinaryUpdatePendingEnvKey(envKey);
+    setBinaryUpdatePendingEnvKeys((current) => new Set(current).add(envKey));
     readBridge()
       .updateAgentBinary({
         agentKind: props.agentKind,
@@ -520,14 +524,18 @@ export function SingleAgentSettings(props: {
       })
       .then(async (result) => {
         if (result.ok) {
-          setRedetectingEnvKey(envKey);
+          setRedetectingEnvKeys((current) => new Set(current).add(envKey));
           try {
             await readBridge().refreshAgentStatuses(wslDistros, {
               agentKinds: [props.agentKind],
               envs: [scopeEnvForStatus(status)],
             });
           } finally {
-            setRedetectingEnvKey(undefined);
+            setRedetectingEnvKeys((current) => {
+              const next = new Set(current);
+              next.delete(envKey);
+              return next;
+            });
           }
           const store = useAgentStatusesStore.getState();
           const pool = status.envKind === "wsl" ? store.wslAgentStatuses : store.agentStatuses;
@@ -577,7 +585,13 @@ export function SingleAgentSettings(props: {
               : t`Unable to update ${agent.label}.`,
         ),
       )
-      .finally(() => setBinaryUpdatePendingEnvKey(undefined));
+      .finally(() =>
+        setBinaryUpdatePendingEnvKeys((current) => {
+          const next = new Set(current);
+          next.delete(envKey);
+          return next;
+        }),
+      );
   };
 
   const installAgentInEnvironment = (status: AgentStatus) => {
@@ -644,10 +658,10 @@ export function SingleAgentSettings(props: {
         agentLabel={agent.label}
         authMethods={methods}
         authPending={authPendingEnvKey === envKey}
-        binaryUpdatePending={binaryUpdatePendingEnvKey === envKey}
+        binaryUpdatePending={binaryUpdatePendingEnvKeys.has(envKey)}
         canLogout={supportsAcpLogoutStatus(status, acpInstanceId)}
         includeAuthFallback={includeAuthFallbackMetadata}
-        isRedetecting={redetectingEnvKey === envKey}
+        isRedetecting={redetectingEnvKeys.has(envKey)}
         latestNpmVersion={latestNpmVersion}
         livePlan={resolveLivePlanLabel(rowMetadata, providerUsage)}
         newestInstalledVersion={newestInstalledVersion}
@@ -726,7 +740,7 @@ export function SingleAgentSettings(props: {
             )}
             <ToggleSwitch
               isSelected={!isDisabled}
-              isDisabled={binaryUpdatePendingEnvKey !== undefined}
+              isDisabled={binaryUpdatePendingEnvKeys.size > 0}
               size="sm"
               aria-label={t`Enabled`}
               onChange={(selected) => {

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx
@@ -162,9 +162,9 @@ export function AgentEnvironmentRow(props: {
     : "";
 
   return (
-    <div className="flex flex-col py-1.5 px-2 -mx-2 hover:bg-surface-secondary/40 rounded-lg transition-colors group/env">
+    <div className="@container flex flex-col py-1.5 px-2 -mx-2 hover:bg-surface-secondary/40 rounded-lg transition-colors group/env">
       <div className="flex items-center justify-between gap-4">
-        <div className="flex min-w-0 items-center gap-2 text-sm font-medium">
+        <div className="flex min-w-0 items-center gap-2 text-sm font-medium @max-[400px]:flex-wrap">
           <span className="shrink-0 text-foreground/90">{env || t`Default`}</span>
           {props.isRedetecting ? (
             <PixelLoader size="xs" />
@@ -175,7 +175,7 @@ export function AgentEnvironmentRow(props: {
           )}
           {props.binaryUpdatePending && !props.isRedetecting ? (
             <div
-              className="flex h-5 min-h-5 items-center"
+              className="flex h-5 min-h-5 items-center @max-[400px]:basis-full"
               role="status"
               aria-label={
                 env ? t`Updating ${props.agentLabel} (${env})` : t`Updating ${props.agentLabel}`
@@ -185,7 +185,7 @@ export function AgentEnvironmentRow(props: {
             </div>
           ) : showUpdateButton ? (
             <Tooltip delay={0}>
-              <Tooltip.Trigger>
+              <Tooltip.Trigger className="@max-[400px]:basis-full">
                 <Button
                   size="sm"
                   variant="ghost"


### PR DESCRIPTION
- **Bugfix:** Track agent update and redetection progress separately for each Windows and WSL environment.
- Keep settings controls consistent while environment-specific updates are in progress.
- Improve narrow-row update loader layout and cover concurrent environment updates with tests.
- Align locked HeroUI style dependency resolution.