### PR TITLE
Fix thinking mode sync when changing models

### DIFF
--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -1330,6 +1330,55 @@ describe("ThreadDraftView", () => {
     });
   });
 
+  it("enables Thinking by default when switching to a supported Cursor model", async () => {
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    render(<ThreadDraftView project={project} agentStatuses={[cursorStatus]} onStart={onStart} />);
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        controls: Array<{
+          kind?: string;
+          currentModel?: string;
+          onChange?: (next: { agentKind: string; model: string }) => void;
+        }>;
+      };
+      expect(
+        props.controls.find((control) => control.kind === "provider-model")?.currentModel,
+      ).toBe("composer-2");
+    });
+
+    const initialProps = composerSpy.mock.lastCall?.[0] as {
+      controls: Array<{
+        kind?: string;
+        onChange?: (next: { agentKind: string; model: string }) => void;
+      }>;
+    };
+    const providerModel = initialProps.controls.find(
+      (control) => control.kind === "provider-model",
+    );
+
+    act(() => {
+      providerModel?.onChange?.({ agentKind: "cursor", model: "gpt-5.5" });
+    });
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        controls: Array<{
+          kind?: string;
+          currentModel?: string;
+          thinkingValue?: boolean;
+        }>;
+      };
+      expect(
+        props.controls.find((control) => control.kind === "provider-model")?.currentModel,
+      ).toBe("gpt-5.5");
+      expect(
+        props.controls.find((control) => control.kind === "effort-context")?.thinkingValue,
+      ).toBe(true);
+    });
+  });
+
   it("does not expose a single Cursor context option as a dropdown control", async () => {
     const onStart = vi.fn<(input: unknown) => void>();
 

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -29,6 +29,7 @@ import {
   appendProviderComposerControls,
   buildModelPickerControls,
   buildProviderModelMenuProviders,
+  patchConfigForModelChange,
 } from "./buildModelPickerControls";
 import {
   agentWithCapabilities,
@@ -709,7 +710,7 @@ export function ThreadDraftView(props: {
     model: nextModel,
     presentationMode: nextPresentationMode,
   }) => {
-    if (!selectedAgent) return;
+    if (!selectedAgent || !selectedAgentForConfig) return;
     hasLocalConfigEditRef.current = true;
     const targetPresentationMode = nextPresentationMode ?? presentationMode;
     if (targetPresentationMode !== presentationMode) {
@@ -765,7 +766,12 @@ export function ThreadDraftView(props: {
         worktreeMode: effectiveWorktreeMode,
       });
     } else {
-      latestConfigPatchRef.current({ model: nextModel });
+      latestConfigPatchRef.current(
+        patchConfigForModelChange(selectedAgentForConfig.capabilities, nextModel, {
+          ...(effort ? { effort } : {}),
+          ...(contextSize ? { contextSize } : {}),
+        }),
+      );
     }
   };
 

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -53,6 +53,7 @@ describe("patchConfigForModelChange", () => {
       model: "b",
       contextSize: "128k",
       fast: false,
+      thinking: true,
     });
   });
 
@@ -67,6 +68,7 @@ describe("patchConfigForModelChange", () => {
       effort: "high",
       contextSize: "128k",
       fast: false,
+      thinking: true,
     });
   });
 

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -179,7 +179,7 @@ export function patchConfigForModelChange(
     ...(!effortValid && nextEfforts.length > 0 ? { effort: nextEfforts[0] } : {}),
     ...(nextContextDefault ? { contextSize: nextContextDefault } : {}),
     ...(supportsUsableFastMode(capabilities, model) ? {} : { fast: false }),
-    ...(capabilities.thinkingModels?.includes(model) ? {} : { thinking: false }),
+    thinking: capabilities.thinkingModels?.includes(model) ?? false,
   };
 }
 


### PR DESCRIPTION
- Synchronize Thinking with the selected model’s capabilities.
- Preserve effort and context settings during model changes.
- Add regression coverage for supported and unsupported model transitions.