### PR TITLE
Enhance GitHub Actions workflow run management

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Führen Sie {loginCommand} aus, um sich anzumelden."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Neuen Thread auf {0} starten."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Ausführungsaktionen"

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Rechtsklicken, um den Ring zu wechseln"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Run {loginCommand} to sign in."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Run a new thread on {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Run actions"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Right-click to switch ring"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Ejecuta {loginCommand} para iniciar sesión."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Ejecutar un hilo nuevo en {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Acciones de ejecución"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Haz clic derecho para cambiar de anillo"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -9093,6 +9093,7 @@ msgstr "Clic droit pour changer d'anneau"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -9121,6 +9121,7 @@ msgstr "Exécutez {loginCommand} pour vous connecter."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Démarrer un nouveau fil sur {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Actions d’exécution"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -9092,6 +9092,7 @@ msgstr "右クリックでリングを切り替え"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -9120,6 +9120,7 @@ msgstr "{loginCommand}を実行してサインインします。"
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "{0} で新しいスレッドを実行します。"
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "実行アクション"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -9122,6 +9122,7 @@ msgstr "{loginCommand}을 실행하여 로그인합니다."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "{0}에서 새 스레드를 실행합니다."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "실행 작업"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -9094,6 +9094,7 @@ msgstr "마우스 오른쪽 버튼을 클릭해 링 전환"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Uruchom {loginCommand}, aby się zalogować."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Uruchom nowy wątek na {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Akcje uruchomienia"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Kliknij prawym przyciskiem, aby przełączyć pierścień"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Execute {loginCommand} para fazer login."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Executar uma nova conversa em {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Ações da execução"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Clique com o botão direito para trocar o anel"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Щелкните правой кнопкой, чтобы переклю�
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Запустите {loginCommand}, чтобы войти."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Запустить новый поток на {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Действия с запуском"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Oturum açmak için {loginCommand} komutunu çalıştırın."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "{0} üzerinde yeni bir iş parçacığı çalıştır."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Çalıştırma eylemleri"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Halkayı değiştirmek için sağ tıklayın"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Клацніть правою кнопкою, щоб перемкнут�
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Запустіть {loginCommand}, щоб увійти."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Запустити новий потік на {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Дії із запуском"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -9094,6 +9094,7 @@ msgstr "Nhấp chuột phải để đổi vòng"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -9122,6 +9122,7 @@ msgstr "Chạy {loginCommand} để đăng nhập."
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "Chạy luồng mới trên {0}."
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "Thao tác lượt chạy"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -9093,6 +9093,7 @@ msgstr "右键点击以切换环"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+#: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -9121,6 +9121,7 @@ msgstr "运行{loginCommand}进行登录。"
 #~ msgid "Run a new thread on {0}."
 #~ msgstr "在 {0} 上运行新线程。"
 
+#: src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
 #: src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
 msgid "Run actions"
 msgstr "运行操作"

--- a/src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
@@ -43,9 +43,8 @@ export function buildWorkflowDispatchInputs(
 
 export function GitHubActionsDispatchPopover(props: {
   workflow: GitHubActionsWorkflow;
-  definition: GitHubActionsWorkflowDefinition;
+  definition: GitHubActionsWorkflowDefinition | null;
   projectId: string;
-  currentBranch: string;
   isOpen: boolean;
   isDefinitionLoading: boolean;
   isPending: boolean;
@@ -54,17 +53,26 @@ export function GitHubActionsDispatchPopover(props: {
   onRun: (ref: string, inputs: Record<string, string>) => Promise<boolean>;
 }) {
   const { t } = useLingui();
-  const [ref, setRef] = useState(props.definition.ref);
-  const [values, setValues] = useState<InputValues>(() => defaultInputValues(props.definition));
+  const [ref, setRef] = useState(props.definition?.ref ?? "");
+  const [values, setValues] = useState<InputValues>(() =>
+    props.definition ? defaultInputValues(props.definition) : {},
+  );
   const [missing, setMissing] = useState<string[]>([]);
 
   useEffect(() => {
+    if (!props.definition) {
+      setRef("");
+      setValues({});
+      setMissing([]);
+      return;
+    }
     setRef(props.definition.ref);
     setValues(defaultInputValues(props.definition));
     setMissing([]);
   }, [props.definition]);
 
   async function runWorkflow() {
+    if (!props.definition) return;
     const result = buildWorkflowDispatchInputs(props.definition, values);
     setMissing(result.missing);
     if (result.missing.length > 0) return;
@@ -88,96 +96,98 @@ export function GitHubActionsDispatchPopover(props: {
             </p>
           </div>
           <div className="max-h-[min(520px,70vh)] space-y-4 overflow-y-auto px-4 py-4">
-            <BranchSelector
-              projectId={props.projectId}
-              currentBranch={props.currentBranch}
-              value={ref}
-              selectionOnly
-              hideWorktreeToggle
-              popoverPlacement="bottom"
-              className="w-full"
-              trigger={
-                <Button
-                  fullWidth
-                  variant="secondary"
-                  className="justify-start px-3"
-                  aria-label={t`Branch or tag`}
-                >
-                  <GitBranch className="size-3.5 text-muted" />
-                  <span className="min-w-0 flex-1 truncate text-left">{ref}</span>
-                  <ChevronDown className="size-3.5 text-muted" />
-                </Button>
-              }
-              onSelect={({ branch }) => {
-                setRef(branch);
-                props.onRefChange(branch);
-              }}
-            />
-            {props.isDefinitionLoading ? (
+            {props.isDefinitionLoading || !props.definition ? (
               <div className="flex items-center gap-2 py-5 text-xs text-muted">
                 <LoaderCircle className="size-4 animate-spin" />
                 <Trans>Loading workflow inputs</Trans>
               </div>
             ) : (
-              props.definition.inputs.map((input) =>
-                input.type === "boolean" ? (
-                  <Checkbox
-                    key={input.name}
-                    isSelected={values[input.name] === true}
-                    onChange={(selected) =>
-                      setValues((current) => ({ ...current, [input.name]: selected }))
-                    }
-                  >
-                    <Checkbox.Content className="items-start">
-                      <Checkbox.Control className="mt-0.5 border border-[var(--hairline-strong)] bg-surface-secondary shadow-none">
-                        <Checkbox.Indicator />
-                      </Checkbox.Control>
-                      <span>
-                        <span className="block text-xs font-medium text-foreground">
-                          {input.description || input.name}
-                        </span>
-                        {input.description ? (
-                          <span className="mt-0.5 block font-mono text-[11px] text-muted">
-                            {input.name}
+              <>
+                <BranchSelector
+                  projectId={props.projectId}
+                  currentBranch={props.definition.defaultBranch}
+                  value={ref}
+                  selectionOnly
+                  hideWorktreeToggle
+                  popoverPlacement="bottom"
+                  className="w-full"
+                  trigger={
+                    <Button
+                      fullWidth
+                      variant="secondary"
+                      className="justify-start px-3"
+                      aria-label={t`Branch or tag`}
+                    >
+                      <GitBranch className="size-3.5 text-muted" />
+                      <span className="min-w-0 flex-1 truncate text-left">{ref}</span>
+                      <ChevronDown className="size-3.5 text-muted" />
+                    </Button>
+                  }
+                  onSelect={({ branch }) => {
+                    setRef(branch);
+                    props.onRefChange(branch);
+                  }}
+                />
+                {props.definition.inputs.map((input) =>
+                  input.type === "boolean" ? (
+                    <Checkbox
+                      key={input.name}
+                      isSelected={values[input.name] === true}
+                      onChange={(selected) =>
+                        setValues((current) => ({ ...current, [input.name]: selected }))
+                      }
+                    >
+                      <Checkbox.Content className="items-start">
+                        <Checkbox.Control className="mt-0.5 border border-[var(--hairline-strong)] bg-surface-secondary shadow-none">
+                          <Checkbox.Indicator />
+                        </Checkbox.Control>
+                        <span>
+                          <span className="block text-xs font-medium text-foreground">
+                            {input.description || input.name}
                           </span>
-                        ) : null}
-                      </span>
-                    </Checkbox.Content>
-                  </Checkbox>
-                ) : input.type === "choice" && input.options.length > 0 ? (
-                  <div key={input.name} className="space-y-1">
-                    <Label className="text-xs font-medium text-foreground">
-                      {input.description || input.name}
-                    </Label>
-                    <Select
-                      aria-label={input.description || input.name}
-                      options={input.options.map((option) => ({ id: option, label: option }))}
+                          {input.description ? (
+                            <span className="mt-0.5 block font-mono text-[11px] text-muted">
+                              {input.name}
+                            </span>
+                          ) : null}
+                        </span>
+                      </Checkbox.Content>
+                    </Checkbox>
+                  ) : input.type === "choice" && input.options.length > 0 ? (
+                    <div key={input.name} className="space-y-1">
+                      <Label className="text-xs font-medium text-foreground">
+                        {input.description || input.name}
+                      </Label>
+                      <Select
+                        aria-label={input.description || input.name}
+                        options={input.options.map((option) => ({ id: option, label: option }))}
+                        value={stringInputValue(values, input.name)}
+                        onChange={(value) =>
+                          setValues((current) => ({ ...current, [input.name]: value }))
+                        }
+                      />
+                      {input.description ? (
+                        <p className="font-mono text-[11px] text-muted">{input.name}</p>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <TextField
+                      key={input.name}
                       value={stringInputValue(values, input.name)}
+                      isRequired={input.required}
+                      isInvalid={missing.includes(input.name)}
+                      type={input.type === "number" ? "number" : "text"}
                       onChange={(value) =>
                         setValues((current) => ({ ...current, [input.name]: value }))
                       }
-                    />
-                    {input.description ? (
-                      <p className="font-mono text-[11px] text-muted">{input.name}</p>
-                    ) : null}
-                  </div>
-                ) : (
-                  <TextField
-                    key={input.name}
-                    value={stringInputValue(values, input.name)}
-                    isRequired={input.required}
-                    isInvalid={missing.includes(input.name)}
-                    type={input.type === "number" ? "number" : "text"}
-                    onChange={(value) =>
-                      setValues((current) => ({ ...current, [input.name]: value }))
-                    }
-                  >
-                    <Label>{input.description || input.name}</Label>
-                    <Input />
-                    {input.description ? <Description>{input.name}</Description> : null}
-                  </TextField>
-                ),
-              )
+                    >
+                      <Label>{input.description || input.name}</Label>
+                      <Input />
+                      {input.description ? <Description>{input.name}</Description> : null}
+                    </TextField>
+                  ),
+                )}
+              </>
             )}
             {missing.length > 0 ? (
               <p className="text-xs text-danger">
@@ -196,7 +206,7 @@ export function GitHubActionsDispatchPopover(props: {
             <Button
               variant="primary"
               isPending={props.isPending}
-              isDisabled={props.isDefinitionLoading}
+              isDisabled={props.isDefinitionLoading || !props.definition}
               onPress={() => void runWorkflow()}
             >
               {({ isPending }) => (
@@ -206,7 +216,7 @@ export function GitHubActionsDispatchPopover(props: {
                   ) : (
                     <Play className="size-4" />
                   )}
-                  <Trans>Run workflow</Trans>
+                  <Trans>Run</Trans>
                 </>
               )}
             </Button>

--- a/src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsRunDetail.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@heroui/react";
+import { Button, ButtonGroup, Dropdown, Label } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
+  ChevronDown,
   ExternalLink,
   GitBranch,
   GitCommitHorizontal,
@@ -39,10 +40,14 @@ export function GitHubActionsRunDetail(props: {
 
   return (
     <section className="h-full min-w-0 overflow-y-auto [scrollbar-gutter:stable]">
-      <div className="flex items-start gap-3 border-b border-[var(--hairline)] px-4 py-3">
+      <div className="flex min-h-[76px] items-center gap-3 border-b border-[var(--hairline)] px-4 py-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <StatusIndicator status={props.run.status} conclusion={props.run.conclusion} />
+            <StatusIndicator
+              status={props.run.status}
+              conclusion={props.run.conclusion}
+              showLabel={false}
+            />
             <h2 className="truncate text-sm font-semibold text-foreground">
               {props.run.title || props.run.workflowName || t`Workflow run`}
             </h2>
@@ -51,70 +56,77 @@ export function GitHubActionsRunDetail(props: {
             {props.run.workflowName} #{props.run.number}
           </p>
         </div>
-        <Button
-          isIconOnly
-          size="sm"
-          variant="ghost"
-          aria-label={t`Close run details`}
-          onPress={props.onClose}
-        >
-          <X className="size-4" />
-        </Button>
-      </div>
-
-      <div className="flex flex-wrap gap-2 border-b border-[var(--hairline)] px-4 py-3">
-        <Button
-          size="sm"
-          variant="secondary"
-          isDisabled={!completed || props.isPending}
-          onPress={() => props.onRerun(false)}
-        >
-          <RotateCcw className="size-3.5" />
-          <Trans>Re-run all jobs</Trans>
-        </Button>
-        {failed ? (
-          <Button
-            size="sm"
-            variant="secondary"
-            isDisabled={!completed || props.isPending}
-            onPress={() => props.onRerun(true)}
-          >
-            <RotateCcw className="size-3.5" />
-            <Trans>Re-run failed jobs</Trans>
-          </Button>
-        ) : null}
-        <Button
-          isIconOnly
-          size="sm"
-          variant="ghost"
-          aria-label={t`Refresh run`}
-          isDisabled={props.loading}
-          onPress={props.onRefresh}
-        >
-          <RefreshCw className={`size-3.5 ${props.loading ? "animate-spin" : ""}`} />
-        </Button>
-        {props.run.url ? (
+        <div className="flex shrink-0 items-center gap-1">
+          <ButtonGroup size="sm" variant="secondary">
+            <Button isDisabled={!completed || props.isPending} onPress={() => props.onRerun(false)}>
+              <RotateCcw className="size-3.5" />
+              <Trans>Re-run all jobs</Trans>
+            </Button>
+            {failed ? (
+              <Dropdown>
+                <Button
+                  isIconOnly
+                  aria-label={t`Run actions`}
+                  isDisabled={!completed || props.isPending}
+                >
+                  <ButtonGroup.Separator />
+                  <ChevronDown className="size-3.5" />
+                </Button>
+                <Dropdown.Popover placement="bottom end">
+                  <Dropdown.Menu aria-label={t`Run actions`} onAction={() => props.onRerun(true)}>
+                    <Dropdown.Item id="rerun-failed" textValue={t`Re-run failed jobs`}>
+                      <RotateCcw className="size-3.5" />
+                      <Label>
+                        <Trans>Re-run failed jobs</Trans>
+                      </Label>
+                    </Dropdown.Item>
+                  </Dropdown.Menu>
+                </Dropdown.Popover>
+              </Dropdown>
+            ) : null}
+          </ButtonGroup>
           <Button
             isIconOnly
             size="sm"
             variant="ghost"
-            aria-label={t`Open on GitHub`}
-            onPress={() => openExternalWithFeedback(props.run.url)}
+            aria-label={t`Refresh run`}
+            isDisabled={props.loading}
+            onPress={props.onRefresh}
           >
-            <ExternalLink className="size-3.5" />
+            <RefreshCw className={`size-3.5 ${props.loading ? "animate-spin" : ""}`} />
           </Button>
-        ) : null}
-        <Button
-          isIconOnly
-          size="sm"
-          variant="ghost"
-          className="text-danger"
-          aria-label={t`Delete workflow run`}
-          isDisabled={!completed || props.isPending}
-          onPress={props.onDelete}
-        >
-          <Trash2 className="size-3.5" />
-        </Button>
+          {props.run.url ? (
+            <Button
+              isIconOnly
+              size="sm"
+              variant="ghost"
+              aria-label={t`Open on GitHub`}
+              onPress={() => openExternalWithFeedback(props.run.url)}
+            >
+              <ExternalLink className="size-3.5" />
+            </Button>
+          ) : null}
+          <Button
+            isIconOnly
+            size="sm"
+            variant="ghost"
+            className="text-danger"
+            aria-label={t`Delete workflow run`}
+            isDisabled={!completed || props.isPending}
+            onPress={props.onDelete}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+          <Button
+            isIconOnly
+            size="sm"
+            variant="ghost"
+            aria-label={t`Close run details`}
+            onPress={props.onClose}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
       </div>
 
       <dl className="grid grid-cols-2 gap-x-5 gap-y-3 border-b border-[var(--hairline)] px-4 py-4 sm:grid-cols-3 xl:grid-cols-2 2xl:grid-cols-3">
@@ -155,38 +167,66 @@ export function GitHubActionsRunDetail(props: {
           </p>
         ) : (
           <div className="divide-y divide-[var(--hairline)] border-y border-[var(--hairline)]">
-            {props.run.jobs.map((job) => (
-              <details key={job.id} className="group">
-                <summary className="flex cursor-pointer list-none items-center gap-3 px-1 py-3">
-                  <StatusIndicator status={job.status} conclusion={job.conclusion} />
-                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+            {props.run.jobs.map((job) => {
+              const hasSteps = job.steps.length > 0;
+              const jobHeader = (
+                <>
+                  <StatusIndicator
+                    status={job.status}
+                    conclusion={job.conclusion}
+                    showLabel={false}
+                  />
+                  <span
+                    className={`min-w-0 flex-1 truncate text-xs font-medium text-foreground ${
+                      hasSteps ? "link cursor-default underline-offset-2" : ""
+                    }`}
+                  >
                     {job.name}
                   </span>
-                  <span className="text-[11px] text-muted">
-                    {t`${job.steps.filter((step) => step.status === "completed").length} of ${job.steps.length} steps`}
-                  </span>
+                  {hasSteps ? (
+                    <span className="shrink-0 text-[11px] text-muted">
+                      {t`${job.steps.filter((step) => step.status === "completed").length} of ${job.steps.length} steps`}
+                    </span>
+                  ) : null}
                   {job.url ? (
                     <Button
                       isIconOnly
                       size="sm"
                       variant="ghost"
+                      className="size-7 min-w-0"
                       aria-label={t`Open job on GitHub`}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                      }}
                       onPress={() => openExternalWithFeedback(job.url!)}
                     >
                       <ExternalLink className="size-3.5" />
                     </Button>
                   ) : null}
-                </summary>
-                <div className="space-y-1 pb-3 pl-7 pr-2">
-                  {job.steps.map((step) => (
-                    <div key={step.number} className="flex items-center gap-3 py-1 text-xs">
-                      <StatusIndicator status={step.status} conclusion={step.conclusion} />
-                      <span className="min-w-0 flex-1 truncate text-muted">{step.name}</span>
-                    </div>
-                  ))}
+                </>
+              );
+
+              return !hasSteps ? (
+                <div key={job.id} className="flex min-h-14 items-center gap-3 px-1 py-2">
+                  {jobHeader}
                 </div>
-              </details>
-            ))}
+              ) : (
+                <details key={job.id} className="group">
+                  <summary className="flex min-h-14 list-none items-center gap-3 px-1 py-2">
+                    {jobHeader}
+                  </summary>
+                  <div className="space-y-1 pb-3 pl-7 pr-2">
+                    {job.steps.map((step) => (
+                      <div key={step.number} className="flex items-center gap-3 py-1 text-xs">
+                        <StatusIndicator status={step.status} conclusion={step.conclusion} />
+                        <span className="min-w-0 flex-1 truncate text-muted">{step.name}</span>
+                      </div>
+                    ))}
+                  </div>
+                </details>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsRunList.tsx
@@ -125,7 +125,7 @@ export function GitHubActionsRunList(props: {
       {props.runs.map((run) => (
         <div
           key={run.id}
-          className={`relative grid min-h-14 w-full grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-x-3 px-2 py-2 transition-colors md:grid-cols-[24px_minmax(180px,2fr)_minmax(100px,1fr)_auto] xl:grid-cols-[24px_minmax(220px,2fr)_minmax(140px,1fr)_minmax(120px,1fr)_minmax(100px,0.8fr)_minmax(90px,0.7fr)_auto] ${
+          className={`relative grid min-h-14 w-full grid-cols-[24px_minmax(0,1fr)_auto] items-center gap-x-3 px-2 py-2 transition-colors @4xl:grid-cols-[24px_minmax(220px,2fr)_minmax(140px,1fr)_minmax(120px,1fr)_minmax(100px,0.8fr)_minmax(90px,0.7fr)_auto] ${
             props.selectedRunId === run.id ? "bg-surface-secondary" : "hover:bg-[var(--row-hover)]"
           }`}
         >
@@ -142,14 +142,15 @@ export function GitHubActionsRunList(props: {
             >
               {run.title || run.workflowName || run.name || t`Workflow run`}
             </Link>
-            <div className="mt-0.5 flex min-w-0 items-center gap-2 text-[11px] text-muted md:hidden">
+            <div className="mt-0.5 flex min-w-0 items-center gap-2 overflow-hidden text-[11px] text-muted @4xl:hidden">
               {run.headBranch ? <span className="truncate font-mono">{run.headBranch}</span> : null}
+              {run.event ? <span className="truncate">{run.event}</span> : null}
               <span className="shrink-0">#{run.number}</span>
-              {run.createdAt ? <RelativeTime iso={run.createdAt} /> : null}
+              {run.createdAt ? <RelativeTime iso={run.createdAt} className="shrink-0" /> : null}
             </div>
           </div>
 
-          <div className="hidden min-w-0 md:block">
+          <div className="hidden min-w-0 @4xl:block">
             <p className="truncate text-[11px] text-muted">
               {(run.workflowName || run.name) ===
               (run.title || run.workflowName || run.name || t`Workflow run`)
@@ -157,13 +158,13 @@ export function GitHubActionsRunList(props: {
                 : run.workflowName || run.name}
             </p>
           </div>
-          <div className="hidden min-w-0 xl:block">
+          <div className="hidden min-w-0 @4xl:block">
             <p className="truncate font-mono text-[11px] text-muted">{run.headBranch || "—"}</p>
           </div>
-          <div className="hidden min-w-0 xl:block">
+          <div className="hidden min-w-0 @4xl:block">
             <p className="truncate text-[11px] text-muted">{run.event || "—"}</p>
           </div>
-          <div className="hidden min-w-0 flex-col text-[11px] text-muted xl:flex">
+          <div className="hidden min-w-0 flex-col text-[11px] text-muted @4xl:flex">
             <span>#{run.number}</span>
             {run.createdAt ? <RelativeTime iso={run.createdAt} /> : null}
           </div>

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   GhDeleteWorkflowRunPayload,
@@ -19,6 +19,7 @@ import type {
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 
 const bridge = vi.hoisted(() => ({
   ghListWorkflows: vi.fn<(payload: GhListWorkflowsPayload) => Promise<GhListWorkflowsResult>>(),
@@ -128,6 +129,7 @@ describe("GitHubActionsView", () => {
             name: "Typecheck",
             status: "in_progress",
             conclusion: "",
+            url: "https://github.com/owner/repo/actions/runs/501/job/9001",
             steps: [
               {
                 number: 1,
@@ -145,6 +147,7 @@ describe("GitHubActionsView", () => {
     bridge.ghDeleteWorkflowRun.mockReset().mockResolvedValue(undefined);
     bridge.openExternal.mockReset().mockResolvedValue(undefined);
     useAppStore.setState({ projects: [project] });
+    useSidebarUiStore.setState({ pinnedGitHubWorkflows: {} });
     useGitStore.setState({
       branches: {
         [project.id]: {
@@ -166,11 +169,25 @@ describe("GitHubActionsView", () => {
     expect(bridge.ghGetWorkflowRun).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("link", { name: new RegExp(run.title) }));
-    expect(await screen.findByText("Typecheck")).toBeInTheDocument();
+    const jobName = await screen.findByText("Typecheck");
     expect(bridge.ghGetWorkflowRun).toHaveBeenCalledWith({
       projectLocation: project.location,
       runId: run.id,
     });
+
+    const jobDetails = jobName.closest("details");
+    expect(jobDetails).not.toHaveAttribute("open");
+    expect(jobName).toHaveClass("cursor-default");
+
+    fireEvent.click(jobName);
+    expect(jobDetails).toHaveAttribute("open");
+    expect(bridge.openExternal).not.toHaveBeenCalled();
+
+    fireEvent.click(within(jobDetails!).getByRole("button", { name: "Open job on GitHub" }));
+    expect(bridge.openExternal).toHaveBeenCalledWith(
+      "https://github.com/owner/repo/actions/runs/501/job/9001",
+    );
+    expect(jobDetails).toHaveAttribute("open");
   });
 
   it("selects the first active project by default", async () => {
@@ -179,6 +196,31 @@ describe("GitHubActionsView", () => {
     expect(await screen.findByRole("button", { name: "Project" })).toHaveTextContent(project.name);
     expect(bridge.ghListWorkflows).toHaveBeenCalledWith({
       projectLocation: project.location,
+    });
+  });
+
+  it("selects the first pinned workflow by default", async () => {
+    bridge.ghListWorkflows.mockResolvedValue({
+      workflows: [
+        { id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" },
+        { id: 22, name: "Zulu", path: ".github/workflows/zulu.yml", state: "active" },
+        { id: 33, name: "Alpha", path: ".github/workflows/alpha.yml", state: "active" },
+      ],
+    });
+    bridge.ghListWorkflowRuns.mockResolvedValue({ runs: [] });
+    bridge.ghGetWorkflowDefinition.mockImplementation(async ({ workflowId }) => ({
+      definition: { ...definition.definition, workflowId },
+    }));
+    useSidebarUiStore.setState({
+      pinnedGitHubWorkflows: { [project.id]: [22, 33] },
+    });
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+
+    expect(await screen.findByRole("heading", { name: "Alpha" })).toBeInTheDocument();
+    expect(bridge.ghListWorkflowRuns).toHaveBeenCalledWith({
+      projectLocation: project.location,
+      workflowId: 33,
     });
   });
 
@@ -202,19 +244,27 @@ describe("GitHubActionsView", () => {
 
     expect(await screen.findByText("Release channel")).toBeInTheDocument();
     expect(screen.getByText("Skip publishing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
     expect(screen.queryByText("Inputs (JSON)")).not.toBeInTheDocument();
   });
 
   it("opens dispatch controls after selecting another workflow from its run button", async () => {
+    let resolveReleaseDefinition: ((result: GhGetWorkflowDefinitionResult) => void) | undefined;
     bridge.ghListWorkflows.mockResolvedValue({
       workflows: [
         { id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" },
         { id: 22, name: "Release", path: ".github/workflows/release.yml", state: "active" },
       ],
     });
-    bridge.ghGetWorkflowDefinition.mockImplementation(async ({ workflowId }) => ({
-      definition: { ...definition.definition, workflowId },
-    }));
+    bridge.ghGetWorkflowDefinition.mockImplementation(({ workflowId }) =>
+      workflowId === 22
+        ? new Promise((resolve) => {
+            resolveReleaseDefinition = resolve;
+          })
+        : Promise.resolve({
+            definition: { ...definition.definition, workflowId },
+          }),
+    );
 
     render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
     const releaseWorkflowButton = (await screen.findByText("Release")).closest("button");
@@ -228,10 +278,174 @@ describe("GitHubActionsView", () => {
       }),
     );
 
+    expect(await screen.findByText("Run Release")).toBeInTheDocument();
+    expect(screen.getByText("Loading workflow inputs")).toBeInTheDocument();
+    await waitFor(() => expect(resolveReleaseDefinition).toBeDefined());
+    await act(async () => {
+      resolveReleaseDefinition!({
+        definition: { ...definition.definition, workflowId: 22 },
+      });
+    });
+
     expect(await screen.findByText("Release channel")).toBeInTheDocument();
     expect(bridge.ghGetWorkflowDefinition).toHaveBeenCalledWith({
       projectLocation: project.location,
       workflowId: 22,
     });
+  });
+
+  it("shows non-dispatchable state only after the workflow definition loads", async () => {
+    let resolveDefinition: ((result: GhGetWorkflowDefinitionResult) => void) | undefined;
+    bridge.ghGetWorkflowDefinition.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDefinition = resolve;
+        }),
+    );
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+    await waitFor(() => expect(bridge.ghGetWorkflowDefinition).toHaveBeenCalled());
+
+    expect(screen.queryByText("This workflow cannot be started manually.")).not.toBeInTheDocument();
+    await act(async () => {
+      resolveDefinition!({
+        definition: {
+          ...definition.definition,
+          dispatchable: false,
+          triggers: ["push"],
+          inputs: [],
+        },
+      });
+    });
+
+    expect(
+      await screen.findByText("This workflow cannot be started manually."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps cached workflow runs visible while refreshing in the background", async () => {
+    const ciRun = { ...run, title: "Cached CI run" };
+    const releaseRun = {
+      ...run,
+      id: 502,
+      workflowId: 22,
+      workflowName: "Release",
+      name: "Release",
+      title: "Release run",
+    };
+    let ciRequestCount = 0;
+    let resolveCiRefresh: ((result: GhListWorkflowRunsResult) => void) | undefined;
+    let ciDefinitionRequestCount = 0;
+    let resolveCiDefinitionRefresh: ((result: GhGetWorkflowDefinitionResult) => void) | undefined;
+    bridge.ghListWorkflows.mockResolvedValue({
+      workflows: [
+        { id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" },
+        { id: 22, name: "Release", path: ".github/workflows/release.yml", state: "active" },
+      ],
+    });
+    bridge.ghListWorkflowRuns.mockImplementation(({ workflowId }) => {
+      if (workflowId === 22) return Promise.resolve({ runs: [releaseRun] });
+      ciRequestCount += 1;
+      if (ciRequestCount === 1) return Promise.resolve({ runs: [ciRun] });
+      return new Promise((resolve) => {
+        resolveCiRefresh = resolve;
+      });
+    });
+    bridge.ghGetWorkflowDefinition.mockImplementation(({ workflowId }) => {
+      if (workflowId !== 11 || ciDefinitionRequestCount++ === 0) {
+        return Promise.resolve({
+          definition: { ...definition.definition, workflowId },
+        });
+      }
+      return new Promise((resolve) => {
+        resolveCiDefinitionRefresh = resolve;
+      });
+    });
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+    expect(await screen.findByText("Cached CI run")).toBeInTheDocument();
+
+    fireEvent.click((await screen.findByText("Release")).closest("button")!);
+    expect(await screen.findByText("Release run")).toBeInTheDocument();
+
+    const ciWorkflowButton = screen
+      .getAllByText("CI")
+      .map((element) => element.closest("button"))
+      .find((button) => button !== null);
+    fireEvent.click(ciWorkflowButton!);
+
+    expect(screen.getByText("Cached CI run")).toBeInTheDocument();
+    const ciHeader = screen.getByRole("heading", { name: "CI" }).closest("header");
+    const cachedRunButton = within(ciHeader!)
+      .getAllByRole("button", { name: "Run workflow" })
+      .find((element) => element.tagName === "BUTTON");
+    expect(cachedRunButton).toBeEnabled();
+    await waitFor(() => {
+      expect(resolveCiRefresh).toBeDefined();
+      expect(resolveCiDefinitionRefresh).toBeDefined();
+    });
+    await act(async () => {
+      resolveCiRefresh!({ runs: [{ ...ciRun, title: "Refreshed CI run" }] });
+      resolveCiDefinitionRefresh!({
+        definition: { ...definition.definition, workflowId: 11 },
+      });
+    });
+    expect(await screen.findByText("Refreshed CI run")).toBeInTheDocument();
+  });
+
+  it("does not expand or count jobs without steps", async () => {
+    bridge.ghGetWorkflowRun.mockResolvedValue({
+      run: {
+        ...run,
+        jobs: [
+          {
+            id: 9002,
+            name: "cleanup",
+            status: "completed",
+            conclusion: "skipped",
+            steps: [],
+          },
+        ],
+      },
+    });
+
+    render(<GitHubActionsView projectId={project.id} runId={run.id} onClose={() => {}} />);
+
+    const jobName = await screen.findByText("cleanup");
+    expect(jobName.closest("summary")).toBeNull();
+    expect(screen.queryByText("0 of 0 steps")).not.toBeInTheDocument();
+  });
+
+  it("groups failed-run rerun choices in a split button", async () => {
+    bridge.ghGetWorkflowRun.mockResolvedValue({
+      run: {
+        ...run,
+        status: "completed",
+        conclusion: "failure",
+        jobs: [],
+      },
+    });
+
+    render(<GitHubActionsView projectId={project.id} runId={run.id} onClose={() => {}} />);
+
+    const heading = await screen.findByRole("heading", { name: run.title });
+    const detail = heading.closest("section");
+    expect(detail).not.toBeNull();
+    expect(within(detail!).getByRole("button", { name: "Re-run all jobs" })).toBeInTheDocument();
+    expect(
+      within(detail!).queryByRole("button", { name: "Re-run failed jobs" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(detail!).getByRole("button", { name: "Run actions" }));
+    expect(screen.queryByRole("menuitem", { name: "Re-run all jobs" })).not.toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Re-run failed jobs" }));
+
+    await waitFor(() =>
+      expect(bridge.ghRerunWorkflowRun).toHaveBeenCalledWith({
+        projectLocation: project.location,
+        runId: run.id,
+        failedOnly: true,
+      }),
+    );
   });
 });

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
@@ -46,9 +46,9 @@ export function GitHubActionsView(props: {
     refreshRun,
     refreshRuns,
     rerunWorkflow,
+    selectDefinitionRef,
     selectRun,
     selectWorkflow,
-    setDefinitionRef,
     setDeleteRun,
   } = useGitHubActionsViewModel(props);
   const pinnedByProject = useSidebarUiStore((state) => state.pinnedGitHubWorkflows);
@@ -56,11 +56,10 @@ export function GitHubActionsView(props: {
   const pinnedWorkflowIds = selectedProject
     ? (pinnedByProject[selectedProject.id] ?? EMPTY_PINNED_WORKFLOWS)
     : EMPTY_PINNED_WORKFLOWS;
-  const [dispatchOpen, setDispatchOpen] = useState(false);
-  const [requestedDispatchWorkflowId, setRequestedDispatchWorkflowId] = useState<number | null>(
-    null,
-  );
+  const [dispatchWorkflowId, setDispatchWorkflowId] = useState<number | null>(null);
   const [displayedRun, setDisplayedRun] = useState(selectedRun);
+  const selectedDefinition = definition?.workflowId === selectedWorkflowId ? definition : null;
+  const dispatchOpen = dispatchWorkflowId !== null && dispatchWorkflowId === selectedWorkflowId;
 
   useEffect(() => {
     if (selectedRun) {
@@ -72,35 +71,31 @@ export function GitHubActionsView(props: {
   }, [selectedRun]);
 
   useEffect(() => {
-    setDispatchOpen(false);
-  }, [selectedWorkflowId]);
+    setDispatchWorkflowId(null);
+  }, [selectedProject?.id]);
 
   useEffect(() => {
-    if (
-      requestedDispatchWorkflowId === null ||
-      requestedDispatchWorkflowId !== selectedWorkflowId ||
-      loadingDefinition ||
-      !definition ||
-      definition.workflowId !== requestedDispatchWorkflowId
-    ) {
+    if (dispatchWorkflowId === null) return;
+    if (dispatchWorkflowId !== selectedWorkflowId) {
+      setDispatchWorkflowId(null);
       return;
     }
-    if (definition.dispatchable) setDispatchOpen(true);
-    setRequestedDispatchWorkflowId(null);
-  }, [definition, loadingDefinition, requestedDispatchWorkflowId, selectedWorkflowId]);
+    if (!loadingDefinition && selectedDefinition && !selectedDefinition.dispatchable) {
+      setDispatchWorkflowId(null);
+    }
+  }, [dispatchWorkflowId, loadingDefinition, selectedDefinition, selectedWorkflowId]);
 
   function selectWorkflowPage(workflowId: number) {
-    setRequestedDispatchWorkflowId(null);
-    setDispatchOpen(false);
+    setDispatchWorkflowId(null);
     selectWorkflow(workflowId);
   }
 
   function requestWorkflowDispatch(workflowId: number) {
-    if (workflowId === selectedWorkflowId && !loadingDefinition && definition?.dispatchable) {
-      setDispatchOpen(true);
+    if (workflowId === selectedWorkflowId && !loadingDefinition && selectedDefinition) {
+      if (selectedDefinition.dispatchable) setDispatchWorkflowId(workflowId);
       return;
     }
-    setRequestedDispatchWorkflowId(workflowId);
+    setDispatchWorkflowId(workflowId);
     if (workflowId !== selectedWorkflowId) selectWorkflow(workflowId);
   }
 
@@ -144,7 +139,7 @@ export function GitHubActionsView(props: {
         </div>
       ) : selectedWorkflow ? (
         <>
-          <header className="flex shrink-0 flex-wrap items-start justify-between gap-3 border-b border-[var(--hairline)] px-5 py-4">
+          <header className="flex min-h-[76px] shrink-0 flex-wrap items-start justify-between gap-3 border-b border-[var(--hairline)] px-5 py-4">
             <div className="min-w-0">
               <h1 className="truncate text-base font-semibold text-foreground">
                 {selectedWorkflow.name}
@@ -158,20 +153,21 @@ export function GitHubActionsView(props: {
                 ) : null}
               </p>
             </div>
-            {definition?.dispatchable && selectedProject ? (
+            {selectedProject && (selectedDefinition?.dispatchable || dispatchOpen) ? (
               <GitHubActionsDispatchPopover
                 workflow={selectedWorkflow}
-                definition={definition}
+                definition={selectedDefinition}
                 projectId={selectedProject.id}
-                currentBranch={definition.defaultBranch}
                 isOpen={dispatchOpen}
-                isDefinitionLoading={loadingDefinition}
+                isDefinitionLoading={
+                  !selectedDefinition || (loadingDefinition && !selectedDefinition.dispatchable)
+                }
                 isPending={dispatching}
-                onOpenChange={setDispatchOpen}
-                onRefChange={setDefinitionRef}
+                onOpenChange={(isOpen) => setDispatchWorkflowId(isOpen ? selectedWorkflowId : null)}
+                onRefChange={selectDefinitionRef}
                 onRun={dispatchWorkflow}
               />
-            ) : loadingDefinition ? (
+            ) : loadingDefinition || !selectedDefinition ? (
               <Button variant="primary" isDisabled>
                 <Play className="size-4" />
                 <Trans>Run workflow</Trans>
@@ -183,7 +179,7 @@ export function GitHubActionsView(props: {
             )}
           </header>
 
-          <section className="min-h-0 min-w-0 flex-1 overflow-y-auto px-5 py-4 [scrollbar-gutter:stable]">
+          <section className="@container min-h-0 min-w-0 flex-1 overflow-y-auto px-5 py-4 [scrollbar-gutter:stable]">
             <div className="mb-2 flex items-center justify-between gap-3">
               <div>
                 <h2 className="text-sm font-semibold text-foreground">
@@ -202,7 +198,9 @@ export function GitHubActionsView(props: {
                 aria-label={t`Refresh workflow runs`}
                 onPress={refreshRuns}
               >
-                <RefreshCw className={`size-3.5 ${loadingRuns ? "animate-spin" : ""}`} />
+                <RefreshCw
+                  className={`size-3.5 ${loadingRuns && runs.length > 0 ? "animate-spin" : ""}`}
+                />
               </Button>
             </div>
             <GitHubActionsRunList

--- a/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
+++ b/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import { useShallow } from "zustand/shallow";
@@ -11,12 +11,21 @@ import { isHomeProject } from "@/shared/homeScope";
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 
 const POLL_INTERVAL_MS = 5_000;
 const DISPATCH_DISCOVERY_TIMEOUT_MS = 30_000;
 
 function workflowRunIsActive(run: GitHubActionsRun): boolean {
   return run.status.toLowerCase() !== "completed";
+}
+
+function workflowCacheKey(projectId: string, workflowId: number): string {
+  return `${projectId}\0${workflowId}`;
+}
+
+function definitionCacheKey(projectId: string, workflowId: number, ref?: string): string {
+  return `${workflowCacheKey(projectId, workflowId)}\0${ref ?? ""}`;
 }
 
 export function useGitHubActionsViewModel(props: { projectId?: string; runId?: number }) {
@@ -30,6 +39,8 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
   const selectedProject =
     activeProjects.find((project) => project.id === props.projectId) ?? activeProjects[0];
   const selectedProjectId = selectedProject?.id;
+  const runsCache = useRef(new Map<string, GitHubActionsRun[]>());
+  const definitionCache = useRef(new Map<string, GitHubActionsWorkflowDefinition>());
   const [workflows, setWorkflows] = useState<GitHubActionsWorkflow[]>([]);
   const [runs, setRuns] = useState<GitHubActionsRun[]>([]);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<number | null>(null);
@@ -58,6 +69,8 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
     setSelectedRunDetails(null);
     setDefinition(null);
     setDefinitionRef(undefined);
+    setLoadingRuns(false);
+    setLoadingDefinition(false);
     setLoadError(null);
     setDispatchRequestedAt(null);
   }, [props.runId, selectedProjectId]);
@@ -78,11 +91,17 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
           const activeWorkflows = result.workflows.filter(
             (workflow) => workflow.state.toLowerCase() === "active",
           );
+          const pinnedWorkflowIds =
+            useSidebarUiStore.getState().pinnedGitHubWorkflows[selectedProject.id] ?? [];
+          const pinned = new Set(pinnedWorkflowIds);
+          const firstPinnedWorkflowId = activeWorkflows
+            .filter((workflow) => pinned.has(workflow.id))
+            .sort((a, b) => a.name.localeCompare(b.name))[0]?.id;
           setWorkflows(activeWorkflows);
           setSelectedWorkflowId((current) =>
             activeWorkflows.some((workflow) => workflow.id === current)
               ? current
-              : (activeWorkflows[0]?.id ?? null),
+              : (firstPinnedWorkflowId ?? activeWorkflows[0]?.id ?? null),
           );
           setLoadingWorkflows(false);
         },
@@ -105,6 +124,9 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       return;
     }
     let cancelled = false;
+    const cacheKey = workflowCacheKey(selectedProject.id, selectedWorkflowId);
+    const cachedRuns = runsCache.current.get(cacheKey);
+    setRuns(cachedRuns ?? []);
     setLoadingRuns(true);
     setLoadError(null);
     void readBridge()
@@ -115,6 +137,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       .then(
         (result) => {
           if (cancelled) return;
+          runsCache.current.set(cacheKey, result.runs);
           setRuns(result.runs);
           if (
             dispatchRequestedAt !== null &&
@@ -130,7 +153,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
         },
         (error: unknown) => {
           if (cancelled) return;
-          setRuns([]);
+          if (!cachedRuns) setRuns([]);
           setLoadError(friendlyError(error));
           setLoadingRuns(false);
         },
@@ -147,6 +170,9 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       return;
     }
     let cancelled = false;
+    const cacheKey = definitionCacheKey(selectedProject.id, selectedWorkflowId, definitionRef);
+    const cachedDefinition = definitionCache.current.get(cacheKey);
+    setDefinition(cachedDefinition ?? null);
     setLoadingDefinition(true);
     void readBridge()
       .ghGetWorkflowDefinition({
@@ -157,12 +183,13 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       .then(
         (result) => {
           if (cancelled) return;
+          definitionCache.current.set(cacheKey, result.definition);
           setDefinition(result.definition);
           setLoadingDefinition(false);
         },
         (error: unknown) => {
           if (cancelled) return;
-          setDefinition(null);
+          if (!cachedDefinition) setDefinition(null);
           setLoadError(friendlyError(error));
           setLoadingDefinition(false);
         },
@@ -231,12 +258,42 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
   }));
 
   function selectWorkflow(workflowId: number) {
+    if (workflowId === selectedWorkflowId) {
+      setSelectedRunId(null);
+      setSelectedRunDetails(null);
+      return;
+    }
+    const cachedRuns = selectedProjectId
+      ? runsCache.current.get(workflowCacheKey(selectedProjectId, workflowId))
+      : undefined;
+    const cachedDefinition = selectedProjectId
+      ? definitionCache.current.get(definitionCacheKey(selectedProjectId, workflowId))
+      : undefined;
     setSelectedWorkflowId(workflowId);
     setSelectedRunId(null);
     setSelectedRunDetails(null);
-    setRuns([]);
-    setDefinition(null);
+    setRuns(cachedRuns ?? []);
+    setDefinition(cachedDefinition ?? null);
     setDefinitionRef(undefined);
+    setLoadingRuns(true);
+    setLoadingDefinition(true);
+  }
+
+  function selectDefinitionRef(ref: string) {
+    if (
+      !selectedProjectId ||
+      !selectedWorkflowId ||
+      ref === definitionRef ||
+      (definition?.workflowId === selectedWorkflowId && ref === definition.ref)
+    ) {
+      return;
+    }
+    setDefinitionRef(ref);
+    setDefinition(
+      definitionCache.current.get(definitionCacheKey(selectedProjectId, selectedWorkflowId, ref)) ??
+        null,
+    );
+    setLoadingDefinition(true);
   }
 
   function refresh() {
@@ -297,7 +354,13 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
         projectLocation: selectedProject.location,
         runId,
       });
-      setRuns((current) => current.filter((run) => run.id !== runId));
+      setRuns((current) => {
+        const nextRuns = current.filter((run) => run.id !== runId);
+        if (selectedProjectId && selectedWorkflowId) {
+          runsCache.current.set(workflowCacheKey(selectedProjectId, selectedWorkflowId), nextRuns);
+        }
+        return nextRuns;
+      });
       if (selectedRunId === runId) {
         setSelectedRunId(null);
         setSelectedRunDetails(null);
@@ -337,9 +400,9 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
     refreshRun: () => setRunRefreshVersion((current) => current + 1),
     refreshRuns: () => setRunsRefreshVersion((current) => current + 1),
     rerunWorkflow,
+    selectDefinitionRef,
     selectRun: setSelectedRunId,
     selectWorkflow,
-    setDefinitionRef,
     setDeleteRun,
   };
 }


### PR DESCRIPTION
## Summary

- improve workflow dispatch loading, branch selection, and typed inputs
- keep cached workflow runs and definitions visible while refreshing incrementally
- add responsive run metadata, job details, and rerun/delete controls
- open the first pinned workflow by default and expand focused view-model coverage
- refresh localization source references

## Why

This is a follow-up to #429. The final workflow-management polish commit was pushed immediately after that pull request was squash-merged, so it was not included in `master`.

## User impact

GitHub Actions opens faster, avoids duplicate loading states and requests, remains useful at narrow widths, and provides more complete run and job management inside Poracode.

## Validation

- `pnpm exec vitest run src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx` — 11 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- focused `oxfmt --check`
- `pnpm i18n:extract` — 0 missing translations in all locales
- `git diff --check origin/master...HEAD`