### PR TITLE
Show pending checks as warnings in pull request views

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Prüfungen fehlgeschlagen"
 msgid "Checks passed"
 msgstr "Prüfungen bestanden"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Prüfungen ausstehend"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Checks failed"
 msgid "Checks passed"
 msgstr "Checks passed"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Checks pending"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Comprobaciones fallidas"
 msgid "Checks passed"
 msgstr "Comprobaciones superadas"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Comprobaciones pendientes"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Vérifications échouées"
 msgid "Checks passed"
 msgstr "Vérifications réussies"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Vérifications en attente"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2028,6 +2028,7 @@ msgstr "チェック失敗"
 msgid "Checks passed"
 msgstr "チェック成功"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "チェック保留中"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2029,6 +2029,7 @@ msgstr "검사 실패"
 msgid "Checks passed"
 msgstr "검사 통과"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "검사 대기 중"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Kontrole zakończone niepowodzeniem"
 msgid "Checks passed"
 msgstr "Kontrole zaliczone"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Kontrole oczekują na realizację"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Verificações falharam"
 msgid "Checks passed"
 msgstr "Verificações aprovadas"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Verificações pendentes"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Проверки не пройдены"
 msgid "Checks passed"
 msgstr "Проверки пройдены"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Проверки ожидают выполнения"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Kontroller başarısız oldu"
 msgid "Checks passed"
 msgstr "Kontroller başarılı"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Kontroller beklemede"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Перевірки не пройдені"
 msgid "Checks passed"
 msgstr "Перевірки пройдені"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Перевірки очікують виконання"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2029,6 +2029,7 @@ msgstr "Kiểm tra thất bại"
 msgid "Checks passed"
 msgstr "Kiểm tra thành công"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "Kiểm tra đang chờ"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2029,6 +2029,7 @@ msgstr "检查失败"
 msgid "Checks passed"
 msgstr "检查通过"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 msgid "Checks pending"
 msgstr "检查待定"

