### PR TITLE
Preserve remote routing for Git review source branch lookup

### DIFF
--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
@@ -303,6 +303,79 @@ describe("GitReviewSidebar", () => {
     expect(screen.queryByText("main-only.ts")).not.toBeInTheDocument();
   });
 
+  it("keeps remote routing when resolving the PR target branch", async () => {
+    const project: Project = {
+      id: "remote:desktop-1:project:project-1",
+      remoteServerId: "desktop-1",
+      remoteId: "project-1",
+      name: "Remote Poracode",
+      createdAt: new Date().toISOString(),
+      location: {
+        kind: "windows",
+        path: "C:\\repo-worktree",
+        remoteServerId: "desktop-1",
+      },
+    };
+    const gitStatus: GitStatusResult = {
+      isRepo: true,
+      branch: "feature/remote",
+      tracking: "",
+      hasRemote: true,
+      remoteInfo: {
+        url: "https://github.com/example/poracode.git",
+        platform: "github",
+        owner: "example",
+        repo: "poracode",
+      },
+      ahead: 0,
+      behind: 0,
+      staged: [
+        {
+          path: "src/remote-change.ts",
+          status: "M",
+          staged: true,
+          insertions: 1,
+          deletions: 0,
+        },
+      ],
+      unstaged: [],
+      totalInsertions: 1,
+      totalDeletions: 0,
+    };
+
+    bridgeMock.gitGetWorktreeSourceBranch.mockResolvedValue({
+      sourceBranch: "main",
+      commitsAhead: 1,
+      sourceAhead: 0,
+    });
+    useGitStore.setState({ ghAvailable: { [project.id]: true } });
+
+    render(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={gitStatus}
+        selectedFile={null}
+        selectedStaged={false}
+        refreshKey={0}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(bridgeMock.gitGetWorktreeSourceBranch).toHaveBeenCalledWith({
+        projectLocation: {
+          kind: "windows",
+          path: "C:\\repo-worktree",
+          remoteServerId: "desktop-1",
+        },
+        branch: "feature/remote",
+      }),
+    );
+    expect(await screen.findByText("Commit & Create PR")).toBeInTheDocument();
+  });
+
   it("virtualizes long staged and unstaged file lists independently", async () => {
     const clientHeightSpy = vi
       .spyOn(HTMLElement.prototype, "clientHeight", "get")

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useSourceBranchData.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useSourceBranchData.ts
@@ -28,6 +28,7 @@ export function useSourceBranchData(params: {
   const projectLocationPath = getProjectPosixPath(project.location);
   const projectLocationDistro = project.location.kind === "wsl" ? project.location.distro : null;
   const projectLocationUncPath = project.location.kind === "wsl" ? project.location.uncPath : null;
+  const projectRemoteServerId = project.location.remoteServerId;
 
   const [sourceBranchLoading, setSourceBranchLoading] = useState(false);
 
@@ -44,10 +45,19 @@ export function useSourceBranchData(params: {
             distro: projectLocationDistro!,
             linuxPath: projectLocationPath,
             uncPath: projectLocationUncPath!,
+            ...(projectRemoteServerId ? { remoteServerId: projectRemoteServerId } : {}),
           }
         : projectLocationKind === "posix"
-          ? { kind: "posix", path: projectLocationPath }
-          : { kind: "windows", path: projectLocationPath };
+          ? {
+              kind: "posix",
+              path: projectLocationPath,
+              ...(projectRemoteServerId ? { remoteServerId: projectRemoteServerId } : {}),
+            }
+          : {
+              kind: "windows",
+              path: projectLocationPath,
+              ...(projectRemoteServerId ? { remoteServerId: projectRemoteServerId } : {}),
+            };
     setSourceBranchLoading(true);
     readBridge()
       .gitGetWorktreeSourceBranch({
@@ -86,6 +96,7 @@ export function useSourceBranchData(params: {
     projectLocationDistro,
     projectLocationKind,
     projectLocationPath,
+    projectRemoteServerId,
     projectLocationUncPath,
     refreshKey,
   ]);


### PR DESCRIPTION
- **Bugfix:** retain the project’s remote server routing when resolving a Git review PR target branch.
- Ensure remote Windows, POSIX, and WSL projects perform source-branch lookups against the correct remote environment.
- Add coverage confirming remote project routing is passed through before creating a PR.