### PR TITLE
Add runtime-aware Cursor SDK updates

### DIFF
--- a/src/renderer/components/providers/cursor/index.tsx
+++ b/src/renderer/components/providers/cursor/index.tsx
@@ -4,10 +4,16 @@ import { msg } from "@lingui/core/macro";
 import { CursorIcon } from "./CursorIcon";
 import providerManifest from "./manifest";
 import type { ComposerControl } from "@/renderer/components/thread/ThreadComposer";
+import {
+  CURSOR_SDK_MAX_EXCLUSIVE_MAJOR,
+  CURSOR_SDK_MIN_SUPPORTED_VERSION,
+  CURSOR_SDK_PACKAGE_NAME,
+} from "@/shared/agents/cursorSdkPackage";
 import { resolveUnrestrictedPermissionConfig } from "@/shared/agents/unrestrictedPermissions";
+import { cursorRuntimeInstallState, cursorSdkUpdateCommand } from "./runtimeInstall";
 import { fullAccessToggle, planWorkToggle } from "../composerControlBuilders";
 import { registerProviderIcon } from "../ProviderIcon";
-import { registerComposerControls } from "../providerComposer";
+import { registerComposerControls, registerComposerRuntimeUpdate } from "../providerComposer";
 import { registerCommitGenDefaults } from "../commitGen";
 import { registerConflictResolverDefaults } from "../conflictResolver";
 import { registerTitleGenDefaults } from "../titleGen";
@@ -15,6 +21,27 @@ import { registerTitleGenDefaults } from "../titleGen";
 const PROVIDER_KIND = providerManifest.kind;
 
 registerProviderIcon(PROVIDER_KIND, CursorIcon);
+registerComposerRuntimeUpdate(PROVIDER_KIND, ({ agentStatus, project }) => {
+  const runtimeLabel = agentStatus.capabilities.runtimeLabel;
+  if (runtimeLabel !== "SDK") return undefined;
+  const sdk = cursorRuntimeInstallState(agentStatus);
+  const command = cursorSdkUpdateCommand(agentStatus, project);
+  return {
+    label: `${agentStatus.label} ${runtimeLabel}`,
+    installed: sdk.sdkInstalled,
+    ...(sdk.sdkVersion ? { installedVersion: sdk.sdkVersion } : {}),
+    ...(command
+      ? {
+          command,
+          npmPackage: {
+            name: CURSOR_SDK_PACKAGE_NAME,
+            minVersion: CURSOR_SDK_MIN_SUPPORTED_VERSION,
+            maxExclusiveMajor: CURSOR_SDK_MAX_EXCLUSIVE_MAJOR,
+          },
+        }
+      : {}),
+  };
+});
 // `composer-2.5-fast` is Cursor's own default — the cheaper "fast" request tier,
 // as quick as plain composer-2.5 at equivalent quality on these utility tasks.
 // Cursor's other models are pricier GPT/Claude pass-throughs, so stay on Composer.

