### PR TITLE
Preserve replacement Codex sessions during teardown

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -897,13 +897,20 @@ export class CodexStructuredSession implements StructuredSessionHandle {
           )
           .catch(() => undefined);
       }
-      await this.rpc
-        .request(
-          "thread/unsubscribe",
-          { threadId: this.remoteThreadId },
-          CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS,
-        )
-        .catch(() => undefined);
+      // Re-check ownership *after* the interrupt round-trip: a force-stopped
+      // session is replaced while this teardown drains, and the replacement
+      // resubscribes to the same provider thread on the shared app-server.
+      // Unsubscribing then would silence the live session's notifications and
+      // strand it on "working" with no output.
+      if (this.rpc.ownsThread(this.remoteThreadId)) {
+        await this.rpc
+          .request(
+            "thread/unsubscribe",
+            { threadId: this.remoteThreadId },
+            CODEX_DISPOSE_INTERRUPT_TIMEOUT_MS,
+          )
+          .catch(() => undefined);
+      }
     }
     this.rpc.dispose(new Error("Codex app-server session disposed."));
     this.releaseAppServer();

--- a/src/supervisor/agents/codex/appServerRpc.test.ts
+++ b/src/supervisor/agents/codex/appServerRpc.test.ts
@@ -652,4 +652,58 @@ describe("CodexAppServerRpc", () => {
       "stdin closed",
     );
   });
+
+  it("keeps a replacement channel alive when the superseded session for the same thread disposes", async () => {
+    let transportListener: CodexStdioTransportListener | undefined;
+    const writes: Array<Record<string, unknown>> = [];
+    const transport: CodexAppServerRpcTransport = {
+      setListener: (listener) => {
+        transportListener = listener;
+      },
+      write: (message) => writes.push(message),
+      dispose: () => {},
+      formatOutput: () => "",
+    };
+    const connection = new CodexAppServerConnection(transport);
+    // A force-stopped session is replaced while its own teardown still drains,
+    // so both sessions share the Poracode thread id.
+    const forceStopped = new CodexAppServerRpc(connection, "local-thread");
+    forceStopped.claimThread("provider-thread");
+    const replacement = new CodexAppServerRpc(connection, "local-thread");
+    const replacementNotifications =
+      vi.fn<(method: string, params: Record<string, unknown> | undefined) => void>();
+    replacement.setListener({
+      onNotification: replacementNotifications,
+      onRuntimeEvents: () => {},
+      onClose: () => {},
+      onError: () => {},
+    });
+    // A sibling channel keeps the connection multi-channel so nothing falls
+    // back to the single-channel delivery path.
+    const sibling = new CodexAppServerRpc(connection, "local-sibling");
+    sibling.claimThread("provider-sibling");
+    replacement.claimThread("provider-thread");
+
+    expect(forceStopped.ownsThread("provider-thread")).toBe(false);
+    expect(replacement.ownsThread("provider-thread")).toBe(true);
+
+    const pending = replacement.request("turn/start", {
+      threadId: "provider-thread",
+      input: [],
+      model: "gpt-5.6-sol",
+    });
+    forceStopped.dispose(new Error("Codex app-server session disposed."));
+
+    transportListener!.onMessage({
+      method: "turn/started",
+      params: { threadId: "provider-thread" },
+    });
+    expect(replacementNotifications).toHaveBeenCalledWith("turn/started", {
+      threadId: "provider-thread",
+    });
+
+    const requestId = writes.find((message) => message.method === "turn/start")?.id;
+    transportListener!.onMessage({ id: requestId, result: { turn: { id: "turn-1" } } });
+    await expect(pending).resolves.toMatchObject({ turn: { id: "turn-1" } });
+  });
 });

--- a/src/supervisor/agents/codex/appServerRpc.ts
+++ b/src/supervisor/agents/codex/appServerRpc.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { RuntimeEvent, ThreadServerRequestId } from "@/shared/contracts";
 import { mapCodexServerRequest, translateCodexCanonicalResponse } from "./canonicalMapping";
 import { parseCodexSocketMessage } from "./acpProtocol";
