### PR TITLE
Sync PR watch status across git state surfaces

### DIFF
--- a/src/main/gitState/GitStateService.test.ts
+++ b/src/main/gitState/GitStateService.test.ts
@@ -310,4 +310,67 @@ describe("GitStateService", () => {
       vi.mocked(fakeExecutor.gitGetWorktreeSourceBranch).mock.invocationCallOrder[0]!,
     );
   });
+
+  it("publishes an externally observed PR without spawning gh", async () => {
+    const { service, executor: fakeExecutor, patches } = createService();
+    const worktree = "/repo/.poracode/worktrees/a";
+    await service.refreshTarget({
+      projectId: project.id,
+      worktreePath: worktree,
+      branch: "feature/unified",
+    });
+    patches.mockClear();
+    vi.mocked(fakeExecutor.ghGetPrForBranch).mockClear();
+
+    const merged = pr({ state: "merged", checksStatus: "SUCCESS" });
+    service.applyObservedPullRequest(
+      { projectId: project.id, headBranch: "feature/unified" },
+      merged,
+      details("SUCCESS"),
+    );
+
+    const prKey = pullRequestKey({ hostId: "host-1", projectId: project.id, prNumber: 42 });
+    const snapshot = service.getSnapshot();
+    expect(snapshot.pullRequests[prKey]?.data.state).toBe("merged");
+    expect(snapshot.pullRequests[prKey]?.details?.checks[0]?.conclusion).toBe("SUCCESS");
+    expect(
+      snapshot.pullRequestKeyByBranch[
+        pullRequestBranchKey({ hostId: "host-1", projectId: project.id }, "feature/unified")
+      ],
+    ).toBe(prKey);
+    expect(
+      snapshot.targets[
+        gitTargetKey({ hostId: "host-1", projectId: project.id, worktreePath: worktree })
+      ]?.pullRequestKey,
+    ).toBe(prKey);
+    expect(patches).toHaveBeenCalledOnce();
+    expect(fakeExecutor.ghGetPrForBranch).not.toHaveBeenCalled();
+  });
+
+  it("leaves the branch alias pointing at a newer PR for the same branch", async () => {
+    const { service } = createService();
+    await service.refreshTarget({
+      projectId: project.id,
+      worktreePath: "/repo/.poracode/worktrees/a",
+      branch: "feature/unified",
+    });
+    const branchKey = pullRequestBranchKey(
+      { hostId: "host-1", projectId: project.id },
+      "feature/unified",
+    );
+    const newerKey = pullRequestKey({ hostId: "host-1", projectId: project.id, prNumber: 42 });
+
+    service.applyObservedPullRequest(
+      { projectId: project.id, headBranch: "feature/unified" },
+      pr({ number: 7, state: "merged" }),
+    );
+
+    const snapshot = service.getSnapshot();
+    expect(snapshot.pullRequestKeyByBranch[branchKey]).toBe(newerKey);
+    expect(
+      snapshot.pullRequests[
+        pullRequestKey({ hostId: "host-1", projectId: project.id, prNumber: 7 })
+      ]?.data.state,
+    ).toBe("merged");
+  });
 });

--- a/src/main/gitState/GitStateService.ts
+++ b/src/main/gitState/GitStateService.ts
@@ -8,6 +8,7 @@ import type {
   GitProjectSnapshotResult,
   GitStatusResult,
   GitWorktreeStatusBatchResult,
+  PrDetails,
   Project,
   ProjectLocation,
 } from "@/shared/contracts";
