### PR TITLE
Fix Computer Use count in composer menu badge

### DIFF
--- a/src/renderer/components/composer/ComposerAddMenu.test.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.test.tsx
@@ -126,6 +126,41 @@ describe("ComposerAddMenu", () => {
     expect(screen.queryByText("Browser")).not.toBeInTheDocument();
   });
 
+  it("counts enabled Computer Use in the parent row badge", () => {
+    render(
+      <ComposerAddMenu
+        mcpServers={[
+          {
+            descriptor: browserMcpServer,
+            enabled: true,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+          {
+            descriptor: crossagentMcpServer,
+            enabled: true,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+          {
+            descriptor: chromeMcpServer,
+            enabled: false,
+            visible: true,
+            onToggle: vi.fn<(next: boolean) => void>(),
+          },
+        ]}
+        computerUse={{ enabled: true, visible: true, onToggle: vi.fn<(next: boolean) => void>() }}
+        showFileOption={false}
+        onPickFiles={vi.fn<() => void>()}
+      />,
+    );
+
+    openMenu();
+
+    // Computer Use is a switch in the same submenu, so it counts: 3 rows are on.
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
   it("toggles a single server without closing the menu", () => {
     const browserToggle = vi.fn<(next: boolean) => void>();
     const crossagentToggle = vi.fn<(next: boolean) => void>();

--- a/src/renderer/components/composer/ComposerAddMenu.tsx
+++ b/src/renderer/components/composer/ComposerAddMenu.tsx
@@ -128,9 +128,13 @@ export function ComposerAddMenu(props: {
     ? t`Controls the paired desktop while the agent clicks or types`
     : t`Takes over the desktop while the agent clicks or types`;
 
+  // Counts every enabled row the submenu shows, Computer Use included — it is
+  // not a registry entry but it renders as one of the switches, so leaving it
+  // out makes the badge disagree with the list the user opens.
   const enabledMcpCount =
     visibleMcpServers.filter((server) => server.enabled).length +
-    customMcpServers.filter((server) => server.enabled).length;
+    customMcpServers.filter((server) => server.enabled).length +
+    (showComputerUse && computerUse.enabled ? 1 : 0);
 
   if (!showFileOption && !hasMcpMenu && !experiment) return null;
 


### PR DESCRIPTION
- Include enabled Computer Use in the composer add-menu badge count.
- Add coverage verifying the badge reflects all enabled submenu controls.