### PR TITLE
Add context menu action to move a thread to a worktree

### DIFF
--- a/src/renderer/actions/moveThreadToWorktreeActions.test.ts
+++ b/src/renderer/actions/moveThreadToWorktreeActions.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Thread } from "@/shared/contracts";
+
+const mocks = vi.hoisted(() => ({
+  appState: {
+    projects: [] as Project[],
+    threads: [] as Thread[],
+    setThreadWorktree: vi.fn<(threadId: string, path: string, branch: string) => void>(),
+  },
+  createWorktree:
+    vi.fn<
+      (project: Project, input: unknown) => Promise<{ path: string; changesTransferred?: boolean }>
+    >(),
+  primeWorktreeGitState: vi.fn<() => Promise<void>>(),
+  refreshGitProject: vi.fn<() => Promise<void>>(),
+  reopenStoredThread: vi.fn<(threadId: string) => void>(),
+  runWorktreeSetupScript: vi.fn<() => Promise<void>>(),
+  unloadStoredThread: vi.fn<(threadId: string) => Promise<void>>(),
+  toast: {
+    danger: vi.fn<(message: string) => void>(),
+    info: vi.fn<(message: string) => void>(),
+    success: vi.fn<(message: string) => void>(),
+  },
+}));
+
+vi.mock("@heroui/react", () => ({ toast: mocks.toast }));
+vi.mock("@/shared/worktreeBranch", () => ({
+  generateWorktreeBranch: () => "poracode/test-branch",
+}));
+vi.mock("@/renderer/i18n/i18n", () => ({ i18n: { _: () => "message" } }));
+vi.mock("@/renderer/state/appStore", () => ({
+  useAppStore: { getState: () => mocks.appState },
+}));
+vi.mock("@/renderer/state/gitRefresh", () => ({
+  refreshGitProject: mocks.refreshGitProject,
+}));
+vi.mock("@/renderer/state/gitStore", () => ({
+  useGitStore: { getState: () => ({ statuses: { "project-1": { branch: "main" } } }) },
+}));
+vi.mock("./threadActions", () => ({
+  reopenStoredThread: mocks.reopenStoredThread,
+  unloadStoredThread: mocks.unloadStoredThread,
+}));
+vi.mock("./worktreeLaunchActions", () => ({
+  createWorktree: mocks.createWorktree,
+  primeWorktreeGitState: mocks.primeWorktreeGitState,
+  runWorktreeSetupScript: mocks.runWorktreeSetupScript,
+}));
+
+import { moveThreadToWorktree } from "./moveThreadToWorktreeActions";
+
+const project = {
+  id: "project-1",
+  name: "Project",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-08-04T00:00:00.000Z",
+} satisfies Project;
+
+function thread(status: Thread["status"]): Thread {
+  return {
+    id: "thread-1",
+    projectId: project.id,
+    status,
+  } as Thread;
+}
+
+describe("moveThreadToWorktree", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.appState.projects = [project];
+    mocks.createWorktree.mockResolvedValue({ path: "C:\\worktrees\\test" });
+    mocks.primeWorktreeGitState.mockResolvedValue(undefined);
+    mocks.refreshGitProject.mockResolvedValue(undefined);
+    mocks.runWorktreeSetupScript.mockResolvedValue(undefined);
+    mocks.unloadStoredThread.mockResolvedValue(undefined);
+  });
+
+  it("keeps an active thread open and relaunches it in the new worktree", async () => {
+    mocks.appState.threads = [thread("idle")];
+
+    await moveThreadToWorktree("thread-1", false);
+
+    expect(mocks.unloadStoredThread).toHaveBeenCalledWith("thread-1");
+    expect(mocks.appState.setThreadWorktree).toHaveBeenCalledWith(
+      "thread-1",
+      "C:\\worktrees\\test",
+      "poracode/test-branch",
+    );
+    expect(mocks.reopenStoredThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("does not launch a thread that was already inactive", async () => {
+    mocks.appState.threads = [thread("inactive")];
+
+    await moveThreadToWorktree("thread-1", false);
+
+    expect(mocks.unloadStoredThread).not.toHaveBeenCalled();
+    expect(mocks.reopenStoredThread).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/actions/moveThreadToWorktreeActions.ts
+++ b/src/renderer/actions/moveThreadToWorktreeActions.ts
@@ -1,0 +1,90 @@
+import { toast } from "@heroui/react";
+import { msg } from "@lingui/core/macro";
+import { friendlyError } from "@/shared/messages";
+import { generateWorktreeBranch } from "@/shared/worktreeBranch";
+import { i18n } from "@/renderer/i18n/i18n";
+import { useAppStore } from "@/renderer/state/appStore";
+import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import { useGitStore } from "@/renderer/state/gitStore";
+import { reopenStoredThread, unloadStoredThread } from "./threadActions";
+import {
+  createWorktree,
+  primeWorktreeGitState,
+  runWorktreeSetupScript,
+} from "./worktreeLaunchActions";
+
+const movingThreadIds = new Set<string>();
+
+/**
+ * Move a main-checkout thread into a fresh git worktree on a new branch.
+ * Active threads are relaunched there. `withChanges` MOVES the project's
+ * uncommitted changes into the worktree, leaving the current branch clean.
+ * Failures are toasted here.
+ */
+export async function moveThreadToWorktree(threadId: string, withChanges: boolean): Promise<void> {
+  if (movingThreadIds.has(threadId)) return;
+  const store = useAppStore.getState();
+  const thread = store.threads.find((item) => item.id === threadId);
+  if (!thread || thread.worktreePath) return;
+  const project = store.projects.find((item) => item.id === thread.projectId);
+  if (!project) return;
+
+  if (thread.status === "launching") {
+    toast.info(i18n._(msg`Wait for the thread to finish starting before moving it to a worktree.`));
+    return;
+  }
+
+  movingThreadIds.add(threadId);
+  try {
+    // Re-tagging only sticks for a stopped thread — unload any live runtime first.
+    if (thread.status !== "inactive") {
+      await unloadStoredThread(threadId);
+    }
+    const currentBranch = useGitStore.getState().statuses[project.id]?.branch;
+    const branch = generateWorktreeBranch();
+    const result = await createWorktree(project, {
+      branch,
+      ...(currentBranch ? { startPoint: currentBranch } : {}),
+      createBranch: true,
+      transferUncommitted: withChanges,
+      keepChangesInSource: false,
+    });
+    useAppStore.getState().setThreadWorktree(threadId, result.path, branch);
+    if (thread.status !== "inactive") reopenStoredThread(threadId);
+    void primeWorktreeGitState(project, result.path);
+    void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
+    const setupScript = project.scripts?.setupScript;
+    if (setupScript) {
+      void runWorktreeSetupScript(project, result.path, setupScript);
+    }
+
+    if (withChanges) {
+      // `newBranch` keeps the msgid identical to the BranchSelector conflict
+      // toast so its translations are reused.
+      const newBranch = branch;
+      if (result.changesTransferred === false) {
+        toast.danger(
+          i18n._(
+            msg`Created a worktree on "${newBranch}", but the changes conflicted and remain in a git stash — resolve them in the worktree.`,
+          ),
+        );
+      } else if (currentBranch) {
+        toast.success(
+          i18n._(
+            msg`Moved the thread and your changes to a new worktree on "${newBranch}". "${currentBranch}" is now clean.`,
+          ),
+        );
+      } else {
+        toast.success(
+          i18n._(msg`Moved the thread and your changes to a new worktree on "${newBranch}".`),
+        );
+      }
+    } else {
+      toast.success(i18n._(msg`Moved the thread to a new worktree on "${branch}".`));
+    }
+  } catch (error) {
+    toast.danger(friendlyError(error));
+  } finally {
+    movingThreadIds.delete(threadId);
+  }
+}

--- a/src/renderer/actions/threadLaunchActions.test.ts
+++ b/src/renderer/actions/threadLaunchActions.test.ts
@@ -2,10 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Project, Thread } from "@/shared/contracts";
 
 const mocks = vi.hoisted(() => {
-  const bridge = {
-    gitAddWorktree:
-      vi.fn<(input: unknown) => Promise<{ path: string; changesTransferred?: boolean }>>(),
-  };
   const appState = {
     updateProjectDraftConfig: vi.fn<(projectId: string, config: unknown) => void>(),
     view: { kind: "home" as const },
@@ -23,9 +19,15 @@ const mocks = vi.hoisted(() => {
     launchRemoteThread: vi.fn<(input: unknown) => Promise<void>>(),
   };
   return {
-    bridge,
     appState,
     remoteState,
+    createWorktree:
+      vi.fn<
+        (
+          project: Project,
+          input: unknown,
+        ) => Promise<{ path: string; changesTransferred?: boolean }>
+      >(),
     primeWorktreeGitState: vi.fn<(project: Project, path: string) => Promise<void>>(),
     runWorktreeSetupScript:
       vi.fn<(project: Project, path: string, script: string) => Promise<void>>(),
@@ -33,10 +35,6 @@ const mocks = vi.hoisted(() => {
     generateTitleAsync: vi.fn<(...args: unknown[]) => void>(),
   };
 });
-
-vi.mock("@/renderer/bridge", () => ({
-  readBridge: () => mocks.bridge,
-}));
 
 vi.mock("@/renderer/state/appStore", () => ({
   useAppStore: {
@@ -85,11 +83,8 @@ vi.mock("@/renderer/utils/titleGen", () => ({
   generateTitleAsync: mocks.generateTitleAsync,
 }));
 
-vi.mock("./worktreePlacement", () => ({
-  worktreePlacementPayload: () => ({ worktreeRoot: "C:\\shared-worktrees" }),
-}));
-
 vi.mock("./worktreeLaunchActions", () => ({
+  createWorktree: mocks.createWorktree,
   primeWorktreeGitState: mocks.primeWorktreeGitState,
   runWorktreeSetupScript: mocks.runWorktreeSetupScript,
 }));
@@ -126,7 +121,7 @@ describe("startThreadFromDraft host transport", () => {
       id: "local-thread",
       projectId: localProject.id,
     } as Thread);
-    mocks.bridge.gitAddWorktree.mockResolvedValue({
+    mocks.createWorktree.mockResolvedValue({
       path: "C:\\shared-worktrees\\feature",
       changesTransferred: true,
     });
@@ -146,14 +141,12 @@ describe("startThreadFromDraft host transport", () => {
       worktreeIsNewBranch: true,
     });
 
-    expect(mocks.bridge.gitAddWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectLocation: localProject.location,
-        branch: "feature",
-        createBranch: true,
-        worktreeRoot: "C:\\shared-worktrees",
-      }),
-    );
+    expect(mocks.createWorktree).toHaveBeenCalledWith(localProject, {
+      branch: "feature",
+      createBranch: true,
+      keepChangesInSource: false,
+      transferUncommitted: false,
+    });
     expect(mocks.appState.createThread).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: localProject.id,
@@ -173,7 +166,7 @@ describe("startThreadFromDraft host transport", () => {
 
   it("launches a helper thread through the same flow and runs setup from the client", async () => {
     mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
-    mocks.bridge.gitAddWorktree.mockResolvedValue({
+    mocks.createWorktree.mockResolvedValue({
       path: "/srv/worktrees/feature",
       changesTransferred: true,
     });
@@ -186,16 +179,12 @@ describe("startThreadFromDraft host transport", () => {
       worktreeIsNewBranch: true,
     });
 
-    expect(mocks.bridge.gitAddWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectLocation: remoteProject.location,
-        branch: "feature",
-        createBranch: true,
-      }),
-    );
-    expect(mocks.bridge.gitAddWorktree).not.toHaveBeenCalledWith(
-      expect.objectContaining({ worktreeRoot: expect.anything() }),
-    );
+    expect(mocks.createWorktree).toHaveBeenCalledWith(remoteProject, {
+      branch: "feature",
+      createBranch: true,
+      keepChangesInSource: false,
+      transferUncommitted: false,
+    });
     expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledWith({
       desktopId: "d1",
       projectId: "p1",
@@ -227,13 +216,13 @@ describe("startThreadFromDraft host transport", () => {
     });
 
     // Bails before creating a worktree we would have to unwind.
-    expect(mocks.bridge.gitAddWorktree).not.toHaveBeenCalled();
+    expect(mocks.createWorktree).not.toHaveBeenCalled();
     expect(mocks.remoteState.launchRemoteThread).not.toHaveBeenCalled();
   });
 
   it("does not duplicate setup owned by a desktop remote host", async () => {
     mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "desktop" }];
-    mocks.bridge.gitAddWorktree.mockResolvedValue({
+    mocks.createWorktree.mockResolvedValue({
       path: "/srv/worktrees/feature",
       changesTransferred: true,
     });

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -30,8 +30,11 @@ import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
 import { buildProjectDraftConfig } from "@/renderer/views/MainView/parts/AppContent/draftConfig";
-import { worktreePlacementPayload } from "./worktreePlacement";
-import { primeWorktreeGitState, runWorktreeSetupScript } from "./worktreeLaunchActions";
+import {
+  createWorktree,
+  primeWorktreeGitState,
+  runWorktreeSetupScript,
+} from "./worktreeLaunchActions";
 
 export async function performInitialThreadLaunch(input: {
   thread: Thread;
@@ -174,13 +177,10 @@ export async function startThreadFromDraft(
   if (!isHomeScope && !worktreePath && worktreeBranch) {
     try {
       const transferUncommitted = worktreeTransferUncommitted ?? false;
-      const result = await readBridge().gitAddWorktree({
-        projectLocation: project.location,
+      const result = await createWorktree(project, {
         branch: worktreeBranch,
         ...(worktreeBaseBranch ? { startPoint: worktreeBaseBranch } : {}),
         createBranch: worktreeIsNewBranch ?? false,
-        ...(!remoteOwner(project) ? worktreePlacementPayload(project) : {}),
-        copyIgnoredPatterns: project.scripts?.worktreeCopyPatterns,
         transferUncommitted,
         keepChangesInSource: transferUncommitted,
       });

--- a/src/renderer/actions/worktreeLaunchActions.test.ts
+++ b/src/renderer/actions/worktreeLaunchActions.test.ts
@@ -3,6 +3,8 @@ import type { Project } from "@/shared/contracts";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 
 const bridge = vi.hoisted(() => ({
+  gitAddWorktree:
+    vi.fn<(payload: unknown) => Promise<{ path: string; changesTransferred?: boolean }>>(),
   startShell: vi.fn<(payload: unknown) => Promise<void>>(),
   onSupervisorEvent: vi.fn<() => () => void>(),
 }));
@@ -11,7 +13,11 @@ vi.mock("@/renderer/bridge", () => ({
   readBridge: () => bridge,
 }));
 
-import { runWorktreeSetupScript } from "./worktreeLaunchActions";
+vi.mock("./worktreePlacement", () => ({
+  worktreePlacementPayload: () => ({ worktreeRoot: "C:\\shared-worktrees" }),
+}));
+
+import { createWorktree, runWorktreeSetupScript } from "./worktreeLaunchActions";
 
 const project = {
   id: "project-1",
@@ -19,6 +25,53 @@ const project = {
   location: { kind: "windows", path: "C:\\repo" },
   createdAt: "2026-07-16T00:00:00.000Z",
 } satisfies Project;
+
+describe("createWorktree", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bridge.gitAddWorktree.mockResolvedValue({ path: "C:\\shared-worktrees\\feature" });
+  });
+
+  it("applies the shared creation payload for local projects", async () => {
+    await createWorktree(project, {
+      branch: "feature",
+      startPoint: "main",
+      createBranch: true,
+      transferUncommitted: true,
+      keepChangesInSource: false,
+    });
+
+    expect(bridge.gitAddWorktree).toHaveBeenCalledWith({
+      projectLocation: project.location,
+      branch: "feature",
+      startPoint: "main",
+      createBranch: true,
+      worktreeRoot: "C:\\shared-worktrees",
+      transferUncommitted: true,
+      keepChangesInSource: false,
+    });
+  });
+
+  it("does not send local placement settings to remote projects", async () => {
+    await createWorktree(
+      { ...project, remoteServerId: "desktop-1", remoteId: "project-1" },
+      {
+        branch: "feature",
+        createBranch: true,
+        transferUncommitted: false,
+        keepChangesInSource: false,
+      },
+    );
+
+    expect(bridge.gitAddWorktree).toHaveBeenCalledWith({
+      projectLocation: project.location,
+      branch: "feature",
+      createBranch: true,
+      transferUncommitted: false,
+      keepChangesInSource: false,
+    });
+  });
+});
 
 describe("runWorktreeSetupScript", () => {
   beforeEach(() => {

--- a/src/renderer/actions/worktreeLaunchActions.ts
+++ b/src/renderer/actions/worktreeLaunchActions.ts
@@ -5,6 +5,7 @@ import { closeAllPanels } from "@/renderer/actions/panelActions";
 import { useDevTerminalStore, type DevTerminalTab } from "@/renderer/state/devTerminalStore";
 import { getProjectActiveWorktreePaths } from "@/renderer/state/gitRefresh";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
   normalizeShellScript,
@@ -12,6 +13,30 @@ import {
   writeScriptToShellThenExitOnSuccess,
 } from "@/renderer/utils/shellUtils";
 import { cancelPendingWorktreeSetup, enqueueWorktreeSetup } from "./worktreeSetupQueue";
+import { worktreePlacementPayload } from "./worktreePlacement";
+
+export function createWorktree(
+  project: Project,
+  input: {
+    branch: string;
+    startPoint?: string;
+    createBranch: boolean;
+    transferUncommitted: boolean;
+    keepChangesInSource: boolean;
+  },
+) {
+  const copyIgnoredPatterns = project.scripts?.worktreeCopyPatterns;
+  return readBridge().gitAddWorktree({
+    projectLocation: project.location,
+    branch: input.branch,
+    ...(input.startPoint ? { startPoint: input.startPoint } : {}),
+    createBranch: input.createBranch,
+    ...(!remoteOwner(project) ? worktreePlacementPayload(project) : {}),
+    ...(copyIgnoredPatterns?.length ? { copyIgnoredPatterns } : {}),
+    transferUncommitted: input.transferUncommitted,
+    keepChangesInSource: input.keepChangesInSource,
+  });
+}
 
 export async function primeWorktreeGitState(project: Project, worktreePath: string): Promise<void> {
   const worktreePaths = [

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1683,6 +1683,10 @@ msgstr "Branch {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "Branch <0>{0}</0> weist nicht zusammengeführte Änderungen auf:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Zweigname"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Branch nicht vollständig zusammengeführt"
@@ -1706,6 +1710,10 @@ msgstr "Zurück ins Panel holen"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Holen Sie ihn zurück in dieses Panel oder wechseln Sie zum Fenster, in dem er läuft."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Nicht festgeschriebene Änderungen mitbringen"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Claude-Profilname"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude-Profil entfernt."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Sauberer Arbeitsbaum"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Mit Agent erstellen"
 #~ msgid "Create:"
 #~ msgstr "Erstellen:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Es wurde ein Arbeitsbaum für „{newBranch}“ erstellt, aber die Änderungen widersprachen und verbleiben in einem Git-Stash – lösen Sie sie im Arbeitsbaum auf."
@@ -6590,6 +6603,14 @@ msgstr "Änderungen in einen neuen Arbeitsbaum verschieben"
 msgid "Move to Workspace"
 msgstr "In Arbeitsbereich verschieben"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "In Arbeitsbaum verschieben"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "In Arbeitsbaum verschieben…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Verschieben Sie das ToDo-Dock in den rechten Bereich"
@@ -6603,6 +6624,18 @@ msgstr "Verschieben Sie das ToDo-Dock in den rechten Bereich"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 Projekt nach {0} verschoben."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Der Thread und Ihre Änderungen wurden in einen neuen Arbeitsbaum unter „{newBranch}“ verschoben."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Der Thread und Ihre Änderungen wurden in einen neuen Arbeitsbaum unter „{newBranch}“ verschoben. „{currentBranch}“ ist jetzt sauber."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Der Thread wurde in einen neuen Arbeitsbaum unter „{branch}“ verschoben."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Terminal öffnen"
 msgid "Open terminal in worktree"
 msgstr "Terminal im Worktree öffnen"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Aufwandsauswahl öffnen"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Modellauswahl öffnen"
@@ -8139,6 +8170,10 @@ msgstr "Poracode wird neu gestartet, sichert seine aktuellen Daten und ersetzt s
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Die integrierten Browser-Tools von Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Modus wechseln: {title}"
 msgid "Switch project"
 msgstr "Projekt wechseln"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Diesen Chat in den Agentenmodus schalten"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Diesen Chat in den Planmodus schalten"
@@ -11149,6 +11182,10 @@ msgstr "Der SSH-Tunnel hat einen inkompatiblen Poracode-Server erreicht."
 msgid "the target provider"
 msgstr "der Zielanbieter"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Der Thread wird in einem separaten Arbeitsbaum auf einem neuen Zweig ausgeführt."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Der Update-Vorgang ist fehlgeschlagen."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Browser-Panel umschalten"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Schnellmodus umschalten"
@@ -12367,6 +12403,10 @@ msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Gewinner zu
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Pull Request öffnen."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Warten Sie, bis der Thread vollständig gestartet ist, bevor Sie ihn in einen Arbeitsbaum verschieben."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1688,6 +1688,10 @@ msgstr "branch {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "Branch <0>{0}</0> has unmerged changes:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Branch name"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Branch not fully merged"
@@ -1711,6 +1715,10 @@ msgstr "Bring back to panel"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bring it back into this panel, or jump to the window it’s running in."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Bring Uncommitted Changes"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2206,6 +2214,10 @@ msgstr "Claude profile name"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude profile removed."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Clean Worktree"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3249,6 +3261,7 @@ msgstr "Create with Agent"
 #~ msgid "Create:"
 #~ msgstr "Create:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
@@ -6595,6 +6608,14 @@ msgstr "Move changes to a new worktree"
 msgid "Move to Workspace"
 msgstr "Move to Workspace"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Move to Worktree"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Move to Worktree…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Move todo dock to right panel"
@@ -6608,6 +6629,18 @@ msgstr "Move todo dock to right panel"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "Moved 1 project to {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Moved the thread to a new worktree on \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7709,12 +7742,10 @@ msgstr "Open terminal"
 msgid "Open terminal in worktree"
 msgstr "Open terminal in worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Open the effort picker"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Open the model picker"
@@ -8144,6 +8175,10 @@ msgstr "Poracode will restart, back up its current data, and replace it with a c
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Poracode's built-in browser tools."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10770,12 +10805,10 @@ msgstr "Switch mode: {title}"
 msgid "Switch project"
 msgstr "Switch project"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Switch this chat to agent mode"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Switch this chat to plan mode"
@@ -11154,6 +11187,10 @@ msgstr "The SSH tunnel reached an incompatible Poracode server."
 msgid "the target provider"
 msgstr "the target provider"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "The thread will run in a separate worktree on a new branch."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "The update operation failed."
@@ -11451,7 +11488,6 @@ msgid "Toggle browser panel"
 msgstr "Toggle browser panel"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Toggle Fast mode"
@@ -12372,6 +12408,10 @@ msgstr "Wait for every candidate to finish before merging a winner."
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Wait for every candidate to finish before opening a pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Wait for the thread to finish starting before moving it to a worktree."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1683,6 +1683,10 @@ msgstr "rama {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "La rama <0>{0}</0> tiene cambios sin fusionar:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Nombre de la rama"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Rama no fusionada por completo"
@@ -1706,6 +1710,10 @@ msgstr "Devolver al panel"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Devuélvelo a este panel o ve a la ventana en la que se está ejecutando."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Traer cambios sin confirmar"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Nombre del perfil de Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Perfil de Claude eliminado."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Worktree limpio"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Crear con un agente"
 #~ msgid "Create:"
 #~ msgstr "Crear:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Se creó un worktree en \"{newBranch}\", pero los cambios entraron en conflicto y permanecen en un stash de git: resuélvelos en el worktree."
@@ -6590,6 +6603,14 @@ msgstr "Mover cambios a un nuevo worktree"
 msgid "Move to Workspace"
 msgstr "Mover a espacio de trabajo"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Mover a worktree"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Mover a worktree…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Mover el dock de tareas al panel derecho"
@@ -6603,6 +6624,18 @@ msgstr "Mover el dock de tareas al panel derecho"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "Se movió 1 proyecto a {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Se movieron el hilo y tus cambios a un nuevo worktree en \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Se movieron el hilo y tus cambios a un nuevo worktree en \"{newBranch}\". \"{currentBranch}\" ahora está limpio."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Se movió el hilo a un nuevo worktree en \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Abrir terminal"
 msgid "Open terminal in worktree"
 msgstr "Abrir terminal en worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Abrir el selector de esfuerzo"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Abrir el selector de modelo"
@@ -8139,6 +8170,10 @@ msgstr "Poracode se reiniciará, hará una copia de seguridad de sus datos actua
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Las herramientas de navegador integradas de Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Cambiar de modo: {title}"
 msgid "Switch project"
 msgstr "Cambiar de proyecto"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Cambiar este chat al modo agente"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Cambiar este chat al modo de plan"
@@ -11149,6 +11182,10 @@ msgstr "El túnel SSH llegó a un servidor de Poracode incompatible."
 msgid "the target provider"
 msgstr "el proveedor de destino"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "El hilo se ejecutará en un worktree separado en una nueva rama."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "La operación de actualización falló."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Alternar el panel del navegador"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Alternar modo rápido"
@@ -12367,6 +12403,10 @@ msgstr "Espera a que todos los candidatos terminen antes de fusionar a un ganado
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Espera a que todos los candidatos terminen antes de abrir una pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Espera a que el hilo termine de iniciarse antes de moverlo a un worktree."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1683,6 +1683,10 @@ msgstr "branche {branch} : {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "La branche <0>{0}</0> comporte des modifications non fusionnées :"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Nom de la branche"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Branche pas complètement fusionnée"
@@ -1706,6 +1710,10 @@ msgstr "Ramener dans le panneau"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Ramenez-le dans ce panneau ou accédez à la fenêtre dans laquelle il s’exécute."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Apporter les modifications non validées"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Nom du profil Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Profil de Claude supprimé."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Worktree propre"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Créer avec un agent"
 #~ msgid "Create:"
 #~ msgstr "Créer :"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Arbre de travail créé sur \"{newBranch}\", mais les modifications sont entrées en conflit et restent dans un stash git — résolvez-les dans l'arbre de travail."
@@ -6589,6 +6602,14 @@ msgstr "Déplacer les modifications vers un nouvel arbre de travail"
 msgid "Move to Workspace"
 msgstr "Déplacer vers un espace de travail"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Déplacer vers un worktree"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Déplacer vers un worktree…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Déplacer le dock Todo vers le panneau de droite"
@@ -6602,6 +6623,18 @@ msgstr "Déplacer le dock Todo vers le panneau de droite"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 projet déplacé vers {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Le fil de discussion et vos modifications ont été déplacés vers un nouveau worktree sur \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Le fil de discussion et vos modifications ont été déplacés vers un nouveau worktree sur \"{newBranch}\". \"{currentBranch}\" est désormais propre."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Le fil de discussion a été déplacé vers un nouveau worktree sur \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7703,12 +7736,10 @@ msgstr "Ouvrir le terminal"
 msgid "Open terminal in worktree"
 msgstr "Ouvrir le terminal dans le worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Ouvrir le sélecteur d'effort"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Ouvrir le sélecteur de modèle"
@@ -8138,6 +8169,10 @@ msgstr "Poracode va redémarrer, sauvegarder ses données actuelles et les rempl
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Les outils de navigateur intégrés de Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10764,12 +10799,10 @@ msgstr "Changer de mode : {title}"
 msgid "Switch project"
 msgstr "Changer de projet"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Passer ce chat en mode agent"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Passer ce chat en mode plan"
@@ -11148,6 +11181,10 @@ msgstr "Le tunnel SSH a atteint un serveur Poracode incompatible."
 msgid "the target provider"
 msgstr "le fournisseur cible"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Le fil de discussion s'exécutera dans un worktree séparé sur une nouvelle branche."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "L’opération de mise à jour a échoué."
@@ -11445,7 +11482,6 @@ msgid "Toggle browser panel"
 msgstr "Basculer le panneau du navigateur"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Activer/désactiver le mode rapide"
@@ -12366,6 +12402,10 @@ msgstr "Attendez que tous les candidats aient terminé avant de fusionner un gag
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Attendez que tous les candidats aient terminé avant d’ouvrir une pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Attendez que le fil de discussion ait fini de démarrer avant de le déplacer vers un worktree."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1682,6 +1682,10 @@ msgstr "ブランチ {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "ブランチ <0>{0}</0> にはマージされていない変更があります:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "ブランチ名"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "ブランチが完全にマージされていません"
@@ -1705,6 +1709,10 @@ msgstr "パネルに戻す"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "このパネルに戻すか、実行中のウィンドウに移動します。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "コミットされていない変更を持ち込む"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2200,6 +2208,10 @@ msgstr "Claude プロファイル名"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude プロファイルが削除されました。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "クリーンなワークツリー"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3243,6 +3255,7 @@ msgstr "エージェントで作成"
 #~ msgid "Create:"
 #~ msgstr "作成:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "「{newBranch}」にワークツリーを作成しましたが、変更が競合し、git stash に残っています。ワークツリー内で解決してください。"
@@ -6588,6 +6601,14 @@ msgstr "変更を新しいワークツリーに移動する"
 msgid "Move to Workspace"
 msgstr "ワークスペースへ移動"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "ワークツリーに移動"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "ワークツリーに移動…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Todo ドックを右側のパネルに移動します"
@@ -6601,6 +6622,18 @@ msgstr "Todo ドックを右側のパネルに移動します"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 件のプロジェクトを {0} に移動しました。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "スレッドと変更内容を「{newBranch}」の新しいワークツリーに移動しました。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "スレッドと変更内容を「{newBranch}」の新しいワークツリーに移動しました。「{currentBranch}」はクリーンになりました。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "スレッドを「{branch}」の新しいワークツリーに移動しました。"
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7702,12 +7735,10 @@ msgstr "ターミナルを開く"
 msgid "Open terminal in worktree"
 msgstr "worktree でターミナルを開く"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "工数ピッカーを開く"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "モデルピッカーを開く"
@@ -8137,6 +8168,10 @@ msgstr "Poracode は再起動し、現在のデータをバックアップして
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Poracode の組み込みブラウザツール。"
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10763,12 +10798,10 @@ msgstr "モードを切り替え: {title}"
 msgid "Switch project"
 msgstr "プロジェクトの切り替え"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "このチャットをエージェント モードに切り替えます"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "このチャットを計画モードに切り替えます"
@@ -11147,6 +11180,10 @@ msgstr "SSH トンネルは互換性のない Poracode サーバーに接続し�
 msgid "the target provider"
 msgstr "対象プロバイダー"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "スレッドは新しいブランチ上の別のワークツリーで実行されます。"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "アップデート操作に失敗しました。"
@@ -11444,7 +11481,6 @@ msgid "Toggle browser panel"
 msgstr "ブラウザパネルの切り替え"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "高速モードの切り替え"
@@ -12365,6 +12401,10 @@ msgstr "勝者をマージする前に、すべての候補が完了するまで
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "プルリクエストを開く前に、すべての候補が完了するまで待ってください。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "ワークツリーに移動する前に、スレッドの起動が完了するまでお待ちください。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1683,6 +1683,10 @@ msgstr "브랜치 {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "<0>{0}</0> 분기에 병합되지 않은 변경 사항이 있습니다:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "브랜치 이름"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "완전히 병합되지 않은 분기"
@@ -1706,6 +1710,10 @@ msgstr "패널로 되돌리기"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "이 패널로 되돌리거나 실행 중인 창으로 이동하세요."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "커밋되지 않은 변경 사항 가져오기"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Claude 프로필 이름"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude 프로필이 삭제되었습니다."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "클린 작업 트리"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "에이전트로 만들기"
 #~ msgid "Create:"
 #~ msgstr "생성:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "\"{newBranch}\"에 작업 트리를 만들었지만 변경 사항이 충돌하여 git stash에 남아 있습니다. 작업 트리에서 해결하세요."
@@ -6590,6 +6603,14 @@ msgstr "변경 사항을 새 작업 트리로 이동"
 msgid "Move to Workspace"
 msgstr "작업 영역으로 이동"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "작업 트리로 이동"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "작업 트리로 이동…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "할 일 도크를 오른쪽 패널로 이동"
@@ -6603,6 +6624,18 @@ msgstr "할 일 도크를 오른쪽 패널로 이동"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "프로젝트 1개를 {0}(으)로 옮겼습니다."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "스레드와 변경 사항을 \"{newBranch}\"의 새 작업 트리로 옮겼습니다."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "스레드와 변경 사항을 \"{newBranch}\"의 새 작업 트리로 옮겼습니다. \"{currentBranch}\"은 이제 깨끗합니다."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "스레드를 \"{branch}\"의 새 작업 트리로 옮겼습니다."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "터미널 열기"
 msgid "Open terminal in worktree"
 msgstr "worktree에서 터미널 열기"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "노력 선택 도구 열기"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "모델 선택기 열기"
@@ -8139,6 +8170,10 @@ msgstr "Poracode가 다시 시작되어 현재 데이터를 백업한 다음 Lig
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Poracode의 기본 제공 브라우저 도구."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "모드 전환: {title}"
 msgid "Switch project"
 msgstr "프로젝트 전환"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "이 채팅을 에이전트 모드로 전환하세요"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "이 채팅을 계획 모드로 전환하세요"
@@ -11149,6 +11182,10 @@ msgstr "SSH 터널이 호환되지 않는 Poracode 서버에 연결되었습니�
 msgid "the target provider"
 msgstr "대상 공급자"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "스레드가 새 브랜치의 별도 작업 트리에서 실행됩니다."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "업데이트 작업에 실패했습니다."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "브라우저 패널 표시 전환"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "빠른 모드 전환"
@@ -12367,6 +12403,10 @@ msgstr "우승자를 병합하기 전에 모든 후보가 완료될 때까지 �
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "풀 리퀘스트를 열기 전에 모든 후보가 완료될 때까지 기다리세요."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "작업 트리로 이동하기 전에 스레드 시작이 완료될 때까지 기다리세요."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1683,6 +1683,10 @@ msgstr "gałąź {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "Gałąź <0>{0}</0> zawiera niescalone zmiany:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Nazwa gałęzi"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Gałąź nie została w pełni scalona"
@@ -1706,6 +1710,10 @@ msgstr "Przywróć do panelu"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Przywróć ją do tego panelu lub przejdź do okna, w którym działa."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Przenieś niezatwierdzone zmiany"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Nazwa profilu Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Usunięto profil Claude'a."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Czyste drzewo robocze"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Utwórz z agentem"
 #~ msgid "Create:"
 #~ msgstr "Utwórz:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Utworzono drzewo pracy na „{newBranch}”, ale zmiany kolidują ze sobą i pozostają w skrytce git — rozwiąż je w drzewie pracy."
@@ -6590,6 +6603,14 @@ msgstr "Przenieś zmiany do nowego drzewa roboczego"
 msgid "Move to Workspace"
 msgstr "Przenieś do obszaru roboczego"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Przenieś do drzewa roboczego"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Przenieś do drzewa roboczego…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Przenieś dok zadań do prawego panelu"
@@ -6603,6 +6624,18 @@ msgstr "Przenieś dok zadań do prawego panelu"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "Przeniesiono 1 projekt do {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Przeniesiono wątek i Twoje zmiany do nowego drzewa roboczego na „{newBranch}”."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Przeniesiono wątek i Twoje zmiany do nowego drzewa roboczego na „{newBranch}”. „{currentBranch}” jest teraz czysty."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Przeniesiono wątek do nowego drzewa roboczego na „{branch}”."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Otwórz terminal"
 msgid "Open terminal in worktree"
 msgstr "Otwórz terminal w worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Otwórz wybór wysiłku"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Otwórz selektor modeli"
@@ -8139,6 +8170,10 @@ msgstr "Poracode uruchomi się ponownie, utworzy kopię zapasową bieżących da
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Wbudowane narzędzia przeglądarki Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Przełącz tryb: {title}"
 msgid "Switch project"
 msgstr "Zmień projekt"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Przełącz ten czat w tryb agenta"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Przełącz ten czat w tryb planu"
@@ -11149,6 +11182,10 @@ msgstr "Tunel SSH połączył się z niezgodnym serwerem Poracode."
 msgid "the target provider"
 msgstr "docelowego dostawcy"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Wątek będzie działać w osobnym drzewie roboczym na nowej gałęzi."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Operacja aktualizacji nie powiodła się."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Przełącz panel przeglądarki"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Przełącz tryb szybki"
@@ -12367,6 +12403,10 @@ msgstr "Przed scaleniem zmian zwycięzcy zaczekaj, aż wszyscy kandydaci zakońc
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Przed otwarciem pull requesta zaczekaj, aż wszyscy kandydaci zakończą pracę."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Poczekaj, aż wątek zakończy uruchamianie, przed przeniesieniem go do drzewa roboczego."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1683,6 +1683,10 @@ msgstr "branch {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "Branch <0>{0}</0> tem alterações não mescladas:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Nome do branch"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Branch não totalmente mesclado"
@@ -1706,6 +1710,10 @@ msgstr "Trazer de volta ao painel"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Traga-o de volta para este painel ou vá para a janela em que ele está sendo executado."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Trazer alterações não commitadas"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Nome do perfil de Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Perfil de Claude removido."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Árvore de trabalho limpa"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Criar com agente"
 #~ msgid "Create:"
 #~ msgstr "Criar:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Criou uma árvore de trabalho em \"{newBranch}\", mas as alterações entraram em conflito e permanecem em um git stash — resolva-as na árvore de trabalho."
@@ -6590,6 +6603,14 @@ msgstr "Mover alterações para uma nova árvore de trabalho"
 msgid "Move to Workspace"
 msgstr "Mover para espaço de trabalho"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Mover para árvore de trabalho"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Mover para árvore de trabalho…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Mover dock de tarefas para o painel direito"
@@ -6603,6 +6624,18 @@ msgstr "Mover dock de tarefas para o painel direito"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 projeto movido para {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "O tópico e suas alterações foram movidos para uma nova árvore de trabalho em \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "O tópico e suas alterações foram movidos para uma nova árvore de trabalho em \"{newBranch}\". \"{currentBranch}\" agora está limpo."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "O tópico foi movido para uma nova árvore de trabalho em \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Abrir terminal"
 msgid "Open terminal in worktree"
 msgstr "Abrir terminal no worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Abra o seletor de esforço"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Abra o seletor de modelo"
@@ -8139,6 +8170,10 @@ msgstr "O Poracode será reiniciado, fará backup dos dados atuais e os substitu
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "As ferramentas de navegador integradas do Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Mudar de modo: {title}"
 msgid "Switch project"
 msgstr "Trocar projeto"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Mude este chat para o modo de agente"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Mude este chat para o modo de planejamento"
@@ -11149,6 +11182,10 @@ msgstr "O túnel SSH alcançou um servidor Poracode incompatível."
 msgid "the target provider"
 msgstr "o provedor alvo"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "O tópico será executado em uma árvore de trabalho separada em um novo branch."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "A operação de atualização falhou."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Alternar painel do navegador"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Alternar modo rápido"
@@ -12367,6 +12403,10 @@ msgstr "Aguarde todos os candidatos terminarem antes de mesclar um vencedor."
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Aguarde todos os candidatos terminarem antes de abrir uma pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Aguarde o tópico terminar de iniciar antes de movê-lo para uma árvore de trabalho."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1683,6 +1683,10 @@ msgstr "ветка {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "В ветке <0>{0}</0> есть несмердженные изменения:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Имя ветки"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Ветка не полностью смерджена"
@@ -1706,6 +1710,10 @@ msgstr "Вернуть на панель"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Верните его на эту панель или перейдите к окну, в котором он запущен."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Перенести незакоммиченные изменения"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Имя профиля Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Профиль Claude удалён."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Чистый worktree"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Создать с агентом"
 #~ msgid "Create:"
 #~ msgstr "Создать:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Worktree создан на \"{newBranch}\", но изменения вызвали конфликт и остаются в git stash — разрешите их в worktree."
@@ -6590,6 +6603,14 @@ msgstr "Переместить изменения в новый worktree"
 msgid "Move to Workspace"
 msgstr "Переместить в рабочую область"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Переместить в worktree"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Переместить в worktree…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Переместить панель задач в правую панель"
@@ -6603,6 +6624,18 @@ msgstr "Переместить панель задач в правую пане�
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 проект перемещён в {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Тред и ваши изменения перемещены в новый worktree на \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Тред и ваши изменения перемещены в новый worktree на \"{newBranch}\". \"{currentBranch}\" теперь чист."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Тред перемещён в новый worktree на \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Открыть терминал"
 msgid "Open terminal in worktree"
 msgstr "Открыть терминал в worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Открыть выбор усилия"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Открыть выбор модели"
@@ -8139,6 +8170,10 @@ msgstr "Poracode перезапустится, создаст резервную
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Встроенные инструменты браузера Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Переключить режим: {title}"
 msgid "Switch project"
 msgstr "Переключить проект"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Переключить этот чат в режим агента"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Переключить этот чат в режим плана"
@@ -11149,6 +11182,10 @@ msgstr "SSH-туннель подключился к несовместимом�
 msgid "the target provider"
 msgstr "целевой провайдер"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Тред будет работать в отдельном worktree на новой ветке."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Не удалось выполнить операцию обновления."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Переключить панель браузера"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Переключить быстрый режим"
@@ -12367,6 +12403,10 @@ msgstr "Дождитесь завершения работы всех канди
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Дождитесь завершения работы всех кандидатов перед созданием pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Дождитесь завершения запуска треда, прежде чем перемещать его в worktree."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1683,6 +1683,10 @@ msgstr "şube {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "<0>{0}</0> şubesinde birleştirilmemiş değişiklikler var:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Şube adı"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Şube tam olarak birleştirilmedi"
@@ -1706,6 +1710,10 @@ msgstr "Panele geri getir"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bu panele geri getirin veya çalıştığı pencereye geçin."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Kaydedilmemiş değişiklikleri getir"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Claude profil adı"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude profili kaldırıldı."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Temiz çalışma ağacı"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Ajanla oluştur"
 #~ msgid "Create:"
 #~ msgstr "Oluştur:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "\"{newBranch}\" üzerinde bir çalışma ağacı oluşturuldu, ancak değişiklikler çakıştı ve bir git stash'inde kaldı; bunları çalışma ağacında çözün."
@@ -6590,6 +6603,14 @@ msgstr "Değişiklikleri yeni bir çalışma ağacına taşı"
 msgid "Move to Workspace"
 msgstr "Çalışma alanına taşı"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Çalışma ağacına taşı"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Çalışma ağacına taşı…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Yapılacaklar panelini sağ panele taşı"
@@ -6603,6 +6624,18 @@ msgstr "Yapılacaklar panelini sağ panele taşı"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 proje {0} alanına taşındı."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Konu ve değişiklikleriniz \"{newBranch}\" üzerindeki yeni bir çalışma ağacına taşındı."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Konu ve değişiklikleriniz \"{newBranch}\" üzerindeki yeni bir çalışma ağacına taşındı. \"{currentBranch}\" artık temiz."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Konu \"{branch}\" üzerindeki yeni bir çalışma ağacına taşındı."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Terminali aç"
 msgid "Open terminal in worktree"
 msgstr "Terminali worktree'de aç"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Çaba seçiciyi aç"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Model seçiciyi açın"
@@ -8139,6 +8170,10 @@ msgstr "Poracode yeniden başlatılacak, mevcut verilerini yedekleyecek ve bunla
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Poracode'un yerleşik tarayıcı araçları."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Mod değiştir: {title}"
 msgid "Switch project"
 msgstr "Projeyi değiştir"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Bu sohbeti temsilci moduna geçir"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Bu sohbeti plan moduna geçir"
@@ -11149,6 +11182,10 @@ msgstr "SSH tüneli uyumsuz bir Poracode sunucusuna ulaştı."
 msgid "the target provider"
 msgstr "hedef sağlayıcı"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Konu, yeni bir şubede ayrı bir çalışma ağacında çalışacak."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Güncelleme işlemi başarısız oldu."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Tarayıcı panelini aç/kapat"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Hızlı modu aç/kapat"
@@ -12367,6 +12403,10 @@ msgstr "Kazananı birleştirmeden önce tüm adayların çalışmasını tamamla
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Pull request açmadan önce tüm adayların çalışmasını tamamlamasını bekleyin."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Çalışma ağacına taşımadan önce konunun başlamasının bitmesini bekleyin."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1683,6 +1683,10 @@ msgstr "гілка {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "У гілці <0>{0}</0> є незмерджені зміни:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Ім'я гілки"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Гілку не повністю змерджено"
@@ -1706,6 +1710,10 @@ msgstr "Повернути на панель"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Поверніть його на цю панель або перейдіть до вікна, де він запущений."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Перенести незакомічені зміни"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Ім'я профілю Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Профіль Claude видалено."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Чистий worktree"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Створити з агентом"
 #~ msgid "Create:"
 #~ msgstr "Створити:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Worktree створено на \"{newBranch}\", але зміни спричинили конфлікт і залишаються в git stash — вирішіть їх у worktree."
@@ -6590,6 +6603,14 @@ msgstr "Перемістити зміни в новий worktree"
 msgid "Move to Workspace"
 msgstr "Перемістити до робочої області"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Перемістити в worktree"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Перемістити в worktree…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Перемістити панель завдань у праву панель"
@@ -6603,6 +6624,18 @@ msgstr "Перемістити панель завдань у праву пан�
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "1 проєкт переміщено до {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Тред і ваші зміни переміщено в новий worktree на \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Тред і ваші зміни переміщено в новий worktree на \"{newBranch}\". \"{currentBranch}\" тепер чистий."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Тред переміщено в новий worktree на \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Открыть терминал"
 msgid "Open terminal in worktree"
 msgstr "Открыть терминал в worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Відкрити вибір зусилля"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Відкрити вибір моделі"
@@ -8139,6 +8170,10 @@ msgstr "Poracode перезапуститься, створить резервн
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Вбудовані інструменти браузера Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Перемкнути режим: {title}"
 msgid "Switch project"
 msgstr "Перемкнути проєкт"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Перемкнути цей чат у режим агента"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Перемкнути цей чат у режим плану"
@@ -11149,6 +11182,10 @@ msgstr "SSH-тунель підключився до несумісного се
 msgid "the target provider"
 msgstr "цільовий провайдер"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Тред працюватиме в окремому worktree на новій гілці."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Не вдалося виконати операцію оновлення."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Перемкнути панель браузера"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Перемкнути швидкий режим"
@@ -12367,6 +12403,10 @@ msgstr "Зачекайте, доки всі кандидати завершат�
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж відкривати pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Дочекайтеся завершення запуску треда, перш ніж переміщувати його в worktree."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1683,6 +1683,10 @@ msgstr "nhánh {branch}: {detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "Nhánh <0>{0}</0> có các thay đổi chưa được hợp nhất:"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "Tên nhánh"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "Nhánh chưa được hợp nhất hoàn toàn"
@@ -1706,6 +1710,10 @@ msgstr "Đưa về bảng điều khiển"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Đưa trở lại bảng điều khiển này, hoặc chuyển đến cửa sổ đang chạy."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "Mang theo các thay đổi chưa được cam kết"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Tên hồ sơ Claude"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Hồ sơ Claude đã bị xóa."
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "Cây làm việc sạch"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "Tạo bằng tác nhân"
 #~ msgid "Create:"
 #~ msgstr "Tạo:"
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Đã tạo một cây làm việc trên \"{newBranch}\", nhưng những thay đổi này xung đột và vẫn nằm trong kho lưu trữ git — hãy giải quyết chúng trong cây làm việc."
@@ -6590,6 +6603,14 @@ msgstr "Di chuyển các thay đổi sang một cây làm việc mới"
 msgid "Move to Workspace"
 msgstr "Chuyển tới không gian làm việc"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "Chuyển sang cây làm việc"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "Chuyển sang cây làm việc…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "Di chuyển khay việc cần làm sang bảng bên phải"
@@ -6603,6 +6624,18 @@ msgstr "Di chuyển khay việc cần làm sang bảng bên phải"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "Đã chuyển 1 dự án sang {0}."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "Đã chuyển luồng và các thay đổi của bạn sang một cây làm việc mới trên \"{newBranch}\"."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "Đã chuyển luồng và các thay đổi của bạn sang một cây làm việc mới trên \"{newBranch}\". \"{currentBranch}\" hiện đã sạch."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "Đã chuyển luồng sang một cây làm việc mới trên \"{branch}\"."
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7704,12 +7737,10 @@ msgstr "Mở terminal"
 msgid "Open terminal in worktree"
 msgstr "Mở terminal trong worktree"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "Mở bộ chọn nỗ lực"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "Mở bộ chọn mô hình"
@@ -8139,6 +8170,10 @@ msgstr "Poracode sẽ khởi động lại, sao lưu dữ liệu hiện tại v�
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Công cụ trình duyệt tích hợp sẵn của Poracode."
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10765,12 +10800,10 @@ msgstr "Chuyển đổi chế độ: {title}"
 msgid "Switch project"
 msgstr "Chuyển đổi dự án"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "Chuyển cuộc trò chuyện này sang chế độ tác nhân"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "Chuyển cuộc trò chuyện này sang chế độ lập kế hoạch"
@@ -11149,6 +11182,10 @@ msgstr "Đường hầm SSH đã kết nối đến một máy chủ Poracode kh
 msgid "the target provider"
 msgstr "nhà cung cấp mục tiêu"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "Luồng sẽ chạy trong một cây làm việc riêng trên một nhánh mới."
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "Thao tác cập nhật không thành công."
@@ -11446,7 +11483,6 @@ msgid "Toggle browser panel"
 msgstr "Bật/tắt bảng điều khiển trình duyệt"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "Chuyển đổi chế độ Nhanh"
@@ -12367,6 +12403,10 @@ msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi hợp nhất
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi mở pull request."
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "Đợi luồng khởi động xong trước khi chuyển nó sang cây làm việc."
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1683,6 +1683,10 @@ msgstr "分支 {branch}：{detail}"
 msgid "Branch <0>{0}</0> has unmerged changes:"
 msgstr "分支 <0>{0}</0> 具有未合并的更改："
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "Branch name"
+#~ msgstr "分支名称"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/ForceDeleteBranchDialog.tsx
 msgid "Branch not fully merged"
 msgstr "分支未完全合并"
@@ -1706,6 +1710,10 @@ msgstr "移回面板"
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserDockSlot.tsx
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "将其移回此面板，或跳转到正在运行它的窗口。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Bring Uncommitted Changes"
+msgstr "带上未提交的更改"
 
 #: src/renderer/views/SettingsOverlay/parts/SshConnectionForm.tsx
 msgid "Browse"
@@ -2201,6 +2209,10 @@ msgstr "Claude 配置文件名称"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Claude profile removed."
 msgstr "Claude 配置文件已删除。"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Clean Worktree"
+msgstr "干净的工作树"
 
 #: src/renderer/views/ProjectSettingsOverlay/parts/ScriptsSection.tsx
 msgid "Cleanup script"
@@ -3244,6 +3256,7 @@ msgstr "使用代理创建"
 #~ msgid "Create:"
 #~ msgstr "创建："
 
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "在“{newBranch}”上创建了一个工作树，但更改发生冲突并保留在 git 存储中 - 在工作树中解决它们。"
@@ -6589,6 +6602,14 @@ msgstr "将更改移至新工作树"
 msgid "Move to Workspace"
 msgstr "移动到工作区"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+msgid "Move to Worktree"
+msgstr "移至工作树"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#~ msgid "Move to Worktree…"
+#~ msgstr "移至工作树…"
+
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 msgid "Move todo dock to right panel"
 msgstr "将待办事项停靠栏移至右侧面板"
@@ -6602,6 +6623,18 @@ msgstr "将待办事项停靠栏移至右侧面板"
 #: src/renderer/actions/workspaceActions.ts
 #~ msgid "Moved 1 project to {0}."
 #~ msgstr "已将 1 个项目移动到 {0}。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\"."
+msgstr "已将线程和您的更改移至“{newBranch}”上的新工作树中。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread and your changes to a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
+msgstr "已将线程和您的更改移至“{newBranch}”上的新工作树中。“{currentBranch}”现在是干净的。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Moved the thread to a new worktree on \"{branch}\"."
+msgstr "已将线程移至“{branch}”上的新工作树中。"
 
 #: src/renderer/components/common/BranchSelector/BranchSelector.tsx
 msgid "Moved your changes into a new worktree on \"{newBranch}\". \"{currentBranch}\" is now clean."
@@ -7703,12 +7736,10 @@ msgstr "打开终端"
 msgid "Open terminal in worktree"
 msgstr "在 worktree 中打开终端"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the effort picker"
 msgstr "打开工作量选择器"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Open the model picker"
 msgstr "打开模型选择器"
@@ -8138,6 +8169,10 @@ msgstr "Poracode 将重新启动，备份当前数据，并用 Lightcode 数据�
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Poracode's built-in browser tools."
 msgstr "Poracode 内置的浏览器工具。"
+
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "poracode/my-branch"
+#~ msgstr "poracode/my-branch"
 
 #: src/mobile/views/DesktopsView.tsx
 #: src/mobile/views/PortsView.tsx
@@ -10764,12 +10799,10 @@ msgstr "切换模式：{title}"
 msgid "Switch project"
 msgstr "切换项目"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to agent mode"
 msgstr "将此聊天切换到代理模式"
 
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Switch this chat to plan mode"
 msgstr "将此聊天切换到计划模式"
@@ -11148,6 +11181,10 @@ msgstr "SSH 隧道连接到了不兼容的 Poracode 服务器。"
 msgid "the target provider"
 msgstr "目标提供商"
 
+#: src/renderer/components/thread/MoveThreadToWorktreeDialog.tsx
+#~ msgid "The thread will run in a separate worktree on a new branch."
+#~ msgstr "线程将在新分支上的独立工作树中运行。"
+
 #: src/renderer/i18n/sharedMessages.ts
 msgid "The update operation failed."
 msgstr "更新操作失败。"
@@ -11445,7 +11482,6 @@ msgid "Toggle browser panel"
 msgstr "切换浏览器面板"
 
 #: src/renderer/commands/composerCommands.ts
-#: src/renderer/components/providers/codex/index.tsx
 #: src/renderer/components/providers/standardGuiSlashCommands.ts
 msgid "Toggle Fast mode"
 msgstr "切换快速模式"
@@ -12366,6 +12402,10 @@ msgstr "请等待所有候选项完成后再合并优胜者。"
 #: src/renderer/actions/experimentDecisionActions.ts
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "请等待所有候选项完成后再创建拉取请求。"
+
+#: src/renderer/actions/moveThreadToWorktreeActions.ts
+msgid "Wait for the thread to finish starting before moving it to a worktree."
+msgstr "请等待线程启动完成，然后再将其移至工作树。"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Wait for the thread to finish starting."

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
@@ -29,6 +29,7 @@ import {
   useProjectAgentStatuses,
 } from "@/renderer/hooks/uiSelectors";
 import { openGitReview } from "@/renderer/actions/panelActions";
+import { moveThreadToWorktree } from "@/renderer/actions/moveThreadToWorktreeActions";
 import {
   gitPull,
   gitPush,
@@ -97,6 +98,26 @@ export function ThreadContextMenu(props: {
                 label: t`Git`,
                 icon: <GitFork className="size-3.5" />,
                 items: worktreeGitItems,
+              },
+            ]
+          : []),
+        ...(!thread.worktreePath && !isExperimentCandidate
+          ? [
+              {
+                type: "submenu" as const,
+                id: "move-to-worktree",
+                label: t`Move to Worktree`,
+                icon: <GitFork className="size-3.5" />,
+                items: [
+                  {
+                    id: "move-to-worktree-with-changes",
+                    label: t`Bring Uncommitted Changes`,
+                  },
+                  {
+                    id: "move-to-worktree-clean",
+                    label: t`Clean Worktree`,
+                  },
+                ],
               },
             ]
           : []),
@@ -218,6 +239,8 @@ export function ThreadContextMenu(props: {
               resolveWorktreeBranch(thread.projectId, thread.worktreePath, thread.worktreeBranch) ??
               thread.worktreePath,
           });
+        if (key === "move-to-worktree-with-changes") void moveThreadToWorktree(thread.id, true);
+        if (key === "move-to-worktree-clean") void moveThreadToWorktree(thread.id, false);
         if (key === "git-review") openGitReview(thread.projectId, thread.worktreePath, thread.id);
         if (key === "git-sync" && thread.worktreePath)
           gitSync(thread.projectId, thread.worktreePath);


### PR DESCRIPTION
- Add move-to-worktree actions and new thread context menu entries to relocate a thread into a new worktree, optionally transferring its uncommitted changes and reloading the thread when active.
- Extract a shared worktree creation helper reused by thread launch and worktree setup paths, centralizing git add-worktree logic.
- Localize all new strings across the 12 non-English catalogs.
- Extend test coverage for the move action and refactored launch paths.