### PR TITLE
Disable Grok auto-update in CLI sessions

### DIFF
--- a/src/supervisor/agents/grok/argv.test.ts
+++ b/src/supervisor/agents/grok/argv.test.ts
@@ -2,20 +2,20 @@ import { describe, expect, it } from "vitest";
 import { buildGrokArgs, buildGrokAcpArgs } from "./argv";
 
 describe("buildGrokArgs (TUI/PTY)", () => {
-  it("emits nothing for a bare default config", () => {
-    expect(buildGrokArgs({ mode: "agent" } as any, "", undefined)).toEqual([]);
+  it("disables auto-update for a bare default config", () => {
+    expect(buildGrokArgs({ mode: "agent" } as any, "", undefined)).toEqual(["--no-auto-update"]);
   });
 
   it("passes -r <id> when resuming a materialized session", () => {
     expect(
       buildGrokArgs({ mode: "agent" } as any, "", { kind: "resume", sessionId: "abc-123" }),
-    ).toEqual(["-r", "abc-123"]);
+    ).toEqual(["--no-auto-update", "-r", "abc-123"]);
   });
 
   it("passes -s <id> when pre-assigning a new session id", () => {
     expect(
       buildGrokArgs({ mode: "agent" } as any, "", { kind: "new", sessionId: "abc-123" }),
-    ).toEqual(["-s", "abc-123"]);
+    ).toEqual(["--no-auto-update", "-s", "abc-123"]);
   });
 
   it("never emits -c, --no-plan, or --permission-mode", () => {
@@ -35,6 +35,7 @@ describe("buildGrokArgs (TUI/PTY)", () => {
 
   it("forwards config.effort as --reasoning-effort", () => {
     expect(buildGrokArgs({ mode: "agent", effort: "low" } as any, "", undefined)).toEqual([
+      "--no-auto-update",
       "--reasoning-effort",
       "low",
     ]);
@@ -49,7 +50,7 @@ describe("buildGrokArgs (TUI/PTY)", () => {
   it("adds --always-approve when approval policy bypasses permissions", () => {
     expect(
       buildGrokArgs({ mode: "agent", approvalPolicy: "bypassPermissions" } as any, "", undefined),
-    ).toEqual(["--always-approve"]);
+    ).toEqual(["--no-auto-update", "--always-approve"]);
   });
 
   it("treats legacy 'never' and 'yolo' policies as bypass", () => {
@@ -68,6 +69,7 @@ describe("buildGrokArgs (TUI/PTY)", () => {
 
   it("passes -m <model> when set", () => {
     expect(buildGrokArgs({ mode: "agent", model: "grok-4.5" } as any, "", undefined)).toEqual([
+      "--no-auto-update",
       "-m",
       "grok-4.5",
     ]);
@@ -86,6 +88,7 @@ describe("buildGrokArgs (TUI/PTY)", () => {
         { kind: "new", sessionId: "abc-123" },
       ),
     ).toEqual([
+      "--no-auto-update",
       "-s",
       "abc-123",
       "-m",

--- a/src/supervisor/agents/grok/argv.ts
+++ b/src/supervisor/agents/grok/argv.ts
@@ -86,7 +86,7 @@ export function buildGrokArgs(
   _prompt: string,
   session?: GrokSessionArg,
 ): string[] {
-  const args: string[] = [];
+  const args = ["--no-auto-update"];
 
   if (session?.kind === "resume") {
     args.push("-r", session.sessionId);

--- a/src/supervisor/agents/grok/grok.test.ts
+++ b/src/supervisor/agents/grok/grok.test.ts
@@ -169,9 +169,10 @@ describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", ()
   it("pre-assigns a fresh UUID with -s and returns it as the session ref", () => {
     const adapter = createGrokAdapter();
     const result = adapter.buildLaunchArgv(location, config, "", undefined, {});
-    expect(result.args[0]).toBe("-s");
-    expect(result.args[1]).toMatch(UUID_RE);
-    expect(result.sessionRef?.providerSessionId).toBe(result.args[1]);
+    expect(result.args[0]).toBe("--no-auto-update");
+    expect(result.args[1]).toBe("-s");
+    expect(result.args[2]).toMatch(UUID_RE);
+    expect(result.sessionRef?.providerSessionId).toBe(result.args[2]);
   });
 
   it("resumes a known id with -r when the session dir has materialized", () => {
@@ -186,7 +187,7 @@ describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", ()
       createKnownSessionRef(SESSION_ID),
       {},
     );
-    expect(result.args.slice(0, 2)).toEqual(["-r", SESSION_ID]);
+    expect(result.args.slice(0, 3)).toEqual(["--no-auto-update", "-r", SESSION_ID]);
     expect(result.sessionRef?.providerSessionId).toBe(SESSION_ID);
   });
 
@@ -199,7 +200,7 @@ describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", ()
       createKnownSessionRef(SESSION_ID),
       {},
     );
-    expect(result.args.slice(0, 2)).toEqual(["-s", SESSION_ID]);
+    expect(result.args.slice(0, 3)).toEqual(["--no-auto-update", "-s", SESSION_ID]);
     expect(result.sessionRef?.providerSessionId).toBe(SESSION_ID);
   });
 
@@ -217,13 +218,13 @@ describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", ()
       createKnownSessionRef(SESSION_ID),
       {},
     );
-    expect(result.args.slice(0, 2)).toEqual(["-r", SESSION_ID]);
+    expect(result.args.slice(0, 3)).toEqual(["--no-auto-update", "-r", SESSION_ID]);
   });
 
   it("buildResumeArgv applies the same materialization fallback", () => {
     const adapter = createGrokAdapter();
     const fresh = adapter.buildResumeArgv(location, config, "", createKnownSessionRef(SESSION_ID));
-    expect(fresh.args.slice(0, 2)).toEqual(["-s", SESSION_ID]);
+    expect(fresh.args.slice(0, 3)).toEqual(["--no-auto-update", "-s", SESSION_ID]);
 
     mkdirSync(join(grokHome, "sessions", encodeURIComponent(projectDir), SESSION_ID), {
       recursive: true,
@@ -234,7 +235,7 @@ describe("createGrokAdapter buildLaunchArgv / buildResumeArgv session flags", ()
       "",
       createKnownSessionRef(SESSION_ID),
     );
-    expect(materialized.args.slice(0, 2)).toEqual(["-r", SESSION_ID]);
+    expect(materialized.args.slice(0, 3)).toEqual(["--no-auto-update", "-r", SESSION_ID]);
   });
 
   it("does not project custom MCP servers into Grok's global config", () => {


### PR DESCRIPTION
## What changed

- prepend `--no-auto-update` to Poracode-managed Grok terminal/PTY launches
- preserve the flag for new `-s` sessions and resumed `-r` sessions
- update terminal argv and adapter lifecycle coverage

## Why

Poracode already disables Grok auto-update for managed Chat/ACP, detection, authentication, and headless utility processes. Terminal sessions should use the same app-controlled update policy instead of allowing the child CLI to update itself.

## Validation

- Grok-focused suite: 100 passed
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run fmt:check`
- direct Grok 0.2.118 `--no-auto-update -s <UUID>` and `--no-auto-update -r <UUID>` marker cycle passed
- real isolated Poracode CLI process command line confirmed `grok.exe --no-auto-update -s <UUID> -m grok-4.5 ...`