### PR TITLE
fix(acp): stream subagent content into per-tool-call items

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ActiveSubAgentTile.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/shared/contracts";
 import { deriveToolDisplay, isCrossagentTool, isWorkflowTool } from "./toolDisplay";
 import { AnimatedFraction } from "@/renderer/components/common/AnimatedNumber";
-import { PixelLoader } from "@/renderer/components/common/PixelLoader";
 import { formatTokenCount } from "@/renderer/components/thread/formatTokenCount";
 import {
   ThreadDockActionRow,
@@ -282,6 +281,12 @@ function ActiveSubAgentRow({
   if (registrationOnly || !item || !payload?.name) return null;
 
   const display = deriveToolDisplay(payload);
+  const args =
+    payload.args && typeof payload.args === "object" && !Array.isArray(payload.args)
+      ? (payload.args as Record<string, unknown>)
+      : undefined;
+  const description = typeof args?.description === "string" ? args.description.trim() : undefined;
+  const rowTitle = description || display.title;
   const isDone = !isRunning;
   const progress = payload?.progress;
   const stepCount = progress?.stepCount ?? childCount;
@@ -289,25 +294,23 @@ function ActiveSubAgentRow({
 
   return (
     <ThreadDockActionRow
-      title={display.title}
+      title={rowTitle}
       onClick={() => openSubAgent(threadId, item.id)}
       className={`${isDone ? "opacity-60" : ""} ${!isDone ? "bg-accent/10" : ""}`}
       action={<X className="size-3" />}
-      actionLabel={t`Remove ${display.title} from panel`}
+      actionLabel={t`Remove ${rowTitle} from panel`}
       actionTitle={t`Remove from panel`}
       onAction={() => dismiss(threadId, itemId)}
     >
       {isDone ? (
         <Check aria-label={t`completed`} className="size-3.5 shrink-0 text-foreground-muted" />
       ) : (
-        <span className="inline-flex size-3.5 shrink-0 items-center justify-center">
-          <PixelLoader size="xxs" className="text-foreground" />
-        </span>
+        <Bot className="size-3.5 shrink-0 text-foreground-muted" />
       )}
       <span
         className={`min-w-0 flex-1 truncate leading-5 ${isDone ? "text-foreground-muted" : "text-foreground"}`}
       >
-        {display.title}
+        {rowTitle}
       </span>
       {workflow && workflowRun ? (
         <WorkflowDockStats run={workflowRun} />

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
@@ -264,7 +264,7 @@ describe("SubAgentContent", () => {
     expect(within(region).getByText("Working…")).toBeInTheDocument();
   });
 
-  it("keeps the composer loader without a leading dot or duplicate agent description", () => {
+  it("renders a clean composer row without a loader or duplicate agent description", () => {
     const threadId = "thread-1";
     const parentItem: RuntimeChatItem = {
       id: "parent-1",
@@ -303,8 +303,9 @@ describe("SubAgentContent", () => {
       row?.querySelector('[data-poracode-shimmer-text="Agent · protocol specialist"]'),
     ).toBeNull();
     expect(view.container).toHaveTextContent("Subagents");
+    expect(screen.getByText("protocol specialist")).toBeInTheDocument();
     expect(row?.textContent).not.toContain("specialist·GPT");
-    expect(row?.querySelector(".poracode-pixel-loader")).not.toBeNull();
+    expect(row?.querySelector(".poracode-pixel-loader")).toBeNull();
   });
 
   it("renders Subagents and Crossagents in separate dock sections", () => {

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -34,6 +34,7 @@ import {
   isAcpSubAgentToolCall,
   isTaskCompleteSummary,
   isUpdateTopicTool,
+  PORACODE_ACP_DETACHED_SUBAGENT_ACTIVITY_META_KEY,
   PORACODE_ACP_DETACHED_SUBAGENT_META_KEY,
   PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY,
   PORACODE_ACP_SYNTHESIZE_SUBAGENT_RESULT_META_KEY,
@@ -41,7 +42,13 @@ import {
   selectActiveSubAgentForToolCall,
   tagSubAgentChildStarts,
 } from "./subagents";
-import { closeOpenContentItems, newItemId } from "./state";
+import {
+  closeAllOpenContentItems,
+  closeOpenContentItems,
+  getContentItemState,
+  hasOpenContentItems,
+  newItemId,
+} from "./state";
 import type { ActiveAcpSubAgent, AcpMapperState } from "./state";
 import {
   mapAcpCanonicalGoalUpdate as mapAcpCommandGoalUpdate,
@@ -83,12 +90,14 @@ export function mapAcpSessionUpdate(
 
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
+      const parentToolCallId = activeSubAgent?.toolCallId;
+      const contentState = getContentItemState(state, parentToolCallId);
       const messageMeta =
         update._meta && typeof update._meta === "object" && !Array.isArray(update._meta)
           ? (update._meta as Record<string, unknown>)
           : undefined;
       if (messageMeta?.[PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY] === true) {
-        events.push(...closeOpenContentItems(state));
+        events.push(...closeAllOpenContentItems(state));
       }
       const content = (update as { content?: ContentBlock }).content;
       // Some ACP agents emit an empty text chunk after every tool call. It is
@@ -103,7 +112,7 @@ export function mapAcpSessionUpdate(
       // chat noise on every turn is just clutter. Drop it before we open an
       // assistant item so the chat stays clean.
       if (
-        !state.openAssistantItemId &&
+        !contentState.openAssistantItemId &&
         content?.type === "text" &&
         /^\[MODE_UPDATE\]/.test(content.text)
       ) {
@@ -112,20 +121,20 @@ export function mapAcpSessionUpdate(
       if (content?.type === "text") {
         const apiError = parseAcpAgentMessageApiError(content.text);
         if (apiError) {
-          events.push(...closeOpenContentItems(state));
+          events.push(...closeOpenContentItems(state, parentToolCallId));
           events.push({ type: "error", threadId, message: apiError });
           break;
         }
       }
       // Open an assistant item on first chunk; emit deltas thereafter.
-      if (!state.openAssistantItemId) {
+      if (!contentState.openAssistantItemId) {
         // Close any prior reasoning/user items — assistant is starting fresh.
-        events.push(...closeOpenContentItems(state));
-        state.openAssistantItemId = newItemId("asst");
+        events.push(...closeOpenContentItems(state, parentToolCallId));
+        contentState.openAssistantItemId = newItemId("asst");
         events.push({
           type: "item.started",
           threadId,
-          itemId: state.openAssistantItemId,
+          itemId: contentState.openAssistantItemId,
           itemType: "assistant_message",
         });
       }
@@ -134,7 +143,7 @@ export function mapAcpSessionUpdate(
           events.push({
             type: "content.delta",
             threadId,
-            itemId: state.openAssistantItemId,
+            itemId: contentState.openAssistantItemId,
             stream: "assistant_text",
             delta: content.text,
           });
@@ -144,7 +153,7 @@ export function mapAcpSessionUpdate(
             events.push({
               type: "item.updated",
               threadId,
-              itemId: state.openAssistantItemId,
+              itemId: contentState.openAssistantItemId,
               payload: { content: [block] },
             });
           }
@@ -154,28 +163,30 @@ export function mapAcpSessionUpdate(
     }
 
     case "agent_thought_chunk": {
+      const parentToolCallId = activeSubAgent?.toolCallId;
+      const contentState = getContentItemState(state, parentToolCallId);
       const thoughtMeta =
         update._meta && typeof update._meta === "object" && !Array.isArray(update._meta)
           ? (update._meta as Record<string, unknown>)
           : undefined;
       if (thoughtMeta?.[PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY] === true) {
-        events.push(...closeOpenContentItems(state));
+        events.push(...closeAllOpenContentItems(state));
       }
-      if (!state.openReasoningItemId) {
+      if (!contentState.openReasoningItemId) {
         // Close any prior assistant — reasoning bracket starts.
-        if (state.openAssistantItemId) {
+        if (contentState.openAssistantItemId) {
           events.push({
             type: "item.completed",
             threadId,
-            itemId: state.openAssistantItemId,
+            itemId: contentState.openAssistantItemId,
           });
-          delete state.openAssistantItemId;
+          delete contentState.openAssistantItemId;
         }
-        state.openReasoningItemId = newItemId("reason");
+        contentState.openReasoningItemId = newItemId("reason");
         events.push({
           type: "item.started",
           threadId,
-          itemId: state.openReasoningItemId,
+          itemId: contentState.openReasoningItemId,
           itemType: "reasoning",
         });
       }
@@ -184,7 +195,7 @@ export function mapAcpSessionUpdate(
         events.push({
           type: "content.delta",
           threadId,
-          itemId: state.openReasoningItemId,
+          itemId: contentState.openReasoningItemId,
           stream: "reasoning_text",
           delta: content.text,
         });
@@ -206,7 +217,7 @@ export function mapAcpSessionUpdate(
 
     case "tool_call": {
       // First seal any open assistant/reasoning so the tool-call surfaces in order.
-      events.push(...closeOpenContentItems(state));
+      events.push(...closeOpenContentItems(state, activeSubAgent?.toolCallId));
       const toolCall = update as {
         toolCallId: string;
         title?: string | null;
@@ -274,7 +285,7 @@ export function mapAcpSessionUpdate(
         state.suppressedTodoWriteIds.add(toolCall.toolCallId);
         const steps = extractAcpTodoWriteSteps(toolCall.rawInput);
         if (steps.length > 0) {
-          events.push(...emitAcpPlanSteps(state, steps));
+          events.push(...emitAcpPlanSteps(state, steps, activeSubAgent?.toolCallId));
         }
         break;
       }
@@ -372,7 +383,7 @@ export function mapAcpSessionUpdate(
         if (state.suppressedTodoWriteIds.has(toolCall.toolCallId)) {
           const steps = extractAcpTodoWriteSteps(toolCall.rawInput);
           if (steps.length > 0) {
-            events.push(...emitAcpPlanSteps(state, steps));
+            events.push(...emitAcpPlanSteps(state, steps, activeSubAgent?.toolCallId));
           }
         }
         if (toolCall.status === "completed" || toolCall.status === "failed") {
@@ -401,6 +412,9 @@ export function mapAcpSessionUpdate(
         item.detached = true;
       }
       const isTerminal = toolCall.status === "completed" || toolCall.status === "failed";
+      const hasTopLevelDetachedReply =
+        updateMeta?.[PORACODE_ACP_DETACHED_SUBAGENT_ACTIVITY_META_KEY] === toolCall.toolCallId &&
+        hasOpenContentItems(state);
       const status =
         toolCall.status === "completed"
           ? "success"
@@ -420,7 +434,7 @@ export function mapAcpSessionUpdate(
         item.isSubAgent &&
         isTerminal &&
         updateMeta?.[PORACODE_ACP_SYNTHESIZE_SUBAGENT_RESULT_META_KEY] !== true &&
-        (state.openAssistantItemId !== undefined || state.openReasoningItemId !== undefined);
+        (hasOpenContentItems(state, activeSubAgent?.toolCallId) || hasTopLevelDetachedReply);
       const subAgentProgress =
         item.isSubAgent && !hasOpenSubAgentContent
           ? buildSubAgentProgress(toolCall, payload, status)
@@ -442,7 +456,8 @@ export function mapAcpSessionUpdate(
         : { merged: mergedRaw, emitted: emittedRaw };
       item.payload = mergedPayload;
       if (isTerminal && item.isSubAgent) {
-        events.push(...closeOpenContentItems(state));
+        if (hasTopLevelDetachedReply) events.push(...closeOpenContentItems(state));
+        events.push(...closeOpenContentItems(state, activeSubAgent?.toolCallId));
       }
       const parentEvent: RuntimeEvent = {
         type: isTerminal ? "item.completed" : "item.updated",
@@ -486,7 +501,7 @@ export function mapAcpSessionUpdate(
       };
       const rawEntries = plan.entries ?? plan.content?.entries ?? [];
       const steps = rawEntries.map((entry) => ({ step: entry.content, status: entry.status }));
-      events.push(...emitAcpPlanSteps(state, steps));
+      events.push(...emitAcpPlanSteps(state, steps, activeSubAgent?.toolCallId));
       break;
     }
 
@@ -514,11 +529,11 @@ export function mapAcpSessionUpdate(
           step: entry.content,
           status: entry.status,
         }));
-        events.push(...emitAcpPlanSteps(state, steps));
+        events.push(...emitAcpPlanSteps(state, steps, activeSubAgent?.toolCallId));
       } else if (content.type === "markdown" && typeof content.content === "string") {
         const steps = parsePlanMarkdownSteps(content.content);
         if (steps.length > 0) {
-          events.push(...emitAcpPlanSteps(state, steps));
+          events.push(...emitAcpPlanSteps(state, steps, activeSubAgent?.toolCallId));
         }
       }
       // `file` variant: the plan lives in a file referenced by URI. The pure
@@ -594,12 +609,13 @@ export function mapAcpSessionUpdate(
 function emitAcpPlanSteps(
   state: AcpMapperState,
   steps: Array<{ step: string; status: "pending" | "in_progress" | "completed" }>,
+  parentToolCallId?: string,
 ): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
   const { threadId } = state;
   state.openPlanSteps = steps;
   if (!state.openPlanItemId) {
-    events.push(...closeOpenContentItems(state));
+    events.push(...closeOpenContentItems(state, parentToolCallId));
     state.openPlanItemId = newItemId("plan");
     events.push({
       type: "item.started",

--- a/src/supervisor/agents/acp/canonicalMapping/state.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/state.ts
@@ -30,6 +30,12 @@ export interface ActiveAcpSubAgent {
   hasChildActivity: boolean;
 }
 
+export interface AcpContentItemState {
+  openAssistantItemId?: string;
+  openReasoningItemId?: string;
+  openUserItemId?: string;
+}
+
 /** Per-session state — tracks open items so deltas land on the right item id. */
 export interface AcpMapperState {
   threadId: string;
@@ -39,6 +45,8 @@ export interface AcpMapperState {
   openReasoningItemId?: string;
   /** Item id of the currently-streaming user message, if any. */
   openUserItemId?: string;
+  /** Open streamed content keyed by its owning subagent tool call. */
+  subAgentContentItems: Map<string, AcpContentItemState>;
   /** Map ACP `toolCallId` → our internal item id + canonical item type + payload. */
   toolCallItems: Map<string, AcpToolCallItemState>;
   /**
@@ -91,6 +99,7 @@ export function createAcpMapperState(threadId: string): AcpMapperState {
     threadId,
     toolCallItems: new Map(),
     activeSubAgents: [],
+    subAgentContentItems: new Map(),
     suppressedToolCallIds: new Set(),
     suppressedTodoWriteIds: new Set(),
   };
@@ -105,13 +114,43 @@ const OPEN_CONTENT_ITEM_KEYS = [
 ] as const;
 
 /** Close any open assistant/user/reasoning items as a turn boundary. */
-export function closeOpenContentItems(state: AcpMapperState): RuntimeEvent[] {
+export function getContentItemState(
+  state: AcpMapperState,
+  parentToolCallId?: string,
+): AcpContentItemState {
+  if (!parentToolCallId) return state;
+  const existing = state.subAgentContentItems.get(parentToolCallId);
+  if (existing) return existing;
+  const created: AcpContentItemState = {};
+  state.subAgentContentItems.set(parentToolCallId, created);
+  return created;
+}
+
+export function hasOpenContentItems(state: AcpMapperState, parentToolCallId?: string): boolean {
+  const contentState = parentToolCallId ? state.subAgentContentItems.get(parentToolCallId) : state;
+  return OPEN_CONTENT_ITEM_KEYS.some((key) => contentState?.[key] !== undefined);
+}
+
+export function closeAllOpenContentItems(state: AcpMapperState): RuntimeEvent[] {
+  const events = closeOpenContentItems(state);
+  for (const toolCallId of state.subAgentContentItems.keys()) {
+    events.push(...closeOpenContentItems(state, toolCallId));
+  }
+  return events;
+}
+
+export function closeOpenContentItems(
+  state: AcpMapperState,
+  parentToolCallId?: string,
+): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
+  const contentState = parentToolCallId ? state.subAgentContentItems.get(parentToolCallId) : state;
+  if (!contentState) return events;
   for (const key of OPEN_CONTENT_ITEM_KEYS) {
-    const itemId = state[key];
+    const itemId = contentState[key];
     if (itemId) {
       events.push({ type: "item.completed", threadId: state.threadId, itemId });
-      delete state[key];
+      delete contentState[key];
     }
   }
   return events;
@@ -129,6 +168,9 @@ export function resetMapperForTurnEnd(state: AcpMapperState): void {
   state.activeSubAgents = state.activeSubAgents.filter((active) =>
     state.toolCallItems.has(active.toolCallId),
   );
+  for (const toolCallId of state.subAgentContentItems.keys()) {
+    if (!state.toolCallItems.has(toolCallId)) state.subAgentContentItems.delete(toolCallId);
+  }
   state.suppressedToolCallIds.clear();
   state.suppressedTodoWriteIds.clear();
   delete state.openPlanItemId;

--- a/src/supervisor/agents/acp/canonicalMapping/subagents.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/subagents.ts
@@ -217,6 +217,7 @@ export function removeActiveSubAgent(state: AcpMapperState, toolCallId: string):
     state.activeSubAgents.splice(index, 1);
     break;
   }
+  state.subAgentContentItems.delete(toolCallId);
 }
 
 export function tagSubAgentChildStarts(

--- a/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
@@ -280,8 +280,9 @@ export function applyTerminalToolCallName(
 /** Close any open assistant/user/reasoning/tool-call/plan items as a turn boundary. */
 export function closeOpenTurnItems(state: AcpMapperState): RuntimeEvent[] {
   const events = closeOpenContentItems(state);
-  for (const item of state.toolCallItems.values()) {
+  for (const [toolCallId, item] of state.toolCallItems) {
     if (item.detached) continue;
+    events.push(...closeOpenContentItems(state, toolCallId));
     events.push({
       type: "item.completed",
       threadId: state.threadId,

--- a/src/supervisor/agents/grok/acpTransform.test.ts
+++ b/src/supervisor/agents/grok/acpTransform.test.ts
@@ -140,6 +140,14 @@ describe("createGrokAcpSessionUpdateTransform", () => {
     );
     const parentItemId = parentStart?.type === "item.started" ? parentStart.itemId : undefined;
     expect(parentItemId).toBeDefined();
+    const parentArgs =
+      parentStart?.type === "item.started" &&
+      parentStart.payload &&
+      typeof parentStart.payload === "object" &&
+      !Array.isArray(parentStart.payload)
+        ? (parentStart.payload as Record<string, unknown>).args
+        : undefined;
+    expect(parentArgs).not.toHaveProperty("subagent_type");
 
     const receipt = transform(
       notification(PARENT_SESSION_ID, {
@@ -319,6 +327,7 @@ describe("createGrokAcpSessionUpdateTransform", () => {
       return started?.type === "item.started" ? started.itemId : undefined;
     });
 
+    const reasoningItemIds: string[] = [];
     for (const [index, childSessionId] of childSessions.entries()) {
       const events = mapAcpSessionUpdate(
         transform(
@@ -336,33 +345,105 @@ describe("createGrokAcpSessionUpdateTransform", () => {
           parentItemId: parentItemIds[index],
         }),
       );
+      const started = events.find(
+        (event) => event.type === "item.started" && event.itemType === "reasoning",
+      );
+      if (started?.type === "item.started") reasoningItemIds[index] = started.itemId;
+    }
+
+    for (const [index, childSessionId] of childSessions.entries()) {
+      const events = mapAcpSessionUpdate(
+        transform(
+          notification(childSessionId, {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: ` continued ${childSessionId}` },
+          }),
+        ),
+        state,
+      );
+      expect(events).not.toContainEqual(expect.objectContaining({ type: "item.started" }));
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "content.delta",
+          itemId: reasoningItemIds[index],
+          delta: ` continued ${childSessionId}`,
+        }),
+      );
     }
   });
 
-  it("suppresses internal Grok goal subagents that have no parent tool card", () => {
+  it("surfaces internal Grok goal subagents that keep the parent thread working", () => {
     const transform = createGrokAcpSessionUpdateTransform();
     const state = createAcpMapperState("thread-1");
 
-    transform(
-      notification(PARENT_SESSION_ID, {
-        sessionUpdate: "subagent_spawned",
-        subagent_id: CHILD_SESSION_ID,
-        child_session_id: CHILD_SESSION_ID,
-        parent_session_id: PARENT_SESSION_ID,
-        subagent_type: "general-purpose",
-        description: "goal plan writer",
-      }),
-    );
-
-    const events = mapAcpSessionUpdate(
+    const launchEvents = mapAcpSessionUpdate(
       transform(
-        notification(CHILD_SESSION_ID, {
-          sessionUpdate: "agent_message_chunk",
-          content: { type: "text", text: "internal goal planning" },
+        notification(PARENT_SESSION_ID, {
+          sessionUpdate: "subagent_spawned",
+          subagent_id: CHILD_SESSION_ID,
+          child_session_id: CHILD_SESSION_ID,
+          parent_session_id: PARENT_SESSION_ID,
+          subagent_type: "general-purpose",
+          description: "goal achievement skeptic",
         }),
       ),
       state,
     );
-    expect(events).toEqual([]);
+    const parentStart = launchEvents.find(
+      (event) =>
+        event.type === "item.started" &&
+        (event.payload as Record<string, unknown> | undefined)?.isSubAgent === true,
+    );
+    const parentItemId = parentStart?.type === "item.started" ? parentStart.itemId : undefined;
+    expect(parentStart).toMatchObject({
+      type: "item.started",
+      payload: expect.objectContaining({
+        status: "running",
+        args: expect.objectContaining({
+          description: "goal achievement skeptic",
+          background: true,
+        }),
+      }),
+    });
+    const parentArgs =
+      parentStart?.type === "item.started" &&
+      parentStart.payload &&
+      typeof parentStart.payload === "object" &&
+      !Array.isArray(parentStart.payload)
+        ? (parentStart.payload as Record<string, unknown>).args
+        : undefined;
+    expect(parentArgs).not.toHaveProperty("subagent_type");
+
+    const childEvents = mapAcpSessionUpdate(
+      transform(
+        notification(CHILD_SESSION_ID, {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Checking whether the goal is complete" },
+        }),
+      ),
+      state,
+    );
+    expect(childEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "assistant_message",
+        parentItemId,
+      }),
+    );
+
+    const finished = mapAcpSessionUpdate(
+      transform(
+        notification(PARENT_SESSION_ID, {
+          sessionUpdate: "subagent_finished",
+          subagent_id: CHILD_SESSION_ID,
+          child_session_id: CHILD_SESSION_ID,
+          status: "completed",
+        }),
+      ),
+      state,
+    );
+    expect(finished).toContainEqual(
+      expect.objectContaining({ type: "item.completed", itemId: parentItemId }),
+    );
   });
 });

--- a/src/supervisor/agents/grok/acpTransform.ts
+++ b/src/supervisor/agents/grok/acpTransform.ts
@@ -1,12 +1,10 @@
 import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { PORACODE_ACP_GOAL_META_KEY, type AcpCanonicalGoalUpdate } from "../acp/canonicalMapping";
 import {
-  PORACODE_ACP_GOAL_META_KEY,
-  PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY,
-  type AcpCanonicalGoalUpdate,
-} from "../acp/canonicalMapping";
-import {
+  buildCanonicalAcpSubagentInput,
   createAcpSubagentCoordinator,
   normalizeAcpSubagentToolCall,
+  type AcpSubagentDescriptor,
   withAcpSubagentParent,
   withAcpTopLevelToolCall,
 } from "../acp/subagentCoordinator";
@@ -22,7 +20,6 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
   const ignoredChildSessions = new Set<string>();
   const seenGoalIds = new Set<string>();
   let parentSessionId: string | undefined;
-  let contentOwnerSessionId: string | undefined;
 
   return (notification) => {
     const update = plainRecord(notification.update);
@@ -43,19 +40,50 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
         readString(update, "description"),
         readString(update, "subagent_type"),
       );
-      if (childSessionId && toolCallId) {
-        const taskId = readString(update, "subagent_id") ?? childSessionId;
-        childSessionByToolCallId.set(toolCallId, childSessionId);
-        toolCallIdByChildSession.set(childSessionId, toolCallId);
-        subagents.registerBackgroundLaunch({
-          sessionId: parentSessionId,
-          toolCallId,
-          taskId,
+      if (!childSessionId) return asNoop(notification);
+
+      const resolvedToolCallId = toolCallId ?? `grok-subagent-${childSessionId}`;
+      const taskId = readString(update, "subagent_id") ?? childSessionId;
+      let syntheticRawInput: Record<string, unknown> | undefined;
+      let syntheticDescription: string | undefined;
+      if (!toolCallId) {
+        const subagentType = readString(update, "subagent_type");
+        syntheticDescription = readString(update, "description");
+        const model = readString(update, "model");
+        const descriptor = subagents.updateCall(resolvedToolCallId, {
+          rawInput: {
+            ...(subagentType ? { subagent_type: subagentType } : {}),
+            ...(syntheticDescription ? { description: syntheticDescription } : {}),
+            ...(model ? { model } : {}),
+            background: true,
+          },
         });
-      } else if (childSessionId) {
-        ignoredChildSessions.add(childSessionId);
+        syntheticRawInput = buildCanonicalGrokSubagentInput(descriptor);
       }
-      return asNoop(notification);
+      childSessionByToolCallId.set(resolvedToolCallId, childSessionId);
+      toolCallIdByChildSession.set(childSessionId, resolvedToolCallId);
+      subagents.registerBackgroundLaunch({
+        sessionId: parentSessionId,
+        toolCallId: resolvedToolCallId,
+        taskId,
+      });
+      if (!syntheticRawInput) return asNoop(notification);
+
+      const syntheticLaunch = withUpdate(notification, {
+        sessionUpdate: "tool_call",
+        toolCallId: resolvedToolCallId,
+        title: syntheticDescription ?? GROK_SPAWN_SUBAGENT_TOOL,
+        kind: "other",
+        status: "in_progress",
+        rawInput: syntheticRawInput,
+      });
+      return withAcpTopLevelToolCall(
+        normalizeAcpSubagentToolCall(syntheticLaunch, {
+          rawInput: syntheticRawInput,
+          detached: true,
+          keepOpen: true,
+        }),
+      );
     }
 
     if (sessionUpdate === "subagent_finished") {
@@ -84,9 +112,7 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
 
     const childToolCallId = toolCallIdByChildSession.get(notification.sessionId);
     if (childToolCallId) {
-      const bounded = withContentBoundary(notification, sessionUpdate, contentOwnerSessionId);
-      contentOwnerSessionId = bounded.ownerSessionId;
-      return withAcpSubagentParent(bounded.notification, childToolCallId);
+      return withAcpSubagentParent(notification, childToolCallId);
     }
     if (
       ignoredChildSessions.has(notification.sessionId) ||
@@ -96,22 +122,18 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
     }
     parentSessionId ??= notification.sessionId;
 
-    const bounded = withContentBoundary(notification, sessionUpdate, contentOwnerSessionId);
-    contentOwnerSessionId = bounded.ownerSessionId;
-    const boundedNotification = bounded.notification;
-
     if (sessionUpdate !== "tool_call" && sessionUpdate !== "tool_call_update") {
-      return boundedNotification;
+      return notification;
     }
     const toolCallId = readString(update, "toolCallId");
-    if (!toolCallId) return boundedNotification;
+    if (!toolCallId) return notification;
     if (isMappedTaskOutput(update, subagents)) return asNoop(notification);
     const metaTool = plainRecord(plainRecord(update._meta)["x.ai/tool"]);
     const isSpawn =
       readString(metaTool, "name") === GROK_SPAWN_SUBAGENT_TOOL ||
       readString(update, "title") === GROK_SPAWN_SUBAGENT_TOOL ||
       subagents.getCall(toolCallId) !== undefined;
-    if (!isSpawn) return boundedNotification;
+    if (!isSpawn) return notification;
 
     const descriptor = subagents.updateCall(toolCallId, {
       rawInput: plainRecord(update.rawInput),
@@ -119,8 +141,8 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
     if (!pendingToolCallIds.includes(toolCallId)) pendingToolCallIds.push(toolCallId);
     const terminal = update.status === "completed" || update.status === "failed";
     const backgroundLaunchReceipt = descriptor.background && terminal;
-    const normalized = normalizeAcpSubagentToolCall(boundedNotification, {
-      rawInput: subagents.canonicalInput(toolCallId),
+    const normalized = normalizeAcpSubagentToolCall(notification, {
+      rawInput: buildCanonicalGrokSubagentInput(descriptor),
       detached: descriptor.background,
       keepOpen: backgroundLaunchReceipt,
       ...(backgroundLaunchReceipt ? { omitContent: true, omitRawOutput: true } : {}),
@@ -140,6 +162,14 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
   };
 }
 
+function buildCanonicalGrokSubagentInput(
+  descriptor: AcpSubagentDescriptor,
+): Record<string, unknown> {
+  const input = buildCanonicalAcpSubagentInput(descriptor);
+  if (input.subagent_type === "general-purpose") delete input.subagent_type;
+  return input;
+}
+
 function isMappedTaskOutput(
   update: Record<string, unknown>,
   subagents: ReturnType<typeof createAcpSubagentCoordinator>,
@@ -147,30 +177,6 @@ function isMappedTaskOutput(
   const rawInput = plainRecord(update.rawInput);
   const taskIds = readStringArray(rawInput, "task_ids");
   return taskIds.length === 1 && subagents.resolveBackgroundToolCallId(taskIds[0]!) !== undefined;
-}
-
-function withContentBoundary(
-  notification: SessionNotification,
-  sessionUpdate: string | undefined,
-  ownerSessionId: string | undefined,
-): { notification: SessionNotification; ownerSessionId: string | undefined } {
-  if (sessionUpdate !== "agent_message_chunk" && sessionUpdate !== "agent_thought_chunk") {
-    return { notification, ownerSessionId };
-  }
-  if (!ownerSessionId || ownerSessionId === notification.sessionId) {
-    return { notification, ownerSessionId: notification.sessionId };
-  }
-  const update = plainRecord(notification.update);
-  return {
-    notification: withUpdate(notification, {
-      ...update,
-      _meta: {
-        ...plainRecord(update._meta),
-        [PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY]: true,
-      },
-    }),
-    ownerSessionId: notification.sessionId,
-  };
 }
 
 function readGrokGoalUpdate(


### PR DESCRIPTION
- Streams ACP subagent working content into per-tool-call items keyed by the owning subagent tool call, so subagent output no longer leaks into the main thread (message, thought, and plan chunks included).
- Opens and closes content items per subagent tool call at turn boundaries and when subagents finish or are removed, with cleanup of orphaned content state.
- Composer tile now uses the subagent's description as the row title and a bot icon instead of the pixel loader while running, producing a cleaner dock row.
- Grok transform drops the internal `subagent_type` from canonical subagent args and removes the stale content-boundary workaround in favor of the new per-tool-call routing.