### PR TITLE
Preserve remote attachments and prevent duplicate recovery messages

### DIFF
--- a/src/main/poracodeData.test.ts
+++ b/src/main/poracodeData.test.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupOrphanedAttachments } from "./poracodeData";
+
+describe("cleanupOrphanedAttachments", () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it("keeps attachment directories referenced by staged composer messages", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "poracode-attachment-cleanup-"));
+    const attachmentsDir = join(tempDir, "attachments");
+    const retained = ["draft-project", "remote-server", "handoff-thread"];
+    for (const directory of [...retained, "orphan-thread"]) {
+      mkdirSync(join(attachmentsDir, directory), { recursive: true });
+      writeFileSync(join(attachmentsDir, directory, "image.png"), "image");
+    }
+
+    cleanupOrphanedAttachments(attachmentsDir, []);
+
+    for (const directory of retained) {
+      expect(existsSync(join(attachmentsDir, directory, "image.png"))).toBe(true);
+    }
+    expect(existsSync(join(attachmentsDir, "orphan-thread"))).toBe(false);
+  });
+
+  it("keeps durable thread directories and removes unknown directories", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "poracode-attachment-cleanup-"));
+    const attachmentsDir = join(tempDir, "attachments");
+    mkdirSync(join(attachmentsDir, "thread-12345"), { recursive: true });
+    mkdirSync(join(attachmentsDir, "unknown"), { recursive: true });
+
+    cleanupOrphanedAttachments(attachmentsDir, ["thread:12345-more"]);
+
+    expect(existsSync(join(attachmentsDir, "thread-12345"))).toBe(true);
+    expect(existsSync(join(attachmentsDir, "unknown"))).toBe(false);
+  });
+});

--- a/src/main/poracodeData.ts
+++ b/src/main/poracodeData.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { resolvePoracodePaths, type PoracodePaths } from "@/shared/poracodePaths";
 import { migrateLegacyDataOnLaunch, type LegacyDataMigrationOptions } from "./legacyDataMigration";
 
