### PR TITLE
feat(sidebar): new thread + browser buttons and context menu in collapsed rail

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Thread archivieren"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Thread archivieren"
 
@@ -2904,7 +2904,7 @@ msgstr "Weiter"
 msgid "Continue in another provider"
 msgstr "In einem anderen Anbieter fortfahren"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Weiter in..."
 
@@ -3600,7 +3600,7 @@ msgstr "Thread löschen"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Thread löschen"
 
@@ -4956,7 +4956,7 @@ msgstr "Aufgabe abrufen"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Gruppe"
 msgid "Group name"
 msgstr "Gruppenname"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Offene Threads gruppieren"
 
@@ -6126,7 +6126,7 @@ msgstr "Als erledigt markieren"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Als erledigt markieren"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Neuer Thread im Worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Neuer Thread im Arbeitsbaum"
 
@@ -6847,7 +6847,7 @@ msgstr "Nächster Tab"
 msgid "No active browser tab"
 msgstr "Kein aktiver Browser-Tab"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Keine aktive Sitzung"
 
@@ -7107,7 +7107,7 @@ msgstr "Kein Mikrofon gefunden."
 msgid "No models found"
 msgstr "Keine Modelle gefunden"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Keine anderen Agenten installiert"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Experiment öffnen"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Experiment-Board öffnen"
 
@@ -8024,7 +8024,7 @@ msgstr "Die Auswahl hat keinen Anhang zurückgegeben"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Oben anheften"
 
@@ -8894,7 +8894,7 @@ msgstr "Umgebungsvariable entfernen"
 msgid "Remove from favorites"
 msgstr "Aus Favoriten entfernen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Aus der Gruppe entfernen"
 
@@ -8952,7 +8952,7 @@ msgstr "Worktree entfernen?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Umbenennen"
@@ -9326,7 +9326,7 @@ msgstr "Rechtsklicken, um den Ring zu wechseln"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Ausführen"
 
@@ -11347,7 +11347,7 @@ msgstr "Der Thread ist beendet oder wartet auf Ihre Eingabe."
 msgid "Thread goal dock"
 msgstr "Thread-Zieldock"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Thread ist bereits entladen."
 
@@ -11916,7 +11916,7 @@ msgstr "Inaktive Threads entladen nach"
 msgid "Unload idle threads after (minutes)"
 msgstr "Inaktive Threads entladen nach (Minuten)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Thread entladen"
 
@@ -11936,7 +11936,7 @@ msgstr "Markierung „Fertig“ aufheben"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Markierung „Fertig“ aufheben"
 
@@ -11951,7 +11951,7 @@ msgstr "Ohne Phase:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Lösen"
 
@@ -12339,7 +12339,7 @@ msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Gewinner zu
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Pull Request öffnen."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Warten Sie, bis der Thread gestartet ist."
 

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Durchsuchen Sie Ihre GitHub-Repositorys oder fügen Sie eine Klon-URL ei
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Neuer Tab in Gruppe"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Neuer Thread"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1329,7 +1329,7 @@ msgstr "Archive thread"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Archive Thread"
 
@@ -2909,7 +2909,7 @@ msgstr "Continue"
 msgid "Continue in another provider"
 msgstr "Continue in another provider"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Continue in..."
 
@@ -3605,7 +3605,7 @@ msgstr "Delete thread"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Delete Thread"
 
@@ -4961,7 +4961,7 @@ msgstr "Get task"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5113,7 +5113,7 @@ msgstr "Group"
 msgid "Group name"
 msgstr "Group name"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Group open threads"
 
@@ -6131,7 +6131,7 @@ msgstr "Mark done"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Mark Done"
 
@@ -6807,7 +6807,7 @@ msgid "New thread in worktree"
 msgstr "New thread in worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "New Thread in Worktree"
 
@@ -6852,7 +6852,7 @@ msgstr "Next tab"
 msgid "No active browser tab"
 msgstr "No active browser tab"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "No active session"
 
@@ -7112,7 +7112,7 @@ msgstr "No microphone found."
 msgid "No models found"
 msgstr "No models found"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "No other agents installed"
 
@@ -7524,7 +7524,7 @@ msgid "Open experiment"
 msgstr "Open experiment"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Open experiment board"
 
@@ -8029,7 +8029,7 @@ msgstr "Picker returned no attachment"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Pin to top"
 
@@ -8899,7 +8899,7 @@ msgstr "Remove environment variable"
 msgid "Remove from favorites"
 msgstr "Remove from favorites"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Remove from group"
 
@@ -8957,7 +8957,7 @@ msgstr "Remove worktree?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Rename"
@@ -9331,7 +9331,7 @@ msgstr "Right-click to switch ring"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Run"
 
@@ -11352,7 +11352,7 @@ msgstr "Thread finished or waiting for your input."
 msgid "Thread goal dock"
 msgstr "Thread goal dock"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Thread is already unloaded."
 
@@ -11921,7 +11921,7 @@ msgstr "Unload idle threads after"
 msgid "Unload idle threads after (minutes)"
 msgstr "Unload idle threads after (minutes)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Unload Thread"
 
@@ -11941,7 +11941,7 @@ msgstr "Unmark done"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Unmark Done"
 
@@ -11956,7 +11956,7 @@ msgstr "Unphased:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Unpin"
 
@@ -12344,7 +12344,7 @@ msgstr "Wait for every candidate to finish before merging a winner."
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Wait for every candidate to finish before opening a pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Wait for the thread to finish starting."
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1735,6 +1735,7 @@ msgstr "Browse your GitHub repositories or paste a clone URL."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6778,6 +6779,7 @@ msgstr "New tab in group"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "New thread"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Archivar hilo"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Archivar hilo"
 
@@ -2904,7 +2904,7 @@ msgstr "Continuar"
 msgid "Continue in another provider"
 msgstr "Continuar en otro proveedor"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Continuar en..."
 
@@ -3600,7 +3600,7 @@ msgstr "Eliminar hilo"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Eliminar hilo"
 
@@ -4956,7 +4956,7 @@ msgstr "Obtener tarea"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Grupo"
 msgid "Group name"
 msgstr "Nombre del grupo"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Agrupar hilos abiertos"
 
@@ -6126,7 +6126,7 @@ msgstr "Marcar hecho"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Marcar como hecho"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Nuevo hilo en worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Nuevo hilo en worktree"
 
@@ -6847,7 +6847,7 @@ msgstr "Pestaña siguiente"
 msgid "No active browser tab"
 msgstr "No hay una pestaña activa del navegador"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Sin sesión activa"
 
@@ -7107,7 +7107,7 @@ msgstr "No se encontró micrófono."
 msgid "No models found"
 msgstr "No se encontraron modelos"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "No hay otros agentes instalados"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Abrir experimento"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Abrir tablero del experimento"
 
@@ -8024,7 +8024,7 @@ msgstr "El selector no devolvió ningún adjunto"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Fijar arriba"
 
@@ -8894,7 +8894,7 @@ msgstr "Eliminar variable de entorno"
 msgid "Remove from favorites"
 msgstr "Quitar de favoritos"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Quitar del grupo"
 
@@ -8952,7 +8952,7 @@ msgstr "¿Eliminar worktree?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Renombrar"
@@ -9326,7 +9326,7 @@ msgstr "Haz clic derecho para cambiar de anillo"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Ejecutar"
 
@@ -11347,7 +11347,7 @@ msgstr "El hilo terminó o está esperando tu respuesta."
 msgid "Thread goal dock"
 msgstr "Panel del objetivo del hilo"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "El hilo ya está descargado."
 
@@ -11916,7 +11916,7 @@ msgstr "Descargar los hilos inactivos tras"
 msgid "Unload idle threads after (minutes)"
 msgstr "Descargar los hilos inactivos tras (minutos)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Descargar hilo"
 
@@ -11936,7 +11936,7 @@ msgstr "Desmarcar como hecho"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Desmarcar como hecho"
 
@@ -11951,7 +11951,7 @@ msgstr "Sin fase:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Desanclar"
 
@@ -12339,7 +12339,7 @@ msgstr "Espera a que todos los candidatos terminen antes de fusionar a un ganado
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Espera a que todos los candidatos terminen antes de abrir una pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Espera a que el hilo termine de iniciarse."
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Explora tus repositorios de GitHub o pega una URL de clonación."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Nueva pestaña en el grupo"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Nuevo hilo"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Archiver le fil de discussion"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Archiver le fil de discussion"
 
