### PR TITLE
Fix launching and probing cursor-agent on Windows without the cmd shim

### DIFF
--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -194,6 +194,7 @@ function resolveWindowsNodeCmdShim(commandPath: string):
       argsPrefix: string[];
     }
   | undefined {
+  if (isWindowsDirectExecutable(commandPath)) return undefined;
   let effectivePath = commandPath;
   if (!/\.cmd$/i.test(commandPath)) {
     // Bare command names like "npx" resolve to "npx.cmd" via PATHEXT.
@@ -467,7 +468,7 @@ async function resolveDetectedBinary(
   return resolveExecutablePathAsync(binary);
 }
 
-function extractSemverFromVersionOutput(raw: string | undefined): string | undefined {
+export function extractSemverFromVersionOutput(raw: string | undefined): string | undefined {
   if (!raw) return undefined;
   // Allow a leading `v` ("v24.14.0"): without it, `\b` cannot match between
   // `v` and the first digit, so the regex would skip past the major segment
@@ -644,7 +645,14 @@ export async function detectAgentInstall(
   const executablePath = await resolveDetectedBinary(ctx, spec);
 
   const versionArgs = spec.versionArgs ?? ["--version"];
-  const version = await readDetectedVersion(location, executablePath, versionArgs, spec.probeEnv);
+  const version = spec.versionProbe
+    ? await spec.versionProbe({
+        location,
+        executablePath,
+        ...(ctx?.agentSettings ? { agentSettings: ctx.agentSettings } : {}),
+        ...(spec.probeEnv ? { probeEnv: spec.probeEnv } : {}),
+      })
+    : await readDetectedVersion(location, executablePath, versionArgs, spec.probeEnv);
 
   let capabilities = spec.capabilities;
   let statusProbeResult: StatusProbeResult | undefined;

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -299,6 +299,8 @@ export interface DetectionSpec {
    * so they can forward it to their own `readAgentCommandOutput` calls.
    */
   probeEnv?: Record<string, string>;
+  /** Provider-specific version probe for CLIs whose Windows shim cannot be spawned safely. */
+  versionProbe?: (ctx: DetectProbeCtx) => Promise<string | undefined>;
   statusProbe?: StatusProbe;
   authProbes?: AuthProbe[];
   capabilitiesProbe?: (ctx: DetectProbeCtx) => Promise<CapabilitiesProbeResult | undefined>;

--- a/src/supervisor/agents/cursor/cursor.test.ts
+++ b/src/supervisor/agents/cursor/cursor.test.ts
@@ -526,7 +526,7 @@ describe("isCursorSemverSupportedForHooks", () => {
 
 describe("buildCursorProbeSpec", () => {
   it.skipIf(process.platform !== "win32")(
-    "routes Windows probes through the same wrapped command path as real launches",
+    "falls back to the wrapped command path when the installer entrypoint is unavailable",
     () => {
       const spec = buildCursorProbeSpec(
         "C:\\Users\\demo\\AppData\\Local\\cursor-agent\\cursor-agent.cmd",

--- a/src/supervisor/agents/cursor/detection.ts
+++ b/src/supervisor/agents/cursor/detection.ts
@@ -15,8 +15,7 @@ import {
   stripBracketParams,
 } from "@/shared/modelLabels";
 import {
-  buildAgentCommand,
-  readAgentCommandOutput,
+  extractSemverFromVersionOutput,
   readCommandOutputAsync,
   readWslLoginShellCommandOutputAsync,
   type AgentEnvContext,
@@ -28,6 +27,7 @@ import { dedupeAcpAuthMethods, probeAcpCapabilities } from "../acp";
 import { getAgentProbeCwd, resolveProbeSpawnCwd } from "../probeCwd";
 import { cursorDefaultHiddenModels } from "./defaultModelVisibility";
 import { cursorModelGrouping } from "./modelGrouping";
+import { buildCursorAgentCommand, readCursorAgentCommandOutput } from "./windowsExecutable";
 
 export const cursorDefaultCapabilities: AgentCapability = {
   models: [],
@@ -89,7 +89,7 @@ export function buildCursorProbeSpec(
   const location: ProjectLocation = isWindows
     ? { kind: "windows", path: resolvedCwd }
     : { kind: "posix", path: resolvedCwd };
-  return buildAgentCommand(location, executablePath, args);
+  return buildCursorAgentCommand(location, args, executablePath);
 }
 
 async function readCursorProbeOutputAsync(
@@ -116,7 +116,7 @@ async function probeCursorLogoutSupport(
 ): Promise<boolean> {
   if (!ctx.executablePath) return false;
   const probeCwd = getAgentProbeCwd(ctx.location);
-  const result = await readAgentCommandOutput(
+  const result = await readCursorAgentCommandOutput(
     ctx.location,
     ctx.executablePath,
     ["logout", "--help"],
@@ -399,7 +399,7 @@ async function probeCursorAcpCapabilities(
   ctx: Parameters<NonNullable<DetectionSpec["capabilitiesProbe"]>>[0],
 ): Promise<CapabilitiesProbeResult | undefined> {
   if (!ctx.executablePath) return undefined;
-  const spec = buildAgentCommand(ctx.location, "cursor-agent", ["acp"], ctx.executablePath);
+  const spec = buildCursorAgentCommand(ctx.location, ["acp"], ctx.executablePath);
   const probeCwd = getAgentProbeCwd(ctx.location);
   const processCwd = resolveProbeSpawnCwd(ctx.location, spec.cwd);
   const result = await probeAcpCapabilities(spec.command, spec.args, probeCwd, {
@@ -630,8 +630,12 @@ async function probeCursorStatus(ctx: Parameters<NonNullable<DetectionSpec["stat
   if (!ctx.executablePath) return undefined;
   const probeCwd = getAgentProbeCwd(ctx.location);
   const [whoamiResult, aboutResult] = await Promise.all([
-    readAgentCommandOutput(ctx.location, ctx.executablePath, ["whoami"], { posixCwd: probeCwd }),
-    readAgentCommandOutput(ctx.location, ctx.executablePath, ["about"], { posixCwd: probeCwd }),
+    readCursorAgentCommandOutput(ctx.location, ctx.executablePath, ["whoami"], {
+      posixCwd: probeCwd,
+    }),
+    readCursorAgentCommandOutput(ctx.location, ctx.executablePath, ["about"], {
+      posixCwd: probeCwd,
+    }),
   ]);
 
   const whoami = parseCursorWhoamiOutput(`${whoamiResult.stdout}\n${whoamiResult.stderr}`);
@@ -656,6 +660,17 @@ export const cursorDetectionSpec: DetectionSpec = {
   update: {
     builtIn: { binary: "cursor-agent", args: ["update"] },
     homebrewCask: "cursor-cli",
+  },
+  async versionProbe(ctx) {
+    if (!ctx.executablePath) return undefined;
+    const result = await readCursorAgentCommandOutput(
+      ctx.location,
+      ctx.executablePath,
+      ["--version"],
+      ctx.probeEnv ? { env: ctx.probeEnv } : undefined,
+    );
+    const text = stripAnsi(result.stdout || result.stderr).trim();
+    return extractSemverFromVersionOutput(text);
   },
   statusProbe: probeCursorStatus,
   async capabilitiesProbe(ctx) {

--- a/src/supervisor/agents/cursor/index.ts
+++ b/src/supervisor/agents/cursor/index.ts
@@ -2,8 +2,6 @@ import type { PromptSegment } from "@/shared/contracts";
 import { inlinePromptSegmentText } from "@/shared/promptContent";
 import { createAcpStructuredSession } from "../acp";
 import {
-  buildAgentCommand,
-  buildAgentLogoutCommand,
   createKnownSessionRef,
   detectAgentInstall,
   detectProbeLocation,
@@ -12,7 +10,6 @@ import {
   type CreateStructuredSessionInput,
   type TerminalStatusHint,
 } from "../base";
-import { resolveAgentBinaryPath } from "../binaryResolver";
 import { resolveInstallNodePath, warnIfPluginManifestMissing } from "../plugin/installerBase";
 import { transformCursorAcpSessionUpdate } from "./acpTransform";
 import { handleCursorAcpExtensionNotification } from "./acpExtension";
@@ -32,6 +29,7 @@ import { createCursorChatSync } from "./session";
 import { CURSOR_IDLE_RE, CURSOR_WORKING_RE, detectCursorTerminalStatus } from "./terminal";
 import { applyCursorSdkProbe, probeCursorSdkRuntime } from "./sdkDetection";
 import { CursorSdkSession } from "./sdkSession";
+import { buildCursorAgentCommand, buildCursorArgvSpec } from "./windowsExecutable";
 import {
   configuredCursorStructuredRuntime,
   CURSOR_SDK_SESSION_PREFIX,
@@ -167,14 +165,13 @@ export function createCursorAdapter(): AgentAdapter {
       const chatId = createCursorChatSync(location);
       const args = buildCursorArgs(config, prompt, chatId);
       return {
-        binary: "cursor-agent",
-        args,
+        ...buildCursorArgvSpec(location, args),
         ...(chatId ? { sessionRef: createKnownSessionRef(chatId) } : {}),
       };
     },
     buildResumeArgv(_location, config, prompt, sessionRef) {
       const args = buildCursorArgs(config, prompt, sessionRef.providerSessionId);
-      return { binary: "cursor-agent", args };
+      return buildCursorArgvSpec(_location, args);
     },
     createInitialSessionRef() {
       return undefined;
@@ -186,12 +183,7 @@ export function createCursorAdapter(): AgentAdapter {
           return CursorSdkSession.create(input);
         }
       }
-      const command = buildAgentCommand(
-        input.projectLocation,
-        "cursor-agent",
-        ["acp"],
-        resolveAgentBinaryPath(input.projectLocation, "cursor-agent"),
-      );
+      const command = buildCursorAgentCommand(input.projectLocation, ["acp"]);
       return createAcpStructuredSession(command, {
         ...input,
         loadSessionErrorRewriter: rewriteCursorLoadSessionError,
@@ -201,14 +193,11 @@ export function createCursorAdapter(): AgentAdapter {
     },
     async buildAcpAuthCommand(ctx?: AgentEnvContext) {
       const location = detectProbeLocation(ctx);
-      return buildAgentCommand(
-        location,
-        "cursor-agent",
-        ["acp"],
-        resolveAgentBinaryPath(location, "cursor-agent"),
-      );
+      return buildCursorAgentCommand(location, ["acp"]);
     },
-    buildAcpLogoutCommand: buildAgentLogoutCommand("cursor-agent", ["logout"]),
+    async buildAcpLogoutCommand(ctx) {
+      return buildCursorAgentCommand(detectProbeLocation(ctx), ["logout"]);
+    },
     buildDirectInput(prompt, _segments, _config, projectLocation) {
       // Cursor's TUI debounces fast incoming bytes as a paste burst. With
       // less than ~120ms between the text and Enter, the agent submits but
@@ -237,14 +226,18 @@ export function createCursorAdapter(): AgentAdapter {
     },
     shouldApplyTerminalStatusWhileHookActive: cursorHookActiveTerminalFallback,
     defaultOneShotModel: "composer-2.5",
-    buildOneShotCommand(model) {
+    buildOneShotCommand(model, _effort, _prompt, location) {
       const args = ["--print", "--force", "--trust", "--output-format", "json"];
       if (model && model !== "auto") {
         args.push("--model", model);
       }
+      if (location) {
+        const spec = buildCursorArgvSpec(location, args);
+        return { command: spec.binary, args: spec.args, ...(spec.env ? { env: spec.env } : {}) };
+      }
       return { command: "cursor-agent", args };
     },
-    buildContextExtractionCommand(sessionRef, _location, model) {
+    buildContextExtractionCommand(sessionRef, location, model) {
       // `sdk:` identifies Cursor's SDK-local Agent store, not a cursor-agent
       // CLI chat. Passing it to `cursor-agent --resume` can open the wrong
       // conversation or fail with an invalid session id.
@@ -260,7 +253,8 @@ export function createCursorAdapter(): AgentAdapter {
       if (model && model !== "auto") {
         args.push("--model", model);
       }
-      return { command: "cursor-agent", args };
+      const spec = buildCursorArgvSpec(location, args);
+      return { command: spec.binary, args: spec.args, ...(spec.env ? { env: spec.env } : {}) };
     },
   };
 }

--- a/src/supervisor/agents/cursor/windowsExecutable.test.ts
+++ b/src/supervisor/agents/cursor/windowsExecutable.test.ts
@@ -1,0 +1,75 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildCursorAgentCommand,
+  buildCursorArgvSpec,
+  resolveCursorWindowsLaunch,
+} from "./windowsExecutable";
+
+describe.skipIf(process.platform !== "win32")("Cursor Windows executable resolution", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeInstall(): {
+    root: string;
+    shim: string;
+    node: string;
+    script: string;
+  } {
+    const root = mkdtempSync(join(tmpdir(), "poracode-cursor-launch-"));
+    tempDirs.push(root);
+    const shim = join(root, "cursor-agent.cmd");
+    writeFileSync(shim, "@echo off\r\n");
+    const oldDir = join(root, "versions", "2026.07.08-0c04a8a");
+    const latestDir = join(root, "versions", "2026.07.09-a3815c0");
+    mkdirSync(oldDir, { recursive: true });
+    mkdirSync(latestDir, { recursive: true });
+    writeFileSync(join(oldDir, "node.exe"), "old");
+    writeFileSync(join(oldDir, "index.js"), "old");
+    const node = join(latestDir, "node.exe");
+    const script = join(latestDir, "index.js");
+    writeFileSync(node, "node");
+    writeFileSync(script, "script");
+    return { root, shim, node, script };
+  }
+
+  it("resolves the installer shim to the newest bundled Node entrypoint", () => {
+    const install = makeInstall();
+
+    expect(resolveCursorWindowsLaunch(install.shim)).toMatchObject({
+      binary: install.node,
+      argsPrefix: [install.script],
+      env: { CURSOR_INVOKED_AS: "cursor-agent.cmd" },
+    });
+  });
+
+  it("builds probes and launches without a PowerShell or cmd wrapper", () => {
+    const install = makeInstall();
+    const location = { kind: "windows" as const, path: install.root };
+
+    const command = buildCursorAgentCommand(location, ["--version"], install.shim);
+    expect(command.command).toBe(install.node);
+    expect(command.args).toEqual([install.script, "--version"]);
+
+    const argv = buildCursorArgvSpec(location, ["acp"], install.shim);
+    expect(argv.binary).toBe(install.node);
+    expect(argv.args).toEqual([install.script, "acp"]);
+  });
+
+  it("falls back when the installer has no complete runnable version", () => {
+    const root = mkdtempSync(join(tmpdir(), "poracode-cursor-launch-"));
+    tempDirs.push(root);
+    const shim = join(root, "cursor-agent.cmd");
+    writeFileSync(shim, "@echo off\r\n");
+    mkdirSync(join(root, "versions", "2026.07.09-a3815c0"), { recursive: true });
+
+    expect(resolveCursorWindowsLaunch(shim)).toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/cursor/windowsExecutable.ts
+++ b/src/supervisor/agents/cursor/windowsExecutable.ts
@@ -1,0 +1,158 @@
+import { existsSync, readdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import type { ProjectLocation } from "@/shared/contracts";
+import {
+  buildAgentCommand,
+  readAgentCommandOutput,
+  readCommandOutputAsync,
+  type AgentArgvSpec,
+  type CommandSpec,
+} from "../base";
+import { resolveAgentBinaryPath } from "../binaryResolver";
+
+interface CursorWindowsLaunch {
+  binary: string;
+  argsPrefix: string[];
+  env: Record<string, string>;
+}
+
+const CURSOR_VERSION_DIR_RE =
+  /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:-(\d{2})-(\d{2})-(\d{2}))?-[a-f0-9]+$/i;
+
+function cursorVersionSortKey(name: string): number | undefined {
+  const match = CURSOR_VERSION_DIR_RE.exec(name);
+  if (!match) return undefined;
+  return Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4] ?? 0),
+    Number(match[5] ?? 0),
+    Number(match[6] ?? 0),
+  );
+}
+
+function launchFromDir(dir: string, invokedAs: string): CursorWindowsLaunch | undefined {
+  const binary = join(dir, "node.exe");
+  const script = join(dir, "index.js");
+  if (!existsSync(binary) || !existsSync(script)) return undefined;
+  return {
+    binary,
+    argsPrefix: [script],
+    env: {
+      CURSOR_INVOKED_AS: invokedAs,
+      ...(process.env.NODE_COMPILE_CACHE
+        ? { NODE_COMPILE_CACHE: process.env.NODE_COMPILE_CACHE }
+        : process.env.LOCALAPPDATA
+          ? { NODE_COMPILE_CACHE: join(process.env.LOCALAPPDATA, "cursor-compile-cache") }
+          : {}),
+    },
+  };
+}
+
+export function resolveCursorWindowsLaunch(
+  executablePath: string | undefined,
+): CursorWindowsLaunch | undefined {
+  if (
+    process.platform !== "win32" ||
+    !executablePath ||
+    !/^(?:cursor-agent|agent)\.(?:cmd|ps1)$/i.test(basename(executablePath)) ||
+    !existsSync(executablePath)
+  ) {
+    return undefined;
+  }
+
+  const invokedAs = basename(executablePath);
+  const shimDir = dirname(executablePath);
+  const local = launchFromDir(shimDir, invokedAs);
+  if (local) return local;
+
+  const versionsDir = join(shimDir, "versions");
+  let versions: Array<{ name: string; sortKey: number }>;
+  try {
+    versions = readdirSync(versionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => ({ name: entry.name, sortKey: cursorVersionSortKey(entry.name) }))
+      .filter((entry): entry is { name: string; sortKey: number } => entry.sortKey !== undefined)
+      .sort((a, b) => b.sortKey - a.sortKey || b.name.localeCompare(a.name));
+  } catch {
+    return undefined;
+  }
+
+  for (const version of versions) {
+    const launch = launchFromDir(join(versionsDir, version.name), invokedAs);
+    if (launch) return launch;
+  }
+  return undefined;
+}
+
+function resolveCursorExecutablePath(
+  location: ProjectLocation,
+  executablePath: string | undefined,
+): string | undefined {
+  return executablePath ?? resolveAgentBinaryPath(location, "cursor-agent");
+}
+
+export function buildCursorAgentCommand(
+  location: ProjectLocation,
+  args: string[],
+  executablePath?: string,
+): CommandSpec {
+  const resolvedPath = resolveCursorExecutablePath(location, executablePath);
+  const launch = location.kind === "windows" ? resolveCursorWindowsLaunch(resolvedPath) : undefined;
+  if (launch) {
+    return buildAgentCommand(
+      location,
+      launch.binary,
+      [...launch.argsPrefix, ...args],
+      launch.binary,
+      launch.env,
+    );
+  }
+  return buildAgentCommand(location, "cursor-agent", args, resolvedPath);
+}
+
+export function buildCursorArgvSpec(
+  location: ProjectLocation,
+  args: string[],
+  executablePath?: string,
+): AgentArgvSpec {
+  const launch =
+    location.kind === "windows"
+      ? resolveCursorWindowsLaunch(resolveCursorExecutablePath(location, executablePath))
+      : undefined;
+  if (!launch) return { binary: "cursor-agent", args };
+  return {
+    binary: launch.binary,
+    args: [...launch.argsPrefix, ...args],
+    env: launch.env,
+  };
+}
+
+export async function readCursorAgentCommandOutput(
+  location: ProjectLocation,
+  executablePath: string,
+  args: string[],
+  options?: {
+    timeoutMs?: number;
+    wslLinuxCwd?: string;
+    posixCwd?: string;
+    env?: Record<string, string>;
+  },
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  if (location.kind !== "windows") {
+    return readAgentCommandOutput(location, executablePath, args, options);
+  }
+  const spec = buildCursorAgentCommand(location, args, executablePath);
+  const effectiveCwd = options?.posixCwd ?? spec.cwd;
+  const runOptions = {
+    ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+    ...(spec.env || options?.env ? { env: { ...spec.env, ...options?.env } } : {}),
+    ...(options?.timeoutMs ? { timeout: options.timeoutMs } : {}),
+  };
+  return readCommandOutputAsync(
+    spec.command,
+    spec.args,
+    Object.keys(runOptions).length > 0 ? runOptions : undefined,
+  );
+}


### PR DESCRIPTION
- Bugfix: cursor-agent was routed through a Windows `.cmd` shim that cannot be spawned or probed safely; resolve the installer's bundled Node entrypoint directly so launches, probes, and version detection work reliably.
- Add a provider-specific `versionProbe` hook to the base detection spec for CLIs whose Windows shim can't be spawned, and wire it into cursor detection.
- Route Cursor status/auth/version probes and one-shot/context-extraction commands through the new Windows launch resolution.
- Add unit tests for newest-version selection, probe command building, and fallback when no runnable bundled version exists.