### PR TITLE
fix(thread): refresh remote server status after auth

### DIFF
--- a/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
+++ b/src/renderer/components/thread/ThreadAuthRequiredDock.tsx
@@ -7,6 +7,7 @@ import { isRemoteSession, readBridge } from "@/renderer/bridge";
 import { runAgentLoginCommand } from "@/renderer/actions/agentLoginActions";
 import { openSettings } from "@/renderer/actions/panelActions";
 import { Button } from "@/renderer/components/common/Button";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import {
   agentAuthTarget,
   currentWslDistros,
@@ -17,7 +18,11 @@ import {
 } from "@/renderer/utils/acpRegistryAuth";
 import { ThreadDockHeader, ThreadDockIconButton, ThreadDockSection } from "./ThreadDockUI";
 
-async function refreshAgentStatus(status: AgentStatus): Promise<void> {
+async function refreshAgentStatus(status: AgentStatus, project?: Project): Promise<void> {
+  if (project?.remoteServerId) {
+    await useRemoteServersStore.getState().refreshServer(project.remoteServerId);
+    return;
+  }
   await readBridge().refreshAgentStatuses(currentWslDistros(), {
     agentKinds: [status.kind],
     envs: [scopeEnvForStatus(status)],
@@ -69,7 +74,7 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
           // Unlock the button as soon as the command exits so the user can
           // retry without waiting for the (post-exit) status refresh.
           setPendingAction(undefined);
-          void refreshAgentStatus(agentStatus)
+          void refreshAgentStatus(agentStatus, project)
             .then(() => {
               if (exitCode === 0) toast.success(t`${agentStatus.label} authenticated.`);
             })
@@ -95,7 +100,7 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
           ...agentAuthTarget(agentStatus),
         });
         void readBridge().focusWindow();
-        await refreshAgentStatus(agentStatus);
+        await refreshAgentStatus(agentStatus, project);
         toast.success(t`${agentStatus.label} authenticated.`);
       } catch (error) {
         toast.danger(
@@ -112,7 +117,7 @@ export function ThreadAuthRequiredDock(props: { agentStatus: AgentStatus; projec
     if (pendingAction) return;
     setPendingAction("refresh");
     try {
-      await refreshAgentStatus(agentStatus);
+      await refreshAgentStatus(agentStatus, project);
     } catch (error) {
       toast.danger(
         error instanceof Error ? error.message : t`Unable to refresh ${agentStatus.label}.`,

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/renderer/state/composerInputInbox";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { ThreadComposerSection } from "./ThreadComposerSection";
 import type { ThreadErrorDockState } from "./threadErrorState";
 
@@ -29,6 +30,12 @@ const runtimeActions = vi.hoisted(() => ({
   changeThreadConfig: vi.fn<() => void>(),
   resolveThreadServerRequest: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   submitThreadInput: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+}));
+
+const loginActions = vi.hoisted(() => ({
+  runAgentLoginCommand: vi.fn<
+    (input: { onCommandComplete?: (exitCode: number) => void }) => boolean
+  >(() => true),
 }));
 
 const analytics = vi.hoisted(() => ({
@@ -52,6 +59,10 @@ vi.mock("@/renderer/actions/threadRuntimeActions", async (importOriginal) => ({
   changeThreadConfig: runtimeActions.changeThreadConfig,
   resolveThreadServerRequest: runtimeActions.resolveThreadServerRequest,
   submitThreadInput: runtimeActions.submitThreadInput,
+}));
+
+vi.mock("@/renderer/actions/agentLoginActions", () => ({
+  runAgentLoginCommand: loginActions.runAgentLoginCommand,
 }));
 
 vi.mock("../../bridge", () => ({
@@ -216,6 +227,7 @@ describe("ThreadComposerSection", () => {
     bridgeMock.clearPendingSteer.mockClear();
     bridgeMock.clearPendingSteer.mockResolvedValue(undefined);
     bridgeMock.refreshAgentStatuses.mockClear();
+    loginActions.runAgentLoginCommand.mockClear();
     bridgeMock.interruptThread.mockClear();
     bridgeMock.interruptThread.mockResolvedValue(undefined);
     bridgeMock.setPendingSteer.mockClear();
@@ -900,6 +912,44 @@ describe("ThreadComposerSection", () => {
     await waitFor(() => {
       expect(bridgeMock.refreshAgentStatuses).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("refreshes the owning remote desktop after remote agent authentication", async () => {
+    const refreshServer = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const originalRefreshServer = useRemoteServersStore.getState().refreshServer;
+    useRemoteServersStore.setState({ refreshServer });
+    useAppStore.setState({
+      projects: [
+        {
+          id: "project-1",
+          name: "Remote repo",
+          location: { kind: "posix", path: "/repo", remoteServerId: "desktop-1" },
+          remoteServerId: "desktop-1",
+          remoteId: "remote-project-1",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    renderComposer({
+      thread: { ...terminalThread, remoteServerId: "desktop-1", remoteId: "remote-thread-1" },
+      agentStatus: {
+        ...claudeTerminalStatus,
+        authState: "missing",
+        loginCommand: "claude auth login",
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+
+    const onCommandComplete =
+      loginActions.runAgentLoginCommand.mock.calls[0]?.[0].onCommandComplete;
+    expect(onCommandComplete).toBeDefined();
+    act(() => onCommandComplete?.(0));
+
+    await waitFor(() => expect(refreshServer).toHaveBeenCalledWith("desktop-1"));
+    expect(bridgeMock.refreshAgentStatuses).not.toHaveBeenCalled();
+    useRemoteServersStore.setState({ refreshServer: originalRefreshServer });
   });
 
   it("disables desktop-local attachment drops in remote sessions", () => {


### PR DESCRIPTION
- Fixes the auth-required dock refreshing local agent statuses when the thread belongs to a remote server, leaving the remote status stale after login
- Routes status refresh to the remote server store's `refreshServer` when the project has a `remoteServerId`, skipping the local bridge refresh
- Applies the fix across all refresh paths: post-login command completion, browser-login completion, and manual refresh
- Adds test coverage verifying remote auth completion calls `refreshServer` and not the local status refresh