@@ -2904,7 +2904,7 @@ msgstr "Continuer"
 msgid "Continue in another provider"
 msgstr "Continuer dans un autre fournisseur"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Continuez dans..."
 
@@ -3600,7 +3600,7 @@ msgstr "Supprimer le fil de discussion"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Supprimer le fil de discussion"
 
@@ -4956,7 +4956,7 @@ msgstr "Obtenir la tâche"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Groupe"
 msgid "Group name"
 msgstr "Nom du groupe"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Grouper les discussions ouvertes"
 
@@ -6126,7 +6126,7 @@ msgstr "Marquer comme terminé"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Marquer terminé"
 
@@ -6801,7 +6801,7 @@ msgid "New thread in worktree"
 msgstr "Nouveau fil dans le worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Nouveau fil de discussion dans le worktree"
 
@@ -6846,7 +6846,7 @@ msgstr "Onglet suivant"
 msgid "No active browser tab"
 msgstr "Aucun onglet de navigateur actif"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Aucune session active"
 
@@ -7106,7 +7106,7 @@ msgstr "Aucun microphone trouvé."
 msgid "No models found"
 msgstr "Aucun modèle trouvé"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Aucun autre agent installé"
 
@@ -7518,7 +7518,7 @@ msgid "Open experiment"
 msgstr "Ouvrir l’expérience"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Ouvrir le tableau de l’expérience"
 
@@ -8023,7 +8023,7 @@ msgstr "Le sélecteur n'a renvoyé aucune pièce jointe"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Épingler en haut"
 
@@ -8893,7 +8893,7 @@ msgstr "Supprimer la variable d'environnement"
 msgid "Remove from favorites"
 msgstr "Supprimer des favoris"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Supprimer du groupe"
 
@@ -8951,7 +8951,7 @@ msgstr "Supprimer le worktree ?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Renommer"
@@ -9325,7 +9325,7 @@ msgstr "Clic droit pour changer d'anneau"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Exécuter"
 
@@ -11346,7 +11346,7 @@ msgstr "Fil de discussion terminé ou en attente de votre saisie."
 msgid "Thread goal dock"
 msgstr "Dock d'objectif du fil"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Le fil est déjà déchargé."
 
@@ -11915,7 +11915,7 @@ msgstr "Décharger les fils de discussion inactifs après"
 msgid "Unload idle threads after (minutes)"
 msgstr "Décharger les fils de discussion inactifs après (minutes)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Décharger le fil de discussion"
 
@@ -11935,7 +11935,7 @@ msgstr "Annuler le marquage terminé"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Décocher Terminé"
 
@@ -11950,7 +11950,7 @@ msgstr "Sans phase :"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Désépingler"
 
@@ -12338,7 +12338,7 @@ msgstr "Attendez que tous les candidats aient terminé avant de fusionner un gag
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Attendez que tous les candidats aient terminé avant d’ouvrir une pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Attendez que le fil de discussion ait fini de démarrer."
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Parcourez vos référentiels GitHub ou collez une URL de clonage."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6772,6 +6773,7 @@ msgstr "Nouvel onglet dans le groupe"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Nouveau fil de discussion"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1729,6 +1729,7 @@ msgstr "GitHub リポジトリを参照するか、クローン URL を貼り付
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6771,6 +6772,7 @@ msgstr "グループ内に新しいタブ"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "新しいスレッド"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1323,7 +1323,7 @@ msgstr "スレッドをアーカイブ"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "アーカイブスレッド"
 
@@ -2903,7 +2903,7 @@ msgstr "続ける"
 msgid "Continue in another provider"
 msgstr "別のプロバイダーで続行する"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "...で続行"
 
@@ -3599,7 +3599,7 @@ msgstr "スレッドの削除"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "スレッドの削除"
 
@@ -4955,7 +4955,7 @@ msgstr "タスクの取得"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5107,7 +5107,7 @@ msgstr "グループ"
 msgid "Group name"
 msgstr "グループ名"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "開いているスレッドをグループ化する"
 
@@ -6125,7 +6125,7 @@ msgstr "完了マークを付ける"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "完了マークを付ける"
 
@@ -6800,7 +6800,7 @@ msgid "New thread in worktree"
 msgstr "worktree で新規スレッド"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "ワークツリーの新しいスレッド"
 
@@ -6845,7 +6845,7 @@ msgstr "次のタブ"
 msgid "No active browser tab"
 msgstr "アクティブなブラウザタブがありません"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "アクティブなセッションがありません"
 
@@ -7105,7 +7105,7 @@ msgstr "マイクが見つかりません。"
 msgid "No models found"
 msgstr "モデルが見つかりません"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "他のエージェントはインストールされていません"
 
@@ -7517,7 +7517,7 @@ msgid "Open experiment"
 msgstr "実験を開く"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "実験ボードを開く"
 
@@ -8022,7 +8022,7 @@ msgstr "ピッカーは添付ファイルを返しませんでした"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "トップにピン留めする"
 
@@ -8892,7 +8892,7 @@ msgstr "環境変数を削除"
 msgid "Remove from favorites"
 msgstr "お気に入りから削除"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "グループから削除"
 
@@ -8950,7 +8950,7 @@ msgstr "ワークツリーを削除しますか?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "名前の変更"
@@ -9324,7 +9324,7 @@ msgstr "右クリックでリングを切り替え"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "実行"
 
@@ -11345,7 +11345,7 @@ msgstr "スレッドが終了したか、入力を待っています。"
 msgid "Thread goal dock"
 msgstr "スレッドゴールドック"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "スレッドはすでにアンロードされています。"
 
@@ -11914,7 +11914,7 @@ msgstr "次の時間後にアイドル状態のスレッドをアンロード"
 msgid "Unload idle threads after (minutes)"
 msgstr "アイドル状態のスレッドをアンロードするまでの時間 (分)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "スレッドをアンロード"
 
@@ -11934,7 +11934,7 @@ msgstr "完了のマークを外す"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "完了のマークを外す"
 
@@ -11949,7 +11949,7 @@ msgstr "フェーズなし:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "固定を解除する"
 
@@ -12337,7 +12337,7 @@ msgstr "勝者をマージする前に、すべての候補が完了するまで
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "プルリクエストを開く前に、すべての候補が完了するまで待ってください。"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "スレッドの開始が完了するまで待ちます。"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1324,7 +1324,7 @@ msgstr "스레드 보관"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "아카이브 스레드"
 
@@ -2904,7 +2904,7 @@ msgstr "계속"
 msgid "Continue in another provider"
 msgstr "다른 제공업체에서 계속"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "다음에서 계속..."
 
@@ -3600,7 +3600,7 @@ msgstr "스레드 삭제"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "스레드 삭제"
 
@@ -4956,7 +4956,7 @@ msgstr "작업 가져오기"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "그룹"
 msgid "Group name"
 msgstr "그룹 이름"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "열린 스레드 그룹화"
 
@@ -6126,7 +6126,7 @@ msgstr "완료로 표시"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "완료로 표시"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "worktree에서 새 스레드"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "작업 트리의 새 스레드"
 
@@ -6847,7 +6847,7 @@ msgstr "다음 탭"
 msgid "No active browser tab"
 msgstr "활성 브라우저 탭이 없습니다."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "활성 세션 없음"
 
@@ -7107,7 +7107,7 @@ msgstr "마이크를 찾을 수 없습니다."
 msgid "No models found"
 msgstr "모델을 찾을 수 없습니다."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "다른 에이전트가 설치되어 있지 않습니다."
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "실험 열기"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "실험 보드 열기"
 
@@ -8024,7 +8024,7 @@ msgstr "선택 도구가 첨부파일을 반환하지 않았습니다."
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "상단에 고정"
 
@@ -8894,7 +8894,7 @@ msgstr "환경 변수 제거"
 msgid "Remove from favorites"
 msgstr "즐겨찾기에서 제거"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "그룹에서 제거"
 
@@ -8952,7 +8952,7 @@ msgstr "작업 트리를 삭제하시겠습니까?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "이름 바꾸기"
@@ -9326,7 +9326,7 @@ msgstr "마우스 오른쪽 버튼을 클릭해 링 전환"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "실행"
 
@@ -11347,7 +11347,7 @@ msgstr "스레드가 완료되었거나 입력을 기다리는 중입니다."
 msgid "Thread goal dock"
 msgstr "스레드 목표 도크"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "스레드가 이미 언로드되었습니다."
 
@@ -11916,7 +11916,7 @@ msgstr "다음 이후에 유휴 스레드 언로드"
 msgid "Unload idle threads after (minutes)"
 msgstr "다음 시간 이후 유휴 스레드 언로드(분)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "스레드 언로드"
 
