### PR TITLE
Handle closed PRs in the Git sidebar and review

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Workflows schließen"
 msgid "Close workflows panel"
 msgstr "Workflow-Bereich schließen"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Close workflows"
 msgid "Close workflows panel"
 msgstr "Close workflows panel"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Cerrar flujos de trabajo"
 msgid "Close workflows panel"
 msgstr "Cerrar el panel de flujos de trabajo"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Fermer les workflows"
 msgid "Close workflows panel"
 msgstr "Fermer le panneau des workflows"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2430,6 +2430,7 @@ msgstr "ワークフローを閉じる"
 msgid "Close workflows panel"
 msgstr "ワークフローパネルを閉じる"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2431,6 +2431,7 @@ msgstr "워크플로 닫기"
 msgid "Close workflows panel"
 msgstr "워크플로 패널 닫기"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Zamknij przepływy pracy"
 msgid "Close workflows panel"
 msgstr "Zamknij panel przepływów pracy"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Fechar fluxos de trabalho"
 msgid "Close workflows panel"
 msgstr "Fechar o painel de fluxos de trabalho"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Закрыть рабочие процессы"
 msgid "Close workflows panel"
 msgstr "Закрыть панель рабочих процессов"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2431,6 +2431,7 @@ msgstr "İş akışlarını kapat"
 msgid "Close workflows panel"
 msgstr "İş akışları panelini kapat"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Закрити робочі процеси"
 msgid "Close workflows panel"
 msgstr "Закрити панель робочих процесів"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2431,6 +2431,7 @@ msgstr "Đóng quy trình làm việc"
 msgid "Close workflows panel"
 msgstr "Đóng bảng quy trình làm việc"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2431,6 +2431,7 @@ msgstr "关闭工作流"
 msgid "Close workflows panel"
 msgstr "关闭工作流面板"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrMetaRow.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Closed"

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -77,6 +77,10 @@ export function isPrCheckActive(check: PrCheck): boolean {
   return status === "running" || status === "pending";
 }
 
