### PR TITLE
Mark threads done after automated PR merges

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -868,6 +868,12 @@ if (!hasSingleInstanceLock) {
             method,
             admin: false,
           }),
+        onPrMerged: (mergedWatch) =>
+          mainWindow?.webContents.send(IPC_EVENT_CHANNELS.prWatchMerged, {
+            projectId: mergedWatch.projectId,
+            prNumber: mergedWatch.prNumber,
+            ...(mergedWatch.worktreePath ? { worktreePath: mergedWatch.worktreePath } : {}),
+          }),
         createThread: sharedAppControlsDeps.createThread,
         isThreadActive: (threadId) => {
           const status = dbGetThread(threadId)?.status;

--- a/src/main/prWatch/PrWatchService.test.ts
+++ b/src/main/prWatch/PrWatchService.test.ts
@@ -378,14 +378,18 @@ describe("PrWatchService", () => {
   });
 
   it("auto-merges with the selected method and removes a green watch", async () => {
+    const onPrMerged = vi.fn<NonNullable<PrWatchServiceOptions["onPrMerged"]>>();
     const { service, store, mergePr, createThread } = setup(
       withoutAgent(watch({ watchEnabled: false, autoMerge: true })),
-      { getMergeMethod: () => "merge" },
+      { getMergeMethod: () => "merge", onPrMerged },
     );
 
     await service.tick();
 
     expect(mergePr).toHaveBeenCalledWith(project, pr.number, "merge");
+    expect(onPrMerged).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: project.id, prNumber: pr.number }),
+    );
     expect(createThread).not.toHaveBeenCalled();
     expect(store.get(project.id, pr.number)).toBeNull();
   });

