### PR TITLE
Fix remote clipboard image uploads and retry message IDs

### DIFF
--- a/src/renderer/components/composer/useAttachments.ts
+++ b/src/renderer/components/composer/useAttachments.ts
@@ -40,7 +40,13 @@ function inferMimeType(name: string): string | undefined {
   return MIME_BY_EXT[getExtension(name)];
 }
 
-export function useAttachments() {
+export type SaveClipboardImage = (input: {
+  threadId: string;
+  data: Uint8Array;
+  extension: string;
+}) => Promise<string>;
+
+export function useAttachments(options: { saveClipboardImage?: SaveClipboardImage } = {}) {
   const [attachments, setAttachments] = useState<Attachment[]>([]);
 
   function addFiles(paths: string[]) {
@@ -61,7 +67,7 @@ export function useAttachments() {
   async function addClipboardImage(file: File, threadId: string) {
     const buffer = await file.arrayBuffer();
     const ext = file.type.split("/")[1]?.replace("svg+xml", "svg") ?? "png";
-    const path = await readBridge().saveClipboardImage({
+    const path = await (options.saveClipboardImage ?? readBridge().saveClipboardImage)({
       threadId,
       data: new Uint8Array(buffer),
       extension: ext,

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -33,7 +33,7 @@ import {
   type McpMentionItem,
   type MentionInputHandle,
 } from "../composer/MentionInput";
-import { useAttachments } from "../composer/useAttachments";
+import { useAttachments, type SaveClipboardImage } from "../composer/useAttachments";
 import type { VoiceInputHandle } from "../composer/VoiceInputButton";
 import { isRemoteSession, readBridge } from "@/renderer/bridge";
 import { threadProductProperties } from "@/renderer/analytics/posthog";
@@ -96,6 +96,7 @@ type ThreadComposerSectionProps = {
    */
   onSubmitInput?: ((prompt: string, segments?: PromptSegment[]) => Promise<void>) | undefined;
   pickFiles?: (() => Promise<string[] | null>) | undefined;
+  saveClipboardImage?: SaveClipboardImage | undefined;
   /** Optional surface-specific placeholder for the active-thread input. */
   composerPlaceholder?: string | undefined;
   /** Override whether unmodified Enter submits instead of inserting a newline. */
@@ -172,7 +173,9 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
   const voiceInputRef = useRef<VoiceInputHandle>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInterrupting, setIsInterrupting] = useState(false);
-  const attachments = useAttachments();
+  const attachments = useAttachments({
+    ...(props.saveClipboardImage ? { saveClipboardImage: props.saveClipboardImage } : {}),
+  });
   // Unsent composer content survives leaving this thread. The primary GUI pane
   // keeps this section mounted across thread switches, so the thread-keyed
   // layout effects below save and restore without exposing another thread's

--- a/src/renderer/components/thread/ThreadContent.tsx
+++ b/src/renderer/components/thread/ThreadContent.tsx
@@ -11,6 +11,7 @@ import type { RemoteTerminalTransport, TerminalPaneHandle } from "./TerminalPane
 import type { CheckpointRevertActions } from "./ChatPane/parts/MessageList";
 import { ThreadComposerSection } from "./ThreadComposerSection";
 import { useThreadDockState, type ThreadDockState } from "./useThreadDockState";
+import type { SaveClipboardImage } from "../composer/useAttachments";
 
 export type ThreadContentCommonProps = {
   threadId: string;
@@ -34,6 +35,7 @@ export type ThreadContentCommonProps = {
   checkpointProjectLocation?: ProjectLocation | undefined;
   remoteTerminalTransport?: RemoteTerminalTransport | undefined;
   pickFiles?: (() => Promise<string[] | null>) | undefined;
+  saveClipboardImage?: SaveClipboardImage | undefined;
 };
 
 export function GuiThreadContent(

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -41,7 +41,10 @@ import {
   type McpMentionItem,
   type MentionInputHandle,
 } from "@/renderer/components/composer/MentionInput";
-import { useAttachments } from "@/renderer/components/composer/useAttachments";
+import {
+  useAttachments,
+  type SaveClipboardImage,
+} from "@/renderer/components/composer/useAttachments";
 import type { VoiceInputHandle } from "@/renderer/components/composer/VoiceInputButton";
 import { getComputerUseScope } from "@/renderer/components/composer/computerUseScope";
 import { useBrowserAttachInbox } from "@/renderer/state/browserAttachInbox";
@@ -273,6 +276,7 @@ export function ThreadDraftComposerArea(props: {
   /** Override whether unmodified Enter submits instead of inserting a newline. */
   submitOnEnter?: boolean;
   pickFiles?: () => Promise<string[] | null>;
+  saveClipboardImage?: SaveClipboardImage;
   onConfigChange: (patch: Partial<ThreadConfig>) => void;
   onWorktreeModeChange: (worktreeMode: boolean) => void;
   onSwitchBranch: (branch: string, createNew: boolean) => void;
@@ -305,7 +309,9 @@ export function ThreadDraftComposerArea(props: {
   const updateProjectMcpServers = useAppStore((s) => s.updateProjectMcpServers);
   const mentionRef = useRef<MentionInputHandle>(null);
   const voiceInputRef = useRef<VoiceInputHandle>(null);
-  const attachments = useAttachments();
+  const attachments = useAttachments({
+    ...(props.saveClipboardImage ? { saveClipboardImage: props.saveClipboardImage } : {}),
+  });
   const inboxKey = props.paneId ?? `draft:${props.project.id}`;
   const fallbackInboxKey = `draft:${props.project.id}`;
   const pendingPickedAttachments = useBrowserAttachInbox((s) =>

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -49,6 +49,7 @@ import { friendlyError } from "@/shared/messages";
 import { PresentationModeTabs } from "./PresentationModeTabs";
 import { ProjectSwitchMenu } from "./ProjectSwitchMenu";
 import { ThreadDraftComposerArea, type DraftStartInput } from "./ThreadDraftComposerArea";
+import type { SaveClipboardImage } from "../composer/useAttachments";
 import { AgentDiscoveryScreen } from "./AgentDiscoveryScreen";
 import {
   isDiscoveryActiveForLocation,
@@ -163,6 +164,7 @@ export function ThreadDraftView(props: {
   /** Override whether unmodified Enter submits instead of inserting a newline. */
   submitOnEnter?: boolean;
   pickFiles?: () => Promise<string[] | null>;
+  saveClipboardImage?: SaveClipboardImage;
   paneAlign?: "left" | "center" | "right";
   showCloseButton?: boolean;
   isDragging?: boolean;
@@ -1093,6 +1095,7 @@ export function ThreadDraftView(props: {
             {...(props.composerPlaceholder ? { placeholder: props.composerPlaceholder } : {})}
             {...(props.submitOnEnter !== undefined ? { submitOnEnter: props.submitOnEnter } : {})}
             {...(props.pickFiles ? { pickFiles: props.pickFiles } : {})}
+            {...(props.saveClipboardImage ? { saveClipboardImage: props.saveClipboardImage } : {})}
             onConfigChange={onConfigPatch}
             onWorktreeModeChange={setWorktreeMode}
             onSwitchBranch={handleSwitchBranch}

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -19,6 +19,7 @@ import { performInitialThreadLaunch } from "@/renderer/actions/threadLaunchActio
 import { macosTrafficLightPadClass } from "@/renderer/components/layout/sidebarChrome";
 import type { RemoteTerminalTransport, TerminalPaneHandle } from "./TerminalPane";
 import type { CheckpointRevertActions } from "./ChatPane/parts/MessageList";
+import type { SaveClipboardImage } from "../composer/useAttachments";
 import { ContinueInProviderDialog } from "./ContinueInProviderDialog";
 import { GuiThreadContent } from "./ThreadContent";
 import { TerminalThreadContent } from "./TerminalThreadContent";
@@ -88,7 +89,8 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.onOpenProjectRelativePath === next.onOpenProjectRelativePath &&
     prev.checkpointActions === next.checkpointActions &&
     prev.remoteTerminalTransport === next.remoteTerminalTransport &&
-    prev.pickFiles === next.pickFiles
+    prev.pickFiles === next.pickFiles &&
+    prev.saveClipboardImage === next.saveClipboardImage
   );
 }
 
@@ -144,6 +146,7 @@ export type ThreadViewProps = {
   checkpointActions?: CheckpointRevertActions | undefined;
   remoteTerminalTransport?: RemoteTerminalTransport | undefined;
   pickFiles?: (() => Promise<string[] | null>) | undefined;
+  saveClipboardImage?: SaveClipboardImage | undefined;
 };
 
 export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
@@ -176,6 +179,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     checkpointActions,
     remoteTerminalTransport,
     pickFiles,
+    saveClipboardImage,
   } = props;
   const { t } = useLingui();
   const terminalPaneRef = useRef<TerminalPaneHandle>(null);
@@ -444,6 +448,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                 {...(onSubmitInput ? { onSubmitInput } : {})}
                 {...(remoteTerminalTransport ? { remoteTerminalTransport } : {})}
                 {...(pickFiles ? { pickFiles } : {})}
+                {...(saveClipboardImage ? { saveClipboardImage } : {})}
               />
             ) : (
               <GuiThreadContent
@@ -459,6 +464,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                 {...(checkpointActions ? { checkpointActions } : {})}
                 {...(thread.remoteServerId ? { checkpointProjectLocation: projectLocation } : {})}
                 {...(pickFiles ? { pickFiles } : {})}
+                {...(saveClipboardImage ? { saveClipboardImage } : {})}
               />
             )}
           </div>

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -1,4 +1,5 @@
 import { useShallow } from "zustand/shallow";
+import type { SaveClipboardImage } from "@/renderer/components/composer/useAttachments";
 import { parseDraftProjectId } from "@/shared/paneId";
 import type {
   AgentStatus,
@@ -251,6 +252,7 @@ export function useDraftEnvironment(project: Project | undefined): {
   agentStatuses: AgentStatus[];
   isDetectingAgents: boolean;
   pickFiles?: () => Promise<string[] | null>;
+  saveClipboardImage?: SaveClipboardImage;
 } {
   const localAgentStatuses = useAgentStatusesStore(
     useShallow((state) =>
@@ -285,6 +287,11 @@ export function useDraftEnvironment(project: Project | undefined): {
             useRemoteServersStore
               .getState()
               .pickAndUploadFiles(remoteServerId, `draft-${remoteProjectId}`),
+          saveClipboardImage: (input) =>
+            useRemoteServersStore.getState().saveClipboardImage(remoteServerId, {
+              ...input,
+              threadId: `draft-${remoteProjectId}`,
+            }),
         }
       : {}),
   };

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -159,6 +159,10 @@ export interface RemoteServersState {
     desktopId: string,
     input: RemoteRuntimeItemsPageRequest,
   ): ReturnType<RemoteDesktopClient["threadRuntimeItemsPage"]>;
+  saveClipboardImage(
+    desktopId: string,
+    input: { readonly threadId: string; readonly data: Uint8Array; readonly extension: string },
+  ): Promise<string>;
   pickAndUploadFiles(desktopId: string, attachmentThreadId: string): Promise<string[] | null>;
   interruptThread(desktopId: string, threadId: string): Promise<void>;
   closeThread(desktopId: string, threadId: string): Promise<void>;

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -146,6 +146,7 @@ function makeClient(opts?: {
   websocketTicket?: RemoteDesktopClient["websocketTicket"];
   websocketUrl?: RemoteDesktopClient["websocketUrl"];
   sendThreadInput?: RemoteDesktopClient["sendThreadInput"];
+  uploadAttachment?: RemoteDesktopClient["uploadAttachment"];
   startNewThread?: RemoteDesktopClient["startNewThread"];
   writeTerminal?: RemoteDesktopClient["writeTerminal"];
   resizeTerminal?: RemoteDesktopClient["resizeTerminal"];
@@ -197,6 +198,7 @@ function makeClient(opts?: {
     websocketUrl: opts?.websocketUrl ?? (() => "ws://192.168.1.9:38987/ws?ticket=ticket-1"),
     parseSocketMessage: (value: string) => JSON.parse(value),
     sendThreadInput: opts?.sendThreadInput ?? (async () => {}),
+    uploadAttachment: opts?.uploadAttachment ?? (async () => "/remote/attachment.png"),
     startNewThread: opts?.startNewThread ?? (async () => ({ threadId: crypto.randomUUID() })),
     writeTerminal: opts?.writeTerminal ?? (async () => {}),
     resizeTerminal: opts?.resizeTerminal ?? (async () => {}),
@@ -1328,6 +1330,35 @@ describe("useRemoteServersStore", () => {
       segments: [{ kind: "text", content: "hello remote" }],
       config: { model: "claude-sonnet" },
       userMessageItemId: "user-1",
+    });
+  });
+
+  it("uploads pasted clipboard images to the remote host", async () => {
+    const uploadAttachment = vi.fn<RemoteDesktopClient["uploadAttachment"]>(
+      async () => "C:\\remote\\attachments\\clipboard.png",
+    );
+    useRemoteServersStore.getState().setClientFactory(factoryFor(makeClient({ uploadAttachment })));
+    useRemoteServersStore.getState().setSocketFactory(() => ({
+      close: vi.fn<() => void>(),
+      onmessage: null,
+      onclose: null,
+    }));
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+
+    const data = new Uint8Array([1, 2, 3]);
+    await expect(
+      useRemoteServersStore.getState().saveClipboardImage("d1", {
+        threadId: "rt-1",
+        data,
+        extension: "png",
+      }),
+    ).resolves.toBe("C:\\remote\\attachments\\clipboard.png");
+    expect(uploadAttachment).toHaveBeenCalledWith({
+      threadId: "rt-1",
+      fileName: expect.stringMatching(/^clipboard-[0-9a-f-]+\.png$/),
+      data,
     });
   });
 

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -1093,6 +1093,14 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           return requireClient(desktopId).threadRuntimeItemsPage(input);
         },
 
+        saveClipboardImage: (desktopId, input) => {
+          return requireClient(desktopId).uploadAttachment({
+            threadId: input.threadId,
+            fileName: `clipboard-${crypto.randomUUID()}.${input.extension}`,
+            data: input.data,
+          });
+        },
+
         pickAndUploadFiles: async (desktopId, attachmentThreadId) => {
           const client = requireClient(desktopId);
           return pickAndUploadBrowserFiles({

--- a/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/AppContent.tsx
@@ -338,6 +338,9 @@ function DraftViewContent(props: {
       agentStatuses={draftEnvironment.agentStatuses}
       isDetectingAgents={draftEnvironment.isDetectingAgents}
       {...(draftEnvironment.pickFiles ? { pickFiles: draftEnvironment.pickFiles } : {})}
+      {...(draftEnvironment.saveClipboardImage
+        ? { saveClipboardImage: draftEnvironment.saveClipboardImage }
+        : {})}
       {...(lastDraftConfig ? { lastDraftConfig } : {})}
       onStart={onStart}
     />

--- a/src/renderer/views/MainView/parts/AppContent/parts/DraftPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/DraftPane.tsx
@@ -48,6 +48,9 @@ export function DraftPane(props: {
       agentStatuses={draftEnvironment.agentStatuses}
       isDetectingAgents={draftEnvironment.isDetectingAgents}
       {...(draftEnvironment.pickFiles ? { pickFiles: draftEnvironment.pickFiles } : {})}
+      {...(draftEnvironment.saveClipboardImage
+        ? { saveClipboardImage: draftEnvironment.saveClipboardImage }
+        : {})}
       compact
       paneAlign={props.paneAlign}
       paneId={props.paneId}

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -130,6 +130,19 @@ export function ThreadPane(props: {
     if (!remoteDesktopId || !remoteThreadId) return Promise.resolve(null);
     return useRemoteServersStore.getState().pickAndUploadFiles(remoteDesktopId, remoteThreadId);
   }
+  function saveRemoteClipboardImage(input: {
+    threadId: string;
+    data: Uint8Array;
+    extension: string;
+  }) {
+    if (!remoteDesktopId || !remoteThreadId) {
+      return Promise.reject(new Error());
+    }
+    return useRemoteServersStore.getState().saveClipboardImage(remoteDesktopId, {
+      ...input,
+      threadId: remoteThreadId,
+    });
+  }
 
   if (!thread) return null;
   if (!project) return null;
@@ -193,6 +206,7 @@ export function ThreadPane(props: {
             checkpointActions,
             remoteTerminalTransport,
             pickFiles: pickRemoteFiles,
+            saveClipboardImage: saveRemoteClipboardImage,
           }
         : {})}
       onContinueInProvider={

--- a/src/supervisor/runtime.test.ts
+++ b/src/supervisor/runtime.test.ts
@@ -693,7 +693,8 @@ describe("SupervisorRuntime thread input", () => {
   });
 
   it("drains a steer staged after the turn already errored", async () => {
-    const runtime = makeRuntime(() => undefined);
+    const emitted: Array<Record<string, unknown>> = [];
+    const runtime = makeRuntime((event) => emitted.push(event as Record<string, unknown>));
     const startTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const interruptTurn = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
@@ -755,6 +756,17 @@ describe("SupervisorRuntime thread input", () => {
     expect(startTurn).toHaveBeenCalledWith("retry this", { model: "gpt-5.4" }, undefined, {
       userMessageItemId: "user-retry",
     });
+    expect(emitted).toContainEqual(
+      expect.objectContaining({
+        type: "thread-runtime-event",
+        threadId: "thread-gui-post-error",
+        event: expect.objectContaining({
+          type: "item.started",
+          itemId: "user-retry",
+          itemType: "user_message",
+        }),
+      }),
+    );
   });
 
   it("does not emit runtime status updates for raw terminal writes", async () => {

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -230,7 +230,12 @@ export interface SpawnPipelineContext {
   failStructuredSession(session: SessionRuntime, error: unknown): void;
   isCurrentSession(session: SessionRuntime): boolean;
   resolveAgentSettings(adapter: AgentAdapter): Record<string, boolean | string>;
-  emitOptimisticUserMessage(threadId: string, prompt: string, segments?: PromptSegment[]): string;
+  emitOptimisticUserMessage(
+    threadId: string,
+    prompt: string,
+    segments?: PromptSegment[],
+    requestedItemId?: string,
+  ): string;
 }
 
 /**
@@ -308,8 +313,12 @@ export class SpawnPipeline {
     // id end-to-end so the chat pane never sees a duplicate.
     const optimisticUserMessageItemId =
       !usesTerminalPresentation && initialPrompt.length > 0 && !payload.sessionRef
-        ? (payload.userMessageItemId ??
-          ctx.emitOptimisticUserMessage(payload.threadId, initialPrompt, effectiveSegments))
+        ? ctx.emitOptimisticUserMessage(
+            payload.threadId,
+            initialPrompt,
+            effectiveSegments,
+            payload.userMessageItemId,
+          )
         : undefined;
     if (optimisticUserMessageItemId) {
       this.emitOptimisticWorkingState(payload.threadId, payload.config);
@@ -707,9 +716,12 @@ export class SpawnPipeline {
         ...(session.presentationMode ? { presentationMode: session.presentationMode } : {}),
       });
       if (prompt.trim().length > 0 && structuredSession.startTurn) {
-        const optimisticItemId =
-          turn.userMessageItemId ??
-          ctx.emitOptimisticUserMessage(session.threadId, prompt, turn.segments);
+        const optimisticItemId = ctx.emitOptimisticUserMessage(
+          session.threadId,
+          prompt,
+          turn.segments,
+          turn.userMessageItemId,
+        );
         const startOptions = {
           userMessageItemId: optimisticItemId,
           ...(turn.inlineInstructions ? { inlineInstructions: turn.inlineInstructions } : {}),

--- a/src/supervisor/runtime/threadSession/structuredTurnQueue.ts
+++ b/src/supervisor/runtime/threadSession/structuredTurnQueue.ts
@@ -30,12 +30,17 @@ export class StructuredTurnQueue {
     // before the structured session's `prompt()` round-trip resolves so the
     // chat doesn't visually stall waiting on the agent. Only meaningful for
     // GUI threads — terminal threads render user input via PTY echo.
-    // Prefer the renderer-supplied id when present (the chat pane has
-    // already painted the message); otherwise emit one from the supervisor.
+    // Reuse the renderer-supplied id when present, but still emit the canonical
+    // events. The originating renderer dedupes them by id, while other paired
+    // renderers need this broadcast to see the submitted user message.
     const optimisticItemId =
       session.presentationMode === "gui" && turn.prompt.length > 0
-        ? (turn.userMessageItemId ??
-          this.emitOptimisticUserMessage(session.threadId, turn.prompt, turn.segments))
+        ? this.emitOptimisticUserMessage(
+            session.threadId,
+            turn.prompt,
+            turn.segments,
+            turn.userMessageItemId,
+          )
         : undefined;
     const startOptions = {
       ...(optimisticItemId ? { userMessageItemId: optimisticItemId } : {}),
@@ -79,9 +84,14 @@ export class StructuredTurnQueue {
    * renderer's per-id dedupe, and the supervisor still drives the rest of the
    * canonical event stream.
    */
-  emitOptimisticUserMessage(threadId: string, prompt: string, segments?: PromptSegment[]): string {
+  emitOptimisticUserMessage(
+    threadId: string,
+    prompt: string,
+    segments?: PromptSegment[],
+    requestedItemId?: string,
+  ): string {
     const turnId = `turn-${randomUUID()}`;
-    const itemId = `user-${randomUUID()}`;
+    const itemId = requestedItemId ?? `user-${randomUUID()}`;
     this.ctx.emit({
       type: "thread-runtime-event",
       threadId,

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -171,8 +171,13 @@ export class ThreadSessionManager {
       failStructuredSession: (session, error) => this.failStructuredSession(session, error),
       isCurrentSession: (session) => this.isCurrentSession(session),
       resolveAgentSettings: (adapter) => this.resolveAgentSettings(adapter),
-      emitOptimisticUserMessage: (threadId, prompt, segments) =>
-        this.structuredTurnQueue.emitOptimisticUserMessage(threadId, prompt, segments),
+      emitOptimisticUserMessage: (threadId, prompt, segments, requestedItemId) =>
+        this.structuredTurnQueue.emitOptimisticUserMessage(
+          threadId,
+          prompt,
+          segments,
+          requestedItemId,
+        ),
     });
     this.invalidSessionRecovery = new InvalidSessionRecoveryCoordinator({
       spawnPipeline: this.spawnPipeline,
@@ -259,13 +264,12 @@ export class ThreadSessionManager {
     // the same item id so the replacement session cannot duplicate it.
     const pending = session.pendingSteer;
     if (!pending) return;
-    const userMessageItemId =
-      pending.userMessageItemId ??
-      this.structuredTurnQueue.emitOptimisticUserMessage(
-        session.threadId,
-        pending.prompt,
-        pending.segments,
-      );
+    const userMessageItemId = this.structuredTurnQueue.emitOptimisticUserMessage(
+      session.threadId,
+      pending.prompt,
+      pending.segments,
+      pending.userMessageItemId,
+    );
     const turn: QueuedStructuredTurn = { ...pending, userMessageItemId };
     clearPendingSteerSlot(session, this.options.emit);
     void this.spawnPipeline.restartThread(session, turn).catch((error) => {


### PR DESCRIPTION
- Bugfix remote thread and draft composers so pasted clipboard images upload as attachments on the remote desktop.
- Preserve renderer-provided user message IDs through retries and queued structured turns to prevent duplicate or mismatched chat messages.
- Add coverage for remote clipboard uploads and post-error retry events.