@@ -499,6 +500,15 @@ export class CodexAppServerConnection {
 export class CodexAppServerRpc {
   private readonly connection: CodexAppServerConnection;
   private readonly ownsConnection: boolean;
+  /**
+   * Channel identity is per *session instance*, not per Poracode thread: a
+   * force-stopped session is replaced by a new session for the same thread id
+   * while its own `dispose()` is still draining. Keying channels by thread id
+   * would let that late teardown unregister the replacement's channel and
+   * reject its in-flight requests, leaving the thread stuck on "working" with
+   * no notifications ever routed to it.
+   */
+  private readonly channelId: string;
 
   constructor(
     transportOrConnection: CodexAppServerRpcTransport | CodexAppServerConnection,
@@ -511,11 +521,12 @@ export class CodexAppServerRpc {
       this.ownsConnection = true;
       this.connection = new CodexAppServerConnection(transportOrConnection);
     }
-    this.connection.registerChannel(this.localThreadId, this.localThreadId);
+    this.channelId = `${this.localThreadId}#${randomUUID()}`;
+    this.connection.registerChannel(this.channelId, this.localThreadId);
   }
 
   setListener(listener: CodexAppServerRpcListener): void {
-    this.connection.setChannelListener(this.localThreadId, listener);
+    this.connection.setChannelListener(this.channelId, listener);
   }
 
   request<M extends keyof CodexClientRequestMap>(
@@ -523,7 +534,7 @@ export class CodexAppServerRpc {
     params: CodexClientRequestMap[M]["params"],
     timeoutMs = 30_000,
   ): Promise<CodexClientRequestMap[M]["result"]> {
-    return this.connection.request(this.localThreadId, method, params, timeoutMs) as Promise<
+    return this.connection.request(this.channelId, method, params, timeoutMs) as Promise<
       CodexClientRequestMap[M]["result"]
     >;
   }
@@ -533,23 +544,23 @@ export class CodexAppServerRpc {
     params: Record<string, unknown> | null,
     timeoutMs = 30_000,
   ): Promise<unknown> {
-    return this.connection.request(this.localThreadId, method, params, timeoutMs);
+    return this.connection.request(this.channelId, method, params, timeoutMs);
   }
 
   notify(method: string): void {
-    this.connection.notify(this.localThreadId, method);
+    this.connection.notify(this.channelId, method);
   }
 
   claimThread(threadId: string): void {
-    this.connection.claimThread(this.localThreadId, threadId);
+    this.connection.claimThread(this.channelId, threadId);
   }
 
   ownsThread(threadId: string): boolean {
-    return this.connection.ownsThread(this.localThreadId, threadId);
+    return this.connection.ownsThread(this.channelId, threadId);
   }
 
   resolveServerRequest(requestId: ThreadServerRequestId, response: unknown): void {
-    this.connection.resolveServerRequest(this.localThreadId, requestId, response);
+    this.connection.resolveServerRequest(this.channelId, requestId, response);
   }
 
   dispose(error: Error): void {
@@ -557,6 +568,6 @@ export class CodexAppServerRpc {
       this.connection.dispose(error);
       return;
     }
-    this.connection.unregisterChannel(this.localThreadId, error);
+    this.connection.unregisterChannel(this.channelId, error);
   }
 }

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -1004,6 +1004,27 @@ describe("CodexStructuredSession", () => {
     expect(releaseAppServer).toHaveBeenCalledOnce();
   });
 
+  it("keeps a replacement session subscribed when a superseded session disposes", async () => {
+    const structuredSession = makeStructuredSession([]);
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    (structuredSession as unknown as Record<string, unknown>)["activeTurnId"] = "turn-1";
+    (structuredSession as unknown as Record<string, unknown>)["releaseAppServer"] = () => {};
+    (structuredSession as unknown as Record<string, unknown>)["rpc"] = {
+      // The replacement session claims the provider thread while this teardown
+      // waits on its interrupt round-trip.
+      ownsThread: () => requests.length === 0,
+      request: (method: string, params: Record<string, unknown>) => {
+        requests.push({ method, params });
+        return Promise.resolve({});
+      },
+      dispose: () => {},
+    };
+
+    await structuredSession.dispose();
+
+    expect(requests.map((request) => request.method)).toEqual(["turn/interrupt"]);
+  });
+
   it("interrupts the active Codex app-server turn", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);


### PR DESCRIPTION
- Keep replacement sessions subscribed when superseded sessions dispose.
- Use per-session channel identities to protect shared Codex connections.
- Add regression coverage for notification routing and teardown behavior.