### PR TITLE
feat(sidebar): add flat thread list layout

### DIFF
--- a/src/renderer/components/common/AnimatedTerminalIcon.tsx
+++ b/src/renderer/components/common/AnimatedTerminalIcon.tsx
@@ -4,6 +4,19 @@ interface AnimatedTerminalIconProps extends SVGProps<SVGSVGElement> {
   isBusy?: boolean | undefined;
 }
 
+/**
+ * Lucide's `square-terminal`, hand-inlined only so the cursor stroke can breathe
+ * while the terminal is busy — `<SquareTerminal />` offers no handle on an
+ * individual path.
+ *
+ * Keep the geometry byte-identical to upstream. It is tempting to shift these
+ * coordinates onto the odd values that let a 1px stroke snap to a single pixel
+ * column at small sizes, but this icon always sits beside stock lucide icons
+ * (folder, archive, trash) that cannot be snapped the same way — and one crisp
+ * glyph among softly-antialiased neighbours reads far worse than a uniformly
+ * soft set. Sharpness at small sizes is a whole-icon-set decision, not one this
+ * component should make alone.
+ */
 export function AnimatedTerminalIcon({ isBusy, className, ...props }: AnimatedTerminalIconProps) {
   return (
     <svg
@@ -30,9 +43,9 @@ export function AnimatedTerminalIcon({ isBusy, className, ...props }: AnimatedTe
           }
         `}</style>
       )}
-      <rect width="20" height="20" x="2" y="2" rx="2" />
-      <path d="m7 8 3 3-3 3" />
-      <path d="m12 14 h4" className={isBusy ? "anim-cursor-breath" : undefined} />
+      <path d="m7 11 2-2-2-2" />
+      <path d="M11 13h4" className={isBusy ? "anim-cursor-breath" : undefined} />
+      <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
     </svg>
   );
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Im Agenten beheben"
 msgid "Fixed"
 msgstr "Behoben"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Flache Liste"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Browseradressleiste fokussieren"
@@ -5114,6 +5118,10 @@ msgstr "Offene Threads gruppieren"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Gruppiere Projekte, damit Seitenleiste, Zeitpläne und Pull Requests jeweils nur eine Gruppe zeigen. Wechsle unten in der Seitenleiste zwischen ihnen."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Nach Projekt gruppiert"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Verknüpft"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Liste"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Listenoptionen"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Suche..."
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Sicherheitsorientiertes Verzeichnis mit verifizierten Skill-Metadaten."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Mehr anzeigen"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Marketplace-Skills sortieren"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Threads sortieren"
+#~ msgid "Sort threads"
+#~ msgstr "Threads sortieren"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Thread-Zieldock"
 msgid "Thread is already unloaded."
 msgstr "Thread ist bereits entladen."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Optionen der Thread-Liste"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Thread-Modus"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Nur Thread"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Sortierreihenfolge der Threads"
+#~ msgid "Thread sort order"
+#~ msgstr "Sortierreihenfolge der Threads"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -4763,6 +4763,10 @@ msgstr "Fix in Agent"
 msgid "Fixed"
 msgstr "Fixed"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Flat list"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Focus browser address bar"
@@ -5119,6 +5123,10 @@ msgstr "Group open threads"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Grouped by project"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5815,6 +5823,10 @@ msgstr "Linked"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "List"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "List options"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9760,7 +9772,7 @@ msgstr "Searching…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Security-focused directory with verified skill metadata."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "See more"
 
@@ -10315,8 +10327,8 @@ msgid "Sort marketplace skills"
 msgstr "Sort marketplace skills"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Sort threads"
+#~ msgid "Sort threads"
+#~ msgstr "Sort threads"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11354,6 +11366,10 @@ msgstr "Thread goal dock"
 msgid "Thread is already unloaded."
 msgstr "Thread is already unloaded."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Thread list options"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Thread mode"
@@ -11364,8 +11380,8 @@ msgid "Thread Only"
 msgstr "Thread Only"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Thread sort order"
+#~ msgid "Thread sort order"
+#~ msgstr "Thread sort order"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Corregir en el agente"
 msgid "Fixed"
 msgstr "Corregido"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Lista plana"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Enfocar barra de direcciones del navegador"
@@ -5114,6 +5118,10 @@ msgstr "Agrupar hilos abiertos"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Agrupa proyectos para que la barra lateral, las programaciones y los pull requests muestren solo un conjunto a la vez. Cambia entre ellos en la parte inferior de la barra lateral."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Agrupado por proyecto"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Vinculado"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Lista"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Opciones de lista"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Buscando…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Directorio centrado en la seguridad con metadatos verificados de las skills."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Ver más"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Ordenar skills del marketplace"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Ordenar hilos"
+#~ msgid "Sort threads"
+#~ msgstr "Ordenar hilos"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Panel del objetivo del hilo"
 msgid "Thread is already unloaded."
 msgstr "El hilo ya está descargado."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Opciones de la lista de hilos"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Modo del hilo"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Solo el hilo"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Orden de los hilos"
+#~ msgid "Thread sort order"
+#~ msgstr "Orden de los hilos"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Correction dans l'agent"
 msgid "Fixed"
 msgstr "Corrigé"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Liste plate"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Accéder à la barre d'adresse du navigateur"
@@ -5114,6 +5118,10 @@ msgstr "Grouper les discussions ouvertes"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Regroupez les projets pour que la barre latérale, les planifications et les pull requests n'affichent qu'un ensemble à la fois. Changez d'espace en bas de la barre latérale."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Groupés par projet"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Liée"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Liste"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Options de liste"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9754,7 +9766,7 @@ msgstr "Recherche…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Annuaire axé sur la sécurité avec des métadonnées de skills vérifiées."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Voir plus"
 
@@ -10309,8 +10321,8 @@ msgid "Sort marketplace skills"
 msgstr "Trier les compétences de la place de marché"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Trier les fils"
+#~ msgid "Sort threads"
+#~ msgstr "Trier les fils"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11348,6 +11360,10 @@ msgstr "Dock d'objectif du fil"
 msgid "Thread is already unloaded."
 msgstr "Le fil est déjà déchargé."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Options de la liste des fils"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Mode fil de discussion"
@@ -11358,8 +11374,8 @@ msgid "Thread Only"
 msgstr "Fil de discussion uniquement"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Ordre de tri des fils de discussion"
+#~ msgid "Thread sort order"
+#~ msgstr "Ordre de tri des fils de discussion"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -4757,6 +4757,10 @@ msgstr "エージェントで修正する"
 msgid "Fixed"
 msgstr "修正"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "フラットリスト"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "ブラウザのアドレスバーをフォーカス"
@@ -5113,6 +5117,10 @@ msgstr "開いているスレッドをグループ化する"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "プロジェクトをグループ化して、サイドバー・スケジュール・プルリクエストに一度に1組だけ表示します。サイドバー下部で切り替えられます。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "プロジェクト別にグループ化"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5809,6 +5817,10 @@ msgstr "リンク済み"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "リスト"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "リストオプション"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9753,7 +9765,7 @@ msgstr "検索中…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "検証済みのスキルメタデータを備えたセキュリティ重視のディレクトリ。"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "もっと見る"
 
@@ -10308,8 +10320,8 @@ msgid "Sort marketplace skills"
 msgstr "マーケットプレイススキルを並べ替え"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "スレッドを並べ替える"
+#~ msgid "Sort threads"
+#~ msgstr "スレッドを並べ替える"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11347,6 +11359,10 @@ msgstr "スレッドゴールドック"
 msgid "Thread is already unloaded."
 msgstr "スレッドはすでにアンロードされています。"
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "スレッドリストのオプション"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "スレッドモード"
@@ -11357,8 +11373,8 @@ msgid "Thread Only"
 msgstr "スレッドのみ"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "スレッドのソート順"
+#~ msgid "Thread sort order"
+#~ msgstr "スレッドのソート順"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -4758,6 +4758,10 @@ msgstr "에이전트에서 수정"
 msgid "Fixed"
 msgstr "수정됨"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "플랫 목록"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "브라우저 주소 표시줄에 포커스"
@@ -5114,6 +5118,10 @@ msgstr "열린 스레드 그룹화"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "프로젝트를 그룹으로 묶어 사이드바, 일정, 풀 리퀘스트에 한 번에 한 묶음만 표시합니다. 사이드바 하단에서 전환할 수 있습니다."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "프로젝트별 그룹화"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "연결됨"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "목록"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "목록 옵션"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "검색 중…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "검증된 스킬 메타데이터를 제공하는 보안 중심 디렉터리입니다."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "자세히 보기"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "마켓플레이스 스킬 정렬"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "스레드 정렬"
+#~ msgid "Sort threads"
+#~ msgstr "스레드 정렬"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "스레드 목표 도크"
 msgid "Thread is already unloaded."
 msgstr "스레드가 이미 언로드되었습니다."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "스레드 목록 옵션"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "스레드 모드"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "스레드만"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "스레드 정렬 순서"
+#~ msgid "Thread sort order"
+#~ msgstr "스레드 정렬 순서"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Napraw w Agencie"
 msgid "Fixed"
 msgstr "Naprawiono"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Płaska lista"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Przejdź do paska adresu przeglądarki"
@@ -5114,6 +5118,10 @@ msgstr "Grupuj otwarte wątki"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Grupuj projekty, aby pasek boczny, harmonogramy i żądania ściągnięcia pokazywały tylko jeden zestaw naraz. Przełączaj je u dołu paska bocznego."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Pogrupowane według projektu"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Połączono"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Lista"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Opcje listy"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Wyszukiwanie…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Katalog ukierunkowany na bezpieczeństwo ze zweryfikowanymi metadanymi skilli."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Zobacz więcej"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Sortuj umiejętności z marketplace"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Sortuj wątki"
+#~ msgid "Sort threads"
+#~ msgstr "Sortuj wątki"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Stacja dokująca celu wątku"
 msgid "Thread is already unloaded."
 msgstr "Wątek został już wyładowany."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Opcje listy wątków"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Tryb wątku"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Tylko wątek"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Kolejność sortowania wątków"
+#~ msgid "Thread sort order"
+#~ msgstr "Kolejność sortowania wątków"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Correção no agente"
 msgid "Fixed"
 msgstr "Corrigido"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Lista plana"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Acessar barra de endereços do navegador"
@@ -5114,6 +5118,10 @@ msgstr "Agrupar tópicos abertos"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Agrupe projetos para que a barra lateral, os agendamentos e os pull requests mostrem apenas um conjunto por vez. Alterne entre eles na parte inferior da barra lateral."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Agrupado por projeto"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Vinculada"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Lista"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Opções de lista"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Procurando…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Diretório focado em segurança com metadados de skills verificados."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Ver mais"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Ordenar skills do marketplace"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Classificar tópicos"
+#~ msgid "Sort threads"
+#~ msgstr "Classificar tópicos"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Doca de meta do tópico"
 msgid "Thread is already unloaded."
 msgstr "O tópico já está descarregado."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Opções da lista de tópicos"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Modo de tópico"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Apenas tópico"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Ordem de classificação de tópicos"
+#~ msgid "Thread sort order"
+#~ msgstr "Ordem de classificação de tópicos"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Исправить в агенте"
 msgid "Fixed"
 msgstr "Исправлено"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Плоский список"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Перейти на адресную строку браузера"
@@ -5114,6 +5118,10 @@ msgstr "Группировать открытые треды"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Группируйте проекты, чтобы боковая панель, расписания и pull request показывали только один набор за раз. Переключайтесь между ними внизу боковой панели."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Группировка по проектам"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Связан"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Список"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Параметры списка"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Поиск…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Каталог с акцентом на безопасность и проверенными метаданными навыков."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Показать больше"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Сортировать навыки маркетплейса"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Сортировать треды"
+#~ msgid "Sort threads"
+#~ msgstr "Сортировать треды"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Панель цели треда"
 msgid "Thread is already unloaded."
 msgstr "Тред уже выгружен."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Параметры списка тредов"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Режим треда"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Только тред"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Порядок сортировки тредов"
+#~ msgid "Thread sort order"
+#~ msgstr "Порядок сортировки тредов"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Aracıda Düzelt"
 msgid "Fixed"
 msgstr "Düzeltildi"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Düz liste"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Tarayıcı adres çubuğuna odakla"
@@ -5114,6 +5118,10 @@ msgstr "Açık konuları gruplandır"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Projeleri gruplayın; böylece kenar çubuğu, zamanlamalar ve çekme istekleri her seferinde yalnızca bir grubu gösterir. Kenar çubuğunun altından geçiş yapabilirsiniz."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Projeye göre gruplandır"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Bağlı"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Liste"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Liste seçenekleri"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Aranıyor…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Doğrulanmış beceri meta verileri sunan güvenlik odaklı dizin."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Daha fazlasını gör"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Marketplace becerilerini sırala"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Konuları sırala"
+#~ msgid "Sort threads"
+#~ msgstr "Konuları sırala"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Konu hedefi yuvası"
 msgid "Thread is already unloaded."
 msgstr "Konu zaten kaldırıldı."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Konu listesi seçenekleri"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Konu modu"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Yalnızca Konu"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Konu sıralama düzeni"
+#~ msgid "Thread sort order"
+#~ msgstr "Konu sıralama düzeni"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Виправити в агенті"
 msgid "Fixed"
 msgstr "Виправлено"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Плоский список"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Встановити фокус на адресний рядок браузера"
@@ -5114,6 +5118,10 @@ msgstr "Групувати відкриті треди"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Групуйте проєкти, щоб бічна панель, розклади та pull request показували лише один набір водночас. Перемикайтеся між ними внизу бічної панелі."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Групування за проєктами"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Зв’язано"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Список"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Параметри списку"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Пошук…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Каталог із фокусом на безпеці та перевіреними метаданими навичок."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Показати більше"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Сортувати навички маркетплейсу"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Сортувати треди"
+#~ msgid "Sort threads"
+#~ msgstr "Сортувати треди"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Панель мети треда"
 msgid "Thread is already unloaded."
 msgstr "Тред уже вивантажено."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Параметри списку тредів"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Режим треда"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Лише тред"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Порядок сортування тредів"
+#~ msgid "Thread sort order"
+#~ msgstr "Порядок сортування тредів"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -4758,6 +4758,10 @@ msgstr "Sửa trong Tác nhân"
 msgid "Fixed"
 msgstr "Đã sửa"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "Danh sách phẳng"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "Tập trung vào thanh địa chỉ trình duyệt"
@@ -5114,6 +5118,10 @@ msgstr "Nhóm chủ đề mở"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "Nhóm các dự án để thanh bên, lịch biểu và pull request chỉ hiển thị một nhóm mỗi lần. Chuyển giữa chúng ở cuối thanh bên."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "Nhóm theo dự án"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "Đã liên kết"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "Danh sách"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "Tùy chọn danh sách"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9755,7 +9767,7 @@ msgstr "Đang tìm kiếm…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "Danh mục tập trung vào bảo mật với siêu dữ liệu skill đã được xác minh."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "Xem thêm"
 
@@ -10310,8 +10322,8 @@ msgid "Sort marketplace skills"
 msgstr "Sắp xếp skill trên marketplace"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "Sắp xếp luồng"
+#~ msgid "Sort threads"
+#~ msgstr "Sắp xếp luồng"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11349,6 +11361,10 @@ msgstr "Dock mục tiêu luồng"
 msgid "Thread is already unloaded."
 msgstr "Luồng đã được dỡ bỏ."
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "Tùy chọn danh sách luồng"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "Chế độ luồng"
@@ -11359,8 +11375,8 @@ msgid "Thread Only"
 msgstr "Chỉ luồng"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "Thứ tự sắp xếp luồng"
+#~ msgid "Thread sort order"
+#~ msgstr "Thứ tự sắp xếp luồng"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -4758,6 +4758,10 @@ msgstr "在代理中修复"
 msgid "Fixed"
 msgstr "已修复"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Flat list"
+msgstr "扁平列表"
+
 #: src/renderer/commands/registry.ts
 msgid "Focus browser address bar"
 msgstr "聚焦浏览器地址栏"
@@ -5114,6 +5118,10 @@ msgstr "对打开的线程进行分组"
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Group projects so the sidebar, schedules, and pull requests only show one set at a time. Switch between them at the bottom of the sidebar."
 msgstr "将项目分组，使侧边栏、计划和拉取请求一次只显示一组。在侧边栏底部切换工作区。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+msgid "Grouped by project"
+msgstr "按项目分组"
 
 #: src/renderer/views/SettingsOverlay/parts/AppearanceSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5810,6 +5818,10 @@ msgstr "已链接"
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "List"
 msgstr "列表"
+
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "List options"
+msgstr "列表选项"
 
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 msgid "List packages"
@@ -9754,7 +9766,7 @@ msgstr "正在搜索…"
 #~ msgid "Security-focused directory with verified skill metadata."
 #~ msgstr "注重安全并提供已验证技能元数据的目录。"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
 msgid "See more"
 msgstr "查看更多"
 
@@ -10309,8 +10321,8 @@ msgid "Sort marketplace skills"
 msgstr "对市场技能排序"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Sort threads"
-msgstr "对线程进行排序"
+#~ msgid "Sort threads"
+#~ msgstr "对线程进行排序"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Source branch {branch} moved before the worktree was created"
@@ -11348,6 +11360,10 @@ msgstr "线程目标停靠栏"
 msgid "Thread is already unloaded."
 msgstr "线程已经卸载。"
 
+#: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+msgid "Thread list options"
+msgstr "线程列表选项"
+
 #: src/renderer/components/thread/PresentationModeTabs.tsx
 msgid "Thread mode"
 msgstr "线程模式"
@@ -11358,8 +11374,8 @@ msgid "Thread Only"
 msgstr "仅线程"
 
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
-msgid "Thread sort order"
-msgstr "线程排序顺序"
+#~ msgid "Thread sort order"
+#~ msgstr "线程排序顺序"
 
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Thread todo dock"

--- a/src/renderer/state/experimentStore.ts
+++ b/src/renderer/state/experimentStore.ts
@@ -135,12 +135,12 @@ export const useExperimentStore = create<ExperimentStore>()(
   ),
 );
 
-export function useProjectExperimentCandidateOrder(projectId: string): ReadonlyMap<string, number> {
+export function useExperimentCandidateOrder(projectId?: string): ReadonlyMap<string, number> {
   return useExperimentStore(
     useShallow((state) => {
       const order = new Map<string, number>();
       for (const experiment of Object.values(state.experiments)) {
-        if (experiment.projectId !== projectId) continue;
+        if (projectId !== undefined && experiment.projectId !== projectId) continue;
         experiment.candidates.forEach((candidate, index) => order.set(candidate.threadId, index));
       }
       return order;

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -1,7 +1,10 @@
 import { create } from "zustand";
 import type { ProjectLocation } from "@/shared/contracts";
 import { persistStoreSlice, readPersistedSlice } from "@/renderer/utils/persistStoreSlice";
-import type { ThreadSortMode } from "@/renderer/views/MainView/parts/Sidebar/parts/sortMode";
+import type {
+  ThreadListLayout,
+  ThreadSortMode,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/sortMode";
 import { useFileEditorStore } from "./fileEditorStore";
 
 export interface GitReviewContext {
@@ -83,6 +86,7 @@ interface PanelState {
   settingsSection: string | null;
   projectSettingsId: string | null;
   threadSortMode: ThreadSortMode;
+  threadListLayout: ThreadListLayout;
   threadSearchOpen: boolean;
   /** Whether the "Start from scratch" create-project modal is open. */
   createProjectModalOpen: boolean;
@@ -90,6 +94,7 @@ interface PanelState {
   cloneProjectModalOpen: boolean;
   setGitReviewContext: (ctx: GitReviewContext | null) => void;
   setThreadSortMode: (mode: ThreadSortMode) => void;
+  setThreadListLayout: (layout: ThreadListLayout) => void;
   setGitReviewAsPanel: (v: boolean) => void;
   setGitOverlayOpen: (v: boolean) => void;
   setPrReviewContext: (ctx: PrReviewContext | null) => void;
@@ -177,7 +182,21 @@ const initialPersisted = readPersistedSlice<{
   browserOverlayDrawerWidth: number;
   rightPanelFollowsThread?: boolean;
   threadToolRailOffset?: number;
+  threadSortMode?: ThreadSortMode;
+  threadListLayout?: ThreadListLayout;
 }>(PERSIST_KEY);
+
+// Kept in sync with `ThreadSortMode`/`ThreadListLayout` manually — importing
+// the option tables would pull the icon module (lucide) into the store.
+// Unknown persisted values (e.g. written by a newer app version) fall back to
+// the defaults.
+function sanitizeThreadSortMode(value: unknown): ThreadSortMode {
+  return value === "updated" || value === "created" || value === "manual" ? value : "updated";
+}
+
+function sanitizeThreadListLayout(value: unknown): ThreadListLayout {
+  return value === "grouped" || value === "flat" ? value : "grouped";
+}
 
 /** Default rail offset: below the pane header, near the top of the conversation. */
 const DEFAULT_THREAD_TOOL_RAIL_OFFSET = 56;
@@ -214,7 +233,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
   settingsOpen: false,
   settingsSection: null,
   projectSettingsId: null,
-  threadSortMode: "updated",
+  threadSortMode: sanitizeThreadSortMode(initialPersisted?.threadSortMode),
+  threadListLayout: sanitizeThreadListLayout(initialPersisted?.threadListLayout),
   threadSearchOpen: false,
   createProjectModalOpen: false,
   cloneProjectModalOpen: false,
@@ -371,6 +391,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
     ),
   setThreadSortMode: (mode) =>
     set((state) => (state.threadSortMode === mode ? {} : { threadSortMode: mode })),
+  setThreadListLayout: (layout) =>
+    set((state) => (state.threadListLayout === layout ? {} : { threadListLayout: layout })),
   openSettings: () =>
     set((state) =>
       state.settingsOpen && state.settingsSection === null
@@ -427,13 +449,14 @@ export const usePanelStore = create<PanelState>()((set) => ({
   },
 }));
 
-// Only the two cross-launch slices persist; every other panel/overlay flag is
+// Only the cross-launch slices persist; every other panel/overlay flag is
 // session-scoped and resets on launch. Persisting just this slice keeps the
 // frequent session-only toggles (right-panel tab, settings/search/modal open,
-// sort mode, …) off localStorage — they change the store constantly but never
-// the persisted value. Initial hydration is synchronous, seeded above from
-// readPersistedSlice so the restored git panel and drawer width are present
-// before first paint.
+// …) off localStorage — they change the store constantly but never the
+// persisted value. The thread sort/layout mode persists so a flat-list user
+// isn't reset to project grouping on relaunch. Initial hydration is
+// synchronous, seeded above from readPersistedSlice so the restored git panel
+// and drawer width are present before first paint.
 persistStoreSlice(usePanelStore, PERSIST_KEY, (state) => ({
   gitReviewContext: state.gitReviewContext
     ? {
@@ -446,6 +469,8 @@ persistStoreSlice(usePanelStore, PERSIST_KEY, (state) => ({
   browserOverlayDrawerWidth: state.browserOverlayDrawerWidth,
   rightPanelFollowsThread: state.rightPanelFollowsThread,
   threadToolRailOffset: state.threadToolRailOffset,
+  threadSortMode: state.threadSortMode,
+  threadListLayout: state.threadListLayout,
 }));
 
 // Returns true when any full-window overlay (z-50) is currently rendered above

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/renderer/state/workspaceSelectors";
 import { useUpdateStore } from "@/renderer/state/updateStore";
 import { SidebarWorkspaceSwitcher } from "./parts/SidebarWorkspaceSwitcher";
+import { SidebarFlatThreadList } from "./parts/SidebarFlatThreadList";
 import { SidebarProjectThreadList } from "./parts/SidebarProjectThreadList";
 import { WhatsNewButton } from "./parts/WhatsNewButton";
 import { DeferredSettingsOverlay } from "@/renderer/deferredFeatures";
@@ -174,16 +175,29 @@ function RemoteAccessSidebarIcon(props: { status: RemoteAccessSidebarStatus }) {
   );
 }
 
-function CollapsedThreadRailButton(props: { thread: Thread }) {
-  const { thread } = props;
+function CollapsedThreadRailButton(props: { thread: Thread; projectName?: string }) {
+  const { thread, projectName } = props;
   const isActive = useIsCurrentThread(thread.id);
+  const title = thread.done ? (
+    <span className="opacity-50 line-through">{thread.title}</span>
+  ) : (
+    thread.title
+  );
   return (
     <SidebarButton
       iconOnly
       icon={<ThreadIcon thread={thread} />}
-      label={
-        thread.done ? <span className="opacity-50 line-through">{thread.title}</span> : thread.title
-      }
+      label={title}
+      {...(projectName
+        ? {
+            tooltip: (
+              <span>
+                {title}
+                <span className="text-muted"> — {projectName}</span>
+              </span>
+            ),
+          }
+        : {})}
       isActive={isActive}
       onPress={() => openThread(thread.id)}
     />
@@ -192,6 +206,9 @@ function CollapsedThreadRailButton(props: { thread: Thread }) {
 
 function CollapsedThreadRail() {
   const homeScopeEnabled = useSharedSettings((s) => s.homeScopeEnabled);
+  const showProjectName = usePanelStore((s) => s.threadListLayout === "flat");
+  const projects = useAppStore((s) => s.projects);
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
   const activeThreads = useAppStore(
     useShallow((state) =>
       state.threads.filter(
@@ -213,9 +230,16 @@ function CollapsedThreadRail() {
       className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto"
       style={scrollFadeStyle}
     >
-      {activeThreads.map((thread) => (
-        <CollapsedThreadRailButton key={thread.id} thread={thread} />
-      ))}
+      {activeThreads.map((thread) => {
+        const projectName = showProjectName ? projectsById.get(thread.projectId)?.name : undefined;
+        return (
+          <CollapsedThreadRailButton
+            key={thread.id}
+            thread={thread}
+            {...(projectName ? { projectName } : {})}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -234,6 +258,7 @@ export function Sidebar() {
   const currentProjectId = useCurrentProjectId();
   const currentWorktreePath = useCurrentWorktreePath();
   const sortMode = usePanelStore((s) => s.threadSortMode);
+  const listLayout = usePanelStore((s) => s.threadListLayout);
   const settingsOpen = usePanelStore((s) => s.settingsOpen);
   const settingsSection = usePanelStore((s) => s.settingsSection);
   // Remote Access has its own sidebar entry, so the generic Settings button
@@ -446,6 +471,8 @@ export function Sidebar() {
                 )}
               </p>
             </div>
+          ) : listLayout === "flat" ? (
+            <SidebarFlatThreadList sortMode={sortMode} />
           ) : (
             <div className="space-y-4">
               {homeScopeEnabled && homeProject ? (

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -148,8 +148,7 @@ describe("GitBadge", () => {
     const icon = badge.querySelector("svg");
 
     expect(badge).toHaveClass("opacity-0");
-    expect(badge).toHaveClass("px-1");
-    expect(badge).toHaveClass("py-0.5");
+    expect(badge).toHaveClass("p-[3px]");
     expect(badge).not.toHaveClass("w-[18px]");
     expect(badge).not.toHaveClass("w-0");
     expect(icon).not.toBeNull();
@@ -189,12 +188,40 @@ describe("GitBadge", () => {
     const icon = badge.querySelector("svg");
 
     expect(badge).toHaveClass("opacity-0");
-    expect(badge).toHaveClass("px-1");
-    expect(badge).toHaveClass("py-0.5");
+    expect(badge).toHaveClass("p-[3px]");
     expect(badge).not.toHaveClass("w-[18px]");
     expect(badge).not.toHaveClass("w-0");
     expect(icon).not.toBeNull();
     expect(icon).toHaveClass("lucide-git-branch");
+  });
+
+  it("pads a glyph-only badge into a square, and only widens one carrying diff counts", () => {
+    useGitStore.setState({
+      worktreeStatuses: { "/wt/feature": makeStatus() },
+      prData: { "/wt/feature": basePr },
+    });
+
+    const { unmount } = render(
+      <GitBadge projectId="project-1" projectName="feature/pr" worktreePath="/wt/feature" />,
+    );
+
+    // PR icon only: an 18px square, matching the row's other icon buttons.
+    expect(screen.getByRole("button", { name: "Git status for feature/pr" })).toHaveClass(
+      "p-[3px]",
+    );
+    unmount();
+
+    useGitStore.setState({
+      worktreeStatuses: {
+        "/wt/feature": makeStatus({ totalInsertions: 12, totalDeletions: 3 }),
+      },
+      prData: { "/wt/feature": basePr },
+    });
+    render(<GitBadge projectId="project-1" projectName="feature/pr" worktreePath="/wt/feature" />);
+
+    const withCounts = screen.getByRole("button", { name: "Git status for feature/pr" });
+    expect(withCounts).toHaveClass("px-1");
+    expect(withCounts).not.toHaveClass("p-[3px]");
   });
 
   it("renders diff stats before the PR icon so the icon stays aligned with the timestamp", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -20,7 +20,26 @@ import {
 import type { DragSourceData } from "@/renderer/dnd";
 
 const gitBadgeButtonClass =
-  "shrink-0 cursor-grab rounded px-1 py-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing";
+  "shrink-0 cursor-grab rounded text-muted/60 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing";
+
+/**
+ * A glyph-only badge is an 18px square around its 12px glyph — the same box as
+ * every other icon button in these rows, so its background can't read as a
+ * different-sized chip and its glyph shares their column. Only a badge carrying
+ * diff counts takes extra horizontal room for the text.
+ */
+const gitBadgeIconPaddingClass = "p-[3px]";
+const gitBadgeTextPaddingClass = "px-1 py-0.5";
+
+/**
+ * "Its Git panel is open" is a persistent accent wash behind the badge, at
+ * roughly hover weight. Deliberately not a glyph recolor — the glyph carries the
+ * PR's status tone, which the open state must not mask — and not a ring, which
+ * drew outside the badge's box and clipped inside truncating rows. Overrides the
+ * base `hover:bg-*` so hovering an open badge deepens the wash instead of
+ * flattening it back to neutral.
+ */
+const activeGitBadgeClass = "bg-accent/15 hover:bg-accent/25";
 const hiddenGitBadgeClass =
   "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
 
@@ -155,8 +174,8 @@ export function GitBadge(props: {
             role="button"
             tabIndex={0}
             aria-label={t`Git status for ${props.projectName}: not a Git repository`}
-            className={`${gitBadgeButtonClass} ${
-              props.isActive ? "bg-accent/15 ring-1 ring-accent/40" : "text-muted/60"
+            className={`${gitBadgeButtonClass} ${gitBadgeIconPaddingClass} ${
+              props.isActive ? activeGitBadgeClass : ""
             }`}
             onClick={(e) => {
               e.stopPropagation();
@@ -188,10 +207,8 @@ export function GitBadge(props: {
             role="button"
             tabIndex={0}
             aria-label={t`Git status for ${props.projectName}`}
-            className={`${gitBadgeButtonClass} ${
-              props.isActive
-                ? "bg-accent/15 ring-1 ring-accent/40"
-                : `text-muted/60 ${hiddenGitBadgeClass}`
+            className={`${gitBadgeButtonClass} ${gitBadgeIconPaddingClass} ${
+              props.isActive ? activeGitBadgeClass : hiddenGitBadgeClass
             }`}
             onClick={(e) => {
               e.stopPropagation();
@@ -228,9 +245,9 @@ export function GitBadge(props: {
       role="button"
       tabIndex={0}
       aria-label={t`Git status for ${props.projectName}`}
-      className={`shrink-0 cursor-grab rounded px-1 py-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
-        props.isActive ? "bg-accent/15 ring-1 ring-accent/40" : "text-muted/60"
-      }`}
+      className={`${gitBadgeButtonClass} ${
+        hasChanges ? gitBadgeTextPaddingClass : gitBadgeIconPaddingClass
+      } ${props.isActive ? activeGitBadgeClass : ""}`}
       onClick={(e) => {
         e.stopPropagation();
         props.onPress?.();

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
@@ -1,0 +1,169 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project, Thread } from "@/shared/contracts";
+import { HOME_PROJECT_ID, HOME_PROJECT_NAME } from "@/shared/homeScope";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useWorkspaceStore } from "@/renderer/state/workspaceStore";
+import { SidebarFlatThreadList } from "./SidebarFlatThreadList";
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({}),
+}));
+
+vi.mock("@/renderer/dnd", () => ({
+  useDragSource: () => null,
+}));
+
+vi.mock("./NewThreadButton", () => ({
+  NewThreadButton: (props: { projectId: string }) => (
+    <button type="button">new-thread:{props.projectId}</button>
+  ),
+}));
+
+vi.mock("./SidebarThreadRow", () => ({
+  SeeMoreThreadsButton: () => <button type="button">see-more</button>,
+  SidebarThreadRow: (props: {
+    row: { key: string };
+    project: { name: string };
+    projectTag?: React.ReactNode;
+  }) => (
+    <div data-testid="row">
+      {props.row.key} in {props.project.name}
+      {props.projectTag}
+    </div>
+  ),
+}));
+
+function makeThread(id: string, projectId: string, updatedAt: string): Thread {
+  return {
+    id,
+    projectId,
+    title: `Thread ${id}`,
+    status: "inactive",
+    done: false,
+    starred: false,
+    archived: false,
+    createdAt: updatedAt,
+    updatedAt,
+    agentKind: "claude",
+  } as unknown as Thread;
+}
+
+// The real Home row is persisted with `disabled: true` (see
+// `ensureHomeProjectRow`); the flat list must not filter it out on that flag.
+const homeProject: Project = {
+  id: HOME_PROJECT_ID,
+  name: HOME_PROJECT_NAME,
+  location: { kind: "windows", path: "C:\\Users\\me" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  disabled: true,
+} as Project;
+
+const localProject: Project = {
+  id: "local-1",
+  name: "Poracode",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  workspaceId: "w1",
+} as Project;
+
+const unreachableRemoteProject: Project = {
+  id: "remote-1",
+  name: "Mac Poracode",
+  location: { kind: "posix", path: "/repo" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  remoteServerId: "desktop-1",
+  remoteId: "rp-1",
+  workspaceId: "w1",
+} as Project;
+
+describe("SidebarFlatThreadList", () => {
+  beforeEach(() => {
+    useRemoteServersStore.setState({ servers: [], runtime: {} });
+    useSharedSettings.setState({
+      homeScopeEnabled: true,
+      workspaces: [{ id: "w1", name: "Side Hustle" }],
+    } as never);
+    useWorkspaceStore.setState({ activeWorkspaceId: "w1" });
+  });
+
+  it("shows Home threads alongside project threads with the new-thread row", () => {
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByText(`new-thread:${HOME_PROJECT_ID}`)).toBeInTheDocument();
+    expect(screen.getByText(/thread:h1 in Home/)).toBeInTheDocument();
+    expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
+  });
+
+  it("keeps Home threads and the new-thread row when the only workspace project is unreachable", () => {
+    useAppStore.setState({
+      projects: [homeProject, unreachableRemoteProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("r1", "remote-1", "2026-08-03T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByText(`new-thread:${HOME_PROJECT_ID}`)).toBeInTheDocument();
+    expect(screen.getByText(/thread:h1 in Home/)).toBeInTheDocument();
+    expect(screen.queryByText(/thread:r1/)).not.toBeInTheDocument();
+  });
+
+  it("hides remote threads while the server reports an error (e.g. relay answering for an off machine)", () => {
+    useRemoteServersStore.setState({
+      runtime: { "desktop-1": { status: "error", projects: [], threads: [] } },
+    } as never);
+    useAppStore.setState({
+      projects: [homeProject, unreachableRemoteProject],
+      threads: [makeThread("r1", "remote-1", "2026-08-03T10:00:00.000Z")],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.queryByText(/thread:r1/)).not.toBeInTheDocument();
+  });
+
+  it("shows remote threads while the server is online", () => {
+    useRemoteServersStore.setState({
+      runtime: { "desktop-1": { status: "online", projects: [], threads: [] } },
+    } as never);
+    useAppStore.setState({
+      projects: [homeProject, unreachableRemoteProject],
+      threads: [makeThread("r1", "remote-1", "2026-08-03T10:00:00.000Z")],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByText(/thread:r1 in Mac Poracode/)).toBeInTheDocument();
+  });
+
+  it("hides Home threads when home scope is disabled", () => {
+    useSharedSettings.setState({ homeScopeEnabled: false } as never);
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.queryByText(/thread:h1/)).not.toBeInTheDocument();
+    expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
+    expect(screen.getByText("new-thread:local-1")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -1,0 +1,165 @@
+import { useShallow } from "zustand/shallow";
+import type { Project } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
+import { openNewThread, openNewThreadSideBySide } from "@/renderer/actions/threadActions";
+import { useDragSource } from "@/renderer/dnd";
+import {
+  useCurrentThreadIdsCount,
+  useHasDraft,
+  useIsCurrentProjectDraft,
+  useLiveBackgroundThreadIds,
+} from "@/renderer/hooks/uiSelectors";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useExperimentCandidateOrder } from "@/renderer/state/experimentStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarUiStore";
+import { useWorkspaceProjectIds } from "@/renderer/state/workspaceSelectors";
+import { NewThreadButton } from "./NewThreadButton";
+import { buildSidebarProjectRows, type SidebarRow } from "./sidebarProjectRows";
+import type { ThreadSortMode } from "./sortMode";
+import { SeeMoreThreadsButton, SidebarThreadRow } from "./SidebarThreadRow";
+
+/**
+ * `threadListLimits`/`revealMoreThreads` scope key for the flat list's single
+ * "See more" pager. Not a real project id.
+ */
+const FLAT_LIST_SCOPE = "__flat__";
+
+/** The project a row belongs to: a thread's own, or its group's first member's. */
+function rowProjectId(row: Exclude<SidebarRow, { kind: "see-more" }>): string | undefined {
+  if (row.kind === "thread") return row.thread.projectId;
+  if (row.kind === "worktree-group") return row.group.threads[0]?.projectId;
+  if (row.kind === "thread-group") return row.entry.group.threads[0]?.projectId;
+  return undefined;
+}
+
+/**
+ * One cross-project thread list (the PWA layout): no project sections, each
+ * row labelled with its project instead. Worktree and provider groups keep
+ * grouping; their headers carry the project tag for their children. The single
+ * "New thread" row targets the most recently active project. Sorting follows
+ * the shared sort mode, except per-project manual order, which has no meaning
+ * across projects and falls back to last-updated.
+ */
+export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
+  const workspaceProjectIds = useWorkspaceProjectIds();
+  const homeScopeEnabled = useSharedSettings((s) => s.homeScopeEnabled);
+  const projects = useAppStore(useShallow((s) => s.projects));
+  const remoteRuntime = useRemoteServersStore((s) => s.runtime);
+  const experimentCandidateOrder = useExperimentCandidateOrder();
+  const collapsedWorktrees = useSidebarUiStore((s) => s.collapsedWorktrees);
+  const editingThreadId = useSidebarUiStore((s) => s.editingThreadId);
+  const setEditingThreadId = useSidebarUiStore((s) => s.setEditingThreadId);
+  const revealMoreThreads = useSidebarUiStore((s) => s.revealMoreThreads);
+  const visibleLimit = useThreadListLimit(FLAT_LIST_SCOPE);
+  const currentThreadCount = useCurrentThreadIdsCount();
+  const source = useDragSource();
+
+  // Same visibility rules as the grouped sidebar — workspace projects plus Home
+  // (when enabled), minus disabled projects — except remote mirrors, which are
+  // stricter here: the grouped view keeps an errored-but-reachable server's
+  // section visible because its header carries the status, but flat rows have
+  // no header to explain a dead server (e.g. a relay answering for a powered-off
+  // machine reports `error`, not `offline`), so only online servers' threads
+  // mix into the list.
+  const includedIds = new Set(workspaceProjectIds);
+  const visibleProjects = projects.filter((project) => {
+    // Home is a synthetic row persisted with `disabled: true` by design — the
+    // home-scope setting alone decides whether it shows (mirrors the grouped
+    // sidebar's dedicated Home section).
+    if (isHomeProject(project)) return homeScopeEnabled;
+    if (!includedIds.has(project.id) || project.disabled) return false;
+    if (!project.remoteServerId) return true;
+    return remoteRuntime[project.remoteServerId]?.status === "online";
+  });
+  const projectsById = new Map(visibleProjects.map((project) => [project.id, project]));
+
+  const allThreads = useAppStore((s) => s.threads);
+  const threads = allThreads.filter(
+    (thread) => !thread.archived && projectsById.has(thread.projectId),
+  );
+  const liveBackgroundThreadIds = useLiveBackgroundThreadIds(threads);
+
+  // "New thread" targets the most recently active project (latest thread
+  // update), falling back to the first visible project on a fresh workspace.
+  let latestProjectId: string | undefined;
+  let latestUpdatedAt = "";
+  for (const thread of threads) {
+    if (thread.updatedAt > latestUpdatedAt) {
+      latestUpdatedAt = thread.updatedAt;
+      latestProjectId = thread.projectId;
+    }
+  }
+  latestProjectId ??= visibleProjects[0]?.id;
+  const hasDraft = useHasDraft(latestProjectId ?? "");
+  const isDraftActive = useIsCurrentProjectDraft(latestProjectId ?? "");
+
+  const rows = buildSidebarProjectRows({
+    projectId: FLAT_LIST_SCOPE,
+    projectThreads: threads,
+    sortMode: props.sortMode === "created" ? "created" : "updated",
+    collapsedWorktrees,
+    visibleLimit,
+    liveBackgroundThreadIds,
+    ...(experimentCandidateOrder.size > 0 ? { experimentCandidateOrder } : {}),
+  });
+
+  return (
+    <div className="space-y-0.5">
+      {latestProjectId ? (
+        <NewThreadButton
+          projectId={latestProjectId}
+          hasDraft={hasDraft}
+          isActive={isDraftActive}
+          isDraggingAnything={!!source}
+          canOpenAsPanel={currentThreadCount > 0 && currentThreadCount < 3}
+          onPress={() => openNewThread(latestProjectId)}
+          onOpenAsPanel={() => openNewThreadSideBySide(latestProjectId)}
+        />
+      ) : null}
+
+      <div>
+        {rows.map((row) => {
+          if (row.kind === "see-more") {
+            return (
+              <SeeMoreThreadsButton
+                key={row.key}
+                onPress={() => revealMoreThreads(FLAT_LIST_SCOPE)}
+              />
+            );
+          }
+          const projectId = rowProjectId(row);
+          const project: Project | undefined = projectId
+            ? projectsById.get(projectId)
+            : visibleProjects[0];
+          if (!project) return null;
+          // Children under a group header omit the tag — the header carries it.
+          const tagged = !(row.kind === "thread" && row.inGroup) && row.kind !== "section-label";
+          return (
+            <SidebarThreadRow
+              key={row.key}
+              row={row}
+              project={project}
+              editingThreadId={editingThreadId}
+              setEditingThreadId={setEditingThreadId}
+              {...(tagged
+                ? {
+                    projectTag: (
+                      // Fixed-height group headers keep the inline form; plain
+                      // thread rows carry the tag on a second line.
+                      <span
+                        className={`${row.kind !== "thread" ? "ml-auto max-w-[9rem] shrink-0 pl-1" : "min-w-0 flex-1"} truncate text-[10px] leading-4 text-muted/70`}
+                      >
+                        {project.name}
+                      </span>
+                    ),
+                  }
+                : {})}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectThreadList.tsx
@@ -1,4 +1,3 @@
-import { useLingui } from "@lingui/react/macro";
 import type { Project } from "@/shared/contracts";
 import {
   useCurrentThreadIdsCount,
@@ -7,24 +6,19 @@ import {
   useLiveBackgroundThreadIds,
   useProjectThreads,
 } from "@/renderer/hooks/uiSelectors";
-import { ChevronDown } from "lucide-react";
 import { useDragSource } from "@/renderer/dnd";
 import { openNewThread, openNewThreadSideBySide } from "@/renderer/actions/threadActions";
 import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarUiStore";
-import { useProjectExperimentCandidateOrder } from "@/renderer/state/experimentStore";
-import { SidebarButton } from "@/renderer/components/common/SidebarButton";
-import { chatRowRailClass } from "@/renderer/components/thread/ChatPane/parts/items/chatRow";
+import { useExperimentCandidateOrder } from "@/renderer/state/experimentStore";
 import { NewThreadButton } from "./NewThreadButton";
-import { buildSidebarProjectRows, type SidebarRow } from "./sidebarProjectRows";
+import { buildSidebarProjectRows } from "./sidebarProjectRows";
 import type { ThreadSortMode } from "./sortMode";
-import { SidebarThreadGroup } from "./SidebarThreadGroup";
-import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
-import { SortableThreadItem } from "./SortableThreadItem/SortableThreadItem";
+import { SeeMoreThreadsButton, SidebarThreadRow } from "./SidebarThreadRow";
 
 export function SidebarProjectThreadList(props: { project: Project; sortMode: ThreadSortMode }) {
   const { project, sortMode } = props;
   const projectThreads = useProjectThreads(project.id);
-  const experimentCandidateOrder = useProjectExperimentCandidateOrder(project.id);
+  const experimentCandidateOrder = useExperimentCandidateOrder(project.id);
   const collapsedWorktrees = useSidebarUiStore((s) => s.collapsedWorktrees);
   const editingThreadId = useSidebarUiStore((s) => s.editingThreadId);
   const setEditingThreadId = useSidebarUiStore((s) => s.setEditingThreadId);
@@ -72,79 +66,6 @@ export function SidebarProjectThreadList(props: { project: Project; sortMode: Th
           ),
         )}
       </div>
-    </div>
-  );
-}
-
-function SeeMoreThreadsButton(props: { onPress: () => void }) {
-  const { t } = useLingui();
-  return (
-    <SidebarButton
-      size="xs"
-      icon={<ChevronDown className="size-3.5" />}
-      label={t`See more`}
-      onPress={props.onPress}
-    />
-  );
-}
-
-function SidebarThreadRow(props: {
-  row: Exclude<SidebarRow, { kind: "see-more" }>;
-  project: Project;
-  editingThreadId: string | null;
-  setEditingThreadId: (id: string | null) => void;
-}) {
-  const { row, project, editingThreadId, setEditingThreadId } = props;
-  const { t } = useLingui();
-
-  if (row.kind === "thread") {
-    const item = (
-      <SortableThreadItem
-        thread={row.thread}
-        threadIndex={row.threadIndex}
-        project={project}
-        showWorktreeBadge={row.showWorktreeBadge}
-        {...(row.showWorktreeFilesButton !== undefined
-          ? { showWorktreeFilesButton: row.showWorktreeFilesButton }
-          : {})}
-        editingThreadId={editingThreadId}
-        setEditingThreadId={setEditingThreadId}
-        group={row.group}
-        {...(row.sortDisabled !== undefined ? { sortDisabled: row.sortDisabled } : {})}
-      />
-    );
-    // Group children hang off the same dashed rail as the chat tool-call group
-    // (shared recipe). `ml-3.5` drops the rail down the centerline of the group
-    // header's icon; no left padding keeps the child hugging the rail so the
-    // nesting reads without a wide indent.
-    if (row.inGroup) {
-      return <div className={`ml-3.5 pl-1 ${chatRowRailClass}`}>{item}</div>;
-    }
-    return item;
-  }
-
-  return (
-    <div className="w-full pb-0.5">
-      {row.kind === "worktree-group" ? (
-        <SidebarWorktreeGroup
-          group={row.group}
-          entryIndex={row.entryIndex}
-          project={project}
-          sortableGroup={row.sortableGroup}
-          sortDisabled={row.sortDisabled}
-        />
-      ) : row.kind === "thread-group" ? (
-        <SidebarThreadGroup
-          entry={row.entry}
-          project={project}
-          editingThreadId={editingThreadId}
-          setEditingThreadId={setEditingThreadId}
-        />
-      ) : (
-        <div className="px-1.5 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-wider text-muted">
-          {t(row.label)}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
@@ -30,6 +30,8 @@ export function SidebarThreadGroup(props: {
   project: Project;
   editingThreadId: string | null;
   setEditingThreadId: (id: string | null) => void;
+  /** Trailing project label for cross-project (flat) lists. */
+  projectTag?: React.ReactNode;
 }) {
   const { entry, editingThreadId, setEditingThreadId } = props;
   const { t } = useLingui();
@@ -230,6 +232,7 @@ export function SidebarThreadGroup(props: {
                     <span className={`shrink-0 text-muted/60 ${isDone ? "opacity-50" : ""}`}>
                       {entry.group.threads.length}
                     </span>
+                    {props.projectTag}
                   </>
                 )}
               </button>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
@@ -1,0 +1,92 @@
+import { useLingui } from "@lingui/react/macro";
+import { ChevronDown } from "lucide-react";
+import type { Project } from "@/shared/contracts";
+import { SidebarButton } from "@/renderer/components/common/SidebarButton";
+import { chatRowRailClass } from "@/renderer/components/thread/ChatPane/parts/items/chatRow";
+import type { SidebarRow } from "./sidebarProjectRows";
+import { SidebarThreadGroup } from "./SidebarThreadGroup";
+import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
+import { SortableThreadItem } from "./SortableThreadItem/SortableThreadItem";
+
+export function SeeMoreThreadsButton(props: { onPress: () => void }) {
+  const { t } = useLingui();
+  return (
+    <SidebarButton
+      size="xs"
+      icon={<ChevronDown className="size-3.5" />}
+      label={t`See more`}
+      onPress={props.onPress}
+    />
+  );
+}
+
+/**
+ * Renders one prebuilt sidebar row (thread, group, or section label). Shared by
+ * the per-project list and the flat cross-project list — the caller resolves
+ * the row's project and, in flat mode, its trailing project tag.
+ */
+export function SidebarThreadRow(props: {
+  row: Exclude<SidebarRow, { kind: "see-more" }>;
+  project: Project;
+  editingThreadId: string | null;
+  setEditingThreadId: (id: string | null) => void;
+  /** Trailing project label for cross-project (flat) lists. */
+  projectTag?: React.ReactNode;
+}) {
+  const { row, project, editingThreadId, setEditingThreadId, projectTag } = props;
+  const { t } = useLingui();
+
+  if (row.kind === "thread") {
+    const item = (
+      <SortableThreadItem
+        thread={row.thread}
+        threadIndex={row.threadIndex}
+        project={project}
+        showWorktreeBadge={row.showWorktreeBadge}
+        {...(row.showWorktreeFilesButton !== undefined
+          ? { showWorktreeFilesButton: row.showWorktreeFilesButton }
+          : {})}
+        editingThreadId={editingThreadId}
+        setEditingThreadId={setEditingThreadId}
+        group={row.group}
+        {...(row.sortDisabled !== undefined ? { sortDisabled: row.sortDisabled } : {})}
+        {...(projectTag !== undefined ? { projectTag } : {})}
+      />
+    );
+    // Group children hang off the same dashed rail as the chat tool-call group
+    // (shared recipe). `ml-3.5` drops the rail down the centerline of the group
+    // header's icon; no left padding keeps the child hugging the rail so the
+    // nesting reads without a wide indent.
+    if (row.inGroup) {
+      return <div className={`ml-3.5 pl-1 ${chatRowRailClass}`}>{item}</div>;
+    }
+    return item;
+  }
+
+  return (
+    <div className="w-full pb-0.5">
+      {row.kind === "worktree-group" ? (
+        <SidebarWorktreeGroup
+          group={row.group}
+          entryIndex={row.entryIndex}
+          project={project}
+          sortableGroup={row.sortableGroup}
+          sortDisabled={row.sortDisabled}
+          {...(projectTag !== undefined ? { projectTag } : {})}
+        />
+      ) : row.kind === "thread-group" ? (
+        <SidebarThreadGroup
+          entry={row.entry}
+          project={project}
+          editingThreadId={editingThreadId}
+          setEditingThreadId={setEditingThreadId}
+          {...(projectTag !== undefined ? { projectTag } : {})}
+        />
+      ) : (
+        <div className="px-1.5 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-wider text-muted">
+          {t(row.label)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -39,6 +39,8 @@ export function SidebarWorktreeGroup(props: {
   project: Project;
   sortableGroup: string;
   sortDisabled?: boolean;
+  /** Trailing project label for cross-project (flat) lists. */
+  projectTag?: React.ReactNode;
 }) {
   const { group, project, sortDisabled = false } = props;
   const { t } = useLingui();
@@ -173,6 +175,7 @@ export function SidebarWorktreeGroup(props: {
           isDraggingAnything={!!source}
           isDone={isDone}
           updatedAt={latestThreadUpdatedAt}
+          {...(props.projectTag !== undefined ? { projectTag: props.projectTag } : {})}
         />
       </ContextMenu>
     </div>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -29,7 +29,11 @@ import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/par
 import { gitMenuIcons } from "@/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons";
 import { DraftIndicator } from "../DraftIndicator";
 import { InlineRenameInput } from "../InlineRenameInput";
-import { ThreadItemSuffix } from "./parts/ThreadItemSuffix";
+import {
+  ThreadItemBottomSuffix,
+  ThreadItemSuffix,
+  ThreadItemTopSuffix,
+} from "./parts/ThreadItemSuffix";
 import {
   useCurrentThreadIdsCount,
   useIsCurrentThread,
@@ -70,6 +74,8 @@ export function SortableThreadItem(props: {
   setEditingThreadId: (id: string | null) => void;
   group: string;
   sortDisabled?: boolean;
+  /** Trailing project label for cross-project (flat) lists. */
+  projectTag?: React.ReactNode;
 }) {
   const {
     thread,
@@ -78,6 +84,7 @@ export function SortableThreadItem(props: {
     showWorktreeFilesButton = false,
     editingThreadId,
     sortDisabled = false,
+    projectTag,
   } = props;
   const { t } = useLingui();
   const experiment = useExperimentStore((state) =>
@@ -123,6 +130,19 @@ export function SortableThreadItem(props: {
 
   const hasBackgroundActivity = useThreadHasBackgroundActivity(thread.id);
   const statusTone = getStatusTone(thread, { hasBackgroundActivity });
+
+  const stacked = projectTag != null;
+  const titleNode = thread.done ? (
+    <span className="opacity-50 line-through">{thread.title}</span>
+  ) : (
+    thread.title
+  );
+  const suffixProps = {
+    thread,
+    showWorktreeBadge,
+    showWorktreeFilesButton,
+    isExperimentCandidate,
+  };
 
   return (
     <div ref={ref} className="relative w-full pb-0.5">
@@ -337,6 +357,7 @@ export function SortableThreadItem(props: {
       >
         <SidebarButton
           size="xs"
+          density={stacked ? "compact" : "default"}
           statusTone={statusTone}
           icon={
             <ThreadProviderIcon thread={thread} tone={statusTone} className="size-3.5 shrink-0" />
@@ -351,32 +372,50 @@ export function SortableThreadItem(props: {
                 }}
                 onCancel={() => props.setEditingThreadId(null)}
               />
+            ) : stacked ? (
+              // Two-line flat-list row: each line owns its right-side cluster,
+              // so the bottom badges never reserve width from the title line.
+              // Line heights match the text (16px title, 14px meta).
+              // pr-0.5 keeps the badges' hover background clear of the label's
+              // overflow clip — SidebarButton wraps the label in a `truncate`
+              // span, so anything flush with its right edge gets cut.
+              <span className="flex flex-col gap-0.5 pr-0.5">
+                <span className="flex h-[18px] items-center gap-1.5">
+                  <span className="min-w-0 flex-1 truncate">{titleNode}</span>
+                  {hasDraft && <DraftIndicator />}
+                  {/* No padding here: the time slot carries the 2px inset that
+                      matches the git badge's own p-0.5, so both rows' icon
+                      columns share the same offset from the row's right edge. */}
+                  <span className="flex shrink-0 items-center gap-[3px]">
+                    <ThreadItemTopSuffix {...suffixProps} />
+                  </span>
+                </span>
+                <span className="flex h-[18px] items-center gap-1.5">
+                  {projectTag}
+                  <span className="flex shrink-0 items-center gap-[3px]">
+                    <ThreadItemBottomSuffix {...suffixProps} />
+                  </span>
+                </span>
+              </span>
             ) : (
               <span className="flex items-center gap-1.5">
-                <span className="min-w-0 truncate">
-                  {thread.done ? (
-                    <span className="opacity-50 line-through">{thread.title}</span>
-                  ) : (
-                    thread.title
-                  )}
-                </span>
+                <span className="min-w-0 truncate">{titleNode}</span>
                 {hasDraft && <DraftIndicator />}
               </span>
             )
           }
-          tooltip={editingThreadId === thread.id ? undefined : thread.title}
+          tooltip={
+            editingThreadId === thread.id
+              ? undefined
+              : stacked
+                ? `${thread.title} — ${project.name}`
+                : thread.title
+          }
           isActive={isCurrentThread}
           onPress={() => openThread(thread.id)}
           onDoubleClick={() => props.setEditingThreadId(thread.id)}
           isDragging={isDragging}
-          suffix={
-            <ThreadItemSuffix
-              thread={thread}
-              showWorktreeBadge={showWorktreeBadge}
-              showWorktreeFilesButton={showWorktreeFilesButton}
-              isExperimentCandidate={isExperimentCandidate}
-            />
-          }
+          {...(stacked ? {} : { suffix: <ThreadItemSuffix {...suffixProps} /> })}
         />
       </ContextMenu>
     </div>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
@@ -20,140 +20,219 @@ import {
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
 import { SidebarPanelDragButton } from "../../SidebarPanelDragButton";
 
-export function ThreadItemSuffix(props: {
+interface ThreadItemSuffixProps {
   thread: Thread;
   showWorktreeBadge: boolean;
   showWorktreeFilesButton: boolean;
   isExperimentCandidate: boolean;
-}) {
-  const { thread, showWorktreeBadge, showWorktreeFilesButton, isExperimentCandidate } = props;
-  const { t } = useLingui();
-  const threadRemoveAction = useSharedSettings((s) => s.threadRemoveAction);
-  const prState = usePrState(thread.worktreePath);
-  // A merged PR means the work landed, so the row offers Done inline instead of
-  // sending the user through the context menu.
-  const showDoneButton =
-    !isExperimentCandidate && !thread.done && !!thread.worktreePath && prState === "merged";
-  const isFilesActive = useIsWorktreeFilesPanelActive(thread.worktreePath);
-  const isGitActive = useIsWorktreeGitPanelActive(thread.worktreePath);
-  const isTerminalActive = useIsWorktreeTerminalActive(thread.worktreePath);
-  const isTerminalOpen = useIsWorktreeTerminalOpen(thread.worktreePath);
-  const isTerminalBusy = useIsWorktreeTerminalBusy(thread.worktreePath);
-  const isTerminalVisible = isTerminalActive || isTerminalOpen;
-  const hiddenPanelButtonClass =
-    "w-0 -mr-[3px] overflow-hidden p-0 opacity-0 pointer-events-none group-hover:w-[18px] group-hover:mr-0 group-hover:p-0.5 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:w-[18px] focus-visible:mr-0 focus-visible:p-0.5 focus-visible:opacity-100 focus-visible:pointer-events-auto";
+}
 
-  // Sits left of the git badge so the PR glyph keeps its slot next to the
-  // timestamp whether or not the row is hovered.
-  const doneButton = showDoneButton ? (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-label={t`Mark ${thread.title} done`}
-      className={`flex h-[18px] shrink-0 items-center justify-center rounded text-muted/60 transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-success ${hiddenPanelButtonClass}`}
-      onClick={(event) => {
-        event.stopPropagation();
-        markThreadDone(thread.id);
-      }}
-      onKeyDown={(event) =>
-        handleKeyActivate(event, () => markThreadDone(thread.id), { stopPropagation: true })
-      }
-    >
-      <CircleCheck className="size-3.5" />
-    </div>
-  ) : null;
+const iconSizeClass = "size-3.5";
+const buttonHeightClass = "h-[18px]";
+const buttonVisibleClass = "w-[18px] p-0.5";
+const hiddenPanelButtonClass =
+  "w-0 -mr-[3px] overflow-hidden p-0 opacity-0 pointer-events-none group-hover:w-[18px] group-hover:mr-0 group-hover:p-0.5 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:w-[18px] focus-visible:mr-0 focus-visible:p-0.5 focus-visible:opacity-100 focus-visible:pointer-events-auto";
+
+function ThreadItemWorktreeActions(props: ThreadItemSuffixProps) {
+  const { thread, showWorktreeBadge, showWorktreeFilesButton } = props;
+  const { t } = useLingui();
+  const worktreePath = showWorktreeBadge ? thread.worktreePath : undefined;
+  const isFilesActive = useIsWorktreeFilesPanelActive(worktreePath);
+  const isTerminalActive = useIsWorktreeTerminalActive(worktreePath);
+  const isTerminalOpen = useIsWorktreeTerminalOpen(worktreePath);
+  const isTerminalBusy = useIsWorktreeTerminalBusy(worktreePath);
+  const isTerminalVisible = isTerminalActive || isTerminalOpen;
 
   return (
     <>
-      {thread.starred && <Star className="size-3 shrink-0 fill-current" aria-label={t`Pinned`} />}
-      {showWorktreeBadge && thread.worktreePath && (
-        <>
-          {showWorktreeFilesButton ? (
-            <SidebarPanelDragButton
-              panel="files"
-              projectId={thread.projectId}
-              worktreePath={thread.worktreePath}
-              ariaLabel={t`Files for ${thread.worktreeBranch ?? thread.title}`}
-              className={`flex h-[18px] shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
-                isFilesActive
-                  ? "w-[18px] p-0.5 text-accent"
-                  : `text-muted/60 ${hiddenPanelButtonClass}`
-              }`}
-              onPress={() => openFilesPanel(thread.projectId, thread.worktreePath)}
-            >
-              <FolderOpen className="size-3.5" />
-            </SidebarPanelDragButton>
-          ) : null}
-          <SidebarPanelDragButton
-            panel="terminal"
-            projectId={thread.projectId}
-            worktreePath={thread.worktreePath}
-            ariaLabel={t`Terminal for ${thread.worktreeBranch}`}
-            className={`flex h-[18px] shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
-              isTerminalVisible
-                ? `w-[18px] p-0.5 ${isTerminalActive ? "text-accent" : "text-foreground"}`
-                : `text-muted/60 ${hiddenPanelButtonClass}`
-            }`}
-            onPress={() => openWorktreeTerminal(thread.projectId, thread.worktreePath!)}
-          >
-            <AnimatedTerminalIcon className="size-3.5" isBusy={isTerminalBusy} />
-          </SidebarPanelDragButton>
-          <SyncBadge projectId={thread.projectId} worktreePath={thread.worktreePath} />
-          {doneButton}
-          <GitBadge
-            projectId={thread.projectId}
-            projectName={thread.worktreeBranch ?? ""}
-            worktreePath={thread.worktreePath}
-            onPress={() => openGitReview(thread.projectId, thread.worktreePath, thread.id)}
-            isActive={isGitActive}
-            fallbackToWorktreeIcon
-          />
-        </>
-      )}
-      {/* Rows inside a worktree group hide the badge cluster — keep the button. */}
-      {!showWorktreeBadge || !thread.worktreePath ? doneButton : null}
-      <span className="relative w-[2.4ch] shrink-0">
+      {thread.starred ? (
+        <Star className="size-3 shrink-0 fill-current" aria-label={t`Pinned`} />
+      ) : null}
+      {worktreePath && showWorktreeFilesButton ? (
+        <SidebarPanelDragButton
+          panel="files"
+          projectId={thread.projectId}
+          worktreePath={worktreePath}
+          ariaLabel={t`Files for ${thread.worktreeBranch ?? thread.title}`}
+          className={`flex ${buttonHeightClass} shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
+            isFilesActive
+              ? `${buttonVisibleClass} text-accent`
+              : `text-muted/60 ${hiddenPanelButtonClass}`
+          }`}
+          onPress={() => openFilesPanel(thread.projectId, worktreePath)}
+        >
+          <FolderOpen className={iconSizeClass} />
+        </SidebarPanelDragButton>
+      ) : null}
+      {worktreePath ? (
+        <SidebarPanelDragButton
+          panel="terminal"
+          projectId={thread.projectId}
+          worktreePath={worktreePath}
+          ariaLabel={t`Terminal for ${thread.worktreeBranch}`}
+          className={`flex ${buttonHeightClass} shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
+            isTerminalVisible
+              ? `${buttonVisibleClass} ${isTerminalActive ? "text-accent" : "text-foreground"}`
+              : `text-muted/60 ${hiddenPanelButtonClass}`
+          }`}
+          onPress={() => openWorktreeTerminal(thread.projectId, worktreePath)}
+        >
+          <AnimatedTerminalIcon className={iconSizeClass} isBusy={isTerminalBusy} />
+        </SidebarPanelDragButton>
+      ) : null}
+    </>
+  );
+}
+
+function ThreadItemStatusBadges(props: ThreadItemSuffixProps) {
+  const { thread, showWorktreeBadge, isExperimentCandidate } = props;
+  const { t } = useLingui();
+  const worktreePath = showWorktreeBadge ? thread.worktreePath : undefined;
+  const prState = usePrState(thread.worktreePath);
+  const isGitActive = useIsWorktreeGitPanelActive(worktreePath);
+  const showDoneButton =
+    !isExperimentCandidate && !thread.done && !!thread.worktreePath && prState === "merged";
+
+  return (
+    <>
+      {worktreePath ? <SyncBadge projectId={thread.projectId} worktreePath={worktreePath} /> : null}
+      {showDoneButton ? (
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label={t`Mark ${thread.title} done`}
+          className={`flex ${buttonHeightClass} shrink-0 items-center justify-center rounded text-muted/60 transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-success ${hiddenPanelButtonClass}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            markThreadDone(thread.id);
+          }}
+          onKeyDown={(event) =>
+            handleKeyActivate(event, () => markThreadDone(thread.id), { stopPropagation: true })
+          }
+        >
+          <CircleCheck className={iconSizeClass} />
+        </div>
+      ) : null}
+      {worktreePath ? (
+        <GitBadge
+          projectId={thread.projectId}
+          projectName={thread.worktreeBranch ?? ""}
+          worktreePath={worktreePath}
+          onPress={() => openGitReview(thread.projectId, worktreePath, thread.id)}
+          isActive={isGitActive}
+          fallbackToWorktreeIcon
+        />
+      ) : null}
+    </>
+  );
+}
+
+function ThreadItemRemovalTime(
+  props: Pick<ThreadItemSuffixProps, "thread" | "isExperimentCandidate"> & {
+    compact?: boolean;
+  },
+) {
+  const { thread, isExperimentCandidate, compact = false } = props;
+  const { t } = useLingui();
+  const threadRemoveAction = useSharedSettings((s) => s.threadRemoveAction);
+  const removeThread = () => {
+    if (threadRemoveAction === "archive") {
+      archiveThread(thread.id);
+    } else {
+      deleteThread(thread.id, thread.worktreePath, thread.projectId);
+    }
+  };
+  const removeLabel =
+    threadRemoveAction === "archive" ? t`Archive ${thread.title}` : t`Delete ${thread.title}`;
+  const removeIcon =
+    threadRemoveAction === "archive" ? (
+      <Archive className={iconSizeClass} />
+    ) : (
+      <Trash2 className={iconSizeClass} />
+    );
+
+  if (compact) {
+    return (
+      <span className="relative flex h-[18px] w-[18px] shrink-0 items-center justify-center">
         <RelativeTime
           iso={thread.updatedAt}
-          className={`block text-center font-mono text-[10px] tabular-nums text-muted ${isExperimentCandidate ? "" : "group-hover:invisible"}`}
+          className={`block font-mono text-[10px] leading-none tabular-nums text-muted ${isExperimentCandidate ? "" : "group-hover:invisible"}`}
         />
         {!isExperimentCandidate ? (
           <div
             role="button"
             tabIndex={0}
-            aria-label={
-              threadRemoveAction === "archive"
-                ? t`Archive ${thread.title}`
-                : t`Delete ${thread.title}`
-            }
-            className={`absolute inset-0 flex items-center justify-center rounded text-muted/55 opacity-0 transition group-hover:opacity-100 ${threadRemoveAction === "archive" ? "hover:text-warning" : "hover:text-danger"}`}
+            aria-label={removeLabel}
+            className={`absolute inset-0 flex items-center justify-center rounded text-muted/55 opacity-0 transition group-hover:opacity-100 ${threadRemoveAction === "archive" ? "hover:bg-[var(--row-hover)] hover:text-warning" : "hover:bg-[var(--row-hover)] hover:text-danger"}`}
             onClick={(event) => {
               event.stopPropagation();
-              if (threadRemoveAction === "archive") {
-                archiveThread(thread.id);
-              } else {
-                deleteThread(thread.id, thread.worktreePath, thread.projectId);
-              }
+              removeThread();
             }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") {
-                event.stopPropagation();
-                if (threadRemoveAction === "archive") {
-                  archiveThread(thread.id);
-                } else {
-                  deleteThread(thread.id, thread.worktreePath, thread.projectId);
-                }
-              }
-            }}
+            onKeyDown={(event) => handleKeyActivate(event, removeThread, { stopPropagation: true })}
           >
-            {threadRemoveAction === "archive" ? (
-              <Archive className="size-3.5" />
-            ) : (
-              <Trash2 className="size-3.5" />
-            )}
+            {removeIcon}
           </div>
         ) : null}
       </span>
+    );
+  }
+
+  return (
+    <span className="relative w-[2.4ch] shrink-0">
+      <RelativeTime
+        iso={thread.updatedAt}
+        className={`block text-center font-mono text-[10px] tabular-nums text-muted ${isExperimentCandidate ? "" : "group-hover:invisible"}`}
+      />
+      {!isExperimentCandidate ? (
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label={removeLabel}
+          className={`absolute inset-0 flex items-center justify-center rounded text-muted/55 opacity-0 transition group-hover:opacity-100 ${threadRemoveAction === "archive" ? "hover:text-warning" : "hover:text-danger"}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            removeThread();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.stopPropagation();
+              removeThread();
+            }
+          }}
+        >
+          {removeIcon}
+        </div>
+      ) : null}
+    </span>
+  );
+}
+
+export function ThreadItemTopSuffix(props: ThreadItemSuffixProps) {
+  return (
+    <>
+      <ThreadItemWorktreeActions {...props} />
+      <ThreadItemRemovalTime
+        thread={props.thread}
+        isExperimentCandidate={props.isExperimentCandidate}
+        compact
+      />
+    </>
+  );
+}
+
+export function ThreadItemBottomSuffix(props: ThreadItemSuffixProps) {
+  return <ThreadItemStatusBadges {...props} />;
+}
+
+export function ThreadItemSuffix(props: ThreadItemSuffixProps) {
+  return (
+    <>
+      <ThreadItemWorktreeActions {...props} />
+      <ThreadItemStatusBadges {...props} />
+      <ThreadItemRemovalTime
+        thread={props.thread}
+        isExperimentCandidate={props.isExperimentCandidate}
+      />
     </>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -28,6 +28,8 @@ export function WorktreeGroupHeader(props: {
   isDone?: boolean;
   updatedAt: string;
   onContextMenu?: React.MouseEventHandler | undefined;
+  /** Trailing project label for cross-project (flat) lists. */
+  projectTag?: React.ReactNode;
 }) {
   const { t } = useLingui();
   const hiddenPanelButtonClass =
@@ -55,10 +57,13 @@ export function WorktreeGroupHeader(props: {
         )
       }
       label={
-        <span
-          className={`font-medium ${props.isDone ? "opacity-50 line-through" : "text-foreground/80"}`}
-        >
-          {props.worktreeBranch}
+        <span className="flex items-center gap-1.5">
+          <span
+            className={`min-w-0 truncate font-medium ${props.isDone ? "opacity-50 line-through" : "text-foreground/80"}`}
+          >
+            {props.worktreeBranch}
+          </span>
+          {props.projectTag}
         </span>
       }
       tooltip={t`Worktree: ${props.worktreeBranch}`}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sortMode.ts
@@ -1,4 +1,4 @@
-import { ArrowDownUp, CalendarClock, GripVertical } from "lucide-react";
+import { ArrowDownUp, CalendarClock, GripVertical, List, ListTree } from "lucide-react";
 import { msg } from "@lingui/core/macro";
 import type { MessageDescriptor } from "@lingui/core";
 
@@ -17,4 +17,26 @@ export const sortModeLabel: Record<ThreadSortMode, MessageDescriptor> = {
   updated: msg`Sort by last updated`,
   created: msg`Sort by created`,
   manual: msg`Manual order`,
+};
+
+/**
+ * How the thread list is structured — orthogonal to the sort order above.
+ * `grouped` renders one section per project; `flat` renders one cross-project
+ * list (the PWA layout) with each row labelled by its project. Manual sort
+ * only applies to the grouped layout; the flat list falls back to last-updated
+ * order.
+ */
+export type ThreadListLayout = "grouped" | "flat";
+
+export const listLayoutOrder: ThreadListLayout[] = ["grouped", "flat"];
+
+export const listLayoutIcon: Record<ThreadListLayout, typeof ArrowDownUp> = {
+  grouped: ListTree,
+  flat: List,
+};
+
+/** Display labels keyed by the stable {@link ThreadListLayout} id; resolve via `useLingui().t`. */
+export const listLayoutLabel: Record<ThreadListLayout, MessageDescriptor> = {
+  grouped: msg`Grouped by project`,
+  flat: msg`Flat list`,
 };

--- a/src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+++ b/src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
@@ -1,10 +1,13 @@
 import { FolderPlus, Globe, Search } from "lucide-react";
-import { Button, Dropdown, Label, Tooltip } from "@heroui/react";
+import { Button, Dropdown, Label, Separator, Tooltip } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { toggleBrowserPanel } from "@/renderer/actions/panelActions";
 import {
   type ThreadSortMode,
+  listLayoutIcon,
+  listLayoutLabel,
+  listLayoutOrder,
   sortModeOrder,
   sortModeIcon,
   sortModeLabel,
@@ -14,6 +17,7 @@ import { CreateProjectMenu } from "@/renderer/views/MainView/parts/CreateProject
 export function SidebarHeaderControls() {
   const { t } = useLingui();
   const threadSortMode = usePanelStore((s) => s.threadSortMode);
+  const threadListLayout = usePanelStore((s) => s.threadListLayout);
   const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
   const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
   const browserVisible = browserPanelOpen && rightPanelTab === "browser";
@@ -51,23 +55,26 @@ export function SidebarHeaderControls() {
       <Dropdown>
         <Button
           isIconOnly
-          aria-label={t`Sort threads`}
+          aria-label={t`List options`}
           size="sm"
           variant="ghost"
           className="size-6 min-w-0 text-muted hover:text-foreground"
         >
           {(() => {
-            const Icon = sortModeIcon[threadSortMode];
+            const Icon =
+              threadListLayout === "flat" ? listLayoutIcon.flat : sortModeIcon[threadSortMode];
             return <Icon className="size-3.5" />;
           })()}
         </Button>
         <Dropdown.Popover>
           <Dropdown.Menu
-            aria-label={t`Thread sort order`}
-            selectionMode="single"
-            selectedKeys={[threadSortMode]}
+            aria-label={t`Thread list options`}
+            selectionMode="multiple"
+            selectedKeys={[threadSortMode, threadListLayout]}
             onAction={(key) => {
-              usePanelStore.getState().setThreadSortMode(key as ThreadSortMode);
+              const state = usePanelStore.getState();
+              if (key === "grouped" || key === "flat") state.setThreadListLayout(key);
+              else state.setThreadSortMode(key as ThreadSortMode);
             }}
           >
             {sortModeOrder.map((mode) => {
@@ -77,6 +84,19 @@ export function SidebarHeaderControls() {
                 <Dropdown.Item key={mode} id={mode} textValue={label}>
                   <Icon className="size-4 shrink-0 text-muted" />
                   <Label>{label}</Label>
+                  <Dropdown.ItemIndicator />
+                </Dropdown.Item>
+              );
+            })}
+            <Separator />
+            {listLayoutOrder.map((layout) => {
+              const Icon = listLayoutIcon[layout];
+              const label = t(listLayoutLabel[layout]);
+              return (
+                <Dropdown.Item key={layout} id={layout} textValue={label}>
+                  <Icon className="size-4 shrink-0 text-muted" />
+                  <Label>{label}</Label>
+                  <Dropdown.ItemIndicator />
                 </Dropdown.Item>
               );
             })}


### PR DESCRIPTION
- Add a flat thread list layout to the sidebar with new SidebarFlatThreadList and SidebarThreadRow components.
- Extend sort modes and update thread/worktree group components so threads can be listed flat instead of nested by project.
- Gate the new layout behind an experiment flag backed by experimentStore and panelStore state changes.
- Align GitBadge, header controls, and sortable thread items with the flat layout and add unit tests for the new components.
- Localize all new UI strings across all 13 locales.