### PR TITLE
Skip fade-in for lazily loaded project settings

### DIFF
--- a/src/renderer/views/MainView/parts/AppOverlays.tsx
+++ b/src/renderer/views/MainView/parts/AppOverlays.tsx
@@ -105,8 +105,12 @@ export function AppOverlays() {
           <DeferredSettingsOverlay onClose={() => usePanelStore.getState().closeSettings()} />
         </Suspense>
       </OverlayShell>
+      {/* No fade-in: the project settings view is lazily loaded and resolves its
+          project as it mounts, so fading it in over the hidden base app just
+          shows full-screen acrylic until the content lands. */}
       <OverlayShell
         open={!!projectSettingsId}
+        instantEnter
         onExited={() => usePanelStore.getState().closeProjectSettings()}
       >
         {projectSettingsId && (


### PR DESCRIPTION
- **Bugfix**: the project settings overlay no longer fades in when opened.
- The settings view is lazily loaded and resolves its project during mount, so the fade-in shows a full-screen acrylic flash over the hidden base app until content lands.
- `instantEnter` skips the transition for this overlay only; other overlays keep their existing fade behavior.