### PR TITLE
Fix bottom terminal visibility on explicit open

### DIFF
--- a/src/renderer/hooks/useRightPanelThreadLock.test.tsx
+++ b/src/renderer/hooks/useRightPanelThreadLock.test.tsx
@@ -81,6 +81,7 @@ describe("useRightPanelThreadLock", () => {
     });
     useDevTerminalStore.setState({
       isOpen: false,
+      explicitlyOpened: false,
       activeProjectId: null,
       activeWorktreePath: null,
       tabs: [],
@@ -292,6 +293,34 @@ describe("useRightPanelThreadLock", () => {
       tabs: [terminalTabA],
     });
     expect(result.current.rightPanelOpen).toBe(false);
+  });
+
+  it("shows a bottom terminal explicitly opened for another scope", () => {
+    usePanelStore.setState({ gitReviewContext: null, gitReviewAsPanel: false });
+    useDevTerminalStore.setState({ tabs: [terminalTabA] });
+    const { result, rerender } = renderHook(() => {
+      useRightPanelThreadLock();
+      return usePanelVisibility();
+    });
+
+    // Focused on thread-a (project-a); the user clicks the terminal icon for
+    // project-b's worktree. The scope does not match the focused thread, but
+    // the explicit open must reveal the bottom panel immediately.
+    useDevTerminalStore.getState().openWorktreePanel("project-b", threadBWorktreePath);
+    rerender();
+
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      activeProjectId: "project-b",
+      activeWorktreePath: threadBWorktreePath,
+    });
+    expect(result.current.rightPanelOpen).toBe(true);
+
+    // The follow lock cannot re-scope (no tab for thread-b's scope), so the
+    // user's explicit terminal stays visible instead of vanishing.
+    focusThread("thread-b");
+    rerender();
+    expect(result.current.rightPanelOpen).toBe(true);
   });
 
   it("hides the bottom terminal on the new-thread page", () => {

--- a/src/renderer/state/devTerminalStore.test.ts
+++ b/src/renderer/state/devTerminalStore.test.ts
@@ -15,6 +15,7 @@ describe("devTerminalStore cycleTab", () => {
   beforeEach(() => {
     useDevTerminalStore.setState({
       isOpen: false,
+      explicitlyOpened: false,
       activeProjectId: null,
       activeWorktreePath: null,
       tabs: [],
@@ -108,6 +109,65 @@ describe("devTerminalStore cycleTab", () => {
     useDevTerminalStore.getState().cycleTab("next");
     expect(useDevTerminalStore.getState().activeTabId).toBe("b");
     expect(useDevTerminalStore.getState().focusRequestId).toBe(6);
+  });
+});
+
+describe("devTerminalStore explicit open marker", () => {
+  beforeEach(() => {
+    useDevTerminalStore.setState({
+      isOpen: false,
+      explicitlyOpened: false,
+      activeProjectId: null,
+      activeWorktreePath: null,
+      tabs: [],
+      activeTabId: null,
+      focusRequestId: 0,
+      tabActivity: {},
+      streamingTabs: {},
+    });
+  });
+
+  it("marks explicit opens and clears the marker on close and lock re-scope", () => {
+    useDevTerminalStore.getState().openPanel("p1");
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: true,
+      explicitlyOpened: true,
+      activeProjectId: "p1",
+    });
+
+    useDevTerminalStore.getState().closePanel();
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      isOpen: false,
+      explicitlyOpened: false,
+    });
+
+    useDevTerminalStore.getState().openWorktreePanel("p1", "/wt/x");
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      explicitlyOpened: true,
+      activeWorktreePath: "/wt/x",
+    });
+
+    useDevTerminalStore.getState().setPanelScope("p2");
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      explicitlyOpened: false,
+      activeProjectId: "p2",
+    });
+  });
+
+  it("clears the marker on a same-scope re-scope without touching the active tab", () => {
+    useDevTerminalStore.setState({
+      activeProjectId: "p1",
+      tabs: [tab("a", "p1"), tab("b", "p1")],
+      activeTabId: "b",
+    });
+    useDevTerminalStore.getState().openPanel("p1");
+
+    useDevTerminalStore.getState().setPanelScope("p1");
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      explicitlyOpened: false,
+      activeProjectId: "p1",
+      activeTabId: "b",
+    });
   });
 });
 // @vitest-environment node

