### PR TITLE
Route GitHub Actions procedures remotely

### DIFF
--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -4656,7 +4656,21 @@ describe("RemoteAccessServer", () => {
     await expect(statusResponse.json()).resolves.toEqual({ result: { ok: "getGitStatus" } });
     expect(calls).toContainEqual({ name: "getGitStatus", payload: { projectLocation } });
 
-    const checkpointCalls = [
+    const dispatchPayload = {
+      projectLocation,
+      workflowId: 12,
+      ref: "main",
+      inputs: { release: "true" },
+    };
+    const forwardedCalls = [
+      {
+        procedure: "ghListWorkflows",
+        payload: { projectLocation },
+      },
+      {
+        procedure: "ghDispatchWorkflow",
+        payload: dispatchPayload,
+      },
       {
         procedure: "rollbackThreadConversation",
         payload: {
@@ -4678,7 +4692,7 @@ describe("RemoteAccessServer", () => {
         payload: { threadId: "thread-1", checkpointItemId: "user-2", projectLocation },
       },
     ] as const;
-    for (const call of checkpointCalls) {
+    for (const call of forwardedCalls) {
       const response = await fetch(new URL("/api/git/call", info.httpBaseUrl), {
         method: "POST",
         headers: fullHeaders,
@@ -4753,6 +4767,17 @@ describe("RemoteAccessServer", () => {
       error: { code: "missing_scope" },
     });
     expect(calls.filter((c) => c.name === "gitPush")).toHaveLength(1);
+
+    const dispatchWithoutOperateResponse = await fetch(new URL("/api/git/call", info.httpBaseUrl), {
+      method: "POST",
+      headers: { authorization: `Bearer ${readToken}`, "content-type": "application/json" },
+      body: JSON.stringify({ procedure: "ghDispatchWorkflow", payload: dispatchPayload }),
+    });
+    expect(dispatchWithoutOperateResponse.status).toBe(403);
+    await expect(dispatchWithoutOperateResponse.json()).resolves.toMatchObject({
+      error: { code: "missing_scope" },
+    });
+    expect(calls.filter((c) => c.name === "ghDispatchWorkflow")).toHaveLength(1);
   });
 
   it("rejects remote Git lifecycle mutations for experiment-owned branches and worktrees", async () => {

--- a/src/renderer/bridge.test.ts
+++ b/src/renderer/bridge.test.ts
@@ -51,6 +51,42 @@ describe("remote-aware renderer bridge", () => {
     expect(local).not.toHaveBeenCalled();
   });
 
+  it("routes GitHub Actions procedures through the remote project owner", async () => {
+    const local = vi.fn<() => Promise<unknown>>(async () => ({ local: true }));
+    const calls = [
+      ["ghListWorkflows", {}],
+      ["ghListWorkflowRuns", { workflowId: 12 }],
+      ["ghGetWorkflowRun", { runId: 34 }],
+      ["ghGetWorkflowDefinition", { workflowId: 12, ref: "main" }],
+      ["ghDispatchWorkflow", { workflowId: 12, ref: "main", inputs: { release: "true" } }],
+      ["ghRerunWorkflowRun", { runId: 34, failedOnly: true }],
+      ["ghDeleteWorkflowRun", { runId: 34 }],
+    ] as const;
+    window.poracode = Object.fromEntries(
+      calls.map(([procedure]) => [procedure, local]),
+    ) as unknown as PoracodeBridge;
+    const remote = vi.fn<RemoteProcedureHost["gitCall"]>(async () => ({ remote: true }));
+    registerRemoteProcedureHost(makeRemoteHost(remote));
+
+    for (const [procedure, fields] of calls) {
+      const payload = {
+        projectLocation: {
+          kind: "posix" as const,
+          path: "/remote/project",
+          remoteServerId: "d1",
+        },
+        ...fields,
+      };
+      const invoke = readBridge()[procedure] as (input: typeof payload) => Promise<unknown>;
+      await expect(invoke(payload)).resolves.toEqual({ remote: true });
+      expect(remote).toHaveBeenLastCalledWith("d1", procedure, {
+        ...payload,
+        projectLocation: { kind: "posix", path: "/remote/project" },
+      });
+    }
+    expect(local).not.toHaveBeenCalled();
+  });
+
   it("falls through to the local bridge when the router declines the payload", async () => {
     const local = vi.fn<() => Promise<unknown>>(async () => ({ local: true }));
     window.poracode = {

--- a/src/renderer/remoteProcedureRouter.ts
+++ b/src/renderer/remoteProcedureRouter.ts
@@ -138,6 +138,10 @@ const REMOTE_GIT_ROUTE_TABLE = {
   ghGetPrFiles: "projectLocation",
   ghGetPrDiff: "projectLocation",
   ghGetPrDetails: "projectLocation",
+  ghListWorkflows: "projectLocation",
+  ghListWorkflowRuns: "projectLocation",
+  ghGetWorkflowRun: "projectLocation",
+  ghGetWorkflowDefinition: "projectLocation",
   gitStage: "projectLocation",
   gitUnstage: "projectLocation",
   gitRevert: "projectLocation",
@@ -173,6 +177,9 @@ const REMOTE_GIT_ROUTE_TABLE = {
   ghSubmitPrReview: "projectLocation",
   ghUpdatePrBranch: "projectLocation",
   ghPostPrComment: "projectLocation",
+  ghDispatchWorkflow: "projectLocation",
+  ghRerunWorkflowRun: "projectLocation",
+  ghDeleteWorkflowRun: "projectLocation",
 } as const satisfies Record<GitRemoteProcedureName, RemoteOwnerStrategy>;
 
 const REMOTE_NOOP_ROUTE_TABLE = {

--- a/src/shared/remote/gitProcedures.ts
+++ b/src/shared/remote/gitProcedures.ts
@@ -71,6 +71,10 @@ export const GIT_REMOTE_PROCEDURE_SCOPES = {
   ghGetPrFiles: "session:read",
   ghGetPrDiff: "session:read",
   ghGetPrDetails: "session:read",
+  ghListWorkflows: "session:read",
+  ghListWorkflowRuns: "session:read",
+  ghGetWorkflowRun: "session:read",
+  ghGetWorkflowDefinition: "session:read",
 
   // Working-tree + index mutations
   gitStage: "session:operate",
@@ -114,6 +118,9 @@ export const GIT_REMOTE_PROCEDURE_SCOPES = {
   ghSubmitPrReview: "session:operate",
   ghUpdatePrBranch: "session:operate",
   ghPostPrComment: "session:operate",
+  ghDispatchWorkflow: "session:operate",
+  ghRerunWorkflowRun: "session:operate",
+  ghDeleteWorkflowRun: "session:operate",
 } as const satisfies Record<string, RemoteAccessScope>;
 
 export type GitRemoteProcedureName = keyof typeof GIT_REMOTE_PROCEDURE_SCOPES;


### PR DESCRIPTION
Tickets: None

- Route GitHub Actions workflow procedures through remote project owners.
- Apply read and operate scopes to workflow access and mutations.
- Add bridge and server coverage for routing and authorization.