### PR TITLE
Add distinct labels and icons for PR automation modes

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8178,6 +8178,14 @@ msgstr "PR-Aktionen"
 msgid "PR automation"
 msgstr "PR-Automatisierung"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR-Automatisierung: Automatisch beheben"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR-Automatisierung: Automatisch mergen"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PR-Optionen"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8183,6 +8183,14 @@ msgstr "PR actions"
 msgid "PR automation"
 msgstr "PR automation"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR automation: Auto Fix"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR automation: Auto Merge"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PR options"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8178,6 +8178,14 @@ msgstr "Acciones de PR"
 msgid "PR automation"
 msgstr "Automatización de PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Automatización de PR: Corrección automática"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Automatización de PR: Fusión automática"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Opciones de PR"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8177,6 +8177,14 @@ msgstr "Actions de la PR"
 msgid "PR automation"
 msgstr "Automatisation des PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Automatisation des PR : Correction auto"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Automatisation des PR : Fusion auto"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Options de la PR"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8176,6 +8176,14 @@ msgstr "PRアクション"
 msgid "PR automation"
 msgstr "PR の自動化"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR の自動化: 自動修正"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR の自動化: 自動マージ"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PRオプション"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8178,6 +8178,14 @@ msgstr "PR 작업"
 msgid "PR automation"
 msgstr "PR 자동화"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR 자동화: 자동 수정"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR 자동화: 자동 병합"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PR 옵션"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8178,6 +8178,14 @@ msgstr "Działania PR"
 msgid "PR automation"
 msgstr "Automatyzacja PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Automatyzacja PR: Automatyczna naprawa"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Automatyzacja PR: Automatyczne scalanie"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Opcje PR"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8178,6 +8178,14 @@ msgstr "Ações de PR"
 msgid "PR automation"
 msgstr "Automação de PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Automação de PR: Correção automática"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Automação de PR: Mesclagem automática"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Opções de PR"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8178,6 +8178,14 @@ msgstr "Действия PR"
 msgid "PR automation"
 msgstr "Автоматизация PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Автоматизация PR: Автоисправление"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Автоматизация PR: Автослияние"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Параметры PR"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8178,6 +8178,14 @@ msgstr "PR eylemleri"
 msgid "PR automation"
 msgstr "PR otomasyonu"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR otomasyonu: Otomatik düzelt"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR otomasyonu: Otomatik birleştir"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PR seçenekleri"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8178,6 +8178,14 @@ msgstr "Дії PR"
 msgid "PR automation"
 msgstr "Автоматизація PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Автоматизація PR: Автовиправлення"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Автоматизація PR: Автозлиття"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Параметри PR"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8178,6 +8178,14 @@ msgstr "hoạt động PR"
 msgid "PR automation"
 msgstr "Tự động hóa PR"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "Tự động hóa PR: Tự động sửa"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "Tự động hóa PR: Tự động hợp nhất"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "Tùy chọn PR"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8177,6 +8177,14 @@ msgstr "PR 操作"
 msgid "PR automation"
 msgstr "PR 自动化"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Fix"
+msgstr "PR 自动化: 自动修复"
+
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+msgid "PR automation: Auto Merge"
+msgstr "PR 自动化: 自动合并"
+
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CreatePrModal.tsx
 msgid "PR options"
 msgstr "PR 选项"

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.test.tsx
@@ -144,11 +144,39 @@ describe("PrWatchControls", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "PR automation" }));
+    fireEvent.click(screen.getByRole("button", { name: "PR automation: Auto Merge" }));
     const slider = screen.getByRole("slider", { name: "PR automation" });
     expect(slider).toHaveValue("2");
     expect(slider).not.toBeDisabled();
     expect(onInitialWatchUsed).toHaveBeenCalledOnce();
+  });
+
+  it("indicates the selected automation mode on the trigger icon and label", async () => {
+    bridge.getPrWatch.mockResolvedValue({
+      projectId: project.id,
+      prNumber: 42,
+      headBranch: "feature/pr-watch",
+      watchEnabled: true,
+      autoMerge: false,
+      agentKind: "codex",
+      config: { model: "gpt-5.7", effort: "high" },
+      lastCommentCursor: null,
+      lastReviewCommentCursor: null,
+      lastReviewCursor: null,
+      lastCheckKey: null,
+      activeThreadId: null,
+      lastError: null,
+    });
+
+    const { container } = render(
+      <PrWatchControls projectId={project.id} prNumber={42} headBranch="feature/pr-watch" />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "PR automation: Auto Fix" })).toBeInTheDocument(),
+    );
+    expect(container.querySelector("svg.lucide-wrench")).not.toBeNull();
+    expect(container.querySelector("svg.lucide-git-merge")).toBeNull();
   });
 
   it("enables watching with the AI Helpers conflict resolver model", async () => {

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/PrWatchControls.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Popover, toast } from "@heroui/react";
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Workflow } from "lucide-react";
+import { GitMerge, Workflow, Wrench } from "lucide-react";
 import type { PrAutomationMode, PrWatch, PrWatchInput } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
 import { readBridge } from "@/renderer/bridge";
@@ -40,6 +40,13 @@ export function PrWatchControls(props: {
   const refreshPrRef = useRef(props.onRefreshPr);
   const mode = automationMode(watch);
   const enabled = mode !== "off";
+  const TriggerIcon = mode === "merge" ? GitMerge : mode === "fix" ? Wrench : Workflow;
+  const triggerLabel =
+    mode === "merge"
+      ? t`PR automation: Auto Merge`
+      : mode === "fix"
+        ? t`PR automation: Auto Fix`
+        : t`PR automation`;
 
   useEffect(() => {
     refreshPrRef.current = props.onRefreshPr;
@@ -156,13 +163,13 @@ export function PrWatchControls(props: {
       <Popover.Trigger className="flex shrink-0 items-center">
         <button
           type="button"
-          aria-label={t`PR automation`}
-          title={t`PR automation`}
+          aria-label={triggerLabel}
+          title={triggerLabel}
           className={`flex items-center justify-center rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground ${
             enabled ? "text-foreground" : "text-muted"
           }`}
         >
-          <Workflow className="size-3.5" />
+          <TriggerIcon className="size-3.5" />
         </button>
       </Popover.Trigger>
       <Popover.Content placement="bottom end" className="w-80">


### PR DESCRIPTION
- PR watch control button now shows a mode-specific label and icon instead of a generic workflow icon for all modes.
- Auto Fix and Auto Merge modes each get distinct visuals (wrench and merge icons) so the active automation mode is recognizable at a glance.
- Updated `PrWatchControls` aria-label/title to reflect the active mode and added tests covering the mode-specific rendering.
- Added translations for the new labels across all 12 non-English locale catalogs.