### PR TITLE
Fix follow-up PR creation after merged pull requests

### DIFF
--- a/src/renderer/state/gitSelectors.ts
+++ b/src/renderer/state/gitSelectors.ts
@@ -60,6 +60,7 @@ function makePrFieldSelector<K extends keyof PrData>(field: K) {
 
 export const usePrNumber = makePrFieldSelector("number");
 export const usePrState = makePrFieldSelector("state");
+export const usePrHeadSha = makePrFieldSelector("headSha");
 export const usePrTitle = makePrFieldSelector("title");
 export const usePrUrl = makePrFieldSelector("url");
 export const usePrChecksStatus = makePrFieldSelector("checksStatus");

--- a/src/renderer/state/gitStore.ts
+++ b/src/renderer/state/gitStore.ts
@@ -184,6 +184,7 @@ function areGitStatusesEqual(a: GitStatusResult | undefined, b: GitStatusResult)
     a.detail === b.detail &&
     a.isRepo === b.isRepo &&
     a.branch === b.branch &&
+    a.headSha === b.headSha &&
     a.tracking === b.tracking &&
     a.hasRemote === b.hasRemote &&
     ((leftRemote === null && rightRemote === null) ||
@@ -283,6 +284,7 @@ function arePrDataEqual(a: PrData | null | undefined, b: PrData | null) {
   return (
     a.number === b.number &&
     a.state === b.state &&
+    a.headSha === b.headSha &&
     a.title === b.title &&
     a.url === b.url &&
     a.baseBranch === b.baseBranch &&

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.test.tsx
@@ -1033,7 +1033,7 @@ describe("GitReviewSidebar", () => {
     expect(screen.queryByText("Merge & Remove Worktree")).not.toBeInTheDocument();
   });
 
-  it("shows the latest merged PR and allows creating a follow-up PR", async () => {
+  it("hides Create PR when the branch still points at the latest merged PR commit", async () => {
     const project: Project = {
       id: "project-1",
       name: "Poracode",
@@ -1043,6 +1043,7 @@ describe("GitReviewSidebar", () => {
     const gitStatus: GitStatusResult = {
       isRepo: true,
       branch: "feature/worktree",
+      headSha: "merged-head",
       tracking: "origin/feature/worktree",
       hasRemote: true,
       remoteInfo: {
@@ -1061,6 +1062,7 @@ describe("GitReviewSidebar", () => {
     const mergedPr: PrData = {
       number: 429,
       state: "merged",
+      headSha: "merged-head",
       title: "Add GitHub Actions workflow management view",
       url: "https://github.com/example/poracode/pull/429",
       baseBranch: "master",
@@ -1076,7 +1078,7 @@ describe("GitReviewSidebar", () => {
     bridgeMock.ghGetPrForBranch.mockResolvedValue(mergedPr);
     useGitStore.setState({ ghAvailable: { [project.id]: true } });
 
-    render(
+    const { rerender } = render(
       <GitReviewSidebar
         project={project}
         gitStatus={gitStatus}
@@ -1094,6 +1096,27 @@ describe("GitReviewSidebar", () => {
     expect(
       await screen.findByText("#429 - Add GitHub Actions workflow management view"),
     ).toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole("button", { name: "Create PR" })
+        .some((button) => button.classList.contains("flex-1")),
+    ).toBe(false);
+
+    rerender(
+      <GitReviewSidebar
+        project={project}
+        gitStatus={{ ...gitStatus, headSha: "new-pushed-head" }}
+        selectedFile={null}
+        selectedStaged={false}
+        worktreeBranch="feature/worktree"
+        worktreePath="C:\\repo-worktree"
+        refreshKey={1}
+        onSelectFile={() => undefined}
+        onClose={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+
     expect(
       screen
         .getAllByRole("button", { name: "Create PR" })

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
@@ -29,6 +29,7 @@ import {
   useCommitsAhead,
   useHasPr,
   usePrBaseBranch,
+  usePrHeadSha,
   usePrNumber,
   usePrState,
   useSourceAhead,
@@ -142,6 +143,7 @@ export function GitReviewSidebar(props: {
   const hasPr = useHasPr(effectivePrKey);
   const prNumber = usePrNumber(effectivePrKey);
   const prState = usePrState(effectivePrKey);
+  const prHeadSha = usePrHeadSha(effectivePrKey);
   const prBaseBranch = usePrBaseBranch(effectivePrKey);
   const sourceBranch = useSourceBranch(effectivePrKey) ?? null;
   const commitsAhead = useCommitsAhead(effectivePrKey);
@@ -256,8 +258,15 @@ export function GitReviewSidebar(props: {
     effectiveBranch && sourceBranch && sourceAhead > 0 && !isExperimentWorktree,
   );
   const isPushed = hasTracking && ahead === 0;
-  // Shared PR eligibility: a GitHub repo with a target branch and no active PR.
-  const prEligible = Boolean(showPrSection && ghAvailable && sourceBranch && !isPrActive(prState));
+  // A merged PR only becomes eligible for a follow-up PR after the branch moves
+  // past the commit that was last included in that PR. Comparing commit IDs is
+  // important here: ahead/behind counts are misleading after squash merges.
+  const hasCommitsAfterMergedPr = Boolean(
+    prState !== "merged" || (gitStatus?.headSha && prHeadSha && gitStatus.headSha !== prHeadSha),
+  );
+  const prEligible = Boolean(
+    showPrSection && ghAvailable && sourceBranch && !isPrActive(prState) && hasCommitsAfterMergedPr,
+  );
   const showCreatePrButton = prEligible && isPushed;
   // Whether the one-click "Commit & Create PR" action is offered. Unlike
   // showCreatePrButton this does NOT require an already-pushed branch (it only

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -26,6 +26,8 @@ export interface GitStatusResult {
   detail?: GitStatusDetail;
   isRepo: boolean;
   branch: string;
+  /** Commit currently checked out at HEAD. */
+  headSha?: string;
   tracking: string;
   hasRemote: boolean;
   remoteInfo: GitRemoteInfo | null;

--- a/src/shared/contracts/github.ts
+++ b/src/shared/contracts/github.ts
@@ -8,6 +8,8 @@ export type PrMergeMethod = z.infer<typeof prMergeMethodSchema>;
 export interface PrData {
   number: number;
   state: PrState;
+  /** Last commit that belonged to this pull request's head branch. */
+  headSha?: string;
   title: string;
   url: string;
   baseBranch: string;

--- a/src/supervisor/git/statusParsing.ts
+++ b/src/supervisor/git/statusParsing.ts
@@ -3,6 +3,7 @@ import { parseRemoteUrl, toForwardSlash } from "./exec";
 
 export interface ParsedPorcelainStatus {
   branch: string;
+  headSha: string;
   tracking: string;
   ahead: number;
   behind: number;
@@ -158,6 +159,7 @@ export const LS_FILES_UNTRACKED_ARGS = ["ls-files", "--others", "--exclude-stand
 
 export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
   let branch = "";
+  let headSha = "";
   let tracking = "";
   let ahead = 0;
   let behind = 0;
@@ -171,7 +173,9 @@ export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
     if (!line) continue;
 
     if (line.startsWith("# ")) {
-      if (line.startsWith("# branch.head ")) {
+      if (line.startsWith("# branch.oid ")) {
+        headSha = line.slice("# branch.oid ".length).trim();
+      } else if (line.startsWith("# branch.head ")) {
         branch = line.slice("# branch.head ".length).trim();
       } else if (line.startsWith("# branch.upstream ")) {
         tracking = line.slice("# branch.upstream ".length).trim();
@@ -240,6 +244,7 @@ export function parseStatusPorcelainV2(output: string): ParsedPorcelainStatus {
 
   return {
     branch,
+    headSha,
     tracking,
     ahead,
     behind,
@@ -353,6 +358,7 @@ export function buildGitStatusResultFromOutputs(args: {
   return {
     isRepo: true,
     branch: parsed.branch,
+    ...(parsed.headSha ? { headSha: parsed.headSha } : {}),
     tracking: parsed.tracking,
     hasRemote,
     remoteInfo,
@@ -403,6 +409,7 @@ export function buildGitStatusSummaryFromOutput(
     detail: "summary",
     isRepo: true,
     branch: parsed.branch,
+    ...(parsed.headSha ? { headSha: parsed.headSha } : {}),
     tracking: parsed.tracking,
     hasRemote: parsed.tracking.length > 0,
     remoteInfo: null,

--- a/src/supervisor/git/statusService.parser.test.ts
+++ b/src/supervisor/git/statusService.parser.test.ts
@@ -34,6 +34,7 @@ describe("parseStatusPorcelainV2", () => {
 
     const result = parseStatusPorcelainV2(output);
     expect(result.branch).toBe("feature/x");
+    expect(result.headSha).toBe("abc123");
     expect(result.tracking).toBe("origin/feature/x");
     expect(result.ahead).toBe(3);
     expect(result.behind).toBe(1);
@@ -43,6 +44,7 @@ describe("parseStatusPorcelainV2", () => {
   it("returns defaults when no header lines are present", () => {
     expect(parseStatusPorcelainV2("")).toEqual({
       branch: "",
+      headSha: "",
       tracking: "",
       ahead: 0,
       behind: 0,

--- a/src/supervisor/git/statusService.ts
+++ b/src/supervisor/git/statusService.ts
@@ -386,6 +386,7 @@ export class GitStatusService {
     // insertion/deletion counts; replaceUntrackedEntries fills them in.
     const parsed: ParsedPorcelainStatus = {
       branch: base.branch,
+      headSha: base.headSha ?? "",
       tracking: base.tracking,
       ahead: base.ahead,
       behind: base.behind,

--- a/src/supervisor/github.ts
+++ b/src/supervisor/github.ts
@@ -62,11 +62,11 @@ const PR_DIFF_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
 const CREATE_PR_STATUS_WAIT_MS = 15_000;
 const CREATE_PR_STATUS_POLL_MS = 5_000;
 const PR_VIEW_FIELDS =
-  "number,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus,author";
+  "number,url,state,title,baseRefName,headRefOid,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus,author";
 // Bulk list: adds `headRefName` (to key per branch) and drops `author` (the icon
 // doesn't need viewerDidAuthor, so we skip the extra `gh api user` lookup).
 const PR_LIST_FIELDS =
-  "number,headRefName,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus";
+  "number,headRefName,headRefOid,url,state,title,baseRefName,isDraft,reviewDecision,statusCheckRollup,updatedAt,mergeable,mergeStateStatus";
 const PULL_REQUEST_LIST_FIELDS = `${PR_LIST_FIELDS},author,additions,deletions,reviewRequests`;
 const PR_CHECK_FIELDS = "name,state,bucket,link,startedAt,completedAt,workflow";
 const PR_CHECK_PENDING_STATES = new Set([

--- a/src/supervisor/githubMappers.ts
+++ b/src/supervisor/githubMappers.ts
@@ -150,6 +150,7 @@ export function mapPrData(raw: Record<string, unknown>, viewerLogin?: string): P
   const result: PrData = {
     number: raw.number as number,
     state: mapPrState({ state: raw.state as string, isDraft: raw.isDraft as boolean }),
+    ...(typeof raw.headRefOid === "string" && raw.headRefOid ? { headSha: raw.headRefOid } : {}),
     title: (raw.title as string) ?? "",
     url: (raw.url as string) ?? "",
     baseBranch: (raw.baseRefName as string) ?? "",


### PR DESCRIPTION
- **Bugfix:** prevent creating a follow-up PR while a branch still points to the latest merged PR commit.
- Track Git HEAD SHAs and pull request head SHAs across supervisor, shared contracts, and renderer state.
- Enable follow-up PR creation only after new commits move the branch beyond the merged PR.
- Add parser and sidebar coverage for SHA propagation and eligibility behavior.