### PR TITLE
Scope auxiliary panels to the focused thread

### DIFF
--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -8,6 +8,7 @@ import type {
   Thread,
 } from "@/shared/contracts";
 import { getProjectAgentStatuses } from "@/shared/agentStatus";
+import { resolveActivePaneId } from "@/renderer/actions/currentProject";
 import {
   isDetectingAgentsForLocation,
   useAgentStatusesStore,
@@ -68,6 +69,16 @@ export function useLiveBackgroundThreadIds(threads: readonly Thread[]): Readonly
 
 export function useCurrentProjectId(): string | undefined {
   return useAppStore(selectCurrentProjectId);
+}
+
+/** The focused pane's thread id, or null when the view is not a thread view. */
+export function selectFocusedThreadId(s: ReturnType<typeof useAppStore.getState>): string | null {
+  if (s.view.kind !== "thread") return null;
+  return resolveActivePaneId(s.view.panes, s.focusedPaneId);
+}
+
+export function useFocusedThreadId(): string | null {
+  return useAppStore(selectFocusedThreadId);
 }
 
 export function useCurrentThreadIds(): string[] {

--- a/src/renderer/hooks/useRightPanelThreadLock.test.tsx
+++ b/src/renderer/hooks/useRightPanelThreadLock.test.tsx
@@ -28,6 +28,7 @@ function makeThread(input: Partial<Thread> = {}): Thread {
 }
 
 const threadA = makeThread({ id: "thread-a", projectId: "project-a" });
+const threadA2 = makeThread({ id: "thread-a2", projectId: "project-a" });
 const threadBWorktreePath = "/repo-b/.poracode/worktrees/feature";
 const threadB = makeThread({
   id: "thread-b",
@@ -38,11 +39,30 @@ const threadB = makeThread({
 function focusThread(threadId: string) {
   useAppStore.setState((state) => ({
     ...state,
-    threads: [threadA, threadB],
+    threads: [threadA, threadA2, threadB],
     view: { kind: "thread", panes: [threadId] },
     focusedPaneId: threadId,
   }));
 }
+
+const terminalTabA = {
+  id: "terminal-a",
+  projectId: "project-a",
+  title: "Project A",
+  createdAt: "2026-03-22T00:00:00.000Z",
+};
+const terminalTabB = {
+  id: "terminal-b",
+  projectId: "project-b",
+  title: "Project B",
+  createdAt: "2026-03-22T00:00:00.000Z",
+};
+/** Same tab id as `terminalTabB`, but scoped to thread-b's worktree. */
+const terminalTabBWorktree = {
+  ...terminalTabB,
+  worktreePath: threadBWorktreePath,
+  title: "Feature",
+};
 
 describe("useRightPanelThreadLock", () => {
   beforeEach(() => {
@@ -118,21 +138,7 @@ describe("useRightPanelThreadLock", () => {
     useDevTerminalStore.setState({
       isOpen: true,
       activeProjectId: "project-a",
-      tabs: [
-        {
-          id: "terminal-a",
-          projectId: "project-a",
-          title: "Project A",
-          createdAt: "2026-03-22T00:00:00.000Z",
-        },
-        {
-          id: "terminal-b",
-          projectId: "project-b",
-          worktreePath: threadBWorktreePath,
-          title: "Feature",
-          createdAt: "2026-03-22T00:00:00.000Z",
-        },
-      ],
+      tabs: [terminalTabA, terminalTabBWorktree],
       activeTabId: "terminal-a",
     });
     const { rerender } = renderHook(() => useRightPanelThreadLock());
@@ -148,13 +154,59 @@ describe("useRightPanelThreadLock", () => {
     });
   });
 
-  it("leaves a right-docked terminal on its existing scope", () => {
+  it("keeps a terminal the user opened for another project", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useDevTerminalStore.setState({ tabs: [terminalTabA, terminalTabB] });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    // Opening a terminal directly is explicit intent — the lock must not snap
+    // it back to the focused thread's project.
+    useDevTerminalStore.getState().openPanel("project-b");
+    rerender();
+
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      activeProjectId: "project-b",
+    });
+  });
+
+  it("re-scopes an explicitly opened terminal on the next thread switch", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useDevTerminalStore.setState({ tabs: [terminalTabA, terminalTabB] });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    useDevTerminalStore.getState().openPanel("project-b");
+    rerender();
+
+    focusThread("thread-a2");
+    rerender();
+
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      activeProjectId: "project-a",
+      activeWorktreePath: null,
+      activeTabId: "terminal-a",
+    });
+  });
+
+  it("keeps a git panel the user re-pointed when a terminal opens", () => {
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    usePanelStore.getState().setGitReviewContext({ projectId: "project-b" });
+    useDevTerminalStore.getState().openPanel("project-b");
+    rerender();
+
+    expect(usePanelStore.getState().gitReviewContext).toEqual({ projectId: "project-b" });
+  });
+
+  it("re-scopes a right-docked terminal to the focused thread", () => {
     usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
     useSharedSettings.setState({ terminalPosition: "right" });
     useDevTerminalStore.setState({
       isOpen: true,
       activeProjectId: "project-a",
       activeWorktreePath: null,
+      tabs: [terminalTabA, terminalTabBWorktree],
+      activeTabId: "terminal-a",
     });
     const { rerender } = renderHook(() => useRightPanelThreadLock());
 
@@ -162,8 +214,34 @@ describe("useRightPanelThreadLock", () => {
     rerender();
 
     expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      activeProjectId: "project-b",
+      activeWorktreePath: threadBWorktreePath,
+      activeTabId: "terminal-b",
+    });
+  });
+
+  it("shows the empty state instead of spawning a shell for an unscoped thread", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useDevTerminalStore.setState({
+      isOpen: true,
       activeProjectId: "project-a",
-      activeWorktreePath: null,
+      tabs: [terminalTabA],
+      activeTabId: "terminal-a",
+    });
+    const { rerender } = renderHook(() => useRightPanelThreadLock());
+
+    focusThread("thread-b");
+    rerender();
+
+    // No tab exists for thread-b's worktree — the panel stays open with no
+    // selected shell rather than starting one.
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      activeProjectId: "project-b",
+      activeWorktreePath: threadBWorktreePath,
+      activeTabId: null,
+      tabs: [terminalTabA],
     });
   });
 });

--- a/src/renderer/hooks/useRightPanelThreadLock.test.tsx
+++ b/src/renderer/hooks/useRightPanelThreadLock.test.tsx
@@ -57,9 +57,10 @@ const terminalTabB = {
   title: "Project B",
   createdAt: "2026-03-22T00:00:00.000Z",
 };
-/** Same tab id as `terminalTabB`, but scoped to thread-b's worktree. */
+/** thread-b's worktree shell — distinct from `terminalTabB`, project-b's plain shell. */
 const terminalTabBWorktree = {
   ...terminalTabB,
+  id: "terminal-b-worktree",
   worktreePath: threadBWorktreePath,
   title: "Feature",
 };
@@ -139,7 +140,7 @@ describe("useRightPanelThreadLock", () => {
       isOpen: true,
       activeProjectId: "project-a",
       tabs: [terminalTabA, terminalTabBWorktree],
-      activeTabId: "terminal-a",
+      activeTabId: terminalTabA.id,
     });
     const { rerender } = renderHook(() => useRightPanelThreadLock());
 
@@ -150,7 +151,7 @@ describe("useRightPanelThreadLock", () => {
       isOpen: true,
       activeProjectId: "project-b",
       activeWorktreePath: threadBWorktreePath,
-      activeTabId: "terminal-b",
+      activeTabId: terminalTabBWorktree.id,
     });
   });
 
