### PR TITLE
Clean up experiment worktrees when removing projects

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -427,7 +427,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/main/app-controls/ingressDeps.ts
+++ b/src/main/app-controls/ingressDeps.ts
@@ -17,7 +17,7 @@ import {
   dbUpsertProject,
   dbUpsertThread,
 } from "@/main/db";
-import { hasPersistedProjectExperiment } from "@/main/remote/experimentOwnership";
+import { discardPersistedProjectExperiments } from "@/main/remote/experimentOwnership";
 import { applyRemoteProjectCommand } from "@/main/remote/projectCommands";
 import { sortOrderForThread } from "@/main/remote/server/snapshots";
 import { ensureHomeProjectRow } from "@/main/schedules";
@@ -73,7 +73,10 @@ export function buildSharedAppControlsIngressDeps(
     applyProjectCommand: async (command) => {
       const result = await applyRemoteProjectCommand(command, {
         getProjects: dbGetProjects,
-        hasProjectExperiment: (projectId) => hasPersistedProjectExperiment(projectId),
+        removeProjectExperiments: (project) =>
+          discardPersistedProjectExperiments(project, (payload) =>
+            call("removeExperimentWorktrees", payload),
+          ),
         hasRunningProjectThread: (projectId) =>
           dbGetThreads().some(
             (thread) => thread.projectId === projectId && thread.status === "working",

--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -3476,13 +3476,25 @@ describe("RemoteAccessServer", () => {
     ws.close();
   });
 
-  it("rejects remote removal of a project with durable experiment ownership", async () => {
+  it("removes durable experiments before remotely removing their project", async () => {
     const project = createTestProject();
-    vi.mocked(dbGetProjects).mockReturnValue([project]);
+    let projects = [project];
+    vi.mocked(dbGetProjects).mockImplementation(() => projects);
+    vi.mocked(dbDeleteProject).mockImplementation((projectId) => {
+      projects = projects.filter((candidate) => candidate.id !== projectId);
+    });
     vi.mocked(dbGetThreads).mockReturnValue([createTestThread()]);
     persistTestExperiment();
     const callSupervisor = vi.fn<RemoteAccessServerOptions["callSupervisor"]>(
-      async () => undefined as never,
+      async (name) =>
+        (name === "removeExperimentWorktrees"
+          ? {
+              candidates: [
+                { threadId: "thread-1", branch: "poracode/experiment-one" },
+                { threadId: "thread-2", branch: "poracode/experiment-two" },
+              ],
+            }
+          : undefined) as never,
     );
     const server = new RemoteAccessServer({
       appVersion: "1.0.0",
@@ -3503,12 +3515,21 @@ describe("RemoteAccessServer", () => {
       body: JSON.stringify({ kind: "remove", projectId: project.id }),
     });
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
-      error: { code: "experiment_owned" },
+      projects: [],
     });
-    expect(callSupervisor).not.toHaveBeenCalled();
-    expect(dbDeleteProject).not.toHaveBeenCalled();
+    expect(callSupervisor).toHaveBeenNthCalledWith(
+      1,
+      "removeExperimentWorktrees",
+      expect.objectContaining({ projectLocation: project.location }),
+    );
+    expect(callSupervisor).toHaveBeenCalledWith("closeThread", { threadId: "thread-1" });
+    expect(dbDeleteProject).toHaveBeenCalledWith(project.id);
+    const persisted = JSON.parse(
+      vi.mocked(dbSetState).mock.calls.findLast(([key]) => key === "poracode-experiments-v1")![1],
+    ) as { state: { experiments: Record<string, unknown> } };
+    expect(persisted.state.experiments).toEqual({});
   });
 
   it("serves browser state/commands and streams mirror status to watchers", async () => {

--- a/src/main/remote/experimentOwnership.ts
+++ b/src/main/remote/experimentOwnership.ts
@@ -8,6 +8,8 @@ import type {
   GitSwitchBranchPayload,
   Project,
   ProjectLocation,
+  RemoveExperimentWorktreesPayload,
+  RemoveExperimentWorktreesResult,
   RemoteThreadCommand,
 } from "@/shared/contracts";
 import {
@@ -17,7 +19,7 @@ import {
 } from "@/shared/contracts";
 import { toWslUncPath } from "@/shared/wsl";
 import { buildWorktreeLocation } from "@/shared/worktree";
-import { dbGetProjects, dbGetState, dbGetThreads } from "../db";
+import { dbGetProjects, dbGetState, dbGetThreads, dbSetState } from "../db";
 import { RemoteHttpError } from "./auth";
 
 function unavailable(): never {
@@ -67,8 +69,45 @@ export function readPersistedExperiments(): Experiment[] {
   }
 }
 
-export function hasPersistedProjectExperiment(projectId: string): boolean {
-  return readPersistedExperiments().some((experiment) => experiment.projectId === projectId);
+export async function discardPersistedProjectExperiments(
+  project: Project,
+  removeWorktrees: (
+    payload: RemoveExperimentWorktreesPayload,
+  ) => Promise<RemoveExperimentWorktreesResult>,
+): Promise<void> {
+  const projectExperiments = readPersistedExperiments().filter(
+    (experiment) => experiment.projectId === project.id,
+  );
+  for (const experiment of projectExperiments) {
+    const candidates = experiment.candidates.filter(
+      (candidate) => candidate.worktreeState !== "removed",
+    );
+    if (candidates.length === 0) continue;
+    const result = await removeWorktrees({
+      projectLocation: project.location,
+      candidates: candidates.map((candidate) => ({
+        threadId: candidate.threadId,
+        branch: candidate.worktreeBranch,
+        ownerToken: candidate.worktreeOwnerToken,
+        ...(candidate.worktreePath ? { worktreePath: candidate.worktreePath } : {}),
+      })),
+    });
+    const failure = result.candidates.find((candidate) => candidate.error);
+    if (failure?.error) throw new Error(failure.error);
+  }
+
+  const experiments = Object.fromEntries(
+    readPersistedExperiments()
+      .filter((experiment) => experiment.projectId !== project.id)
+      .map((experiment) => [experiment.id, experiment]),
+  );
+  dbSetState(
+    EXPERIMENT_STORE_KEY,
+    JSON.stringify({
+      state: { experiments },
+      version: EXPERIMENT_STORE_VERSION,
+    }),
+  );
 }
 
 export function assertRemoteThreadCommandExperimentSafe(command: RemoteThreadCommand): void {

--- a/src/main/remote/projectCommands.test.ts
+++ b/src/main/remote/projectCommands.test.ts
@@ -19,7 +19,9 @@ function makeDeps(overrides?: Partial<RemoteProjectCommandDeps>) {
   });
   const deps: RemoteProjectCommandDeps = {
     getProjects: () => [...projects],
-    hasProjectExperiment: () => false,
+    removeProjectExperiments: vi.fn<RemoteProjectCommandDeps["removeProjectExperiments"]>(
+      async () => {},
+    ),
     hasRunningProjectThread: () => false,
     listProjectThreadIds: () => [],
     upsertProject,
@@ -228,11 +230,47 @@ describe("applyRemoteProjectCommand", () => {
     ).rejects.toMatchObject({ status: 404, code: "project_not_found" });
   });
 
-  it("rejects removing a project that owns an experiment before closing threads", async () => {
+  it("removes a project's experiments before closing threads and deleting the project", async () => {
+    const calls: string[] = [];
+    const closeThread = vi.fn<RemoteProjectCommandDeps["closeThread"]>(async () => {
+      calls.push("close-thread");
+    });
+    const removeProjectExperiments = vi.fn<RemoteProjectCommandDeps["removeProjectExperiments"]>(
+      async () => {
+        calls.push("remove-experiments");
+      },
+    );
+    const { deps, projects, deleteProject } = makeDeps({
+      closeThread,
+      removeProjectExperiments,
+      listProjectThreadIds: () => ["t1"],
+    });
+    deleteProject.mockImplementation((id) => {
+      calls.push("delete-project");
+      const index = projects.findIndex((project) => project.id === id);
+      if (index !== -1) projects.splice(index, 1);
+    });
+    projects.push({
+      id: "p1",
+      name: "x",
+      location: { kind: "posix", path: "/x" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    await expect(
+      applyRemoteProjectCommand({ kind: "remove", projectId: "p1" }, deps),
+    ).resolves.toMatchObject({ projects: [] });
+    expect(removeProjectExperiments).toHaveBeenCalledWith(expect.objectContaining({ id: "p1" }));
+    expect(calls).toEqual(["remove-experiments", "close-thread", "delete-project"]);
+  });
+
+  it("keeps the project when experiment cleanup fails", async () => {
     const closeThread = vi.fn<RemoteProjectCommandDeps["closeThread"]>(async () => {});
     const { deps, projects, deleteProject } = makeDeps({
       closeThread,
-      hasProjectExperiment: (projectId) => projectId === "p1",
+      removeProjectExperiments: async () => {
+        throw new Error("cleanup failed");
+      },
       listProjectThreadIds: () => ["t1"],
     });
     projects.push({
@@ -244,7 +282,7 @@ describe("applyRemoteProjectCommand", () => {
 
     await expect(
       applyRemoteProjectCommand({ kind: "remove", projectId: "p1" }, deps),
-    ).rejects.toMatchObject({ status: 409, code: "experiment_owned" });
+    ).rejects.toThrow("cleanup failed");
     expect(closeThread).not.toHaveBeenCalled();
     expect(deleteProject).not.toHaveBeenCalled();
     expect(projects).toHaveLength(1);

--- a/src/main/remote/projectCommands.ts
+++ b/src/main/remote/projectCommands.ts
@@ -17,7 +17,7 @@ import { RemoteHttpError } from "./auth";
  */
 export interface RemoteProjectCommandDeps {
   getProjects(): Project[];
-  hasProjectExperiment(projectId: string): boolean;
+  removeProjectExperiments(project: Project): Promise<void>;
   hasRunningProjectThread(projectId: string): boolean;
   /** Thread ids belonging to a project, closed best-effort before removal. */
   listProjectThreadIds(projectId: string): readonly string[];
@@ -246,13 +246,11 @@ export async function applyRemoteProjectCommand(
       };
     }
     case "remove": {
-      const exists = deps.getProjects().some((project) => project.id === command.projectId);
-      if (!exists) {
+      const project = deps.getProjects().find((candidate) => candidate.id === command.projectId);
+      if (!project) {
         throw new RemoteHttpError("project_not_found", msg("remote.project.notFound"), 404);
       }
-      if (deps.hasProjectExperiment(command.projectId)) {
-        throw new RemoteHttpError("experiment_owned", msg("remote.project.experimentsOwned"), 409);
-      }
+      await deps.removeProjectExperiments(project);
       // Tear down running sessions before the cascade drops their rows.
       for (const threadId of deps.listProjectThreadIds(command.projectId)) {
         await deps.closeThread(threadId).catch(() => undefined);

--- a/src/main/remote/server/threadCommands.ts
+++ b/src/main/remote/server/threadCommands.ts
@@ -31,7 +31,7 @@ import { buildWorktreeLocation } from "@/shared/worktree";
 import { makeThreadTitle, titlePromptFromSegments } from "@/shared/threadTitle";
 import {
   assertRemoteGitMutationExperimentSafe,
-  hasPersistedProjectExperiment,
+  discardPersistedProjectExperiments,
 } from "../experimentOwnership";
 import { applyRemoteProjectCommand } from "../projectCommands";
 import type { RemoteServerContext } from "./context";
@@ -83,7 +83,10 @@ export function runProjectCommand(
 ): Promise<RemoteProjectCommandResult> {
   return applyRemoteProjectCommand(command, {
     getProjects: () => dbGetProjects(),
-    hasProjectExperiment: (projectId) => hasPersistedProjectExperiment(projectId),
+    removeProjectExperiments: (project) =>
+      discardPersistedProjectExperiments(project, (payload) =>
+        ctx.options.callSupervisor("removeExperimentWorktrees", payload),
+      ),
     hasRunningProjectThread: (projectId) =>
       dbGetThreads().some(
         (thread) => thread.projectId === projectId && thread.status === "working",

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -836,6 +836,23 @@ describe("App", () => {
     });
 
     expect(useAppStore.getState().projects).toEqual([project]);
+    act(() => {
+      useExperimentStore.setState({
+        experiments: {
+          "experiment-1": {
+            id: "experiment-1",
+            projectId: project.id,
+          } as never,
+        },
+      });
+    });
+    expect(useExperimentStore.getState().experiments).toHaveProperty("experiment-1");
+
+    act(() => {
+      projectStateChangedListeners.at(-1)?.({ projects: [] });
+    });
+
+    expect(useExperimentStore.getState().experiments).toEqual({});
   });
 
   it("creates and queues the thread submitted by the quick composer", async () => {

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -18,6 +18,7 @@ import {
 } from "./notifications";
 
 import { useAppStore } from "./state/appStore";
+import { useExperimentStore } from "./state/experimentStore";
 import { useGitReadModelStore } from "./state/gitReadModelStore";
 import {
   acknowledgeThread,
@@ -429,6 +430,9 @@ const mainWindowCleanups: Array<() => void> = isMainWindow
       // before its next dbSyncAll persistence write.
       readBridge().onProjectStateChanged(({ projects }) => {
         useAppStore.setState({ projects });
+        useExperimentStore
+          .getState()
+          .reconcileExperiments(new Set(projects.map((project) => project.id)));
       }),
       readBridge().onGitStateChanged((patch) => {
         useGitReadModelStore.getState().applyPatch(patch);


### PR DESCRIPTION
- **Bugfix:** remove durable experiment worktrees and persisted experiment state before deleting a project.
- Preserve projects and their threads when experiment cleanup fails.
- Reconcile renderer experiment state after project updates to remove orphaned experiments.
- Add remote command and renderer coverage for project removal cleanup.