### PR TITLE
Prevent GitHub Actions overlay flicker on reopen

### DIFF
--- a/src/renderer/components/layout/OverlayShell.test.tsx
+++ b/src/renderer/components/layout/OverlayShell.test.tsx
@@ -1,0 +1,115 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OverlayShell } from "./OverlayShell";
+
+function surface(container: HTMLElement) {
+  return container.querySelector("[data-overlay-surface]")!;
+}
+
+async function flushFadeIn() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+describe("OverlayShell", () => {
+  it("retains the open content until the exit transition finishes", () => {
+    const onExited = vi.fn<() => void>();
+    const { container, rerender } = render(
+      <OverlayShell open onExited={onExited}>
+        <div>GitHub Actions</div>
+      </OverlayShell>,
+    );
+
+    // The GitHub Actions overlay clears its own context on close, so `open` and
+    // `children` drop in the same render — the content must survive the fade.
+    rerender(
+      <OverlayShell open={false} onExited={onExited}>
+        {null}
+      </OverlayShell>,
+    );
+
+    expect(screen.getByText("GitHub Actions")).toBeInTheDocument();
+
+    fireEvent.transitionEnd(surface(container), { propertyName: "opacity" });
+
+    expect(screen.queryByText("GitHub Actions")).not.toBeInTheDocument();
+    expect(onExited).toHaveBeenCalledOnce();
+
+    rerender(
+      <OverlayShell open onExited={onExited}>
+        <div>GitHub Actions reopened</div>
+      </OverlayShell>,
+    );
+
+    expect(screen.getByText("GitHub Actions reopened")).toBeInTheDocument();
+  });
+
+  it("ignores transitionEnd from content that bubbles up to the surface", async () => {
+    const onExited = vi.fn<() => void>();
+    const { container, rerender } = render(
+      <OverlayShell open onExited={onExited}>
+        <div data-testid="content">GitHub Actions</div>
+      </OverlayShell>,
+    );
+
+    await flushFadeIn();
+    rerender(
+      <OverlayShell open={false} onExited={onExited}>
+        <div data-testid="content">GitHub Actions</div>
+      </OverlayShell>,
+    );
+
+    // A child's own fade bubbles to the surface — it must not cut the exit short.
+    fireEvent.transitionEnd(screen.getByTestId("content"), { propertyName: "opacity" });
+    expect(onExited).not.toHaveBeenCalled();
+    // Neither may a non-opacity transition on the surface itself.
+    fireEvent.transitionEnd(surface(container), { propertyName: "transform" });
+    expect(onExited).not.toHaveBeenCalled();
+
+    fireEvent.transitionEnd(surface(container), { propertyName: "opacity" });
+    expect(onExited).toHaveBeenCalledOnce();
+  });
+
+  it("fades in by default", async () => {
+    const { container } = render(
+      <OverlayShell open>
+        <div>Settings</div>
+      </OverlayShell>,
+    );
+
+    expect(surface(container).className).toContain("opacity-0");
+
+    await flushFadeIn();
+
+    expect(surface(container).className).toContain("opacity-100");
+  });
+
+  it("appears fully opaque with instantEnter, and still fades out", () => {
+    const onExited = vi.fn<() => void>();
+    const { container, rerender } = render(
+      <OverlayShell open instantEnter onExited={onExited}>
+        <div>GitHub Actions</div>
+      </OverlayShell>,
+    );
+
+    // Opaque on the first painted frame — no opacity-0 pass, so no frame
+    // composites the overlay against bare desktop material.
+    expect(surface(container).className).toContain("opacity-100");
+    expect(surface(container).hasAttribute("data-overlay-visible")).toBe(true);
+
+    rerender(
+      <OverlayShell open={false} instantEnter onExited={onExited}>
+        {null}
+      </OverlayShell>,
+    );
+
+    expect(surface(container).className).toContain("opacity-0");
+    expect(screen.getByText("GitHub Actions")).toBeInTheDocument();
+
+    fireEvent.transitionEnd(surface(container), { propertyName: "opacity" });
+    expect(onExited).toHaveBeenCalledOnce();
+  });
+});

--- a/src/renderer/components/layout/OverlayShell.tsx
+++ b/src/renderer/components/layout/OverlayShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode, type TransitionEvent } from "react";
 import { pushEscapeHandler } from "./overlayEscapeStack";
 
 export type OverlayShellMode = "fixed" | "absolute";