@@ -184,7 +185,7 @@ describe("useRightPanelThreadLock", () => {
     expect(useDevTerminalStore.getState()).toMatchObject({
       activeProjectId: "project-a",
       activeWorktreePath: null,
-      activeTabId: "terminal-a",
+      activeTabId: terminalTabA.id,
     });
   });
 
@@ -206,7 +207,7 @@ describe("useRightPanelThreadLock", () => {
       activeProjectId: "project-a",
       activeWorktreePath: null,
       tabs: [terminalTabA, terminalTabBWorktree],
-      activeTabId: "terminal-a",
+      activeTabId: terminalTabA.id,
     });
     const { rerender } = renderHook(() => useRightPanelThreadLock());
 
@@ -217,7 +218,7 @@ describe("useRightPanelThreadLock", () => {
       isOpen: true,
       activeProjectId: "project-b",
       activeWorktreePath: threadBWorktreePath,
-      activeTabId: "terminal-b",
+      activeTabId: terminalTabBWorktree.id,
     });
   });
 
@@ -227,7 +228,7 @@ describe("useRightPanelThreadLock", () => {
       isOpen: true,
       activeProjectId: "project-a",
       tabs: [terminalTabA],
-      activeTabId: "terminal-a",
+      activeTabId: terminalTabA.id,
     });
     const { rerender } = renderHook(() => useRightPanelThreadLock());
 

