### PR TITLE
Pool Codex app-server connections and route MCP threads

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -1,4 +1,3 @@
-import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
@@ -6,6 +5,8 @@ import {
   areAgentSlashCommandsEqual,
   type AgentSlashCommand,
   type PromptSegment,
+  type ProjectLocation,
+  type ResolvedMcpServer,
   type RuntimeEvent,
   type SessionRef,
   type ThreadConfig,
@@ -13,13 +14,10 @@ import {
   type ThreadServerRequestId,
 } from "@/shared/contracts";
 import { buildPromptContentBlocks } from "@/shared/promptContent";
-import { terminateChildProcessTree } from "@/shared/processTree";
 import { toWslUncPath } from "@/shared/wsl";
-import { resolveNodeForDistro } from "../../wsl/runtime";
 import {
   createKnownSessionRef,
   type AgentLaunchOptions,
-  type CommandSpec,
   type CreateStructuredSessionInput,
   type StartTurnOptions,
   type StructuredSessionHandle,
@@ -27,7 +25,6 @@ import {
   type StructuredSessionUpdate,
   type ThreadHistory,
 } from "../base";
-import { buildCodexAppServerCommand } from "./argv";
 import {
   createCodexMapperState,
   CodexUsageScopeTracker,
@@ -51,7 +48,7 @@ import {
 } from "./acpTurn";
 import { CodexAppServerRpc, isUnsupportedCodexRequestError } from "./appServerRpc";
 import type { CodexClientRequestMap } from "./protocol";
-import { CodexStdioTransport } from "./stdioTransport";
+import { acquireCodexAppServer } from "./serverPool";
 import { buildCodexThreadOverrides } from "./threadOverrides";
 import {
   mapCodexSkillsToSlashCommands,
@@ -82,6 +79,7 @@ function sleep(ms: number): Promise<void> {
 const CODEX_SYSTEM_ERROR_FALLBACK_DELAY_MS = 250;
 const CODEX_RESUME_STATUS_REPLAY_SUPPRESSION_MS = 500;
 const CODEX_FORK_NOTIFICATION_BUFFER_LIMIT = 100;
+const CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS = 2_000;
 const CODEX_EVENT_DEBUG_ENV = "PORACODE_DEBUG_CODEX_EVENTS";
 
 type CodexEventDebugDirection =
@@ -102,20 +100,6 @@ function stringifyCodexEventDebugPayload(payload: unknown): string {
   } catch {
     return String(payload);
   }
-}
-
-function spawnAppServer(command: CommandSpec): ChildProcess {
-  return spawn(command.command, command.args, {
-    cwd: command.cwd ?? process.cwd(),
-    env: {
-      ...process.env,
-      ...command.env,
-      TERM: "xterm-256color",
-    },
-    stdio: ["pipe", "pipe", "pipe"],
-    shell: false,
-    windowsHide: true,
-  });
 }
 
 function toSessionRef(threadId: string): SessionRef {
@@ -157,13 +141,13 @@ function readNotificationThreadId(
 // ── Structured Session ──────────────────────────────────────────
 //
 // Lifecycle for a new thread:
-//   1. create()       → spawn app-server and attach stdio JSON-RPC
+//   1. create()       → acquire the shared app-server and attach a JSON-RPC channel
 //   2. activate()     → initialize handshake with the server
 //   3. openThread()   → thread/start on the server, get Codex thread ID
 //   4. startTurn()    → fire turns through the structured server
 //
 // Lifecycle for resuming a saved thread:
-//   1. create()       → spawn app-server and attach stdio JSON-RPC
+//   1. create()       → acquire the shared app-server and attach a JSON-RPC channel
 //   2. activate()     → initialize handshake
 //   3. openThread()   → thread/resume with saved session ID
 
@@ -171,9 +155,11 @@ function readNotificationThreadId(
 export class CodexStructuredSession implements StructuredSessionHandle {
   launchOptions: AgentLaunchOptions;
 
-  private readonly appServer: ChildProcess;
   private readonly rpc: CodexAppServerRpc;
   private readonly threadId: string;
+  private readonly projectLocation: ProjectLocation;
+  private readonly mcpServers: readonly ResolvedMcpServer[];
+  private readonly releaseAppServer: () => void;
   private listener: StructuredSessionListener | undefined;
   private isDisposed = false;
   private activated = false;
@@ -228,14 +214,18 @@ export class CodexStructuredSession implements StructuredSessionHandle {
    */
   private bufferedRuntimeEvents: RuntimeEvent[] = [];
   private constructor(
-    appServer: ChildProcess,
     rpc: CodexAppServerRpc,
     threadId: string,
+    projectLocation: ProjectLocation,
+    mcpServers: readonly ResolvedMcpServer[],
+    releaseAppServer: () => void,
     wslDistro?: string,
   ) {
-    this.appServer = appServer;
     this.rpc = rpc;
     this.threadId = threadId;
+    this.projectLocation = projectLocation;
+    this.mcpServers = mcpServers;
+    this.releaseAppServer = releaseAppServer;
     this.wslDistro = wslDistro;
     this.launchOptions = {
       suppressResumeConfigOverrides: true,
@@ -407,7 +397,15 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   }
 
   private async refreshSkillSlashCommands(forceReload: boolean): Promise<void> {
-    const result = await this.rpc.request("skills/list", { forceReload });
+    const projectCwd = this.projectLocation
+      ? this.projectLocation.kind === "wsl"
+        ? this.projectLocation.linuxPath
+        : this.projectLocation.path
+      : undefined;
+    const result = await this.rpc.request("skills/list", {
+      ...(projectCwd ? { cwds: [projectCwd] } : {}),
+      forceReload,
+    });
     this.currentSkillSlashCommands = mapCodexSkillsToSlashCommands(result);
     this.rebuildSlashCommands();
   }
@@ -416,34 +414,18 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     input: CreateStructuredSessionInput,
     wslExecPath?: string,
   ): Promise<CodexStructuredSession> {
-    const wslNodePath =
-      input.projectLocation.kind === "wsl"
-        ? (await resolveNodeForDistro(input.projectLocation.distro)).nodePath
-        : undefined;
-    const appServer = spawnAppServer(
-      buildCodexAppServerCommand(input.projectLocation, {
-        ...(wslExecPath !== undefined ? { wslExecPath } : {}),
-        ...(wslNodePath !== undefined ? { wslNodePath } : {}),
-        ...(input.mcpServers !== undefined ? { mcpServers: input.mcpServers } : {}),
-      }),
-    );
-    const transport = new CodexStdioTransport(appServer);
-
-    const spawnError = await new Promise<Error | undefined>((resolve) => {
-      appServer.once("error", (error) => resolve(error));
-      setImmediate(() => resolve(undefined));
-    });
-    if (spawnError) {
-      throw new Error(`Codex app-server failed to spawn: ${spawnError.message}`);
-    }
-    if (appServer.exitCode !== null) {
-      throw new Error(`Codex app-server exited early.${transport.formatOutput()}`);
-    }
-
+    const acquired = await acquireCodexAppServer(input, wslExecPath);
     const wslDistro =
       input.projectLocation.kind === "wsl" ? input.projectLocation.distro : undefined;
-    const rpc = new CodexAppServerRpc(transport, input.threadId);
-    const session = new CodexStructuredSession(appServer, rpc, input.threadId, wslDistro);
+    const rpc = new CodexAppServerRpc(acquired.connection, input.threadId);
+    const session = new CodexStructuredSession(
+      rpc,
+      input.threadId,
+      input.projectLocation,
+      input.mcpServers ?? [],
+      acquired.dispose,
+      wslDistro,
+    );
     session.attachRpcHandlers();
 
     return session;
@@ -498,7 +480,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     // `mode` does not exist on `thread/start` or `thread/resume`; plan mode is
     // a per-turn override sent via `collaborationMode` on `turn/start`.
     this.currentConfig = config;
-    const threadOverrides = buildCodexThreadOverrides(config);
+    const threadOverrides = buildCodexThreadOverrides(config, {
+      projectLocation: this.projectLocation,
+      mcpServers: this.mcpServers,
+    });
 
     let threadId: string;
     // `fresh` marks a brand-new provider thread (usage ledger baseline 0). A
@@ -544,6 +529,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     }
 
     this.remoteThreadId = threadId;
+    this.rpc.claimThread(threadId);
     this.ensureMapperState().usageScope = new CodexUsageScopeTracker(threadId, createdNewThread);
     this.launchOptions = { ...this.launchOptions, resumeThreadId: threadId };
     if (!createdNewThread) {
@@ -834,7 +820,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
       throw new Error("Cannot roll back a Codex thread before its configuration is initialized.");
     }
     this.currentConfig = rollbackConfig;
-    const threadOverrides = buildCodexThreadOverrides(rollbackConfig);
+    const threadOverrides = buildCodexThreadOverrides(rollbackConfig, {
+      projectLocation: this.projectLocation,
+      mcpServers: this.mcpServers,
+    });
     this.forkNotificationBuffer = [];
     try {
       forkResult = await this.rpc.request("thread/fork", {
@@ -858,6 +847,7 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     }
 
     this.remoteThreadId = newThreadId;
+    this.rpc.claimThread(newThreadId);
     this.launchOptions = { ...this.launchOptions, resumeThreadId: newThreadId };
     // The fork created a NEW provider thread carrying inherited history: bump
     // the usage scope epoch so the first sample on it is a baseline, and do it
@@ -865,9 +855,11 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     // scope.
     this.mapperState?.usageScope?.replaceScope(newThreadId);
     this.replayForkNotifications(newThreadId);
-    void this.rpc.request("thread/unsubscribe", { threadId }).catch((error) => {
-      console.log("[codex] failed to unsubscribe old thread after fork:", error);
-    });
+    await this.rpc
+      .request("thread/unsubscribe", { threadId }, CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS)
+      .catch((error) => {
+        console.log("[codex] failed to unsubscribe old thread after fork:", error);
+      });
     this.pendingTurnInterrupt = false;
     this.activeTurnId = undefined;
     await this.syncRemoteThreadState(newThreadId, toSessionRef(newThreadId));
@@ -881,6 +873,10 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     this.rpc.resolveServerRequest(requestId, response);
   }
 
+  ownsProviderSession(providerSessionId: string): boolean {
+    return this.rpc.ownsThread(providerSessionId);
+  }
+
   async dispose(): Promise<void> {
     if (this.isDisposed) {
       return;
@@ -888,11 +884,29 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     this.isDisposed = true;
 
     this.clearPendingSystemErrorFallback();
-    this.rpc.dispose(new Error("Codex app-server session disposed."));
-
-    if (!this.appServer.killed) {
-      terminateChildProcessTree(this.appServer);
+    if (this.remoteThreadId) {
+      if (this.activeTurnId) {
+        await this.rpc
+          .request(
+            "turn/interrupt",
+            {
+              threadId: this.remoteThreadId,
+              turnId: this.activeTurnId,
+            },
+            CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS,
+          )
+          .catch(() => undefined);
+      }
+      await this.rpc
+        .request(
+          "thread/unsubscribe",
+          { threadId: this.remoteThreadId },
+          CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS,
+        )
+        .catch(() => undefined);
     }
+    this.rpc.dispose(new Error("Codex app-server session disposed."));
+    this.releaseAppServer();
   }
 
   private attachRpcHandlers(): void {
@@ -940,6 +954,13 @@ export class CodexStructuredSession implements StructuredSessionHandle {
     );
     if (childEvents !== undefined) {
       if (childEvents.length > 0) this.emitRuntimeEvents(childEvents);
+      return;
+    }
+    if (
+      notificationThreadId &&
+      this.remoteThreadId !== undefined &&
+      notificationThreadId !== this.remoteThreadId
+    ) {
       return;
     }
 

--- a/src/supervisor/agents/codex/appServerRpc.test.ts
+++ b/src/supervisor/agents/codex/appServerRpc.test.ts
@@ -1,9 +1,11 @@
 import type { RuntimeEvent } from "@/shared/contracts";
 import { describe, expect, it, vi } from "vitest";
 import {
+  CodexAppServerConnection,
   CodexAppServerRpc,
   CodexRpcResponseError,
   isUnsupportedCodexRequestError,
+  type CodexAppServerRpcListener,
   type CodexAppServerRpcTransport,
   type CodexRpcDebugDirection,
 } from "./appServerRpc";
@@ -347,5 +349,307 @@ describe("CodexAppServerRpc", () => {
     await expect(pending).rejects.toBe(error);
     expect(dispose).toHaveBeenCalledOnce();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shares initialization and routes thread notifications across RPC channels", async () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const writes: Array<Record<string, unknown>> = [];
+    const dispose = vi.fn<() => void>();
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: (message) => writes.push(message),
+      dispose,
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    const first = new CodexAppServerRpc(connection, "local-first");
+    const second = new CodexAppServerRpc(connection, "local-second");
+    const firstNotifications =
+      vi.fn<(method: string, params: Record<string, unknown> | undefined) => void>();
+    const secondNotifications =
+      vi.fn<(method: string, params: Record<string, unknown> | undefined) => void>();
+    const listener = (onNotification: typeof firstNotifications): CodexAppServerRpcListener => ({
+      onNotification,
+      onRuntimeEvents: () => {},
+      onClose: () => {},
+      onError: () => {},
+    });
+    first.setListener(listener(firstNotifications));
+    second.setListener(listener(secondNotifications));
+
+    const firstInitialize = first.request("initialize", {
+      clientInfo: { name: "poracode", version: "test" },
+      capabilities: null,
+    });
+    const secondInitialize = second.request("initialize", {
+      clientInfo: { name: "poracode", version: "test" },
+      capabilities: null,
+    });
+    expect(writes).toHaveLength(1);
+    transportListener!.onMessage({ id: "poracode-0", result: { userAgent: "codex/test" } });
+    await expect(Promise.all([firstInitialize, secondInitialize])).resolves.toHaveLength(2);
+    first.notify("initialized");
+    second.notify("initialized");
+    expect(writes.filter((message) => message.method === "initialized")).toHaveLength(1);
+
+    first.claimThread("provider-first");
+    second.claimThread("provider-second");
+    transportListener!.onMessage({
+      method: "turn/started",
+      params: { threadId: "provider-second" },
+    });
+    expect(firstNotifications).not.toHaveBeenCalled();
+    expect(secondNotifications).toHaveBeenCalledWith("turn/started", {
+      threadId: "provider-second",
+    });
+
+    first.dispose(new Error("first closed"));
+    expect(dispose).not.toHaveBeenCalled();
+    const pending = second.request("thread/read", {
+      threadId: "provider-second",
+      includeTurns: false,
+    });
+    transportListener!.onMessage({
+      id: "poracode-1",
+      result: { thread: { id: "provider-second" } },
+    });
+    await expect(pending).resolves.toMatchObject({ thread: { id: "provider-second" } });
+
+    connection.dispose(new Error("shutdown"));
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("routes inbound server requests to the owning local thread", () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const writes: Array<Record<string, unknown>> = [];
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: (message) => writes.push(message),
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    const first = new CodexAppServerRpc(connection, "local-first");
+    const second = new CodexAppServerRpc(connection, "local-second");
+    const firstEvents: RuntimeEvent[] = [];
+    const secondEvents: RuntimeEvent[] = [];
+    const listener = (events: RuntimeEvent[]): CodexAppServerRpcListener => ({
+      onNotification: () => {},
+      onRuntimeEvents: (next) => events.push(...next),
+      onClose: () => {},
+      onError: () => {},
+    });
+    first.setListener(listener(firstEvents));
+    second.setListener(listener(secondEvents));
+    first.claimThread("provider-first");
+    second.claimThread("provider-second");
+
+    transportListener!.onMessage({
+      id: "approval-2",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "provider-second", command: "pnpm test" },
+    });
+
+    expect(firstEvents).toEqual([]);
+    expect(secondEvents).toContainEqual(
+      expect.objectContaining({
+        type: "request.opened",
+        threadId: "local-second",
+        requestId: "approval-2",
+      }),
+    );
+    second.resolveServerRequest("approval-2", { optionId: "accept" });
+    expect(writes.at(-1)).toEqual({ id: "approval-2", result: { decision: "accept" } });
+  });
+
+  it("routes legacy conversation approvals and child threads to their owning channel", () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const writes: Array<Record<string, unknown>> = [];
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: (message) => writes.push(message),
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    const first = new CodexAppServerRpc(connection, "local-first");
+    const second = new CodexAppServerRpc(connection, "local-second");
+    const firstEvents: RuntimeEvent[] = [];
+    const secondEvents: RuntimeEvent[] = [];
+    const firstNotifications = vi.fn<CodexAppServerRpcListener["onNotification"]>();
+    const secondNotifications = vi.fn<CodexAppServerRpcListener["onNotification"]>();
+    const listener = (
+      events: RuntimeEvent[],
+      onNotification: CodexAppServerRpcListener["onNotification"],
+    ): CodexAppServerRpcListener => ({
+      onNotification,
+      onRuntimeEvents: (next) => events.push(...next),
+      onClose: () => {},
+      onError: () => {},
+    });
+    first.setListener(listener(firstEvents, firstNotifications));
+    second.setListener(listener(secondEvents, secondNotifications));
+    first.claimThread("provider-first");
+    second.claimThread("provider-second");
+
+    transportListener!.onMessage({
+      id: "legacy-approval",
+      method: "execCommandApproval",
+      params: {
+        conversationId: "provider-second",
+        callId: "call-1",
+        approvalId: null,
+        command: ["pwd"],
+        cwd: "C:\\repo",
+        reason: null,
+        parsedCmd: [],
+      },
+    });
+    expect(firstEvents).toEqual([]);
+    expect(secondEvents).toContainEqual(
+      expect.objectContaining({
+        type: "request.opened",
+        threadId: "local-second",
+        requestId: "legacy-approval",
+      }),
+    );
+    second.resolveServerRequest("legacy-approval", { optionId: "decline" });
+    expect(writes.at(-1)).toEqual({
+      id: "legacy-approval",
+      result: { decision: "decline" },
+    });
+
+    transportListener!.onMessage({
+      method: "thread/started",
+      params: { thread: { id: "provider-child", parentThreadId: "provider-second" } },
+    });
+    transportListener!.onMessage({
+      method: "turn/started",
+      params: { threadId: "provider-child", turn: { id: "child-turn" } },
+    });
+    expect(first.ownsThread("provider-child")).toBe(false);
+    expect(second.ownsThread("provider-child")).toBe(true);
+    expect(firstNotifications).not.toHaveBeenCalled();
+    expect(secondNotifications).toHaveBeenCalledWith("turn/started", {
+      threadId: "provider-child",
+      turn: { id: "child-turn" },
+    });
+  });
+
+  it("buffers startup notifications until the matching thread is claimed", () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: () => {},
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    const first = new CodexAppServerRpc(connection, "local-first");
+    const second = new CodexAppServerRpc(connection, "local-second");
+    const firstNotifications = vi.fn<CodexAppServerRpcListener["onNotification"]>();
+    const secondNotifications = vi.fn<CodexAppServerRpcListener["onNotification"]>();
+    const listener = (
+      onNotification: CodexAppServerRpcListener["onNotification"],
+    ): CodexAppServerRpcListener => ({
+      onNotification,
+      onRuntimeEvents: () => {},
+      onClose: () => {},
+      onError: () => {},
+    });
+    first.setListener(listener(firstNotifications));
+    second.setListener(listener(secondNotifications));
+
+    transportListener!.onMessage({
+      method: "thread/started",
+      params: { thread: { id: "provider-second", status: { type: "idle" } } },
+    });
+    transportListener!.onMessage({
+      method: "thread/status/changed",
+      params: { threadId: "provider-second", status: { type: "active" } },
+    });
+    expect(firstNotifications).not.toHaveBeenCalled();
+    expect(secondNotifications).not.toHaveBeenCalled();
+
+    second.claimThread("provider-second");
+    expect(secondNotifications.mock.calls).toEqual([
+      ["thread/started", { thread: { id: "provider-second", status: { type: "idle" } } }],
+      ["thread/status/changed", { threadId: "provider-second", status: { type: "active" } }],
+    ]);
+    expect(firstNotifications).not.toHaveBeenCalled();
+  });
+
+  it("cancels a closing channel's request and keeps sibling requests working", async () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const writes: Array<Record<string, unknown>> = [];
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: (message) => writes.push(message),
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    const first = new CodexAppServerRpc(connection, "local-first");
+    const second = new CodexAppServerRpc(connection, "local-second");
+    const listener: CodexAppServerRpcListener = {
+      onNotification: () => {},
+      onRuntimeEvents: () => {},
+      onClose: () => {},
+      onError: () => {},
+    };
+    first.setListener(listener);
+    second.setListener(listener);
+    first.claimThread("provider-first");
+    second.claimThread("provider-second");
+
+    transportListener!.onMessage({
+      id: "approval-first",
+      method: "item/commandExecution/requestApproval",
+      params: { threadId: "provider-first", command: "pnpm test" },
+    });
+    first.dispose(new Error("first closed"));
+    expect(writes.at(-1)).toEqual({
+      id: "approval-first",
+      error: {
+        code: -32800,
+        message: "Request cancelled because the Poracode thread closed.",
+      },
+    });
+
+    const pending = second.request("thread/read", {
+      threadId: "provider-second",
+      includeTurns: false,
+    });
+    transportListener!.onMessage({
+      id: "poracode-0",
+      result: { thread: { id: "provider-second" } },
+    });
+    await expect(pending).resolves.toMatchObject({ thread: { id: "provider-second" } });
+  });
+
+  it("rejects immediately when writing a request fails", async () => {
+    const transport: CodexAppServerRpcTransport = {
+      setListener: () => {},
+      write: () => {
+        throw new Error("stdin closed");
+      },
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const rpc = new CodexAppServerRpc(transport, "local-thread");
+
+    await expect(rpc.request("thread/read", { threadId: "provider-thread" })).rejects.toThrow(
+      "stdin closed",
+    );
   });
 });

--- a/src/supervisor/agents/codex/appServerRpc.ts
+++ b/src/supervisor/agents/codex/appServerRpc.ts
@@ -20,20 +20,30 @@ export interface CodexAppServerRpcListener {
   onDebug?(direction: CodexRpcDebugDirection, payload: unknown): void;
 }
 
+interface RpcChannel {
+  localThreadId: string;
+  listener: CodexAppServerRpcListener | undefined;
+  remoteThreadIds: Set<string>;
+}
+
 type PendingRequest = {
+  channelId: string;
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
   timeout: NodeJS.Timeout;
 };
 
 type InboundRequest = {
+  channelId: string;
   id: string | number;
   method: string;
   params: Record<string, unknown> | undefined;
 };
 
 const SERVER_OVERLOADED_ERROR_CODE = -32001;
+const REQUEST_CANCELLED_ERROR_CODE = -32800;
 const MAX_OVERLOAD_RETRIES = 2;
+const MAX_BUFFERED_THREAD_NOTIFICATIONS = 100;
 
 export class CodexRpcResponseError extends Error {
   constructor(
@@ -52,20 +62,62 @@ export function isUnsupportedCodexRequestError(error: unknown): boolean {
   );
 }
 
-/** Owns JSON-RPC correlation and server-request bookkeeping above stdio framing. */
-export class CodexAppServerRpc {
-  private listener: CodexAppServerRpcListener | undefined;
+function readMessageThreadId(params: Record<string, unknown> | undefined): string | undefined {
+  if (typeof params?.threadId === "string") {
+    return params.threadId;
+  }
+  if (typeof params?.conversationId === "string") {
+    return params.conversationId;
+  }
+  const thread =
+    params && typeof params.thread === "object" && params.thread !== null
+      ? (params.thread as Record<string, unknown>)
+      : undefined;
+  if (typeof thread?.id === "string") {
+    return thread.id;
+  }
+  const turn =
+    params && typeof params.turn === "object" && params.turn !== null
+      ? (params.turn as Record<string, unknown>)
+      : undefined;
+  return typeof turn?.threadId === "string" ? turn.threadId : undefined;
+}
+
+function readStartedParentThreadId(
+  method: string,
+  params: Record<string, unknown> | undefined,
+): string | undefined {
+  if (method !== "thread/started" || !params || typeof params.thread !== "object") {
+    return undefined;
+  }
+  const thread = params.thread as Record<string, unknown>;
+  return typeof thread.parentThreadId === "string" ? thread.parentThreadId : undefined;
+}
+
+function shouldBufferUntilThreadClaim(method: string): boolean {
+  return (
+    method === "thread/started" ||
+    method === "thread/status/changed" ||
+    method === "thread/settings/updated"
+  );
+}
+
+/** Owns one app-server transport and multiplexes it across Poracode thread sessions. */
+export class CodexAppServerConnection {
   private requestSequence = 0;
+  private readonly channels = new Map<string, RpcChannel>();
+  private readonly remoteThreadChannels = new Map<string, string>();
   private readonly pendingRequests = new Map<string, PendingRequest>();
   private readonly inboundRequests = new Map<string, InboundRequest>();
+  private readonly bufferedThreadNotifications = new Map<
+    string,
+    Array<{ method: string; params: Record<string, unknown> | undefined }>
+  >();
+  private initializePromise: Promise<unknown> | undefined;
+  private initializedNotified = false;
+  private disposed = false;
 
-  constructor(
-    private readonly transport: CodexAppServerRpcTransport,
-    private readonly localThreadId: string,
-  ) {}
-
-  setListener(listener: CodexAppServerRpcListener): void {
-    this.listener = listener;
+  constructor(private readonly transport: CodexAppServerRpcTransport) {
     this.transport.setListener({
       onMessage: (payload) => this.handleMessage(payload),
       onClose: () => this.handleClose(),
@@ -73,32 +125,152 @@ export class CodexAppServerRpc {
     });
   }
 
-  request<M extends keyof CodexClientRequestMap>(
-    method: M,
-    params: CodexClientRequestMap[M]["params"],
-    timeoutMs = 30_000,
-  ): Promise<CodexClientRequestMap[M]["result"]> {
-    return this.requestWithRetry(method, params, timeoutMs) as Promise<
-      CodexClientRequestMap[M]["result"]
-    >;
+  registerChannel(channelId: string, localThreadId: string): void {
+    this.channels.set(channelId, {
+      localThreadId,
+      listener: undefined,
+      remoteThreadIds: new Set(),
+    });
   }
 
-  requestUnmapped(
-    method: string,
-    params: Record<string, unknown> | null,
-    timeoutMs = 30_000,
-  ): Promise<unknown> {
-    return this.requestWithRetry(method, params, timeoutMs);
+  setChannelListener(channelId: string, listener: CodexAppServerRpcListener): void {
+    const channel = this.channels.get(channelId);
+    if (channel) {
+      channel.listener = listener;
+    }
+  }
+
+  claimThread(channelId: string, remoteThreadId: string): void {
+    const channel = this.channels.get(channelId);
+    if (!channel) return;
+
+    for (const claimedId of channel.remoteThreadIds) {
+      if (this.remoteThreadChannels.get(claimedId) === channelId) {
+        this.remoteThreadChannels.delete(claimedId);
+      }
+    }
+    channel.remoteThreadIds.clear();
+    this.bindRemoteThread(channelId, remoteThreadId);
+
+    const buffered = this.bufferedThreadNotifications.get(remoteThreadId);
+    this.bufferedThreadNotifications.delete(remoteThreadId);
+    if (buffered) {
+      for (const notification of buffered) {
+        channel.listener?.onNotification(notification.method, notification.params);
+      }
+    }
+  }
+
+  ownsThread(channelId: string, remoteThreadId: string): boolean {
+    return this.remoteThreadChannels.get(remoteThreadId) === channelId;
+  }
+
+  request(channelId: string, method: string, params: unknown, timeoutMs: number): Promise<unknown> {
+    if (method !== "initialize") {
+      return this.requestWithRetry(channelId, method, params, timeoutMs);
+    }
+    this.initializePromise ??= this.requestWithRetry(channelId, method, params, timeoutMs).catch(
+      (error: unknown) => {
+        this.initializePromise = undefined;
+        throw error;
+      },
+    );
+    return this.initializePromise;
+  }
+
+  notify(channelId: string, method: string): void {
+    if (method === "initialized") {
+      if (this.initializedNotified) return;
+      this.initializedNotified = true;
+    }
+    this.write(channelId, { method });
+  }
+
+  resolveServerRequest(
+    channelId: string,
+    requestId: ThreadServerRequestId,
+    response: unknown,
+  ): void {
+    const inbound = this.inboundRequests.get(String(requestId));
+    if (inbound && inbound.channelId !== channelId) {
+      return;
+    }
+    this.inboundRequests.delete(String(requestId));
+    const result = inbound
+      ? translateCodexCanonicalResponse(inbound.method, inbound.params, response)
+      : response;
+    this.write(channelId, {
+      id: inbound?.id ?? requestId,
+      result,
+    });
+    if (inbound?.method === "item/tool/requestUserInput") {
+      const channel = this.channels.get(channelId);
+      if (channel) {
+        channel.listener?.onRuntimeEvents(
+          buildCodexQuestionAnswerEvents({
+            threadId: channel.localThreadId,
+            params: inbound.params,
+            response,
+          }),
+        );
+      }
+    }
+  }
+
+  unregisterChannel(channelId: string, error: Error): void {
+    const channel = this.channels.get(channelId);
+    if (channel) {
+      for (const remoteThreadId of channel.remoteThreadIds) {
+        if (this.remoteThreadChannels.get(remoteThreadId) === channelId) {
+          this.remoteThreadChannels.delete(remoteThreadId);
+        }
+      }
+      this.channels.delete(channelId);
+    }
+    for (const [id, pending] of this.pendingRequests) {
+      if (pending.channelId !== channelId) continue;
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+      this.pendingRequests.delete(id);
+    }
+    for (const [id, inbound] of this.inboundRequests) {
+      if (inbound.channelId === channelId) {
+        this.inboundRequests.delete(id);
+        try {
+          this.transport.write({
+            id: inbound.id,
+            error: {
+              code: REQUEST_CANCELLED_ERROR_CODE,
+              message: "Request cancelled because the Poracode thread closed.",
+            },
+          });
+        } catch {
+          // The shared process may have exited while this thread was closing.
+        }
+      }
+    }
+  }
+
+  dispose(error: Error): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.transport.dispose();
+    this.rejectPendingRequests(error);
+    this.channels.clear();
+    this.remoteThreadChannels.clear();
+    this.inboundRequests.clear();
+    this.bufferedThreadNotifications.clear();
   }
 
   private async requestWithRetry(
+    channelId: string,
     method: string,
     params: unknown,
     timeoutMs: number,
   ): Promise<unknown> {
     for (let attempt = 0; ; attempt += 1) {
       try {
-        return await this.requestOnce(method, params, timeoutMs);
+        return await this.requestOnce(channelId, method, params, timeoutMs);
       } catch (error) {
         if (
           !(error instanceof CodexRpcResponseError) ||
@@ -114,76 +286,43 @@ export class CodexAppServerRpc {
     }
   }
 
-  private requestOnce(method: string, params: unknown, timeoutMs: number): Promise<unknown> {
+  private requestOnce(
+    channelId: string,
+    method: string,
+    params: unknown,
+    timeoutMs: number,
+  ): Promise<unknown> {
     const id = `poracode-${this.requestSequence++}`;
-
     const pending = new Promise<unknown>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id);
         reject(new Error(`Timed out waiting for Codex app-server response to ${method}.`));
       }, timeoutMs);
-
-      this.pendingRequests.set(id, {
-        resolve,
-        reject,
-        timeout,
-      });
+      this.pendingRequests.set(id, { channelId, resolve, reject, timeout });
     });
 
-    this.write({
-      id,
-      method,
-      params,
-    });
-
+    try {
+      this.write(channelId, { id, method, params });
+    } catch (error) {
+      const request = this.pendingRequests.get(id);
+      if (request) {
+        clearTimeout(request.timeout);
+        this.pendingRequests.delete(id);
+        request.reject(error);
+      }
+    }
     return pending;
   }
 
-  notify(method: string): void {
-    this.write({
-      method,
-    });
-  }
-
-  resolveServerRequest(requestId: ThreadServerRequestId, response: unknown): void {
-    const inbound = this.inboundRequests.get(String(requestId));
-    this.inboundRequests.delete(String(requestId));
-    const result = inbound
-      ? translateCodexCanonicalResponse(inbound.method, inbound.params, response)
-      : response;
-    this.write({
-      id: inbound?.id ?? requestId,
-      result,
-    });
-    if (inbound?.method === "item/tool/requestUserInput") {
-      this.listener?.onRuntimeEvents(
-        buildCodexQuestionAnswerEvents({
-          threadId: this.localThreadId,
-          params: inbound.params,
-          response,
-        }),
-      );
-    }
-  }
-
-  dispose(error: Error): void {
-    this.transport.dispose();
-    this.rejectPendingRequests(error);
-  }
-
   private handleMessage(payload: unknown): void {
-    this.listener?.onDebug?.("codex->poracode", payload);
     const message = parseCodexSocketMessage(payload);
 
     if (message.kind === "response") {
       const pending = this.pendingRequests.get(message.id);
-      if (!pending) {
-        return;
-      }
-
+      if (!pending) return;
+      this.debugChannel(pending.channelId, "codex->poracode", payload);
       this.pendingRequests.delete(message.id);
       clearTimeout(pending.timeout);
-
       if (message.error !== undefined) {
         const error = message.error;
         const messageText =
@@ -206,63 +345,145 @@ export class CodexAppServerRpc {
 
     if (message.kind === "request") {
       if (message.method === "currentTime/read") {
-        this.write({
+        this.transport.write({
           id: message.id,
           result: { currentTimeAt: Math.floor(Date.now() / 1000) },
         });
         return;
       }
-      const canonical = mapCodexServerRequest(
-        this.localThreadId,
-        String(message.id),
-        message.method,
-        message.params,
-      );
-      if (canonical) {
-        this.inboundRequests.set(String(message.id), {
-          id: message.id,
-          method: message.method,
-          params: message.params,
-        });
-        this.listener?.onRuntimeEvents([canonical]);
-      } else {
-        console.warn(
-          `[codex] no canonical mapping for app-server request method "${message.method}"; replying method not found.`,
-        );
-        // Rejecting account/chatgptAuthTokens/refresh here is intentional: external-auth mode
-        // alone sends it, and Poracode never enables that mode (codex-rs app-server/src/external_auth.rs).
-        this.write({
-          id: message.id,
-          error: {
-            code: -32601,
-            message: `Unsupported Codex app-server request method "${message.method}".`,
-          },
-        });
-      }
+      this.handleInboundRequest(message.id, message.method, message.params);
       return;
     }
 
     if (message.kind === "notification") {
-      this.listener?.onNotification(message.method, message.params);
+      this.handleNotification(message.method, message.params, payload);
     }
+  }
+
+  private handleInboundRequest(
+    id: string | number,
+    method: string,
+    params: Record<string, unknown> | undefined,
+  ): void {
+    const threadId = readMessageThreadId(params);
+    const channelId =
+      (threadId ? this.remoteThreadChannels.get(threadId) : undefined) ??
+      (this.channels.size === 1 ? this.channels.keys().next().value : undefined);
+    const channel = channelId ? this.channels.get(channelId) : undefined;
+    const canonical = channel
+      ? mapCodexServerRequest(channel.localThreadId, String(id), method, params)
+      : undefined;
+    if (channelId && channel && canonical) {
+      this.debugChannel(channelId, "codex->poracode", { id, method, params });
+      this.inboundRequests.set(String(id), { channelId, id, method, params });
+      channel.listener?.onRuntimeEvents([canonical]);
+      return;
+    }
+
+    console.warn(
+      `[codex] no canonical mapping or owning thread for app-server request method "${method}"; replying method not found.`,
+    );
+    this.transport.write({
+      id,
+      error: {
+        code: -32601,
+        message: `Unsupported Codex app-server request method "${method}".`,
+      },
+    });
+  }
+
+  private handleNotification(
+    method: string,
+    params: Record<string, unknown> | undefined,
+    payload: unknown,
+  ): void {
+    const threadId = readMessageThreadId(params);
+    if (!threadId) {
+      for (const channel of this.channels.values()) {
+        channel.listener?.onDebug?.("codex->poracode", payload);
+        channel.listener?.onNotification(method, params);
+      }
+      return;
+    }
+
+    let channelId = this.remoteThreadChannels.get(threadId);
+    if (!channelId) {
+      const parentThreadId = readStartedParentThreadId(method, params);
+      const parentChannelId = parentThreadId
+        ? this.remoteThreadChannels.get(parentThreadId)
+        : undefined;
+      if (parentChannelId) {
+        this.bindRemoteThread(parentChannelId, threadId);
+        channelId = parentChannelId;
+      }
+    }
+
+    if (channelId) {
+      const channel = this.channels.get(channelId);
+      channel?.listener?.onDebug?.("codex->poracode", payload);
+      channel?.listener?.onNotification(method, params);
+      return;
+    }
+
+    if (this.channels.size === 1) {
+      const channel = this.channels.values().next().value;
+      channel?.listener?.onDebug?.("codex->poracode", payload);
+      channel?.listener?.onNotification(method, params);
+      return;
+    }
+
+    if (shouldBufferUntilThreadClaim(method)) {
+      const buffered = this.bufferedThreadNotifications.get(threadId) ?? [];
+      if (buffered.length < MAX_BUFFERED_THREAD_NOTIFICATIONS) {
+        buffered.push({ method, params });
+        this.bufferedThreadNotifications.set(threadId, buffered);
+      }
+    }
+    for (const channel of this.channels.values()) {
+      if (channel.remoteThreadIds.size === 0) continue;
+      channel.listener?.onDebug?.("codex->poracode", payload);
+      channel.listener?.onNotification(method, params);
+    }
+  }
+
+  private bindRemoteThread(channelId: string, remoteThreadId: string): void {
+    const channel = this.channels.get(channelId);
+    if (!channel) return;
+    channel.remoteThreadIds.add(remoteThreadId);
+    this.remoteThreadChannels.set(remoteThreadId, channelId);
   }
 
   private handleClose(): void {
     const output = this.transport.formatOutput();
-    this.listener?.onDebug?.("transport", { event: "close", output });
-    this.rejectPendingRequests(new Error(`Codex app-server exited.${output}`));
-    this.listener?.onClose();
+    const error = new Error(`Codex app-server exited.${output}`);
+    for (const channel of this.channels.values()) {
+      channel.listener?.onDebug?.("transport", { event: "close", output });
+      channel.listener?.onClose();
+    }
+    this.inboundRequests.clear();
+    this.rejectPendingRequests(error);
   }
 
   private handleError(error: Error): void {
-    this.listener?.onDebug?.("transport", { event: "error", message: error.message });
+    for (const channel of this.channels.values()) {
+      channel.listener?.onDebug?.("transport", { event: "error", message: error.message });
+      channel.listener?.onError(error);
+    }
+    this.inboundRequests.clear();
     this.rejectPendingRequests(error);
-    this.listener?.onError(error);
   }
 
-  private write(message: Record<string, unknown>): void {
-    this.listener?.onDebug?.("poracode->codex", message);
+  private write(channelId: string, message: Record<string, unknown>): void {
+    this.debugChannel(channelId, "poracode->codex", message);
     this.transport.write(message);
+  }
+
+  private debugChannel(
+    channelId: string,
+    direction: CodexRpcDebugDirection,
+    payload: unknown,
+  ): void {
+    this.channels.get(channelId)?.listener?.onDebug?.(direction, payload);
   }
 
   private rejectPendingRequests(error: Error): void {
@@ -271,5 +492,71 @@ export class CodexAppServerRpc {
       pending.reject(error);
     }
     this.pendingRequests.clear();
+  }
+}
+
+/** Per-thread facade over a shared app-server connection. */
+export class CodexAppServerRpc {
+  private readonly connection: CodexAppServerConnection;
+  private readonly ownsConnection: boolean;
+
+  constructor(
+    transportOrConnection: CodexAppServerRpcTransport | CodexAppServerConnection,
+    private readonly localThreadId: string,
+  ) {
+    if (transportOrConnection instanceof CodexAppServerConnection) {
+      this.ownsConnection = false;
+      this.connection = transportOrConnection;
+    } else {
+      this.ownsConnection = true;
+      this.connection = new CodexAppServerConnection(transportOrConnection);
+    }
+    this.connection.registerChannel(this.localThreadId, this.localThreadId);
+  }
+
+  setListener(listener: CodexAppServerRpcListener): void {
+    this.connection.setChannelListener(this.localThreadId, listener);
+  }
+
+  request<M extends keyof CodexClientRequestMap>(
+    method: M,
+    params: CodexClientRequestMap[M]["params"],
+    timeoutMs = 30_000,
+  ): Promise<CodexClientRequestMap[M]["result"]> {
+    return this.connection.request(this.localThreadId, method, params, timeoutMs) as Promise<
+      CodexClientRequestMap[M]["result"]
+    >;
+  }
+
+  requestUnmapped(
+    method: string,
+    params: Record<string, unknown> | null,
+    timeoutMs = 30_000,
+  ): Promise<unknown> {
+    return this.connection.request(this.localThreadId, method, params, timeoutMs);
+  }
+
+  notify(method: string): void {
+    this.connection.notify(this.localThreadId, method);
+  }
+
+  claimThread(threadId: string): void {
+    this.connection.claimThread(this.localThreadId, threadId);
+  }
+
+  ownsThread(threadId: string): boolean {
+    return this.connection.ownsThread(this.localThreadId, threadId);
+  }
+
+  resolveServerRequest(requestId: ThreadServerRequestId, response: unknown): void {
+    this.connection.resolveServerRequest(this.localThreadId, requestId, response);
+  }
+
+  dispose(error: Error): void {
+    if (this.ownsConnection) {
+      this.connection.dispose(error);
+      return;
+    }
+    this.connection.unregisterChannel(this.localThreadId, error);
   }
 }

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -165,19 +165,21 @@ export function buildCodexAppServerCommand(
     wslExecPath?: string;
     wslNodePath?: string;
     mcpServers?: readonly ResolvedMcpServer[];
+    includeMcpConfig?: boolean;
   },
 ): CommandSpec {
   const wslExecPath = options?.wslExecPath;
   const wslNodePath = options?.wslNodePath;
   const mcpServers = options?.mcpServers ?? [];
   const mcp = buildCodexMcp(mcpServers);
+  const includeMcpConfig = options?.includeMcpConfig ?? true;
   const mcpSkillConflictArgs = buildCodexMcpSkillConflictArgs(location, mcpServers);
   const mcpEnv = mcp.env;
   const hasMcpEnv = Object.keys(mcpEnv).length > 0;
   const args = [
     ...(isCodexGoalsSupported(location, wslExecPath) ? ["--enable", CODEX_GOALS_FEATURE_FLAG] : []),
     ...mcpSkillConflictArgs,
-    ...mcp.args,
+    ...(includeMcpConfig ? mcp.args : []),
     "app-server",
   ];
   if (location.kind === "wsl") {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -920,6 +920,8 @@ describe("CodexStructuredSession", () => {
     session["seenErrorMessages"] = new Set<string>();
     session["resumeActiveStatusSuppressionUntil"] = new Map();
     session["rpc"] = {
+      claimThread: () => {},
+      ownsThread: (threadId: string) => threadId === "provider-thread",
       request: async (
         method: string,
         params: Record<string, unknown> | null,
@@ -954,6 +956,53 @@ describe("CodexStructuredSession", () => {
       }
     ).handleNotification(message.method, message.params);
   }
+
+  it("exposes provider-thread ownership for shared Crossagents routing", () => {
+    const structuredSession = makeStructuredSession([]);
+
+    expect(structuredSession.ownsProviderSession("provider-thread")).toBe(true);
+    expect(structuredSession.ownsProviderSession("unrelated-thread")).toBe(false);
+  });
+
+  it("interrupts its provider turn and releases its shared-server lease once", async () => {
+    const structuredSession = makeStructuredSession([]);
+    const requests: Array<{
+      method: string;
+      params: Record<string, unknown>;
+      timeoutMs?: number;
+    }> = [];
+    const rpcDispose = vi.fn<(error: Error) => void>();
+    const releaseAppServer = vi.fn<() => void>();
+    (structuredSession as unknown as Record<string, unknown>)["activeTurnId"] = "turn-1";
+    (structuredSession as unknown as Record<string, unknown>)["releaseAppServer"] =
+      releaseAppServer;
+    (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      ownsThread: () => true,
+      request: (method: string, params: Record<string, unknown>, timeoutMs?: number) => {
+        requests.push({ method, params, ...(timeoutMs !== undefined ? { timeoutMs } : {}) });
+        return Promise.resolve({});
+      },
+      dispose: rpcDispose,
+    };
+
+    await structuredSession.dispose();
+    await structuredSession.dispose();
+
+    expect(requests).toEqual([
+      {
+        method: "turn/interrupt",
+        params: { threadId: "provider-thread", turnId: "turn-1" },
+        timeoutMs: 2_000,
+      },
+      {
+        method: "thread/unsubscribe",
+        params: { threadId: "provider-thread" },
+        timeoutMs: 2_000,
+      },
+    ]);
+    expect(rpcDispose).toHaveBeenCalledOnce();
+    expect(releaseAppServer).toHaveBeenCalledOnce();
+  });
 
   it("interrupts the active Codex app-server turn", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -1006,6 +1055,7 @@ describe("CodexStructuredSession", () => {
       onRuntimeEvent: (event: RuntimeEvent) => runtimeEvents.push(event),
     };
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: (method: string, params: Record<string, unknown>) => {
         requests.push({ method, params });
         if (method === "thread/read" && params.includeTurns === true) {
@@ -1050,7 +1100,7 @@ describe("CodexStructuredSession", () => {
 
     const history = await structuredSession.rollbackThread(2, rollbackConfig);
 
-    expect(requests.slice(0, 2)).toEqual([
+    expect(requests).toEqual([
       {
         method: "thread/read",
         params: {
@@ -1073,11 +1123,20 @@ describe("CodexStructuredSession", () => {
           lastTurnId: "turn-2",
         },
       },
+      {
+        method: "thread/unsubscribe",
+        params: {
+          threadId: "provider-thread",
+        },
+      },
+      {
+        method: "thread/read",
+        params: {
+          threadId: "forked-thread",
+          includeTurns: false,
+        },
+      },
     ]);
-    expect(requests[2]).toEqual({
-      method: "thread/unsubscribe",
-      params: { threadId: "provider-thread" },
-    });
     expect(history).toEqual({ providerSessionId: "forked-thread", messages: [] });
     expect((structuredSession as unknown as { remoteThreadId: string }).remoteThreadId).toBe(
       "forked-thread",
@@ -1109,6 +1168,7 @@ describe("CodexStructuredSession", () => {
     mapperState.usageScope = new CodexUsageScopeTracker("provider-thread", false);
     (structuredSession as unknown as Record<string, unknown>)["mapperState"] = mapperState;
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: (method: string, params: Record<string, unknown>) => {
         requests.push({ method, params });
         if (method === "thread/read" && params.includeTurns === true) {
@@ -1175,6 +1235,7 @@ describe("CodexStructuredSession", () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: async (method: string, params: Record<string, unknown>) => {
         requests.push({ method, params });
         if (method === "thread/read" && params.includeTurns === true) {
@@ -1210,6 +1271,7 @@ describe("CodexStructuredSession", () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: async (method: string, params: Record<string, unknown>) => {
         requests.push({ method, params });
         if (method === "thread/read") {
@@ -1519,6 +1581,7 @@ describe("CodexStructuredSession", () => {
       onRuntimeEvent: (event) => runtimeEvents.push(event),
     });
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: async (method: string, params: Record<string, unknown>) => {
         requests.push({ method, params });
         if (method === "thread/goal/get") {
@@ -1626,6 +1689,7 @@ describe("CodexStructuredSession", () => {
     const requests: CodexRequestRecord[] = [];
     const structuredSession = makeStructuredSession(requests);
     (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      claimThread: () => {},
       request: async (
         method: string,
         params: Record<string, unknown> | null,
@@ -1897,6 +1961,7 @@ describe("CodexStructuredSession", () => {
     session["bufferedRuntimeEvents"] = [];
     session["resumeActiveStatusSuppressionUntil"] = new Map();
     session["rpc"] = {
+      claimThread: () => {},
       request: async (method: string, params: Record<string, unknown>, timeoutMs?: number) => {
         requests.push({
           method,

--- a/src/supervisor/agents/codex/detection.ts
+++ b/src/supervisor/agents/codex/detection.ts
@@ -203,9 +203,13 @@ export const codexDefaultCapabilities: AgentCapability = {
   defaultApprovalsReviewer: "auto_review",
   defaultSandboxMode: "workspace-write",
   bypassPermissions: { approvalPolicy: "never", sandboxMode: "danger-full-access" },
-  // MCP config rides the `-c` launch argv in both presentations — baked in at
-  // spawn, read-only once the session is running.
+  // Terminal MCP config rides the `-c` launch argv. GUI sessions apply the
+  // same shape as a per-thread app-server config override.
   mcpScope: { terminal: "launch", gui: "launch" },
+  // Codex attaches its provider thread id to MCP tools/call `_meta.threadId`.
+  // Crossagents resolves that id through the supervisor session registry, so
+  // pooled GUI threads can share one credential without losing parent routing.
+  crossagentMcpRouting: "provider-session",
   settingDefs: [],
   slashCommands: CODEX_BUILT_IN_SLASH_COMMANDS,
   // Codex delivers its enabled skills through the ACP session (`skills/list`),

--- a/src/supervisor/agents/codex/serverPool.test.ts
+++ b/src/supervisor/agents/codex/serverPool.test.ts
@@ -1,0 +1,261 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedMcpServer } from "@/shared/contracts";
+import type { CreateStructuredSessionInput } from "../base";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn<(...args: unknown[]) => unknown>(),
+  terminateChildProcessTree: vi.fn<(child: unknown) => void>(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: mocks.spawn,
+}));
+vi.mock("@/shared/processTree", () => ({
+  terminateChildProcessTree: mocks.terminateChildProcessTree,
+}));
+vi.mock("./argv", () => ({
+  buildCodexAppServerCommand: () => ({
+    command: process.execPath,
+    args: [],
+  }),
+}));
+vi.mock("./mcpSkillConflicts", () => ({
+  buildCodexMcpSkillConflictArgs: () => [],
+}));
+
+import {
+  acquireCodexAppServer,
+  codexAppServerPoolKey,
+  shutdownSpawnedCodexAppServers,
+} from "./serverPool";
+
+function fakeChildProcess() {
+  return Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    exitCode: null,
+    killed: false,
+  });
+}
+
+function browserServer(threadId: string, baseUrl = "http://127.0.0.1:9000"): ResolvedMcpServer {
+  return {
+    id: "browser",
+    name: "browser",
+    timeoutMs: 30_000,
+    transport: {
+      type: "http",
+      url: `${baseUrl}/mcp?thread=${threadId}&title=task`,
+      headers: { Authorization: "Bearer shared-token" },
+    },
+  };
+}
+
+function httpServer(id: string, url: string, token = "shared-token"): ResolvedMcpServer {
+  return {
+    id,
+    name: id,
+    timeoutMs: 30_000,
+    transport: {
+      type: "http",
+      url,
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  };
+}
+
+function input(threadId: string, server: ResolvedMcpServer): CreateStructuredSessionInput {
+  return {
+    threadId,
+    projectLocation: { kind: "windows", path: "C:\\repo" },
+    config: { model: "gpt-5.6" },
+    mcpServers: [server],
+    presentationMode: "gui",
+  };
+}
+
+describe("Codex app-server pool", () => {
+  beforeEach(() => {
+    mocks.spawn.mockReset();
+    mocks.terminateChildProcessTree.mockReset();
+    mocks.spawn.mockImplementation(() => fakeChildProcess());
+  });
+
+  afterEach(() => {
+    shutdownSpawnedCodexAppServers();
+  });
+
+  it("reuses one process when only thread-scoped MCP query values differ", async () => {
+    const first = await acquireCodexAppServer(input("local-a", browserServer("local-a")));
+    const secondInput = {
+      ...input("local-b", browserServer("local-b")),
+      projectLocation: { kind: "windows" as const, path: "D:\\other-repo" },
+    };
+    const second = await acquireCodexAppServer(secondInput);
+
+    expect(mocks.spawn).toHaveBeenCalledOnce();
+    expect(second.connection).toBe(first.connection);
+
+    first.dispose();
+    expect(mocks.terminateChildProcessTree).not.toHaveBeenCalled();
+    second.dispose();
+    expect(mocks.terminateChildProcessTree).toHaveBeenCalledOnce();
+  });
+
+  it("starts a fresh process after the final lease is released", async () => {
+    const launch = input("local-a", browserServer("local-a"));
+    const first = await acquireCodexAppServer(launch);
+
+    first.dispose();
+    await acquireCodexAppServer(launch);
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse a process across different MCP endpoints", async () => {
+    await acquireCodexAppServer(input("local-a", browserServer("local-a")));
+    await acquireCodexAppServer(
+      input("local-b", browserServer("local-b", "http://127.0.0.1:9100")),
+    );
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps incompatible execution runtimes in separate pools", () => {
+    const server = browserServer("local-a");
+    const windows = codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [server]);
+    const posix = codexAppServerPoolKey({ kind: "posix", path: "/repo" }, [server]);
+    const ubuntu = codexAppServerPoolKey(
+      { kind: "wsl", distro: "Ubuntu", linuxPath: "/repo", uncPath: "\\\\wsl$\\Ubuntu\\repo" },
+      [server],
+    );
+    const debian = codexAppServerPoolKey(
+      { kind: "wsl", distro: "Debian", linuxPath: "/repo", uncPath: "\\\\wsl$\\Debian\\repo" },
+      [server],
+    );
+
+    expect(new Set([windows, posix, ubuntu, debian])).toHaveLength(4);
+  });
+
+  it("reuses a pool across project roots within the same execution runtime", () => {
+    expect(
+      codexAppServerPoolKey({ kind: "windows", path: "C:\\repo-a" }, [browserServer("local-a")]),
+    ).toBe(
+      codexAppServerPoolKey({ kind: "windows", path: "D:\\repo-b" }, [browserServer("local-b")]),
+    );
+    expect(
+      codexAppServerPoolKey({ kind: "posix", path: "/repo-a" }, [browserServer("local-a")]),
+    ).toBe(codexAppServerPoolKey({ kind: "posix", path: "/repo-b" }, [browserServer("local-b")]));
+    expect(
+      codexAppServerPoolKey(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/repo-a",
+          uncPath: "\\\\wsl$\\Ubuntu\\repo-a",
+        },
+        [browserServer("local-a")],
+        "C:\\Windows\\System32\\wsl.exe",
+        "/usr/bin/node",
+      ),
+    ).toBe(
+      codexAppServerPoolKey(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/repo-b",
+          uncPath: "\\\\wsl$\\Ubuntu\\repo-b",
+        },
+        [browserServer("local-b")],
+        "C:\\Windows\\System32\\wsl.exe",
+        "/usr/bin/node",
+      ),
+    );
+  });
+
+  it("keeps different WSL launch runtimes in separate pools", () => {
+    const location = {
+      kind: "wsl" as const,
+      distro: "Ubuntu",
+      linuxPath: "/repo",
+      uncPath: "\\\\wsl$\\Ubuntu\\repo",
+    };
+    const server = browserServer("local-a");
+    const baseline = codexAppServerPoolKey(location, [server], "wsl.exe", "/usr/bin/node");
+
+    expect(codexAppServerPoolKey(location, [server], "other-wsl.exe", "/usr/bin/node")).not.toBe(
+      baseline,
+    );
+    expect(codexAppServerPoolKey(location, [server], "wsl.exe", "/opt/node/bin/node")).not.toBe(
+      baseline,
+    );
+  });
+
+  it.each(["app-controls", "browser", "chrome", "computer-use"])(
+    "normalizes thread-scoped query values for %s",
+    (id) => {
+      const first = httpServer(
+        id,
+        `http://127.0.0.1:9000/mcp?thread=local-a&title=first&disable=one&stable=yes`,
+      );
+      const second = httpServer(
+        id,
+        `http://127.0.0.1:9000/mcp?thread=local-b&title=second&disable=two&stable=yes`,
+      );
+
+      expect(codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [first])).toBe(
+        codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [second]),
+      );
+    },
+  );
+
+  it("does not normalize custom MCP query values", () => {
+    const first = httpServer("custom", "http://127.0.0.1:9000/mcp?thread=local-a");
+    const second = httpServer("custom", "http://127.0.0.1:9000/mcp?thread=local-b");
+
+    expect(codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [first])).not.toBe(
+      codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [second]),
+    );
+  });
+
+  it("does not reuse a pool when MCP credentials differ", () => {
+    const first = httpServer("browser", "http://127.0.0.1:9000/mcp?thread=local-a", "token-a");
+    const second = httpServer("browser", "http://127.0.0.1:9000/mcp?thread=local-b", "token-b");
+
+    expect(codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [first])).not.toBe(
+      codexAppServerPoolKey({ kind: "windows", path: "C:\\repo" }, [second]),
+    );
+  });
+
+  it("evicts an exited process before the next acquisition", async () => {
+    const firstChild = fakeChildProcess();
+    mocks.spawn.mockImplementationOnce(() => firstChild);
+    const launch = input("local-a", browserServer("local-a"));
+
+    await acquireCodexAppServer(launch);
+    firstChild.emit("exit", 1);
+    await acquireCodexAppServer(launch);
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts a failed spawn so the next acquisition can retry", async () => {
+    mocks.spawn.mockImplementationOnce(() => {
+      const child = fakeChildProcess();
+      queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+      return child;
+    });
+
+    const launch = input("local-a", browserServer("local-a"));
+    await expect(acquireCodexAppServer(launch)).rejects.toThrow(
+      "Codex app-server failed to spawn: spawn failed",
+    );
+    await acquireCodexAppServer(launch);
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/supervisor/agents/codex/serverPool.ts
+++ b/src/supervisor/agents/codex/serverPool.ts
@@ -1,0 +1,204 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import type { ProjectLocation, ResolvedMcpServer } from "@/shared/contracts";
+import { terminateChildProcessTree } from "@/shared/processTree";
+import { resolveNodeForDistro } from "../../wsl/runtime";
+import type { CreateStructuredSessionInput } from "../base";
+import { buildCodexMcp } from "../userMcp";
+import { buildCodexAppServerCommand } from "./argv";
+import { CodexAppServerConnection } from "./appServerRpc";
+import { buildCodexMcpSkillConflictArgs } from "./mcpSkillConflicts";
+import { CodexStdioTransport } from "./stdioTransport";
+
+interface ServerSnapshot {
+  appServer: ChildProcess;
+  connection: CodexAppServerConnection;
+  transport: CodexStdioTransport;
+}
+
+interface PoolEntry {
+  ready: Promise<ServerSnapshot>;
+  leases: number;
+}
+
+export interface AcquiredCodexAppServer {
+  connection: CodexAppServerConnection;
+  dispose(): void;
+}
+
+const THREAD_SCOPED_MCP_SERVER_IDS = new Set(["app-controls", "browser", "chrome", "computer-use"]);
+const pool = new Map<string, PoolEntry>();
+const spawnedAppServers = new Set<ChildProcess>();
+const spawnedConnections = new Set<CodexAppServerConnection>();
+
+function executionRuntimeKey(location: ProjectLocation): string {
+  switch (location.kind) {
+    case "windows":
+      return "windows";
+    case "wsl":
+      return `wsl:${location.distro}`;
+    case "posix":
+      return "posix";
+  }
+}
+
+function normalizedMcpServer(server: ResolvedMcpServer): ResolvedMcpServer {
+  if (!THREAD_SCOPED_MCP_SERVER_IDS.has(server.id) || server.transport.type === "stdio") {
+    return server;
+  }
+  const url = new URL(server.transport.url);
+  url.searchParams.delete("thread");
+  url.searchParams.delete("title");
+  url.searchParams.delete("disable");
+  return {
+    ...server,
+    transport: {
+      ...server.transport,
+      url: url.toString(),
+    },
+  };
+}
+
+function poolFingerprint(
+  location: ProjectLocation,
+  mcpServers: readonly ResolvedMcpServer[],
+): string {
+  const normalizedServers = mcpServers.map(normalizedMcpServer);
+  const mcp = buildCodexMcp(normalizedServers);
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        servers: normalizedServers,
+        env: mcp.env,
+        skillConflictArgs: buildCodexMcpSkillConflictArgs(location, normalizedServers),
+      }),
+    )
+    .digest("hex");
+}
+
+export function codexAppServerPoolKey(
+  location: ProjectLocation,
+  mcpServers: readonly ResolvedMcpServer[],
+  wslExecPath?: string,
+  wslNodePath?: string,
+): string {
+  return [
+    executionRuntimeKey(location),
+    wslExecPath ?? "",
+    wslNodePath ?? "",
+    poolFingerprint(location, mcpServers),
+  ].join("|");
+}
+
+function spawnAppServer(command: ReturnType<typeof buildCodexAppServerCommand>): ChildProcess {
+  return spawn(command.command, command.args, {
+    cwd: command.cwd ?? process.cwd(),
+    env: {
+      ...process.env,
+      ...command.env,
+      TERM: "xterm-256color",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: false,
+    windowsHide: true,
+  });
+}
+
+async function spawnAndWire(
+  input: CreateStructuredSessionInput,
+  wslExecPath: string | undefined,
+  wslNodePath: string | undefined,
+  onExit: (appServer: ChildProcess, connection: CodexAppServerConnection) => void,
+): Promise<ServerSnapshot> {
+  const appServer = spawnAppServer(
+    buildCodexAppServerCommand(input.projectLocation, {
+      ...(wslExecPath !== undefined ? { wslExecPath } : {}),
+      ...(wslNodePath !== undefined ? { wslNodePath } : {}),
+      ...(input.mcpServers !== undefined ? { mcpServers: input.mcpServers } : {}),
+      includeMcpConfig: false,
+    }),
+  );
+  spawnedAppServers.add(appServer);
+  const transport = new CodexStdioTransport(appServer);
+  const connection = new CodexAppServerConnection(transport);
+  spawnedConnections.add(connection);
+  appServer.prependOnceListener("exit", () => onExit(appServer, connection));
+
+  const spawnError = await new Promise<Error | undefined>((resolve) => {
+    appServer.once("error", (error) => resolve(error));
+    setImmediate(() => resolve(undefined));
+  });
+  if (spawnError) {
+    spawnedAppServers.delete(appServer);
+    spawnedConnections.delete(connection);
+    throw new Error(`Codex app-server failed to spawn: ${spawnError.message}`);
+  }
+  if (appServer.exitCode !== null) {
+    spawnedAppServers.delete(appServer);
+    spawnedConnections.delete(connection);
+    throw new Error(`Codex app-server exited early.${transport.formatOutput()}`);
+  }
+
+  return { appServer, connection, transport };
+}
+
+export async function acquireCodexAppServer(
+  input: CreateStructuredSessionInput,
+  wslExecPath?: string,
+): Promise<AcquiredCodexAppServer> {
+  const wslNodePath =
+    input.projectLocation.kind === "wsl"
+      ? (await resolveNodeForDistro(input.projectLocation.distro)).nodePath
+      : undefined;
+  const mcpServers = input.mcpServers ?? [];
+  const key = codexAppServerPoolKey(input.projectLocation, mcpServers, wslExecPath, wslNodePath);
+  let entry = pool.get(key);
+  if (!entry) {
+    const ready = spawnAndWire(input, wslExecPath, wslNodePath, (appServer, connection) => {
+      spawnedAppServers.delete(appServer);
+      spawnedConnections.delete(connection);
+      if (pool.get(key) === entry) pool.delete(key);
+    });
+    entry = { ready, leases: 0 };
+    pool.set(key, entry);
+    ready.catch(() => {
+      if (pool.get(key) === entry) pool.delete(key);
+    });
+  }
+
+  const snapshot = await entry.ready;
+  entry.leases += 1;
+  let released = false;
+  return {
+    connection: snapshot.connection,
+    dispose: () => {
+      if (released) return;
+      released = true;
+      entry.leases -= 1;
+      if (entry.leases > 0) return;
+
+      if (pool.get(key) === entry) pool.delete(key);
+      spawnedConnections.delete(snapshot.connection);
+      spawnedAppServers.delete(snapshot.appServer);
+      snapshot.connection.dispose(new Error("Last Codex app-server pool lease released."));
+      if (!snapshot.appServer.killed) {
+        terminateChildProcessTree(snapshot.appServer);
+      }
+    },
+  };
+}
+
+export function shutdownSpawnedCodexAppServers(): void {
+  pool.clear();
+  const error = new Error("Codex app-server pool disposed.");
+  for (const connection of spawnedConnections) {
+    connection.dispose(error);
+  }
+  spawnedConnections.clear();
+  for (const appServer of spawnedAppServers) {
+    if (!appServer.killed) {
+      terminateChildProcessTree(appServer);
+    }
+  }
+  spawnedAppServers.clear();
+}

--- a/src/supervisor/agents/codex/threadOverrides.test.ts
+++ b/src/supervisor/agents/codex/threadOverrides.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedMcpServer } from "@/shared/contracts";
+import { codexMcpTokenEnvVar } from "../userMcp";
+import { buildCodexThreadOverrides } from "./threadOverrides";
+
+describe("buildCodexThreadOverrides", () => {
+  it("scopes cwd and MCP configuration to the app-server thread", () => {
+    const browser: ResolvedMcpServer = {
+      id: "browser",
+      name: "browser",
+      timeoutMs: 30_000,
+      transport: {
+        type: "http",
+        url: "http://127.0.0.1:9000/mcp?thread=local-thread",
+        headers: { Authorization: "Bearer secret-token" },
+      },
+    };
+
+    const overrides = buildCodexThreadOverrides(
+      { model: "gpt-5.6", effort: "high" },
+      {
+        projectLocation: { kind: "windows", path: "C:\\repo" },
+        mcpServers: [browser],
+      },
+    );
+
+    expect(overrides.cwd).toBe("C:\\repo");
+    expect(overrides.config).toMatchObject({
+      model_reasoning_effort: "high",
+      "mcp_servers.browser": {
+        url: "http://127.0.0.1:9000/mcp?thread=local-thread",
+        bearer_token_env_var: codexMcpTokenEnvVar(browser),
+        tool_timeout_sec: 30,
+      },
+    });
+    expect(JSON.stringify(overrides.config)).not.toContain("secret-token");
+  });
+});

--- a/src/supervisor/agents/codex/threadOverrides.ts
+++ b/src/supervisor/agents/codex/threadOverrides.ts
@@ -1,15 +1,25 @@
-import type { ThreadConfig } from "@/shared/contracts";
+import type { ProjectLocation, ResolvedMcpServer, ThreadConfig } from "@/shared/contracts";
+import { getProjectPosixPath } from "@/shared/wsl";
+import { buildCodexMcp } from "../userMcp";
 import type { CodexClientRequestMap } from "./protocol";
 
 type ThreadForkParams = CodexClientRequestMap["thread/fork"]["params"];
 type ThreadConfigOverrides = Pick<
   ThreadForkParams,
-  "model" | "approvalPolicy" | "approvalsReviewer" | "sandbox" | "config"
+  "model" | "cwd" | "approvalPolicy" | "approvalsReviewer" | "sandbox" | "config"
 >;
 
-export function buildCodexThreadOverrides(config: ThreadConfig): ThreadConfigOverrides {
+export function buildCodexThreadOverrides(
+  config: ThreadConfig,
+  options?: {
+    projectLocation?: ProjectLocation;
+    mcpServers?: readonly ResolvedMcpServer[];
+  },
+): ThreadConfigOverrides {
+  const mcpConfig = options?.mcpServers ? buildCodexMcp(options.mcpServers).config : {};
   return {
     model: config.model,
+    ...(options?.projectLocation ? { cwd: getProjectPosixPath(options.projectLocation) } : {}),
     ...(config.approvalPolicy
       ? {
           approvalPolicy: config.approvalPolicy as NonNullable<ThreadForkParams["approvalPolicy"]>,
@@ -28,6 +38,7 @@ export function buildCodexThreadOverrides(config: ThreadConfig): ThreadConfigOve
     config: {
       ...(config.effort ? { model_reasoning_effort: config.effort } : {}),
       model_reasoning_summary: "auto",
+      ...mcpConfig,
     },
   };
 }

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -213,6 +213,28 @@ describe("agent command builders", () => {
     expect(Object.values(spec.env ?? {})).toContain("secret-token");
   });
 
+  it("keeps pooled Codex MCP config out of argv while preserving token env vars", () => {
+    const spec = buildCodexAppServerCommand(windowsProject, {
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp?thread=local-thread",
+            headers: { Authorization: "Bearer secret-token" },
+          },
+        },
+      ],
+      includeMcpConfig: false,
+    });
+    const { cmdArgs } = parseWindowsSpec(spec);
+
+    expect(cmdArgs.some((arg) => arg.startsWith("mcp_servers.browser"))).toBe(false);
+    expect(Object.values(spec.env ?? {})).toContain("secret-token");
+  });
+
   it("injects Codex Crossagents MCP config when enabled, using a distinct token env var", () => {
     const spec = buildCodexAppServerCommand(windowsProject, {
       mcpServers: [

--- a/src/supervisor/agents/userMcp/translate.ts
+++ b/src/supervisor/agents/userMcp/translate.ts
@@ -353,31 +353,42 @@ function bearerToken(headers: Record<string, string>): string | undefined {
 export interface CodexMcp {
   args: string[];
   env: Record<string, string>;
+  config: Record<string, unknown>;
 }
 
 export function buildCodexMcp(servers: readonly ResolvedMcpServer[]): CodexMcp {
   const args: string[] = [];
   const env: Record<string, string> = {};
+  const config: Record<string, unknown> = {};
   let remoteClientEnabled = false;
 
   for (const server of servers) {
     const transport = server.transport;
     const key = `mcp_servers.${tomlKeySegment(server.name)}`;
+    const serverConfig: Record<string, unknown> = {};
     if (transport.type === "stdio") {
       args.push("-c", `${key}.command=${tomlString(transport.command)}`);
+      serverConfig.command = transport.command;
       if (transport.args.length > 0) {
         args.push("-c", `${key}.args=${tomlStringArray(transport.args)}`);
+        serverConfig.args = transport.args;
       }
       if (Object.keys(transport.env).length > 0) {
         args.push("-c", `${key}.env=${tomlInlineTable(transport.env)}`);
+        serverConfig.env = transport.env;
       }
-      if (transport.cwd) args.push("-c", `${key}.cwd=${tomlString(transport.cwd)}`);
+      if (transport.cwd) {
+        args.push("-c", `${key}.cwd=${tomlString(transport.cwd)}`);
+        serverConfig.cwd = transport.cwd;
+      }
     } else {
       if (!remoteClientEnabled) {
         args.push("-c", "experimental_use_rmcp_client=true");
+        config.experimental_use_rmcp_client = true;
         remoteClientEnabled = true;
       }
       args.push("-c", `${key}.url=${tomlString(transport.url)}`);
+      serverConfig.url = transport.url;
       const token = bearerToken(transport.headers);
       const envHeaders: Record<string, string> = {};
       for (const [headerName, headerValue] of Object.entries(transport.headers)) {
@@ -388,18 +399,23 @@ export function buildCodexMcp(servers: readonly ResolvedMcpServer[]): CodexMcp {
       }
       if (Object.keys(envHeaders).length > 0) {
         args.push("-c", `${key}.env_http_headers=${tomlInlineTable(envHeaders)}`);
+        serverConfig.env_http_headers = envHeaders;
       }
       if (token) {
         const envVar = codexMcpTokenEnvVar(server);
         args.push("-c", `${key}.bearer_token_env_var=${tomlString(envVar)}`);
+        serverConfig.bearer_token_env_var = envVar;
         env[envVar] = token;
       }
     }
     args.push("-c", `${key}.tool_timeout_sec=${Math.ceil(server.timeoutMs / 1000)}`);
+    serverConfig.tool_timeout_sec = Math.ceil(server.timeoutMs / 1000);
     if (server.approvalMode) {
       args.push("-c", `${key}.default_tools_approval_mode=${tomlString(server.approvalMode)}`);
+      serverConfig.default_tools_approval_mode = server.approvalMode;
     }
+    config[key] = serverConfig;
   }
 
-  return { args, env };
+  return { args, env, config };
 }

--- a/src/supervisor/crossagentMcp/CrossagentMcpIngress.test.ts
+++ b/src/supervisor/crossagentMcp/CrossagentMcpIngress.test.ts
@@ -155,8 +155,8 @@ describe("CrossagentMcpIngress", () => {
         arguments: {
           provider: "codex",
           prompt: "first",
-          [CROSSAGENT_PROVIDER_SESSION_ID_ARG]: "session-1",
         },
+        _meta: { threadId: "session-1" },
       }),
       providerRpc("tools/call", {
         name: "spawn_agent",

--- a/src/supervisor/crossagentMcp/CrossagentMcpIngress.ts
+++ b/src/supervisor/crossagentMcp/CrossagentMcpIngress.ts
@@ -198,8 +198,11 @@ export class CrossagentMcpIngress {
     return null;
   }
 
-  private resolveProviderSessionThreadId(args: Record<string, unknown>): string | undefined {
-    const sessionId = args[CROSSAGENT_PROVIDER_SESSION_ID_ARG];
+  private resolveProviderSessionThreadId(
+    args: Record<string, unknown>,
+    meta?: Record<string, unknown>,
+  ): string | undefined {
+    const sessionId = args[CROSSAGENT_PROVIDER_SESSION_ID_ARG] ?? meta?.threadId;
     delete args[CROSSAGENT_PROVIDER_SESSION_ID_ARG];
     if (typeof sessionId !== "string" || sessionId.length === 0) return undefined;
     const threadId = this.deps.resolveProviderSessionThreadId?.(sessionId);
@@ -354,13 +357,19 @@ export class CrossagentMcpIngress {
         };
       }
       if (method === "tools/call") {
-        const p = (params ?? {}) as { name?: string; arguments?: Record<string, unknown> };
+        const p = (params ?? {}) as {
+          name?: string;
+          arguments?: Record<string, unknown>;
+          _meta?: Record<string, unknown>;
+        };
         const name = String(p.name ?? "");
         const rawArgs = p.arguments;
         const args =
           rawArgs && typeof rawArgs === "object" && !Array.isArray(rawArgs) ? { ...rawArgs } : {};
         const threadId =
-          auth.mode === "thread" ? auth.threadId : this.resolveProviderSessionThreadId(args);
+          auth.mode === "thread"
+            ? auth.threadId
+            : this.resolveProviderSessionThreadId(args, p._meta);
         if (!threadId) {
           return {
             jsonrpc: "2.0",

--- a/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
@@ -4,6 +4,7 @@ import {
   applyAgentSettingsMcpFlags,
   composeResolvedMcpServers,
   effectiveLaunchConfig,
+  usesProviderSessionCrossagentRouting,
 } from "./spawnPipeline";
 
 const baseConfig: ThreadConfig = {
@@ -82,6 +83,35 @@ describe("applyAgentSettingsMcpFlags", () => {
       computerUse: false,
       crossagentMcp: false,
     });
+  });
+});
+
+describe("usesProviderSessionCrossagentRouting", () => {
+  const adapter = {
+    capabilities: {
+      presentationMode: "terminal",
+      crossagentMcpRouting: "provider-session",
+    },
+  } as const;
+
+  it("uses provider-session routing for a GUI thread", () => {
+    expect(usesProviderSessionCrossagentRouting(adapter, "gui", "thread-1")).toBe(true);
+  });
+
+  it("keeps terminal threads on direct routing", () => {
+    expect(usesProviderSessionCrossagentRouting(adapter, "terminal", "thread-1")).toBe(false);
+    expect(usesProviderSessionCrossagentRouting(adapter, undefined, "thread-1")).toBe(false);
+  });
+
+  it("requires a thread id and provider support", () => {
+    expect(usesProviderSessionCrossagentRouting(adapter, "gui", undefined)).toBe(false);
+    expect(
+      usesProviderSessionCrossagentRouting(
+        { capabilities: { presentationMode: "gui" } },
+        "gui",
+        "thread-1",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -149,6 +149,25 @@ export function applyAgentSettingsMcpFlags(
   );
 }
 
+export function usesProviderSessionCrossagentRouting(
+  adapter:
+    | {
+        capabilities: {
+          presentationMode: ThreadPresentationMode;
+          crossagentMcpRouting?: AgentAdapter["capabilities"]["crossagentMcpRouting"];
+        };
+      }
+    | undefined,
+  presentationMode: ThreadPresentationMode | undefined,
+  crossagentThreadId: string | undefined,
+): boolean {
+  return (
+    adapter?.capabilities.crossagentMcpRouting === "provider-session" &&
+    (presentationMode ?? adapter.capabilities.presentationMode) !== "terminal" &&
+    crossagentThreadId !== undefined
+  );
+}
+
 export function composeResolvedMcpServers(
   snapshot: McpLaunchSnapshot,
   browserMcp: BrowserMcpHttpConfig | undefined,
@@ -337,6 +356,7 @@ export class SpawnPipeline {
       identity: mcpIdentity,
       crossagentThreadId: payload.threadId,
       adapter,
+      presentationMode: requestedPresentation,
     });
     const structuredSession = await this.createStructuredSession(
       adapter,
@@ -625,6 +645,7 @@ export class SpawnPipeline {
       identity: mcpIdentity,
       crossagentThreadId: session.threadId,
       adapter: session.adapter,
+      ...(session.presentationMode ? { presentationMode: session.presentationMode } : {}),
     });
     const structuredSession = await this.createStructuredSession(
       session.adapter,
@@ -913,6 +934,7 @@ export class SpawnPipeline {
     identity,
     crossagentThreadId,
     adapter,
+    presentationMode,
   }: {
     location: ProjectLocation;
     config: ThreadConfig;
@@ -920,10 +942,13 @@ export class SpawnPipeline {
     identity?: McpThreadIdentity;
     crossagentThreadId?: string;
     adapter?: AgentAdapter;
+    presentationMode?: ThreadPresentationMode;
   }): Promise<ResolvedMcpServer[]> {
-    const providerSessionCrossagents =
-      adapter?.capabilities.crossagentMcpRouting === "provider-session" &&
-      crossagentThreadId !== undefined;
+    const providerSessionCrossagents = usesProviderSessionCrossagentRouting(
+      adapter,
+      presentationMode,
+      crossagentThreadId,
+    );
     if (adapter?.capabilities.mcpConfigSource === "agentSettings") {
       // Provider-level MCP: flags come from the provider's settings page. Drop
       // the thread identity so a shared provider runtime never retains

--- a/src/supervisor/supervisorRuntime.ts
+++ b/src/supervisor/supervisorRuntime.ts
@@ -807,6 +807,8 @@ export class SupervisorRuntime {
     });
     const { shutdownSpawnedOpenCodeServers } = await import("./agents/opencode/sdkClient");
     shutdownSpawnedOpenCodeServers();
+    const { shutdownSpawnedCodexAppServers } = await import("./agents/codex/serverPool");
+    shutdownSpawnedCodexAppServers();
   }
 
   private handlePtyData(session: SessionRuntime, data: string): void {


### PR DESCRIPTION
- Add pooled Codex app-server connections with multiplexed thread-aware RPC handling.
- Apply per-thread working directory, model, and MCP configuration without exposing credentials in launch arguments.
- Route Crossagent MCP requests through provider thread metadata and cleanly shut down pooled servers.
- Expand coverage for pooling, overrides, routing, command generation, and lifecycle behavior.