@@ -11936,7 +11936,7 @@ msgstr "완료 표시 해제"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "완료 표시 해제"
 
@@ -11951,7 +11951,7 @@ msgstr "단계 미지정:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "고정 해제"
 
@@ -12339,7 +12339,7 @@ msgstr "우승자를 병합하기 전에 모든 후보가 완료될 때까지 �
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "풀 리퀘스트를 열기 전에 모든 후보가 완료될 때까지 기다리세요."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "스레드 시작이 완료될 때까지 기다리세요."
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1730,6 +1730,7 @@ msgstr "GitHub 리포지토리를 찾아보거나 복제 URL을 붙여넣으세�
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "그룹에 새 탭"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "새 스레드"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Przeglądaj swoje repozytoria GitHub lub wklej adres URL do klonowania."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Nowa karta w grupie"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Nowy wątek"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Archiwizuj wątek"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Archiwum wątku"
 
@@ -2904,7 +2904,7 @@ msgstr "Kontynuuj"
 msgid "Continue in another provider"
 msgstr "Kontynuuj u innego dostawcy"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Kontynuuj w..."
 
@@ -3600,7 +3600,7 @@ msgstr "Usuń wątek"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Usuń wątek"
 
@@ -4956,7 +4956,7 @@ msgstr "Pobierz zadanie"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Grupa"
 msgid "Group name"
 msgstr "Nazwa grupy"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Grupuj otwarte wątki"
 
@@ -6126,7 +6126,7 @@ msgstr "Oznacz gotowe"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Oznacz gotowe"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Nowy wątek w worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Nowy wątek w drzewie roboczym"
 
@@ -6847,7 +6847,7 @@ msgstr "Następna karta"
 msgid "No active browser tab"
 msgstr "Brak aktywnej karty przeglądarki"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Brak aktywnej sesji"
 
@@ -7107,7 +7107,7 @@ msgstr "Nie znaleziono mikrofonu."
 msgid "No models found"
 msgstr "Nie znaleziono żadnych modeli"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Nie zainstalowano żadnych innych agentów"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Otwórz eksperyment"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Otwórz tablicę eksperymentu"
 
@@ -8024,7 +8024,7 @@ msgstr "Selektor nie zwrócił żadnego załącznika"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Przypnij do góry"
 
@@ -8894,7 +8894,7 @@ msgstr "Usuń zmienną środowiskową"
 msgid "Remove from favorites"
 msgstr "Usuń z ulubionych"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Usuń z grupy"
 
@@ -8952,7 +8952,7 @@ msgstr "Usunąć drzewo robocze?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Zmień nazwę"
@@ -9326,7 +9326,7 @@ msgstr "Kliknij prawym przyciskiem, aby przełączyć pierścień"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Uruchom"
 
@@ -11347,7 +11347,7 @@ msgstr "Wątek został zakończony lub oczekuje na Twoje dane wejściowe."
 msgid "Thread goal dock"
 msgstr "Stacja dokująca celu wątku"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Wątek został już wyładowany."
 
@@ -11916,7 +11916,7 @@ msgstr "Zwolnij bezczynne wątki po"
 msgid "Unload idle threads after (minutes)"
 msgstr "Zwolnij bezczynne wątki po (minutach)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Zwolnij wątek"
 
@@ -11936,7 +11936,7 @@ msgstr "Odznacz jako gotowe"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Odznacz jako gotowe"
 
@@ -11951,7 +11951,7 @@ msgstr "Bez fazy:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Odepnij"
 
@@ -12339,7 +12339,7 @@ msgstr "Przed scaleniem zmian zwycięzcy zaczekaj, aż wszyscy kandydaci zakońc
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Przed otwarciem pull requesta zaczekaj, aż wszyscy kandydaci zakończą pracę."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Poczekaj, aż wątek zakończy uruchamianie."
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Arquivar tópico"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Arquivar Tópico"
 
@@ -2904,7 +2904,7 @@ msgstr "Continuar"
 msgid "Continue in another provider"
 msgstr "Continuar em outro provedor"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Continuar em..."
 
@@ -3600,7 +3600,7 @@ msgstr "Excluir tópico"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Excluir tópico"
 
@@ -4956,7 +4956,7 @@ msgstr "Obter tarefa"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Grupo"
 msgid "Group name"
 msgstr "Nome do grupo"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Agrupar tópicos abertos"
 
@@ -6126,7 +6126,7 @@ msgstr "Marcar como concluído"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Marcar como concluído"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Nova thread no worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Novo tópico na árvore de trabalho"
 
@@ -6847,7 +6847,7 @@ msgstr "Próxima guia"
 msgid "No active browser tab"
 msgstr "Nenhuma guia do navegador ativa"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Nenhuma sessão ativa"
 
@@ -7107,7 +7107,7 @@ msgstr "Nenhum microfone encontrado."
 msgid "No models found"
 msgstr "Nenhum modelo encontrado"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Nenhum outro agente instalado"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Abrir experimento"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Abrir painel do experimento"
 
@@ -8024,7 +8024,7 @@ msgstr "O seletor não retornou nenhum anexo"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Fixar no topo"
 
@@ -8894,7 +8894,7 @@ msgstr "Remover variável de ambiente"
 msgid "Remove from favorites"
 msgstr "Remover dos favoritos"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Remover do grupo"
 
@@ -8952,7 +8952,7 @@ msgstr "Remover árvore de trabalho?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Renomear"
@@ -9326,7 +9326,7 @@ msgstr "Clique com o botão direito para trocar o anel"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Executar"
 
@@ -11347,7 +11347,7 @@ msgstr "Tópico finalizado ou aguardando sua entrada."
 msgid "Thread goal dock"
 msgstr "Doca de meta do tópico"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "O tópico já está descarregado."
 
@@ -11916,7 +11916,7 @@ msgstr "Descarregar tópicos ociosos após"
 msgid "Unload idle threads after (minutes)"
 msgstr "Descarregar tópicos inativos após (minutos)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Descarregar tópico"
 
@@ -11936,7 +11936,7 @@ msgstr "Desmarcar como concluído"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Desmarcar como concluído"
 
@@ -11951,7 +11951,7 @@ msgstr "Sem fase:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Desafixar"
 
@@ -12339,7 +12339,7 @@ msgstr "Aguarde todos os candidatos terminarem antes de mesclar um vencedor."
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Aguarde todos os candidatos terminarem antes de abrir uma pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Aguarde o tópico terminar de iniciar."
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Navegue pelos seus repositórios do GitHub ou cole uma URL de clonagem."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Nova aba no grupo"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Novo tópico"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Архивировать тред"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Архивировать тред"
 
@@ -2904,7 +2904,7 @@ msgstr "Продолжить"
 msgid "Continue in another provider"
 msgstr "Продолжить в другом провайдере"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Продолжить в..."
 
@@ -3600,7 +3600,7 @@ msgstr "Удалить тред"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Удалить тред"
 
@@ -4956,7 +4956,7 @@ msgstr "Получить задачу"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Группа"
 msgid "Group name"
 msgstr "Название группы"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Группировать открытые треды"
 
@@ -6126,7 +6126,7 @@ msgstr "Отметить выполненным"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Отметить выполненным"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Новый поток в worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Новый тред в worktree"
 
@@ -6847,7 +6847,7 @@ msgstr "Следующая вкладка"
 msgid "No active browser tab"
 msgstr "Нет активной вкладки браузера"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Нет активной сессии"
 
@@ -7107,7 +7107,7 @@ msgstr "Микрофон не найден."
 msgid "No models found"
 msgstr "Модели не найдены"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Других установленных агентов нет"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Открыть эксперимент"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Открыть доску эксперимента"
 
@@ -8024,7 +8024,7 @@ msgstr "Выбор не вернул вложение"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Закрепить вверху"
 
@@ -8894,7 +8894,7 @@ msgstr "Удалить переменную окружения"
 msgid "Remove from favorites"
 msgstr "Удалить из избранного"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Удалить из группы"
 
@@ -8952,7 +8952,7 @@ msgstr "Удалить worktree?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Переименовать"
@@ -9326,7 +9326,7 @@ msgstr "Щелкните правой кнопкой, чтобы переклю�
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Запустить"
 
@@ -11347,7 +11347,7 @@ msgstr "Тред завершён или ожидает вашего ввода.
 msgid "Thread goal dock"
 msgstr "Панель цели треда"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Тред уже выгружен."
 