--- a/src/renderer/hooks/useRightPanelThreadLock.ts
+++ b/src/renderer/hooks/useRightPanelThreadLock.ts
@@ -1,20 +1,13 @@
 import { useEffect, useRef } from "react";
 import { isHomeProjectId } from "@/shared/homeScope";
-import { resolveActivePaneId } from "@/renderer/actions/currentProject";
 import { showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { selectFocusedThreadId, useFocusedThreadId } from "./uiSelectors";
 
-type AppState = ReturnType<typeof useAppStore.getState>;
-
-function selectFocusedThreadId(state: AppState): string | null {
-  if (state.view.kind !== "thread") return null;
-  return resolveActivePaneId(state.view.panes, state.focusedPaneId);
-}
-
-function selectFocusedThread(state: AppState) {
+function selectFocusedThread(state: ReturnType<typeof useAppStore.getState>) {
   const paneId = selectFocusedThreadId(state);
   return paneId === null ? undefined : state.threads.find((item) => item.id === paneId);
 }
@@ -39,7 +32,7 @@ function selectFocusedThread(state: AppState) {
  */
 export function useRightPanelThreadLock(): void {
   const enabled = usePanelStore((s) => s.rightPanelFollowsThread);
-  const threadId = useAppStore(selectFocusedThreadId);
+  const threadId = useFocusedThreadId();
   const projectId = useAppStore((state) => selectFocusedThread(state)?.projectId ?? null);
   const worktreePath = useAppStore((state) => selectFocusedThread(state)?.worktreePath ?? null);
 

--- a/src/renderer/hooks/useRightPanelThreadLock.ts
+++ b/src/renderer/hooks/useRightPanelThreadLock.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { isHomeProjectId } from "@/shared/homeScope";
 import { resolveActivePaneId } from "@/renderer/actions/currentProject";
 import { showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
@@ -6,45 +6,62 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
-import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+
+type AppState = ReturnType<typeof useAppStore.getState>;
+
+function selectFocusedThreadId(state: AppState): string | null {
+  if (state.view.kind !== "thread") return null;
+  return resolveActivePaneId(state.view.panes, state.focusedPaneId);
+}
+
+function selectFocusedThread(state: AppState) {
+  const paneId = selectFocusedThreadId(state);
+  return paneId === null ? undefined : state.threads.find((item) => item.id === paneId);
+}
 
 /**
  * Keeps the right panel pinned to the focused thread while
  * `rightPanelFollowsThread` is on: whichever scope-bearing tools are already
- * open (git, files, bottom terminal) re-target that thread's project +
- * worktree on every thread switch. Panels the user has closed stay closed —
- * the lock re-scopes, it does not open anything or spawn a new shell.
+ * open (git, files, terminal) re-target that thread's project + worktree on
+ * every thread switch. Panels the user has closed stay closed — the lock
+ * re-scopes, it does not open anything or spawn a new shell.
  *
- * A right-docked terminal is deliberately left alone. It shares the right
- * panel itself, while the bottom terminal is a separate surface that should
- * follow the panel lock.
+ * The terminal follows the lock in both dock positions. `setPanelScope` only
+ * selects an existing shell for the new scope; when the thread has none, the
+ * panel shows its "Open a terminal" empty state instead of spawning one.
+ *
+ * The lock fires on thread switches only. Opening a terminal or panel for
+ * another project is an explicit user choice and must win: surface state
+ * (`isOpen`, panel contexts) is therefore sampled inside the effect rather than
+ * subscribed to, and `appliedScopeRef` keeps a repeat run on the same thread
+ * from re-scoping what the user just opened. The lock takes over again on the
+ * next thread switch.
  */
 export function useRightPanelThreadLock(): void {
   const enabled = usePanelStore((s) => s.rightPanelFollowsThread);
-  const terminalOpen = useDevTerminalStore((s) => s.isOpen);
-  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
-  const projectId = useAppStore((state) => {
-    if (state.view.kind !== "thread") return null;
-    const paneId = resolveActivePaneId(state.view.panes, state.focusedPaneId);
-    const thread = state.threads.find((item) => item.id === paneId);
-    return thread?.projectId ?? null;
-  });
-  const worktreePath = useAppStore((state) => {
-    if (state.view.kind !== "thread") return null;
-    const paneId = resolveActivePaneId(state.view.panes, state.focusedPaneId);
-    const thread = state.threads.find((item) => item.id === paneId);
-    return thread?.worktreePath ?? null;
-  });
+  const threadId = useAppStore(selectFocusedThreadId);
+  const projectId = useAppStore((state) => selectFocusedThread(state)?.projectId ?? null);
+  const worktreePath = useAppStore((state) => selectFocusedThread(state)?.worktreePath ?? null);
+
+  const appliedScopeRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!enabled || projectId === null || isHomeProjectId(projectId)) return;
+    if (!enabled) {
+      // Re-arm so turning the lock back on snaps the open surfaces once.
+      appliedScopeRef.current = null;
+      return;
+    }
+    if (projectId === null || isHomeProjectId(projectId)) return;
+    const scopeKey = JSON.stringify([threadId, projectId, worktreePath]);
+    if (appliedScopeRef.current === scopeKey) return;
+    appliedScopeRef.current = scopeKey;
     const scopedWorktree = worktreePath ?? undefined;
 
     const panel = usePanelStore.getState();
     const gitPanelOpen = panel.gitReviewContext !== null && panel.gitReviewAsPanel;
     const filesPanelOpen = panel.filesPanelContext !== null;
-    const bottomTerminalOpen = terminalOpen && terminalPosition === "bottom";
-    if (!gitPanelOpen && !filesPanelOpen && !bottomTerminalOpen) return;
+    const terminal = useDevTerminalStore.getState();
+    if (!gitPanelOpen && !filesPanelOpen && !terminal.isOpen) return;
 
     // Both `show*Panel` helpers force their own tab; remember what the user was
     // actually looking at and restore it after re-scoping.
@@ -59,12 +76,11 @@ export function useRightPanelThreadLock(): void {
         showFilesPanel(projectId, scopedWorktree);
       }
     }
-    if (bottomTerminalOpen) {
-      const terminal = useDevTerminalStore.getState();
+    if (terminal.isOpen) {
       terminal.setPanelScope(projectId, scopedWorktree);
     }
     if (usePanelStore.getState().rightPanelTab !== activeTab) {
       panel.setRightPanelTab(activeTab);
     }
-  }, [enabled, projectId, terminalOpen, terminalPosition, worktreePath]);
+  }, [enabled, projectId, threadId, worktreePath]);
 }

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -4,7 +4,7 @@ import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
-import { resolveActivePaneId } from "@/renderer/actions/currentProject";
+import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 
 export function usePanelVisibility() {
   const devTerminalOpen = useDevTerminalStore((s) => s.isOpen);
@@ -17,10 +17,7 @@ export function usePanelVisibility() {
   const usagePanelOpen = usePanelStore((s) => s.usagePanelOpen);
   const notesPanelOpen = usePanelStore((s) => s.notesPanelOpen);
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
-  const currentThreadId = useAppStore((state) => {
-    if (state.view.kind !== "thread") return null;
-    return resolveActivePaneId(state.view.panes, state.focusedPaneId);
-  });
+  const currentThreadId = useFocusedThreadId();
   const todoDockPlacement = useThreadTodoDockStore((state) =>
     currentThreadId
       ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -44,7 +44,8 @@ import {
   showGitReviewPanel,
 } from "@/renderer/actions/panelActions";
 import { showTerminalPanel } from "@/renderer/actions/terminalActions";
-import { getCurrentProjectId, resolveActivePaneId } from "@/renderer/actions/currentProject";
+import { getCurrentProjectId } from "@/renderer/actions/currentProject";
+import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 import { buildFileEditorContext } from "@/renderer/utils/gitHelpers";
 import { formatProjectScopeLabel } from "@/renderer/utils/projectScopeLabel";
 import { GitReviewPanelContent } from "./RightPanel/parts/GitReviewPanelContent";
@@ -113,10 +114,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   const terminalProjectId = useDevTerminalStore((s) => s.activeProjectId);
   const terminalWorktreePath = useDevTerminalStore((s) => s.activeWorktreePath);
   const terminalProject = projects.find((project) => project.id === terminalProjectId);
-  const currentThreadId = useAppStore((state) => {
-    if (state.view.kind !== "thread") return null;
-    return resolveActivePaneId(state.view.panes, state.focusedPaneId);
-  });
+  const currentThreadId = useFocusedThreadId();
   const todoDockPlacement = useThreadTodoDockStore((state) =>
     currentThreadId
       ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)


### PR DESCRIPTION
- Bugfix: keep right-panel tools aligned with the focused thread’s project and worktree.
- Centralize focused-thread selection for consistent panel visibility and scoping.
- Avoid spawning terminal shells when no matching thread-scoped tab exists.
- Add regression coverage for thread switching and unscoped terminal behavior.