### PR TITLE
refactor(browser-host): extract webview positioning into a hook

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -15,7 +15,7 @@ import { clearTimelineMeasurementCache } from "./timelineMeasurementCache";
 type MockLegendProps = {
   data: readonly ChatTimelineEntry[];
   dataKey: string;
-  drawDistance: number;
+  drawDistance?: number;
   estimatedItemSize: number;
   getFixedItemSize: (item: ChatTimelineEntry, index: number, type: string) => number | undefined;
   getItemType: (item: ChatTimelineEntry, index: number) => string;
@@ -217,7 +217,7 @@ describe("MessageList", () => {
 
     const props = latestLegendProps.current as MockLegendProps;
     expect(props.dataKey).toBe("thread-1");
-    expect(props.drawDistance).toBe(1_000);
+    expect(props.drawDistance).toBeUndefined();
     expect(props.estimatedItemSize).toBe(59);
     expect(props.initialScrollAtEnd).toBe(true);
     expect(props.maintainScrollAtEnd).toEqual({

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.tsx
@@ -113,9 +113,6 @@ interface MessageListProps {
   ) => void;
 }
 
-// Keep enough content mounted around the viewport that fast trackpad movement
-// cannot outrun the next virtual range.
-const CHAT_TRANSCRIPT_DRAW_DISTANCE_PX = 1_000;
 const DEFAULT_ROW_ESTIMATE_PX = 59;
 const INLINE_IMAGE_ROW_CHROME_PX = 27;
 const INLINE_IMAGE_MAX_HEIGHT_REM = 18;
@@ -423,7 +420,6 @@ export function MessageList({
         ref={setListRef}
         data={entries}
         dataKey={threadId}
-        drawDistance={CHAT_TRANSCRIPT_DRAW_DISTANCE_PX}
         estimatedItemSize={DEFAULT_ROW_ESTIMATE_PX}
         extraData={`${lastLiveIndex}:${isTurnActive}:${markTailAsLive}:${suppressInlineTurnAnchorId ?? ""}:${canRevertCheckpoints}`}
         getFixedItemSize={(entry) =>

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserHost.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserHost.tsx
@@ -11,25 +11,17 @@ import { createPortal } from "react-dom";
 import { useLingui } from "@lingui/react/macro";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
-import { useBrowserDockStore } from "@/renderer/state/browserDockStore";
 import { pushEscapeHandler } from "@/renderer/components/layout/overlayEscapeStack";
 import { BrowserPanel } from "./BrowserPanel";
+import {
+  HEADLESS_HEIGHT,
+  HEADLESS_WIDTH,
+  HEADLESS_Z,
+  type BrowserHostMode,
+  useBrowserHostPositioning,
+} from "./useBrowserHostPositioning";
 
 const MemoBrowserPanel = memo(BrowserPanel);
-
-type BrowserHostMode = "hidden" | "background" | "docked" | "drawer" | "fullscreen";
-
-// Box the browser lives in while the panel/overlay are closed but tabs are alive
-// (headless agent work). It sits IN-window (top-left) at `opacity:0` so the
-// <webview> keeps a live, painting guest surface — a fully off-screen webview
-// never paints, which breaks screenshots — while being completely invisible to
-// the user (opacity:0 composites transparently, unlike display:none which
-// suspends paint). Capture works because `webContents.capturePage()` reads the
-// guest's OWN surface, not the composited-at-0-opacity result. A negative
-// z-index keeps it under the app too; pointer-events are disabled regardless.
-const HEADLESS_Z = "-1";
-const HEADLESS_WIDTH = 1280;
-const HEADLESS_HEIGHT = 800;
 
 // Step used when the drawer's resize handle is nudged via arrow keys.
 const DRAWER_RESIZE_STEP_PX = 24;
@@ -80,92 +72,7 @@ export function BrowserHost() {
   const [isResizing, setIsResizing] = useState(false);
 
   const dockedVisible = rightPanelTab === "browser";
-
-  // Position imperatively for every mode so leftover inline styles never fight
-  // the next mode's layout. While docked, track the panel slot's rect each
-  // frame — sidebar collapse / panel resize can move it without a React render.
-  useLayoutEffect(() => {
-    const w = wrapperRef.current;
-    if (!w) return;
-    if (mode === "fullscreen") {
-      Object.assign(w.style, { top: "0px", left: "0px", right: "0px", bottom: "0px" });
-      w.style.width = "";
-      w.style.height = "";
-      w.style.maxWidth = "";
-      // Clear the docked z-index override so the fullscreen class (z-80) wins.
-      w.style.zIndex = "";
-      return;
-    }
-    if (mode === "drawer") {
-      Object.assign(w.style, {
-        top: "2rem",
-        right: "2rem",
-        bottom: "2rem",
-        left: "auto",
-        width: `${drawerWidth}px`,
-        maxWidth: "calc(100vw - 4rem)",
-      });
-      w.style.height = "";
-      // Clear the docked z-index override so the drawer class (z-60) wins.
-      w.style.zIndex = "";
-      return;
-    }
-    if (mode === "background") {
-      Object.assign(w.style, {
-        top: "0px",
-        left: "0px",
-        right: "auto",
-        bottom: "auto",
-        width: `${HEADLESS_WIDTH}px`,
-        height: `${HEADLESS_HEIGHT}px`,
-        maxWidth: "",
-      });
-      // Behind the opaque app UI: painting (so screenshots work) but unseen.
-      w.style.zIndex = HEADLESS_Z;
-      return;
-    }
-    // docked
-    if (!dockedVisible) return;
-    let raf = 0;
-    let last = "";
-    let lastOverlay: boolean | null = null;
-    const measure = () => {
-      const el = useBrowserDockStore.getState().slotEl;
-      if (!el) return;
-      // On narrow viewports the right panel that hosts the slot floats as a
-      // fixed, opaque overlay (z-50). The webview is body-portaled at z-30, so
-      // it would paint *behind* that panel. Detect the overlay from the slot's
-      // own ancestry — its containing panel <aside> switches from `relative`
-      // (docked) to `fixed` (overlay) — and lift the webview above it (z-55,
-      // matching the drawer's intent of riding over panel/settings chrome).
-      const panelAside = el.closest("aside");
-      const overlay = !!panelAside && getComputedStyle(panelAside).position === "fixed";
-      if (overlay !== lastOverlay) {
-        lastOverlay = overlay;
-        w.style.zIndex = overlay ? "55" : "";
-      }
-      const r = el.getBoundingClientRect();
-      const key = `${r.top}|${r.left}|${r.width}|${r.height}`;
-      if (key === last) return;
-      last = key;
-      Object.assign(w.style, {
-        top: `${r.top}px`,
-        left: `${r.left}px`,
-        width: `${r.width}px`,
-        height: `${r.height}px`,
-        right: "auto",
-        bottom: "auto",
-        maxWidth: "",
-      });
-    };
-    measure();
-    const tick = () => {
-      measure();
-      raf = requestAnimationFrame(tick);
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [mode, drawerWidth, dockedVisible]);
+  useBrowserHostPositioning({ wrapperRef, mode, drawerWidth, dockedVisible });
 
   useLayoutEffect(() => {
     if (mode !== "drawer" && mode !== "fullscreen") return;

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/useBrowserHostPositioning.ts
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/useBrowserHostPositioning.ts
@@ -1,0 +1,150 @@
+import { useLayoutEffect, type RefObject } from "react";
+import { useBrowserDockStore } from "@/renderer/state/browserDockStore";
+
+// Box the browser lives in while the panel/overlay are closed but tabs are alive.
+// It stays in-window at opacity 0 so the webview keeps a painting guest surface
+// for headless screenshots, while a negative z-index and disabled pointer events
+// keep it behind the app.
+export const HEADLESS_Z = "-1";
+export const HEADLESS_WIDTH = 1280;
+export const HEADLESS_HEIGHT = 800;
+
+export type BrowserHostMode = "hidden" | "background" | "docked" | "drawer" | "fullscreen";
+
+export function useBrowserHostPositioning(input: {
+  wrapperRef: RefObject<HTMLDivElement | null>;
+  mode: BrowserHostMode;
+  drawerWidth: number;
+  dockedVisible: boolean;
+}) {
+  const { wrapperRef, mode, drawerWidth, dockedVisible } = input;
+
+  // Position imperatively for every mode so leftover inline styles never fight
+  // the next mode's layout. While docked, track slot resizes and the panel's
+  // short open/overlay transitions without forcing layout on every idle frame.
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    if (mode === "fullscreen") {
+      Object.assign(wrapper.style, { top: "0px", left: "0px", right: "0px", bottom: "0px" });
+      wrapper.style.width = "";
+      wrapper.style.height = "";
+      wrapper.style.maxWidth = "";
+      // Clear the docked z-index override so the fullscreen class (z-80) wins.
+      wrapper.style.zIndex = "";
+      return;
+    }
+    if (mode === "drawer") {
+      Object.assign(wrapper.style, {
+        top: "2rem",
+        right: "2rem",
+        bottom: "2rem",
+        left: "auto",
+        width: `${drawerWidth}px`,
+        maxWidth: "calc(100vw - 4rem)",
+      });
+      wrapper.style.height = "";
+      // Clear the docked z-index override so the drawer class (z-60) wins.
+      wrapper.style.zIndex = "";
+      return;
+    }
+    if (mode === "background") {
+      Object.assign(wrapper.style, {
+        top: "0px",
+        left: "0px",
+        right: "auto",
+        bottom: "auto",
+        width: `${HEADLESS_WIDTH}px`,
+        height: `${HEADLESS_HEIGHT}px`,
+        maxWidth: "",
+      });
+      // Behind the opaque app UI: painting (so screenshots work) but unseen.
+      wrapper.style.zIndex = HEADLESS_Z;
+      return;
+    }
+    if (!dockedVisible) return;
+
+    let raf = 0;
+    let activeTransitions = 0;
+    let observedSlot: HTMLElement | null = null;
+    let observedAside: HTMLElement | null = null;
+    let last = "";
+    let lastOverlay: boolean | null = null;
+    const measure = () => {
+      const slot = observedSlot;
+      if (!slot) return;
+      // On narrow viewports the right panel that hosts the slot floats as a
+      // fixed, opaque overlay (z-50). The webview is body-portaled at z-30, so
+      // it would paint behind that panel. Lift it to z-55 while overlaid.
+      const overlay =
+        observedAside !== null && getComputedStyle(observedAside).position === "fixed";
+      if (overlay !== lastOverlay) {
+        lastOverlay = overlay;
+        wrapper.style.zIndex = overlay ? "55" : "";
+      }
+      const rect = slot.getBoundingClientRect();
+      const key = `${rect.top}|${rect.left}|${rect.width}|${rect.height}`;
+      if (key === last) return;
+      last = key;
+      Object.assign(wrapper.style, {
+        top: `${rect.top}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        right: "auto",
+        bottom: "auto",
+        maxWidth: "",
+      });
+    };
+    const tick = () => {
+      raf = 0;
+      measure();
+      if (activeTransitions > 0) scheduleMeasure();
+    };
+    const scheduleMeasure = () => {
+      if (raf === 0) raf = requestAnimationFrame(tick);
+    };
+    const onTransitionRun = (event: TransitionEvent) => {
+      if (event.target !== observedAside) return;
+      activeTransitions += 1;
+      scheduleMeasure();
+    };
+    const onTransitionDone = (event: TransitionEvent) => {
+      if (event.target !== observedAside) return;
+      activeTransitions = Math.max(0, activeTransitions - 1);
+    };
+    const resizeObserver = new ResizeObserver(scheduleMeasure);
+    const observeSlot = (nextSlot: HTMLElement | null) => {
+      if (nextSlot === observedSlot) return;
+      resizeObserver.disconnect();
+      observedAside?.removeEventListener("transitionrun", onTransitionRun);
+      observedAside?.removeEventListener("transitionend", onTransitionDone);
+      observedAside?.removeEventListener("transitioncancel", onTransitionDone);
+      if (raf !== 0) cancelAnimationFrame(raf);
+      raf = 0;
+      activeTransitions = 0;
+      observedSlot = nextSlot;
+      observedAside = nextSlot?.closest("aside") ?? null;
+      if (!nextSlot) return;
+      resizeObserver.observe(nextSlot);
+      observedAside?.addEventListener("transitionrun", onTransitionRun);
+      observedAside?.addEventListener("transitionend", onTransitionDone);
+      observedAside?.addEventListener("transitioncancel", onTransitionDone);
+      measure();
+    };
+    const unsubscribe = useBrowserDockStore.subscribe((state, previousState) => {
+      if (state.slotEl !== previousState.slotEl) observeSlot(state.slotEl);
+    });
+    window.addEventListener("resize", scheduleMeasure);
+    observeSlot(useBrowserDockStore.getState().slotEl);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("resize", scheduleMeasure);
+      resizeObserver.disconnect();
+      observedAside?.removeEventListener("transitionrun", onTransitionRun);
+      observedAside?.removeEventListener("transitionend", onTransitionDone);
+      observedAside?.removeEventListener("transitioncancel", onTransitionDone);
+      if (raf !== 0) cancelAnimationFrame(raf);
+    };
+  }, [dockedVisible, drawerWidth, mode, wrapperRef]);
+}


### PR DESCRIPTION
- Extract the imperative webview positioning logic (headless box, docked tracking, overlay/drawer/fullscreen modes) from BrowserHost.tsx into a dedicated `useBrowserHostPositioning` hook, slimming the component and centralizing mode math.
- Drop the custom `CHAT_TRANSCRIPT_DRAW_DISTANCE_PX` override from MessageList, relying on the virtualizer's default draw distance for cleaner, consistent rendering.
- Update MessageList tests to reflect the removed `drawDistance` prop (now undefined).