### PR TITLE
Scroll editor tab strip and keep active tab in view

### DIFF
--- a/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/FileEditorPane.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/FileEditorPane.tsx
@@ -212,6 +212,10 @@ function TabStripHeader(props: {
         className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
         role="tablist"
         aria-label={t`Editor tabs`}
+        onWheel={(event) => {
+          // Map vertical wheel to horizontal scrolling so overflowed tabs are reachable.
+          if (event.deltaY !== 0) event.currentTarget.scrollLeft += event.deltaY;
+        }}
       >
         {paths.map((path, index) => (
           <SortableTab
@@ -225,7 +229,6 @@ function TabStripHeader(props: {
         ))}
       </div>
 
-      <div className="flex-1" />
       <div className="poracode-content-over-drag-region flex items-center gap-1.5">
         <EditorToolbar
           isMarkdown={props.isMarkdown}

--- a/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/SortableTab.tsx
+++ b/src/renderer/views/FileEditorOverlay/parts/FileEditorPane/parts/SortableTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useIsDraggingEditorTab, type DragSourceData } from "@/renderer/dnd";
@@ -20,8 +21,9 @@ export function SortableTab(props: {
   const isActive = useIsTabActive(path);
   const isPreview = useIsTabPreview(path);
   const isDirty = useIsTabDirty(path);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
 
-  const { ref } = useSortable({
+  const { ref: setSortableRef } = useSortable({
     id: `editor-tab:${path}`,
     index,
     type: "editor-tab",
@@ -32,9 +34,18 @@ export function SortableTab(props: {
 
   const isDragging = useIsDraggingEditorTab(path);
 
+  // Keep the active tab visible in the overflow strip (new tabs append at the end).
+  useEffect(() => {
+    if (!isActive) return;
+    nodeRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [isActive]);
+
   return (
     <div
-      ref={ref}
+      ref={(node) => {
+        nodeRef.current = node;
+        setSortableRef(node);
+      }}
       role="tab"
       aria-selected={isActive}
       // Roving tabindex: only the active tab sits in the tab order, matching


### PR DESCRIPTION
- Map the vertical mouse wheel to horizontal scrolling on the editor tab strip so overflowed tabs are reachable.
- Auto-scroll the active tab into view when it becomes active, since new tabs append at the end of the strip.
- Drop the now-unneeded spacer in the tab strip so the scrollable region uses the available width.