### PR TITLE
Add shared standard GUI slash commands

### DIFF
--- a/src/renderer/components/providers/codex/index.tsx
+++ b/src/renderer/components/providers/codex/index.tsx
@@ -10,6 +10,11 @@ import type { AgentCapability, ThreadConfig } from "@/shared/contracts";
 import { registerProviderIcon } from "../ProviderIcon";
 import { registerComposerControls, registerConfigNormalizer } from "../providerComposer";
 import { registerGuiSlashCommands } from "../providerSlashCommands";
+import {
+  buildStandardGuiSlashCommands,
+  guiSlashCommand,
+  resolveStandardLocalSlashAction,
+} from "../standardGuiSlashCommands";
 import { registerCommitGenDefaults } from "../commitGen";
 import { registerConflictResolverDefaults } from "../conflictResolver";
 import { registerTitleGenDefaults } from "../titleGen";
@@ -46,32 +51,13 @@ registerConfigNormalizer(PROVIDER_KIND, ({ config, presentationMode }) => {
   return {};
 });
 
-// A slash command's label is its id followed by the (translated) description, so
-// the description is translated once and the `/id` keyword stays untranslatable.
-const codexCommand = (id: string, description: string) => ({
-  id,
-  description,
-  label: `${id} - ${description}`,
-});
-
 registerGuiSlashCommands(PROVIDER_KIND, {
-  buildCommands: ({ hasEffort, supportsFast }) => [
-    codexCommand("model", i18n._(msg`Open the model picker`)),
-    codexCommand("plan", i18n._(msg`Switch this chat to plan mode`)),
-    codexCommand("agent", i18n._(msg`Switch this chat to agent mode`)),
-    codexCommand("goal", i18n._(msg`Set or view an experimental goal`)),
-    ...(hasEffort ? [codexCommand("effort", i18n._(msg`Open the effort picker`))] : []),
-    ...(supportsFast ? [codexCommand("fast", i18n._(msg`Toggle Fast mode`))] : []),
-  ],
-  resolveLocalAction: (typed) => {
-    const normalized = typed.trim().toLowerCase();
-    if (normalized === "/model") return { kind: "open-control", target: "model" };
-    if (normalized === "/effort") return { kind: "open-control", target: "effort" };
-    if (normalized === "/fast") return { kind: "toggle-fast" };
-    if (normalized === "/plan") return { kind: "set-mode", mode: "plan" };
-    if (normalized === "/agent") return { kind: "set-mode", mode: "agent" };
-    return null;
-  },
+  buildCommands: (ctx) =>
+    buildStandardGuiSlashCommands(ctx, [
+      // `/goal` has no local action: it submits to the provider.
+      guiSlashCommand("goal", i18n._(msg`Set or view an experimental goal`)),
+    ]),
+  resolveLocalAction: resolveStandardLocalSlashAction,
 });
 
 const CODEX_PERMISSION_PRESETS = [

--- a/src/renderer/components/providers/cursor/index.tsx
+++ b/src/renderer/components/providers/cursor/index.tsx
@@ -14,6 +14,11 @@ import { cursorRuntimeInstallState, cursorSdkUpdateCommand } from "./runtimeInst
 import { fullAccessToggle, planWorkToggle } from "../composerControlBuilders";
 import { registerProviderIcon } from "../ProviderIcon";
 import { registerComposerControls, registerComposerRuntimeUpdate } from "../providerComposer";
+import { registerGuiSlashCommands } from "../providerSlashCommands";
+import {
+  buildStandardGuiSlashCommands,
+  resolveStandardLocalSlashAction,
+} from "../standardGuiSlashCommands";
 import { registerCommitGenDefaults } from "../commitGen";
 import { registerConflictResolverDefaults } from "../conflictResolver";
 import { registerTitleGenDefaults } from "../titleGen";
@@ -21,6 +26,14 @@ import { registerTitleGenDefaults } from "../titleGen";
 const PROVIDER_KIND = providerManifest.kind;
 
 registerProviderIcon(PROVIDER_KIND, CursorIcon);
+// The SDK runtime reports no session commands, so the GUI slash menu offers
+// Poracode's composer-local set (mode, model, fast). ACP sessions keep the
+// commands cursor-agent reports via `available_commands_update` instead.
+registerGuiSlashCommands(PROVIDER_KIND, {
+  isEnabled: ({ runtimeLabel }) => runtimeLabel === "SDK",
+  buildCommands: buildStandardGuiSlashCommands,
+  resolveLocalAction: resolveStandardLocalSlashAction,
+});
 registerComposerRuntimeUpdate(PROVIDER_KIND, ({ agentStatus, project }) => {
   const runtimeLabel = agentStatus.capabilities.runtimeLabel;
   if (runtimeLabel !== "SDK") return undefined;

--- a/src/renderer/components/providers/providerSlashCommands.test.ts
+++ b/src/renderer/components/providers/providerSlashCommands.test.ts
@@ -2,6 +2,11 @@
 
 import { describe, expect, it } from "vitest";
 import "./codex";
+import "./cursor";
+import {
+  resolveAvailableSlashCommands,
+  resolveLocalSlashCommandAction,
+} from "../thread/threadSlashCommands";
 import { getGuiSlashCommands } from "./providerSlashCommands";
 
 describe("provider slash-command registry", () => {
@@ -17,6 +22,50 @@ describe("provider slash-command registry", () => {
     ).toEqual(["model", "plan", "agent", "goal", "effort", "fast"]);
   });
 
+  it("builds Cursor commands from the active control capabilities", () => {
+    const registration = getGuiSlashCommands("cursor");
+
+    expect(registration).toBeDefined();
+    expect(
+      registration?.buildCommands({ hasEffort: false, supportsFast: false }).map(({ id }) => id),
+    ).toEqual(["model", "plan", "agent"]);
+    expect(
+      registration?.buildCommands({ hasEffort: true, supportsFast: true }).map(({ id }) => id),
+    ).toEqual(["model", "plan", "agent", "effort", "fast"]);
+  });
+
+  it("offers Cursor local commands only under the SDK runtime", () => {
+    const sdk = resolveAvailableSlashCommands(undefined, undefined, {
+      agentKind: "cursor",
+      presentationMode: "gui",
+      runtimeLabel: "SDK",
+    });
+    expect(sdk.map(({ id }) => id)).toEqual(["model", "plan", "agent"]);
+
+    // ACP sessions keep the commands cursor-agent reports itself.
+    const acp = resolveAvailableSlashCommands(
+      [{ id: "summarize", label: "summarize" }],
+      undefined,
+      { agentKind: "cursor", presentationMode: "gui", runtimeLabel: "ACP" },
+    );
+    expect(acp.map(({ id }) => id)).toEqual(["summarize"]);
+
+    expect(
+      resolveLocalSlashCommandAction("/model", {
+        agentKind: "cursor",
+        presentationMode: "gui",
+        runtimeLabel: "SDK",
+      }),
+    ).toEqual({ kind: "open-control", target: "model" });
+    expect(
+      resolveLocalSlashCommandAction("/model", {
+        agentKind: "cursor",
+        presentationMode: "gui",
+        runtimeLabel: "ACP",
+      }),
+    ).toBeNull();
+  });
+
   it.each([
     [" /MODEL ", { kind: "open-control", target: "model" }],
     ["/effort", { kind: "open-control", target: "effort" }],
@@ -26,5 +75,6 @@ describe("provider slash-command registry", () => {
     ["/goal", null],
   ])("resolves local action %s", (typed, expected) => {
     expect(getGuiSlashCommands("codex")?.resolveLocalAction(typed)).toEqual(expected);
+    expect(getGuiSlashCommands("cursor")?.resolveLocalAction(typed)).toEqual(expected);
   });
 });

--- a/src/renderer/components/providers/providerSlashCommands.ts
+++ b/src/renderer/components/providers/providerSlashCommands.ts
@@ -6,12 +6,23 @@ export interface GuiSlashCommandContext {
   supportsFast: boolean;
 }
 
+/** Runtime scope the composer is bound to when the registration is consulted. */
+export interface GuiSlashCommandScope {
+  runtimeLabel?: string | undefined;
+}
+
 export type LocalSlashCommandAction =
   | { kind: "set-mode"; mode: "agent" | "plan" }
   | { kind: "open-control"; target: "model" | "effort" }
   | { kind: "toggle-fast" };
 
 export interface GuiSlashCommandRegistration {
+  /**
+   * When present, the registration only applies in matching runtime scopes.
+   * Outside of them the composer falls back to the provider-reported command
+   * catalog (e.g. ACP `available_commands_update`).
+   */
+  isEnabled?: (scope: GuiSlashCommandScope) => boolean;
   buildCommands: (context: GuiSlashCommandContext) => readonly AgentSlashCommand[];
   resolveLocalAction: (typedCommand: string) => LocalSlashCommandAction | null;
 }

--- a/src/renderer/components/providers/standardGuiSlashCommands.ts
+++ b/src/renderer/components/providers/standardGuiSlashCommands.ts
@@ -1,0 +1,41 @@
+import { msg } from "@lingui/core/macro";
+import type { AgentSlashCommand } from "@/shared/contracts";
+import { i18n } from "@/renderer/i18n/i18n";
+import type { GuiSlashCommandContext, LocalSlashCommandAction } from "./providerSlashCommands";
+
+// A slash command's label is its id followed by the (translated) description, so
+// the description is translated once and the `/id` keyword stays untranslatable.
+export const guiSlashCommand = (id: string, description: string): AgentSlashCommand => ({
+  id,
+  description,
+  label: `${id} - ${description}`,
+});
+
+/**
+ * The provider-agnostic GUI command set: composer-local actions every
+ * structured-chat provider supports. Provider-specific extras (e.g. Codex
+ * `/goal`) insert after the mode commands and before effort/fast.
+ */
+export function buildStandardGuiSlashCommands(
+  { hasEffort, supportsFast }: GuiSlashCommandContext,
+  extras: readonly AgentSlashCommand[] = [],
+): AgentSlashCommand[] {
+  return [
+    guiSlashCommand("model", i18n._(msg`Open the model picker`)),
+    guiSlashCommand("plan", i18n._(msg`Switch this chat to plan mode`)),
+    guiSlashCommand("agent", i18n._(msg`Switch this chat to agent mode`)),
+    ...extras,
+    ...(hasEffort ? [guiSlashCommand("effort", i18n._(msg`Open the effort picker`))] : []),
+    ...(supportsFast ? [guiSlashCommand("fast", i18n._(msg`Toggle Fast mode`))] : []),
+  ];
+}
+
+export function resolveStandardLocalSlashAction(typed: string): LocalSlashCommandAction | null {
+  const normalized = typed.trim().toLowerCase();
+  if (normalized === "/model") return { kind: "open-control", target: "model" };
+  if (normalized === "/effort") return { kind: "open-control", target: "effort" };
+  if (normalized === "/fast") return { kind: "toggle-fast" };
+  if (normalized === "/plan") return { kind: "set-mode", mode: "plan" };
+  if (normalized === "/agent") return { kind: "set-mode", mode: "agent" };
+  return null;
+}

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -288,6 +288,7 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     {
       agentKind: thread.agentKind,
       presentationMode,
+      runtimeLabel: effectiveAgentStatus?.capabilities.runtimeLabel,
       hasEffort:
         ((
           effectiveAgentStatus?.capabilities.modelEfforts?.[thread.config?.model ?? ""] ??

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -367,12 +367,16 @@ export function ThreadDraftComposerArea(props: {
     props.project.location,
     props.selectedAgent.kind,
   );
+  const slashLookupContext = {
+    agentKind: props.selectedAgent.kind,
+    presentationMode: props.presentationMode,
+    runtimeLabel: props.selectedAgent.capabilities.runtimeLabel,
+  };
   const availableCommands = resolveAvailableSlashCommands(
     undefined,
     props.selectedAgent.capabilities.slashCommands,
     {
-      agentKind: props.selectedAgent.kind,
-      presentationMode: props.presentationMode,
+      ...slashLookupContext,
       hasEffort:
         ((
           props.selectedAgent.capabilities.modelEfforts?.[props.config.model] ??
@@ -588,10 +592,11 @@ export function ThreadDraftComposerArea(props: {
       void runExperiment(allSegments, fallbackPrompt);
       return;
     }
-    const boundSegments = bindLeadingSkillUnlessLocalAction(allSegments, availableCommands, {
-      agentKind: props.selectedAgent.kind,
-      presentationMode: props.presentationMode,
-    });
+    const boundSegments = bindLeadingSkillUnlessLocalAction(
+      allSegments,
+      availableCommands,
+      slashLookupContext,
+    );
     const currentSegments = rebindSkillSegments(
       boundSegments,
       availableCommands,
@@ -601,10 +606,11 @@ export function ThreadDraftComposerArea(props: {
     if (flatPrompt.length === 0) {
       return;
     }
-    const localAction = resolveLocalActionUnlessSkill(currentSegments, flatPrompt, {
-      agentKind: props.selectedAgent.kind,
-      presentationMode: props.presentationMode,
-    });
+    const localAction = resolveLocalActionUnlessSkill(
+      currentSegments,
+      flatPrompt,
+      slashLookupContext,
+    );
     if (localAction?.kind === "set-mode") {
       props.onConfigChange({ mode: localAction.mode });
       mentionRef.current?.clear();
@@ -684,10 +690,11 @@ export function ThreadDraftComposerArea(props: {
   }
 
   function resolveExperimentInput(allSegments: PromptSegment[], fallbackPrompt = "") {
-    const boundSegments = bindLeadingSkillUnlessLocalAction(allSegments, availableCommands, {
-      agentKind: props.selectedAgent.kind,
-      presentationMode: props.presentationMode,
-    });
+    const boundSegments = bindLeadingSkillUnlessLocalAction(
+      allSegments,
+      availableCommands,
+      slashLookupContext,
+    );
     const segments = rebindSkillSegments(
       boundSegments,
       availableCommands,

--- a/src/renderer/components/thread/threadComposerSubmit.ts
+++ b/src/renderer/components/thread/threadComposerSubmit.ts
@@ -88,10 +88,16 @@ export function submitComposerPrompt(segments: PromptSegment[], ctx: ComposerSub
             attachmentName: a.name,
           }),
     }));
-  const boundSegments = bindLeadingSkillUnlessLocalAction(segments, ctx.availableCommands, {
+  const slashLookupContext = {
     agentKind: thread.agentKind,
     presentationMode: ctx.presentationMode,
-  });
+    runtimeLabel: agentStatus?.capabilities.runtimeLabel,
+  };
+  const boundSegments = bindLeadingSkillUnlessLocalAction(
+    segments,
+    ctx.availableCommands,
+    slashLookupContext,
+  );
   const allSegments = [...attachmentSegments, ...selectorSegments, ...boundSegments];
   const flat = flattenSegments(allSegments);
   if (flat.length === 0 || !ctx.canSubmit) return;
@@ -100,10 +106,7 @@ export function submitComposerPrompt(segments: PromptSegment[], ctx: ComposerSub
     ctx.setHasContent(false);
     ctx.latestSegmentsRef.current = [];
   };
-  const localAction = resolveLocalActionUnlessSkill(allSegments, flat, {
-    agentKind: thread.agentKind,
-    presentationMode: ctx.presentationMode,
-  });
+  const localAction = resolveLocalActionUnlessSkill(allSegments, flat, slashLookupContext);
   if (localAction?.kind === "set-mode") {
     changeThreadConfig(thread.id, { ...thread.config, mode: localAction.mode });
     mentionRef.current?.clear();

--- a/src/renderer/components/thread/threadSlashCommands.ts
+++ b/src/renderer/components/thread/threadSlashCommands.ts
@@ -10,10 +10,35 @@ import { flattenSegments } from "@/renderer/components/composer/serializeMention
 import type { MentionInputHandle } from "@/renderer/components/composer/MentionInput";
 import {
   getGuiSlashCommands,
+  type GuiSlashCommandRegistration,
   type LocalSlashCommandAction,
 } from "@/renderer/components/providers/providerSlashCommands";
 
 export type { LocalSlashCommandAction };
+
+/** Fields every local GUI slash-command lookup needs from the composer. */
+export type SlashCommandLookupContext = {
+  agentKind?: AgentStatus["kind"] | undefined;
+  presentationMode?: ThreadPresentationMode | undefined;
+  runtimeLabel?: string | undefined;
+};
+
+/**
+ * A provider's local GUI command registration can opt out of runtime scopes
+ * (e.g. Cursor's applies to the SDK runtime only, so ACP sessions keep the
+ * commands the agent reports itself).
+ */
+function activeGuiSlashCommands(
+  context: Pick<SlashCommandLookupContext, "agentKind" | "runtimeLabel">,
+): GuiSlashCommandRegistration | undefined {
+  if (!context.agentKind) return undefined;
+  const registration = getGuiSlashCommands(context.agentKind);
+  if (!registration) return undefined;
+  if (registration.isEnabled && !registration.isEnabled({ runtimeLabel: context.runtimeLabel })) {
+    return undefined;
+  }
+  return registration;
+}
 
 const EMPTY_SLASH_COMMANDS: AgentSlashCommand[] = [];
 
@@ -160,9 +185,7 @@ export function rebindSkillSegments(
 export function resolveAvailableSlashCommands(
   threadCommands: readonly AgentSlashCommand[] | undefined,
   capabilityCommands: readonly AgentSlashCommand[] | undefined,
-  context?: {
-    agentKind?: AgentStatus["kind"] | undefined;
-    presentationMode?: ThreadPresentationMode | undefined;
+  context?: SlashCommandLookupContext & {
     hasEffort?: boolean | undefined;
     supportsFast?: boolean | undefined;
     skillCommands?: readonly AgentSlashCommand[] | undefined;
@@ -183,8 +206,8 @@ export function resolveAvailableSlashCommands(
     const base = threadCommands ?? capabilityCommands ?? EMPTY_SLASH_COMMANDS;
     return [...dedupeBaseCommands(base, skills), ...skills];
   }
-  if (context?.agentKind) {
-    const registration = getGuiSlashCommands(context.agentKind);
+  if (context) {
+    const registration = activeGuiSlashCommands(context);
     if (registration) {
       return [
         ...registration.buildCommands({
@@ -201,13 +224,10 @@ export function resolveAvailableSlashCommands(
 
 export function resolveLocalSlashCommandAction(
   input: string,
-  context: {
-    agentKind?: AgentStatus["kind"] | undefined;
-    presentationMode?: ThreadPresentationMode | undefined;
-  },
+  context: SlashCommandLookupContext,
 ): LocalSlashCommandAction | null {
-  if (!context.agentKind || context.presentationMode === "terminal") return null;
-  const registration = getGuiSlashCommands(context.agentKind);
+  if (context.presentationMode === "terminal") return null;
+  const registration = activeGuiSlashCommands(context);
   return registration ? registration.resolveLocalAction(input) : null;
 }
 
@@ -219,10 +239,7 @@ export function resolveLocalSlashCommandAction(
 export function bindLeadingSkillUnlessLocalAction(
   segments: PromptSegment[],
   commands: readonly AgentSlashCommand[],
-  context: {
-    agentKind?: AgentStatus["kind"] | undefined;
-    presentationMode?: ThreadPresentationMode | undefined;
-  },
+  context: SlashCommandLookupContext,
 ): PromptSegment[] {
   return resolveLocalSlashCommandAction(flattenSegments(segments), context)
     ? segments
@@ -236,10 +253,7 @@ export function bindLeadingSkillUnlessLocalAction(
 export function resolveLocalActionUnlessSkill(
   segments: readonly PromptSegment[],
   input: string,
-  context: {
-    agentKind?: AgentStatus["kind"] | undefined;
-    presentationMode?: ThreadPresentationMode | undefined;
-  },
+  context: SlashCommandLookupContext,
 ): LocalSlashCommandAction | null {
   return segments.some((segment) => segment.kind === "skill")
     ? null

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Terminal im Worktree öffnen"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Aufwandsauswahl öffnen"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Modellauswahl öffnen"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Projekt wechseln"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Diesen Chat in den Agentenmodus schalten"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Diesen Chat in den Planmodus schalten"
 
@@ -11435,6 +11439,7 @@ msgstr "Browser-Panel umschalten"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Schnellmodus umschalten"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -7710,10 +7710,12 @@ msgid "Open terminal in worktree"
 msgstr "Open terminal in worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Open the effort picker"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Open the model picker"
 
@@ -10761,10 +10763,12 @@ msgid "Switch project"
 msgstr "Switch project"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Switch this chat to agent mode"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Switch this chat to plan mode"
 
@@ -11440,6 +11444,7 @@ msgstr "Toggle browser panel"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Toggle Fast mode"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Abrir terminal en worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Abrir el selector de esfuerzo"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Abrir el selector de modelo"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Cambiar de proyecto"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Cambiar este chat al modo agente"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Cambiar este chat al modo de plan"
 
@@ -11435,6 +11439,7 @@ msgstr "Alternar el panel del navegador"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Alternar modo rápido"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -7704,10 +7704,12 @@ msgid "Open terminal in worktree"
 msgstr "Ouvrir le terminal dans le worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Ouvrir le sélecteur d'effort"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Ouvrir le sélecteur de modèle"
 
@@ -10755,10 +10757,12 @@ msgid "Switch project"
 msgstr "Changer de projet"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Passer ce chat en mode agent"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Passer ce chat en mode plan"
 
@@ -11434,6 +11438,7 @@ msgstr "Basculer le panneau du navigateur"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Activer/désactiver le mode rapide"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -7703,10 +7703,12 @@ msgid "Open terminal in worktree"
 msgstr "worktree でターミナルを開く"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "工数ピッカーを開く"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "モデルピッカーを開く"
 
@@ -10754,10 +10756,12 @@ msgid "Switch project"
 msgstr "プロジェクトの切り替え"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "このチャットをエージェント モードに切り替えます"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "このチャットを計画モードに切り替えます"
 
@@ -11433,6 +11437,7 @@ msgstr "ブラウザパネルの切り替え"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "高速モードの切り替え"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "worktree에서 터미널 열기"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "노력 선택 도구 열기"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "모델 선택기 열기"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "프로젝트 전환"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "이 채팅을 에이전트 모드로 전환하세요"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "이 채팅을 계획 모드로 전환하세요"
 
@@ -11435,6 +11439,7 @@ msgstr "브라우저 패널 표시 전환"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "빠른 모드 전환"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Otwórz terminal w worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Otwórz wybór wysiłku"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Otwórz selektor modeli"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Zmień projekt"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Przełącz ten czat w tryb agenta"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Przełącz ten czat w tryb planu"
 
@@ -11435,6 +11439,7 @@ msgstr "Przełącz panel przeglądarki"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Przełącz tryb szybki"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Abrir terminal no worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Abra o seletor de esforço"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Abra o seletor de modelo"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Trocar projeto"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Mude este chat para o modo de agente"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Mude este chat para o modo de planejamento"
 
@@ -11435,6 +11439,7 @@ msgstr "Alternar painel do navegador"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Alternar modo rápido"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Открыть терминал в worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Открыть выбор усилия"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Открыть выбор модели"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Переключить проект"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Переключить этот чат в режим агента"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Переключить этот чат в режим плана"
 
@@ -11435,6 +11439,7 @@ msgstr "Переключить панель браузера"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Переключить быстрый режим"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Terminali worktree'de aç"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Çaba seçiciyi aç"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Model seçiciyi açın"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Projeyi değiştir"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Bu sohbeti temsilci moduna geçir"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Bu sohbeti plan moduna geçir"
 
@@ -11435,6 +11439,7 @@ msgstr "Tarayıcı panelini aç/kapat"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Hızlı modu aç/kapat"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Открыть терминал в worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Відкрити вибір зусилля"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Відкрити вибір моделі"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Перемкнути проєкт"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Перемкнути цей чат у режим агента"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Перемкнути цей чат у режим плану"
 
@@ -11435,6 +11439,7 @@ msgstr "Перемкнути панель браузера"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Перемкнути швидкий режим"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -7705,10 +7705,12 @@ msgid "Open terminal in worktree"
 msgstr "Mở terminal trong worktree"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Mở bộ chọn nỗ lực"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Mở bộ chọn mô hình"
 
@@ -10756,10 +10758,12 @@ msgid "Switch project"
 msgstr "Chuyển đổi dự án"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Chuyển cuộc trò chuyện này sang chế độ tác nhân"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Chuyển cuộc trò chuyện này sang chế độ lập kế hoạch"
 
@@ -11435,6 +11439,7 @@ msgstr "Bật/tắt bảng điều khiển trình duyệt"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Chuyển đổi chế độ Nhanh"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -7704,10 +7704,12 @@ msgid "Open terminal in worktree"
 msgstr "在 worktree 中打开终端"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "打开工作量选择器"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "打开模型选择器"
 
@@ -10755,10 +10757,12 @@ msgid "Switch project"
 msgstr "切换项目"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "将此聊天切换到代理模式"
 
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "将此聊天切换到计划模式"
 
@@ -11434,6 +11438,7 @@ msgstr "切换浏览器面板"
 
 #: src/renderer/commands/composerCommands.ts
 #: src/renderer/components/providers/codex/index.tsx
+#: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "切换快速模式"
 


### PR DESCRIPTION
- Introduce a shared standard GUI slash-command builder reused by the Codex and Cursor providers for consistent `/model`, `/effort`, `/fast`, `/plan`, and `/agent` actions.
- Scope slash-command registration to matching runtimes so Cursor ACP sessions fall back to the provider-reported command catalog instead of the standard set.
- Thread the runtime label through the composer slash-command lookup to drive the new scoping.
- Extend provider slash-command tests to cover both the Codex and Cursor registrations.
- Localize the new messages across all 12 non-English catalogs.