### PR TITLE
Fix git panel losing badge target when it opens

### DIFF
--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
@@ -1,0 +1,101 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { I18nProvider } from "@lingui/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Thread } from "@/shared/contracts";
+import { i18n } from "@/renderer/i18n/i18n";
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { ProjectAuxiliaryPanel } from "./ProjectAuxiliaryPanel";
+
+vi.mock("@/renderer/analytics/useProductViewTracking", () => ({
+  productSurfaceView: vi.fn<(tab: string, mode: string) => string>(() => "git"),
+  useProductViewTracking: vi.fn<() => void>(),
+}));
+
+vi.mock("@/renderer/state/gitRefresh", () => ({
+  prefetchVisibleGitPanelPrData: vi.fn<(projectId: string, worktreePath?: string) => Promise<void>>(
+    () => Promise.resolve(),
+  ),
+}));
+
+vi.mock("@/renderer/components/layout/UnifiedRightPanel", () => ({
+  UnifiedRightPanel: () => null,
+}));
+
+function makeThread(id: string, projectId: string, worktreePath: string): Thread {
+  const now = "2026-08-03T00:00:00.000Z";
+  return {
+    id,
+    projectId,
+    worktreePath,
+    title: id,
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    status: "idle",
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+const threadA = makeThread("thread-a", "project-a", "/worktree-a");
+const threadB = makeThread("thread-b", "project-b", "/worktree-b");
+const threadC = makeThread("thread-c", "project-c", "/worktree-c");
+
+function focusThread(threadId: string): void {
+  useAppStore.setState({
+    threads: [threadA, threadB, threadC],
+    view: { kind: "thread", panes: [threadId] },
+    focusedPaneId: threadId,
+  });
+}
+
+describe("ProjectAuxiliaryPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    focusThread(threadA.id);
+    usePanelStore.setState({
+      gitReviewContext: {
+        projectId: threadB.projectId,
+        worktreePath: threadB.worktreePath!,
+        originComposerId: threadB.id,
+      },
+      gitReviewAsPanel: true,
+      rightPanelFollowsThread: true,
+      rightPanelTab: "git",
+      filesPanelContext: null,
+      browserPanelOpen: false,
+      usagePanelOpen: false,
+      notesPanelOpen: false,
+    });
+  });
+
+  it("preserves a git badge target when the locked panel opens", async () => {
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectAuxiliaryPanel includeTerminal visible />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(usePanelStore.getState().gitReviewContext).toEqual({
+        projectId: threadB.projectId,
+        worktreePath: threadB.worktreePath!,
+        originComposerId: threadB.id,
+      });
+    });
+
+    act(() => focusThread(threadC.id));
+
+    await waitFor(() => {
+      expect(usePanelStore.getState().gitReviewContext).toEqual({
+        projectId: threadC.projectId,
+        worktreePath: threadC.worktreePath!,
+      });
+    });
+  });
+});

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -155,6 +155,10 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     todoDockState !== null &&
     todoDockState.sourceItemId !== retiredTodoSourceItemId;
 
+  const previousGitReviewContextRef = useRef<GitReviewContext | null>(null);
+  const gitReviewContextChanged = previousGitReviewContextRef.current !== gitReviewContext;
+  previousGitReviewContextRef.current = gitReviewContext;
+
   const lastGitPanelContextRef = useRef(gitReviewContext);
   if (gitReviewContext && gitReviewAsPanel) {
     lastGitPanelContextRef.current = gitReviewContext;
@@ -212,7 +216,12 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     if (!props.visible) return;
     let refreshTimer: number | undefined;
     const frame = requestAnimationFrame(() => {
-      syncRightPanelTabToFocusedThread(activeTab);
+      // A new git context is an explicit target (for example, clicking thread
+      // B's badge while thread A is focused). Let that open win; the follow
+      // lock will take over again on the next thread or tab change.
+      if (activeTab !== "git" || !gitReviewContextChanged) {
+        syncRightPanelTabToFocusedThread(activeTab);
+      }
       if (activeTab !== "git") return;
 
       // Let the thread and linked-panel frames paint before paying for PR I/O.
@@ -230,7 +239,14 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       cancelAnimationFrame(frame);
       if (refreshTimer !== undefined) window.clearTimeout(refreshTimer);
     };
-  }, [activeTab, currentThreadId, props.visible, rightPanelFollowsThread]);
+  }, [
+    activeTab,
+    currentThreadId,
+    gitReviewContext,
+    gitReviewContextChanged,
+    props.visible,
+    rightPanelFollowsThread,
+  ]);
   useProductViewTracking(productSurfaceView(activeTab, "panel"), "panel", {
     active: props.visible,
     finishWhenInactive: true,


### PR DESCRIPTION
- Preserve an explicitly chosen git review target (e.g. clicking another thread's badge) when the auxiliary panel opens, instead of overwriting it with the follow-focused-thread sync.
- The follow lock resumes on the next thread or tab change.
- Add a regression test covering a git context set before the panel opens with a subsequent focus change.