### PR TITLE
Add remote project sync and reachability status

### DIFF
--- a/src/mobile/NarrowShell.tsx
+++ b/src/mobile/NarrowShell.tsx
@@ -17,7 +17,7 @@ import { SubAgentHeaderText } from "@/renderer/components/thread/ChatPane/parts/
 import { ConnectionPill, SheetMenu } from "./components";
 import { NarrowThreadHostProvider } from "./narrowThreadHostContext";
 import { preselectWorktreeDraft, runThreadAction } from "./navHelpers";
-import { desktopTitle } from "./presentation";
+import { desktopTitle } from "@/shared/remote/desktopLabel";
 import { ThreadDetail } from "./ThreadDetail";
 import { ThreadTitleRow } from "./ThreadTitleRow";
 import { ThreadUsageIndicator } from "./ThreadUsageIndicator";

--- a/src/mobile/WideShell.tsx
+++ b/src/mobile/WideShell.tsx
@@ -14,7 +14,7 @@ import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { ConnectionBanner } from "./components";
 import { Brand, ConnectionControl } from "./NarrowShell";
 import { openWorktreeDraft, threadIdFromPath } from "./navHelpers";
-import { desktopTitle } from "./presentation";
+import { desktopTitle } from "@/shared/remote/desktopLabel";
 import { MobileSetupEmptyState } from "./setupEmptyState";
 import type { RemoteDesktopSession } from "./useRemoteDesktop";
 import { ThreadsView } from "./views/ThreadsView";

--- a/src/mobile/presentation.ts
+++ b/src/mobile/presentation.ts
@@ -31,13 +31,6 @@ export const THREAD_STATUS_LABELS: Record<ThreadStatus, MessageDescriptor> = {
   error: msg`Error`,
 };
 
