### PR TITLE
Show paired desktop name in wide mobile sidebar

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -427,7 +427,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/mobile/NarrowShell.tsx
+++ b/src/mobile/NarrowShell.tsx
@@ -17,6 +17,7 @@ import { SubAgentHeaderText } from "@/renderer/components/thread/ChatPane/parts/
 import { ConnectionPill, SheetMenu } from "./components";
 import { NarrowThreadHostProvider } from "./narrowThreadHostContext";
 import { preselectWorktreeDraft, runThreadAction } from "./navHelpers";
+import { desktopTitle } from "./presentation";
 import { ThreadDetail } from "./ThreadDetail";
 import { ThreadTitleRow } from "./ThreadTitleRow";
 import { ThreadUsageIndicator } from "./ThreadUsageIndicator";
@@ -35,22 +36,20 @@ export function Brand(props: { readonly onPress: () => void }) {
   );
 }
 
-/** Header/sidebar connection indicator: silent when online, otherwise a
- * {@link ConnectionPill} that doubles as the recovery action. Shared by
- * {@link NarrowShell} and the wide-shell sidebar. */
+/** Header/sidebar connection indicator that doubles as the recovery action.
+ * Shared by {@link NarrowShell} and the wide-shell sidebar. */
 export function ConnectionControl(props: {
   readonly remote: RemoteDesktopSession;
   readonly onPair: () => void;
+  readonly showDesktopName?: boolean;
 }) {
   const { remote } = props;
-  // Healthy is silent: the pill appears only when the session needs attention
-  // (booting/pairing spinner, reconnecting, offline, expired, errored) and is
-  // itself the recovery action.
   if (!remote.activeDesktop) return null;
-  if (remote.connection === "online") return null;
+  if (remote.connection === "online" && !props.showDesktopName) return null;
   return (
     <ConnectionPill
       state={remote.connection}
+      {...(props.showDesktopName ? { label: desktopTitle(remote.activeDesktop.label) } : {})}
       onPress={() => {
         if (remote.connection === "unauthorized") {
           props.onPair();

--- a/src/mobile/RootLayout.test.tsx
+++ b/src/mobile/RootLayout.test.tsx
@@ -107,13 +107,15 @@ vi.mock("./components", () => ({
   ConnectionBanner: (props: { state: string }) => (
     <div data-testid="connection-banner" data-state={props.state} />
   ),
-  ConnectionPill: (props: { state: string }) => (
+  ConnectionPill: (props: { state: string; label?: string }) => (
     <button
       type="button"
       data-testid="connection-pill"
       data-state={props.state}
       aria-label="Connection status"
-    />
+    >
+      {props.label}
+    </button>
   ),
   EmptyState: (props: { title: ReactNode; hint?: ReactNode; action?: ReactNode }) => (
     <div>
@@ -347,6 +349,16 @@ describe("mobile RootLayout", () => {
     render(<RootLayout />);
 
     expect(screen.getByRole("button", { name: "New thread" })).toHaveClass("button--ghost");
+  });
+
+  it("shows the remote name and online connection state in the wide sidebar", () => {
+    mediaMock.isWide = true;
+
+    render(<RootLayout />);
+
+    expect(screen.getByTestId("connection-pill")).toHaveAttribute("data-state", "online");
+    expect(screen.getByTestId("connection-pill")).toHaveTextContent("Mac");
+    expect(screen.queryByText("Poracode on Mac")).not.toBeInTheDocument();
   });
 
   it("hosts shared image previews opened from user messages", () => {

--- a/src/mobile/WideShell.tsx
+++ b/src/mobile/WideShell.tsx
@@ -14,6 +14,7 @@ import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { ConnectionBanner } from "./components";
 import { Brand, ConnectionControl } from "./NarrowShell";
 import { openWorktreeDraft, threadIdFromPath } from "./navHelpers";
+import { desktopTitle } from "./presentation";
 import { MobileSetupEmptyState } from "./setupEmptyState";
 import type { RemoteDesktopSession } from "./useRemoteDesktop";
 import { ThreadsView } from "./views/ThreadsView";
@@ -196,7 +197,11 @@ export function WideShell(props: {
       <aside className="m-sidebar">
         <header className="m-sidebar__head">
           <Brand onPress={() => void navigate({ to: "/threads" })} />
-          <ConnectionControl remote={remote} onPair={() => void navigate({ to: "/desktops" })} />
+          <ConnectionControl
+            remote={remote}
+            showDesktopName
+            onPair={() => void navigate({ to: "/desktops" })}
+          />
           <Button
             size="sm"
             variant="ghost"
@@ -317,7 +322,11 @@ export function WideShell(props: {
           >
             <Server className="size-4" />
             <span>
-              <strong>{remote.activeDesktop?.label ?? t`No connection paired`}</strong>
+              <strong>
+                {remote.activeDesktop
+                  ? desktopTitle(remote.activeDesktop.label)
+                  : t`No connection paired`}
+              </strong>
               <span>
                 <Plural
                   value={remote.desktops.length}

--- a/src/mobile/components.tsx
+++ b/src/mobile/components.tsx
@@ -12,10 +12,12 @@ import { DESKTOP_POINTER_QUERY, useMediaQuery } from "./useMediaQuery";
 
 export function ConnectionPill(props: {
   readonly state: ConnectionState;
+  readonly label?: string;
   /** Tapping the pill re-syncs with the desktop (replaces a refresh button). */
   readonly onPress?: () => void;
 }) {
   const { t } = useLingui();
+  const stateLabel = t(CONNECTION_LABELS[props.state]);
   const icon =
     props.state === "online" ? (
       <Wifi className="size-3.5" />
@@ -28,15 +30,14 @@ export function ConnectionPill(props: {
     <button
       className="m-connection"
       data-state={props.state}
+      data-labeled={props.label ? true : undefined}
       type="button"
-      // Icon-only now: the state word is dropped from the header (color carries
-      // the state), but it stays the accessible name so AT still announces
-      // "Live" / "Reconnecting" / "Offline" / "Pair again".
-      aria-label={t(CONNECTION_LABELS[props.state])}
+      aria-label={props.label ? `${props.label}: ${stateLabel}` : stateLabel}
       title={t`Sync with desktop`}
       onClick={props.onPress}
     >
       {icon}
+      {props.label ? <span className="m-connection__label">{props.label}</span> : null}
     </button>
   );
 }

--- a/src/mobile/presentation.ts
+++ b/src/mobile/presentation.ts
@@ -31,6 +31,13 @@ export const THREAD_STATUS_LABELS: Record<ThreadStatus, MessageDescriptor> = {
   error: msg`Error`,
 };
 
+/** "Poracode on host" → "host"; the brand prefix is noise inside the app.
+ *  Legacy "Lightcode on …" labels (paired pre-rebrand) are stripped too. */
+export function desktopTitle(label: string): string {
+  const stripped = label.replace(/^(?:Poracode|Lightcode)\s+on\s+/i, "");
+  return stripped || label;
+}
+
 export function sortThreadsByRecency(threads: readonly Thread[]): Thread[] {
   return threads
     .filter((thread) => !thread.archived)

--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -791,10 +791,8 @@ html[data-theme="dark"][data-theme-preset="default"] .m-shell:not(.m-shell--wide
   font-size: 0.875rem;
 }
 
-/* Icon-only connection/sync affordance. The state word and pill border are
-   gone — color alone carries the state — so it stays small and leaves the
-   thread title room. The glyph is small but the button keeps a full tap
-   target via width/height (transparent, no border). */
+/* Compact connection/sync affordance. The narrow header uses the icon alone;
+   the wide sidebar includes the remote name. */
 .m-connection {
   display: inline-flex;
   flex: none;
@@ -808,6 +806,24 @@ html[data-theme="dark"][data-theme-preset="default"] .m-shell:not(.m-shell--wide
   background: transparent;
   color: var(--muted);
   cursor: pointer;
+}
+
+.m-connection[data-labeled="true"] {
+  min-width: 0;
+  max-width: min(8rem, 35%);
+  gap: 0.25rem;
+  width: auto;
+  margin-right: 0;
+  padding-inline: 0.125rem;
+}
+
+.m-connection__label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 0.6875rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .m-connection svg {

--- a/src/mobile/views/DesktopsView.tsx
+++ b/src/mobile/views/DesktopsView.tsx
@@ -22,6 +22,7 @@ import { InlineRenameInput } from "@/renderer/views/MainView/parts/Sidebar/parts
 import { Fab, EmptyState, FullScreenDrawer, SheetMenu, useSheet } from "../components";
 import { QrScanner } from "../QrScanner";
 import { parsePairingUrl } from "../pairing";
+import { desktopTitle } from "../presentation";
 import { isNativeApp, isStandaloneDisplay, promptInstall, useCanInstall } from "../pwaInstall";
 import type { StoredDesktop } from "../storage";
 
@@ -79,13 +80,6 @@ export interface MobileSshPairRequest {
   readonly port: number;
   readonly fingerprint: string;
   readonly authentication: SshBridgeAuthentication;
-}
-
-/** "Poracode on host" → "host"; the brand prefix is noise inside the app.
- *  Legacy "Lightcode on …" labels (paired pre-rebrand) are stripped too. */
-function desktopTitle(label: string): string {
-  const stripped = label.replace(/^(?:Poracode|Lightcode)\s+on\s+/i, "");
-  return stripped || label;
 }
 
 /** "http://172.16.21.25:49152/" → "172.16.21.25:49152". */


### PR DESCRIPTION
- **Feature:** display the paired desktop name alongside its connection state in the wide mobile sidebar for clearer context.
- Keep narrow headers compact while preserving accessible connection-status labels.
- Reuse normalized desktop titles across the sidebar and desktop views, including legacy Lightcode labels.
- Add coverage for the online wide-sidebar connection indicator.