@@ -12,23 +12,46 @@ export type OverlayShellMode = "fixed" | "absolute";
  * `mode="fixed"` (default) covers the whole window. `mode="absolute"` covers
  * the nearest positioned ancestor — used for pane-scoped overlays (e.g. the
  * sub-agent drawer over a single chat pane in a split-pane layout).
+ *
+ * `instantEnter` skips the fade-in. Glass overlays hide the base app while they
+ * are shown, so a fade-in composites the overlay against bare desktop material.
+ * That is fine for content that paints in one frame, but an overlay that is
+ * still mounting during the fade (GitHub Actions builds its view model and
+ * fetches workflows) leaves the user watching full-screen acrylic instead. Such
+ * overlays appear at full opacity and keep the fade-out only.
  */
 export function OverlayShell(props: {
   open: boolean;
   onExited?: () => void;
   children: ReactNode;
   mode?: OverlayShellMode;
+  instantEnter?: boolean;
 }) {
-  const { open, onExited, children, mode = "fixed" } = props;
+  const { open, onExited, children, mode = "fixed", instantEnter = false } = props;
   const [mounted, setMounted] = useState(open);
   const [visible, setVisible] = useState(false);
   const escapeClosingRef = useRef(false);
+  // Overlays that clear their own context on close (e.g. the GitHub Actions
+  // view) drop their children in the same render that flips `open` to false,
+  // which would blank the surface before the fade-out ran. Keep the last open
+  // children and render those for the duration of the exit transition.
+  const exitChildrenRef = useRef(children);
+
+  useEffect(() => {
+    if (open) exitChildrenRef.current = children;
+  }, [children, open]);
 
   // Mount immediately when opened, fade in on next frame
   useEffect(() => {
     if (open) {
       if (escapeClosingRef.current) return undefined;
       setMounted(true);
+      // Batched with setMounted into a single render, so the surface never
+      // paints at opacity-0 and no enter transition runs.
+      if (instantEnter) {
+        setVisible(true);
+        return undefined;
+      }
       // Delay to allow the DOM to render at opacity-0 before transitioning
       const raf = requestAnimationFrame(() => setVisible(true));
       return () => cancelAnimationFrame(raf);
@@ -38,7 +61,7 @@ export function OverlayShell(props: {
     // Start fade-out
     setVisible(false);
     return undefined;
-  }, [open]);
+  }, [open, instantEnter]);
 
   // Close on Escape via the overlay escape stack — only the topmost overlay
   // dismisses, so a transient overlay floating above this one (e.g. the
@@ -52,8 +75,12 @@ export function OverlayShell(props: {
     });
   }, [open, onExited]);
 
