### PR TITLE
Fix desktop provider model popover width during list windowing

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
@@ -150,6 +150,28 @@ describe("ProviderModelMenu", () => {
     expect(await screen.findByText("Model 500")).toBeInTheDocument();
   });
 
+  it("keeps the desktop popover width fixed while windowing model rows", async () => {
+    render(
+      <ProviderModelMenu
+        providers={[makeProvider(500)]}
+        currentAgentKind="codex"
+        currentModel="model-1"
+        onChange={vi.fn<(next: { agentKind: string; model: string }) => void>()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const listbox = await screen.findByRole("listbox", { name: "Models" });
+    const fixedWidthPopover = listbox.closest(".w-96");
+    expect(fixedWidthPopover).not.toBeNull();
+
+    fireEvent.scroll(listbox, { target: { scrollTop: 500 * 28 } });
+
+    expect(await screen.findByText("Model 500")).toBeInTheDocument();
+    expect(listbox.closest(".w-96")).toBe(fixedWidthPopover);
+  });
+
   it("renders normalized model rate descriptions as muted row hints", async () => {
     const provider = makeProvider(1);
     provider.capabilities.models = [

--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -507,7 +507,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
         )
       }
       placement="top start"
-      contentClassName="w-fit min-w-64 max-w-96 p-0"
+      contentClassName="w-96 p-0"
       dialogClassName="flex max-h-[28rem] flex-col overflow-hidden !p-0"
     >
       {renderContent}


### PR DESCRIPTION
- Bugfix: keep the desktop provider model selector at a fixed width while virtualized model rows update.
- Add coverage confirming the popover width remains stable when scrolling large model lists.