@@ -11916,7 +11916,7 @@ msgstr "Выгружать неактивные треды через"
 msgid "Unload idle threads after (minutes)"
 msgstr "Выгружать неактивные треды через (минут)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Выгрузить тред"
 
@@ -11936,7 +11936,7 @@ msgstr "Снять отметку «готово»"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Снять отметку «готово»"
 
@@ -11951,7 +11951,7 @@ msgstr "Без фазы:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Открепить"
 
@@ -12339,7 +12339,7 @@ msgstr "Дождитесь завершения работы всех канди
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Дождитесь завершения работы всех кандидатов перед созданием pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Подождите, пока тред завершит запуск."
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Просмотрите свои репозитории GitHub или в�
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Новая вкладка в группе"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Новый тред"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1730,6 +1730,7 @@ msgstr "GitHub depolarınıza göz atın veya bir klon URL'si yapıştırın."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Grupta yeni sekme"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Yeni konu"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Konuyu arşivle"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "İleti Dizisini Arşivle"
 
@@ -2904,7 +2904,7 @@ msgstr "Devam et"
 msgid "Continue in another provider"
 msgstr "Başka bir sağlayıcıda devam et"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Şurada devam et..."
 
@@ -3600,7 +3600,7 @@ msgstr "Konuyu sil"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Konuyu Sil"
 
@@ -4956,7 +4956,7 @@ msgstr "Görev al"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Grup"
 msgid "Group name"
 msgstr "Grup adı"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Açık konuları gruplandır"
 
@@ -6126,7 +6126,7 @@ msgstr "Tamamlandı olarak işaretle"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Tamamlandı Olarak İşaretle"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Worktree'de yeni iş parçacığı"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Worktree'de Yeni Konu"
 
@@ -6847,7 +6847,7 @@ msgstr "Sonraki sekme"
 msgid "No active browser tab"
 msgstr "Etkin tarayıcı sekmesi yok"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Aktif oturum yok"
 
@@ -7107,7 +7107,7 @@ msgstr "Mikrofon bulunamadı."
 msgid "No models found"
 msgstr "Hiçbir model bulunamadı"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Başka aracı yüklü değil"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Deneyi aç"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Deney panosunu aç"
 
@@ -8024,7 +8024,7 @@ msgstr "Seçici hiçbir ek döndürmedi"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "En üste sabitle"
 
@@ -8894,7 +8894,7 @@ msgstr "Ortam değişkenini kaldır"
 msgid "Remove from favorites"
 msgstr "Favorilerden kaldır"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Gruptan kaldır"
 
@@ -8952,7 +8952,7 @@ msgstr "Çalışma ağacı kaldırılsın mı?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Yeniden adlandır"
@@ -9326,7 +9326,7 @@ msgstr "Halkayı değiştirmek için sağ tıklayın"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Çalıştır"
 
@@ -11347,7 +11347,7 @@ msgstr "Konu bitti veya girişinizi bekliyor."
 msgid "Thread goal dock"
 msgstr "Konu hedefi yuvası"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Konu zaten kaldırıldı."
 
@@ -11916,7 +11916,7 @@ msgstr "Boşta kalan konuları şu süreden sonra kaldır"
 msgid "Unload idle threads after (minutes)"
 msgstr "Boşta kalan konuları şu süreden sonra kaldır (dakika)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Konuyu Kaldır"
 
@@ -11936,7 +11936,7 @@ msgstr "Tamamlandı işaretini kaldır"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Bitti işaretini kaldır"
 
@@ -11951,7 +11951,7 @@ msgstr "Aşamasız:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Sabitlemeyi kaldır"
 
@@ -12339,7 +12339,7 @@ msgstr "Kazananı birleştirmeden önce tüm adayların çalışmasını tamamla
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Pull request açmadan önce tüm adayların çalışmasını tamamlamasını bekleyin."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Konunun başlatılmasının bitmesini bekleyin."
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Архівувати тред"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Архівувати тред"
 
@@ -2904,7 +2904,7 @@ msgstr "Продовжити"
 msgid "Continue in another provider"
 msgstr "Продовжити в іншому провайдері"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Продовжити в..."
 
@@ -3600,7 +3600,7 @@ msgstr "Видалити тред"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Видалити тред"
 
@@ -4956,7 +4956,7 @@ msgstr "Отримати завдання"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Група"
 msgid "Group name"
 msgstr "Назва групи"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Групувати відкриті треди"
 
@@ -6126,7 +6126,7 @@ msgstr "Позначити виконаним"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Позначити виконаним"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Новий потік у worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Новий тред у worktree"
 
@@ -6847,7 +6847,7 @@ msgstr "Наступна вкладка"
 msgid "No active browser tab"
 msgstr "Немає активної вкладки браузера"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Немає активної сесії"
 
@@ -7107,7 +7107,7 @@ msgstr "Мікрофон не знайдено."
 msgid "No models found"
 msgstr "Моделі не знайдено"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Інших встановлених агентів немає"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Відкрити експеримент"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Відкрити дошку експерименту"
 
@@ -8024,7 +8024,7 @@ msgstr "Вибір не повернув вкладення"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Закріпити вгорі"
 
@@ -8894,7 +8894,7 @@ msgstr "Видалити змінну середовища"
 msgid "Remove from favorites"
 msgstr "Видалити з обраного"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Видалити з групи"
 
@@ -8952,7 +8952,7 @@ msgstr "Видалити worktree?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Перейменувати"
@@ -9326,7 +9326,7 @@ msgstr "Клацніть правою кнопкою, щоб перемкнут�
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Запустити"
 
@@ -11347,7 +11347,7 @@ msgstr "Тред завершено або він очікує на ваш вв�
 msgid "Thread goal dock"
 msgstr "Панель мети треда"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Тред уже вивантажено."
 
@@ -11916,7 +11916,7 @@ msgstr "Вивантажувати неактивні треди через"
 msgid "Unload idle threads after (minutes)"
 msgstr "Вивантажувати неактивні треди через (хвилин)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Вивантажити тред"
 
@@ -11936,7 +11936,7 @@ msgstr "Зняти позначку «готово»"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Зняти позначку «готово»"
 
@@ -11951,7 +11951,7 @@ msgstr "Без фази:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Відкріпити"
 
@@ -12339,7 +12339,7 @@ msgstr "Зачекайте, доки всі кандидати завершат�
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж відкривати pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Зачекайте, поки тред завершить запуск."
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Перегляньте свої репозиторії GitHub або в�
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Нова вкладка в групі"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Новий тред"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1324,7 +1324,7 @@ msgstr "Lưu trữ luồng"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "Lưu trữ luồng"
 
@@ -2904,7 +2904,7 @@ msgstr "Tiếp tục"
 msgid "Continue in another provider"
 msgstr "Tiếp tục ở nhà cung cấp khác"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "Tiếp tục trong..."
 
@@ -3600,7 +3600,7 @@ msgstr "Xóa chủ đề"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "Xóa chủ đề"
 
@@ -4956,7 +4956,7 @@ msgstr "Nhận nhiệm vụ"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "Nhóm"
 msgid "Group name"
 msgstr "Tên nhóm"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "Nhóm chủ đề mở"
 
@@ -6126,7 +6126,7 @@ msgstr "Đánh dấu là xong"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "Đánh dấu xong"
 
@@ -6802,7 +6802,7 @@ msgid "New thread in worktree"
 msgstr "Luồng mới trong worktree"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "Luồng mới trong Worktree"
 
@@ -6847,7 +6847,7 @@ msgstr "Tab tiếp theo"
 msgid "No active browser tab"
 msgstr "Không có tab trình duyệt đang hoạt động"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "Không có phiên hoạt động"
 
@@ -7107,7 +7107,7 @@ msgstr "Không tìm thấy micrô."
 msgid "No models found"
 msgstr "Không tìm thấy mô hình nào"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "Không có tác nhân nào khác được cài đặt"
 
@@ -7519,7 +7519,7 @@ msgid "Open experiment"
 msgstr "Mở thử nghiệm"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "Mở bảng thử nghiệm"
 
@@ -8024,7 +8024,7 @@ msgstr "Bộ chọn không trả về tệp đính kèm nào"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "Ghim lên đầu"
 
@@ -8894,7 +8894,7 @@ msgstr "Xóa biến môi trường"
 msgid "Remove from favorites"
 msgstr "Xóa khỏi mục yêu thích"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "Xóa khỏi nhóm"
 