--- a/src/renderer/state/devTerminalStore.ts
+++ b/src/renderer/state/devTerminalStore.ts
@@ -13,6 +13,15 @@ export interface DevTerminalTab {
 
 interface DevTerminalState {
   isOpen: boolean;
+  /**
+   * True while the panel was opened by an explicit user action (icon click,
+   * auto-show) and the follow-the-thread lock has not re-scoped it since. The
+   * bottom-panel visibility gate uses it so an explicit open shows immediately
+   * even when the terminal's scope does not match the focused thread's scope.
+   * Cleared on close and whenever the lock re-scopes via `setPanelScope`.
+   * Ephemeral — never persisted.
+   */
+  explicitlyOpened: boolean;
   activeProjectId: string | null;
   /** When set, the panel shows worktree tabs for this path; when null, project tabs. */
   activeWorktreePath: string | null;
@@ -75,6 +84,7 @@ function clearStreaming(ids: string[]): void {
 
 export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>()((set, get) => ({
   isOpen: false,
+  explicitlyOpened: false,
   activeProjectId: null,
   activeWorktreePath: null,
   tabs: [],
@@ -86,6 +96,7 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
   openPanel: (projectId) =>
     set((state) => ({
       isOpen: true,
+      explicitlyOpened: true,
       activeProjectId: projectId,
       activeWorktreePath: null,
       focusRequestId: state.focusRequestId + 1,
@@ -93,11 +104,13 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
   openWorktreePanel: (projectId, worktreePath) =>
     set((state) => ({
       isOpen: true,
+      explicitlyOpened: true,
       activeProjectId: projectId,
       activeWorktreePath: worktreePath,
       focusRequestId: state.focusRequestId + 1,
     })),
-  closePanel: () => set({ isOpen: false, activeProjectId: null, activeWorktreePath: null }),
+  closePanel: () =>
+    set({ isOpen: false, explicitlyOpened: false, activeProjectId: null, activeWorktreePath: null }),
 
   setActiveProject: (projectId) => {
     const tabs = get().tabs.filter((t) => t.projectId === projectId);
@@ -109,19 +122,22 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
 
   setPanelScope: (projectId, worktreePath) =>
     set((state) => {
-      if (
+      // The follow lock re-scoping the panel takes over from any explicit
+      // open, so the visibility gate falls back to scope matching.
+      const sameScope =
         state.activeProjectId === projectId &&
-        (state.activeWorktreePath ?? undefined) === worktreePath
-      ) {
+        (state.activeWorktreePath ?? undefined) === worktreePath;
+      if (sameScope && !state.explicitlyOpened) {
         return {};
       }
       const scopedTab = state.tabs.find(
         (tab) => tab.projectId === projectId && (tab.worktreePath ?? undefined) === worktreePath,
       );
       return {
+        explicitlyOpened: false,
         activeProjectId: projectId,
         activeWorktreePath: worktreePath ?? null,
-        activeTabId: scopedTab?.id ?? null,
+        ...(sameScope ? {} : { activeTabId: scopedTab?.id ?? null }),
       };
     }),
 
@@ -336,6 +352,7 @@ export function resetDevTerminalStore(): void {
   clearStreaming([...streamingTimers.keys()]);
   useDevTerminalStore.setState({
     isOpen: false,
+    explicitlyOpened: false,
     activeProjectId: null,
     activeWorktreePath: null,
     tabs: [],

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -8,6 +8,7 @@ import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 
 export function usePanelVisibility() {
   const devTerminalOpen = useDevTerminalStore((s) => s.isOpen);
+  const devTerminalExplicitlyOpened = useDevTerminalStore((s) => s.explicitlyOpened);
   const gitReviewContext = usePanelStore((s) => s.gitReviewContext);
   const gitReviewAsPanel = usePanelStore((s) => s.gitReviewAsPanel);
   const filesPanelContext = usePanelStore((s) => s.filesPanelContext);
@@ -70,9 +71,14 @@ export function usePanelVisibility() {
     todoDockPlacement === "right" &&
     todoDockState !== null &&
     todoDockState.sourceItemId !== retiredTodoSourceItemId;
+  // An explicitly opened terminal shows regardless of the focused thread — the
+  // user asked for it. Once the follow lock re-scopes it (setPanelScope clears
+  // the marker), visibility depends on matching the focused thread's scope.
   const bottomTerminalOpen =
     devTerminalOpen &&
-    (!rightPanelFollowsThread || (currentThreadId !== null && activeTerminalScopeHasTabs));
+    (!rightPanelFollowsThread ||
+      devTerminalExplicitlyOpened ||
+      (currentThreadId !== null && activeTerminalScopeHasTabs));
 
   const rightPanelOpen = isTerminalRight
     ? devTerminalOpen ||


### PR DESCRIPTION
- When the user explicitly opened the bottom terminal (icon click or auto-show) for a scope other than the focused thread, the follow-the-thread visibility gate kept the panel hidden.
- Add an `explicitlyOpened` marker to the dev terminal store, set on explicit open and cleared on close or whenever the follow lock re-scopes the panel via `setPanelScope`.
- The bottom panel now appears immediately for explicit opens; scope matching only governs visibility once the follow lock has taken over.
- Update store and panel-visibility tests to cover the new marker lifecycle and cross-scope explicit open behavior.