--- a/src/renderer/components/providers/cursor/runtimeInstall.ts
+++ b/src/renderer/components/providers/cursor/runtimeInstall.ts
@@ -1,0 +1,122 @@
+import { CURSOR_SDK_INSTALL_SPEC } from "@/shared/agents/cursorSdkPackage";
+import type { AgentStatus, Project } from "@/shared/contracts";
+
+export type CursorInstallRuntime = "acp" | "sdk" | "both";
+
+export interface CursorRuntimeInstallState {
+  acpInstalled: boolean;
+  sdkInstalled: boolean;
+  acpVersion?: string;
+  sdkVersion?: string;
+  sdkInstallationSource?: string;
+}
+
+export function cursorRuntimeInstallState(
+  status: AgentStatus | undefined,
+): CursorRuntimeInstallState {
+  const variants = status?.runtimeVariants;
+  const acpVersion =
+    variants?.acp?.version ?? (variants?.acp?.installed ? status?.version : undefined);
+  const sdkVersion =
+    variants?.sdk?.version ?? (!variants?.acp?.installed ? status?.version : undefined);
+  return {
+    // Older cached Cursor statuses predate runtimeVariants and always represent
+    // the installed Cursor Agent, so preserve that as the ACP fallback.
+    acpInstalled: variants?.acp?.installed ?? status?.installed ?? false,
+    sdkInstalled: variants?.sdk?.installed ?? false,
+    ...(acpVersion ? { acpVersion } : {}),
+    ...(sdkVersion ? { sdkVersion } : {}),
+    ...(variants?.sdk?.installationSource
+      ? { sdkInstallationSource: variants.sdk.installationSource }
+      : {}),
+  };
+}
+
+/**
+ * Cursor install/update commands branch on the *project* location rather than
+ * the detected host platform (the registry's `posixOrWindows` helper): a remote
+ * client's advertised platform can fall back to the client UA before pairing
+ * completes, while `location.kind` always describes the shell the command will
+ * actually run in.
+ */
+function isWindowsProject(project: Project): boolean {
+  return project.location.kind === "windows";
+}
+
+/** `if <tool> exists then <body> else explain` in the project's shell dialect. */
+function guardedCommand(
+  project: Project,
+  tool: string,
+  body: string,
+  missingMessage: string,
+): string {
+  return isWindowsProject(project)
+    ? `if (Get-Command ${tool} -ErrorAction SilentlyContinue) { ${body} } else { Write-Host '${missingMessage}' }`
+    : `if command -v ${tool} >/dev/null 2>&1; then ${body}; else printf '${missingMessage}\\n'; fi`;
+}
+
+/** Shell-quoted install spec; the range itself lives in `cursorSdkPackage.ts`. */
+const CURSOR_SDK_PACKAGE_SPEC = `'${CURSOR_SDK_INSTALL_SPEC}'`;
+const MISSING_CURL_MESSAGE =
+  "curl is required to install Cursor. Install curl, then refresh detected agents.";
+const MISSING_WINDOWS_INSTALLER_MESSAGE =
+  "No supported installer found. Install PowerShell Invoke-RestMethod first, then refresh detected agents.";
+const MISSING_NPM_MESSAGE =
+  "npm is required to install the Cursor SDK. Install Node.js/npm first, then refresh detected agents.";
+const MISSING_PNPM_MESSAGE = "pnpm is required to update this Cursor SDK installation.";
+
+export function cursorAgentInstallCommand(project: Project): string {
+  return isWindowsProject(project)
+    ? guardedCommand(
+        project,
+        "irm",
+        "irm 'https://cursor.com/install?win32=true' | iex",
+        MISSING_WINDOWS_INSTALLER_MESSAGE,
+      )
+    : guardedCommand(
+        project,
+        "curl",
+        "curl https://cursor.com/install -fsS | bash",
+        MISSING_CURL_MESSAGE,
+      );
+}
+
+export function cursorSdkInstallCommand(project: Project): string {
+  return guardedCommand(
+    project,
+    "npm",
+    `npm install -g ${CURSOR_SDK_PACKAGE_SPEC}`,
+    MISSING_NPM_MESSAGE,
+  );
+}
+
+export function cursorSdkUpdateCommand(status: AgentStatus, project: Project): string | undefined {
+  const source = cursorRuntimeInstallState(status).sdkInstallationSource;
+  if (source === "global-pnpm") {
+    return guardedCommand(
+      project,
+      "pnpm",
+      `pnpm add -g ${CURSOR_SDK_PACKAGE_SPEC}`,
+      MISSING_PNPM_MESSAGE,
+    );
+  }
+  if (source !== "global-npm") return undefined;
+  return cursorSdkInstallCommand(project);
+}
+
+export function canUpdateCursorSdk(status: AgentStatus): boolean {
+  const source = cursorRuntimeInstallState(status).sdkInstallationSource;
+  return source === "global-npm" || source === "global-pnpm";
+}
+
+export function cursorRuntimeInstallCommand(
+  runtime: CursorInstallRuntime,
+  project: Project,
+): string {
+  if (runtime === "acp") return cursorAgentInstallCommand(project);
+  if (runtime === "sdk") return cursorSdkInstallCommand(project);
+
+  const acp = cursorAgentInstallCommand(project);
+  const sdk = cursorSdkInstallCommand(project);
+  return isWindowsProject(project) ? `${acp}; if ($?) { ${sdk} }` : `( ${acp} ) && ( ${sdk} )`;
+}

