### PR TITLE
Fix model visibility popovers overflowing the viewport

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/ModelVisibilityPopover.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelVisibilityPopover.tsx
@@ -151,9 +151,12 @@ export function ModelVisibilityPopover(props: {
           </span>
         </Button>
       </Popover.Trigger>
-      <Popover.Content placement="bottom end" className="w-80 p-0">
-        <Popover.Dialog className="flex max-h-[28rem] flex-col overflow-hidden !p-0">
-          <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+      <Popover.Content placement="bottom end" maxHeight={448} className="w-80 p-0">
+        {/* max-h-[inherit] tracks the available-height cap React Aria sets on the
+            popover element, so the list shrinks near screen edges instead of
+            overflowing the window. */}
+        <Popover.Dialog className="flex max-h-[inherit] flex-col overflow-hidden !p-0">
+          <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
             <Search className="size-3.5 shrink-0 text-muted" />
             <Input
               aria-label={t`Search models`}
@@ -164,7 +167,7 @@ export function ModelVisibilityPopover(props: {
               onKeyDown={(event) => event.stopPropagation()}
             />
           </div>
-          <div className="flex items-center justify-between gap-2 border-b border-border/40 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted/80">
+          <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted/80">
             <span className="tabular-nums">
               {props.summaryKind === "usable" ? (
                 <Trans>
@@ -205,7 +208,7 @@ export function ModelVisibilityPopover(props: {
               aria-label={props.listAriaLabel}
               selectionMode="none"
               onAction={activateItem}
-              className="poracode-menu no-scrollbar max-h-[22rem] overflow-y-auto py-1.5"
+              className="poracode-menu no-scrollbar min-h-0 overflow-y-auto py-1.5"
             >
               {items.map((item) => (
                 <ModelVisibilityRow
@@ -227,7 +230,7 @@ export function ModelVisibilityPopover(props: {
             </ListBox>
           )}
           {props.footer ? (
-            <p className="border-t border-border/40 px-3 py-1.5 text-[10px] text-muted">
+            <p className="shrink-0 border-t border-border/40 px-3 py-1.5 text-[10px] text-muted">
               {props.footer}
             </p>
           ) : null}

--- a/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ModelVisibilitySection.tsx
@@ -272,9 +272,12 @@ export function ModelVisibilitySection() {
             {visibleCount} / {totalCount}
           </Button>
         </Popover.Trigger>
-        <Popover.Content placement="bottom end" className="w-96 p-0">
-          <Popover.Dialog className="flex max-h-[32rem] flex-col overflow-hidden !p-0">
-            <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <Popover.Content placement="bottom end" maxHeight={512} className="w-96 p-0">
+          {/* max-h-[inherit] tracks the available-height cap React Aria sets on
+              the popover element, so the list shrinks near screen edges instead
+              of overflowing the window. */}
+          <Popover.Dialog className="flex max-h-[inherit] flex-col overflow-hidden !p-0">
+            <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
               <Search className="size-3.5 shrink-0 text-muted" />
               <input
                 aria-label={t`Search models`}
@@ -285,7 +288,7 @@ export function ModelVisibilitySection() {
                 onKeyDown={(event) => event.stopPropagation()}
               />
             </div>
-            <div className="flex items-center justify-between gap-2 border-b border-border/40 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted/80">
+            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3 py-1.5 text-[10px] uppercase tracking-wider text-muted/80">
               <span className="tabular-nums">
                 <Trans>
                   {visibleCount} of {totalCount} visible
@@ -318,7 +321,7 @@ export function ModelVisibilitySection() {
                 role="listbox"
                 aria-label={t`Visible models`}
                 aria-multiselectable="true"
-                className="poracode-menu no-scrollbar max-h-[26rem] overflow-y-auto py-1.5"
+                className="poracode-menu no-scrollbar min-h-0 overflow-y-auto py-1.5"
               >
                 {(() => {
                   let underSub = false;


### PR DESCRIPTION
- Caps the model visibility popovers' height to the available viewport space instead of using fixed maximum heights.
- Popover content now shrinks near screen edges, preventing the model list from overflowing the window.
- Applies the fix to both the settings model-visibility popover and the model visibility section list.
- Also pins the popover headers, search bar, and footer so only the model list scrolls.