-  // Unmount after fade-out transition completes
-  function handleTransitionEnd() {
+  // Unmount after this surface's own fade-out completes. Overlay content
+  // animates too, and those transitions bubble — unmounting on a child's
+  // transitionEnd cut the fade short and read as a flicker.
+  function handleTransitionEnd(event: TransitionEvent<HTMLDivElement>) {
+    if (event.target !== event.currentTarget) return;
+    if (event.propertyName !== "opacity") return;
     if (!visible) {
       setMounted(false);
       onExited?.();
@@ -66,17 +93,18 @@ export function OverlayShell(props: {
   return (
     <div
       data-overlay-surface=""
-      // Present only while fully shown (not during fade-in/out). The glass-sidebar
-      // CSS hides the base app behind a translucent overlay, but only when the
-      // overlay is opaque — so on close the app reappears as the overlay fades,
-      // instead of revealing bare desktop underneath.
+      // Present from the start of the fade-in until the start of the fade-out.
+      // The glass-sidebar CSS hides the base app behind this overlay, so it
+      // must engage immediately — leaving the app painted during the fade
+      // shows the main-window sidebar through the translucent overlay. The
+      // overlay is responsible for painting its own chrome on the first frame.
       {...(visible ? { "data-overlay-visible": "" } : {})}
       className={`${positionClass} flex flex-col bg-background transition-opacity duration-150 ${
         visible ? "opacity-100" : "opacity-0"
       }`}
       onTransitionEnd={handleTransitionEnd}
     >
-      {children}
+      {open ? children : exitChildrenRef.current}
     </div>
   );
 }

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/renderer/bridge", () => ({
 
 import { buildWorkflowDispatchInputs } from "./GitHubActionsDispatchPopover";
 import { GitHubActionsView } from "./GitHubActionsView";
+import { resetGitHubActionsCaches } from "./useGitHubActionsViewModel";
 
 const project: Project = {
   id: "project-1",
@@ -115,6 +116,9 @@ describe("buildWorkflowDispatchInputs", () => {
 
 describe("GitHubActionsView", () => {
   beforeEach(() => {
+    // The workflow/run/definition caches persist across mounts by design, so
+    // each case has to start cold or it inherits the previous one's data.
+    resetGitHubActionsCaches();
     bridge.ghListWorkflows.mockReset().mockResolvedValue({
       workflows: [{ id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" }],
     });
@@ -391,6 +395,93 @@ describe("GitHubActionsView", () => {
       });
     });
     expect(await screen.findByText("Refreshed CI run")).toBeInTheDocument();
+  });
+
+  it("renders workflows and runs from cache on the first frame after reopening", async () => {
+    const { unmount } = render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+    expect(await screen.findByText(run.title)).toBeInTheDocument();
+
+    // Closing the overlay unmounts the view; the caches must outlive it.
+    unmount();
+
+    let resolveWorkflows: ((result: GhListWorkflowsResult) => void) | undefined;
+    bridge.ghListWorkflows.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveWorkflows = resolve;
+        }),
+    );
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+
+    // Synchronous — no findBy, no awaited fetch: the sidebar and run list are
+    // painted from cache while the refetch is still pending.
+    expect(screen.getByRole("heading", { name: "CI" })).toBeInTheDocument();
+    expect(screen.getByText(run.title)).toBeInTheDocument();
+    expect(resolveWorkflows).toBeDefined();
+
+    await act(async () => {
+      resolveWorkflows!({
+        workflows: [{ id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" }],
+      });
+    });
+    expect(screen.getByText(run.title)).toBeInTheDocument();
+  });
+
+  it("drops the cached seed once its TTL lapses", async () => {
+    const { unmount } = render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+    expect(await screen.findByText(run.title)).toBeInTheDocument();
+    unmount();
+
+    // Runs expire after a minute; the workflow list lasts ten.
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 2 * 60_000);
+
+    let resolveWorkflows: ((result: GhListWorkflowsResult) => void) | undefined;
+    bridge.ghListWorkflows.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveWorkflows = resolve;
+        }),
+    );
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+
+    // Sidebar still seeds from the workflow cache, but the stale run is gone.
+    expect(screen.getByRole("heading", { name: "CI" })).toBeInTheDocument();
+    expect(screen.queryByText(run.title)).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveWorkflows!({
+        workflows: [{ id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" }],
+      });
+    });
+    expect(await screen.findByText(run.title)).toBeInTheDocument();
+    vi.mocked(Date.now).mockRestore();
+  });
+
+  it("re-applies the pinned default after reopening with a cached list", async () => {
+    bridge.ghListWorkflows.mockResolvedValue({
+      workflows: [
+        { id: 11, name: "CI", path: ".github/workflows/ci.yml", state: "active" },
+        { id: 33, name: "Alpha", path: ".github/workflows/alpha.yml", state: "active" },
+      ],
+    });
+    bridge.ghListWorkflowRuns.mockResolvedValue({ runs: [] });
+    bridge.ghGetWorkflowDefinition.mockImplementation(async ({ workflowId }) => ({
+      definition: { ...definition.definition, workflowId },
+    }));
+
+    const { unmount } = render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+    expect(await screen.findByRole("heading", { name: "CI" })).toBeInTheDocument();
+    unmount();
+
+    // Pinned while the overlay was closed — the cache seed must not pin the
+    // stale selection in place once the fresh list arrives.
+    useSidebarUiStore.setState({ pinnedGitHubWorkflows: { [project.id]: [33] } });
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+
+    expect(await screen.findByRole("heading", { name: "Alpha" })).toBeInTheDocument();
   });
 
   it("does not expand or count jobs without steps", async () => {

--- a/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
+++ b/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
@@ -28,6 +28,98 @@ function definitionCacheKey(projectId: string, workflowId: number, ref?: string)
   return `${workflowCacheKey(projectId, workflowId)}\0${ref ?? ""}`;
 }
 
+// Module scope rather than refs: the overlay unmounts on close, so per-instance
+// caches were discarded every time and each reopen sat on an empty sidebar
+// waiting for the gh calls. Kept here, a reopen paints the last known workflows
+// and runs on its first frame while the refetch updates them in place. Bounded
+// by the projects and workflows actually visited, and dropped on reload.
+//
+// Every read is followed by a refetch, so the TTL is not about freshness — it
+// only caps how stale the seed may be before showing nothing beats showing the
+// wrong thing. Runs expire quickly because a run's status moves on its own;
+// the workflow list and a workflow's definition only change when the repo does.
+const RUNS_CACHE_TTL_MS = 60_000;
+const WORKFLOWS_CACHE_TTL_MS = 10 * 60_000;
+const DEFINITION_CACHE_TTL_MS = 10 * 60_000;
+
+interface CacheEntry<T> {
+  value: T;
+  storedAt: number;
+}
+
+const workflowsCache = new Map<string, CacheEntry<GitHubActionsWorkflow[]>>();
+const runsCache = new Map<string, CacheEntry<GitHubActionsRun[]>>();
+const definitionCache = new Map<string, CacheEntry<GitHubActionsWorkflowDefinition>>();
+
+function readCache<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  ttlMs: number,
+): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.storedAt > ttlMs) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+function writeCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T): void {
+  cache.set(key, { value, storedAt: Date.now() });
+}
+
+// Stable empties so seeding never re-renders with a fresh [] on mount.
+const EMPTY_WORKFLOWS: GitHubActionsWorkflow[] = [];
+const EMPTY_RUNS: GitHubActionsRun[] = [];
+
+/**
+ * Which workflow to show: the current one if it still exists, else the first
+ * pinned one by name, else the first workflow.
+ */
+function resolveSelectedWorkflowId(
+  projectId: string,
+  workflows: GitHubActionsWorkflow[],
+  current: number | null,
+): number | null {
+  if (workflows.some((workflow) => workflow.id === current)) return current;
+  const pinned = new Set(useSidebarUiStore.getState().pinnedGitHubWorkflows[projectId] ?? []);
+  const firstPinnedWorkflowId = workflows
+    .filter((workflow) => pinned.has(workflow.id))
+    .sort((a, b) => a.name.localeCompare(b.name))[0]?.id;
+  return firstPinnedWorkflowId ?? workflows[0]?.id ?? null;
+}
+
+function cachedWorkflowsFor(projectId: string | undefined): GitHubActionsWorkflow[] | undefined {
+  return projectId ? readCache(workflowsCache, projectId, WORKFLOWS_CACHE_TTL_MS) : undefined;
+}
+
+function cachedRunsFor(projectId: string, workflowId: number): GitHubActionsRun[] | undefined {
+  return readCache(runsCache, workflowCacheKey(projectId, workflowId), RUNS_CACHE_TTL_MS);
+}
+
+function cachedDefinitionFor(
+  projectId: string,
+  workflowId: number,
+  ref?: string,
+): GitHubActionsWorkflowDefinition | undefined {
+  return readCache(
+    definitionCache,
+    definitionCacheKey(projectId, workflowId, ref),
+    DEFINITION_CACHE_TTL_MS,
+  );
+}
+
+/**
+ * Drops every cached list. These caches deliberately outlive the component, so
+ * tests need a seam to get a cold start between cases.
+ */
+export function resetGitHubActionsCaches(): void {
+  workflowsCache.clear();
+  runsCache.clear();
+  definitionCache.clear();
+}
+
 export function useGitHubActionsViewModel(props: { projectId?: string; runId?: number }) {
   const { t } = useLingui();
   const activeProjects = useAppStore(
@@ -39,11 +131,18 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
   const selectedProject =
     activeProjects.find((project) => project.id === props.projectId) ?? activeProjects[0];
   const selectedProjectId = selectedProject?.id;
-  const runsCache = useRef(new Map<string, GitHubActionsRun[]>());
-  const definitionCache = useRef(new Map<string, GitHubActionsWorkflowDefinition>());
-  const [workflows, setWorkflows] = useState<GitHubActionsWorkflow[]>([]);
-  const [runs, setRuns] = useState<GitHubActionsRun[]>([]);
-  const [selectedWorkflowId, setSelectedWorkflowId] = useState<number | null>(null);
+  // Seeded from the cross-open cache so a reopen renders the last known list on
+  // its first frame instead of an empty sidebar.
+  const seedWorkflows = cachedWorkflowsFor(selectedProjectId);
+  const [workflows, setWorkflows] = useState<GitHubActionsWorkflow[]>(
+    seedWorkflows ?? EMPTY_WORKFLOWS,
+  );
+  const [runs, setRuns] = useState<GitHubActionsRun[]>(EMPTY_RUNS);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<number | null>(() =>
+    seedWorkflows && selectedProjectId
+      ? resolveSelectedWorkflowId(selectedProjectId, seedWorkflows, null)
+      : null,
+  );
   const [selectedRunId, setSelectedRunId] = useState<number | null>(props.runId ?? null);
   const [selectedRunDetails, setSelectedRunDetails] = useState<GitHubActionsRun | null>(null);
   const [definition, setDefinition] = useState<GitHubActionsWorkflowDefinition | null>(null);
@@ -60,11 +159,25 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
   const [dispatching, setDispatching] = useState(false);
   const [pendingRunId, setPendingRunId] = useState<number | null>(null);
   const [deleteRun, setDeleteRun] = useState<GitHubActionsRun | null>(null);
+  // A selection derived from the cache seed is a guess, not a choice: once the
+  // real list lands it must still resolve to the default (first pinned), or a
+  // workflow pinned while the overlay was closed would be ignored. Only an
+  // explicit pick survives the refresh.
+  const userPickedWorkflowRef = useRef(false);
 
+  // Switching project resets the view. Seed from cache rather than clearing, so
+  // this also leaves the mount-time seed above intact (same references in, no
+  // extra render out) instead of blanking it before the first paint.
   useEffect(() => {
-    setWorkflows([]);
-    setRuns([]);
-    setSelectedWorkflowId(null);
+    userPickedWorkflowRef.current = false;
+    const cached = cachedWorkflowsFor(selectedProjectId);
+    setWorkflows(cached ?? EMPTY_WORKFLOWS);
+    setRuns(EMPTY_RUNS);
+    setSelectedWorkflowId(
+      cached && selectedProjectId
+        ? resolveSelectedWorkflowId(selectedProjectId, cached, null)
+        : null,
+    );
     setSelectedRunId(props.runId ?? null);
     setSelectedRunDetails(null);
     setDefinition(null);
@@ -91,23 +204,23 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
           const activeWorkflows = result.workflows.filter(
             (workflow) => workflow.state.toLowerCase() === "active",
           );
-          const pinnedWorkflowIds =
-            useSidebarUiStore.getState().pinnedGitHubWorkflows[selectedProject.id] ?? [];
-          const pinned = new Set(pinnedWorkflowIds);
-          const firstPinnedWorkflowId = activeWorkflows
-            .filter((workflow) => pinned.has(workflow.id))
-            .sort((a, b) => a.name.localeCompare(b.name))[0]?.id;
+          writeCache(workflowsCache, selectedProject.id, activeWorkflows);
           setWorkflows(activeWorkflows);
           setSelectedWorkflowId((current) =>
-            activeWorkflows.some((workflow) => workflow.id === current)
-              ? current
-              : (firstPinnedWorkflowId ?? activeWorkflows[0]?.id ?? null),
+            resolveSelectedWorkflowId(
+              selectedProject.id,
+              activeWorkflows,
+              userPickedWorkflowRef.current ? current : null,
+            ),
           );
           setLoadingWorkflows(false);
         },
         (error: unknown) => {
           if (cancelled) return;
-          setWorkflows([]);
+          // Keep whatever the cache seeded — showing a stale list beside the
+          // error beats blanking the sidebar on a transient gh failure. An
+          // expired entry counts as absent, so this clears once the TTL lapses.
+          if (!cachedWorkflowsFor(selectedProject.id)) setWorkflows(EMPTY_WORKFLOWS);
           setLoadError(friendlyError(error));
           setLoadingWorkflows(false);
         },
@@ -119,14 +232,14 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
 
   useEffect(() => {
     if (!selectedProject || !selectedWorkflowId) {
-      setRuns([]);
+      setRuns(EMPTY_RUNS);
       setLoadingRuns(false);
       return;
     }
     let cancelled = false;
     const cacheKey = workflowCacheKey(selectedProject.id, selectedWorkflowId);
-    const cachedRuns = runsCache.current.get(cacheKey);
-    setRuns(cachedRuns ?? []);
+    const cachedRuns = cachedRunsFor(selectedProject.id, selectedWorkflowId);
+    setRuns(cachedRuns ?? EMPTY_RUNS);
     setLoadingRuns(true);
     setLoadError(null);
     void readBridge()
@@ -137,7 +250,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       .then(
         (result) => {
           if (cancelled) return;
-          runsCache.current.set(cacheKey, result.runs);
+          writeCache(runsCache, cacheKey, result.runs);
           setRuns(result.runs);
           if (
             dispatchRequestedAt !== null &&
@@ -153,7 +266,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
         },
         (error: unknown) => {
           if (cancelled) return;
-          if (!cachedRuns) setRuns([]);
+          if (!cachedRuns) setRuns(EMPTY_RUNS);
           setLoadError(friendlyError(error));
           setLoadingRuns(false);
         },
@@ -171,7 +284,11 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
     }
     let cancelled = false;
     const cacheKey = definitionCacheKey(selectedProject.id, selectedWorkflowId, definitionRef);
-    const cachedDefinition = definitionCache.current.get(cacheKey);
+    const cachedDefinition = cachedDefinitionFor(
+      selectedProject.id,
+      selectedWorkflowId,
+      definitionRef,
+    );
     setDefinition(cachedDefinition ?? null);
     setLoadingDefinition(true);
     void readBridge()
@@ -183,7 +300,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       .then(
         (result) => {
           if (cancelled) return;
-          definitionCache.current.set(cacheKey, result.definition);
+          writeCache(definitionCache, cacheKey, result.definition);
           setDefinition(result.definition);
           setLoadingDefinition(false);
         },
@@ -258,21 +375,20 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
   }));
 
   function selectWorkflow(workflowId: number) {
+    userPickedWorkflowRef.current = true;
     if (workflowId === selectedWorkflowId) {
       setSelectedRunId(null);
       setSelectedRunDetails(null);
       return;
     }
-    const cachedRuns = selectedProjectId
-      ? runsCache.current.get(workflowCacheKey(selectedProjectId, workflowId))
-      : undefined;
+    const cachedRuns = selectedProjectId ? cachedRunsFor(selectedProjectId, workflowId) : undefined;
     const cachedDefinition = selectedProjectId
-      ? definitionCache.current.get(definitionCacheKey(selectedProjectId, workflowId))
+      ? cachedDefinitionFor(selectedProjectId, workflowId)
       : undefined;
     setSelectedWorkflowId(workflowId);
     setSelectedRunId(null);
     setSelectedRunDetails(null);
-    setRuns(cachedRuns ?? []);
+    setRuns(cachedRuns ?? EMPTY_RUNS);
     setDefinition(cachedDefinition ?? null);
     setDefinitionRef(undefined);
     setLoadingRuns(true);
@@ -289,10 +405,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       return;
     }
     setDefinitionRef(ref);
-    setDefinition(
-      definitionCache.current.get(definitionCacheKey(selectedProjectId, selectedWorkflowId, ref)) ??
-        null,
-    );
+    setDefinition(cachedDefinitionFor(selectedProjectId, selectedWorkflowId, ref) ?? null);
     setLoadingDefinition(true);
   }
 
@@ -357,7 +470,7 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
       setRuns((current) => {
         const nextRuns = current.filter((run) => run.id !== runId);
         if (selectedProjectId && selectedWorkflowId) {
-          runsCache.current.set(workflowCacheKey(selectedProjectId, selectedWorkflowId), nextRuns);
+          writeCache(runsCache, workflowCacheKey(selectedProjectId, selectedWorkflowId), nextRuns);
         }
         return nextRuns;
       });

--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -208,8 +208,12 @@ export function AppOverlays() {
           </Suspense>
         )}
       </OverlayShell>
+      {/* No fade-in: this view builds its model and fetches workflows as it
+          mounts, so fading it in over the hidden base app just shows
+          full-screen acrylic until the content lands. */}
       <OverlayShell
         open={githubActionsVisible}
+        instantEnter
         onExited={() => usePanelStore.getState().setGitHubActionsContext(null)}
       >
         {githubActionsContext && (


### PR DESCRIPTION
- Preserve overlay content through exit transitions and support instant entry
- Cache workflows, runs, and definitions for faster reopening
- Add regression coverage for transitions, caching, and selection behavior