### PR TITLE
Render remote-hosted images in chat

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { isThreadTurnActive, type ProjectLocation, type Thread } from "@/shared/contracts";
 import { resolveGrokSessionDir } from "@/shared/grokSessionMedia";
 import { isHomeProjectId } from "@/shared/homeScope";
+import { resolveLocalFileUrlPath } from "@/shared/promptContent";
 import { readBridge } from "@/renderer/bridge";
 import { useScrollFade } from "@/renderer/hooks/useScrollFade";
 import { useThreadHasBackgroundActivity } from "@/renderer/hooks/uiSelectors";
@@ -21,6 +22,7 @@ import {
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { useProjectRootNames } from "@/renderer/state/projectRootNamesStore";
 import { useProjectTreeStore } from "@/renderer/state/projectTreeStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import {
   buildFileEditorContext,
   openFileInEditor,
@@ -197,6 +199,18 @@ export function ChatPane(props: ChatPaneProps) {
       projectLocation: targetContext.projectLocation,
       projectRootNames,
       ...(markdownImageRoots ? { markdownImageRoots } : {}),
+      ...(thread.remoteServerId
+        ? {
+            remoteLocalImageUrl: (url: string) => {
+              const platform = targetContext.projectLocation.kind === "windows" ? "win32" : "linux";
+              return useRemoteServersStore
+                .getState()
+                .localImageUrl(thread.remoteServerId!, resolveLocalFileUrlPath(url, platform));
+            },
+            remoteImageRefUrl: (ref) =>
+              useRemoteServersStore.getState().imageRefUrl(thread.remoteServerId!, ref),
+          }
+        : {}),
     };
   }, [
     project,
@@ -209,6 +223,7 @@ export function ChatPane(props: ChatPaneProps) {
     onOpenProjectRelativePath,
     onRevealProjectFolderInTree,
     canShowProjectEntryInExplorer,
+    thread.remoteServerId,
   ]);
 
   useEffect(() => {

--- a/src/renderer/components/thread/ChatPane/chatPaneActionsContext.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneActionsContext.ts
@@ -1,5 +1,6 @@
 import { createContext, useContext } from "react";
 import type { ProjectLocation } from "@/shared/contracts";
+import type { RemoteImageRefValue } from "@/shared/remote";
 
 export type ChatPaneActions = {
   openProjectRelativePath: (path: string, lineNumber?: number) => Promise<void>;
@@ -32,6 +33,10 @@ export type ChatPaneActions = {
    * dir so `images/1.jpg` from image_gen resolves under ~/.grok/sessions/…).
    */
   markdownImageRoots?: readonly string[] | undefined;
+  /** Resolve an image held on a remote project's host. */
+  remoteLocalImageUrl?: ((url: string) => string) | undefined;
+  /** Resolve an inline-image reference held in a remote host's transcript. */
+  remoteImageRefUrl?: ((ref: RemoteImageRefValue) => string) | undefined;
 };
 
 export const ChatPaneActionsContext = createContext<ChatPaneActions | null>(null);

--- a/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/AssistantMessage.tsx
@@ -9,6 +9,7 @@ import {
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import { chatMessageSurfaceClass } from "./chatMessageSurface";
+import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { CopyTextButton } from "./CopyTextButton";
 import { ImageCard } from "./ImageCard";
 import { imageViewSourceFromImageBlock } from "./imageViewSource";
@@ -26,6 +27,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   isTurnActive,
 }: AssistantMessageProps) {
   const { t } = useLingui();
+  const actions = useChatPaneActions();
   // The copy action only appears under a turn's *final* answer: the message
   // must be the last top-level item of its turn — any trailing item (another
   // message, a tool call, an error from a failed turn) means the text was an
@@ -65,9 +67,9 @@ export const AssistantMessage = memo(function AssistantMessage({
     () =>
       (payload?.content ?? [])
         .filter((b) => b.kind === "image")
-        .map((b) => imageViewSourceFromImageBlock(b))
+        .map((b) => imageViewSourceFromImageBlock(b, actions?.remoteImageRefUrl))
         .filter((s): s is NonNullable<typeof s> => s !== null),
-    [payload?.content],
+    [actions?.remoteImageRefUrl, payload?.content],
   );
   const showCopyButton = finalAnswerStatus === "confirmed" && !isStreaming && rawText.length > 0;
   // The tail answer's copy action becomes available only once its turn

--- a/src/renderer/components/thread/ChatPane/parts/items/ImageView.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ImageView.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from "react";
 import { Surface } from "@heroui/react";
 import type { ToolCallPayload } from "@/shared/contracts";
 import type { RuntimeChatItem } from "@/renderer/state/slices/runtimeEventSlice";
+import { useChatPaneActions } from "../../chatPaneActionsContext";
 import { chatMessageSurfaceClass } from "./chatMessageSurface";
 import { ImageCard } from "./ImageCard";
 import { resolveImageViewSource } from "./imageViewSource";
@@ -22,7 +23,11 @@ interface ImageViewProps {
  */
 export const ImageView = memo(function ImageView({ item }: ImageViewProps) {
   const payload = item.payload as ToolCallPayload | undefined;
-  const source = useMemo(() => resolveImageViewSource(payload), [payload]);
+  const actions = useChatPaneActions();
+  const source = useMemo(
+    () => resolveImageViewSource(payload, actions?.remoteImageRefUrl),
+    [actions?.remoteImageRefUrl, payload],
+  );
 
   if (!source || payload?.status === "error") {
     return <ToolCall item={item} />;

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.test.tsx
@@ -176,6 +176,27 @@ describe("ItemMarkdownInner", () => {
     );
   });
 
+  it("renders remote markdown image paths through the host image endpoint", () => {
+    const remoteLocalImageUrl = vi.fn<(url: string) => string>(
+      () => "https://remote.test/api/files/image?path=screenshot.png",
+    );
+    const actions = makeActions({ remoteLocalImageUrl });
+
+    render(
+      <AppProvider>
+        <ChatPaneActionsContext.Provider value={actions}>
+          <ItemMarkdownInner text={"![Screenshot](/tmp/screenshot.png)"} />
+        </ChatPaneActionsContext.Provider>
+      </AppProvider>,
+    );
+
+    expect(remoteLocalImageUrl).toHaveBeenCalledWith("poracode-local://local/tmp/screenshot.png");
+    expect(screen.getByAltText("Screenshot")).toHaveAttribute(
+      "src",
+      "https://remote.test/api/files/image?path=screenshot.png",
+    );
+  });
+
   it("renders Windows backslash markdown image paths without CommonMark escape corruption", () => {
     // Paths with `\.` (dot-folders) are mangled by CommonMark unless rewritten
     // to poracode-local:// before parse.

--- a/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ItemMarkdownInner.tsx
@@ -53,11 +53,15 @@ type RehypePlugins = NonNullable<ComponentProps<typeof Streamdown>["rehypePlugin
 // (e.g. `https://sent`) routinely trip it, producing a "[blocked]" flash on
 // otherwise valid URLs. We control external opens through `MdAnchor` and gate
 // file/folder hrefs there too, so harden is redundant here.
-const REHYPE_PLUGINS: RehypePlugins = Object.entries(defaultRehypePlugins)
-  .filter(([key]) => key !== "harden")
-  .flatMap(([key, plugin]) =>
-    key === "sanitize" ? [rehypeLocalImageUrls, allowLocalImageProtocol(plugin)] : [plugin],
-  );
+function buildRehypePlugins(remoteLocalImageUrl?: (url: string) => string): RehypePlugins {
+  return Object.entries(defaultRehypePlugins)
+    .filter(([key]) => key !== "harden")
+    .flatMap(([key, plugin]) =>
+      key === "sanitize"
+        ? [[rehypeLocalImageUrls, { remoteLocalImageUrl }], allowLocalImageProtocol(plugin)]
+        : [plugin],
+    ) as RehypePlugins;
+}
 
 interface ItemMarkdownInnerProps {
   text: string;
@@ -72,6 +76,10 @@ interface ItemMarkdownInnerProps {
 export default function ItemMarkdownInner({ text }: ItemMarkdownInnerProps) {
   const actions = useChatPaneActions();
   const rootNames = actions?.projectRootNames;
+  const rehypePlugins = useMemo(
+    () => buildRehypePlugins(actions?.remoteLocalImageUrl),
+    [actions?.remoteLocalImageUrl],
+  );
   // Escape the React Compiler: the plugin tuple captures `rootNames`, which
   // the compiler conservatively re-creates each render. Streaming chats
   // re-render on every chunk, so anchor the array to `rootNames` identity.
@@ -114,7 +122,7 @@ export default function ItemMarkdownInner({ text }: ItemMarkdownInnerProps) {
     <div className="lc-chat-markdown prose max-w-none text-[length:var(--lc-chat-font-size)] leading-snug text-foreground prose-headings:text-[length:var(--lc-chat-font-size)] prose-p:text-[length:var(--lc-chat-font-size)] prose-p:whitespace-pre-wrap prose-li:text-[length:var(--lc-chat-font-size)] prose-pre:my-2 prose-pre:rounded prose-pre:border-0 prose-pre:bg-foreground/10 prose-pre:px-[0.5em] prose-pre:py-[0.25em] prose-pre:font-mono prose-pre:text-[0.875em] prose-pre:leading-snug prose-pre:whitespace-pre-wrap prose-pre:break-words prose-pre:overflow-x-hidden prose-code:before:content-none prose-code:after:content-none prose-a:text-foreground prose-a:no-underline prose-a:text-[length:inherit] hover:prose-a:underline hover:prose-a:decoration-1 prose-a:underline-offset-2">
       <Streamdown
         remarkPlugins={remarkPlugins}
-        rehypePlugins={REHYPE_PLUGINS}
+        rehypePlugins={rehypePlugins}
         components={MD_COMPONENTS}
         urlTransform={transformMarkdownUrl}
         parseIncompleteMarkdown
@@ -229,13 +237,16 @@ interface MarkdownHastNode {
   children?: MarkdownHastNode[];
 }
 
-function rehypeLocalImageUrls() {
+function rehypeLocalImageUrls(options?: { remoteLocalImageUrl?: (url: string) => string }) {
   return (tree: MarkdownHastNode) => {
-    rewriteLocalImageUrls(tree);
+    rewriteLocalImageUrls(tree, options?.remoteLocalImageUrl);
   };
 }
 
-function rewriteLocalImageUrls(node: MarkdownHastNode): void {
+function rewriteLocalImageUrls(
+  node: MarkdownHastNode,
+  remoteLocalImageUrl?: (url: string) => string,
+): void {
   const src = node.properties?.src;
   // Fallback for absolute paths that skip the pre-parse rewrite (e.g. HTML
   // <img>). Relative project paths need projectRoot and are handled only there.
@@ -245,9 +256,13 @@ function rewriteLocalImageUrls(node: MarkdownHastNode): void {
     // Remote PWA: swap poracode-local sources for the desktop's authenticated
     // HTTP image endpoint. A no-op inside the desktop Electron app, which
     // never installs a resolver (see shared/localImageDisplay.ts).
-    node.properties!.src = resolveLocalImageDisplayUrl(node.properties!.src as string);
+    const localUrl = node.properties!.src as string;
+    node.properties!.src =
+      localUrl.startsWith("poracode-local://") && remoteLocalImageUrl
+        ? remoteLocalImageUrl(localUrl) || localUrl
+        : resolveLocalImageDisplayUrl(localUrl);
   }
-  node.children?.forEach(rewriteLocalImageUrls);
+  node.children?.forEach((child) => rewriteLocalImageUrls(child, remoteLocalImageUrl));
 }
 
 function allowLocalImageProtocol(plugin: RehypePlugins[number]): RehypePlugins[number] {

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.test.ts
@@ -196,6 +196,27 @@ describe("host-minted image references", () => {
     expect(source?.fileName).toBe("a-cat.jpg");
   });
 
+  it("resolves a reference through the current remote pane", () => {
+    const source = resolveImageViewSource(
+      { status: "success", images: [ref] },
+      (value) => `https://remote.test/img/${value.itemId}`,
+    );
+    expect(source?.src).toBe("https://remote.test/img/i1");
+  });
+
+  it("resolves a referenced assistant image block through the current remote pane", () => {
+    const source = imageViewSourceFromImageBlock(
+      { dataUrl: ref, name: "result" },
+      (value) => `https://remote.test/img/${value.itemId}`,
+    );
+    expect(source).toMatchObject({
+      src: "https://remote.test/img/i1",
+      alt: "result",
+      width: 800,
+      height: 600,
+    });
+  });
+
   it("groups as an inline image so the timeline does not demote the row", () => {
     setRemoteImageRefResolver(() => "https://desktop.test/img/i1");
     expect(imageViewRendersInline({ status: "success", images: [ref] })).toBe(true);

--- a/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/imageViewSource.ts
@@ -32,7 +32,11 @@ import {
   type InlineImageClassification,
 } from "@/shared/inlineImagePayload";
 import { readImageDimensions } from "@/shared/imageDimensions";
-import { findDisplayableImageRef, type RemoteImageRefValue } from "@/shared/remote";
+import {
+  findDisplayableImageRef,
+  readRemoteImageRef,
+  type RemoteImageRefValue,
+} from "@/shared/remote";
 import { resolveRemoteImageRefUrl } from "@/shared/imageRefDisplay";
 
 export interface ImageViewSource {
@@ -93,9 +97,12 @@ export function imageViewRendersInline(payload: unknown): boolean {
 }
 
 /** Full resolution: returns the `<img>`-ready source, or `null` when there's no image. */
-export function resolveImageViewSource(payload: unknown): ImageViewSource | null {
+export function resolveImageViewSource(
+  payload: unknown,
+  remoteImageRefUrl?: (ref: RemoteImageRefValue) => string,
+): ImageViewSource | null {
   const ref = readStatus(payload) === "error" ? null : findDisplayableImageRef(payload);
-  if (ref) return imageViewSourceFromRef(ref, payload);
+  if (ref) return imageViewSourceFromRef(ref, payload, remoteImageRefUrl);
   const found = findRenderableInlineImageCandidate(payload);
   if (!found) return null;
   const { value, classification } = found;
@@ -128,8 +135,9 @@ export function resolveImageViewSource(payload: unknown): ImageViewSource | null
 function imageViewSourceFromRef(
   ref: RemoteImageRefValue,
   payload: unknown,
+  remoteImageRefUrl?: (ref: RemoteImageRefValue) => string,
 ): ImageViewSource | null {
-  const src = resolveRemoteImageRefUrl(ref);
+  const src = remoteImageRefUrl?.(ref) || resolveRemoteImageRefUrl(ref);
   if (!src) return null;
   const extension = EXTENSION_BY_MIME[ref.mime] ?? "png";
   const promptText = readPromptText(payload);
@@ -151,11 +159,35 @@ function imageViewSourceFromRef(
  * content block (`{ kind: "image", dataUrl, mimeType?, name? }`). Returns null
  * when the data URL isn't a recognizable inline image.
  */
-export function imageViewSourceFromImageBlock(block: {
-  dataUrl?: unknown;
-  mimeType?: unknown;
-  name?: unknown;
-}): ImageViewSource | null {
+export function imageViewSourceFromImageBlock(
+  block: {
+    dataUrl?: unknown;
+    mimeType?: unknown;
+    name?: unknown;
+  },
+  remoteImageRefUrl?: (ref: RemoteImageRefValue) => string,
+): ImageViewSource | null {
+  const ref = readRemoteImageRef(block.dataUrl);
+  if (ref) {
+    const src = remoteImageRefUrl?.(ref) || resolveRemoteImageRefUrl(ref);
+    if (!src) return null;
+    const extension = EXTENSION_BY_MIME[ref.mime] ?? "png";
+    const name =
+      typeof block.name === "string" && block.name.trim().length > 0
+        ? block.name.trim()
+        : undefined;
+    return {
+      src,
+      mime: ref.mime,
+      extension,
+      fileName: buildFileName(name ?? "", extension),
+      alt: name ?? i18n._(msg`Generated image`),
+      ...(ref.width !== undefined && ref.height !== undefined
+        ? { width: ref.width, height: ref.height }
+        : {}),
+      ...(ref.preview ? { preview: ref.preview } : {}),
+    };
+  }
   if (typeof block.dataUrl !== "string" || block.dataUrl.length === 0) return null;
   const classification = classifyInlineImageCandidate(block.dataUrl);
   if (!classification) return null;

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -18,6 +18,7 @@ import type {
   RemoteAccessScope,
   RemoteAgentStatuses,
   RemoteHostMode,
+  RemoteImageRefValue,
   RemoteProjectCommand,
   RemoteRuntimeItemsPageRequest,
   RemoteShellSnapshot,
@@ -165,6 +166,7 @@ export interface RemoteServersState {
   ): Promise<string>;
   pickAndUploadFiles(desktopId: string, attachmentThreadId: string): Promise<string[] | null>;
   localImageUrl(desktopId: string, path: string): string;
+  imageRefUrl(desktopId: string, ref: RemoteImageRefValue): string;
   interruptThread(desktopId: string, threadId: string): Promise<void>;
   closeThread(desktopId: string, threadId: string): Promise<void>;
 }

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -1117,6 +1117,14 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           }
         },
 
+        imageRefUrl: (desktopId, ref) => {
+          try {
+            return requireClient(desktopId).imageRefUrl(ref);
+          } catch {
+            return "";
+          }
+        },
+
         interruptThread: async (desktopId, threadId) => {
           // Callers use `void interruptThread(...)`; the renderer's global
           // unhandledrejection handler shows the full-app crash screen for any


### PR DESCRIPTION
- Feature: display remote markdown and inline assistant images through host image endpoints.
- Add remote image URL resolution to chat rendering and remote server state.
- Add coverage for remote markdown paths and referenced image blocks.