### PR TITLE
Deduplicate mirrored pull request checkouts

### DIFF
--- a/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   GhListPullRequestsPayload,
   GhListPullRequestsResult,
+  GitStatusResult,
   Project,
   PullRequestSummary,
 } from "@/shared/contracts";
@@ -42,6 +43,23 @@ const wslProject: Project = {
   },
   createdAt: "2026-07-13T10:00:00.000Z",
 };
+
+function makeStatus(overrides: Partial<GitStatusResult> = {}): GitStatusResult {
+  return {
+    isRepo: true,
+    branch: "main",
+    tracking: "origin/main",
+    hasRemote: true,
+    remoteInfo: null,
+    ahead: 0,
+    behind: 0,
+    staged: [],
+    unstaged: [],
+    totalInsertions: 0,
+    totalDeletions: 0,
+    ...overrides,
+  };
+}
 
 const summary: PullRequestSummary = {
   pr: {
@@ -103,6 +121,45 @@ describe("PullRequestsView", () => {
 
     act(() => usePanelStore.getState().setPrReviewContext(null));
     await waitFor(() => expect(bridge.ghListPullRequests).toHaveBeenCalledTimes(4));
+  });
+
+  it("queries only the local checkout when a mirrored project shares its origin", async () => {
+    const mirroredProject: Project = {
+      id: "mirrored-project",
+      name: "Mac app",
+      location: { kind: "posix", path: "/Users/leon/work/windows-app", remoteServerId: "mac" },
+      remoteServerId: "mac",
+      remoteId: "remote-1",
+      createdAt: "2026-07-13T10:00:00.000Z",
+    };
+    const remoteInfo = {
+      url: "https://github.com/example/windows-app.git",
+      platform: "github" as const,
+      owner: "example",
+      repo: "windows-app",
+    };
+    useAppStore.setState({ projects: [mirroredProject, windowsProject] });
+    useGitStore.setState({
+      statuses: {
+        [windowsProject.id]: makeStatus({ remoteInfo }),
+        // The same repo over an SSH host alias, so the URL and platform differ.
+        [mirroredProject.id]: makeStatus({
+          remoteInfo: { ...remoteInfo, url: "gh:example/windows-app.git", platform: "unknown" },
+        }),
+      },
+    });
+
+    render(<PullRequestsView />);
+
+    expect(await screen.findByText(summary.pr.title)).toBeInTheDocument();
+    expect(bridge.ghListPullRequests).toHaveBeenCalledTimes(1);
+    expect(bridge.ghListPullRequests).toHaveBeenCalledWith({
+      projectLocation: windowsProject.location,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter pull requests" }));
+    expect(screen.getByRole("checkbox", { name: windowsProject.name })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: mirroredProject.name })).not.toBeInTheDocument();
   });
 
   it("shows a successful project while another project is still loading", async () => {

--- a/src/renderer/views/PullRequestsView/PullRequestsView.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.tsx
@@ -16,6 +16,7 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { getPrStatusTone, PR_TONE_BG_CLASS, PR_TONE_TEXT_CLASS } from "@/renderer/utils/prStatus";
 import { SettingsPage } from "@/renderer/views/SettingsOverlay/parts/SettingsForm";
+import { dedupePrProjects, repoIdentityKey } from "./prProjectDedupe";
 
 type FilterMode = "all" | "reviewing" | "authored";
 
@@ -47,6 +48,16 @@ export function PullRequestsView() {
       ),
     ),
   );
+  // Two checkouts of the same origin (typically a local clone plus the same
+  // clone mirrored from a remote desktop) return identical `gh pr list` rows, so
+  // only one of them is queried — the local one when there is one.
+  const prProjects = useGitStore(
+    useShallow((state) =>
+      dedupePrProjects(activeProjects, (project) =>
+        repoIdentityKey(state.statuses[project.id]?.remoteInfo),
+      ),
+    ),
+  );
   const prReviewOpen = usePanelStore((state) => state.prReviewContext !== null);
   const [loadedProjects, setLoadedProjects] = useState<LoadedProject[]>([]);
   const [failures, setFailures] = useState<ProjectFailure[]>([]);
@@ -63,9 +74,9 @@ export function PullRequestsView() {
     let cancelled = false;
     setLoadedProjects([]);
     setFailures([]);
-    setLoading(activeProjects.length > 0);
+    setLoading(prProjects.length > 0);
 
-    const requests = activeProjects.map((project) =>
+    const requests = prProjects.map((project) =>
       readBridge()
         .ghListPullRequests({ projectLocation: project.location })
         .then(
@@ -94,7 +105,7 @@ export function PullRequestsView() {
     return () => {
       cancelled = true;
     };
-  }, [activeProjects, prReviewOpen, refreshVersion]);
+  }, [prProjects, prReviewOpen, refreshVersion]);
 
   const accountLogins = [
     ...new Set(
@@ -250,7 +261,7 @@ export function PullRequestsView() {
                 </div>
                 <div className="max-h-80 space-y-3 overflow-y-auto px-3 py-3">
                   <FilterGroup title={<Trans>Projects</Trans>}>
-                    {activeProjects.map((project) => (
+                    {prProjects.map((project) => (
                       <Checkbox
                         key={project.id}
                         className="block"
@@ -351,7 +362,7 @@ export function PullRequestsView() {
         <div className="py-12 text-center text-muted">
           <GitPullRequest className="mx-auto mb-3 size-8" />
           <p className="text-sm font-medium text-foreground">
-            {activeProjects.length === 0 ? (
+            {prProjects.length === 0 ? (
               <Trans>Add a project to see pull requests.</Trans>
             ) : totalPullRequests === 0 && failures.length === 0 ? (
               <Trans>No pull requests found.</Trans>

--- a/src/renderer/views/PullRequestsView/prProjectDedupe.test.ts
+++ b/src/renderer/views/PullRequestsView/prProjectDedupe.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { GitRemoteInfo, Project } from "@/shared/contracts";
+import { dedupePrProjects, repoIdentityKey } from "./prProjectDedupe";
+
+function project(id: string, overrides: Partial<Project> = {}): Project {
+  return {
+    id,
+    name: id,
+    location: { kind: "windows", path: `E:\\work\\${id}` },
+    createdAt: "2026-07-13T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const httpsRemote: GitRemoteInfo = {
+  url: "https://github.com/SDSLeon/lightcode.git",
+  platform: "github",
+  owner: "SDSLeon",
+  repo: "lightcode",
+};
+
+const sshAliasRemote: GitRemoteInfo = {
+  url: "gh-personal:sdsleon/Lightcode.git",
+  platform: "unknown",
+  owner: "sdsleon",
+  repo: "Lightcode",
+};
+
+describe("repoIdentityKey", () => {
+  it("matches the same repo across https and SSH-alias remotes", () => {
+    expect(repoIdentityKey(httpsRemote)).toBe("sdsleon/lightcode");
+    expect(repoIdentityKey(sshAliasRemote)).toBe(repoIdentityKey(httpsRemote));
+  });
+
+  it("returns null when the origin remote is unknown", () => {
+    expect(repoIdentityKey(null)).toBeNull();
+    expect(repoIdentityKey(undefined)).toBeNull();
+    expect(repoIdentityKey({ ...httpsRemote, owner: " " })).toBeNull();
+  });
+});
+
+describe("dedupePrProjects", () => {
+  const local = project("local");
+  const mirrored = project("mirrored", { remoteServerId: "mac", remoteId: "remote-1" });
+
+  it("keeps the local checkout when a mirrored project shares its origin", () => {
+    const keys = { local: "sdsleon/lightcode", mirrored: "sdsleon/lightcode" };
+    expect(dedupePrProjects([local, mirrored], (p) => keys[p.id as keyof typeof keys])).toEqual([
+      local,
+    ]);
+    expect(dedupePrProjects([mirrored, local], (p) => keys[p.id as keyof typeof keys])).toEqual([
+      local,
+    ]);
+  });
+
+  it("keeps the first project when neither or both are mirrored", () => {
+    const second = project("second", { remoteServerId: "mac", remoteId: "remote-2" });
+    expect(dedupePrProjects([mirrored, second], () => "sdsleon/lightcode")).toEqual([mirrored]);
+    expect(dedupePrProjects([local, project("other")], () => "sdsleon/lightcode")).toEqual([local]);
+  });
+
+  it("keeps projects with different or unknown repo identities", () => {
+    const other = project("other");
+    const unknownA = project("unknown-a");
+    const unknownB = project("unknown-b");
+    const keys: Record<string, string | null> = {
+      local: "sdsleon/lightcode",
+      other: "sdsleon/other",
+      "unknown-a": null,
+      "unknown-b": null,
+    };
+    expect(dedupePrProjects([local, other, unknownA, unknownB], (p) => keys[p.id] ?? null)).toEqual(
+      [local, other, unknownA, unknownB],
+    );
+  });
+});

--- a/src/renderer/views/PullRequestsView/prProjectDedupe.ts
+++ b/src/renderer/views/PullRequestsView/prProjectDedupe.ts
@@ -1,0 +1,53 @@
+import type { GitRemoteInfo, Project } from "@/shared/contracts";
+
+/**
+ * Identity of the repository a project points at, derived from its cached origin
+ * remote. Keyed on `owner/repo` only: the same repo is reachable over https and
+ * over an SSH host alias, so the URL (and the platform we classify from it)
+ * differs between two checkouts that are really the same repository.
+ *
+ * Returns `null` when the origin remote isn't known yet — such a project must
+ * never be collapsed into another one.
+ */
+export function repoIdentityKey(remoteInfo: GitRemoteInfo | null | undefined): string | null {
+  const owner = remoteInfo?.owner.trim().toLocaleLowerCase();
+  const repo = remoteInfo?.repo.trim().toLocaleLowerCase();
+  if (!owner || !repo) return null;
+  return `${owner}/${repo}`;
+}
+
+/** Projects mirrored from a remote desktop lose to a local checkout of the same repo. */
+function isLocalProject(project: Project): boolean {
+  return !project.remoteServerId;
+}
+
+/**
+ * Collapse projects that are checkouts of the same repository down to one per
+ * repo, preferring a local project over one mirrored from a remote desktop.
+ * `gh pr list` is repo-wide, so every extra checkout of the same origin only
+ * duplicates rows (and, when the remote desktop is unreachable, adds a load
+ * error for PRs we already have). The local clone is also the one PR review can
+ * check out against.
+ *
+ * Input order is preserved, and projects whose repo identity is unknown are
+ * always kept.
+ */
+export function dedupePrProjects(
+  projects: readonly Project[],
+  repoKeyOf: (project: Project) => string | null,
+): Project[] {
+  const primaryByRepo = new Map<string, Project>();
+  for (const project of projects) {
+    const key = repoKeyOf(project);
+    if (!key) continue;
+    const current = primaryByRepo.get(key);
+    // First project wins unless a later one is local and the incumbent is not.
+    if (!current || (isLocalProject(project) && !isLocalProject(current))) {
+      primaryByRepo.set(key, project);
+    }
+  }
+  return projects.filter((project) => {
+    const key = repoKeyOf(project);
+    return key === null || primaryByRepo.get(key) === project;
+  });
+}


### PR DESCRIPTION
- Prevent duplicate pull request queries for mirrored checkouts of the same repository.
- Prefer local projects and preserve projects with unknown or distinct repository identities.
- Add focused unit and view coverage for repository matching and filtering behavior.