+const PERSISTED_STAGING_ATTACHMENT_PREFIXES = ["draft-", "remote-", "handoff-"] as const;
+
 function ensureBaseDirectories(paths: PoracodePaths): void {
   mkdirSync(paths.baseDir, { recursive: true });
   mkdirSync(paths.worktreesDir, { recursive: true });
@@ -52,10 +54,14 @@ export function cleanupOrphanedAttachments(attachmentsDir: string, validThreadId
   }
 
   for (const entry of entries) {
-    // Draft-pane attachments live under directories prefixed with `draft-` and
-    // are referenced by file path from persisted user messages once the draft
-    // is sent. Keep them so re-opened threads can still resolve their images.
-    if (entry.startsWith("draft-")) continue;
+    // Composer attachments may be staged before a durable thread id exists.
+    // Their directory keeps the sanitized staging id (`draft:…`, projected
+    // `remote:…`, or `handoff:…`) even after the resulting user message is
+    // persisted. Keep those directories because the message and provider turn
+    // continue to reference the original absolute file path.
+    if (PERSISTED_STAGING_ATTACHMENT_PREFIXES.some((prefix) => entry.startsWith(prefix))) {
+      continue;
+    }
     if (!validDirNames.has(entry)) {
       rmSync(join(attachmentsDir, entry), { recursive: true, force: true });
     }

--- a/src/renderer/components/composer/AttachmentBar.test.tsx
+++ b/src/renderer/components/composer/AttachmentBar.test.tsx
@@ -57,6 +57,33 @@ describe("AttachmentBar", () => {
     expect(screen.getByAltText("screenshot.png").getAttribute("loading")).toBeNull();
   });
 
+  it("uses the owning remote machine URL for remote attachment previews", () => {
+    const imageUrlForPath = vi.fn<(path: string) => string>(
+      (path: string) => `https://mac.test/api/files/image?path=${encodeURIComponent(path)}`,
+    );
+    render(
+      <AttachmentBar
+        attachments={[
+          {
+            id: "image-1",
+            path: "/Users/host/.poracode/attachments/shot.png",
+            name: "shot.png",
+            mimeType: "image/png",
+            isImage: true,
+          },
+        ]}
+        imagesAsPreview
+        imageUrlForPath={imageUrlForPath}
+      />,
+    );
+
+    expect(screen.getByAltText("shot.png")).toHaveAttribute(
+      "src",
+      "https://mac.test/api/files/image?path=%2FUsers%2Fhost%2F.poracode%2Fattachments%2Fshot.png",
+    );
+    expect(imageUrlForPath).toHaveBeenCalledWith("/Users/host/.poracode/attachments/shot.png");
+  });
+
   it("renders flush attachment bars for inline message attachments", () => {
     const { container } = render(
       <AttachmentBar

--- a/src/renderer/components/composer/AttachmentBar.tsx
+++ b/src/renderer/components/composer/AttachmentBar.tsx
@@ -121,9 +121,17 @@ function AttachmentChip(props: {
   onPreviewImage?: ((attachment: Attachment) => void) | undefined;
   onPreviewPdf?: ((attachment: Attachment) => void) | undefined;
   hideImageName?: boolean;
+  imageUrlForPath?: ((path: string) => string) | undefined;
 }) {
   const { t } = useLingui();
-  const { attachment: att, onRemove, onPreviewImage, onPreviewPdf, hideImageName } = props;
+  const {
+    attachment: att,
+    onRemove,
+    onPreviewImage,
+    onPreviewPdf,
+    hideImageName,
+    imageUrlForPath,
+  } = props;
   const isPicked = !!att.selector;
   const labelText = isPicked ? att.selector! : att.name;
   const showLabel = isPicked || !att.isImage || !hideImageName;
@@ -141,7 +149,7 @@ function AttachmentChip(props: {
       {att.isImage ? (
         <img
           className="poracode-attachment-chip__thumb"
-          src={resolveLocalImageDisplayUrl(toLocalFileUrl(att.path))}
+          src={imageUrlForPath?.(att.path) ?? resolveLocalImageDisplayUrl(toLocalFileUrl(att.path))}
           alt={att.name}
           decoding="async"
           draggable={false}
@@ -207,12 +215,13 @@ function AttachmentChip(props: {
 function ImagePreview(props: {
   attachment: Attachment;
   onPreviewImage?: ((attachment: Attachment) => void) | undefined;
+  imageUrlForPath?: ((path: string) => string) | undefined;
 }) {
   const { t } = useLingui();
-  const { attachment: att, onPreviewImage } = props;
+  const { attachment: att, onPreviewImage, imageUrlForPath } = props;
   const img = (
     <img
-      src={resolveLocalImageDisplayUrl(toLocalFileUrl(att.path))}
+      src={imageUrlForPath?.(att.path) ?? resolveLocalImageDisplayUrl(toLocalFileUrl(att.path))}
       alt={att.name}
       decoding="async"
       draggable={false}
@@ -249,6 +258,7 @@ export function AttachmentBar(props: {
   layout?: "inset" | "flush";
   hideImageNames?: boolean;
   imagesAsPreview?: boolean;
+  imageUrlForPath?: (path: string) => string;
   leading?: ReactNode;
 }) {
   const {
@@ -259,6 +269,7 @@ export function AttachmentBar(props: {
     layout = "inset",
     hideImageNames,
     imagesAsPreview,
+    imageUrlForPath,
     leading,
   } = props;
   if (attachments.length === 0 && !leading) return null;
@@ -273,7 +284,12 @@ export function AttachmentBar(props: {
       {leading}
       {attachments.map((att) =>
         imagesAsPreview && att.isImage && !att.selector ? (
-          <ImagePreview key={att.id} attachment={att} onPreviewImage={onPreviewImage} />
+          <ImagePreview
+            key={att.id}
+            attachment={att}
+            onPreviewImage={onPreviewImage}
+            imageUrlForPath={imageUrlForPath}
+          />
         ) : (
           <AttachmentChip
             key={att.id}
@@ -281,6 +297,7 @@ export function AttachmentBar(props: {
             onRemove={onRemove}
             onPreviewImage={onPreviewImage}
             onPreviewPdf={onPreviewPdf}
+            imageUrlForPath={imageUrlForPath}
             {...(hideImageNames === undefined ? {} : { hideImageName: hideImageNames })}
           />
         ),

--- a/src/renderer/components/composer/ImageLightbox.tsx
+++ b/src/renderer/components/composer/ImageLightbox.tsx
@@ -65,10 +65,11 @@ export function openImageLightbox(images: readonly LightboxImage[], initialIndex
 export function openAttachmentLightbox(
   attachments: readonly Attachment[],
   initialIndex: number,
+  imageUrlForPath?: (path: string) => string,
 ): void {
   openImageLightbox(
     attachments.map((img) => ({
-      src: resolveLocalImageDisplayUrl(toLocalFileUrl(img.path)),
+      src: imageUrlForPath?.(img.path) ?? resolveLocalImageDisplayUrl(toLocalFileUrl(img.path)),
       alt: img.name,
     })),
     initialIndex,

--- a/src/renderer/components/composer/useAttachments.test.tsx
+++ b/src/renderer/components/composer/useAttachments.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAttachments, type SaveClipboardImage } from "./useAttachments";
+
+describe("useAttachments", () => {
+  it("uses the remote image saver for pasted images", async () => {
+    const saveImage = vi.fn<SaveClipboardImage>(async () =>
+      Promise.resolve("/Users/host/.poracode/attachments/draft/image.png"),
+    );
+    const file = new File([new Uint8Array([1, 2, 3])], "clipboard.png", {
+      type: "image/png",
+    });
+    const { result } = renderHook(() => useAttachments({ saveClipboardImage: saveImage }));
+
+    await act(async () => {
+      await result.current.addClipboardImage(file, "draft:remote-project");
+    });
+
+    expect(saveImage).toHaveBeenCalledWith({
+      data: new Uint8Array([1, 2, 3]),
+      extension: "png",
+      threadId: "draft:remote-project",
+    });
+    expect(result.current.toSegments()).toEqual([
+      {
+        kind: "attachment",
+        path: "/Users/host/.poracode/attachments/draft/image.png",
+        mimeType: "image/png",
+      },
+    ]);
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ChatItemRow.tsx
@@ -108,7 +108,7 @@ function renderItem(
 ) {
   switch (item.type) {
     case "user_message":
-      return <UserMessage item={item} checkpointRevert={checkpointRevert} />;
+      return <UserMessage threadId={threadId} item={item} checkpointRevert={checkpointRevert} />;
     case "question_answer":
       return <QuestionAnswer item={item} checkpointRevert={checkpointRevert} />;
     case "assistant_message":

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { openExternalWithFeedback } from "@/renderer/utils/openExternal";
 import { useLongPress } from "@/renderer/hooks/useLongPress";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { normalizeChatProjectPath } from "../../chatPathUtils";
 import { openUserMessageActions } from "../../userMessageActions";
@@ -36,6 +38,7 @@ import {
 } from "./userMessageOverflow";
 
 interface UserMessageProps {
+  threadId: string;
   item: RuntimeChatItem;
   checkpointRevert: CheckpointRevertRequest | null;
 }
@@ -54,9 +57,19 @@ const lineClampClass =
 const collapsedFadeClass =
   "[mask-image:linear-gradient(to_bottom,black_65%,transparent)] [-webkit-mask-image:linear-gradient(to_bottom,black_65%,transparent)]";
 
-export const UserMessage = memo(function UserMessage({ item, checkpointRevert }: UserMessageProps) {
+export const UserMessage = memo(function UserMessage({
+  threadId,
+  item,
+  checkpointRevert,
+}: UserMessageProps) {
   const { t } = useLingui();
   const actions = useChatPaneActions();
+  const remoteServerId = useAppStore(
+    (state) => state.threads.find((thread) => thread.id === threadId)?.remoteServerId,
+  );
+  const imageUrlForPath = remoteServerId
+    ? (path: string) => useRemoteServersStore.getState().localImageUrl(remoteServerId, path)
+    : undefined;
   const [isExpanded, setIsExpanded] = useState(false);
   const [hasVisualOverflow, setHasVisualOverflow] = useState(false);
   // Starts false so the body renders clamped on first paint; flipped true after
@@ -243,10 +256,11 @@ export const UserMessage = memo(function UserMessage({ item, checkpointRevert }:
               attachments={attachments}
               layout="flush"
               imagesAsPreview
+              {...(imageUrlForPath ? { imageUrlForPath } : {})}
               onPreviewImage={(att) => {
                 const imageAttachments = attachments.filter((a) => a.isImage);
                 const idx = imageAttachments.findIndex((a) => a.id === att.id);
-                if (idx >= 0) openAttachmentLightbox(imageAttachments, idx);
+                if (idx >= 0) openAttachmentLightbox(imageAttachments, idx, imageUrlForPath);
               }}
               onPreviewPdf={(att) => openPdfPreview(att.path)}
             />

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -164,6 +164,7 @@ export interface RemoteServersState {
     input: { readonly threadId: string; readonly data: Uint8Array; readonly extension: string },
   ): Promise<string>;
   pickAndUploadFiles(desktopId: string, attachmentThreadId: string): Promise<string[] | null>;
+  localImageUrl(desktopId: string, path: string): string;
   interruptThread(desktopId: string, threadId: string): Promise<void>;
   closeThread(desktopId: string, threadId: string): Promise<void>;
 }

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -1109,6 +1109,14 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           });
         },
 
+        localImageUrl: (desktopId, path) => {
+          try {
+            return requireClient(desktopId).localImageUrl(path);
+          } catch {
+            return "";
+          }
+        },
+
         interruptThread: async (desktopId, threadId) => {
           // Callers use `void interruptThread(...)`; the renderer's global
           // unhandledrejection handler shows the full-app crash screen for any

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -716,12 +716,13 @@ export class SpawnPipeline {
         ...(session.presentationMode ? { presentationMode: session.presentationMode } : {}),
       });
       if (prompt.trim().length > 0 && structuredSession.startTurn) {
-        const optimisticItemId = ctx.emitOptimisticUserMessage(
-          session.threadId,
-          prompt,
-          turn.segments,
-          turn.userMessageItemId,
-        );
+        // Retry/recovery callers preserve the id of a user message that was
+        // already broadcast before the old session stopped. Reuse it without
+        // emitting another turn.started + item pair. A missing id means this
+        // path owns the first canonical paint and must emit it now.
+        const optimisticItemId =
+          turn.userMessageItemId ??
+          ctx.emitOptimisticUserMessage(session.threadId, prompt, turn.segments);
         const startOptions = {
           userMessageItemId: optimisticItemId,
           ...(turn.inlineInstructions ? { inlineInstructions: turn.inlineInstructions } : {}),

--- a/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.staleInterrupt.test.ts
@@ -359,13 +359,24 @@ describe("ThreadSessionManager structured stale-interrupt watchdog", () => {
     ) {
       throw new Error("Expected an optimistic steer user message.");
     }
+    const optimisticItemId = optimisticStart.event.itemId;
+
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "thread-runtime-event" &&
+          event.event.type === "item.started" &&
+          event.event.itemType === "user_message" &&
+          event.event.itemId === optimisticItemId,
+      ),
+    ).toHaveLength(1);
 
     expect(startTurn).toHaveBeenCalledTimes(1);
     expect(startTurn).toHaveBeenCalledWith(
       "redirect with this image\n\n@/tmp/reference.png",
       { model: `${AGENT_KIND}/model` },
       segments,
-      { userMessageItemId: optimisticStart.event.itemId },
+      { userMessageItemId: optimisticItemId },
     );
     expect(session.pendingSteer).toBeUndefined();
     expect(events).toContainEqual({


### PR DESCRIPTION
- Bugfix
- Preserve staged draft, remote, and handoff attachment files so persisted messages retain their previews.
- Render remote attachment images through their owning server, including lightbox previews and pasted clipboard images.
- Prevent duplicate optimistic user messages when structured sessions recover or retry.