@@ -8952,7 +8952,7 @@ msgstr "Xóa worktree?"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "Đổi tên"
@@ -9326,7 +9326,7 @@ msgstr "Nhấp chuột phải để đổi vòng"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "Chạy"
 
@@ -11347,7 +11347,7 @@ msgstr "Luồng đã kết thúc hoặc đang chờ bạn nhập."
 msgid "Thread goal dock"
 msgstr "Dock mục tiêu luồng"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "Luồng đã được dỡ bỏ."
 
@@ -11916,7 +11916,7 @@ msgstr "Dỡ bỏ các luồng nhàn rỗi sau"
 msgid "Unload idle threads after (minutes)"
 msgstr "Gỡ bỏ các chủ đề không hoạt động sau (phút)"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "Dỡ bỏ chủ đề"
 
@@ -11936,7 +11936,7 @@ msgstr "Bỏ đánh dấu xong"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "Bỏ đánh dấu xong"
 
@@ -11951,7 +11951,7 @@ msgstr "Không phân giai đoạn:"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "Bỏ ghim"
 
@@ -12339,7 +12339,7 @@ msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi hợp nhất
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi mở pull request."
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "Chờ cho luồng khởi động xong."
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1730,6 +1730,7 @@ msgstr "Duyệt qua kho GitHub của bạn hoặc dán URL nhân bản."
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6773,6 +6774,7 @@ msgstr "Tab mới trong nhóm"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "Luồng mới"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1324,7 +1324,7 @@ msgstr "归档线程"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Archive Thread"
 msgstr "存档线程"
 
@@ -2904,7 +2904,7 @@ msgstr "继续"
 msgid "Continue in another provider"
 msgstr "继续使用另一个提供商"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Continue in..."
 msgstr "在其他工具中继续..."
 
@@ -3600,7 +3600,7 @@ msgstr "删除线程"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Delete Thread"
 msgstr "删除线程"
 
@@ -4956,7 +4956,7 @@ msgstr "获取任务"
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5108,7 +5108,7 @@ msgstr "分组"
 msgid "Group name"
 msgstr "分组名称"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Group open threads"
 msgstr "对打开的线程进行分组"
 
@@ -6126,7 +6126,7 @@ msgstr "标记完成"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Mark Done"
 msgstr "标记完成"
 
@@ -6801,7 +6801,7 @@ msgid "New thread in worktree"
 msgstr "在 worktree 中新建线程"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "New Thread in Worktree"
 msgstr "工作树中的新线程"
 
@@ -6846,7 +6846,7 @@ msgstr "下一个选项卡"
 msgid "No active browser tab"
 msgstr "没有活动的浏览器选项卡"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No active session"
 msgstr "没有活动会话"
 
@@ -7106,7 +7106,7 @@ msgstr "找不到麦克风。"
 msgid "No models found"
 msgstr "未找到模型"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "No other agents installed"
 msgstr "没有安装其他代理"
 
@@ -7518,7 +7518,7 @@ msgid "Open experiment"
 msgstr "打开实验"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ExperimentGroupHeader.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Open experiment board"
 msgstr "打开实验面板"
 
@@ -8023,7 +8023,7 @@ msgstr "选择器未返回任何附件"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Pin to top"
 msgstr "固定到顶部"
 
@@ -8893,7 +8893,7 @@ msgstr "移除环境变量"
 msgid "Remove from favorites"
 msgstr "从收藏夹中删除"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Remove from group"
 msgstr "从组中删除"
 
@@ -8951,7 +8951,7 @@ msgstr "删除工作树？"
 #: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/FileEditorOverlay/parts/ProjectTreeView/parts/TreeEntryRow.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/TodoRow.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 msgid "Rename"
 msgstr "重命名"
@@ -9325,7 +9325,7 @@ msgstr "右键点击以切换环"
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Run"
 msgstr "运行"
 
@@ -11346,7 +11346,7 @@ msgstr "线程已完成或正在等待您的输入。"
 msgid "Thread goal dock"
 msgstr "线程目标停靠栏"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Thread is already unloaded."
 msgstr "线程已经卸载。"
 
@@ -11915,7 +11915,7 @@ msgstr "在以下时间后卸载空闲线程"
 msgid "Unload idle threads after (minutes)"
 msgstr "在以下分钟数后卸载空闲线程"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unload Thread"
 msgstr "卸载线程"
 
@@ -11935,7 +11935,7 @@ msgstr "取消标记完成"
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unmark Done"
 msgstr "取消标记完成"
 
@@ -11950,7 +11950,7 @@ msgstr "未分阶段："
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Unpin"
 msgstr "取消固定"
 
@@ -12338,7 +12338,7 @@ msgstr "请等待所有候选项完成后再合并优胜者。"
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "请等待所有候选项完成后再创建拉取请求。"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."
 msgstr "等待线程完成启动。"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1730,6 +1730,7 @@ msgstr "浏览您的 GitHub 存储库或粘贴克隆 URL。"
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
@@ -6772,6 +6773,7 @@ msgstr "在分组中新建标签页"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 #: src/renderer/views/MainView/parts/RightPanel/parts/NotesPanel/NotesEditor.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/QuickComposerOverlay/QuickComposerOverlay.tsx
 msgid "New thread"
 msgstr "新线程"

--- a/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/AppShell.tsx
@@ -280,7 +280,10 @@ function ShellSidebarAside(props: {
             } ${!hasHeaders ? "-mt-5 h-[calc(100%+0.75rem)]" : ""}`
       }`}
     >