+export function isPrActive(state: PrState | null | undefined): boolean {
+  return state === "open" || state === "draft";
+}
+
 export function formatPrCheckDuration(check: PrCheck, now = Date.now()): string | undefined {
   if (!check.startedAt) return undefined;
   const startedAt = Date.parse(check.startedAt);

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { GitStatusResult, Project } from "@/shared/contracts";
+import type { GitStatusResult, PrData, Project } from "@/shared/contracts";
 
 const bridgeMock = vi.hoisted(() => ({
   gitStage: vi.fn<() => Promise<void>>(),
@@ -17,7 +17,7 @@ const bridgeMock = vi.hoisted(() => ({
     vi.fn<
       () => Promise<{ sourceBranch: string | null; commitsAhead: number; sourceAhead: number }>
     >(),
-  ghGetPrForBranch: vi.fn<() => Promise<null>>(),
+  ghGetPrForBranch: vi.fn<() => Promise<PrData | null>>(),
   generateCommitMessage: vi.fn<() => Promise<{ message: string }>>(),
 }));
 
@@ -104,6 +104,7 @@ vi.mock("@heroui/react", () => {
     ButtonGroup,
     Dropdown,
     Label: (props: { children: ReactNode }) => <span>{props.children}</span>,
+    Link: Button,
     ListBox,
     Select,
     Separator: () => <span />,
@@ -1014,6 +1015,74 @@ describe("GitReviewSidebar", () => {
     expect(screen.getByText("Merge Worktree")).toBeInTheDocument();
     expect(screen.getByText("Merge Locally & Remove Worktree")).toBeInTheDocument();
     expect(screen.queryByText("Merge & Remove Worktree")).not.toBeInTheDocument();
+  });
+
+  it("shows the latest merged PR and allows creating a follow-up PR", async () => {
+    const project: Project = {
+      id: "project-1",
+      name: "Poracode",
+      createdAt: new Date().toISOString(),
+      location: { kind: "windows", path: "C:\\repo-worktree" },
+    };
+    const gitStatus: GitStatusResult = {
+      isRepo: true,
+      branch: "feature/worktree",
+      tracking: "origin/feature/worktree",
+      hasRemote: true,
+      remoteInfo: {
+        url: "https://github.com/example/poracode.git",
+        platform: "github",
+        owner: "example",
+        repo: "poracode",
+      },
+      ahead: 0,
+      behind: 0,
+      staged: [],
+      unstaged: [],
+      totalInsertions: 0,
+      totalDeletions: 0,
+    };
+    const mergedPr: PrData = {
+      number: 429,
+      state: "merged",
+      title: "Add GitHub Actions workflow management view",
+      url: "https://github.com/example/poracode/pull/429",
+      baseBranch: "master",
+      isDraft: false,
+      updatedAt: "2026-07-30T00:00:00.000Z",
+    };
+
+    bridgeMock.gitGetWorktreeSourceBranch.mockResolvedValue({
+      sourceBranch: "master",
+      commitsAhead: 1,
+      sourceAhead: 0,
+    });
+    bridgeMock.ghGetPrForBranch.mockResolvedValue(mergedPr);
+    useGitStore.setState({ ghAvailable: { [project.id]: true } });
+
+    render(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={gitStatus}
+        selectedFile={null}
+        selectedStaged={false}
+        worktreeBranch="feature/worktree"
+        worktreePath="C:\\repo-worktree"
+        refreshKey={1}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+
+    expect(
+      await screen.findByText("#429 - Add GitHub Actions workflow management view"),
+    ).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole("button", { name: "Create PR" })
+        .some((button) => button.classList.contains("flex-1")),
+    ).toBe(true);
   });
 
   it("does not show the removed merge section while worktree source info is still loading", () => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
@@ -37,6 +37,7 @@ import {
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { PixelLoader, SidebarButton } from "@/renderer/components/common";
 import { useScrollFade } from "@/renderer/hooks/useScrollFade";
+import { isPrActive } from "@/renderer/utils/prStatus";
 import { useSidebar } from "@/renderer/views/MainView/parts/AppShell/AppShell";
 import { getCommitGenCandidates } from "@/renderer/components/providers/commitGen";
 import {
@@ -255,10 +256,8 @@ export function GitReviewSidebar(props: {
     effectiveBranch && sourceBranch && sourceAhead > 0 && !isExperimentWorktree,
   );
   const isPushed = hasTracking && ahead === 0;
-  // Shared PR eligibility: a GitHub repo with a target branch and no open PR.
-  const prEligible = Boolean(
-    showPrSection && ghAvailable && sourceBranch && (!prState || prState === "closed"),
-  );
+  // Shared PR eligibility: a GitHub repo with a target branch and no active PR.
+  const prEligible = Boolean(showPrSection && ghAvailable && sourceBranch && !isPrActive(prState));
   const showCreatePrButton = prEligible && isPushed;
   // Whether the one-click "Commit & Create PR" action is offered. Unlike
   // showCreatePrButton this does NOT require an already-pushed branch (it only
@@ -540,7 +539,7 @@ export function GitReviewSidebar(props: {
             />
           )}
 
-          {showPrSection && ghAvailable && hasPr && prState !== "closed" && effectivePrKey && (
+          {showPrSection && ghAvailable && hasPr && effectivePrKey && (
             <PrSection
               prKey={effectivePrKey}
               projectId={project.id}

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -132,7 +132,14 @@ export function PrSection(props: {
 
   const stateBadge = state === "draft" ? t`(Draft)` : "";
   const fallbackTitle =
-    title || (state === "merged" ? t`Merged` : state === "draft" ? "" : t`Open`);
+    title ||
+    (state === "merged"
+      ? t`Merged`
+      : state === "closed"
+        ? t`Closed`
+        : state === "draft"
+          ? ""
+          : t`Open`);
 
   const canReview = number !== undefined && state !== "merged" && state !== "closed";
   // Offer refresh for live PRs only — a merged/closed PR's head branch is often
@@ -309,7 +316,7 @@ export function PrSection(props: {
           </Dropdown>
         </ButtonGroup>
       )}
-      {state !== "merged" && state !== "draft" && (
+      {state === "open" && (
         <>
           {isBlocked && (
             <div className="flex flex-col gap-1 text-xs">

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -6,6 +6,7 @@ import type { GitStatusResult, PrData, ProjectLocation } from "@/shared/contract
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
+import { getWorktreeActionVisibility } from "./useWorktreeActions";
 import { GitBadge } from "./GitBadge";
 
 const ghGetPrForBranchMock = vi.hoisted(() =>
@@ -93,6 +94,26 @@ describe("GitBadge", () => {
     expect(icon).not.toBeNull();
     expect(icon).toHaveClass("text-[color:var(--git-branch-tone)]");
     expect(icon).toHaveClass("lucide-git-pull-request");
+  });
+
+  it("keeps the latest merged PR status visible while allowing another PR", () => {
+    useGitStore.setState({
+      worktreeStatuses: { "/wt/feature": makeStatus() },
+      ghAvailable: { "project-1": true },
+      prData: {
+        "/wt/feature": { ...basePr, number: 2, state: "merged" },
+      },
+    });
+
+    render(<GitBadge projectId="project-1" projectName="feature/pr" worktreePath="/wt/feature" />);
+
+    const badge = screen.getByRole("button", { name: "Git status for feature/pr" });
+    const icon = badge.querySelector(".lucide-git-pull-request");
+    const actions = getWorktreeActionVisibility("project-1", "/wt/feature");
+
+    expect(icon).toHaveClass("text-[color:var(--pr-merged)]");
+    expect(actions.showCreatePr).toBe(true);
+    expect(actions.showOpenPr).toBe(false);
   });
 
   it("falls back to a worktree fork icon when a clean worktree has no PR", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -14,6 +14,7 @@ import {
   aggregatePrChecksStatus,
   combineChecksStatus,
   getPrStatusTone,
+  isPrActive,
   PR_TONE_TEXT_CLASS,
 } from "@/renderer/utils/prStatus";
 import type { DragSourceData } from "@/renderer/dnd";
@@ -83,7 +84,7 @@ export function GitBadge(props: {
       const details = pr?.number ? s.prDetails[`${props.projectId}#${pr.number}`] : undefined;
       const detailsStatus = aggregatePrChecksStatus(details?.checks);
       const isWorktree = props.worktreePath !== undefined;
-      const hasPr = pr !== undefined && pr !== null && pr.state !== "closed";
+      const hasActivePr = isPrActive(pr?.state);
       return {
         hasStatus: gitStatus !== undefined,
         isRepo: gitStatus?.isRepo ?? false,
@@ -97,7 +98,7 @@ export function GitBadge(props: {
         canCreatePr:
           isWorktree &&
           (s.ghAvailable[props.projectId] ?? false) &&
-          !hasPr &&
+          !hasActivePr &&
           Boolean(gitStatus?.tracking) &&
           (gitStatus?.ahead ?? 0) === 0,
       };
@@ -169,7 +170,7 @@ export function GitBadge(props: {
     );
   }
   const hasVisiblePr =
-    prState !== undefined && prState !== "closed" && (prState !== "merged" || isWorktree);
+    prState !== undefined && (isWorktree || (prState !== "merged" && prState !== "closed"));
   const showPrIcon = hasVisiblePr || canCreatePr;
   const showWorktreeFork = (props.fallbackToWorktreeIcon ?? false) && isWorktree && !showPrIcon;
   if (!isRepo || (!hasChanges && !showPrIcon && !showWorktreeFork)) {
@@ -205,9 +206,10 @@ export function GitBadge(props: {
       </Tooltip>
     );
   }
-  const prIconColor = canCreatePr
-    ? "text-[color:var(--git-branch-tone)]"
-    : PR_TONE_TEXT_CLASS[getPrStatusTone(prState, checksStatus)];
+  const prIconColor =
+    prState === undefined
+      ? "text-[color:var(--git-branch-tone)]"
+      : PR_TONE_TEXT_CLASS[getPrStatusTone(prState, checksStatus)];
   return (
     <div
       ref={elementRef}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -3,6 +3,7 @@ import { msg } from "@lingui/core/macro";
 import { i18n } from "@/renderer/i18n/i18n";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { deriveSyncAction, type SyncAction } from "@/renderer/actions/gitCommandRunner";
+import { isPrActive } from "@/renderer/utils/prStatus";
 
 export type GitMenuIcons = {
   review: React.ReactNode;
@@ -135,7 +136,7 @@ function derive(
   const ahead = wtStatus?.ahead ?? 0;
   const behind = wtStatus?.behind ?? 0;
   const isPushed = hasTracking && ahead === 0;
-  const hasPr = Boolean(pr && pr.state !== "closed");
+  const activePr = pr && isPrActive(pr.state) ? pr : undefined;
 
   return {
     syncAction: deriveSyncAction(hasTracking, ahead, behind),
@@ -144,10 +145,10 @@ function derive(
     sourceAhead: sourceInfo?.sourceAhead ?? 0,
     ahead,
     behind,
-    showCreatePr: ghOk && !hasPr && isPushed,
-    showOpenPr: ghOk && hasPr,
-    prNumber: hasPr ? pr!.number : undefined,
-    prUrl: hasPr ? pr!.url : undefined,
+    showCreatePr: ghOk && !activePr && isPushed,
+    showOpenPr: ghOk && Boolean(activePr),
+    prNumber: activePr?.number,
+    prUrl: activePr?.url,
     isPushed,
   };
 }


### PR DESCRIPTION
- Keep closed and merged PRs visible with accurate status labels.
- Restrict PR actions to active open or draft PRs.
- Correct sidebar badge colors and worktree actions for inactive PRs.
- Update localized catalogs and add regression coverage.