--- a/src/renderer/components/providers/providerComposer.ts
+++ b/src/renderer/components/providers/providerComposer.ts
@@ -1,5 +1,12 @@
 import type { ComposerControl } from "@/renderer/components/thread/ThreadComposer";
-import type { AgentCapability, ThreadConfig, ThreadPresentationMode } from "@/shared/contracts";
+import type {
+  AgentCapability,
+  AgentStatus,
+  NpmPackageVersionQuery,
+  Project,
+  ThreadConfig,
+  ThreadPresentationMode,
+} from "@/shared/contracts";
 import { lookupProviderRegistration } from "./providerRegistry";
 
 export interface ComposerControlsInput {
@@ -64,4 +71,30 @@ export function registerConfigNormalizer(kind: string, normalizer: ConfigNormali
 
 export function getConfigNormalizer(kind: string): ConfigNormalizer | undefined {
   return lookupProviderRegistration(configNormalizerRegistry, kind);
+}
+
+export interface ComposerRuntimeUpdate {
+  label: string;
+  installed: boolean;
+  installedVersion?: string;
+  npmPackage?: NpmPackageVersionQuery;
+  command?: string;
+}
+
+type ComposerRuntimeUpdateResolver = (input: {
+  agentStatus: AgentStatus;
+  project: Project;
+}) => ComposerRuntimeUpdate | undefined;
+
+const composerRuntimeUpdateRegistry = new Map<string, ComposerRuntimeUpdateResolver>();
+
+export function registerComposerRuntimeUpdate(
+  kind: string,
+  resolver: ComposerRuntimeUpdateResolver,
+) {
+  composerRuntimeUpdateRegistry.set(kind, resolver);
+}
+
+export function getComposerRuntimeUpdate(kind: string): ComposerRuntimeUpdateResolver | undefined {
+  return lookupProviderRegistration(composerRuntimeUpdateRegistry, kind);
 }

--- a/src/renderer/components/thread/ThreadAgentUpdateDock.test.tsx
+++ b/src/renderer/components/thread/ThreadAgentUpdateDock.test.tsx
@@ -1,0 +1,187 @@
+import type { ReactNode } from "react";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { AgentCapability, AgentStatus, Project } from "@/shared/contracts";
+
+const toastMock = vi.hoisted(() => ({
+  danger: vi.fn<(message: string) => void>(),
+  success: vi.fn<(message: string) => void>(),
+}));
+
+vi.mock("@heroui/react", () => ({
+  Button: (props: {
+    children?: ReactNode | ((state: { isPending?: boolean | undefined }) => ReactNode);
+    isDisabled?: boolean;
+    isPending?: boolean;
+    onPress?: () => void;
+  }) => (
+    <button type="button" disabled={props.isDisabled} onClick={props.onPress}>
+      {typeof props.children === "function"
+        ? props.children({ isPending: props.isPending })
+        : props.children}
+    </button>
+  ),
+  toast: toastMock,
+}));
+
+const bridgeMock = vi.hoisted(() => ({
+  getLatestAgentVersion:
+    vi.fn<(payload: unknown) => Promise<{ version?: string; source?: string }>>(),
+  refreshAgentStatuses: vi.fn<(...args: unknown[]) => Promise<void>>(),
+  updateAgentBinary: vi.fn<(payload: unknown) => Promise<{ ok: boolean }>>(),
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridgeMock,
+}));
+
+const runAgentInstallCommandMock = vi.hoisted(() =>
+  vi.fn<
+    (input: {
+      command: string;
+      label: string;
+      onCommandComplete?: (exitCode: number) => void;
+      purpose?: string;
+    }) => boolean
+  >(),
+);
+
+vi.mock("@/renderer/actions/agentLoginActions", () => ({
+  runAgentInstallCommand: runAgentInstallCommandMock,
+}));
+
+import "@/renderer/components/providers/cursor";
+import { ThreadAgentUpdateDock } from "./ThreadAgentUpdateDock";
+
+const project: Project = {
+  id: "project",
+  name: "Project",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-07-31T00:00:00.000Z",
+};
+
+const capabilities: AgentCapability = {
+  models: [{ id: "auto", label: "Auto" }],
+  efforts: [],
+  modelEfforts: {},
+  modes: ["agent"],
+  approvalPolicies: [],
+  sandboxModes: [],
+  supportsResume: true,
+  supportsDirectInput: true,
+  liveInputMode: "server",
+  presentationMode: "gui",
+  settingDefs: [],
+};
+
+const sdkStatus: AgentStatus = {
+  kind: "cursor",
+  label: "Cursor",
+  installed: true,
+  version: "2026.07.09-a3815c0",
+  update: { builtIn: { binary: "cursor-agent", args: ["update"] } },
+  authState: "authenticated",
+  envKind: "windows",
+  capabilities: { ...capabilities, runtimeLabel: "SDK" },
+  runtimeVariants: {
+    acp: {
+      presentationMode: "gui",
+      installed: true,
+      version: "2026.07.09-a3815c0",
+      authState: "authenticated",
+      authUsesProviderLogin: true,
+      capabilities: { ...capabilities, runtimeLabel: "ACP" },
+    },
+    sdk: {
+      presentationMode: "gui",
+      installed: true,
+      version: "1.0.24",
+      installationSource: "global-npm",
+      authState: "authenticated",
+      authUsesProviderLogin: false,
+      capabilities: { ...capabilities, runtimeLabel: "SDK" },
+    },
+  },
+};
+
+describe("ThreadAgentUpdateDock", () => {
+  beforeEach(() => {
+    bridgeMock.getLatestAgentVersion
+      .mockReset()
+      .mockResolvedValue({ version: "1.0.31", source: "npm" });
+    bridgeMock.refreshAgentStatuses.mockReset().mockResolvedValue(undefined);
+    bridgeMock.updateAgentBinary.mockReset().mockResolvedValue({ ok: true });
+    runAgentInstallCommandMock.mockReset().mockReturnValue(true);
+    toastMock.danger.mockReset();
+    toastMock.success.mockReset();
+  });
+
+  it("shows and updates the selected Cursor SDK runtime instead of Cursor ACP", async () => {
+    render(<ThreadAgentUpdateDock agentStatus={sdkStatus} project={project} />);
+
+    expect(
+      await screen.findByText(/Cursor SDK: Windows · v1\.0\.24 → v1\.0\.31/u),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/2026\.07\.09/u)).toBeNull();
+    expect(bridgeMock.getLatestAgentVersion).toHaveBeenCalledWith({
+      agentKind: "cursor",
+      npmPackage: {
+        name: "@cursor/sdk",
+        minVersion: "1.0.24",
+        maxExclusiveMajor: 2,
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    expect(runAgentInstallCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: "Cursor SDK",
+        command: expect.stringContaining("npm install -g '@cursor/sdk@^1.0.24'"),
+        purpose: "update",
+      }),
+    );
+    expect(bridgeMock.updateAgentBinary).not.toHaveBeenCalled();
+
+    await act(async () => {
+      runAgentInstallCommandMock.mock.calls[0]?.[0].onCommandComplete?.(0);
+    });
+
+    expect(bridgeMock.refreshAgentStatuses).toHaveBeenCalledWith([], {
+      agentKinds: ["cursor"],
+      envs: [{ kind: "native" }],
+    });
+  });
+
+  it("keeps the provider binary updater for the selected Cursor ACP runtime", async () => {
+    bridgeMock.getLatestAgentVersion.mockResolvedValue({
+      version: "2026.07.23-e383d2b",
+      source: "unknown",
+    });
+    render(
+      <ThreadAgentUpdateDock
+        agentStatus={{
+          ...sdkStatus,
+          capabilities: { ...sdkStatus.capabilities, runtimeLabel: "ACP" },
+        }}
+        project={project}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Cursor: Windows · v2026\.07\.09-a3815c0 → v2026\.07\.23-e383d2b/u),
+    ).toBeInTheDocument();
+    expect(bridgeMock.getLatestAgentVersion).toHaveBeenCalledWith({ agentKind: "cursor" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await vi.waitFor(() =>
+      expect(bridgeMock.updateAgentBinary).toHaveBeenCalledWith({
+        agentKind: "cursor",
+        envKind: "windows",
+      }),
+    );
+    expect(runAgentInstallCommandMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/thread/ThreadAgentUpdateDock.tsx
+++ b/src/renderer/components/thread/ThreadAgentUpdateDock.tsx
@@ -2,15 +2,17 @@ import { useEffect, useState } from "react";
 import { toast } from "@heroui/react";
 import { Download } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { extractAcpGenericInstanceId, type AgentStatus } from "@/shared/contracts";
+import { extractAcpGenericInstanceId, type AgentStatus, type Project } from "@/shared/contracts";
 import {
   formatUpdateCommandLine,
   isNewerVersion,
   resolveSharedUpdateCommand,
 } from "@/shared/agents/updateResolver";
 import { readBridge } from "@/renderer/bridge";
+import { runAgentInstallCommand } from "@/renderer/actions/agentLoginActions";
 import { Button } from "@/renderer/components/common/Button";
 import { PixelLoader } from "@/renderer/components/common/PixelLoader";
+import { getComposerRuntimeUpdate } from "@/renderer/components/providers/providerComposer";
 import {
   currentWslDistros,
   envLabelForStatus,
@@ -24,7 +26,9 @@ import { ThreadDockHeader, ThreadDockSection } from "./ThreadDockUI";
  * available" with an inline Update button. Reads the *project-scoped* status
  * (Windows for Windows projects, the matching WSL distro for WSL projects), so
  * a draft against a WSL project never offers to update the Windows binary —
- * and vice versa.
+ * and vice versa. Providers with independently versioned composer runtimes can
+ * register a runtime-specific probe and update command; otherwise this uses the
+ * provider binary metadata on `AgentStatus`.
  *
  * Mirrors `ThreadAuthRequiredDock` in pattern. Hidden when:
  *   - The agent is not installed in the project's env.
@@ -36,27 +40,50 @@ import { ThreadDockHeader, ThreadDockSection } from "./ThreadDockUI";
  */
 export function ThreadAgentUpdateDock(props: {
   agentStatus: AgentStatus;
+  project: Project;
   onUpdatingChange?: (updating: boolean) => void;
 }) {
-  const { agentStatus, onUpdatingChange } = props;
+  const { agentStatus, project, onUpdatingChange } = props;
   const { t } = useLingui();
   const [latestVersion, setLatestVersion] = useState<
-    { agentKind: string; version: string | undefined } | undefined
+    { updateKey: string; version: string | undefined } | undefined
   >(undefined);
   const [pending, setPending] = useState(false);
 
   const registryAgentId = extractAcpGenericInstanceId(agentStatus.kind);
+  const runtimeUpdate = getComposerRuntimeUpdate(agentStatus.kind)?.({ agentStatus, project });
+  const updateKey = `${agentStatus.kind}:${runtimeUpdate?.label ?? "provider"}`;
+  const installed = runtimeUpdate?.installed ?? agentStatus.installed;
+  const installedVersion = runtimeUpdate?.installedVersion ?? agentStatus.version;
+  const npmPackageName = runtimeUpdate?.npmPackage?.name;
+  const npmPackageMinVersion = runtimeUpdate?.npmPackage?.minVersion;
+  const npmPackageMaxExclusiveMajor = runtimeUpdate?.npmPackage?.maxExclusiveMajor;
+  const runtimeUpdateHandled = runtimeUpdate !== undefined;
 
   useEffect(() => {
     if (registryAgentId) return;
-    if (!agentStatus.installed || !agentStatus.version) return;
+    if (!installed || !installedVersion) return;
+    if (runtimeUpdateHandled && !npmPackageName) return;
     let cancelled = false;
     const kind = agentStatus.kind;
     readBridge()
-      .getLatestAgentVersion({ agentKind: kind })
+      .getLatestAgentVersion({
+        agentKind: kind,
+        ...(npmPackageName
+          ? {
+              npmPackage: {
+                name: npmPackageName,
+                ...(npmPackageMinVersion ? { minVersion: npmPackageMinVersion } : {}),
+                ...(npmPackageMaxExclusiveMajor
+                  ? { maxExclusiveMajor: npmPackageMaxExclusiveMajor }
+                  : {}),
+              },
+            }
+          : {}),
+      })
       .then((result) => {
         if (cancelled) return;
-        setLatestVersion({ agentKind: kind, version: result.version });
+        setLatestVersion({ updateKey, version: result.version });
       })
       .catch((error) => {
         console.warn(
@@ -67,19 +94,26 @@ export function ThreadAgentUpdateDock(props: {
     return () => {
       cancelled = true;
     };
-  }, [agentStatus.kind, agentStatus.installed, agentStatus.version, registryAgentId]);
+  }, [
+    agentStatus.kind,
+    installed,
+    installedVersion,
+    npmPackageMaxExclusiveMajor,
+    npmPackageMinVersion,
+    npmPackageName,
+    registryAgentId,
+    runtimeUpdateHandled,
+    updateKey,
+  ]);
 
   // Identity-gated read so a stale entry from a previous agent never matches
   // the current one (avoids one-frame flash on agent switch).
   const resolvedLatest =
-    latestVersion && latestVersion.agentKind === agentStatus.kind
-      ? latestVersion.version
-      : undefined;
+    latestVersion && latestVersion.updateKey === updateKey ? latestVersion.version : undefined;
 
-  const installedVersion = agentStatus.version;
   const isOutdated =
     registryAgentId === undefined &&
-    agentStatus.installed &&
+    installed &&
     resolvedLatest !== undefined &&
     installedVersion !== undefined &&
     isNewerVersion(resolvedLatest, installedVersion);
@@ -89,39 +123,57 @@ export function ThreadAgentUpdateDock(props: {
   }
 
   const scope = statusUpdateScope(agentStatus);
-  const previewCommand = resolveSharedUpdateCommand({
-    update: agentStatus.update,
-    executablePath: agentStatus.executablePath,
-    envKind: scope.envKind,
-  });
+  const previewCommand = runtimeUpdate
+    ? undefined
+    : resolveSharedUpdateCommand({
+        update: agentStatus.update,
+        executablePath: agentStatus.executablePath,
+        envKind: scope.envKind,
+      });
   const previewCommandLine = previewCommand ? formatUpdateCommandLine(previewCommand) : undefined;
 
   const envLabel = envLabelForStatus(agentStatus);
+  const updateLabel = runtimeUpdate?.label ?? agentStatus.label;
 
   async function handleUpdate() {
     if (pending) return;
     setPending(true);
     onUpdatingChange?.(true);
     try {
-      const result = await readBridge().updateAgentBinary({
-        agentKind: agentStatus.kind,
-        envKind: scope.envKind,
-        ...(scope.wslDistro ? { wslDistro: scope.wslDistro } : {}),
-      });
-      if (result.ok) {
-        toast.success(t`${agentStatus.label} updated to v${resolvedLatest}.`);
-        await readBridge().refreshAgentStatuses(currentWslDistros(), {
-          agentKinds: [agentStatus.kind],
-          envs: [scopeEnvForStatus(agentStatus)],
+      const runtimeCommand = runtimeUpdate?.command;
+      if (runtimeCommand) {
+        const exitCode = await new Promise<number>((resolve) => {
+          const opened = runAgentInstallCommand({
+            label: updateLabel,
+            command: runtimeCommand,
+            project,
+            purpose: "update",
+            onCommandComplete: resolve,
+          });
+          if (!opened) resolve(-1);
         });
+        if (exitCode !== 0) return;
       } else {
-        const detail = result.output?.trim();
-        toast.danger(
-          detail
-            ? t`Unable to update ${agentStatus.label}: ${detail.slice(0, 240)}`
-            : t`Unable to update ${agentStatus.label}.`,
-        );
+        const result = await readBridge().updateAgentBinary({
+          agentKind: agentStatus.kind,
+          envKind: scope.envKind,
+          ...(scope.wslDistro ? { wslDistro: scope.wslDistro } : {}),
+        });
+        if (!result.ok) {
+          const detail = result.output?.trim();
+          toast.danger(
+            detail
+              ? t`Unable to update ${agentStatus.label}: ${detail.slice(0, 240)}`
+              : t`Unable to update ${agentStatus.label}.`,
+          );
+          return;
+        }
       }
+      toast.success(t`${agentStatus.label} updated to v${resolvedLatest}.`);
+      await readBridge().refreshAgentStatuses(currentWslDistros(), {
+        agentKinds: [agentStatus.kind],
+        envs: [scopeEnvForStatus(agentStatus)],
+      });
     } catch (error) {
       toast.danger(
         error instanceof Error ? error.message : t`Unable to update ${agentStatus.label}.`,
@@ -159,7 +211,7 @@ export function ThreadAgentUpdateDock(props: {
         }
       >
         <span className="min-w-0 flex-1 truncate leading-5 text-[color:var(--muted)]">
-          {agentStatus.label}: {description}
+          {updateLabel}: {description}
         </span>
       </ThreadDockHeader>
     </ThreadDockSection>

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -907,6 +907,7 @@ export function ThreadDraftComposerArea(props: {
               <>
                 <ThreadAgentUpdateDock
                   agentStatus={props.selectedAgent}
+                  project={props.project}
                   onUpdatingChange={setAgentUpdating}
                 />
                 <HookInstallProposal

--- a/src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
+++ b/src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
@@ -1,127 +1,20 @@
 import { msg } from "@lingui/core/macro";
-import { CURSOR_SDK_INSTALL_SPEC } from "@/shared/agents/cursorSdkPackage";
-import type { AgentStatus, Project } from "@/shared/contracts";
+import {
+  canUpdateCursorSdk,
+  cursorRuntimeInstallCommand,
+  cursorRuntimeInstallState,
+  cursorSdkUpdateCommand,
+} from "@/renderer/components/providers/cursor/runtimeInstall";
 import type { NativeAgentRuntimeSlots } from "./nativeAgentRuntimes";
 
-export type CursorInstallRuntime = "acp" | "sdk" | "both";
-
-export interface CursorRuntimeInstallState {
-  acpInstalled: boolean;
-  sdkInstalled: boolean;
-  acpVersion?: string;
-  sdkVersion?: string;
-  sdkInstallationSource?: string;
-}
-
-export function cursorRuntimeInstallState(
-  status: AgentStatus | undefined,
-): CursorRuntimeInstallState {
-  const variants = status?.runtimeVariants;
-  const acpVersion =
-    variants?.acp?.version ?? (variants?.acp?.installed ? status?.version : undefined);
-  const sdkVersion =
-    variants?.sdk?.version ?? (!variants?.acp?.installed ? status?.version : undefined);
-  return {
-    // Older cached Cursor statuses predate runtimeVariants and always represent
-    // the installed Cursor Agent, so preserve that as the ACP fallback.
-    acpInstalled: variants?.acp?.installed ?? status?.installed ?? false,
-    sdkInstalled: variants?.sdk?.installed ?? false,
-    ...(acpVersion ? { acpVersion } : {}),
-    ...(sdkVersion ? { sdkVersion } : {}),
-    ...(variants?.sdk?.installationSource
-      ? { sdkInstallationSource: variants.sdk.installationSource }
-      : {}),
-  };
-}
-
-/**
- * Cursor install/update commands branch on the *project* location rather than
- * the detected host platform (the registry's `posixOrWindows` helper): a remote
- * client's advertised platform can fall back to the client UA before pairing
- * completes, while `location.kind` always describes the shell the command will
- * actually run in.
- */
-function isWindowsProject(project: Project): boolean {
-  return project.location.kind === "windows";
-}
-
-/** `if <tool> exists then <body> else explain` in the project's shell dialect. */
-function guardedCommand(
-  project: Project,
-  tool: string,
-  body: string,
-  missingMessage: string,
-): string {
-  return isWindowsProject(project)
-    ? `if (Get-Command ${tool} -ErrorAction SilentlyContinue) { ${body} } else { Write-Host '${missingMessage}' }`
-    : `if command -v ${tool} >/dev/null 2>&1; then ${body}; else printf '${missingMessage}\\n'; fi`;
-}
-
-/** Shell-quoted install spec; the range itself lives in `cursorSdkPackage.ts`. */
-const CURSOR_SDK_PACKAGE_SPEC = `'${CURSOR_SDK_INSTALL_SPEC}'`;
-const MISSING_CURL_MESSAGE =
-  "curl is required to install Cursor. Install curl, then refresh detected agents.";
-const MISSING_WINDOWS_INSTALLER_MESSAGE =
-  "No supported installer found. Install PowerShell Invoke-RestMethod first, then refresh detected agents.";
-const MISSING_NPM_MESSAGE =
-  "npm is required to install the Cursor SDK. Install Node.js/npm first, then refresh detected agents.";
-const MISSING_PNPM_MESSAGE = "pnpm is required to update this Cursor SDK installation.";
-
-export function cursorAgentInstallCommand(project: Project): string {
-  return isWindowsProject(project)
-    ? guardedCommand(
-        project,
-        "irm",
-        "irm 'https://cursor.com/install?win32=true' | iex",
-        MISSING_WINDOWS_INSTALLER_MESSAGE,
-      )
-    : guardedCommand(
-        project,
-        "curl",
-        "curl https://cursor.com/install -fsS | bash",
-        MISSING_CURL_MESSAGE,
-      );
-}
-
-export function cursorSdkInstallCommand(project: Project): string {
-  return guardedCommand(
-    project,
-    "npm",
-    `npm install -g ${CURSOR_SDK_PACKAGE_SPEC}`,
-    MISSING_NPM_MESSAGE,
-  );
-}
-
-export function cursorSdkUpdateCommand(status: AgentStatus, project: Project): string | undefined {
-  const source = cursorRuntimeInstallState(status).sdkInstallationSource;
-  if (source === "global-pnpm") {
-    return guardedCommand(
-      project,
-      "pnpm",
-      `pnpm add -g ${CURSOR_SDK_PACKAGE_SPEC}`,
-      MISSING_PNPM_MESSAGE,
-    );
-  }
-  if (source !== "global-npm") return undefined;
-  return cursorSdkInstallCommand(project);
-}
-
-export function canUpdateCursorSdk(status: AgentStatus): boolean {
-  const source = cursorRuntimeInstallState(status).sdkInstallationSource;
-  return source === "global-npm" || source === "global-pnpm";
-}
-
-export function cursorRuntimeInstallCommand(
-  runtime: CursorInstallRuntime,
-  project: Project,
-): string {
-  if (runtime === "acp") return cursorAgentInstallCommand(project);
-  if (runtime === "sdk") return cursorSdkInstallCommand(project);
-
-  const acp = cursorAgentInstallCommand(project);
-  const sdk = cursorSdkInstallCommand(project);
-  return isWindowsProject(project) ? `${acp}; if ($?) { ${sdk} }` : `( ${acp} ) && ( ${sdk} )`;
-}
+export {
+  canUpdateCursorSdk,
+  cursorAgentInstallCommand,
+  cursorRuntimeInstallCommand,
+  cursorRuntimeInstallState,
+  cursorSdkInstallCommand,
+  cursorSdkUpdateCommand,
+} from "@/renderer/components/providers/cursor/runtimeInstall";
 
 /** Cursor's install-source vocabulary; only Cursor knows what these mean. */
 function cursorSdkSourceLabel(source: string) {


### PR DESCRIPTION
- Add provider-specific runtime update registration for Cursor SDK installations.
- Support ACP binary and SDK package updates with project-aware commands and refreshes.
- Centralize Cursor runtime install helpers and cover both update paths with tests.