### PR TITLE
fix(chat): dedupe question rendered twice when header repeats it

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.test.tsx
@@ -40,6 +40,28 @@ describe("QuestionAnswer", () => {
     expect(revertButton.closest(".poracode-message-action-strip")).not.toBeNull();
   });
 
+  it("renders the question only once when the header repeats it (Kimi ACP shape)", () => {
+    const item: RuntimeChatItem = {
+      id: "qa-1",
+      type: "question_answer",
+      state: "completed",
+      payload: {
+        questions: [
+          {
+            header: "Which scope should be implemented?",
+            question: "Which scope should be implemented?",
+            selected: [{ label: "Focused" }],
+          },
+        ],
+      },
+      streams: {},
+    };
+
+    render(<QuestionAnswer item={item} checkpointRevert={null} />);
+
+    expect(screen.getAllByText("Which scope should be implemented?")).toHaveLength(1);
+  });
+
   it("renders nothing when the payload has no questions", () => {
     const item: RuntimeChatItem = {
       id: "qa-1",

--- a/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/QuestionAnswer.tsx
@@ -26,9 +26,13 @@ export function QuestionAnswer({ item, checkpointRevert }: QuestionAnswerProps) 
             key={`${entry.header}-${index}`}
             className={`min-w-0 space-y-1 ${index > 0 ? "border-t border-[color:var(--border)] pt-2" : ""}`}
           >
-            <div className="text-[10px] font-semibold uppercase tracking-wide text-muted">
-              {entry.header}
-            </div>
+            {/* Providers without a distinct header (Kimi) repeat the question as
+                the header; render it once instead of duplicating the same line. */}
+            {entry.header.length > 0 && entry.header !== entry.question ? (
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted">
+                {entry.header}
+              </div>
+            ) : null}
             {entry.question.length > 0 ? (
               <div className="text-[11px] text-[color:var(--muted)]">{entry.question}</div>
             ) : null}


### PR DESCRIPTION
- Providers like Kimi repeat the question text as the question header, causing the same line to render twice in question/answer items.
- Omit the header line when it is empty or identical to the question text.
- Adds a regression test covering the repeated-header (Kimi ACP) payload shape.