### PR TITLE
Fix built-in agent updates with version verification fallback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: ^3.2.2
-        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0(@types/node@25.9.5)
@@ -430,7 +430,7 @@ importers:
         version: 3.2.2(@react-spectrum/provider@3.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)
       '@heroui/styles':
         specifier: 3.2.2
-        version: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.2)
+        version: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.2)
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -73,6 +73,8 @@ const agentUpdateCommandSchema = z.object({
 
 export const agentUpdateInfoSchema = z.object({
   builtIn: agentUpdateCommandSchema.optional(),
+  /** Fall back when the built-in command exits successfully without changing the detected version. */
+  verifyBuiltInVersionChange: z.boolean().optional(),
   npm: z.string().min(1).optional(),
   homebrewCask: z.string().min(1).optional(),
   brew: z.string().min(1).optional(),

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -476,7 +476,7 @@ function extractSemverFromVersionOutput(raw: string | undefined): string | undef
   return match ? match[1] : raw.trim() || undefined;
 }
 
-async function readDetectedVersion(
+export async function readDetectedVersion(
   location: ProjectLocation,
   executablePath: string | undefined,
   versionArgs: string[],

--- a/src/supervisor/agents/qwen/detection.ts
+++ b/src/supervisor/agents/qwen/detection.ts
@@ -203,6 +203,7 @@ export const qwenDetectionSpec: DetectionSpec = {
   capabilities: qwenDefaultCapabilities,
   update: {
     builtIn: { binary: "qwen", args: ["update"] },
+    verifyBuiltInVersionChange: true,
     npm: "@qwen-code/qwen-code",
     brew: "qwen-code",
   },

--- a/src/supervisor/agents/qwen/qwen.test.ts
+++ b/src/supervisor/agents/qwen/qwen.test.ts
@@ -78,6 +78,7 @@ describe("createQwenAdapter", () => {
     expect(adapter.createStructuredSession).toBeTypeOf("function");
     expect(adapter.update).toEqual({
       builtIn: { binary: "qwen", args: ["update"] },
+      verifyBuiltInVersionChange: true,
       npm: "@qwen-code/qwen-code",
       brew: "qwen-code",
     });

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -1,11 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentStatus } from "@/shared/contracts";
 import type { AgentAdapter, AgentEnvContext } from "./base";
+const readAgentCommandOutputMock = vi.hoisted(() =>
+  vi.fn<typeof import("./base").readAgentCommandOutput>(),
+);
+
+vi.mock("./base", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./base")>();
+  return { ...actual, readAgentCommandOutput: readAgentCommandOutputMock };
+});
+
 import {
   clearLatestVersionCache,
   getLatestSupportedNpmPackageVersion,
   getLatestVersionForAdapter,
   resolveUpdateCommand,
+  runUpdateCommandWithFallback,
 } from "./updateAgent";
 
 const updateByKind: Record<string, AgentAdapter["update"]> = {
@@ -22,6 +32,12 @@ const updateByKind: Record<string, AgentAdapter["update"]> = {
   gemini: {
     npm: "@google/gemini-cli",
     brew: "gemini-cli",
+  },
+  qwen: {
+    builtIn: { binary: "qwen", args: ["update"] },
+    verifyBuiltInVersionChange: true,
+    npm: "@qwen-code/qwen-code",
+    brew: "qwen-code",
   },
   opencode: {
     builtIn: { binary: "opencode", args: ["upgrade"] },
@@ -194,6 +210,24 @@ describe("resolveUpdateCommand", () => {
     expect(command?.args).toEqual(["install", "-g", "@google/gemini-cli@latest"]);
   });
 
+  it("uses Qwen's built-in command before its package-manager fallback", () => {
+    const adapter = makeAdapter("qwen");
+    const status = makeStatus({
+      kind: "qwen",
+      executablePath: "C:\\Users\\me\\AppData\\Roaming\\fnm\\aliases\\default\\qwen.cmd",
+    });
+    expect(resolveUpdateCommand(adapter, status, NATIVE_WIN)).toEqual({
+      binary: "qwen",
+      args: ["update"],
+      strategy: "built-in",
+    });
+    expect(resolveUpdateCommand(adapter, status, NATIVE_WIN, { skipBuiltIn: true })).toEqual({
+      binary: "npm",
+      args: ["install", "-g", "@qwen-code/qwen-code@latest"],
+      strategy: "npm-global",
+    });
+  });
+
   it("uses brew for Homebrew-installed Gemini", () => {
     const adapter = makeAdapter("gemini");
     const status = makeStatus({
@@ -262,6 +296,42 @@ describe("resolveUpdateCommand", () => {
     const adapter = makeAdapter("homemade-agent");
     const status = makeStatus({ kind: "homemade-agent" });
     expect(resolveUpdateCommand(adapter, status, NATIVE_POSIX)).toBeUndefined();
+  });
+});
+
+describe("runUpdateCommandWithFallback", () => {
+  it("uses the package-manager fallback when a successful built-in update is not verified", async () => {
+    readAgentCommandOutputMock
+      .mockResolvedValueOnce({ ok: true, stdout: "Run npm install -g", stderr: "" })
+      .mockResolvedValueOnce({ ok: true, stdout: "updated", stderr: "" });
+    const verifyBuiltInSuccess = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+    const adapter = makeAdapter("qwen");
+    const status = makeStatus({
+      kind: "qwen",
+      version: "0.21.0",
+      executablePath: "C:\\Users\\me\\AppData\\Roaming\\npm\\qwen.cmd",
+    });
+
+    const result = await runUpdateCommandWithFallback(adapter, status, NATIVE_WIN, {
+      verifyBuiltInSuccess,
+    });
+
+    expect(result).toEqual({ ok: true, strategy: "npm-global", output: "updated" });
+    expect(verifyBuiltInSuccess).toHaveBeenCalledOnce();
+    expect(readAgentCommandOutputMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      "qwen",
+      ["update"],
+      { timeoutMs: 5 * 60 * 1000 },
+    );
+    expect(readAgentCommandOutputMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      "npm",
+      ["install", "-g", "@qwen-code/qwen-code@latest"],
+      { timeoutMs: 5 * 60 * 1000 },
+    );
   });
 });
 

--- a/src/supervisor/agents/updateAgent.ts
+++ b/src/supervisor/agents/updateAgent.ts
@@ -95,13 +95,18 @@ export async function runUpdateCommandWithFallback(
   adapter: AgentAdapter,
   status: AgentStatus,
   envContext: AgentEnvContext,
+  options?: { verifyBuiltInSuccess?: () => Promise<boolean> },
 ): Promise<UpdateAgentBinaryResult> {
   const command = resolveUpdateCommand(adapter, status, envContext);
   if (!command) return buildUnsupportedResult();
 
   try {
     const result = await runUpdateCommand(command, envContext);
-    if (result.ok || command.strategy !== "built-in") {
+    const needsFallback =
+      command.strategy === "built-in" &&
+      (!result.ok ||
+        (options?.verifyBuiltInSuccess ? !(await options.verifyBuiltInSuccess()) : false));
+    if (!needsFallback) {
       return {
         ok: result.ok,
         strategy: command.strategy,

--- a/src/supervisor/runtime/agentRegistryService.test.ts
+++ b/src/supervisor/runtime/agentRegistryService.test.ts
@@ -3,20 +3,16 @@ import type {
   AgentStatus,
   GetLatestAgentVersionResult,
   NpmPackageVersionQuery,
-  UpdateAgentBinaryResult,
 } from "@/shared/contracts";
-import type { AgentAdapter, AgentEnvContext } from "../agents/base";
+import type { AgentAdapter } from "../agents/base";
 import type { AgentStatusService } from "./agentStatusService";
 import type { SupervisorSharedSettingsCache } from "./supervisorSharedSettings";
 
+const readDetectedVersionMock = vi.hoisted(() =>
+  vi.fn<typeof import("../agents/base").readDetectedVersion>(),
+);
 const runUpdateCommandWithFallbackMock = vi.hoisted(() =>
-  vi.fn<
-    (
-      adapter: AgentAdapter,
-      status: AgentStatus,
-      envContext: AgentEnvContext,
-    ) => Promise<UpdateAgentBinaryResult>
-  >(),
+  vi.fn<typeof import("../agents/updateAgent").runUpdateCommandWithFallback>(),
 );
 
 const getLatestVersionForAdapterMock = vi.hoisted(() =>
@@ -25,6 +21,11 @@ const getLatestVersionForAdapterMock = vi.hoisted(() =>
 const getLatestSupportedNpmPackageVersionMock = vi.hoisted(() =>
   vi.fn<(query: NpmPackageVersionQuery) => Promise<GetLatestAgentVersionResult>>(),
 );
+
+vi.mock("../agents/base", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/base")>();
+  return { ...actual, readDetectedVersion: readDetectedVersionMock };
+});
 
 vi.mock("../agents/updateAgent", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/updateAgent")>();
@@ -207,6 +208,80 @@ describe("AgentRegistryService.updateAgentBinary", () => {
         agentKinds: ["claude", "claude:personal", "claude:work"],
       },
     });
+  });
+
+  it("tracks the installed version for built-in updaters that require verification", async () => {
+    const status: AgentStatus = {
+      kind: "qwen",
+      label: "Qwen Code",
+      installed: true,
+      version: "0.21.0",
+      executablePath: "C:\\Users\\test\\AppData\\Roaming\\npm\\qwen.cmd",
+      authState: "authenticated",
+      capabilities,
+      envKind: "windows",
+      update: {
+        builtIn: { binary: "qwen", args: ["update"] },
+        verifyBuiltInVersionChange: true,
+        npm: "@qwen-code/qwen-code",
+      },
+    };
+    const adapter = {
+      kind: "qwen",
+      label: "Qwen Code",
+      capabilities,
+      update: status.update,
+      detectInstall: vi.fn<AgentAdapter["detectInstall"]>(),
+      buildLaunchArgv: vi.fn<AgentAdapter["buildLaunchArgv"]>(),
+      buildResumeArgv: vi.fn<AgentAdapter["buildResumeArgv"]>(),
+      createInitialSessionRef: vi.fn<AgentAdapter["createInitialSessionRef"]>(() => undefined),
+    } as unknown as AgentAdapter;
+    const refreshAgentStatuses = vi
+      .fn<AgentStatusService["refreshAgentStatuses"]>()
+      .mockResolvedValueOnce({ windows: [status], wsl: [], fromCache: false })
+      .mockResolvedValue({
+        windows: [{ ...status, version: "0.21.2" }],
+        wsl: [],
+        fromCache: false,
+      });
+    const agentStatusService = {
+      refreshAgentStatuses,
+      getAgentStatuses: vi.fn<AgentStatusService["getAgentStatuses"]>(),
+      listWslDistros: vi.fn<AgentStatusService["listWslDistros"]>().mockResolvedValue([]),
+    } as unknown as AgentStatusService;
+    const service = new AgentRegistryService({
+      adapters: new Map([["qwen", adapter]]),
+      settingsPath: "C:\\data\\settings.json",
+      baseDir: "C:\\data",
+      acpIconsDir: "C:\\data\\icons",
+      sharedSettingsCache: {
+        invalidate: vi.fn<SupervisorSharedSettingsCache["invalidate"]>(),
+      } as unknown as SupervisorSharedSettingsCache,
+      getAgentStatusService: () => agentStatusService,
+    });
+    readDetectedVersionMock.mockResolvedValueOnce("0.21.0");
+    runUpdateCommandWithFallbackMock.mockImplementationOnce(
+      async (_adapter, _status, _envContext, options) => {
+        expect(await options?.verifyBuiltInSuccess?.()).toBe(false);
+        return { ok: true, strategy: "npm-global" };
+      },
+    );
+
+    const result = await service.updateAgentBinary({ agentKind: "qwen", envKind: "windows" });
+
+    expect(result).toEqual({ ok: true, strategy: "npm-global" });
+    expect(runUpdateCommandWithFallbackMock).toHaveBeenCalledWith(
+      adapter,
+      status,
+      { envKind: "windows", baseDir: "C:\\data" },
+      { verifyBuiltInSuccess: expect.any(Function) },
+    );
+    expect(readDetectedVersionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "windows" }),
+      status.executablePath,
+      ["--version"],
+    );
+    expect(refreshAgentStatuses).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/supervisor/runtime/agentRegistryService.test.ts
+++ b/src/supervisor/runtime/agentRegistryService.test.ts
@@ -11,6 +11,9 @@ import type { SupervisorSharedSettingsCache } from "./supervisorSharedSettings";
 const readDetectedVersionMock = vi.hoisted(() =>
   vi.fn<typeof import("../agents/base").readDetectedVersion>(),
 );
+const detectProbeLocationMock = vi.hoisted(() =>
+  vi.fn<typeof import("../agents/base").detectProbeLocation>(),
+);
 const runUpdateCommandWithFallbackMock = vi.hoisted(() =>
   vi.fn<typeof import("../agents/updateAgent").runUpdateCommandWithFallback>(),
 );
@@ -24,7 +27,11 @@ const getLatestSupportedNpmPackageVersionMock = vi.hoisted(() =>
 
 vi.mock("../agents/base", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../agents/base")>();
-  return { ...actual, readDetectedVersion: readDetectedVersionMock };
+  return {
+    ...actual,
+    detectProbeLocation: detectProbeLocationMock,
+    readDetectedVersion: readDetectedVersionMock,
+  };
 });
 
 vi.mock("../agents/updateAgent", async (importOriginal) => {
@@ -258,6 +265,10 @@ describe("AgentRegistryService.updateAgentBinary", () => {
         invalidate: vi.fn<SupervisorSharedSettingsCache["invalidate"]>(),
       } as unknown as SupervisorSharedSettingsCache,
       getAgentStatusService: () => agentStatusService,
+    });
+    detectProbeLocationMock.mockReturnValueOnce({
+      kind: "windows",
+      path: "C:\\Users\\test",
     });
     readDetectedVersionMock.mockResolvedValueOnce("0.21.0");
     runUpdateCommandWithFallbackMock.mockImplementationOnce(

--- a/src/supervisor/runtime/agentRegistryService.ts
+++ b/src/supervisor/runtime/agentRegistryService.ts
@@ -39,7 +39,12 @@ import {
   setAcpRegistryAgentAuth as setAcpRegistryAgentAuthInRegistry,
   updateAcpRegistryAgent as updateAcpRegistryAgentFromRegistry,
 } from "../agents/acpRegistry";
-import { type AgentAdapter, type AgentEnvContext } from "../agents/base";
+import {
+  detectProbeLocation,
+  readDetectedVersion,
+  type AgentAdapter,
+  type AgentEnvContext,
+} from "../agents/base";
 import {
   getLatestSupportedNpmPackageVersion,
   getLatestVersionForAdapter,
@@ -282,7 +287,21 @@ export class AgentRegistryService {
       };
     }
 
-    const result = await runUpdateCommandWithFallback(adapter, status, envContext);
+    const verifyBuiltInVersionChange = (status.update ?? adapter.update)
+      ?.verifyBuiltInVersionChange;
+    const result =
+      verifyBuiltInVersionChange && status.version
+        ? await runUpdateCommandWithFallback(adapter, status, envContext, {
+            verifyBuiltInSuccess: async () => {
+              const refreshedVersion = await readDetectedVersion(
+                detectProbeLocation(envContext),
+                status.executablePath,
+                ["--version"],
+              );
+              return refreshedVersion !== undefined && refreshedVersion !== status.version;
+            },
+          })
+        : await runUpdateCommandWithFallback(adapter, status, envContext);
     if (result.ok) {
       // Drop the cached executable path so the next detection probe runs a
       // fresh `command -v` / `where.exe`. Without this we keep returning the


### PR DESCRIPTION
- Add version-change verification for built-in updates.
- Fall back to npm when Qwen’s built-in update succeeds without changing its version.
- Extend update contracts and registry handling with focused test coverage.
- Refresh lockfile dependency resolution.