@@ -29,6 +30,32 @@ import { buildWorktreeLocation } from "@/shared/worktree";
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_REMOTE_FETCH_INTERVAL_MS = 3 * 60_000;
+
+/**
+ * One PR reading folded into its snapshot entry. `existing` is spread first so a
+ * core/details publish keeps the review-bundle fields (`files`, `diff`,
+ * `reviewThreads`) and their freshness stamps, which only
+ * {@link GitStateService.refreshPullRequestReviewBundle} fetches.
+ */
+function mergePullRequestState(input: {
+  readonly existing: PullRequestState | undefined;
+  readonly ref: PullRequestState["ref"];
+  readonly data: PullRequestState["data"];
+  readonly details: PrDetails | undefined;
+  readonly at: string;
+}): PullRequestState {
+  return {
+    ...input.existing,
+    ref: input.ref,
+    data: input.data,
+    ...(input.details ? { details: input.details } : {}),
+    freshness: {
+      ...input.existing?.freshness,
+      core: input.at,
+      ...(input.details ? { details: input.at } : {}),
+    },
+  };
+}
 
 export interface GitStateExecutor {
   gitFetch(input: {
@@ -262,22 +289,53 @@ export class GitStateService {
         : undefined;
       this.publish({
         pullRequests: {
-          [key]: {
-            ...existing,
-            ref,
-            data,
-            ...(details ? { details } : {}),
-            freshness: {
-              ...existing?.freshness,
-              core: fetchedAt,
-              ...(details ? { details: fetchedAt } : {}),
-            },
-          },
+          [key]: mergePullRequestState({ existing, ref, data, details, at: fetchedAt }),
         },
         pullRequestKeyByBranch: { [branchKey]: key },
         targets: this.targetsForBranch(projectId, branch, key),
       });
       return data;
+    });
+  }
+
+  /**
+   * Fold a PR reading taken outside this service — the PR-watch loop, which
+   * polls its own watches — into the snapshot so remote clients see it on the
+   * next patch instead of waiting for their own poll to come around. Publishes
+   * only; it never spawns `gh`. `watch` is structural so callers can hand over
+   * their `PrWatch` row as-is.
+   *
+   * The branch alias is left alone when it already points at a different PR:
+   * that means a newer PR for the same head branch was discovered elsewhere,
+   * and the watched PR must not steal the branch back.
+   */
+  applyObservedPullRequest(
+    watch: { readonly projectId: string; readonly headBranch: string },
+    data: PullRequestState["data"],
+    details?: PrDetails,
+  ): void {
+    const projectRef = { hostId: this.options.hostId, projectId: watch.projectId };
+    const ref = { ...projectRef, prNumber: data.number };
+    const key = pullRequestKey(ref);
+    const branchKey = pullRequestBranchKey(projectRef, watch.headBranch);
+    const existingBranchKey = this.snapshot.pullRequestKeyByBranch[branchKey];
+    const ownsBranch = existingBranchKey === undefined || existingBranchKey === key;
+    this.publish({
+      pullRequests: {
+        [key]: mergePullRequestState({
+          existing: this.snapshot.pullRequests[key],
+          ref,
+          data,
+          details,
+          at: this.timestamp(),
+        }),
+      },
+      ...(ownsBranch
+        ? {
+            pullRequestKeyByBranch: { [branchKey]: key },
+            targets: this.targetsForBranch(watch.projectId, watch.headBranch, key),
+          }
+        : {}),
     });
   }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -77,6 +77,7 @@ import {
   IPC_WINDOW_CHANNELS,
   isAgentStatusSupervisorEvent,
   quickComposerSubmissionSchema,
+  type PrWatchStatusEvent,
   type QuickComposerSubmission,
   type SupervisorEvent,
   type UpdateStatus,
@@ -874,6 +875,20 @@ if (!hasSingleInstanceLock) {
             prNumber: mergedWatch.prNumber,
             ...(mergedWatch.worktreePath ? { worktreePath: mergedWatch.worktreePath } : {}),
           }),
+        onPrObserved: (observedWatch, pr, details) => {
+          mainWindow?.webContents.send(IPC_EVENT_CHANNELS.prWatchStatus, {
+            projectId: observedWatch.projectId,
+            prNumber: observedWatch.prNumber,
+            headBranch: observedWatch.headBranch,
+            ...(observedWatch.worktreePath ? { worktreePath: observedWatch.worktreePath } : {}),
+            pr,
+            details,
+          } satisfies PrWatchStatusEvent);
+          // Paired remote clients read PR state from the git-state snapshot, not
+          // this IPC channel, so hand the same observation to the service that
+          // publishes their patches.
+          gitStateService?.applyObservedPullRequest(observedWatch, pr, details);
+        },
         createThread: sharedAppControlsDeps.createThread,
         isThreadActive: (threadId) => {
           const status = dbGetThread(threadId)?.status;

--- a/src/main/prWatch/PrWatchService.test.ts
+++ b/src/main/prWatch/PrWatchService.test.ts
@@ -83,6 +83,7 @@ function setup(
   store: PrWatchStore;
   createThread: ReturnType<typeof vi.fn<PrWatchServiceOptions["createThread"]>>;
   mergePr: ReturnType<typeof vi.fn<PrWatchServiceOptions["mergePr"]>>;
+  onPrObserved: ReturnType<typeof vi.fn<NonNullable<PrWatchServiceOptions["onPrObserved"]>>>;
 } {
   const store = memoryStore(initial);
   const createThread = vi.fn<PrWatchServiceOptions["createThread"]>(async () => ({
@@ -91,6 +92,7 @@ function setup(
     projectId: project.id,
   }));
   const mergePr = vi.fn<PrWatchServiceOptions["mergePr"]>(async () => undefined);
+  const onPrObserved = vi.fn<NonNullable<PrWatchServiceOptions["onPrObserved"]>>();
   const service = new PrWatchService({
     store,
     getProject: () => project,
@@ -99,12 +101,13 @@ function setup(
     getPrReviewThreads: async () => [],
     getMergeMethod: () => "squash",
     mergePr,
+    onPrObserved,
     createThread,
     isThreadActive: () => false,
     worktreeExists: () => false,
     ...overrides,
   });
-  return { service, store, createThread, mergePr };
+  return { service, store, createThread, mergePr, onPrObserved };
 }
 
 describe("PrWatchService", () => {
@@ -471,5 +474,52 @@ describe("PrWatchService", () => {
     await service.tick();
 
     expect(store.get(project.id, pr.number)).toBeNull();
+  });
+
+  it("publishes the PR state seen on every poll", async () => {
+    const { service, onPrObserved } = setup(watch({ worktreePath: "/repo-wt" }));
+
+    await service.tick();
+
+    expect(onPrObserved).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ prNumber: pr.number, worktreePath: "/repo-wt" }),
+      pr,
+      details,
+    );
+  });
+
+  it("publishes a terminal PR state before dropping the watch", async () => {
+    const mergedPr: PrData = { ...pr, state: "merged" };
+    const { service, store, onPrObserved } = setup(watch(), {
+      getPrForBranch: async () => mergedPr,
+    });
+
+    await service.tick();
+
+    expect(onPrObserved).toHaveBeenCalledWith(expect.anything(), mergedPr, details);
+    expect(store.get(project.id, pr.number)).toBeNull();
+  });
+
+  it("publishes the merged state it produced when auto-merging", async () => {
+    const { service, mergePr, onPrObserved } = setup(
+      withoutAgent(watch({ watchEnabled: false, autoMerge: true })),
+    );
+
+    await service.tick();
+
+    expect(mergePr).toHaveBeenCalledOnce();
+    expect(onPrObserved).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { ...pr, state: "merged" },
+      details,
+    );
+  });
+
+  it("skips publishing when the branch has no PR", async () => {
+    const { service, onPrObserved } = setup(watch(), { getPrForBranch: async () => null });
+
+    await service.tick();
+
+    expect(onPrObserved).not.toHaveBeenCalled();
   });
 });

