### PR TITLE
fix(codex): clear existing goal before /goal replacement

### DIFF
--- a/src/supervisor/agents/codex/acp.ts
+++ b/src/supervisor/agents/codex/acp.ts
@@ -344,6 +344,9 @@ export class CodexStructuredSession implements StructuredSessionHandle {
   ): Promise<void> {
     switch (command.kind) {
       case "set":
+        if (this.ensureMapperState().goalItemId) {
+          await this.rpc.request("thread/goal/clear", { threadId });
+        }
         await this.rpc.request("thread/goal/set", {
           threadId,
           objective: command.objective,
@@ -369,12 +372,15 @@ export class CodexStructuredSession implements StructuredSessionHandle {
 
   async controlGoal(control: ThreadGoalControl): Promise<void> {
     const threadId = await this.waitForRemoteThreadId();
-    await this.dispatchCodexGoalCommand(
-      threadId,
-      control.action === "edit"
-        ? { kind: "set", objective: control.objective }
-        : { kind: control.action },
-    );
+    if (control.action === "edit") {
+      await this.rpc.request("thread/goal/set", {
+        threadId,
+        objective: control.objective,
+        status: "active",
+      });
+      return;
+    }
+    await this.dispatchCodexGoalCommand(threadId, { kind: control.action });
   }
 
   private updateSlashCommands(commands: AgentSlashCommand[]): void {

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -1573,6 +1573,46 @@ describe("CodexStructuredSession", () => {
     expect(updates).not.toContainEqual({ status: "idle", attention: "none" });
   });
 
+  it("clears an existing goal before /goal replaces it", async () => {
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const structuredSession = makeStructuredSession(requests);
+    dispatchNotification(structuredSession, {
+      jsonrpc: "2.0",
+      method: "thread/goal/updated",
+      params: {
+        threadId: "provider-thread",
+        turnId: null,
+        goal: {
+          threadId: "provider-thread",
+          objective: "previous goal",
+          status: "active",
+          tokenBudget: null,
+          tokensUsed: 7_900_000,
+          timeUsedSeconds: 29_580,
+          createdAt: 1778570000,
+          updatedAt: 1778599580,
+        },
+      },
+    });
+
+    await structuredSession.startTurn("/goal start fresh", { model: "gpt-5.4" });
+
+    expect(requests).toEqual([
+      {
+        method: "thread/goal/clear",
+        params: { threadId: "provider-thread" },
+      },
+      {
+        method: "thread/goal/set",
+        params: {
+          threadId: "provider-thread",
+          objective: "start fresh",
+          status: "active",
+        },
+      },
+    ]);
+  });
+
   it("settles /goal <objective> when Codex does not start a model turn", async () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     const structuredSession = makeStructuredSession(requests);


### PR DESCRIPTION
- Clear an existing goal before applying a new `/goal` replacement so a previous objective doesn't linger or conflict, keeping the active goal consistent.
- Make goal **edit** act directly via `thread/goal/set` with an `active` status instead of routing through the generic dispatch path.
- Add a test covering the clear-then-set request sequence for `/goal <objective>` replacement.