-      {sidebarHeader && (
+      {/* Collapsed icon rail on Windows/Linux starts at the window top — the
+          titlebar-height header row would only be an empty spacer there. macOS
+          keeps it so the rail clears the hidden-inset traffic-light controls. */}
+      {sidebarHeader && (isMac() || !effectiveIsCollapsed || effectiveIsOverlay) && (
         <div
           className={`poracode-overlay-header flex shrink-0 items-center gap-3 ${
             isMac() ? "pl-3 pr-2 pt-0.5" : "px-2"

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -4,9 +4,11 @@ import {
   ChevronRight,
   Download,
   GitPullRequest,
+  Globe,
   House,
   PanelLeft,
   PanelLeftClose,
+  Plus,
   RefreshCw,
   Search,
   Settings2,
@@ -34,11 +36,15 @@ import { SIDEBAR_MIN_WIDTH } from "@/renderer/views/MainView/parts/AppShell/part
 import { SidebarPanelDragButton } from "@/renderer/views/MainView/parts/Sidebar/parts/SidebarPanelDragButton";
 import { SidebarProjectSection } from "@/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectSection";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
-import { readBridge } from "@/renderer/bridge";
-import { openRemoteAccessSettings, openSettings } from "@/renderer/actions/panelActions";
+import { isMac, readBridge } from "@/renderer/bridge";
+import {
+  openRemoteAccessSettings,
+  openSettings,
+  toggleBrowserPanel,
+} from "@/renderer/actions/panelActions";
 import { ProviderUsageRail } from "@/renderer/components/providers/ProviderUsageRail";
 import { openTerminal } from "@/renderer/actions/terminalActions";
-import { openThread } from "@/renderer/actions/threadActions";
+import { openNewThread, openThread } from "@/renderer/actions/threadActions";
 import {
   useCurrentProjectId,
   useIsCurrentThread,
@@ -241,6 +247,7 @@ export function Sidebar() {
   const remoteAccessSettingsActive = settingsOpen && settingsSection === "remoteAccess";
   const otherSettingsActive = settingsOpen && !remoteAccessSettingsActive;
   const threadSearchOpen = usePanelStore((s) => s.threadSearchOpen);
+  const browserVisible = usePanelStore((s) => s.browserPanelOpen && s.rightPanelTab === "browser");
   const githubActionsOpen = usePanelStore((s) => s.githubActionsContext !== null);
   const openThreadSearch = usePanelStore((s) => s.openThreadSearch);
   const isHomeProjectCollapsed = useSidebarUiStore((s) =>
@@ -367,7 +374,14 @@ export function Sidebar() {
   return (
     <div className="relative h-full">
       {isCollapsed && (
-        <div className="absolute inset-y-0 left-0 z-10 flex h-full min-h-0 w-12 flex-col items-start gap-3 pl-2 pb-0 pt-0">
+        <div
+          className={`absolute inset-y-0 left-0 z-10 flex h-full min-h-0 w-12 flex-col items-start gap-3 pl-2 pb-0 ${
+            // macOS keeps the rail below the hidden-inset titlebar (traffic
+            // lights); elsewhere the header spacer is dropped when collapsed,
+            // so the rail starts at the window top with its own inset.
+            isMac() ? "pt-0" : "pt-2"
+          }`}
+        >
           <div className="flex shrink-0 flex-col gap-0.5">
             <SidebarButton
               iconOnly
@@ -382,6 +396,20 @@ export function Sidebar() {
               label={t`Search`}
               isActive={threadSearchOpen}
               onPress={openThreadSearch}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<Globe className="size-3.5" />}
+              label={t`Browser`}
+              isActive={browserVisible}
+              onPress={toggleBrowserPanel}
+            />
+            <SidebarButton
+              iconOnly
+              icon={<Plus className="size-3.5" />}
+              label={t`New thread`}
+              isActive={appView.kind === "draft"}
+              onPress={() => openNewThread()}
             />
           </div>
           <CollapsedThreadRail />

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -35,6 +35,7 @@ import { useSidebar } from "@/renderer/views/MainView/parts/AppShell/AppShell";
 import { SIDEBAR_MIN_WIDTH } from "@/renderer/views/MainView/parts/AppShell/parts/useResizablePanels";
 import { SidebarPanelDragButton } from "@/renderer/views/MainView/parts/Sidebar/parts/SidebarPanelDragButton";
 import { SidebarProjectSection } from "@/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectSection";
+import { ThreadContextMenu } from "@/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { isMac, readBridge } from "@/renderer/bridge";
 import {
@@ -183,7 +184,8 @@ function RemoteAccessSidebarIcon(props: { status: RemoteAccessSidebarStatus }) {
 function CollapsedThreadRailButton(props: { thread: Thread }) {
   const { thread } = props;
   const isActive = useIsCurrentThread(thread.id);
-  return (
+  const project = useAppStore((s) => s.projects.find((p) => p.id === thread.projectId));
+  const button = (
     <SidebarButton
       iconOnly
       icon={<ThreadIcon thread={thread} />}
@@ -193,6 +195,13 @@ function CollapsedThreadRailButton(props: { thread: Thread }) {
       isActive={isActive}
       onPress={() => openThread(thread.id)}
     />
+  );
+  if (!project) return button;
+  // No `onRename`: the icon rail has no inline rename affordance.
+  return (
+    <ThreadContextMenu thread={thread} project={project}>
+      {button}
+    </ThreadContextMenu>
   );
 }
 

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -1,64 +1,20 @@
-import {
-  Archive,
-  ArrowDownToLine,
-  ArrowRightLeft,
-  CircleCheck,
-  Columns2,
-  FlaskConical,
-  GitFork,
-  Pencil,
-  Play,
-  Plus,
-  Star,
-  Trash2,
-} from "lucide-react";
-import { useLingui } from "@lingui/react/macro";
 import type { Project, Thread } from "@/shared/contracts";
-import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentStore } from "@/renderer/state/experimentStore";
-import { useGitStore } from "@/renderer/state/gitStore";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useIsDraggingThread, type DragSourceData } from "@/renderer/dnd";
-import { ContextMenu } from "@/renderer/components/common/ContextMenu";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import { getStatusTone } from "@/renderer/components/providers/statusTone";
 import { ThreadProviderIcon } from "@/renderer/components/providers/ThreadProviderIcon";
-import { readBridge } from "@/renderer/bridge";
-import { resolveActionIcon } from "@/renderer/utils/actionIcons";
-import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions";
-import { gitMenuIcons } from "@/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons";
+import { ThreadContextMenu } from "@/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu";
 import { DraftIndicator } from "../DraftIndicator";
 import { InlineRenameInput } from "../InlineRenameInput";
 import { ThreadItemSuffix } from "./parts/ThreadItemSuffix";
 import {
-  useCurrentThreadIdsCount,
   useIsCurrentThread,
-  useProjectAgentStatuses,
   useThreadHasBackgroundActivity,
   useThreadHasDraft,
 } from "@/renderer/hooks/uiSelectors";
-import { openGitReview } from "@/renderer/actions/panelActions";
-import {
-  gitPull,
-  gitPush,
-  gitSync,
-  gitPullFromSource,
-  gitMergeToSource,
-  gitMergeAndRemove,
-} from "@/renderer/actions/gitActions";
-import {
-  openThread,
-  archiveThread,
-  unloadThread,
-  toggleMarkThreadDone,
-  toggleStarThread,
-  deleteThread,
-  renameThread,
-  continueInProvider,
-  openNewThreadInWorktree,
-} from "@/renderer/actions/threadActions";
-import { runProjectAction } from "@/renderer/actions/terminalActions";
-import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
+import { openThread, renameThread } from "@/renderer/actions/threadActions";
 
 export function SortableThreadItem(props: {
   thread: Thread;
@@ -79,26 +35,11 @@ export function SortableThreadItem(props: {
     editingThreadId,
     sortDisabled = false,
   } = props;
-  const { t } = useLingui();
-  const experiment = useExperimentStore((state) =>
-    thread.groupId ? state.experiments[thread.groupId] : undefined,
+  const isExperimentCandidate = useExperimentStore(
+    (state) => thread.groupId !== undefined && state.experiments[thread.groupId] !== undefined,
   );
-  const isExperimentCandidate = experiment !== undefined;
   const isCurrentThread = useIsCurrentThread(thread.id);
   const hasDraft = useThreadHasDraft(thread.id);
-  const currentThreadCount = useCurrentThreadIdsCount();
-  const projectAgents = useProjectAgentStatuses(project.location);
-  const worktreeGitItems = useWorktreeGitItems(
-    thread.projectId,
-    thread.worktreePath ?? "",
-    gitMenuIcons,
-  );
-  const unloadDisabledReason =
-    thread.status === "inactive"
-      ? t`Thread is already unloaded.`
-      : thread.status === "launching"
-        ? t`Wait for the thread to finish starting.`
-        : undefined;
 
   const { ref } = useSortable({
     id: `thread:${thread.id}`,
@@ -126,214 +67,10 @@ export function SortableThreadItem(props: {
 
   return (
     <div ref={ref} className="relative w-full pb-0.5">
-      <ContextMenu
-        items={[
-          ...(thread.worktreePath && !isExperimentCandidate
-            ? [
-                {
-                  id: "new-thread-in-worktree",
-                  label: t`New Thread in Worktree`,
-                  icon: <Plus className="size-3.5" />,
-                },
-                {
-                  type: "submenu" as const,
-                  id: "git",
-                  label: t`Git`,
-                  icon: <GitFork className="size-3.5" />,
-                  items: worktreeGitItems,
-                },
-              ]
-            : []),
-          ...(thread.worktreePath && project.scripts?.actions?.length
-            ? [
-                {
-                  type: "submenu" as const,
-                  id: "run-action",
-                  label: t`Run`,
-                  icon: <Play className="size-3.5" />,
-                  items: project.scripts.actions.map((action) => ({
-                    id: `action:${action.id}`,
-                    label: action.name,
-                    icon: resolveActionIcon(action.icon),
-                  })),
-                },
-              ]
-            : []),
-          {
-            id: "rename",
-            label: t`Rename`,
-            icon: <Pencil className="size-3.5" />,
-          },
-          ...(experiment
-            ? [
-                {
-                  id: "open-experiment",
-                  label: t`Open experiment board`,
-                  icon: <FlaskConical className="size-3.5" />,
-                },
-              ]
-            : []),
-          {
-            id: "unload",
-            label: t`Unload Thread`,
-            icon: <ArrowDownToLine className="size-3.5" />,
-            isDisabled: unloadDisabledReason !== undefined,
-            ...(unloadDisabledReason ? { disabledReason: unloadDisabledReason } : {}),
-          },
-          ...(!isExperimentCandidate
-            ? [
-                {
-                  id: "mark-done",
-                  label: thread.done ? t`Unmark Done` : t`Mark Done`,
-                  icon: <CircleCheck className="size-3.5" />,
-                },
-              ]
-            : []),
-          {
-            id: "toggle-star",
-            label: thread.starred ? t`Unpin` : t`Pin to top`,
-            icon: <Star className="size-3.5" />,
-          },
-          ...(!isExperimentCandidate
-            ? [
-                {
-                  id: "continue-in",
-                  label: t`Continue in...`,
-                  icon: <ArrowRightLeft className="size-3.5" />,
-                  isDisabled:
-                    !thread.sessionRef ||
-                    projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0,
-                  ...(!thread.sessionRef ||
-                  projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0
-                    ? {
-                        disabledReason: !thread.sessionRef
-                          ? t`No active session`
-                          : t`No other agents installed`,
-                      }
-                    : {}),
-                },
-              ]
-            : []),
-          ...(thread.groupId && !isExperimentCandidate
-            ? [
-                {
-                  id: "ungroup",
-                  label: t`Remove from group`,
-                },
-              ]
-            : []),
-          ...(currentThreadCount >= 2 && isCurrentThread && !thread.groupId
-            ? [
-                {
-                  id: "group-open-threads",
-                  label: t`Group open threads`,
-                  icon: <Columns2 className="size-3.5" />,
-                },
-              ]
-            : []),
-          ...(!isExperimentCandidate
-            ? [
-                { type: "separator" as const },
-                {
-                  id: "archive",
-                  label: t`Archive Thread`,
-                  icon: <Archive className="size-3.5" />,
-                  variant: "warning" as const,
-                },
-                {
-                  id: "delete",
-                  label: t`Delete Thread`,
-                  icon: <Trash2 className="size-3.5" />,
-                  variant: "danger" as const,
-                },
-              ]
-            : []),
-        ]}
-        onAction={(key) => {
-          if (key === "new-thread-in-worktree" && thread.worktreePath)
-            openNewThreadInWorktree({
-              projectId: thread.projectId,
-              worktreePath: thread.worktreePath,
-              worktreeBranch:
-                resolveWorktreeBranch(
-                  thread.projectId,
-                  thread.worktreePath,
-                  thread.worktreeBranch,
-                ) ?? thread.worktreePath,
-            });
-          if (key === "git-review") openGitReview(thread.projectId, thread.worktreePath, thread.id);
-          if (key === "git-sync" && thread.worktreePath)
-            gitSync(thread.projectId, thread.worktreePath);
-          if (key === "git-push" && thread.worktreePath)
-            gitPush(thread.projectId, thread.worktreePath);
-          if (key === "git-pull" && thread.worktreePath)
-            gitPull(thread.projectId, thread.worktreePath);
-          if (key === "git-pull-from-source" && thread.worktreePath)
-            gitPullFromSource(thread.projectId, thread.worktreePath);
-          if (key === "git-merge-to-source" && thread.worktreePath)
-            gitMergeToSource(thread.projectId, thread.worktreePath);
-          if (key === "git-merge-and-remove" && thread.worktreePath)
-            gitMergeAndRemove(thread.projectId, thread.worktreePath);
-          if (key === "open-pr" && thread.worktreePath) {
-            const pr = useGitStore.getState().prData[thread.worktreePath];
-            if (pr?.url) void readBridge().openExternal(pr.url);
-          }
-          if (key === "create-pr") openGitReview(thread.projectId, thread.worktreePath, thread.id);
-          if (key === "open-experiment" && experiment)
-            useAppStore.getState().openExperiment(experiment.id, experiment.projectId);
-          if (key === "continue-in" && !isExperimentCandidate) continueInProvider(thread.id);
-          if (key === "group-open-threads") {
-            const state = useAppStore.getState();
-            if (state.view.kind !== "thread") return;
-            const openThreads = state.threads.filter(
-              (other) => state.view.kind === "thread" && state.view.panes.includes(other.id),
-            );
-            const projectId = openThreads[0]?.projectId;
-            if (!projectId || !openThreads.every((other) => other.projectId === projectId)) return;
-            const groupId = crypto.randomUUID();
-            const groupName = thread.title;
-            useAppStore.setState((s) => ({
-              threads: s.threads.map((other) =>
-                s.view.kind === "thread" && s.view.panes.includes(other.id)
-                  ? { ...other, groupId, groupName }
-                  : other,
-              ),
-              view: s.view.kind === "thread" ? { ...s.view, activeGroupId: groupId } : s.view,
-            }));
-          }
-          if (key === "ungroup") {
-            useAppStore.setState((state) => {
-              let updatedThreads = state.threads.map((other) =>
-                other.id === thread.id
-                  ? { ...other, groupId: undefined, groupName: undefined }
-                  : other,
-              );
-              const remaining = updatedThreads.filter((other) => other.groupId === thread.groupId);
-              if (remaining.length === 1) {
-                updatedThreads = updatedThreads.map((other) =>
-                  other.id === remaining[0]!.id
-                    ? { ...other, groupId: undefined, groupName: undefined }
-                    : other,
-                );
-              }
-              const view =
-                state.view.kind === "thread" && state.view.activeGroupId === thread.groupId
-                  ? { kind: "thread" as const, panes: [state.view.panes[0]] as [string] }
-                  : state.view;
-              return { threads: updatedThreads, view };
-            });
-          }
-          if (key === "archive" && !isExperimentCandidate) archiveThread(thread.id);
-          if (key === "rename") props.setEditingThreadId(thread.id);
-          if (key === "unload") unloadThread(thread.id);
-          if (key === "mark-done") toggleMarkThreadDone(thread.id);
-          if (key === "toggle-star") toggleStarThread(thread.id);
-          if (key === "delete" && !isExperimentCandidate)
-            deleteThread(thread.id, thread.worktreePath, thread.projectId);
-          if (key.startsWith("action:")) {
-            runProjectAction(project.id, key.slice("action:".length), thread.worktreePath);
-          }
-        }}
+      <ThreadContextMenu
+        thread={thread}
+        project={project}
+        onRename={() => props.setEditingThreadId(thread.id)}
       >
         <SidebarButton
           size="xs"
@@ -378,7 +115,7 @@ export function SortableThreadItem(props: {
             />
           }
         />
-      </ContextMenu>
+      </ThreadContextMenu>
     </div>
   );
 }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
@@ -1,0 +1,298 @@
+import {
+  Archive,
+  ArrowDownToLine,
+  ArrowRightLeft,
+  CircleCheck,
+  Columns2,
+  FlaskConical,
+  GitFork,
+  Pencil,
+  Play,
+  Plus,
+  Star,
+  Trash2,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useLingui } from "@lingui/react/macro";
+import type { Project, Thread } from "@/shared/contracts";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useExperimentStore } from "@/renderer/state/experimentStore";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { ContextMenu } from "@/renderer/components/common/ContextMenu";
+import { readBridge } from "@/renderer/bridge";
+import { resolveActionIcon } from "@/renderer/utils/actionIcons";
+import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions";
+import { gitMenuIcons } from "@/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons";
+import {
+  useCurrentThreadIdsCount,
+  useIsCurrentThread,
+  useProjectAgentStatuses,
+} from "@/renderer/hooks/uiSelectors";
+import { openGitReview } from "@/renderer/actions/panelActions";
+import {
+  gitPull,
+  gitPush,
+  gitSync,
+  gitPullFromSource,
+  gitMergeToSource,
+  gitMergeAndRemove,
+} from "@/renderer/actions/gitActions";
+import {
+  archiveThread,
+  unloadThread,
+  toggleMarkThreadDone,
+  toggleStarThread,
+  deleteThread,
+  continueInProvider,
+  openNewThreadInWorktree,
+} from "@/renderer/actions/threadActions";
+import { runProjectAction } from "@/renderer/actions/terminalActions";
+import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
+
+/**
+ * Right-click menu shared by every sidebar surface that shows a thread —
+ * the expanded thread rows and the collapsed icon rail. `onRename` is
+ * optional because icon-only surfaces have no inline rename affordance.
+ */
+export function ThreadContextMenu(props: {
+  thread: Thread;
+  project: Project;
+  onRename?: () => void;
+  children: ReactNode;
+}) {
+  const { thread, project, onRename } = props;
+  const { t } = useLingui();
+  const experiment = useExperimentStore((state) =>
+    thread.groupId ? state.experiments[thread.groupId] : undefined,
+  );
+  const isExperimentCandidate = experiment !== undefined;
+  const isCurrentThread = useIsCurrentThread(thread.id);
+  const currentThreadCount = useCurrentThreadIdsCount();
+  const projectAgents = useProjectAgentStatuses(project.location);
+  const worktreeGitItems = useWorktreeGitItems(
+    thread.projectId,
+    thread.worktreePath ?? "",
+    gitMenuIcons,
+  );
+  const unloadDisabledReason =
+    thread.status === "inactive"
+      ? t`Thread is already unloaded.`
+      : thread.status === "launching"
+        ? t`Wait for the thread to finish starting.`
+        : undefined;
+
+  return (
+    <ContextMenu
+      items={[
+        ...(thread.worktreePath && !isExperimentCandidate
+          ? [
+              {
+                id: "new-thread-in-worktree",
+                label: t`New Thread in Worktree`,
+                icon: <Plus className="size-3.5" />,
+              },
+              {
+                type: "submenu" as const,
+                id: "git",
+                label: t`Git`,
+                icon: <GitFork className="size-3.5" />,
+                items: worktreeGitItems,
+              },
+            ]
+          : []),
+        ...(thread.worktreePath && project.scripts?.actions?.length
+          ? [
+              {
+                type: "submenu" as const,
+                id: "run-action",
+                label: t`Run`,
+                icon: <Play className="size-3.5" />,
+                items: project.scripts.actions.map((action) => ({
+                  id: `action:${action.id}`,
+                  label: action.name,
+                  icon: resolveActionIcon(action.icon),
+                })),
+              },
+            ]
+          : []),
+        ...(onRename
+          ? [
+              {
+                id: "rename",
+                label: t`Rename`,
+                icon: <Pencil className="size-3.5" />,
+              },
+            ]
+          : []),
+        ...(experiment
+          ? [
+              {
+                id: "open-experiment",
+                label: t`Open experiment board`,
+                icon: <FlaskConical className="size-3.5" />,
+              },
+            ]
+          : []),
+        {
+          id: "unload",
+          label: t`Unload Thread`,
+          icon: <ArrowDownToLine className="size-3.5" />,
+          isDisabled: unloadDisabledReason !== undefined,
+          ...(unloadDisabledReason ? { disabledReason: unloadDisabledReason } : {}),
+        },
+        ...(!isExperimentCandidate
+          ? [
+              {
+                id: "mark-done",
+                label: thread.done ? t`Unmark Done` : t`Mark Done`,
+                icon: <CircleCheck className="size-3.5" />,
+              },
+            ]
+          : []),
+        {
+          id: "toggle-star",
+          label: thread.starred ? t`Unpin` : t`Pin to top`,
+          icon: <Star className="size-3.5" />,
+        },
+        ...(!isExperimentCandidate
+          ? [
+              {
+                id: "continue-in",
+                label: t`Continue in...`,
+                icon: <ArrowRightLeft className="size-3.5" />,
+                isDisabled:
+                  !thread.sessionRef ||
+                  projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0,
+                ...(!thread.sessionRef ||
+                projectAgents.filter((a) => a.kind !== thread.agentKind).length === 0
+                  ? {
+                      disabledReason: !thread.sessionRef
+                        ? t`No active session`
+                        : t`No other agents installed`,
+                    }
+                  : {}),
+              },
+            ]
+          : []),
+        ...(thread.groupId && !isExperimentCandidate
+          ? [
+              {
+                id: "ungroup",
+                label: t`Remove from group`,
+              },
+            ]
+          : []),
+        ...(currentThreadCount >= 2 && isCurrentThread && !thread.groupId
+          ? [
+              {
+                id: "group-open-threads",
+                label: t`Group open threads`,
+                icon: <Columns2 className="size-3.5" />,
+              },
+            ]
+          : []),
+        ...(!isExperimentCandidate
+          ? [
+              { type: "separator" as const },
+              {
+                id: "archive",
+                label: t`Archive Thread`,
+                icon: <Archive className="size-3.5" />,
+                variant: "warning" as const,
+              },
+              {
+                id: "delete",
+                label: t`Delete Thread`,
+                icon: <Trash2 className="size-3.5" />,
+                variant: "danger" as const,
+              },
+            ]
+          : []),
+      ]}
+      onAction={(key) => {
+        if (key === "new-thread-in-worktree" && thread.worktreePath)
+          openNewThreadInWorktree({
+            projectId: thread.projectId,
+            worktreePath: thread.worktreePath,
+            worktreeBranch:
+              resolveWorktreeBranch(thread.projectId, thread.worktreePath, thread.worktreeBranch) ??
+              thread.worktreePath,
+          });
+        if (key === "git-review") openGitReview(thread.projectId, thread.worktreePath, thread.id);
+        if (key === "git-sync" && thread.worktreePath)
+          gitSync(thread.projectId, thread.worktreePath);
+        if (key === "git-push" && thread.worktreePath)
+          gitPush(thread.projectId, thread.worktreePath);
+        if (key === "git-pull" && thread.worktreePath)
+          gitPull(thread.projectId, thread.worktreePath);
+        if (key === "git-pull-from-source" && thread.worktreePath)
+          gitPullFromSource(thread.projectId, thread.worktreePath);
+        if (key === "git-merge-to-source" && thread.worktreePath)
+          gitMergeToSource(thread.projectId, thread.worktreePath);
+        if (key === "git-merge-and-remove" && thread.worktreePath)
+          gitMergeAndRemove(thread.projectId, thread.worktreePath);
+        if (key === "open-pr" && thread.worktreePath) {
+          const pr = useGitStore.getState().prData[thread.worktreePath];
+          if (pr?.url) void readBridge().openExternal(pr.url);
+        }
+        if (key === "create-pr") openGitReview(thread.projectId, thread.worktreePath, thread.id);
+        if (key === "open-experiment" && experiment)
+          useAppStore.getState().openExperiment(experiment.id, experiment.projectId);
+        if (key === "continue-in" && !isExperimentCandidate) continueInProvider(thread.id);
+        if (key === "group-open-threads") {
+          const state = useAppStore.getState();
+          if (state.view.kind !== "thread") return;
+          const openThreads = state.threads.filter(
+            (other) => state.view.kind === "thread" && state.view.panes.includes(other.id),
+          );
+          const projectId = openThreads[0]?.projectId;
+          if (!projectId || !openThreads.every((other) => other.projectId === projectId)) return;
+          const groupId = crypto.randomUUID();
+          const groupName = thread.title;
+          useAppStore.setState((s) => ({
+            threads: s.threads.map((other) =>
+              s.view.kind === "thread" && s.view.panes.includes(other.id)
+                ? { ...other, groupId, groupName }
+                : other,
+            ),
+            view: s.view.kind === "thread" ? { ...s.view, activeGroupId: groupId } : s.view,
+          }));
+        }
+        if (key === "ungroup") {
+          useAppStore.setState((state) => {
+            let updatedThreads = state.threads.map((other) =>
+              other.id === thread.id
+                ? { ...other, groupId: undefined, groupName: undefined }
+                : other,
+            );
+            const remaining = updatedThreads.filter((other) => other.groupId === thread.groupId);
+            if (remaining.length === 1) {
+              updatedThreads = updatedThreads.map((other) =>
+                other.id === remaining[0]!.id
+                  ? { ...other, groupId: undefined, groupName: undefined }
+                  : other,
+              );
+            }
+            const view =
+              state.view.kind === "thread" && state.view.activeGroupId === thread.groupId
+                ? { kind: "thread" as const, panes: [state.view.panes[0]] as [string] }
+                : state.view;
+            return { threads: updatedThreads, view };
+          });
+        }
+        if (key === "archive" && !isExperimentCandidate) archiveThread(thread.id);
+        if (key === "rename") onRename?.();
+        if (key === "unload") unloadThread(thread.id);
+        if (key === "mark-done") toggleMarkThreadDone(thread.id);
+        if (key === "toggle-star") toggleStarThread(thread.id);
+        if (key === "delete" && !isExperimentCandidate)
+          deleteThread(thread.id, thread.worktreePath, thread.projectId);
+        if (key.startsWith("action:")) {
+          runProjectAction(project.id, key.slice("action:".length), thread.worktreePath);
+        }
+      }}
+    >
+      {props.children}
+    </ContextMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- Add **New thread (+)** and **Browser** buttons to the collapsed sidebar icon rail, grouped with Home and Search. The + reuses `openNewThread()` (targets the currently viewed project) and highlights while a draft page is open; the globe toggles the Browser panel.
- Start the collapsed rail at the window top on Windows/Linux by skipping the empty titlebar-height header spacer when collapsed; macOS keeps the spacer so the rail clears the hidden-inset traffic-light controls.
- Add the full thread right-click menu to the collapsed rail's thread icons by extracting the ~200-line menu from `SortableThreadItem` into a shared `ThreadContextMenu` component used by both surfaces. Rename is omitted in the rail (no inline rename affordance there); expanded-row behavior is unchanged.

## i18n
No new strings — all labels reuse existing msgids; `pnpm i18n:extract` shows 0 missing across all 12 non-English catalogs (only source-reference comments changed).

## Testing
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅
- `pnpm exec vitest run .../SortableThreadItem` — 7/7 ✅

## Note
Removing the collapsed-rail header spacer on Windows also removes the 48px-wide window-drag strip above the rail; the titlebar over the content area remains draggable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)