--- a/src/main/prWatch/PrWatchService.ts
+++ b/src/main/prWatch/PrWatchService.ts
@@ -33,6 +33,12 @@ export interface PrWatchServiceOptions {
   getMergeMethod(): PrMergeMethod;
   mergePr(project: Project, prNumber: number, method: PrMergeMethod): Promise<void>;
   onPrMerged?(watch: PrWatch): void;
+  /**
+   * Live PR state seen on a poll. Every tick already refetches the PR and its
+   * details, so handing them out lets the UI's cached snapshot follow a watched
+   * PR — including the merge this service performs itself — for free.
+   */
+  onPrObserved?(watch: PrWatch, pr: PrData, details: PrDetails): void;
   createThread(request: CreateAppThreadRequest): Promise<CreateAppThreadResult>;
   isThreadActive(threadId: string): boolean;
   worktreeExists(path: string): boolean;
@@ -162,6 +168,10 @@ export class PrWatchService {
       ]);
       const current = this.options.store.get(watch.projectId, watch.prNumber);
       if (!current) return;
+      // Publish before the terminal-state bail-out below: a PR merged or closed
+      // outside Poracode drops its watch here, and that observation is the only
+      // notice the UI gets that its cached "open" snapshot went stale.
+      if (pr) this.options.onPrObserved?.(current, pr, details);
       if (!pr || pr.state === "merged" || pr.state === "closed") {
         this.options.store.delete(current.projectId, current.prNumber);
         return;
@@ -218,6 +228,11 @@ export class PrWatchService {
       if (current.autoMerge && isReadyForAutoMerge(pr, details.checks)) {
         try {
           await this.options.mergePr(project, current.prNumber, this.options.getMergeMethod());
+          // The watch is about to be dropped, so this is the last chance to tell
+          // the UI the PR is no longer open. `pr` was fetched moments ago and the
+          // merge just succeeded, so patching its state avoids a refetch whose
+          // head branch may already be deleted.
+          this.options.onPrObserved?.(current, { ...pr, state: "merged" }, details);
           this.options.onPrMerged?.(current);
           this.options.store.delete(current.projectId, current.prNumber);
         } catch (error) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -13,6 +13,7 @@ import {
   type PoracodeBridge,
   type PoracodeWindowKind,
   type PrWatchMergedEvent,
+  type PrWatchStatusEvent,
   type ProjectStateChangedEvent,
   type QuickComposerSubmission,
   type SupervisorEvent,
@@ -207,6 +208,15 @@ const bridge: PoracodeBridge = {
     ipcRenderer.on(IPC_EVENT_CHANNELS.prWatchMerged, handler);
     return () => {
       ipcRenderer.removeListener(IPC_EVENT_CHANNELS.prWatchMerged, handler);
+    };
+  },
+  onPrWatchStatus(listener) {
+    const handler = (_event: Electron.IpcRendererEvent, payload: PrWatchStatusEvent) => {
+      listener(payload);
+    };
+    ipcRenderer.on(IPC_EVENT_CHANNELS.prWatchStatus, handler);
+    return () => {
+      ipcRenderer.removeListener(IPC_EVENT_CHANNELS.prWatchStatus, handler);
     };
   },
   onThreadOpenRequested(listener) {

--- a/src/mobile/bridge.ts
+++ b/src/mobile/bridge.ts
@@ -365,6 +365,7 @@ const remoteBridge = {
   onSupervisorEvent: () => () => undefined,
   onGitStateChanged: () => () => undefined,
   onPrWatchMerged: () => () => undefined,
+  onPrWatchStatus: () => () => undefined,
   onUpdateStatus: () => () => undefined,
   onBrowserEvent: () => () => undefined,
   onRemoteThreadCommand: () => () => undefined,

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -202,6 +202,7 @@ const {
       }),
       onGitStateChanged: vi.fn<() => () => void>(() => () => undefined),
       onPrWatchMerged: vi.fn<() => () => void>(() => () => undefined),
+      onPrWatchStatus: vi.fn<() => () => void>(() => () => undefined),
       onThreadOpenRequested: vi.fn<
         (listener: (event: ThreadOpenRequestedEvent) => void) => () => void
       >((listener) => {

--- a/src/renderer/hooks/useAppHydration.test.tsx
+++ b/src/renderer/hooks/useAppHydration.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
     getThreadSnapshots: vi.fn<() => Promise<ThreadRuntimeSnapshot[]>>(),
     closeThread: vi.fn<(payload: { threadId: string }) => Promise<void>>(),
     onPrWatchMerged: vi.fn<() => () => void>(() => () => undefined),
+    onPrWatchStatus: vi.fn<() => () => void>(() => () => undefined),
     gitListWorktrees: vi.fn<
       (payload: unknown) => Promise<{
         worktrees: Array<{ path: string; branch: string }>;

--- a/src/renderer/hooks/useAppHydration.ts
+++ b/src/renderer/hooks/useAppHydration.ts
@@ -12,6 +12,7 @@ import { hydrateThreadRuntimeItems } from "@/renderer/state/chatRuntimePersister
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { bootstrapWorkspaces } from "@/renderer/state/workspaceStore";
 import { startPrMergeAutoDone } from "@/renderer/state/prMergeAutoDone";
+import { startPrWatchStatusSync } from "@/renderer/state/prWatchStatusSync";
 import { startDeferredFeaturePrewarm } from "@/renderer/deferredFeatures";
 
 interface IdleCallbackHandle {
@@ -190,11 +191,13 @@ export function useAppHydration(options: { runtimeOwner?: boolean } = {}) {
     });
 
     const stopPrMergeAutoDone = startPrMergeAutoDone();
+    const stopPrWatchStatusSync = startPrWatchStatusSync();
 
     return () => {
       isActive = false;
       idleHandle.cancel();
       stopPrMergeAutoDone();
+      stopPrWatchStatusSync();
     };
   }, [
     loadT0,

--- a/src/renderer/state/gitReadModelLegacyProjection.test.ts
+++ b/src/renderer/state/gitReadModelLegacyProjection.test.ts
@@ -5,6 +5,7 @@ import {
   pullRequestKey,
   type GitStateSnapshot,
 } from "@/shared/gitState";
+import { buildBranchPrKey } from "./gitSelectors";
 import { resetGitStoreCache, useGitStore } from "./gitStore";
 import { projectGitReadModelIntoLegacyStore } from "./gitReadModelLegacyProjection";
 
@@ -73,5 +74,73 @@ describe("projectGitReadModelIntoLegacyStore", () => {
     expect(useGitStore.getState().prDetails["project-1#42"]?.checks).toEqual([
       { name: "build", state: "COMPLETED", conclusion: "SUCCESS" },
     ]);
+  });
+
+  it("projects the project-root PR under the __branch: key legacy readers use", () => {
+    const targetRef = { hostId: "desktop-1", projectId: "project-1" };
+    const prRef = { hostId: "desktop-1", projectId: "project-1", prNumber: 7 };
+    const prKey = pullRequestKey(prRef);
+    const snapshot: GitStateSnapshot = {
+      ...emptyGitStateSnapshot(),
+      revision: 1,
+      targets: {
+        [gitTargetKey(targetRef)]: {
+          ref: targetRef,
+          pullRequestKey: prKey,
+          refreshedAt: "2026-07-28T00:00:00.000Z",
+        },
+      },
+      pullRequests: {
+        [prKey]: {
+          ref: prRef,
+          data: {
+            number: 7,
+            state: "merged",
+            title: "Root branch PR",
+            url: "https://github.test/pr/7",
+            baseBranch: "main",
+            isDraft: false,
+            checksStatus: "SUCCESS",
+            updatedAt: "2026-07-28T00:00:00.000Z",
+          },
+          freshness: { core: "2026-07-28T00:00:00.000Z" },
+        },
+      },
+    };
+
+    projectGitReadModelIntoLegacyStore(snapshot);
+
+    expect(useGitStore.getState().prData[buildBranchPrKey("project-1")]).toMatchObject({
+      number: 7,
+      state: "merged",
+    });
+    expect(useGitStore.getState().prData["project-1"]).toBeUndefined();
+  });
+
+  it("clears the __branch: key when the project root loses its PR", () => {
+    const targetRef = { hostId: "desktop-1", projectId: "project-1" };
+    useGitStore.getState().setPrData(buildBranchPrKey("project-1"), {
+      number: 7,
+      state: "open",
+      title: "Root branch PR",
+      url: "https://github.test/pr/7",
+      baseBranch: "main",
+      isDraft: false,
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    });
+
+    projectGitReadModelIntoLegacyStore({
+      ...emptyGitStateSnapshot(),
+      revision: 2,
+      targets: {
+        [gitTargetKey(targetRef)]: {
+          ref: targetRef,
+          pullRequestKey: null,
+          refreshedAt: "2026-07-28T00:00:00.000Z",
+        },
+      },
+    });
+
+    expect(useGitStore.getState().prData[buildBranchPrKey("project-1")]).toBeNull();
   });
 });

--- a/src/renderer/state/gitReadModelLegacyProjection.ts
+++ b/src/renderer/state/gitReadModelLegacyProjection.ts
@@ -1,4 +1,5 @@
 import type { GitStateSnapshot } from "@/shared/gitState";
+import { resolvePrKey } from "./gitSelectors";
 import { useGitStore } from "./gitStore";
 
 /**
@@ -27,7 +28,9 @@ export function projectGitReadModelIntoLegacyStore(snapshot: GitStateSnapshot): 
       }
     }
     const pr = target.pullRequestKey ? snapshot.pullRequests[target.pullRequestKey] : undefined;
-    const legacyPrKey = target.ref.worktreePath ?? target.ref.projectId;
+    // Legacy readers key the project row by the `__branch:` sentinel, never the
+    // bare project id.
+    const legacyPrKey = resolvePrKey(target.ref.projectId, target.ref.worktreePath);
     if (target.pullRequestKey === null) {
       store.setPrData(legacyPrKey, null);
     } else if (pr) {

--- a/src/renderer/state/prWatchStatusSync.test.ts
+++ b/src/renderer/state/prWatchStatusSync.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitStatusResult, PrData, PrDetails, Thread } from "@/shared/contracts";
+import type { PrWatchStatusEvent } from "@/shared/ipc";
+import { useAppStore } from "./appStore";
+import { buildBranchNamePrKey, buildBranchPrKey } from "./gitSelectors";
+import { useGitStore } from "./gitStore";
+import { startPrWatchStatusSync } from "./prWatchStatusSync";
+
+let statusListener: ((event: PrWatchStatusEvent) => void) | undefined;
+
+const openPr: PrData = {
+  number: 7,
+  state: "open",
+  title: "Land the thing",
+  url: "https://github.com/owner/repo/pull/7",
+  baseBranch: "main",
+  isDraft: false,
+  checksStatus: "SUCCESS",
+  updatedAt: "2026-07-20T00:00:00.000Z",
+};
+const mergedPr: PrData = { ...openPr, state: "merged" };
+
+const details: PrDetails = {
+  number: 7,
+  title: openPr.title,
+  body: "",
+  baseBranch: "main",
+  headBranch: "feature/wt",
+  additions: 202,
+  deletions: 5,
+  changedFiles: 8,
+  commits: [],
+  comments: [],
+  reviews: [],
+  checks: [],
+};
+
+const thread: Thread = {
+  id: "t1",
+  projectId: "p1",
+  title: "Worktree thread",
+  agentKind: "codex",
+  config: { model: "gpt-5" },
+  status: "idle",
+  attention: "none",
+  canResumeWithConfig: false,
+  worktreePath: "/repo-wt",
+  worktreeBranch: "feature/wt",
+  prNumber: 7,
+  archived: false,
+  done: false,
+  starred: false,
+  createdAt: "2026-07-20T00:00:00.000Z",
+  updatedAt: "2026-07-20T00:00:00.000Z",
+};
+
+function statusEvent(overrides: Partial<PrWatchStatusEvent> = {}): PrWatchStatusEvent {
+  return {
+    projectId: "p1",
+    prNumber: 7,
+    headBranch: "feature/wt",
+    pr: mergedPr,
+    details,
+    ...overrides,
+  };
+}
+
+function gitStatus(branch: string): GitStatusResult {
+  return {
+    isRepo: true,
+    branch,
+    tracking: `origin/${branch}`,
+    hasRemote: true,
+    remoteInfo: null,
+    ahead: 0,
+    behind: 0,
+    staged: [],
+    unstaged: [],
+    totalInsertions: 0,
+    totalDeletions: 0,
+  };
+}
+
+let stop: () => void = () => {};
+
+describe("prWatchStatusSync", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "poracode", {
+      configurable: true,
+      value: {
+        platform: "darwin",
+        onPrWatchStatus: vi.fn<(listener: (event: PrWatchStatusEvent) => void) => () => void>(
+          (listener) => {
+            statusListener = listener;
+            return () => {
+              statusListener = undefined;
+            };
+          },
+        ),
+        dbSetState: vi
+          .fn<(key: string, value: string) => Promise<void>>()
+          .mockResolvedValue(undefined),
+      },
+    });
+    useGitStore.setState({ prData: {}, prDetails: {}, statuses: {} });
+    useAppStore.setState({ threads: [thread], view: { kind: "home" } });
+    stop = startPrWatchStatusSync();
+  });
+
+  afterEach(() => {
+    stop();
+  });
+
+  it("flips a stale open snapshot to the observed merged state", () => {
+    useGitStore.getState().setPrData("/repo-wt", openPr);
+
+    statusListener?.(statusEvent({ worktreePath: "/repo-wt" }));
+
+    const state = useGitStore.getState();
+    expect(state.prData["/repo-wt"]?.state).toBe("merged");
+    expect(state.prData[buildBranchNamePrKey("p1", "feature/wt")]?.state).toBe("merged");
+    expect(state.prDetails["p1#7"]).toEqual(details);
+  });
+
+  it("reaches worktree threads on the head branch when the watch has no worktree path", () => {
+    useGitStore.getState().setPrData("/repo-wt", openPr);
+
+    statusListener?.(statusEvent());
+
+    expect(useGitStore.getState().prData["/repo-wt"]?.state).toBe("merged");
+  });
+
+  it("updates the project row when the head branch is checked out", () => {
+    useGitStore.getState().setStatus("p1", gitStatus("feature/wt"));
+
+    statusListener?.(statusEvent());
+
+    expect(useGitStore.getState().prData[buildBranchPrKey("p1")]?.state).toBe("merged");
+  });
+
+  it("leaves the project row alone on another branch", () => {
+    useGitStore.getState().setStatus("p1", gitStatus("master"));
+
+    statusListener?.(statusEvent());
+
+    expect(useGitStore.getState().prData[buildBranchPrKey("p1")]).toBeUndefined();
+  });
+
+  it("keeps a newer PR cached for the same worktree", () => {
+    const followUpPr: PrData = { ...openPr, number: 9 };
+    useGitStore.getState().setPrData("/repo-wt", followUpPr);
+
+    statusListener?.(statusEvent({ worktreePath: "/repo-wt" }));
+
+    expect(useGitStore.getState().prData["/repo-wt"]).toEqual(followUpPr);
+  });
+});

--- a/src/renderer/state/prWatchStatusSync.ts
+++ b/src/renderer/state/prWatchStatusSync.ts
@@ -1,0 +1,57 @@
+import type { PrData } from "@/shared/contracts";
+import type { PrWatchStatusEvent } from "@/shared/ipc";
+import { readBridge } from "@/renderer/bridge";
+import { useAppStore } from "./appStore";
+import { buildBranchNamePrKey, buildBranchPrKey } from "./gitSelectors";
+import { useGitStore } from "./gitStore";
+
+/**
+ * Keeps the git store's PR snapshot in step with the PR-watch loop.
+ *
+ * A watched PR is polled in the main process, not by the renderer's own refresh
+ * cycle: the pending-PR poll only follows PRs whose checks are still running, so
+ * once checks turn green nothing re-reads the PR until the next periodic remote
+ * fetch (minutes later). An auto-merge lands inside that window, which left the
+ * sidebar badge and git panel showing a green *open* PR for a PR that was
+ * already merged — visibly at odds with the thread the same merge marked done.
+ *
+ * The watch loop refetches the PR every tick anyway, so this just writes what it
+ * saw into every key that addresses this PR. Both stores dedupe equal values, so
+ * an unchanged poll costs no re-render.
+ */
+
+/** Every prData key that addresses this PR: worktree paths, branch name, project branch. */
+function collectPrKeys(event: PrWatchStatusEvent): Set<string> {
+  const keys = new Set<string>([buildBranchNamePrKey(event.projectId, event.headBranch)]);
+  if (event.worktreePath) keys.add(event.worktreePath);
+  if (useGitStore.getState().statuses[event.projectId]?.branch === event.headBranch) {
+    keys.add(buildBranchPrKey(event.projectId));
+  }
+  for (const thread of useAppStore.getState().threads) {
+    if (thread.projectId !== event.projectId || !thread.worktreePath) continue;
+    if (thread.worktreeBranch === event.headBranch || thread.prNumber === event.prNumber) {
+      keys.add(thread.worktreePath);
+    }
+  }
+  return keys;
+}
+
+function applyPrWatchStatus(event: PrWatchStatusEvent): void {
+  const gitStore = useGitStore.getState();
+  const updates: Record<string, PrData> = {};
+  for (const key of collectPrKeys(event)) {
+    // A key already holding a different PR belongs to newer work on the same
+    // branch (a reopened worktree, a follow-up PR) — leave it to the refresh
+    // that discovered it rather than overwriting it with the watched PR.
+    const cached = gitStore.prData[key];
+    if (cached && cached.number !== event.prNumber) continue;
+    updates[key] = event.pr;
+  }
+  if (Object.keys(updates).length > 0) gitStore.setPrDataBatch(updates);
+  gitStore.setPrDetails(`${event.projectId}#${event.prNumber}`, event.details);
+}
+
+/** Starts the sync. Runtime-owner only, so a remote session never duplicates it. */
+export function startPrWatchStatusSync(): () => void {
+  return readBridge().onPrWatchStatus(applyPrWatchStatus);
+}

--- a/src/server/createHeadlessRemoteHost.ts
+++ b/src/server/createHeadlessRemoteHost.ts
@@ -277,6 +277,10 @@ export async function createHeadlessRemoteHost(
         method,
         admin: false,
       }),
+    // Headless has no renderer; connected remote clients read PR state from the
+    // git-state snapshot, so the watch loop's observations go straight there.
+    onPrObserved: (observedWatch, pr, details) =>
+      gitStateService?.applyObservedPullRequest(observedWatch, pr, details),
     createThread: sharedAppControlsDeps.createThread,
     isThreadActive: (threadId) => {
       const status = dbGetThread(threadId)?.status;

--- a/src/shared/ipc/bridge.ts
+++ b/src/shared/ipc/bridge.ts
@@ -15,6 +15,7 @@ import {
 import type {
   BrowserEvent,
   PrWatchMergedEvent,
+  PrWatchStatusEvent,
   ProjectStateChangedEvent,
   SupervisorEvent,
   ThreadOpenRequestedEvent,
@@ -66,6 +67,8 @@ export type PoracodeBridge = PoracodeInvokeBridge & {
   onProjectStateChanged(listener: (event: ProjectStateChangedEvent) => void): () => void;
   onGitStateChanged(listener: (patch: GitStatePatch) => void): () => void;
   onPrWatchMerged(listener: (event: PrWatchMergedEvent) => void): () => void;
+  /** Live PR state observed by the PR-watch loop, so watched PRs stay fresh. */
+  onPrWatchStatus(listener: (event: PrWatchStatusEvent) => void): () => void;
   onThreadOpenRequested(listener: (event: ThreadOpenRequestedEvent) => void): () => void;
   submitQuickComposer(submission: QuickComposerSubmission): Promise<void>;
   dismissQuickComposer(): Promise<void>;
@@ -131,6 +134,7 @@ export const IPC_EVENT_CHANNELS = {
   projectStateChanged: createChannel("projectStateChanged"),
   gitStateChanged: createChannel("gitStateChanged"),
   prWatchMerged: createChannel("prWatchMerged"),
+  prWatchStatus: createChannel("prWatchStatus"),
   threadOpenRequested: createChannel("threadOpenRequested"),
   quickComposerSubmit: createChannel("quickComposerSubmit"),
   quickComposerDismissRequested: createChannel("quickComposerDismissRequested"),

--- a/src/shared/ipc/events.ts
+++ b/src/shared/ipc/events.ts
@@ -4,6 +4,8 @@ import type {
   AgentSlashCommand,
   AgentStatus,
   PendingSteerState,
+  PrData,
+  PrDetails,
   Project,
   RuntimeEvent,
   ThreadAttention,
@@ -180,6 +182,21 @@ export type PrWatchMergedEvent = {
   projectId: string;
   prNumber: number;
   worktreePath?: string;
+};
+
+/**
+ * Live PR state seen by the desktop PR-watch loop on one of its polls. The loop
+ * already refetches the PR (and its details) every tick, so forwarding what it
+ * saw keeps the renderer's cached snapshot honest — including the open→merged
+ * flip an auto-merge performs behind the UI's back — without extra `gh` calls.
+ */
+export type PrWatchStatusEvent = {
+  projectId: string;
+  prNumber: number;
+  headBranch: string;
+  worktreePath?: string;
+  pr: PrData;
+  details: PrDetails;
 };
 
 export type UpdateStatus =

--- a/src/shared/ipc/index.ts
+++ b/src/shared/ipc/index.ts
@@ -36,6 +36,7 @@ export {
   type AgentStatusSupervisorEvent,
   type BrowserEvent,
   type PrWatchMergedEvent,
+  type PrWatchStatusEvent,
   type ProjectStateChangedEvent,
   type ThreadOpenRequestedEvent,
   type SupervisorEvent,


### PR DESCRIPTION
- Keep watched PR snapshots current, including auto-merged status.
- Propagate live PR updates through desktop, renderer, and remote clients.
- Correct legacy PR projection keys across branches and worktrees.
- Add coverage for synchronization, merging, and stale-cache handling.