--- a/src/renderer/utils/prStatus.ts
+++ b/src/renderer/utils/prStatus.ts
@@ -167,11 +167,34 @@ export function getPrStatusTone(
 ): PrStatusTone {
   if (state === "merged") return "merged";
   if (state === "draft") return "draft";
-  if (state === "closed" || isPrMergeBlocked(mergeStatus)) return "danger";
+  if (state === "closed") return "danger";
+  if (isPrBlockedOnlyByPendingChecks(checksStatus, mergeStatus)) return "warning";
+  if (isPrMergeBlocked(mergeStatus)) return "danger";
   if (mergeStatus?.mergeStateStatus === "BEHIND") return "warning";
   const checksTone = getChecksStatusTone(normalizeChecksStatus(checksStatus));
   if (checksTone) return checksTone;
   return "success";
+}
+
+/**
+ * GitHub reports protected PRs as BLOCKED while required checks are running.
+ * Treat that otherwise-ambiguous merge state as pending unless GitHub also
+ * reports a concrete review or conflict blocker.
+ */
+export function isPrBlockedOnlyByPendingChecks(
+  checksStatus: string | undefined,
+  status: PrMergeStatus | null | undefined,
+): boolean {
+  if (normalizeChecksStatus(checksStatus) !== "PENDING" || status?.mergeStateStatus !== "BLOCKED") {
+    return false;
+  }
+
+  const reviewDecision = status.reviewDecision?.toUpperCase();
+  return (
+    reviewDecision !== "CHANGES_REQUESTED" &&
+    reviewDecision !== "REVIEW_REQUIRED" &&
+    status.mergeable !== "CONFLICTING"
+  );
 }
 
 export function isPrMergeBlocked(status: PrMergeStatus | null | undefined): boolean {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.test.tsx
@@ -203,6 +203,30 @@ describe("PrSection", () => {
     expect(indicator).not.toHaveClass("bg-success");
   });
 
+  it("shows pending checks instead of a danger status when GitHub blocks a running check", () => {
+    useGitStore.setState({
+      prData: {
+        [prKey]: {
+          ...pr,
+          checksStatus: "PENDING",
+          mergeStateStatus: "BLOCKED",
+        },
+      },
+    });
+    useGitStore.getState().setPrDetails(`${projectId}#${pr.number}`, details);
+
+    render(<PrSection {...baseProps} />);
+
+    const indicator = screen
+      .getByText("#42 - Improve PR summary")
+      .parentElement?.querySelector(".rounded-full");
+    expect(indicator).toHaveClass("bg-warning");
+    expect(indicator).not.toHaveClass("bg-danger");
+    expect(screen.getByText("Checks pending").parentElement).toHaveClass("text-warning");
+    expect(screen.queryByText("Merging is blocked")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Merge PR: Squash" })).toBeDisabled();
+  });
+
   it.each(["CHANGES_REQUESTED", "REVIEW_REQUIRED"])(
     "shows a danger status for %s when merge-state data is missing",
     (reviewDecision) => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrSection.tsx
@@ -41,7 +41,12 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { usePrCombinedChecksStatus } from "@/renderer/hooks/usePrCombinedChecksStatus";
-import { countPassedPrChecks, getPrStatusTone, PR_TONE_BG_CLASS } from "@/renderer/utils/prStatus";
+import {
+  countPassedPrChecks,
+  getPrStatusTone,
+  isPrBlockedOnlyByPendingChecks,
+  PR_TONE_BG_CLASS,
+} from "@/renderer/utils/prStatus";
 import { GitReviewSection } from "./GitReviewSection";
 import { PrWatchControls } from "./PrWatchControls";
 
@@ -120,6 +125,11 @@ export function PrSection(props: {
   }, [cacheKey, details, isRefreshingPr, onRefreshPr, state]);
 
   const reasonKey = mergeable === "CONFLICTING" ? "DIRTY" : mergeStateStatus;
+  const isPendingChecksBlock = isPrBlockedOnlyByPendingChecks(combinedChecksStatus, {
+    reviewDecision,
+    mergeable,
+    mergeStateStatus,
+  });
   const indicatorColor =
     PR_TONE_BG_CLASS[
       getPrStatusTone(state, combinedChecksStatus, {
@@ -328,10 +338,16 @@ export function PrSection(props: {
         <>
           {isBlocked && (
             <div className="flex flex-col gap-1 text-xs">
-              <div className="flex items-center gap-2 text-danger">
+              <div
+                className={`flex items-center gap-2 ${isPendingChecksBlock ? "text-warning" : "text-danger"}`}
+              >
                 <AlertTriangle className="size-3.5 shrink-0" />
                 <span className="min-w-0 flex-1 truncate font-medium">
-                  <Trans>Merging is blocked</Trans>
+                  {isPendingChecksBlock ? (
+                    <Trans>Checks pending</Trans>
+                  ) : (
+                    <Trans>Merging is blocked</Trans>
+                  )}
                 </span>
                 {canBypass && (
                   <Tooltip>
@@ -343,7 +359,11 @@ export function PrSection(props: {
                       onChange={setBypass}
                       isDisabled={prLoading}
                       aria-label={t`Bypass branch protection rules`}
-                      className="size-5 shrink-0 text-danger data-[selected=true]:bg-danger data-[selected=true]:text-white"
+                      className={`size-5 shrink-0 ${
+                        isPendingChecksBlock
+                          ? "text-warning data-[selected=true]:bg-warning data-[selected=true]:text-warning-foreground"
+                          : "text-danger data-[selected=true]:bg-danger data-[selected=true]:text-white"
+                      }`}
                     >
                       <ShieldOff className="size-3" />
                     </ToggleButton>
@@ -353,7 +373,9 @@ export function PrSection(props: {
                   </Tooltip>
                 )}
               </div>
-              {blockReason && <span className="text-muted">{blockReason}</span>}
+              {!isPendingChecksBlock && blockReason && (
+                <span className="text-muted">{blockReason}</span>
+              )}
             </div>
           )}
           {mergeStateStatus === "BEHIND" && handleUpdatePrBranch && (

--- a/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.test.tsx
@@ -212,6 +212,31 @@ describe("PullRequestsView", () => {
     expect(row.querySelector(".rounded-full")).toHaveClass("bg-danger");
   });
 
+  it("shows pending checks when GitHub blocks a PR while CI is running", async () => {
+    useAppStore.setState({ projects: [windowsProject] });
+    bridge.ghListPullRequests.mockResolvedValue({
+      pullRequests: [
+        {
+          ...summary,
+          pr: {
+            ...summary.pr,
+            checksStatus: "PENDING",
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "BLOCKED",
+          },
+        },
+      ],
+      viewerLogin: "reviewer",
+    });
+
+    render(<PullRequestsView />);
+
+    const row = await screen.findByRole("button", { name: new RegExp(summary.pr.title) });
+    expect(within(row).getByText("Checks pending")).toBeInTheDocument();
+    expect(row.querySelector(".lucide-git-pull-request")).toHaveClass("text-warning");
+    expect(row.querySelector(".rounded-full")).toHaveClass("bg-warning");
+  });
+
   it("refreshes every project on demand", async () => {
     render(<PullRequestsView />);
 

--- a/src/renderer/views/PullRequestsView/PullRequestsView.tsx
+++ b/src/renderer/views/PullRequestsView/PullRequestsView.tsx
@@ -16,6 +16,7 @@ import { useGitStore } from "@/renderer/state/gitStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import {
   getPrStatusTone,
+  isPrBlockedOnlyByPendingChecks,
   isPrMergeBlocked,
   PR_TONE_BG_CLASS,
   PR_TONE_TEXT_CLASS,
@@ -416,6 +417,10 @@ function PullRequestRows(props: {
       {props.entries.map((entry) => {
         const { project, summary } = entry;
         const tone = getPrStatusTone(summary.pr.state, summary.pr.checksStatus, summary.pr);
+        const isPendingChecksBlock = isPrBlockedOnlyByPendingChecks(
+          summary.pr.checksStatus,
+          summary.pr,
+        );
         const statusLabel =
           summary.pr.state === "draft"
             ? t`Draft`
@@ -423,15 +428,17 @@ function PullRequestRows(props: {
               ? t`Merged`
               : summary.pr.state === "closed"
                 ? t`Closed`
-                : isPrMergeBlocked(summary.pr)
-                  ? t`Merging is blocked`
-                  : tone === "danger"
-                    ? t`Checks failed`
-                    : tone === "warning"
-                      ? t`Checks pending`
-                      : summary.pr.checksStatus
-                        ? t`Checks passed`
-                        : t`Open`;
+                : isPendingChecksBlock
+                  ? t`Checks pending`
+                  : isPrMergeBlocked(summary.pr)
+                    ? t`Merging is blocked`
+                    : tone === "danger"
+                      ? t`Checks failed`
+                      : tone === "warning"
+                        ? t`Checks pending`
+                        : summary.pr.checksStatus
+                          ? t`Checks passed`
+                          : t`Open`;
         return (
           <button
             key={`${project.id}:${summary.pr.number}`}


### PR DESCRIPTION
- **Bugfix:** Display PRs blocked only by running CI checks with a warning status instead of an error.
- Preserve error status for merge conflicts, required reviews, requested changes, failed checks, and closed PRs.
- Apply the pending-checks label and styling consistently in pull request lists and review sidebars.
- Add coverage for pending CI states and update translations for all supported locales.