-/** "Poracode on host" → "host"; the brand prefix is noise inside the app.
- *  Legacy "Lightcode on …" labels (paired pre-rebrand) are stripped too. */
-export function desktopTitle(label: string): string {
-  const stripped = label.replace(/^(?:Poracode|Lightcode)\s+on\s+/i, "");
-  return stripped || label;
-}
-
 export function sortThreadsByRecency(threads: readonly Thread[]): Thread[] {
   return threads
     .filter((thread) => !thread.archived)

--- a/src/mobile/views/DesktopsView.tsx
+++ b/src/mobile/views/DesktopsView.tsx
@@ -22,7 +22,7 @@ import { InlineRenameInput } from "@/renderer/views/MainView/parts/Sidebar/parts
 import { Fab, EmptyState, FullScreenDrawer, SheetMenu, useSheet } from "../components";
 import { QrScanner } from "../QrScanner";
 import { parsePairingUrl } from "../pairing";
-import { desktopTitle } from "../presentation";
+import { desktopTitle } from "@/shared/remote/desktopLabel";
 import { isNativeApp, isStandaloneDisplay, promptInstall, useCanInstall } from "../pwaInstall";
 import type { StoredDesktop } from "../storage";
 

--- a/src/mobile/views/GitView.test.tsx
+++ b/src/mobile/views/GitView.test.tsx
@@ -138,7 +138,11 @@ describe("GitView", () => {
 
   it("reports failed refresh fetches instead of silently doing nothing", async () => {
     const project = makeProject();
-    bridge.gitFetch.mockRejectedValueOnce(new Error("fetch failed"));
+    // A real git failure, not the bare "fetch failed" undici emits for an
+    // unreachable host — that one is remapped by friendlyError (messages.ts).
+    bridge.gitFetch.mockRejectedValueOnce(
+      new Error("fatal: could not read from remote repository"),
+    );
 
     render(
       <GitView
@@ -152,7 +156,7 @@ describe("GitView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh changes" }));
 
     await waitFor(() => {
-      expect(toastDanger).toHaveBeenCalledWith("fetch failed");
+      expect(toastDanger).toHaveBeenCalledWith("fatal: could not read from remote repository");
     });
   });
 

--- a/src/renderer/actions/threadLaunchActions.test.ts
+++ b/src/renderer/actions/threadLaunchActions.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
       hostMode?: "desktop" | "helper";
       transport?: { kind: "direct" } | { kind: "ssh" };
     }>,
+    runtime: {} as Record<string, { status: string }>,
     launchRemoteThread: vi.fn<(input: unknown) => Promise<void>>(),
   };
   return {
@@ -130,6 +131,7 @@ describe("startThreadFromDraft host transport", () => {
       changesTransferred: true,
     });
     mocks.remoteState.servers = [];
+    mocks.remoteState.runtime = { d1: { status: "online" } };
     mocks.remoteState.launchRemoteThread.mockResolvedValue(undefined);
     mocks.primeWorktreeGitState.mockResolvedValue(undefined);
     mocks.runWorktreeSetupScript.mockResolvedValue(undefined);
@@ -210,6 +212,23 @@ describe("startThreadFromDraft host transport", () => {
       "/srv/worktrees/feature",
       "pnpm install",
     );
+  });
+
+  it("refuses to launch on a remote project whose server is offline", async () => {
+    mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
+    mocks.remoteState.runtime = { d1: { status: "offline" } };
+
+    await startThreadFromDraft(remoteProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build it",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+
+    // Bails before creating a worktree we would have to unwind.
+    expect(mocks.bridge.gitAddWorktree).not.toHaveBeenCalled();
+    expect(mocks.remoteState.launchRemoteThread).not.toHaveBeenCalled();
   });
 
   it("does not duplicate setup owned by a desktop remote host", async () => {

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -24,6 +24,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { findExperimentByGroupId } from "@/renderer/state/experimentStore";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import { isRemoteProjectUnreachable } from "@/renderer/state/remoteServers/reachability";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
@@ -145,6 +146,16 @@ export async function startThreadFromDraft(
     worktreeTransferUncommitted,
     presentationMode,
   } = input;
+  // Everything below runs on the project's host, so a mirrored remote project
+  // can't launch while its server is unreachable. Bail before creating a
+  // worktree we would then have to unwind.
+  if (isRemoteProjectUnreachable(project)) {
+    toast.danger(
+      i18n._(msg`This project's remote server is offline. Reconnect it to start a thread.`),
+    );
+    return;
+  }
+
   const isHomeScope = isHomeProject(project);
   const host = threadLaunchHost(project);
 

--- a/src/renderer/components/common/RemoteServerStatusDot.tsx
+++ b/src/renderer/components/common/RemoteServerStatusDot.tsx
@@ -1,0 +1,24 @@
+import { useLingui } from "@lingui/react/macro";
+import {
+  remoteServerStatusDotClass,
+  type RemoteServerStatus,
+} from "@/renderer/state/remoteServers/types";
+
+export function useRemoteServerStatusLabel(status: RemoteServerStatus): string {
+  const { t } = useLingui();
+  if (status === "online") return t`Online`;
+  if (status === "connecting") return t`Connecting…`;
+  if (status === "error") return t`Connection error`;
+  return t`Offline`;
+}
+
+/** Connection light for a paired desktop — same palette in Settings and the sidebar. */
+export function RemoteServerStatusDot(props: { status: RemoteServerStatus }) {
+  const label = useRemoteServerStatusLabel(props.status);
+  return (
+    <span
+      title={label}
+      className={`size-1.5 shrink-0 rounded-full ${remoteServerStatusDotClass(props.status)}`}
+    />
+  );
+}

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -221,6 +221,9 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "remote.project.experimentsOwned": msg({
     message: "Remove the project's experiments before removing the project.",
   }),
+  "remote.server.unreachable": msg({
+    message: "Can't reach the remote server. Check that it is online, then reconnect it.",
+  }),
 };
 
 /**

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Kamerazugriff blockiert"
 msgid "Can't load ports"
 msgstr "Ports konnten nicht geladen werden"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Der Remote-Server ist nicht erreichbar. Prüfe, ob er online ist, und verbinde ihn neu."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Verbindung zum Desktop-Browser wird hergestellt…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Verbindet…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Verbindungsfehler"
 
@@ -4206,6 +4211,10 @@ msgstr "Jede Stunde"
 msgid "Every hour at {0} minutes past"
 msgstr "Jede Stunde {0} Minuten nach der vollen Stunde"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Von Synchronisierung ausschließen"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Das Scannen mit der Kamera in der App funktioniert nur über HTTPS. Nutz
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Inaktiv"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "In Synchronisierung aufnehmen"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Keine Projekte"
 msgid "No projects in this workspace"
 msgstr "Keine Projekte in diesem Arbeitsbereich"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Keine Projekte auf diesem Server."
 
@@ -7161,6 +7174,10 @@ msgstr "Nicht angemeldet"
 msgid "Not supported"
 msgstr "Nicht unterstützt"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Nicht synchronisiert"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Nur offizielle Quellen"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Offline"
 
@@ -7256,9 +7273,9 @@ msgstr "Ein KEY=VALUE-Paar pro Zeile"
 msgid "One time"
 msgstr "Einmalig"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Online"
 
@@ -8456,6 +8473,10 @@ msgstr "Aktuelle Threads"
 msgid "Reconnect"
 msgstr "Neu verbinden"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Verbinde den Server neu, um Projekte hinzuzufügen."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Verbindung wird wiederhergestellt"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Angeheftete Route für {tagLabel} entfernen"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Projekt entfernen"
 
@@ -10343,6 +10363,10 @@ msgstr "Weiterleitung stoppen"
 msgid "Stop response"
 msgstr "Antwort stoppen"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Synchronisierung beenden"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Aufgabe stoppen"
@@ -10994,6 +11018,10 @@ msgstr "Dadurch wird der Branch „{0}“ dauerhaft gelöscht."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "dieses Projekt"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Der Remote-Server dieses Projekts ist offline. Verbinde ihn neu, um einen Thread zu starten."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Camera access blocked"
 msgid "Can't load ports"
 msgstr "Can't load ports"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Can't reach the remote server. Check that it is online, then reconnect it."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Connecting to the desktop browser…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Connecting…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Connection error"
 
@@ -4206,6 +4211,10 @@ msgstr "Every hour"
 msgid "Every hour at {0} minutes past"
 msgstr "Every hour at {0} minutes past"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Exclude from sync"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "In-app camera scanning only works over HTTPS. Use your phone's camera ap
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Inactive"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Include in sync"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "No projects"
 msgid "No projects in this workspace"
 msgstr "No projects in this workspace"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "No projects on this server."
 
@@ -7161,6 +7174,10 @@ msgstr "Not signed in"
 msgid "Not supported"
 msgstr "Not supported"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Not synced"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Official sources only"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Offline"
 
@@ -7256,9 +7273,9 @@ msgstr "One KEY=VALUE pair per line"
 msgid "One time"
 msgstr "One time"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Online"
 
@@ -8456,6 +8473,10 @@ msgstr "Recent threads"
 msgid "Reconnect"
 msgstr "Reconnect"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Reconnect the server to add projects."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Reconnecting"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Remove pinned route for {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Remove project"
 
@@ -10343,6 +10363,10 @@ msgstr "Stop forwarding"
 msgid "Stop response"
 msgstr "Stop response"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Stop syncing"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Stop task"
@@ -10994,6 +11018,10 @@ msgstr "This permanently deletes the branch \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "this project"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "This project's remote server is offline. Reconnect it to start a thread."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Acceso a la cámara bloqueado"
 msgid "Can't load ports"
 msgstr "No se pudieron cargar los puertos"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "No se puede conectar con el servidor remoto. Comprueba que esté en línea y vuelve a conectarlo."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Conectando al navegador del escritorio…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Conectando…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Error de conexión"
 
@@ -4206,6 +4211,10 @@ msgstr "Cada hora"
 msgid "Every hour at {0} minutes past"
 msgstr "Cada hora, a los {0} minutos"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Excluir de la sincronización"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "El escaneo con cámara dentro de la app solo funciona con HTTPS. Usa la 
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Inactivo"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Incluir en la sincronización"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "No hay proyectos"
 msgid "No projects in this workspace"
 msgstr "No hay proyectos en este espacio de trabajo"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "No hay proyectos en este servidor."
 
@@ -7161,6 +7174,10 @@ msgstr "No has iniciado sesión"
 msgid "Not supported"
 msgstr "No compatible"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Sin sincronizar"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Solo fuentes oficiales"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Sin conexión"
 
@@ -7256,9 +7273,9 @@ msgstr "Un par KEY=VALUE por línea"
 msgid "One time"
 msgstr "Una vez"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "En línea"
 
@@ -8456,6 +8473,10 @@ msgstr "Hilos recientes"
 msgid "Reconnect"
 msgstr "Reconectar"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Vuelve a conectar el servidor para agregar proyectos."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Reconectando"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Eliminar la ruta fijada para {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Eliminar proyecto"
 
@@ -10343,6 +10363,10 @@ msgstr "Detener reenvío"
 msgid "Stop response"
 msgstr "Detener respuesta"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Dejar de sincronizar"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Detener tarea"
@@ -10994,6 +11018,10 @@ msgstr "Esto elimina permanentemente la rama \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "este proyecto"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "El servidor remoto de este proyecto está sin conexión. Vuelve a conectarlo para iniciar un hilo."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Accès à la caméra bloqué"
 msgid "Can't load ports"
 msgstr "Impossible de charger les ports"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Serveur distant inaccessible. Vérifiez qu'il est en ligne, puis reconnectez-le."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Connexion au navigateur de l'ordinateur…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Connexion…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Erreur de connexion"
 
@@ -4206,6 +4211,10 @@ msgstr "Toutes les heures"
 msgid "Every hour at {0} minutes past"
 msgstr "Toutes les heures, à {0} minutes"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Exclure de la synchronisation"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Le scan avec la caméra dans l'app ne fonctionne qu'en HTTPS. Utilisez l
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Inactif"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Inclure dans la synchronisation"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6980,7 +6993,7 @@ msgstr "Aucun projet"
 msgid "No projects in this workspace"
 msgstr "Aucun projet dans cet espace de travail"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Aucun projet sur ce serveur."
 
@@ -7160,6 +7173,10 @@ msgstr "Non connecté"
 msgid "Not supported"
 msgstr "Non pris en charge"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Non synchronisé"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7214,7 +7231,7 @@ msgid "Official sources only"
 msgstr "Sources officielles uniquement"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Hors ligne"
 
@@ -7255,9 +7272,9 @@ msgstr "Une paire KEY=VALUE par ligne"
 msgid "One time"
 msgstr "Une seule fois"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "En ligne"
 
@@ -8455,6 +8472,10 @@ msgstr "Fils de discussion récents"
 msgid "Reconnect"
 msgstr "Reconnecter"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Reconnectez le serveur pour ajouter des projets."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Reconnexion"
@@ -8697,7 +8718,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Supprimer la route épinglée pour {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Supprimer le projet"
 
@@ -10342,6 +10362,10 @@ msgstr "Arrêter le transfert"
 msgid "Stop response"
 msgstr "Arrêter la réponse"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Arrêter la synchronisation"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Arrêter la tâche"
@@ -10993,6 +11017,10 @@ msgstr "Cela supprime définitivement la branche \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "ce projet"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Le serveur distant de ce projet est hors ligne. Reconnectez-le pour démarrer un fil."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1810,6 +1810,10 @@ msgstr "カメラアクセスがブロックされています"
 msgid "Can't load ports"
 msgstr "ポートを読み込めません"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "リモートサーバーに接続できません。オンラインであることを確認してから再接続してください。"
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2754,11 +2758,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "デスクトップのブラウザに接続しています…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "接続中…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "接続エラー"
 
@@ -4205,6 +4210,10 @@ msgstr "毎時"
 msgid "Every hour at {0} minutes past"
 msgstr "毎時{0}分"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "同期から除外"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5282,6 +5291,10 @@ msgstr "アプリ内のカメラスキャンは HTTPS でのみ動作します�
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "非アクティブ"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "同期に追加"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6979,7 +6992,7 @@ msgstr "プロジェクトがありません"
 msgid "No projects in this workspace"
 msgstr "このワークスペースにプロジェクトはありません"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "このサーバーにプロジェクトはありません。"
 
@@ -7159,6 +7172,10 @@ msgstr "サインインしていません"
 msgid "Not supported"
 msgstr "サポートされていません"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "未同期"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7213,7 +7230,7 @@ msgid "Official sources only"
 msgstr "公式ソースのみ"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "オフライン"
 
@@ -7254,9 +7271,9 @@ msgstr "1行につきKEY=VALUEのペアを1つ"
 msgid "One time"
 msgstr "1回のみ"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "オンライン"
 
@@ -8454,6 +8471,10 @@ msgstr "最近のスレッド"
 msgid "Reconnect"
 msgstr "再接続"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "プロジェクトを追加するにはサーバーに再接続してください。"
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "再接続中"
@@ -8696,7 +8717,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "{tagLabel} の固定ルートを削除"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "プロジェクトを削除"
 
@@ -10341,6 +10361,10 @@ msgstr "転送を停止"
 msgid "Stop response"
 msgstr "応答停止"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "同期を停止"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "タスクの停止"
@@ -10992,6 +11016,10 @@ msgstr "これにより、ブランチ「{0}」が完全に削除されます。
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "このプロジェクト"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "このプロジェクトのリモートサーバーはオフラインです。スレッドを開始するには再接続してください。"
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1811,6 +1811,10 @@ msgstr "카메라 접근이 차단됨"
 msgid "Can't load ports"
 msgstr "포트를 불러올 수 없습니다"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "원격 서버에 연결할 수 없습니다. 온라인 상태인지 확인한 후 다시 연결하세요."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "데스크톱 브라우저에 연결 중…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "연결 중…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "연결 오류"
 
@@ -4206,6 +4211,10 @@ msgstr "매시간"
 msgid "Every hour at {0} minutes past"
 msgstr "매시 {0}분"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "동기화에서 제외"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "앱 내 카메라 스캔은 HTTPS에서만 작동합니다. 휴대폰의
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "비활성"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "동기화에 포함"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "프로젝트 없음"
 msgid "No projects in this workspace"
 msgstr "이 작업 영역에 프로젝트가 없습니다"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "이 서버에 프로젝트가 없습니다."
 
@@ -7161,6 +7174,10 @@ msgstr "로그인되지 않음"
 msgid "Not supported"
 msgstr "지원되지 않음"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "동기화되지 않음"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "공식 소스만"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "오프라인"
 
@@ -7256,9 +7273,9 @@ msgstr "한 줄에 KEY=VALUE 쌍 하나"
 msgid "One time"
 msgstr "한 번"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "온라인"
 
@@ -8456,6 +8473,10 @@ msgstr "최근 스레드"
 msgid "Reconnect"
 msgstr "다시 연결"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "프로젝트를 추가하려면 서버에 다시 연결하세요."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "다시 연결 중"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "{tagLabel}의 고정 경로 제거"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "프로젝트 제거"
 
@@ -10343,6 +10363,10 @@ msgstr "전달 중지"
 msgid "Stop response"
 msgstr "응답 중지"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "동기화 중지"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "작업 중지"
@@ -10994,6 +11018,10 @@ msgstr "이렇게 하면 \"{0}\" 분기가 영구적으로 삭제됩니다."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "이 프로젝트"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "이 프로젝트의 원격 서버가 오프라인입니다. 스레드를 시작하려면 다시 연결하세요."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Dostęp do kamery zablokowany"
 msgid "Can't load ports"
 msgstr "Nie można wczytać portów"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Nie można połączyć się z serwerem zdalnym. Sprawdź, czy jest online, i połącz ponownie."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Łączenie z przeglądarką desktopa…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Łączenie…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Błąd połączenia"
 
@@ -4206,6 +4211,10 @@ msgstr "Co godzinę"
 msgid "Every hour at {0} minutes past"
 msgstr "Co godzinę, {0} minut po pełnej godzinie"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Wyklucz z synchronizacji"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Skanowanie kamerą w aplikacji działa tylko przez HTTPS. Użyj aplikacj
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Nieaktywny"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Uwzględnij w synchronizacji"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Brak projektów"
 msgid "No projects in this workspace"
 msgstr "Brak projektów w tym obszarze roboczym"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Brak projektów na tym serwerze."
 
@@ -7161,6 +7174,10 @@ msgstr "Niezalogowany"
 msgid "Not supported"
 msgstr "Nieobsługiwane"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Niezsynchronizowany"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Tylko oficjalne źródła"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Offline"
 
@@ -7256,9 +7273,9 @@ msgstr "Jedna para KEY=VALUE w każdym wierszu"
 msgid "One time"
 msgstr "Jednorazowo"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Online"
 
@@ -8456,6 +8473,10 @@ msgstr "Najnowsze wątki"
 msgid "Reconnect"
 msgstr "Połącz ponownie"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Połącz ponownie z serwerem, aby dodać projekty."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Ponowne łączenie"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Usuń przypiętą trasę dla {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Usuń projekt"
 
@@ -10343,6 +10363,10 @@ msgstr "Zatrzymaj przekierowywanie"
 msgid "Stop response"
 msgstr "Zatrzymaj odpowiedź"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Zatrzymaj synchronizację"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Zatrzymaj zadanie"
@@ -10994,6 +11018,10 @@ msgstr "Spowoduje to trwałe usunięcie gałęzi „{0}”."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "ten projekt"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Serwer zdalny tego projektu jest offline. Połącz ponownie, aby rozpocząć wątek."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Acesso à câmera bloqueado"
 msgid "Can't load ports"
 msgstr "Não foi possível carregar as portas"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Não foi possível acessar o servidor remoto. Verifique se ele está online e reconecte-o."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Conectando ao navegador do desktop…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Conectando…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Erro de conexão"
 
@@ -4206,6 +4211,10 @@ msgstr "A cada hora"
 msgid "Every hour at {0} minutes past"
 msgstr "A cada hora, aos {0} minutos"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Excluir da sincronização"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "A leitura pela câmera dentro do app só funciona por HTTPS. Use o app d
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Inativo"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Incluir na sincronização"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Nenhum projeto"
 msgid "No projects in this workspace"
 msgstr "Nenhum projeto neste espaço de trabalho"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Nenhum projeto neste servidor."
 
@@ -7161,6 +7174,10 @@ msgstr "Não conectado"
 msgid "Not supported"
 msgstr "Não compatível"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Não sincronizado"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Somente fontes oficiais"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Offline"
 
@@ -7256,9 +7273,9 @@ msgstr "Um par KEY=VALUE por linha"
 msgid "One time"
 msgstr "Uma vez"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Online"
 
@@ -8456,6 +8473,10 @@ msgstr "Tópicos recentes"
 msgid "Reconnect"
 msgstr "Reconectar"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Reconecte o servidor para adicionar projetos."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Reconectando"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Remover a rota fixada para {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Remover projeto"
 
@@ -10343,6 +10363,10 @@ msgstr "Parar encaminhamento"
 msgid "Stop response"
 msgstr "Parar resposta"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Parar de sincronizar"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Parar tarefa"
@@ -10994,6 +11018,10 @@ msgstr "Isso exclui permanentemente o branch \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "este projeto"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "O servidor remoto deste projeto está offline. Reconecte-o para iniciar uma conversa."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Доступ к камере заблокирован"
 msgid "Can't load ports"
 msgstr "Не удалось загрузить порты"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Не удалось связаться с удалённым сервером. Убедитесь, что он в сети, и переподключите его."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Подключение к браузеру на десктопе…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Подключение…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Ошибка подключения"
 
@@ -4206,6 +4211,10 @@ msgstr "Каждый час"
 msgid "Every hour at {0} minutes past"
 msgstr "Каждый час в {0} мин."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Исключить из синхронизации"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Сканирование камерой внутри приложени�
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Неактивно"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Добавить в синхронизацию"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Нет проектов"
 msgid "No projects in this workspace"
 msgstr "В этой рабочей области нет проектов"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "На этом сервере нет проектов."
 
@@ -7161,6 +7174,10 @@ msgstr "Вход не выполнен"
 msgid "Not supported"
 msgstr "Не поддерживается"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Не синхронизируется"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Только официальные источники"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Офлайн"
 
@@ -7256,9 +7273,9 @@ msgstr "Одна пара KEY=VALUE в строке"
 msgid "One time"
 msgstr "Один раз"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Онлайн"
 
@@ -8456,6 +8473,10 @@ msgstr "Недавние треды"
 msgid "Reconnect"
 msgstr "Переподключить"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Переподключите сервер, чтобы добавлять проекты."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Переподключение"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Удалить закреплённый маршрут для {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Удалить проект"
 
@@ -10343,6 +10363,10 @@ msgstr "Остановить перенаправление"
 msgid "Stop response"
 msgstr "Остановить ответ"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Остановить синхронизацию"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Остановить задачу"
@@ -10994,6 +11018,10 @@ msgstr "Это безвозвратно удалит ветку \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "этот проект"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Удалённый сервер этого проекта офлайн. Переподключите его, чтобы начать тред."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Kamera erişimi engellendi"
 msgid "Can't load ports"
 msgstr "Portlar yüklenemedi"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Uzak sunucuya ulaşılamıyor. Çevrimiçi olduğunu doğrulayıp yeniden bağlanın."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Masaüstü tarayıcısına bağlanılıyor…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Bağlanıyor…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Bağlantı hatası"
 
@@ -4206,6 +4211,10 @@ msgstr "Her saat"
 msgid "Every hour at {0} minutes past"
 msgstr "Her saat {0} geçe"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Senkronizasyondan çıkar"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Uygulama içi kamera taraması yalnızca HTTPS üzerinden çalışır. M
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Etkin değil"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Senkronizasyona ekle"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Proje yok"
 msgid "No projects in this workspace"
 msgstr "Bu çalışma alanında proje yok"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Bu sunucuda proje yok."
 
@@ -7161,6 +7174,10 @@ msgstr "Oturum açılmadı"
 msgid "Not supported"
 msgstr "Desteklenmiyor"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Senkronize değil"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Yalnızca resmî kaynaklar"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Çevrimdışı"
 
@@ -7256,9 +7273,9 @@ msgstr "Satır başına bir KEY=VALUE çifti"
 msgid "One time"
 msgstr "Bir kez"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Çevrimiçi"
 
@@ -8456,6 +8473,10 @@ msgstr "Son konular"
 msgid "Reconnect"
 msgstr "Yeniden bağlan"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Proje eklemek için sunucuya yeniden bağlanın."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Yeniden bağlanıyor"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "{tagLabel} için sabitlenmiş rotayı kaldır"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Projeyi kaldır"
 
@@ -10343,6 +10363,10 @@ msgstr "Yönlendirmeyi durdur"
 msgid "Stop response"
 msgstr "Yanıtı durdur"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Senkronizasyonu durdur"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Görevi durdur"
@@ -10994,6 +11018,10 @@ msgstr "Bu, \"{0}\" dalını kalıcı olarak siler."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "bu proje"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Bu projenin uzak sunucusu çevrimdışı. Bir iş parçacığı başlatmak için yeniden bağlanın."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Доступ до камери заблоковано"
 msgid "Can't load ports"
 msgstr "Не вдалося завантажити порти"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Не вдалося зв’язатися з віддаленим сервером. Переконайтеся, що він у мережі, і перепідключіть його."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Підключення до браузера на десктопі…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Підключення…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Помилка підключення"
 
@@ -4206,6 +4211,10 @@ msgstr "Щогодини"
 msgid "Every hour at {0} minutes past"
 msgstr "Щогодини о {0} хв."
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Виключити із синхронізації"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Сканування камерою в застосунку працює
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Неактивно"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Додати до синхронізації"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Немає проєктів"
 msgid "No projects in this workspace"
 msgstr "У цій робочій області немає проєктів"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "На цьому сервері немає проєктів."
 
@@ -7161,6 +7174,10 @@ msgstr "Вхід не виконано"
 msgid "Not supported"
 msgstr "Не підтримується"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Не синхронізується"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Лише офіційні джерела"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Офлайн"
 
@@ -7256,9 +7273,9 @@ msgstr "Одна пара KEY=VALUE на рядок"
 msgid "One time"
 msgstr "Один раз"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Онлайн"
 
@@ -8456,6 +8473,10 @@ msgstr "Нещодавні треди"
 msgid "Reconnect"
 msgstr "Перепідключити"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Перепідключіть сервер, щоб додавати проєкти."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Перепідключення"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Видалити закріплений маршрут для {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Видалити проєкт"
 
@@ -10343,6 +10363,10 @@ msgstr "Зупинити переспрямування"
 msgid "Stop response"
 msgstr "Зупинити відповідь"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Припинити синхронізацію"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Зупинити завдання"
@@ -10994,6 +11018,10 @@ msgstr "Це назавжди видалить гілку \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "цей проєкт"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Віддалений сервер цього проєкту офлайн. Перепідключіть його, щоб почати тред."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1811,6 +1811,10 @@ msgstr "Quyền truy cập camera bị chặn"
 msgid "Can't load ports"
 msgstr "Không thể tải danh sách cổng"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "Không thể kết nối tới máy chủ từ xa. Hãy kiểm tra máy chủ đang trực tuyến rồi kết nối lại."
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "Đang kết nối tới trình duyệt trên desktop…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "Đang kết nối…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "Lỗi kết nối"
 
@@ -4206,6 +4211,10 @@ msgstr "Mỗi giờ"
 msgid "Every hour at {0} minutes past"
 msgstr "Mỗi giờ vào phút thứ {0}"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "Loại khỏi đồng bộ hóa"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "Quét bằng camera trong ứng dụng chỉ hoạt động qua HTTPS. D
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "Không hoạt động"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "Thêm vào đồng bộ hóa"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6981,7 +6994,7 @@ msgstr "Không có dự án"
 msgid "No projects in this workspace"
 msgstr "Không có dự án nào trong không gian làm việc này"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "Không có dự án nào trên máy chủ này."
 
@@ -7161,6 +7174,10 @@ msgstr "Chưa đăng nhập"
 msgid "Not supported"
 msgstr "Không được hỗ trợ"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "Chưa đồng bộ"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7215,7 +7232,7 @@ msgid "Official sources only"
 msgstr "Chỉ nguồn chính thức"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "Ngoại tuyến"
 
@@ -7256,9 +7273,9 @@ msgstr "Mỗi dòng một cặp KEY=VALUE"
 msgid "One time"
 msgstr "Một lần"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "Trực tuyến"
 
@@ -8456,6 +8473,10 @@ msgstr "Luồng gần đây"
 msgid "Reconnect"
 msgstr "Kết nối lại"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "Kết nối lại máy chủ để thêm dự án."
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "Đang kết nối lại"
@@ -8698,7 +8719,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "Xóa tuyến đã ghim cho {tagLabel}"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "Xóa dự án"
 
@@ -10343,6 +10363,10 @@ msgstr "Dừng chuyển tiếp"
 msgid "Stop response"
 msgstr "Dừng phản hồi"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "Ngừng đồng bộ hóa"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "Dừng tác vụ"
@@ -10994,6 +11018,10 @@ msgstr "Việc này sẽ xóa vĩnh viễn nhánh \"{0}\"."
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "dự án này"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "Máy chủ từ xa của dự án này đang ngoại tuyến. Hãy kết nối lại để bắt đầu một luồng."
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1811,6 +1811,10 @@ msgstr "摄像头访问已被阻止"
 msgid "Can't load ports"
 msgstr "无法加载端口"
 
+#: src/renderer/i18n/sharedMessages.ts
+msgid "Can't reach the remote server. Check that it is online, then reconnect it."
+msgstr "无法连接远程服务器。请确认其处于在线状态，然后重新连接。"
+
 #. Dialog button: dismiss without deleting
 #: src/mobile/push/WebPushPermissionPrompt.tsx
 #: src/mobile/views/DesktopsView.tsx
@@ -2755,11 +2759,12 @@ msgid "Connecting to the desktop browser…"
 msgstr "正在连接桌面浏览器…"
 
 #: src/mobile/views/DesktopsView.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Connecting…"
 msgstr "正在连接…"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Connection error"
 msgstr "连接错误"
 
@@ -4206,6 +4211,10 @@ msgstr "每小时"
 msgid "Every hour at {0} minutes past"
 msgstr "每小时过 {0} 分钟"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Exclude from sync"
+msgstr "从同步中排除"
+
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Exclude patterns"
@@ -5283,6 +5292,10 @@ msgstr "应用内摄像头扫描仅支持 HTTPS。请使用手机相机应用扫
 #: src/renderer/components/thread/ThreadHeaderStatus.tsx
 msgid "Inactive"
 msgstr "不活跃"
+
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Include in sync"
+msgstr "加入同步"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Inherit global"
@@ -6980,7 +6993,7 @@ msgstr "没有项目"
 msgid "No projects in this workspace"
 msgstr "此工作区中没有项目"
 
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
 msgid "No projects on this server."
 msgstr "此服务器上没有项目。"
 
@@ -7160,6 +7173,10 @@ msgstr "未登录"
 msgid "Not supported"
 msgstr "不支持"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+msgid "Not synced"
+msgstr "未同步"
+
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
@@ -7214,7 +7231,7 @@ msgid "Official sources only"
 msgstr "仅官方来源"
 
 #: src/mobile/useRemoteDesktop.ts
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 msgid "Offline"
 msgstr "离线"
 
@@ -7255,9 +7272,9 @@ msgstr "每行一组 KEY=VALUE"
 msgid "One time"
 msgstr "仅一次"
 
+#: src/renderer/components/common/RemoteServerStatusDot.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Online"
 msgstr "在线"
 
@@ -8455,6 +8472,10 @@ msgstr "最近的线程"
 msgid "Reconnect"
 msgstr "重新连接"
 
+#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+msgid "Reconnect the server to add projects."
+msgstr "重新连接服务器后即可添加项目。"
+
 #: src/mobile/useRemoteDesktop.ts
 msgid "Reconnecting"
 msgstr "正在重新连接"
@@ -8697,7 +8718,6 @@ msgid "Remove pinned route for {tagLabel}"
 msgstr "移除 {tagLabel} 的固定路由"
 
 #: src/mobile/views/ManageProjectsView.tsx
-#: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Remove project"
 msgstr "移除项目"
 
@@ -10342,6 +10362,10 @@ msgstr "停止转发"
 msgid "Stop response"
 msgstr "停止响应"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+msgid "Stop syncing"
+msgstr "停止同步"
+
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Stop task"
 msgstr "停止任务"
@@ -10993,6 +11017,10 @@ msgstr "这将永久删除分支“{0}”。"
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"
 msgstr "此项目"
+
+#: src/renderer/actions/threadLaunchActions.ts
+msgid "This project's remote server is offline. Reconnect it to start a thread."
+msgstr "该项目的远程服务器处于离线状态。请重新连接后再开始线程。"
 
 #: src/renderer/views/RemoteProjectModal/RemoteProjectModal.tsx
 #~ msgid "This remote project is unavailable. Reconnect the environment and try again."

--- a/src/renderer/state/remoteServers/projectSync.test.ts
+++ b/src/renderer/state/remoteServers/projectSync.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { HOME_PROJECT_ID } from "@/shared/homeScope";
+import {
+  filterSyncedRemoteProjects,
+  isRemoteProjectSynced,
+  selectableRemoteProjects,
+  withRemoteProjectSync,
+} from "./projectSync";
+
+const projects = [{ id: HOME_PROJECT_ID }, { id: "p1" }, { id: "p2" }] as const;
+
+describe("isRemoteProjectSynced", () => {
+  it("syncs anything the user has not excluded", () => {
+    expect(isRemoteProjectSynced("p1", undefined)).toBe(true);
+    expect(isRemoteProjectSynced("p1", [])).toBe(true);
+    expect(isRemoteProjectSynced("p1", ["p2"])).toBe(true);
+  });
+
+  it("skips excluded projects", () => {
+    expect(isRemoteProjectSynced("p1", ["p1"])).toBe(false);
+  });
+
+  it("never syncs the remote's built-in Home scope row", () => {
+    expect(isRemoteProjectSynced(HOME_PROJECT_ID, undefined)).toBe(false);
+  });
+});
+
+describe("filterSyncedRemoteProjects", () => {
+  it("drops the Home scope row and excluded projects", () => {
+    expect(filterSyncedRemoteProjects(projects, ["p2"])).toEqual([{ id: "p1" }]);
+  });
+});
+
+describe("selectableRemoteProjects", () => {
+  it("offers every real project regardless of exclusion", () => {
+    expect(selectableRemoteProjects(projects)).toEqual([{ id: "p1" }, { id: "p2" }]);
+  });
+});
+
+describe("withRemoteProjectSync", () => {
+  it("records an exclusion", () => {
+    expect(withRemoteProjectSync({}, "d1", "p1", false)).toEqual({ d1: ["p1"] });
+  });
+
+  it("prunes the server entry once nothing is excluded", () => {
+    expect(withRemoteProjectSync({ d1: ["p1"] }, "d1", "p1", true)).toEqual({});
+  });
+
+  it("keeps other servers and other exclusions intact", () => {
+    expect(withRemoteProjectSync({ d1: ["p1"], d2: ["p9"] }, "d1", "p2", false)).toEqual({
+      d1: ["p1", "p2"],
+      d2: ["p9"],
+    });
+  });
+
+  it("returns the same object when nothing changes", () => {
+    const current = { d1: ["p1"] };
+    expect(withRemoteProjectSync(current, "d1", "p1", false)).toBe(current);
+    expect(withRemoteProjectSync(current, "d1", "p2", true)).toBe(current);
+  });
+});

--- a/src/renderer/state/remoteServers/projectSync.ts
+++ b/src/renderer/state/remoteServers/projectSync.ts
@@ -1,0 +1,70 @@
+import { isHomeProjectId } from "@/shared/homeScope";
+
+/**
+ * Which of a remote server's projects this client mirrors.
+ *
+ * A paired server offers every project in its own database, but the desktop
+ * client only imports the ones the user wants in their sidebar:
+ *
+ * - The remote's built-in **Home scope** row is never mirrored. It is not a real
+ *   project (it is re-created on every launch and exists so the mobile client
+ *   can run home-scoped threads); this client already has its own Home scope.
+ * - Anything the user excluded is skipped. Exclusion is purely local state, so
+ *   it applies — and can be changed — while the server is offline.
+ *
+ * Pure helpers, kept free of store imports so the store can use them without a
+ * cycle and so the selection rules stay unit-testable on their own.
+ */
+
+/** Remote (server-side) project ids excluded from sync, keyed by desktopId. */
+export type ExcludedRemoteProjectIds = Record<string, readonly string[]>;
+
+export function isRemoteProjectSynced(
+  remoteProjectId: string,
+  excluded: readonly string[] | undefined,
+): boolean {
+  if (isHomeProjectId(remoteProjectId)) return false;
+  return !excluded?.includes(remoteProjectId);
+}
+
+/** The subset of a snapshot's projects this client mirrors. */
+export function filterSyncedRemoteProjects<T extends { readonly id: string }>(
+  projects: readonly T[],
+  excluded: readonly string[] | undefined,
+): T[] {
+  return projects.filter((project) => isRemoteProjectSynced(project.id, excluded));
+}
+
+/**
+ * Projects the user can choose to sync — everything the server offers except
+ * its Home scope row, which is never a real project.
+ */
+export function selectableRemoteProjects<T extends { readonly id: string }>(
+  projects: readonly T[],
+): T[] {
+  return projects.filter((project) => !isHomeProjectId(project.id));
+}
+
+/**
+ * Add or drop one project in the exclusion map. Empty entries are pruned so a
+ * fully-synced server leaves nothing behind in persisted state.
+ */
+export function withRemoteProjectSync(
+  excludedByDesktopId: ExcludedRemoteProjectIds,
+  desktopId: string,
+  remoteProjectId: string,
+  synced: boolean,
+): ExcludedRemoteProjectIds {
+  const current = excludedByDesktopId[desktopId] ?? [];
+  const isExcluded = current.includes(remoteProjectId);
+  if (synced === !isExcluded) return excludedByDesktopId;
+
+  const next = synced
+    ? current.filter((id) => id !== remoteProjectId)
+    : [...current, remoteProjectId];
+  if (next.length === 0) {
+    const { [desktopId]: _dropped, ...rest } = excludedByDesktopId;
+    return rest;
+  }
+  return { ...excludedByDesktopId, [desktopId]: next };
+}

--- a/src/renderer/state/remoteServers/reachability.ts
+++ b/src/renderer/state/remoteServers/reachability.ts
@@ -1,0 +1,17 @@
+import type { Project } from "@/shared/contracts";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+
+/**
+ * True when a project lives on a paired server this client can't reach right
+ * now — a server with no runtime entry yet counts as unreachable. Local
+ * projects are always reachable.
+ *
+ * Every action on a mirrored project — git, run scripts, launching a thread,
+ * deleting it on the host — goes over that connection, so callers use this to
+ * lock those affordances instead of failing at the network call.
+ */
+export function isRemoteProjectUnreachable(project: Pick<Project, "remoteServerId">): boolean {
+  const { remoteServerId } = project;
+  if (!remoteServerId) return false;
+  return useRemoteServersStore.getState().runtime[remoteServerId]?.status !== "online";
+}

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -73,6 +73,13 @@ export type RemoteSocketFactory = (url: string) => RemoteSocketLike;
 export interface RemoteServersState {
   servers: RemoteServerRecord[];
   runtime: Record<string, RemoteServerRuntime>;
+  /**
+   * Remote (server-side) project ids the user excluded from sync, keyed by
+   * desktopId. Local-only state, so a project can be dropped from — or restored
+   * to — the sidebar while its server is offline. See `projectSync.ts`.
+   */
+  excludedProjectIds: Record<string, readonly string[]>;
+  setRemoteProjectSynced(desktopId: string, remoteProjectId: string, synced: boolean): void;
   clientFactory: RemoteClientFactory;
   socketFactory: RemoteSocketFactory;
   setClientFactory(factory: RemoteClientFactory): void;

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitStatusResult, Project, Thread } from "@/shared/contracts";
+import { HOME_PROJECT_ID } from "@/shared/homeScope";
 import type { RemoteGitSummaries } from "@/shared/remote";
 import type { RemoteDesktopClient } from "@/shared/remote/client";
 import { __resetRemoteServersStoreForTest, useRemoteServersStore } from "./remoteServersStore";
@@ -222,7 +223,12 @@ describe("useRemoteServersStore", () => {
     // connection state so sockets/timers/seq cursors don't bleed across tests.
     __resetRemoteServersStoreForTest();
     useRemoteServersStore.getState().setSocketFactory(() => makeSocket());
-    useRemoteServersStore.setState({ servers: [], runtime: {}, openThread: null });
+    useRemoteServersStore.setState({
+      servers: [],
+      runtime: {},
+      excludedProjectIds: {},
+      openThread: null,
+    });
     useGitStore.setState({ statuses: {}, worktreeStatuses: {} });
     sync.applyThreadSnapshot.mockClear();
     sync.dispatchRemoteSupervisorEvent.mockClear();
@@ -1678,6 +1684,61 @@ describe("useRemoteServersStore", () => {
     expect(useRemoteServersStore.getState().runtime.d1?.status).toBe("error");
     expect(useRemoteServersStore.getState().runtime.d1?.message).toBe("server offline");
     expect(useRemoteServersStore.getState().openThread).toBeNull();
+  });
+
+  // ── Selective project sync ──────────────────────────────────────────
+  it("never mirrors the remote's built-in Home scope project", async () => {
+    const home: Project = { ...proj, id: HOME_PROJECT_ID, name: "Home" };
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(factoryFor(makeClient({ snapshotProjects: [home, proj] })));
+
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+
+    const mirrored = useAppStore
+      .getState()
+      .projects.filter((project) => project.remoteServerId === "d1");
+    expect(mirrored.map((project) => project.remoteId)).toEqual(["p1"]);
+    // The full list stays in the runtime snapshot for the settings picker.
+    expect(useRemoteServersStore.getState().runtime.d1?.projects).toHaveLength(2);
+  });
+
+  it("excludes a project from sync locally, without reaching the server", async () => {
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => ({
+      snapshotSeq: 0,
+      projects: [proj, proj2],
+      threads: [remoteThread],
+      runtimeSummariesByThread: {},
+      updatedAt: "now",
+    }));
+    useRemoteServersStore.getState().setClientFactory(factoryFor(makeClient({ snapshot })));
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+    const callsAfterPairing = snapshot.mock.calls.length;
+
+    useRemoteServersStore.getState().setRemoteProjectSynced("d1", "p1", false);
+
+    const remoteIds = () =>
+      useAppStore
+        .getState()
+        .projects.filter((project) => project.remoteServerId === "d1")
+        .map((project) => project.remoteId);
+    expect(remoteIds()).toEqual(["p2"]);
+    // Threads of an unsynced project would be orphans in the sidebar.
+    expect(useAppStore.getState().threads.map((thread) => thread.remoteId)).not.toContain("rt-1");
+    // Purely local state — nothing was asked of the server.
+    expect(snapshot).toHaveBeenCalledTimes(callsAfterPairing);
+    expect(useRemoteServersStore.getState().excludedProjectIds.d1).toEqual(["p1"]);
+
+    // A later refresh must not resurrect it.
+    await useRemoteServersStore.getState().refreshServer("d1");
+    expect(remoteIds()).toEqual(["p2"]);
+
+    useRemoteServersStore.getState().setRemoteProjectSynced("d1", "p1", true);
+    expect(remoteIds()).toEqual(expect.arrayContaining(["p1", "p2"]));
   });
 
   it("does not reject when interruptThread fails against an offline server", async () => {

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -12,6 +12,7 @@ import type {
   TerminalSize,
   WriteProjectFileResult,
 } from "@/shared/contracts";
+import { friendlyError } from "@/shared/messages";
 import { RemoteDesktopClient, type RemoteFetch } from "@/shared/remote/client";
 import { reconnectBackoffDelay } from "@/shared/remote/backoff";
 import { waitForRemoteThreadAppearance } from "@/shared/remote/threadAppearance";
@@ -52,6 +53,10 @@ import {
   shouldRefreshRemoteServerAfterEvent,
 } from "@/renderer/state/remoteServers/eventRouting";
 import { syncRemoteGitSummaries } from "@/renderer/state/remoteServers/gitSummaries";
+import {
+  filterSyncedRemoteProjects,
+  withRemoteProjectSync,
+} from "@/renderer/state/remoteServers/projectSync";
 import type {
   OpenRemoteThread,
   RemoteClientFactory,
@@ -155,7 +160,30 @@ function buildOpenThread(
   };
 }
 
-function syncRemoteAppRows(desktopId: string, projects?: Project[], threads?: Thread[]): void {
+/**
+ * Mirror a server's snapshot into the app store, restricted to the projects the
+ * user syncs. Threads of an unsynced project are dropped too — without their
+ * project row they would be orphans in the sidebar.
+ */
+function syncRemoteAppRows(
+  desktopId: string,
+  allProjects?: readonly Project[],
+  allThreads?: readonly Thread[],
+): void {
+  const remoteState = useRemoteServersStore.getState();
+  const excluded = remoteState.excludedProjectIds[desktopId];
+  const projects = allProjects ? filterSyncedRemoteProjects(allProjects, excluded) : undefined;
+  // A threads-only update has no project list to scope against, so fall back to
+  // the cached snapshot — always written before rows are synced.
+  const cachedProjects = remoteState.runtime[desktopId]?.projects ?? [];
+  const syncedProjectIds = allThreads
+    ? new Set(
+        (projects ?? filterSyncedRemoteProjects(cachedProjects, excluded)).map(
+          (project) => project.id,
+        ),
+      )
+    : undefined;
+  const threads = allThreads?.filter((thread) => syncedProjectIds?.has(thread.projectId));
   const currentProjects = projects
     ? new Map(
         useAppStore
@@ -275,10 +303,6 @@ function clearRemoteServerRefreshTimer(desktopId: string): void {
   remoteServerAgentStatusRefreshes.delete(desktopId);
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function normalizeEndpoint(raw: string): string {
   const trimmed = raw.trim();
   const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
@@ -294,7 +318,7 @@ export const useRemoteServersStore = create<RemoteServersState>()(
        * offline/errored. The renderer's global unhandledrejection handler would
        * otherwise crash-screen on any stray rejection from a `void action(...)`. */
       const reportRemoteServerError = (desktopId: string, error: unknown, fallback: string) => {
-        const message = errorMessage(error) || fallback;
+        const message = friendlyError(error) || fallback;
         toast.danger(message);
         set((state) => {
           const current = state.runtime[desktopId];
@@ -591,6 +615,7 @@ export const useRemoteServersStore = create<RemoteServersState>()(
       return {
         servers: [],
         runtime: {},
+        excludedProjectIds: {},
         openThread: null,
         clientFactory: defaultClientFactory,
         socketFactory: defaultSocketFactory,
@@ -931,7 +956,7 @@ export const useRemoteServersStore = create<RemoteServersState>()(
             if (!isLatest()) return;
             setRuntime({
               status: "error",
-              message: error instanceof Error ? error.message : i18n._(msg`Connection failed.`),
+              message: friendlyError(error) || i18n._(msg`Connection failed.`),
               projects: cached()?.projects ?? [],
               threads: cached()?.threads ?? [],
             });
@@ -974,6 +999,17 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           const server = get().servers.find((entry) => entry.desktopId === desktopId);
           if (!server) return;
           await connectServer(server);
+        },
+
+        setRemoteProjectSynced: (desktopId, remoteId, synced) => {
+          const current = get().excludedProjectIds;
+          const next = withRemoteProjectSync(current, desktopId, remoteId, synced);
+          if (next === current) return;
+          set({ excludedProjectIds: next });
+          // Re-mirror from the cached snapshot. Selection is local state, so
+          // adding or dropping a project never needs the server to be reachable.
+          const runtime = get().runtime[desktopId];
+          if (runtime) syncRemoteAppRows(desktopId, runtime.projects, runtime.threads);
         },
 
         runProjectCommand: async (desktopId, command) => {
@@ -1047,7 +1083,10 @@ export const useRemoteServersStore = create<RemoteServersState>()(
       // connect and the socket/client factories are process-local. Storing the
       // token in renderer localStorage mirrors the PWA (IndexedDB) and is scoped
       // to the Electron renderer; the server can revoke a session at any time.
-      partialize: (state) => ({ servers: state.servers }),
+      partialize: (state) => ({
+        servers: state.servers,
+        excludedProjectIds: state.excludedProjectIds,
+      }),
     },
   ),
 );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project } from "@/shared/contracts";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import type { RemoteServerRecord } from "@/renderer/state/remoteServers/types";
+import { SidebarProjectHeader } from "./SidebarProjectHeader";
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({}),
+}));
+
+vi.mock("@dnd-kit/react", () => ({
+  useDraggable: () => undefined,
+}));
+
+vi.mock("@heroui/react", () => {
+  const Tooltip = Object.assign((props: { children: ReactNode }) => <>{props.children}</>, {
+    Trigger: (props: { children: ReactNode }) => <>{props.children}</>,
+    Content: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  });
+  return { Tooltip };
+});
+
+const project: Project = {
+  id: "project-1",
+  name: "Mac Poracode",
+  location: { kind: "posix", path: "/repo" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  remoteServerId: "desktop-1",
+  remoteId: "remote-project-1",
+};
+
+const server: RemoteServerRecord = {
+  desktopId: "desktop-1",
+  label: "Poracode on H1FCM6T4GX",
+  endpoint: "http://192.168.1.10:49152/",
+  accessToken: "token",
+  scopes: ["projects:manage"],
+};
+
+function seedRemote(status: "online" | "offline") {
+  useRemoteServersStore.setState({
+    servers: [server],
+    runtime: { [server.desktopId]: { status, projects: [], threads: [] } },
+  });
+}
+
+describe("SidebarProjectHeader", () => {
+  beforeEach(() => {
+    seedRemote("online");
+  });
+
+  it("shows the bare server name without the Poracode brand prefix", () => {
+    render(<SidebarProjectHeader project={project} isCollapsed isDragging={false} />);
+
+    expect(screen.getByText("H1FCM6T4GX")).toBeInTheDocument();
+    expect(screen.queryByText("Poracode on H1FCM6T4GX")).not.toBeInTheDocument();
+  });
+
+  it("lights the connection dot green while the remote server is online", () => {
+    render(<SidebarProjectHeader project={project} isCollapsed isDragging={false} />);
+
+    expect(screen.getByTitle("Online")).toHaveClass("bg-success");
+  });
+
+  it("dims the connection dot when the remote server is offline", () => {
+    seedRemote("offline");
+
+    render(<SidebarProjectHeader project={project} isCollapsed isDragging={false} />);
+
+    expect(screen.getByTitle("Offline")).toHaveClass("bg-default-400");
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
@@ -1,5 +1,6 @@
 import {
   ChevronRight,
+  EyeOff,
   FileDiff,
   FolderOpen,
   GitFork,
@@ -15,7 +16,12 @@ import {
 } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { Project } from "@/shared/contracts";
+import { desktopTitle } from "@/shared/remote/desktopLabel";
 import { TuxIcon } from "@/renderer/components/common/TuxIcon";
+import {
+  RemoteServerStatusDot,
+  useRemoteServerStatusLabel,
+} from "@/renderer/components/common/RemoteServerStatusDot";
 import { ContextMenu } from "@/renderer/components/common/ContextMenu";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import { setProjectDisabled, deleteProject } from "@/renderer/actions/projectActions";
@@ -71,7 +77,17 @@ export function SidebarProjectHeader(props: {
       ? state.servers.find((server) => server.desktopId === project.remoteServerId)
       : undefined,
   );
+  const remoteStatus = useRemoteServersStore((state) =>
+    project.remoteServerId ? state.runtime[project.remoteServerId]?.status : undefined,
+  );
+  const setRemoteProjectSynced = useRemoteServersStore((state) => state.setRemoteProjectSynced);
+  const remoteServerName = remoteServer ? desktopTitle(remoteServer.label) : undefined;
+  const remoteStatusLabel = useRemoteServerStatusLabel(remoteStatus ?? "offline");
   const isRemote = project.remoteServerId !== undefined && project.remoteId !== undefined;
+  // Git, run-scripts and removal all execute on the project's host, so they are
+  // unavailable while a mirrored project's server is unreachable. The row
+  // tooltip carries the status, so the greyed-out items read as explained.
+  const isUnreachable = project.remoteServerId !== undefined && remoteStatus !== "online";
   const showBody = !isCollapsed && !isDisabled;
 
   return (
@@ -95,16 +111,19 @@ export function SidebarProjectHeader(props: {
                     id: "git-review",
                     label: t`Review Changes`,
                     icon: <FileDiff className="size-3.5" />,
+                    isDisabled: isUnreachable,
                   },
                   {
                     id: "github-actions",
                     label: t`GitHub Actions`,
                     icon: <Workflow className="size-3.5" />,
+                    isDisabled: isUnreachable,
                   },
                   {
                     id: "git-sync",
                     label: t`Sync`,
                     icon: <RefreshCw className="size-3.5" />,
+                    isDisabled: isUnreachable,
                   },
                 ],
               },
@@ -119,6 +138,7 @@ export function SidebarProjectHeader(props: {
                         id: `action:${action.id}`,
                         label: action.name,
                         icon: resolveActionIcon(action.icon),
+                        isDisabled: isUnreachable,
                       })),
                     },
                   ]
@@ -153,15 +173,31 @@ export function SidebarProjectHeader(props: {
           label: isDisabled ? t`Enable Project` : t`Disable Project`,
           icon: isDisabled ? <Power className="size-3.5" /> : <PowerOff className="size-3.5" />,
         },
+        // Dropping a mirrored project from this client is local state, so it
+        // stays available while the server is offline — unlike Remove Project,
+        // which deletes it on the host.
+        ...(isRemote
+          ? [
+              {
+                id: "stop-syncing",
+                label: t`Stop syncing`,
+                icon: <EyeOff className="size-3.5" />,
+              },
+            ]
+          : []),
         {
           id: "remove-project",
           label: t`Remove Project`,
           icon: <Trash2 className="size-3.5" />,
           variant: "danger" as const,
+          isDisabled: isUnreachable,
         },
       ]}
       onAction={(key) => {
         if (key === "project-settings") openProjectSettings(project.id);
+        if (key === "stop-syncing" && project.remoteServerId && project.remoteId) {
+          setRemoteProjectSynced(project.remoteServerId, project.remoteId, false);
+        }
         if (key === "remove-project") deleteProject(project.id);
         if (key === "toggle-disabled") setProjectDisabled(project.id, !isDisabled);
         if (key === "git-review") openGitReview(project.id);
@@ -192,9 +228,12 @@ export function SidebarProjectHeader(props: {
           <span className="flex items-center gap-1.5">
             <span className="truncate text-xs font-semibold text-foreground">{project.name}</span>
             {isRemote ? <Server className="size-3 shrink-0 text-muted/60" /> : null}
-            {remoteServer ? (
-              <span className="max-w-24 truncate text-[10px] font-normal text-muted/60">
-                {remoteServer.label}
+            {remoteServerName ? (
+              <span className="flex min-w-0 items-center gap-1">
+                <RemoteServerStatusDot status={remoteStatus ?? "offline"} />
+                <span className="max-w-24 truncate text-[10px] font-normal text-muted/60">
+                  {remoteServerName}
+                </span>
               </span>
             ) : null}
             {project.location.kind === "wsl" && (
@@ -205,8 +244,8 @@ export function SidebarProjectHeader(props: {
         tooltip={
           isDisabled
             ? t`${projectLocation} (disabled)`
-            : remoteServer
-              ? `${projectLocation} · ${remoteServer.label}`
+            : remoteServerName
+              ? `${projectLocation} · ${remoteServerName} · ${remoteStatusLabel}`
               : projectLocation
         }
         className={`poracode-sidebar-project-nudge !pl-1${isDragging ? " opacity-60" : ""}${

--- a/src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteServerProjectList.tsx
@@ -1,0 +1,95 @@
+import { Folder, Plus, X } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { Project } from "@/shared/contracts";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import {
+  isRemoteProjectSynced,
+  selectableRemoteProjects,
+} from "@/renderer/state/remoteServers/projectSync";
+
+function projectPath(project: Project): string {
+  return "path" in project.location ? project.location.path : project.location.uncPath;
+}
+
+/**
+ * One project offered by a paired server. Syncing is local state — excluding a
+ * project only drops it from this client's sidebar, never from the server — so
+ * both directions stay available while the server is offline.
+ */
+function RemoteProjectRow(props: {
+  readonly desktopId: string;
+  readonly project: Project;
+  readonly isSynced: boolean;
+}) {
+  const { desktopId, project, isSynced } = props;
+  const { t } = useLingui();
+  const setRemoteProjectSynced = useRemoteServersStore((s) => s.setRemoteProjectSynced);
+  const toggleLabel = isSynced ? t`Exclude from sync` : t`Include in sync`;
+
+  return (
+    <div className="group flex items-center gap-2 rounded-md py-0.5 pl-5">
+      <Folder className={`size-3.5 shrink-0 ${isSynced ? "text-muted" : "text-muted/40"}`} />
+      <span className={`truncate text-sm ${isSynced ? "text-foreground" : "text-muted/60"}`}>
+        {project.name}
+      </span>
+      <span
+        className={`min-w-0 flex-1 truncate text-xs ${isSynced ? "text-muted/70" : "text-muted/40"}`}
+      >
+        {projectPath(project)}
+      </span>
+      {isSynced ? null : (
+        <span className="shrink-0 text-xs text-muted/50">
+          <Trans>Not synced</Trans>
+        </span>
+      )}
+      <button
+        type="button"
+        className={`shrink-0 rounded p-0.5 ${
+          isSynced
+            ? "hidden text-muted hover:text-danger group-hover:block"
+            : "text-muted hover:text-foreground"
+        }`}
+        aria-label={toggleLabel}
+        title={toggleLabel}
+        onClick={() => setRemoteProjectSynced(desktopId, project.id, !isSynced)}
+      >
+        {isSynced ? <X className="size-3.5" /> : <Plus className="size-3.5" />}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Every project a paired server offers, each with its sync toggle. The server's
+ * own Home scope row is left out — it is not a real project and this client has
+ * its own.
+ */
+export function RemoteServerProjectList(props: {
+  readonly desktopId: string;
+  readonly projects: readonly Project[];
+}) {
+  const { desktopId, projects } = props;
+  const excluded = useRemoteServersStore((s) => s.excludedProjectIds[desktopId]);
+  const selectable = selectableRemoteProjects(projects);
+
+  if (selectable.length === 0) {
+    return (
+      <p className="pl-5 text-xs text-muted">
+        <Trans>No projects on this server.</Trans>
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {selectable.map((project) => (
+        <RemoteProjectRow
+          key={project.id}
+          desktopId={desktopId}
+          project={project}
+          isSynced={isRemoteProjectSynced(project.id, excluded)}
+        />
+      ))}
+    </>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
@@ -3,7 +3,6 @@ import { Button } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
   ChevronRight,
-  Folder,
   FolderOpen,
   FolderPlus,
   GitBranch,
@@ -14,15 +13,15 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import type { Project } from "@/shared/contracts";
 import { cloneFolderNameFromUrl } from "@/shared/createProject";
 import { useAsyncOperation } from "@/renderer/hooks/useAsyncOperation";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import type { RemoteServerRecord } from "@/renderer/state/remoteServers/types";
 import {
-  remoteServerStatusDotClass,
-  type RemoteServerRecord,
-  type RemoteServerStatus,
-} from "@/renderer/state/remoteServers/types";
+  RemoteServerStatusDot,
+  useRemoteServerStatusLabel,
+} from "@/renderer/components/common/RemoteServerStatusDot";
+import { RemoteServerProjectList } from "./RemoteServerProjectList";
 import { SettingsPage } from "./SettingsForm";
 import { RemoteHostFolderPicker } from "./RemoteHostFolderPicker";
 import { SshConnectionForm } from "./SshConnectionForm";
@@ -37,18 +36,6 @@ function endpointHost(endpoint: string): string {
   } catch {
     return endpoint;
   }
-}
-
-function useStatusLabel(status: RemoteServerStatus): string {
-  const { t } = useLingui();
-  if (status === "online") return t`Online`;
-  if (status === "connecting") return t`Connecting…`;
-  if (status === "error") return t`Connection error`;
-  return t`Offline`;
-}
-
-function projectPath(project: Project): string {
-  return "path" in project.location ? project.location.path : project.location.uncPath;
 }
 
 /** Compact bare input used across the remote-server forms. */
@@ -81,8 +68,17 @@ function CompactInput(props: {
   );
 }
 
-/** Reveal-on-click "add folder" / "clone repo" affordances for one server. */
-function ManageProjects({ desktopId }: { readonly desktopId: string }) {
+/**
+ * Reveal-on-click "add folder" / "clone repo" affordances for one server. Both
+ * create the project on the host, so they are locked while it is unreachable.
+ */
+function ManageProjects({
+  desktopId,
+  isOnline,
+}: {
+  readonly desktopId: string;
+  readonly isOnline: boolean;
+}) {
   const { t } = useLingui();
   const runProjectCommand = useRemoteServersStore((s) => s.runProjectCommand);
   const { busy, error, run } = useAsyncOperation();
@@ -118,15 +114,20 @@ function ManageProjects({ desktopId }: { readonly desktopId: string }) {
 
   if (mode === "none") {
     return (
-      <div className="flex gap-1 pl-5 pt-0.5">
-        <Button variant="ghost" size="sm" onPress={() => setMode("folder")}>
+      <div className="flex flex-wrap items-center gap-1 pl-5 pt-0.5">
+        <Button variant="ghost" size="sm" isDisabled={!isOnline} onPress={() => setMode("folder")}>
           <FolderPlus className="size-3.5" />
           <Trans>Add folder</Trans>
         </Button>
-        <Button variant="ghost" size="sm" onPress={() => setMode("clone")}>
+        <Button variant="ghost" size="sm" isDisabled={!isOnline} onPress={() => setMode("clone")}>
           <GitBranch className="size-3.5" />
           <Trans>Clone repo</Trans>
         </Button>
+        {isOnline ? null : (
+          <span className="text-xs text-muted/70">
+            <Trans>Reconnect the server to add projects.</Trans>
+          </span>
+        )}
       </div>
     );
   }
@@ -215,12 +216,11 @@ function RemoteServerRow({ server }: { readonly server: RemoteServerRecord }) {
   const runtime = useRemoteServersStore((s) => s.runtime[server.desktopId]);
   const reconnectServer = useRemoteServersStore((s) => s.reconnectServer);
   const removeServer = useRemoteServersStore((s) => s.removeServer);
-  const runProjectCommand = useRemoteServersStore((s) => s.runProjectCommand);
   const { busy, run } = useAsyncOperation();
   const [expanded, setExpanded] = useState(false);
 
   const status = runtime?.status ?? "offline";
-  const statusLabel = useStatusLabel(status);
+  const statusLabel = useRemoteServerStatusLabel(status);
   const canManage = server.scopes.includes("projects:manage");
   const projects = runtime?.projects ?? [];
 
@@ -235,10 +235,7 @@ function RemoteServerRow({ server }: { readonly server: RemoteServerRecord }) {
           <ChevronRight
             className={`size-3.5 shrink-0 text-muted transition-transform ${expanded ? "rotate-90" : ""}`}
           />
-          <span
-            className={`size-1.5 shrink-0 rounded-full ${remoteServerStatusDotClass(status)}`}
-            title={statusLabel}
-          />
+          <RemoteServerStatusDot status={status} />
           <span className="truncate text-sm text-foreground">{server.label}</span>
           {status !== "online" ? (
             <span className="shrink-0 text-xs text-muted">{statusLabel}</span>
@@ -275,43 +272,9 @@ function RemoteServerRow({ server }: { readonly server: RemoteServerRecord }) {
           {runtime?.status === "error" && runtime.message ? (
             <p className="pl-5 text-xs text-danger">{runtime.message}</p>
           ) : null}
-          {projects.length === 0 ? (
-            <p className="pl-5 text-xs text-muted">
-              <Trans>No projects on this server.</Trans>
-            </p>
-          ) : (
-            projects.map((project) => (
-              <div
-                key={project.id}
-                className="group flex items-center gap-2 rounded-md py-0.5 pl-5"
-              >
-                <Folder className="size-3.5 shrink-0 text-muted" />
-                <span className="truncate text-sm text-foreground">{project.name}</span>
-                <span className="min-w-0 flex-1 truncate text-xs text-muted/70">
-                  {projectPath(project)}
-                </span>
-                {canManage ? (
-                  <button
-                    type="button"
-                    className="hidden shrink-0 rounded p-0.5 text-muted hover:text-danger group-hover:block"
-                    aria-label={t`Remove project`}
-                    onClick={() =>
-                      run(() =>
-                        runProjectCommand(server.desktopId, {
-                          kind: "remove",
-                          projectId: project.id,
-                        }),
-                      )
-                    }
-                  >
-                    <X className="size-3.5" />
-                  </button>
-                ) : null}
-              </div>
-            ))
-          )}
+          <RemoteServerProjectList desktopId={server.desktopId} projects={projects} />
           {canManage ? (
-            <ManageProjects desktopId={server.desktopId} />
+            <ManageProjects desktopId={server.desktopId} isOnline={status === "online"} />
           ) : (
             <p className="pl-5 pt-0.5 text-xs text-muted/70">
               <Trans>View-only — this connection can't manage projects.</Trans>

--- a/src/shared/messages.test.ts
+++ b/src/shared/messages.test.ts
@@ -12,6 +12,21 @@ describe("friendlyErrorWithDetail", () => {
     expect(friendlyError(wrapped)).toBe("real message");
   });
 
+  it("strips the IPC wrapper for a non-Error class such as undici's TypeError", () => {
+    const wrapped = new Error(
+      "Error invoking remote method 'poracode:remote-http-request': TypeError: fetch failed",
+    );
+    expect(friendlyError(wrapped)).toBe(
+      "Can't reach the remote server. Check that it is online, then reconnect it.",
+    );
+  });
+
+  it("maps transport-level failures to the unreachable-server message", () => {
+    expect(friendlyError(new Error("connect ECONNREFUSED 127.0.0.1:39001"))).toBe(
+      "Can't reach the remote server. Check that it is online, then reconnect it.",
+    );
+  });
+
   it("splits an attached details block out of the message", () => {
     const composed = attachErrorDetails("Git commit failed: stuff", "stderr line 1\nstderr line 2");
     const result = friendlyErrorWithDetail(new Error(composed));

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -146,6 +146,8 @@ const messages = {
   "remote.project.runningThreads": "Stop the project's running threads before changing its folder.",
   "remote.project.experimentsOwned":
     "Remove the project's experiments before removing the project.",
+  "remote.server.unreachable":
+    "Can't reach the remote server. Check that it is online, then reconnect it.",
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -254,6 +256,18 @@ const errorPatterns: Array<{
     test: /Poracode Helper failed to start|Poracode SSH requires (?:Node 24\.10 or newer|npm)|Uploaded Poracode runtime archive was not found|No remote loopback port is available for Poracode/i,
     key: "remote.helper.startFailed",
   },
+  {
+    // undici collapses every transport-level failure into this opaque message
+    // (the OS errno, if any, lives only in the cause chain). Anchored so a
+    // longer message that merely mentions fetching keeps its own wording.
+    test: /^fetch failed\.?$/i,
+    key: "remote.server.unreachable",
+  },
+  {
+    // Errno codes that unambiguously mean "the host was not reachable".
+    test: /\b(?:ECONNREFUSED|ENOTFOUND|EHOSTUNREACH|ENETUNREACH)\b/,
+    key: "remote.server.unreachable",
+  },
 ];
 
 const remoteErrorMessageKeys: Readonly<Record<string, MessageKey>> = {
@@ -272,9 +286,13 @@ function remoteErrorMessageKey(error: unknown): MessageKey | undefined {
   return typeof code === "string" ? remoteErrorMessageKeys[code] : undefined;
 }
 
-/** Strip Electron IPC wrapper noise from error messages. */
+/**
+ * Strip Electron IPC wrapper noise from error messages. The wrapped class name
+ * varies (`Error:`, `TypeError:` from undici's `fetch failed`, …) and may be
+ * absent, so match any of them rather than plain `Error:`.
+ */
 function stripIpcPrefix(raw: string): string {
-  return raw.replace(/^Error invoking remote method '[^']+': Error:\s*/i, "");
+  return raw.replace(/^Error invoking remote method '[^']+':\s*(?:[A-Za-z]*Error:\s*)?/i, "");
 }
 
 /**

--- a/src/shared/remote/desktopLabel.ts
+++ b/src/shared/remote/desktopLabel.ts
@@ -1,0 +1,6 @@
+/** "Poracode on host" → "host"; the brand prefix is noise inside the app.
+ *  Legacy "Lightcode on …" labels (paired pre-rebrand) are stripped too. */
+export function desktopTitle(label: string): string {
+  const stripped = label.replace(/^(?:Poracode|Lightcode)\s+on\s+/i, "");
+  return stripped || label;
+}


### PR DESCRIPTION
- Add remote project synchronization and persistence across desktop connections.
- Prevent thread launches for unreachable remote projects with localized guidance.
- Show remote server reachability in desktop, sidebar, settings, and mobile views.
- Improve remote error normalization and expand coverage with focused tests.