### PR TITLE
Keep remote thread and git state consistent

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -427,7 +427,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -36,7 +36,7 @@ import {
   writeImageFile,
 } from "../attachments/localFiles";
 import { createProjectDirectory } from "../projectDirectory";
-import { diffSyncedThreads } from "./threadSyncBroadcast";
+import { diffSyncedThreads, syncedProjectsChanged } from "./threadSyncBroadcast";
 import { showOsNotification } from "../osNotifications";
 import { showAndFocusWindow } from "../window/showAndFocusWindow";
 import {
@@ -53,7 +53,11 @@ import {
   readSharedSettingsFile,
   writeSharedSettingsFile,
 } from "../sharedSettingsFile";
-import type { RemoteAccessPairingInfo, RemoteGitSummaries } from "@/shared/remote";
+import {
+  remoteProjectSchema,
+  type RemoteAccessPairingInfo,
+  type RemoteGitSummaries,
+} from "@/shared/remote";
 import { readKeybindingsFile, writeKeybindingsFile } from "../keybindingsFile";
 import type { KeybindingsFile } from "@/shared/keybindings";
 import type { RemoteAccessServer } from "../remote";
@@ -172,6 +176,25 @@ export async function showAddFilesDialog(
 export function createLocalIpcHandlers(
   options: CreateLocalIpcHandlersOptions,
 ): MainLocalIpcHandlerMap {
+  const publishProjectsChanged = (projects = dbGetProjects()): void => {
+    const server = options.getRemoteAccessServer();
+    if (!server) return;
+    server.publishSupervisorEvent({
+      type: "remote-projects-changed",
+      projects: projects.map((project) => remoteProjectSchema.parse(project)),
+    });
+  };
+  const publishThreadsChanged = (
+    threadIds: readonly string[],
+    viewedThreadIds: readonly string[] = [],
+  ): void => {
+    if (threadIds.length === 0) return;
+    options.getRemoteAccessServer()?.publishSupervisorEvent({
+      type: "remote-threads-changed",
+      threadIds: [...new Set(threadIds)],
+      ...(viewedThreadIds.length > 0 ? { viewedThreadIds: [...new Set(viewedThreadIds)] } : {}),
+    });
+  };
   return defineMainLocalIpcHandlers({
     pickFolder: async (defaultPath) => {
       const result = await dialog.showOpenDialog(options.getMainWindow()!, {
@@ -415,32 +438,43 @@ export function createLocalIpcHandlers(
     dbGetThreads: () => dbGetThreads(),
     dbGetState: (key) => dbGetState(key),
     dbSetState: ({ key, value }) => dbSetState(key, value),
-    dbUpsertProject: (project) => dbUpsertProject(project, 0),
-    dbUpsertThread: (thread) => dbUpsertThread(thread, 0),
+    dbUpsertProject: (project) => {
+      dbUpsertProject(project, 0);
+      publishProjectsChanged();
+    },
+    dbUpsertThread: (thread) => {
+      dbUpsertThread(thread, 0);
+      publishThreadsChanged([thread.id]);
+    },
     dbDeleteThread: ({ threadId }) => {
       dbDeleteThread(threadId);
       deleteThreadAttachments(options.requirePoracodePaths(), threadId);
+      publishThreadsChanged([threadId]);
     },
-    dbDeleteProject: ({ projectId }) => dbDeleteProject(projectId),
+    dbDeleteProject: ({ projectId }) => {
+      const threadIds = dbGetThreads()
+        .filter((thread) => thread.projectId === projectId)
+        .map((thread) => thread.id);
+      dbDeleteProject(projectId);
+      publishProjectsChanged();
+      publishThreadsChanged(threadIds);
+    },
     dbSyncAll: ({ projects, threads, viewJson }) => {
-      // Desktop-originated thread changes (auto-title, rename, done/star,
-      // archive, status, delete) reach SQLite only through this persist — they
-      // emit no supervisor event, so remote clients never learned about them.
-      // Diff before writing, then publish the same event remote-issued thread
-      // commands send; the remote's debounced refresh reads the post-write
-      // state.
+      // Desktop-originated project and thread changes reach SQLite only through
+      // this persist. Diff before writing, then publish the same events remote
+      // commands send; the remote's debounced refresh reads the post-write state.
+      const projectsChanged = syncedProjectsChanged(dbGetProjects(), projects);
       const { changedThreadIds, viewedThreadIds } = diffSyncedThreads(dbGetThreads(), threads);
       dbSyncAll(projects, threads, viewJson);
-      if (changedThreadIds.length > 0) {
-        options.getRemoteAccessServer()?.publishSupervisorEvent({
-          type: "remote-threads-changed",
-          threadIds: changedThreadIds,
-          ...(viewedThreadIds.length > 0 ? { viewedThreadIds } : {}),
-        });
-      }
+      if (projectsChanged) publishProjectsChanged(projects);
+      publishThreadsChanged(changedThreadIds, viewedThreadIds);
     },
     dbPersistExperimentState: async (payload) => {
       dbPersistExperimentState(payload);
+      publishThreadsChanged([
+        ...payload.upsertThreads.map(({ thread }) => thread.id),
+        ...payload.deletedThreadIds,
+      ]);
       const paths = options.requirePoracodePaths();
       await Promise.all(
         payload.deletedThreadIds.map((threadId) => deleteThreadAttachmentsAsync(paths, threadId)),

--- a/src/main/ipc/threadSyncBroadcast.test.ts
+++ b/src/main/ipc/threadSyncBroadcast.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
-import type { Thread } from "@/shared/contracts";
-import { diffSyncedThreadIds, diffSyncedThreads } from "./threadSyncBroadcast";
+import type { Project, Thread } from "@/shared/contracts";
+import {
+  diffSyncedThreadIds,
+  diffSyncedThreads,
+  syncedProjectsChanged,
+} from "./threadSyncBroadcast";
+
+const project: Project = {
+  id: "project-1",
+  name: "Test project",
+  location: { kind: "windows", path: "C:\\test" },
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
 
 function testThread(overrides: Partial<Thread> = {}): Thread {
   return {
@@ -81,5 +92,39 @@ describe("diffSyncedThreadIds", () => {
       changedThreadIds: ["thread-1", "thread-2", "thread-3"],
       viewedThreadIds: ["thread-1"],
     });
+  });
+});
+
+describe("syncedProjectsChanged", () => {
+  it("detects added, removed, reordered, and edited projects", () => {
+    const second = { ...project, id: "project-2", name: "Second project" };
+
+    expect(syncedProjectsChanged([project], [project, second])).toBe(true);
+    expect(syncedProjectsChanged([project, second], [project])).toBe(true);
+    expect(syncedProjectsChanged([project, second], [second, project])).toBe(true);
+    expect(syncedProjectsChanged([project], [{ ...project, name: "Renamed" }])).toBe(true);
+  });
+
+  it("ignores secret project MCP settings that remote snapshots omit", () => {
+    expect(
+      syncedProjectsChanged(
+        [project],
+        [
+          {
+            ...project,
+            mcpServers: [
+              {
+                id: "private-id",
+                name: "private",
+                description: "Private server",
+                enabled: true,
+                timeoutMs: 30_000,
+                transport: { type: "stdio", command: "secret", args: [], env: {} },
+              },
+            ],
+          },
+        ],
+      ),
+    ).toBe(false);
   });
 });

--- a/src/main/ipc/threadSyncBroadcast.ts
+++ b/src/main/ipc/threadSyncBroadcast.ts
@@ -1,4 +1,15 @@
-import type { Thread } from "@/shared/contracts";
+import type { Project, Thread } from "@/shared/contracts";
+import { remoteProjectSchema } from "@/shared/remote";
+
+export function syncedProjectsChanged(
+  before: readonly Project[],
+  after: readonly Project[],
+): boolean {
+  return (
+    JSON.stringify(before.map((project) => remoteProjectSchema.parse(project))) !==
+    JSON.stringify(after.map((project) => remoteProjectSchema.parse(project)))
+  );
+}
 
 /**
  * Diff the renderer's persisted thread list against the rows currently in

--- a/src/mobile/browserMirror.test.ts
+++ b/src/mobile/browserMirror.test.ts
@@ -55,4 +55,16 @@ describe("browserMirror watch lifecycle", () => {
     setBrowserSocketSender(b.fn);
     expect(b.messages).toEqual([{ type: "browser-watch" }]);
   });
+
+  it("drops a stale frame when the authoritative state removes its tab", () => {
+    useBrowserMirrorStore.getState().setFrame({
+      tabId: "tab-1",
+      dataUrl: "data:image/jpeg;base64,frame",
+      metadata: {} as never,
+    });
+
+    useBrowserMirrorStore.getState().setState({ tabs: [], activeTabId: null });
+
+    expect(useBrowserMirrorStore.getState().frame).toBeNull();
+  });
 });

--- a/src/mobile/browserMirror.ts
+++ b/src/mobile/browserMirror.ts
@@ -49,7 +49,10 @@ export const useBrowserMirrorStore = create<BrowserMirrorStore>()((set) => ({
   // The reused desktop components (BrowserTabStrip, …) read tab state from
   // the renderer's browser panel store, so mirror it on every update.
   setState: (state) => {
-    set({ state });
+    set((current) => ({
+      state,
+      ...(current.frame?.tabId === state.activeTabId ? {} : { frame: null }),
+    }));
     useBrowserPanelStore.getState().setState(state);
   },
   setFrame: (frame) => set({ frame }),

--- a/src/mobile/storeSync.applyShellSnapshot.test.tsx
+++ b/src/mobile/storeSync.applyShellSnapshot.test.tsx
@@ -169,6 +169,34 @@ describe("applyShellSnapshot", () => {
     expect(after[1]).toBe(before[1]);
   });
 
+  it("closes an open thread pane when the authoritative snapshot removes it", () => {
+    useAppStore.setState({ threads: [makeThread("idle")] });
+    useAppStore.getState().openThread(THREAD_ID);
+
+    applyShellSnapshot(makeShellSnapshot([]));
+
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(useAppStore.getState().view).toEqual({ kind: "home" });
+  });
+
+  it("closes an open project draft when the authoritative snapshot removes it", () => {
+    const project = {
+      id: "proj-1",
+      name: "Demo",
+      location: { kind: "windows" as const, path: "C:\\demo" },
+      createdAt: "2026-03-21T10:00:00.000Z",
+    };
+    useAppStore.setState({
+      projects: [project],
+      view: { kind: "draft", projectId: project.id },
+    });
+
+    applyShellSnapshot(makeShellSnapshot([]));
+
+    expect(useAppStore.getState().projects).toEqual([]);
+    expect(useAppStore.getState().view).toEqual({ kind: "home" });
+  });
+
   it("hydrates the host-owned Git read model from the shell snapshot", () => {
     applyShellSnapshot({
       ...makeShellSnapshot([]),

--- a/src/mobile/storeSync.applyThreadSnapshot.test.tsx
+++ b/src/mobile/storeSync.applyThreadSnapshot.test.tsx
@@ -411,7 +411,10 @@ describe("applyThreadSnapshot", () => {
   });
 
   it("keeps a settled GUI thread idle when a trailing runtime event arrives after a server snapshot", () => {
-    useAppStore.setState({ threads: [makeThread("idle")] });
+    useAppStore.setState({
+      threads: [makeThread("idle")],
+      view: { kind: "thread", panes: [THREAD_ID] },
+    });
 
     applyThreadSnapshot(makeSnapshot({ status: "idle", items: [makeItem({ id: "msg-1" })] }));
 

--- a/src/mobile/storeSync.resetRemoteStores.test.tsx
+++ b/src/mobile/storeSync.resetRemoteStores.test.tsx
@@ -26,6 +26,7 @@ describe("resetRemoteStores", () => {
     useAppStore.setState({
       projects: [{ id: "p" } as never],
       threads: [{ id: tid } as never],
+      view: { kind: "thread", panes: [tid] },
       // A representative of the maps reset already cleared…
       runtimeStructuralVersionByThread: { [tid]: 3 },
       // …plus the four it used to leak across desktop switches (stale "running"
@@ -97,6 +98,7 @@ describe("resetRemoteStores", () => {
     const s = useAppStore.getState();
     expect(s.projects).toHaveLength(0);
     expect(s.threads).toHaveLength(0);
+    expect(s.view).toEqual({ kind: "home" });
     expect(s.runtimeStructuralVersionByThread).toEqual({});
     expect(s.runtimeOpenTurnByThread).toEqual({});
     expect(s.fileCheckpointsByThread).toEqual({});

--- a/src/mobile/storeSync.ts
+++ b/src/mobile/storeSync.ts
@@ -61,6 +61,14 @@ function reuseSnapshotRows<T extends { readonly id: string }>(current: T[], inco
 }
 
 export function applyShellSnapshot(snapshot: RemoteShellSnapshot): void {
+  const projectIds = new Set(snapshot.projects.map((project) => project.id));
+  for (const project of useAppStore.getState().projects) {
+    if (!projectIds.has(project.id)) useAppStore.getState().deleteProject(project.id);
+  }
+  const threadIds = new Set(snapshot.threads.map((thread) => thread.id));
+  for (const thread of useAppStore.getState().threads) {
+    if (!threadIds.has(thread.id)) useAppStore.getState().deleteThread(thread.id);
+  }
   useAppStore.setState((current) => {
     const currentById = new Map(current.threads.map((thread) => [thread.id, thread]));
     // "finished" is a client-side derivation (an unwatched turn completed —
@@ -115,6 +123,7 @@ export function resetRemoteStores(): void {
   useAppStore.setState({
     projects: [],
     threads: [],
+    view: { kind: "home" },
     // Spread the slices' own initial state so every per-thread runtime map is
     // cleared — a hand-listed subset here previously leaked runtimeOpenTurn,
     // fileCheckpoint(s|Turns) and openSubAgent maps across desktop switches

--- a/src/renderer/actions/gitActions.test.ts
+++ b/src/renderer/actions/gitActions.test.ts
@@ -61,8 +61,8 @@ vi.mock("@/renderer/utils/shellUtils", () => ({
 }));
 vi.mock("./gitCommandRunner", () => runnerMock);
 vi.mock("./worktreeActions", () => ({
-  performWorktreeRemoval:
-    vi.fn<(project: Project, path: string, branch: string) => Promise<void>>(),
+  deleteWorktreeGroup:
+    vi.fn<(projectId: string, worktreePath: string, threadIds: string[]) => void>(),
 }));
 
 import { gitPullFromSource } from "./gitActions";

--- a/src/renderer/actions/gitActions.ts
+++ b/src/renderer/actions/gitActions.ts
@@ -7,7 +7,6 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { usePullFromSourceDialogStore } from "@/renderer/state/pullFromSourceDialogStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
-import { closeThreads } from "@/renderer/utils/shellUtils";
 import {
   runGitMergeToSource,
   runGitPullFromSource,
@@ -16,7 +15,7 @@ import {
   showGitActionError,
   showGitOperationFailure,
 } from "./gitCommandRunner";
-import { performWorktreeRemoval } from "./worktreeActions";
+import { deleteWorktreeGroup } from "./worktreeActions";
 
 function captureGitActionError(error: unknown): void {
   showGitActionError(error, { capture: true });
@@ -151,12 +150,11 @@ export function gitMergeAndRemove(projectId: string, worktreePath: string): void
       if (!result.merged) return;
       const allThreads = useAppStore.getState().threads;
       const siblings = allThreads.filter((t) => t.worktreePath === worktreePath);
-      const deleteThread = useAppStore.getState().deleteThread;
-      for (const sib of siblings) {
-        deleteThread(sib.id);
-      }
-      await closeThreads(siblings.map((sib) => sib.id));
-      await performWorktreeRemoval(project, worktreePath, worktreeBranch);
+      deleteWorktreeGroup(
+        projectId,
+        worktreePath,
+        siblings.map((sibling) => sibling.id),
+      );
     } catch (error) {
       captureGitActionError(error);
       // ignored — user can open git review for details

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -26,8 +26,9 @@ const { hasHydratedThreadRuntimeItems, hydrateThreadRuntimeItems } = vi.hoisted(
   hasHydratedThreadRuntimeItems: vi.fn<(threadId: string) => boolean>().mockReturnValue(false),
   hydrateThreadRuntimeItems: vi.fn<(threadId: string) => Promise<void>>().mockResolvedValue(),
 }));
-const { performWorktreeRemoval } = vi.hoisted(() => ({
-  performWorktreeRemoval: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+const { deleteWorktreeGroup } = vi.hoisted(() => ({
+  deleteWorktreeGroup:
+    vi.fn<(projectId: string, worktreePath: string, threadIds: string[]) => void>(),
 }));
 
 vi.mock("@/renderer/bridge", () => ({
@@ -35,7 +36,7 @@ vi.mock("@/renderer/bridge", () => ({
 }));
 
 vi.mock("@/renderer/actions/worktreeActions", () => ({
-  performWorktreeRemoval,
+  deleteWorktreeGroup,
 }));
 
 vi.mock("@/renderer/state/chatRuntimePersister", () => ({
@@ -49,7 +50,7 @@ describe("threadActions", () => {
     localStorage.clear();
     hasHydratedThreadRuntimeItems.mockReturnValue(false);
     hydrateThreadRuntimeItems.mockResolvedValue(undefined);
-    performWorktreeRemoval.mockResolvedValue(undefined);
+    deleteWorktreeGroup.mockReset();
     useAppStore.setState((state) => ({
       ...state,
       projects: [],
@@ -381,12 +382,7 @@ describe("threadActions", () => {
     });
   });
 
-  it("waits for the thread to close before removing the worktree", async () => {
-    let resolveClose: () => void = () => undefined;
-    const closePromise = new Promise<void>((resolve) => {
-      resolveClose = resolve;
-    });
-    bridge.closeThread.mockReturnValueOnce(closePromise);
+  it("routes local worktree deletion through the group action", () => {
     localStorage.setItem("poracode-delete-worktree-pref", "thread-and-worktree");
     const worktreePath = "/repo/.worktrees/feature";
     const project = useAppStore.getState().addProject({
@@ -402,20 +398,35 @@ describe("threadActions", () => {
 
     deleteThread(thread.id, worktreePath, project.id);
 
-    expect(useAppStore.getState().threads).toHaveLength(0);
-    expect(bridge.closeThread).toHaveBeenCalledTimes(1);
-    expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: thread.id });
-    expect(performWorktreeRemoval).not.toHaveBeenCalled();
+    expect(deleteWorktreeGroup).toHaveBeenCalledWith(project.id, worktreePath, [thread.id]);
+    expect(bridge.closeThread).not.toHaveBeenCalled();
+  });
 
-    resolveClose();
-
-    await waitFor(() => {
-      expect(performWorktreeRemoval).toHaveBeenCalledWith(
-        project,
-        worktreePath,
-        "poracode/feature",
-      );
+  it("routes remote worktree deletion through the remote-aware group action", () => {
+    localStorage.setItem("poracode-delete-worktree-pref", "thread-and-worktree");
+    const worktreePath = "/repo/.worktrees/feature";
+    const localProject = useAppStore.getState().addProject({
+      kind: "posix",
+      path: "/repo",
     });
+    const project = {
+      ...localProject,
+      remoteServerId: "remote-server",
+      remoteId: "remote-project",
+    };
+    const thread = makeThread({
+      projectId: project.id,
+      worktreePath,
+      worktreeBranch: "poracode/feature",
+      remoteServerId: project.remoteServerId,
+      remoteId: "remote-thread",
+    });
+    useAppStore.setState((state) => ({ ...state, projects: [project], threads: [thread] }));
+
+    deleteThread(thread.id, worktreePath, project.id);
+
+    expect(deleteWorktreeGroup).toHaveBeenCalledWith(project.id, worktreePath, [thread.id]);
+    expect(bridge.closeThread).not.toHaveBeenCalled();
   });
 
   it("closes worktree dev terminals when marking a worktree thread done", () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -21,7 +21,7 @@ import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads } from "@/renderer/utils/shellUtils";
 import { closePanelsForUnloadedThread } from "./panelActions";
 import { getCurrentProjectId } from "./currentProject";
-import { performWorktreeRemoval } from "./worktreeActions";
+import { deleteWorktreeGroup } from "./worktreeActions";
 
 let openThreadRequestId = 0;
 
@@ -530,16 +530,12 @@ export function deleteThread(threadId: string, worktreePath?: string, projectId?
   }
 
   if (pref === "thread-and-worktree") {
-    const thread = allThreads.find((t) => t.id === threadId);
-    useAppStore.getState().deleteThread(threadId);
-
     const project = useAppStore.getState().projects.find((p) => p.id === projectId);
     if (project) {
-      void (async () => {
-        await closeThreads([threadId]);
-        await performWorktreeRemoval(project, worktreePath, thread?.worktreeBranch);
-      })();
+      deleteWorktreeGroup(project.id, worktreePath, [threadId]);
+      return;
     }
+    useAppStore.getState().deleteThread(threadId);
     return;
   }
 

--- a/src/renderer/actions/worktreeActions.ts
+++ b/src/renderer/actions/worktreeActions.ts
@@ -11,6 +11,7 @@ import { findExperimentByThreadId } from "@/renderer/state/experimentStore";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads, runShellScriptToCompletion } from "@/renderer/utils/shellUtils";
@@ -128,14 +129,36 @@ export function deleteWorktreeGroup(
   threadIds: string[],
 ): void {
   if (threadIds.some((threadId) => findExperimentByThreadId(threadId))) return;
-  const project = useAppStore.getState().projects.find((p) => p.id === projectId);
+  const app = useAppStore.getState();
+  const project = app.projects.find((p) => p.id === projectId);
   if (!project) return;
 
-  const sampleThread = useAppStore
-    .getState()
-    .threads.find((t) => threadIds.includes(t.id) && t.worktreeBranch);
+  const threadIdSet = new Set(threadIds);
+  const groupThreads = app.threads.filter((thread) => threadIdSet.has(thread.id));
+  const sampleThread = groupThreads.find((thread) => thread.worktreeBranch);
 
-  const deleteThread = useAppStore.getState().deleteThread;
+  const deleteThread = app.deleteThread;
+  if (project.remoteServerId && project.remoteId) {
+    const remoteThreadIds = groupThreads
+      .filter((thread) => thread.remoteServerId === project.remoteServerId && thread.remoteId)
+      .map((thread) => thread.remoteId!);
+    if (remoteThreadIds.length !== threadIds.length) return;
+    for (const threadId of threadIds) deleteThread(threadId);
+    void useRemoteServersStore
+      .getState()
+      .sendThreadCommand(project.remoteServerId, {
+        kind: "delete-worktree-group",
+        threadId: remoteThreadIds[0]!,
+        projectId: project.remoteId,
+        worktreePath,
+        threadIds: remoteThreadIds,
+      })
+      .catch((error) => {
+        toast.danger(errorDetail(error) || i18n._(msg`Unable to remove worktree.`));
+        void useRemoteServersStore.getState().refreshServer(project.remoteServerId!);
+      });
+    return;
+  }
   for (const threadId of threadIds) {
     deleteThread(threadId);
   }

--- a/src/renderer/state/remoteServers/eventRouting.ts
+++ b/src/renderer/state/remoteServers/eventRouting.ts
@@ -4,11 +4,10 @@ export function shouldRefreshRemoteServerAfterEvent(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const type = (value as { type?: unknown }).type;
   return (
+    shouldRefreshRemoteAgentStatusesAfterEvent(value) ||
     type === "thread-state" ||
     type === "thread-exited" ||
     type === "thread-reset" ||
-    type === "windows-agent-statuses" ||
-    type === "wsl-agent-statuses" ||
     type === "remote-projects-changed" ||
     type === "remote-threads-changed"
   );
@@ -17,7 +16,11 @@ export function shouldRefreshRemoteServerAfterEvent(value: unknown): boolean {
 export function shouldRefreshRemoteAgentStatusesAfterEvent(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const type = (value as { type?: unknown }).type;
-  return type === "windows-agent-statuses" || type === "wsl-agent-statuses";
+  return (
+    type === "agent-status-updated" ||
+    type === "windows-agent-statuses" ||
+    type === "wsl-agent-statuses"
+  );
 }
 
 export function filterRemoteThreadEvents(value: unknown, threadIds: ReadonlySet<string>): unknown {
@@ -51,6 +54,8 @@ export function filterRemoteThreadEvents(value: unknown, threadIds: ReadonlySet<
     const threadId = (value as { threadId?: unknown }).threadId;
     return typeof threadId === "string" && threadIds.has(threadId) ? value : null;
   }
+
+  if (type === "remote-git-summaries") return value;
 
   return null;
 }

--- a/src/renderer/state/remoteServers/gitSummaries.ts
+++ b/src/renderer/state/remoteServers/gitSummaries.ts
@@ -1,0 +1,52 @@
+import type { RemoteGitSummaries } from "@/shared/remote";
+import type { Project } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
+import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import { useGitStore } from "@/renderer/state/gitStore";
+
+export function syncRemoteGitSummaries(desktopId: string, summaries: RemoteGitSummaries): void {
+  const app = useAppStore.getState();
+  const git = useGitStore.getState();
+  const threadsByRemoteId = new Map(
+    app.threads
+      .filter((thread) => thread.remoteServerId === desktopId && thread.remoteId)
+      .map((thread) => [thread.remoteId!, thread]),
+  );
+  const projectsById = new Map(
+    app.projects
+      .filter((project) => project.remoteServerId === desktopId)
+      .map((project) => [project.id, project]),
+  );
+  const projectsToRefresh = new Map<string, Project>();
+
+  for (const [remoteThreadId, summary] of Object.entries(summaries)) {
+    const thread = threadsByRemoteId.get(remoteThreadId);
+    if (!thread) continue;
+    const current = thread.worktreePath
+      ? git.worktreeStatuses[thread.worktreePath]
+      : git.statuses[thread.projectId];
+    if (!current) {
+      const project = projectsById.get(thread.projectId);
+      if (project) projectsToRefresh.set(project.id, project);
+      continue;
+    }
+    const status = {
+      ...current,
+      isRepo: summary.isRepo,
+      branch: summary.branch,
+      ahead: summary.ahead,
+      behind: summary.behind,
+      totalInsertions: summary.totalInsertions,
+      totalDeletions: summary.totalDeletions,
+    };
+    if (thread.worktreePath) {
+      git.setWorktreeStatus(thread.worktreePath, status);
+    } else {
+      git.setStatus(thread.projectId, status);
+    }
+  }
+
+  for (const project of projectsToRefresh.values()) {
+    void refreshGitProject(project, "watcher", "status");
+  }
+}

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Project, Thread } from "@/shared/contracts";
+import type { GitStatusResult, Project, Thread } from "@/shared/contracts";
+import type { RemoteGitSummaries } from "@/shared/remote";
 import type { RemoteDesktopClient } from "@/shared/remote/client";
 import { __resetRemoteServersStoreForTest, useRemoteServersStore } from "./remoteServersStore";
 import { filterRemoteThreadEvent } from "./remoteServers/eventRouting";
@@ -10,6 +11,7 @@ import type {
 } from "./remoteServers/types";
 import { useAgentStatusesStore } from "./agentStatusesStore";
 import { useAppStore } from "./appStore";
+import { useGitStore } from "./gitStore";
 import { watchRemoteTerminal } from "./remoteTerminalFeed";
 import { remoteProjectId, remoteThreadId } from "./remoteProjection";
 import { routeRemoteProcedure } from "../remoteProcedureRouter";
@@ -34,7 +36,19 @@ vi.mock("@/renderer/state/remote", async (importOriginal) => {
   return {
     ...actual,
     applyThreadSnapshot: (snapshot: unknown) => sync.applyThreadSnapshot(snapshot),
-    dispatchRemoteSupervisorEvent: (value: unknown) => sync.dispatchRemoteSupervisorEvent(value),
+    dispatchRemoteSupervisorEvent: (
+      value: unknown,
+      hooks?: { onGitSummaries?: (summaries: RemoteGitSummaries) => void },
+    ) => {
+      sync.dispatchRemoteSupervisorEvent(value);
+      if (
+        value &&
+        typeof value === "object" &&
+        (value as { type?: unknown }).type === "remote-git-summaries"
+      ) {
+        hooks?.onGitSummaries?.((value as { summaries: RemoteGitSummaries }).summaries);
+      }
+    },
   };
 });
 
@@ -67,6 +81,22 @@ const remoteThread = {
   config: { foo: "bar" },
   status: "idle",
 } as unknown as Thread; // shape-checked loosely; only fields the store reads matter
+
+function gitStatus(behind: number): GitStatusResult {
+  return {
+    isRepo: true,
+    branch: "main",
+    tracking: "origin/main",
+    hasRemote: true,
+    remoteInfo: null,
+    ahead: 0,
+    behind,
+    staged: [],
+    unstaged: [],
+    totalInsertions: 0,
+    totalDeletions: 0,
+  };
+}
 
 type RemoteThreadHistorySnapshot = Awaited<ReturnType<RemoteDesktopClient["threadHistory"]>>;
 type RemoteShellSnapshot = Awaited<ReturnType<RemoteDesktopClient["snapshot"]>>;
@@ -193,6 +223,7 @@ describe("useRemoteServersStore", () => {
     __resetRemoteServersStoreForTest();
     useRemoteServersStore.getState().setSocketFactory(() => makeSocket());
     useRemoteServersStore.setState({ servers: [], runtime: {}, openThread: null });
+    useGitStore.setState({ statuses: {}, worktreeStatuses: {} });
     sync.applyThreadSnapshot.mockClear();
     sync.dispatchRemoteSupervisorEvent.mockClear();
     toastDanger.mockClear();
@@ -894,6 +925,166 @@ describe("useRemoteServersStore", () => {
     expect(useRemoteServersStore.getState().runtime.d1?.threads[0]?.title).toBe("Renamed remotely");
   });
 
+  it("closes a remote thread pane when the refreshed snapshot no longer contains it", async () => {
+    const socket: RemoteSocketLike = { close: vi.fn<() => void>(), onmessage: null, onclose: null };
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => ({
+      snapshotSeq: 1,
+      projects: [proj],
+      threads: [remoteThread],
+      runtimeSummariesByThread: {},
+      updatedAt: "now",
+    }));
+    useRemoteServersStore.getState().setClientFactory(factoryFor(makeClient({ snapshot })));
+    await pairIsolated(() => socket);
+    await useRemoteServersStore.getState().openRemoteThread("d1", "rt-1");
+    const projectedThreadId = remoteThreadId("d1", "rt-1");
+    useAppStore.setState({ view: { kind: "thread", panes: [projectedThreadId] } });
+    snapshot.mockResolvedValue({
+      snapshotSeq: 2,
+      projects: [proj],
+      threads: [],
+      runtimeSummariesByThread: {},
+      updatedAt: "later",
+    });
+    vi.useFakeTimers();
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 2,
+        event: { type: "remote-threads-changed", threadIds: ["rt-1"] },
+      }),
+    });
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(useAppStore.getState().threads).not.toContainEqual(
+      expect.objectContaining({ id: projectedThreadId }),
+    );
+    expect(useAppStore.getState().view).toEqual({ kind: "home" });
+    expect(useRemoteServersStore.getState().openThread).toBeNull();
+  });
+
+  it("closes a remote project draft when the refreshed snapshot no longer contains it", async () => {
+    const socket: RemoteSocketLike = { close: vi.fn<() => void>(), onmessage: null, onclose: null };
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => ({
+      snapshotSeq: 1,
+      projects: [proj],
+      threads: [],
+      runtimeSummariesByThread: {},
+      updatedAt: "now",
+    }));
+    useRemoteServersStore.getState().setClientFactory(factoryFor(makeClient({ snapshot })));
+    useRemoteServersStore.getState().setSocketFactory(() => socket);
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+    const projectedProjectId = remoteProjectId("d1", "p1");
+    useAppStore.setState({ view: { kind: "draft", projectId: projectedProjectId } });
+    snapshot.mockResolvedValue({
+      snapshotSeq: 2,
+      projects: [],
+      threads: [],
+      runtimeSummariesByThread: {},
+      updatedAt: "later",
+    });
+    vi.useFakeTimers();
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 2,
+        event: { type: "remote-projects-changed", projects: [] },
+      }),
+    });
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(useAppStore.getState().projects).not.toContainEqual(
+      expect.objectContaining({ id: projectedProjectId }),
+    );
+    expect(useAppStore.getState().view).toEqual({ kind: "home" });
+  });
+
+  it("reconciles cached Git counts from the authoritative shell snapshot", async () => {
+    const projectedProjectId = remoteProjectId("d1", "p1");
+    useGitStore.setState({ statuses: { [projectedProjectId]: gitStatus(6) } });
+    useRemoteServersStore.getState().setClientFactory(
+      factoryFor(
+        makeClient({
+          snapshot: async () => ({
+            snapshotSeq: 1,
+            projects: [proj],
+            threads: [remoteThread],
+            runtimeSummariesByThread: {},
+            gitSummariesByThread: {
+              "rt-1": {
+                isRepo: true,
+                branch: "main",
+                totalInsertions: 0,
+                totalDeletions: 0,
+                ahead: 0,
+                behind: 0,
+                pr: null,
+              },
+            },
+            updatedAt: "now",
+          }),
+        }),
+      ),
+    );
+
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+
+    expect(useGitStore.getState().statuses[projectedProjectId]?.behind).toBe(0);
+  });
+
+  it("updates cached Git counts when the remote desktop publishes a pull result", async () => {
+    const socket = makeSocket();
+    useRemoteServersStore.getState().setClientFactory(
+      factoryFor(
+        makeClient({
+          snapshot: async () => ({
+            snapshotSeq: 1,
+            projects: [proj],
+            threads: [remoteThread],
+            runtimeSummariesByThread: {},
+            updatedAt: "now",
+          }),
+        }),
+      ),
+    );
+    useRemoteServersStore.getState().setSocketFactory(() => socket);
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+    const projectedProjectId = remoteProjectId("d1", "p1");
+    useGitStore.setState({ statuses: { [projectedProjectId]: gitStatus(6) } });
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 2,
+        event: {
+          type: "remote-git-summaries",
+          summaries: {
+            "rt-1": {
+              isRepo: true,
+              branch: "main",
+              totalInsertions: 0,
+              totalDeletions: 0,
+              ahead: 0,
+              behind: 0,
+              pr: null,
+            },
+          },
+        },
+      }),
+    });
+
+    expect(useGitStore.getState().statuses[projectedProjectId]?.behind).toBe(0);
+  });
+
   it("reconnects the shared server socket from the latest seen event seq", async () => {
     vi.useFakeTimers();
     let ticketSeq = 0;
@@ -1141,7 +1332,7 @@ describe("useRemoteServersStore", () => {
 
   // ── Finding #1: desktop-as-client event filtering ──────────────────
   describe("filterRemoteThreadEvent", () => {
-    it("drops desktop-global agent-status/git-summary/project events", () => {
+    it("drops unrelated desktop-global events but keeps Git summaries", () => {
       expect(
         filterRemoteThreadEvent({ type: "windows-agent-statuses", statuses: [] }, "rt-1"),
       ).toBeNull();
@@ -1151,9 +1342,8 @@ describe("useRemoteServersStore", () => {
       expect(
         filterRemoteThreadEvent({ type: "agent-status-updated", status: {} }, "rt-1"),
       ).toBeNull();
-      expect(
-        filterRemoteThreadEvent({ type: "remote-git-summaries", summaries: {} }, "rt-1"),
-      ).toBeNull();
+      const gitSummaries = { type: "remote-git-summaries", summaries: {} };
+      expect(filterRemoteThreadEvent(gitSummaries, "rt-1")).toBe(gitSummaries);
       expect(
         filterRemoteThreadEvent({ type: "remote-projects-changed", projects: [] }, "rt-1"),
       ).toBeNull();
@@ -1455,6 +1645,17 @@ describe("useRemoteServersStore", () => {
     await vi.advanceTimersByTimeAsync(600);
     expect(snapshot).toHaveBeenCalledTimes(2);
     expect(agentStatuses).toHaveBeenCalledTimes(1);
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 21,
+        event: { type: "agent-status-updated", status: { kind: "claude" } },
+      }),
+    });
+    await vi.advanceTimersByTimeAsync(600);
+    expect(snapshot).toHaveBeenCalledTimes(3);
+    expect(agentStatuses).toHaveBeenCalledTimes(2);
   });
 
   // ── Finding #6: failing openRemoteThread does not reject ────────────

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -51,6 +51,7 @@ import {
   shouldRefreshRemoteAgentStatusesAfterEvent,
   shouldRefreshRemoteServerAfterEvent,
 } from "@/renderer/state/remoteServers/eventRouting";
+import { syncRemoteGitSummaries } from "@/renderer/state/remoteServers/gitSummaries";
 import type {
   OpenRemoteThread,
   RemoteClientFactory,
@@ -175,6 +176,22 @@ function syncRemoteAppRows(desktopId: string, projects?: Project[], threads?: Th
       : projected;
   });
   const projectedThreads = threads?.map((thread) => projectRemoteThread(desktopId, thread));
+  if (projectedProjects) {
+    const projectedProjectIds = new Set(projectedProjects.map((project) => project.id));
+    for (const project of useAppStore.getState().projects) {
+      if (project.remoteServerId === desktopId && !projectedProjectIds.has(project.id)) {
+        useAppStore.getState().deleteProject(project.id);
+      }
+    }
+  }
+  if (projectedThreads) {
+    const projectedThreadIds = new Set(projectedThreads.map((thread) => thread.id));
+    for (const thread of useAppStore.getState().threads) {
+      if (thread.remoteServerId === desktopId && !projectedThreadIds.has(thread.id)) {
+        useAppStore.getState().deleteThread(thread.id);
+      }
+    }
+  }
   useAppStore.setState((state) => ({
     ...(projectedProjects
       ? {
@@ -202,27 +219,7 @@ function syncRemoteAppRows(desktopId: string, projects?: Project[], threads?: Th
 }
 
 function removeRemoteAppRows(desktopId: string): void {
-  useAppStore.setState((state) => {
-    const removedProjectIds = new Set(
-      state.projects
-        .filter((project) => project.remoteServerId === desktopId)
-        .map((project) => project.id),
-    );
-    const removedThreadIds = new Set(
-      state.threads
-        .filter((thread) => thread.remoteServerId === desktopId)
-        .map((thread) => thread.id),
-    );
-    const viewContainsRemovedRow =
-      (state.view.kind === "draft" && removedProjectIds.has(state.view.projectId)) ||
-      (state.view.kind === "thread" &&
-        state.view.panes.some((paneId) => removedThreadIds.has(paneId)));
-    return {
-      projects: state.projects.filter((project) => project.remoteServerId !== desktopId),
-      threads: state.threads.filter((thread) => thread.remoteServerId !== desktopId),
-      ...(viewContainsRemovedRow ? { view: { kind: "home" as const } } : {}),
-    };
-  });
+  syncRemoteAppRows(desktopId, [], []);
 }
 
 function remoteServerEventSocketReconnectDelay(attempt: number): number {
@@ -478,6 +475,10 @@ export const useRemoteServersStore = create<RemoteServersState>()(
                   if (forward !== null) {
                     dispatchRemoteSupervisorEvent(
                       projectRemoteThreadEvent(server.desktopId, forward),
+                      {
+                        onGitSummaries: (summaries) =>
+                          syncRemoteGitSummaries(server.desktopId, summaries),
+                      },
                     );
                   }
                   if (shouldRefreshRemoteServerAfterEvent(message.event)) {
@@ -579,6 +580,9 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           },
         }));
         syncRemoteAppRows(record.desktopId, snapshot.projects, snapshot.threads);
+        if (snapshot.gitSummariesByThread) {
+          syncRemoteGitSummaries(record.desktopId, snapshot.gitSummariesByThread);
+        }
         remoteServerSnapshotSeqByDesktopId.set(record.desktopId, snapshot.snapshotSeq);
         startRemoteServerEventStream(record);
         return record;
@@ -911,6 +915,17 @@ export const useRemoteServersStore = create<RemoteServersState>()(
                 projectsChanged ? projects : undefined,
                 threadsChanged ? threads : undefined,
               );
+            }
+            if (snapshot.gitSummariesByThread) {
+              syncRemoteGitSummaries(desktopId, snapshot.gitSummariesByThread);
+            }
+            const openThread = get().openThread;
+            if (
+              threadsChanged &&
+              openThread?.desktopId === desktopId &&
+              !threads.some((thread) => thread.id === openThread.threadId)
+            ) {
+              set({ openThread: null });
             }
           } catch (error) {
             if (!isLatest()) return;

--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -26,8 +26,7 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { resolvePrKey } from "@/renderer/state/gitSelectors";
 
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
-import { closeThreads } from "@/renderer/utils/shellUtils";
-import { performWorktreeRemoval } from "@/renderer/actions/worktreeActions";
+import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 
 import { readBridge } from "@/renderer/bridge";
 import { Button } from "@/renderer/components/common/Button";
@@ -150,21 +149,15 @@ export function AppOverlays() {
                           onMergeAndRemove: () => {
                             const allThreads = useAppStore.getState().threads;
                             const wtPath = gitReviewContext!.worktreePath;
-                            const wtBranch = wtPath
-                              ? resolveWorktreeBranch(gitReviewContext!.projectId, wtPath)
-                              : undefined;
                             usePanelStore.getState().setGitOverlayOpen(false);
                             usePanelStore.getState().setGitReviewContext(null);
                             if (wtPath) {
                               const siblings = allThreads.filter((t) => t.worktreePath === wtPath);
-                              const deleteThreadStoreAction = useAppStore.getState().deleteThread;
-                              for (const sib of siblings) {
-                                deleteThreadStoreAction(sib.id);
-                              }
-                              void (async () => {
-                                await closeThreads(siblings.map((sib) => sib.id));
-                                await performWorktreeRemoval(gitReviewProject, wtPath, wtBranch);
-                              })();
+                              deleteWorktreeGroup(
+                                gitReviewProject.id,
+                                wtPath,
+                                siblings.map((sibling) => sibling.id),
+                              );
                             }
                           },
                         }),

--- a/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/GitReviewPanelContent.tsx
@@ -5,9 +5,8 @@ import { findExperimentByWorktree } from "@/renderer/state/experimentStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
-import { closeThreads } from "@/renderer/utils/shellUtils";
 import { archiveThread } from "@/renderer/actions/threadActions";
-import { deleteWorktreeGroup, performWorktreeRemoval } from "@/renderer/actions/worktreeActions";
+import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 import { DeferredGitReviewPanel } from "@/renderer/deferredFeatures";
 
 export function GitReviewPanelContent(props: {
@@ -61,20 +60,14 @@ export function GitReviewPanelContent(props: {
               onMergeAndRemove: () => {
                 const allThreads = useAppStore.getState().threads;
                 const wtPath = gitPanelContext!.worktreePath;
-                const wtBranch = wtPath
-                  ? resolveWorktreeBranch(gitPanelContext!.projectId, wtPath)
-                  : undefined;
                 onClose();
                 if (project && wtPath) {
                   const siblings = allThreads.filter((t) => t.worktreePath === wtPath);
-                  const deleteThreadStoreAction = useAppStore.getState().deleteThread;
-                  for (const sib of siblings) {
-                    deleteThreadStoreAction(sib.id);
-                  }
-                  void (async () => {
-                    await closeThreads(siblings.map((sib) => sib.id));
-                    await performWorktreeRemoval(project, wtPath, wtBranch);
-                  })();
+                  deleteWorktreeGroup(
+                    project.id,
+                    wtPath,
+                    siblings.map((sibling) => sibling.id),
+                  );
                 }
               },
               onRemove: () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
@@ -16,12 +16,11 @@ import { ContextMenu, type ContextMenuEntry } from "@/renderer/components/common
 import { ConfirmDialog } from "@/renderer/components/common/ConfirmDialog";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
 import { discardExperiment } from "@/renderer/actions/experimentActions";
-import { archiveThread, markThreadDone } from "@/renderer/actions/threadActions";
+import { archiveThread, deleteThread, markThreadDone } from "@/renderer/actions/threadActions";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentStore } from "@/renderer/state/experimentStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useIsWorktreeCollapsed, useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
-import { closeThreads } from "@/renderer/utils/shellUtils";
 import { ExperimentGroupHeader } from "./ExperimentGroupHeader";
 import { InlineRenameInput } from "./InlineRenameInput";
 import type { ThreadListEntry } from "./groupThreads";
@@ -62,11 +61,9 @@ export function SidebarThreadGroup(props: {
       }
     }
     if (threadRemoveAction === "delete") {
-      const deleteThread = useAppStore.getState().deleteThread;
       for (const threadId of threadIds) {
         deleteThread(threadId);
       }
-      void closeThreads(threadIds);
     }
     clearThreadGroup(groupKey);
   };

--- a/src/renderer/views/MainView/parts/WorktreeDeleteDialogs.tsx
+++ b/src/renderer/views/MainView/parts/WorktreeDeleteDialogs.tsx
@@ -6,8 +6,8 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 
-import { closeThreads } from "@/renderer/utils/shellUtils";
-import { performWorktreeRemoval } from "@/renderer/actions/worktreeActions";
+import { deleteThread } from "@/renderer/actions/threadActions";
+import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 
 export type { WorktreeDeleteDialogState } from "@/renderer/state/worktreeDeleteStore";
 
@@ -23,11 +23,7 @@ export function WorktreeDeleteDialogs() {
           worktreeBranch={worktreeDeleteDialog.worktreeBranch}
           onClose={closeDialog}
           onDeleteThreadOnly={() => {
-            const deleteThread = useAppStore.getState().deleteThread;
             deleteThread(worktreeDeleteDialog.threadId);
-            void readBridge()
-              .closeThread({ threadId: worktreeDeleteDialog.threadId })
-              .catch(() => undefined);
             closeDialog();
           }}
           onDeleteThreadAndWorktree={() => {
@@ -39,25 +35,10 @@ export function WorktreeDeleteDialogs() {
                   t.worktreePath === worktreeDeleteDialog.worktreePath &&
                   t.id !== worktreeDeleteDialog.threadId,
               );
-            const deleteThread = useAppStore.getState().deleteThread;
-            deleteThread(worktreeDeleteDialog.threadId);
-            for (const t of siblings) {
-              deleteThread(t.id);
-            }
-
-            const project = useAppStore
-              .getState()
-              .projects.find((p) => p.id === worktreeDeleteDialog.projectId);
-            if (project) {
-              void (async () => {
-                await closeThreads([worktreeDeleteDialog.threadId, ...siblings.map((t) => t.id)]);
-                await performWorktreeRemoval(
-                  project,
-                  worktreeDeleteDialog.worktreePath,
-                  worktreeDeleteDialog.worktreeBranch,
-                );
-              })();
-            }
+            deleteWorktreeGroup(worktreeDeleteDialog.projectId, worktreeDeleteDialog.worktreePath, [
+              worktreeDeleteDialog.threadId,
+              ...siblings.map((thread) => thread.id),
+            ]);
             closeDialog();
           }}
         />


### PR DESCRIPTION
- **Bugfix**
- Keep remote project, thread, and mobile view state aligned with authoritative snapshots.
- Synchronize remote Git summaries and refresh affected repository status.
- Route remote worktree deletion through the server to keep desktop state consistent.