--- a/src/main/prWatch/PrWatchService.ts
+++ b/src/main/prWatch/PrWatchService.ts
@@ -32,6 +32,7 @@ export interface PrWatchServiceOptions {
   getPrReviewThreads(project: Project, prNumber: number): Promise<PrReviewThread[]>;
   getMergeMethod(): PrMergeMethod;
   mergePr(project: Project, prNumber: number, method: PrMergeMethod): Promise<void>;
+  onPrMerged?(watch: PrWatch): void;
   createThread(request: CreateAppThreadRequest): Promise<CreateAppThreadResult>;
   isThreadActive(threadId: string): boolean;
   worktreeExists(path: string): boolean;
@@ -217,6 +218,7 @@ export class PrWatchService {
       if (current.autoMerge && isReadyForAutoMerge(pr, details.checks)) {
         try {
           await this.options.mergePr(project, current.prNumber, this.options.getMergeMethod());
+          this.options.onPrMerged?.(current);
           this.options.store.delete(current.projectId, current.prNumber);
         } catch (error) {
           this.saveError(observed, error);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -12,6 +12,7 @@ import {
   type BrowserEvent,
   type PoracodeBridge,
   type PoracodeWindowKind,
+  type PrWatchMergedEvent,
   type ProjectStateChangedEvent,
   type QuickComposerSubmission,
   type SupervisorEvent,
@@ -197,6 +198,15 @@ const bridge: PoracodeBridge = {
     ipcRenderer.on(IPC_EVENT_CHANNELS.gitStateChanged, handler);
     return () => {
       ipcRenderer.removeListener(IPC_EVENT_CHANNELS.gitStateChanged, handler);
+    };
+  },
+  onPrWatchMerged(listener) {
+    const handler = (_event: Electron.IpcRendererEvent, payload: PrWatchMergedEvent) => {
+      listener(payload);
+    };
+    ipcRenderer.on(IPC_EVENT_CHANNELS.prWatchMerged, handler);
+    return () => {
+      ipcRenderer.removeListener(IPC_EVENT_CHANNELS.prWatchMerged, handler);
     };
   },
   onThreadOpenRequested(listener) {

--- a/src/mobile/bridge.ts
+++ b/src/mobile/bridge.ts
@@ -364,6 +364,7 @@ const remoteBridge = {
   // Event subscriptions: remote events arrive over the WebSocket instead.
   onSupervisorEvent: () => () => undefined,
   onGitStateChanged: () => () => undefined,
+  onPrWatchMerged: () => () => undefined,
   onUpdateStatus: () => () => undefined,
   onBrowserEvent: () => () => undefined,
   onRemoteThreadCommand: () => () => undefined,

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -201,6 +201,7 @@ const {
         return () => undefined;
       }),
       onGitStateChanged: vi.fn<() => () => void>(() => () => undefined),
+      onPrWatchMerged: vi.fn<() => () => void>(() => () => undefined),
       onThreadOpenRequested: vi.fn<
         (listener: (event: ThreadOpenRequestedEvent) => void) => () => void
       >((listener) => {

--- a/src/renderer/hooks/useAppHydration.test.tsx
+++ b/src/renderer/hooks/useAppHydration.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   bridge: {
     getThreadSnapshots: vi.fn<() => Promise<ThreadRuntimeSnapshot[]>>(),
     closeThread: vi.fn<(payload: { threadId: string }) => Promise<void>>(),
+    onPrWatchMerged: vi.fn<() => () => void>(() => () => undefined),
     gitListWorktrees: vi.fn<
       (payload: unknown) => Promise<{
         worktrees: Array<{ path: string; branch: string }>;

--- a/src/renderer/state/prMergeAutoDone.test.ts
+++ b/src/renderer/state/prMergeAutoDone.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrData, Thread } from "@/shared/contracts";
+import type { PrWatchMergedEvent } from "@/shared/ipc";
 import { useAppStore } from "./appStore";
 import { useGitStore } from "./gitStore";
 import { useSharedSettings } from "./sharedSettingsStore";
 import { startPrMergeAutoDone } from "./prMergeAutoDone";
 
 const markThreadDoneMock = vi.fn<(threadId: string) => void>();
+let prWatchMergedListener: ((event: PrWatchMergedEvent) => void) | undefined;
 
 vi.mock("@/renderer/actions/threadActions", () => ({
   markThreadDone: (threadId: string) => markThreadDoneMock(threadId),
@@ -50,6 +52,14 @@ describe("prMergeAutoDone", () => {
       configurable: true,
       value: {
         platform: "darwin",
+        onPrWatchMerged: vi.fn<(listener: (event: PrWatchMergedEvent) => void) => () => void>(
+          (listener) => {
+            prWatchMergedListener = listener;
+            return () => {
+              prWatchMergedListener = undefined;
+            };
+          },
+        ),
         dbSetState: vi
           .fn<(key: string, value: string) => Promise<void>>()
           .mockResolvedValue(undefined),
@@ -71,6 +81,25 @@ describe("prMergeAutoDone", () => {
 
     useGitStore.getState().setPrData("/repo-wt", mergedPr);
     expect(markThreadDoneMock).toHaveBeenCalledExactlyOnceWith("t1");
+  });
+
+  it("marks the thread done when the background watcher publishes its merge", () => {
+    prWatchMergedListener?.({
+      projectId: "p1",
+      prNumber: 7,
+      worktreePath: "/repo-wt",
+    });
+
+    expect(markThreadDoneMock).toHaveBeenCalledExactlyOnceWith("t1");
+  });
+
+  it("releases the background merge listener when stopped", () => {
+    expect(prWatchMergedListener).toBeDefined();
+
+    stop();
+    stop = () => {};
+
+    expect(prWatchMergedListener).toBeUndefined();
   });
 
   it("ignores a PR that is already merged the first time it is seen", () => {

--- a/src/renderer/state/prMergeAutoDone.ts
+++ b/src/renderer/state/prMergeAutoDone.ts
@@ -1,5 +1,7 @@
 import { isThreadTurnActive, type PrData, type Thread } from "@/shared/contracts";
+import type { PrWatchMergedEvent } from "@/shared/ipc";
 import { markThreadDone } from "@/renderer/actions/threadActions";
+import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "./appStore";
 import { useGitStore } from "./gitStore";
 import { useSharedSettings } from "./sharedSettingsStore";
@@ -61,6 +63,18 @@ function settleWorktreeThreads(prKeys: ReadonlySet<string>): void {
   }
 }
 
+function settlePrWatchThreads(merged: PrWatchMergedEvent): void {
+  for (const thread of useAppStore.getState().threads) {
+    if (
+      thread.worktreePath &&
+      (thread.worktreePath === merged.worktreePath ||
+        (thread.projectId === merged.projectId && thread.prNumber === merged.prNumber))
+    ) {
+      settleThread(thread);
+    }
+  }
+}
+
 function flushPendingThreads(): void {
   const threads = useAppStore.getState().threads;
   for (const threadId of [...pendingThreadIds]) {
@@ -75,6 +89,11 @@ function flushPendingThreads(): void {
 
 /** Starts the watcher. Runtime-owner only, so a remote session never duplicates it. */
 export function startPrMergeAutoDone(): () => void {
+  const unsubscribePrWatchMerged = readBridge().onPrWatchMerged((merged) => {
+    if (!useSharedSettings.getState().autoMarkDoneOnPrMerge) return;
+    settlePrWatchThreads(merged);
+  });
+
   const unsubscribeGit = useGitStore.subscribe((state, prev) => {
     if (state.prData === prev.prData) return;
     if (!useSharedSettings.getState().autoMarkDoneOnPrMerge) return;
@@ -92,6 +111,7 @@ export function startPrMergeAutoDone(): () => void {
   });
 
   return () => {
+    unsubscribePrWatchMerged();
     unsubscribeGit();
     unsubscribeThreads();
     pendingThreadIds.clear();

--- a/src/shared/ipc/bridge.ts
+++ b/src/shared/ipc/bridge.ts
@@ -14,6 +14,7 @@ import {
 } from "./procedureMap";
 import type {
   BrowserEvent,
+  PrWatchMergedEvent,
   ProjectStateChangedEvent,
   SupervisorEvent,
   ThreadOpenRequestedEvent,
@@ -64,6 +65,7 @@ export type PoracodeBridge = PoracodeInvokeBridge & {
   onSharedSettingsChanged(listener: (settings: SharedSettings) => void): () => void;
   onProjectStateChanged(listener: (event: ProjectStateChangedEvent) => void): () => void;
   onGitStateChanged(listener: (patch: GitStatePatch) => void): () => void;
+  onPrWatchMerged(listener: (event: PrWatchMergedEvent) => void): () => void;
   onThreadOpenRequested(listener: (event: ThreadOpenRequestedEvent) => void): () => void;
   submitQuickComposer(submission: QuickComposerSubmission): Promise<void>;
   dismissQuickComposer(): Promise<void>;
@@ -128,6 +130,7 @@ export const IPC_EVENT_CHANNELS = {
   sharedSettingsChanged: createChannel("sharedSettingsChanged"),
   projectStateChanged: createChannel("projectStateChanged"),
   gitStateChanged: createChannel("gitStateChanged"),
+  prWatchMerged: createChannel("prWatchMerged"),
   threadOpenRequested: createChannel("threadOpenRequested"),
   quickComposerSubmit: createChannel("quickComposerSubmit"),
   quickComposerDismissRequested: createChannel("quickComposerDismissRequested"),

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -175,6 +175,13 @@ export type ProjectStateChangedEvent = {
   projects: Project[];
 };
 
+/** Successful desktop PR automation merge; consumed once by the runtime-owner renderer. */
+export type PrWatchMergedEvent = {
+  projectId: string;
+  prNumber: number;
+  worktreePath?: string;
+};
+
 export type UpdateStatus =
   | { type: "checking" }
   | { type: "update-available"; version: string }

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -35,6 +35,7 @@ export {
   isAgentStatusSupervisorEvent,
   type AgentStatusSupervisorEvent,
   type BrowserEvent,
+  type PrWatchMergedEvent,
   type ProjectStateChangedEvent,
   type ThreadOpenRequestedEvent,
   type SupervisorEvent,


### PR DESCRIPTION
- **Bugfix:** mark matching threads done when the background PR watcher successfully auto-merges a pull request.
- Deliver merge events through the desktop IPC bridge so the runtime-owner renderer can update thread state immediately.
- Preserve mobile bridge compatibility and cover merge notification, cleanup, and renderer behavior with tests.