### PR TITLE
Surface proposed plans from exit_plan_mode tool calls

### DIFF
--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/ThreadRuntimeRequestPanel.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/ThreadRuntimeRequestPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { friendlyError } from "@/shared/messages";
 import { applyOptimisticRequestResolution } from "@/renderer/state/runtimeRequestActions";
 import type { OpenRuntimeRequest } from "@/renderer/state/slices/runtimeEventSlice";
+import { ItemMarkdown } from "../ChatPane/parts/items/ItemMarkdown";
 import { ThreadDockSection } from "../ThreadDockUI";
 import {
   asOpenCodePermissionDetails,
@@ -125,6 +126,10 @@ export function ThreadRuntimeRequestPanel(props: ThreadRuntimeRequestPanelProps)
     isPlanApproval && permissionDetails
       ? readInputString(permissionDetails.input, "planFilePath", "plan_filename")
       : undefined;
+  const planText =
+    isPlanApproval && permissionDetails
+      ? readInputString(permissionDetails.input, "plan")
+      : undefined;
   const opencodePermission =
     !permissionDetails && !isCustomForm
       ? asOpenCodePermissionDetails(request.payload.details)
@@ -223,12 +228,13 @@ export function ThreadRuntimeRequestPanel(props: ThreadRuntimeRequestPanelProps)
           ) : contextLine ? (
             <div className="text-[11px] text-[color:var(--muted)]">{contextLine}</div>
           ) : null}
-          {requestDetails || planFilePath ? (
+          {requestDetails || planFilePath || planText ? (
             <div
               role="region"
               aria-label={t`Request details`}
               className="mt-0.5 max-h-[min(12rem,35vh)] overflow-y-auto pr-1 [scrollbar-gutter:stable]"
             >
+              {planText ? <ItemMarkdown text={planText} /> : null}
               {requestDetails}
               {planFilePath ? <PlanFileLine path={planFilePath} /> : null}
             </div>

--- a/src/renderer/i18n/sharedMessages.ts
+++ b/src/renderer/i18n/sharedMessages.ts
@@ -174,6 +174,7 @@ const SHARED_MESSAGE_DESCRIPTORS: Record<MessageKey, MessageDescriptor> = {
   "supervisor.restarted": msg({ message: "Background process restarted" }),
   "supervisor.exited": msg({ message: "Background process exited unexpectedly" }),
   "supervisor.notRunning": msg({ message: "Background process is not running" }),
+  "supervisor.proposedPlan": msg({ message: "Proposed plan" }),
   "kimi.credentialsLocked": msg({
     message:
       "Kimi Code could not update its credentials because another process is using the credential file. Close other Poracode or Kimi Code processes, then retry.",

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -117,6 +117,7 @@ const messages = {
   "supervisor.restarted": "Background process restarted",
   "supervisor.exited": "Background process exited unexpectedly",
   "supervisor.notRunning": "Background process is not running",
+  "supervisor.proposedPlan": "Proposed plan",
 
   // ── Kimi Code ─────────────────────────────────────────────
   "kimi.credentialsLocked":

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -2409,6 +2409,96 @@ describe("mapAcpPermissionRequest", () => {
     });
   });
 
+  it("maps ExitPlanMode approvals to the unified plan review shape", () => {
+    const state = createAcpMapperState("t-perm-plan");
+
+    const event = mapAcpPermissionRequest(
+      {
+        sessionId: "s1",
+        toolCall: {
+          toolCallId: "tool-plan-1",
+          title: "ExitPlanMode",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "Plan saved to: /home/me/.kimi-code/sessions/ws/sid/agents/main/plans/p.md\n\n# KIMI_PLAN_SMOKE\n\n1. Step one\n2. Step two",
+              },
+            },
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "Requesting approval to Presenting plan and exiting plan mode",
+              },
+            },
+          ],
+        },
+        options: [
+          { optionId: "plan_approve", name: "Approve", kind: "allow_once" },
+          { optionId: "plan_revise", name: "Revise", kind: "reject_once" },
+          { optionId: "plan_reject_and_exit", name: "Reject and Exit", kind: "reject_once" },
+        ],
+      } as Parameters<typeof mapAcpPermissionRequest>[0],
+      state,
+      "acp-perm-plan-0",
+    );
+
+    expect(event).toEqual({
+      type: "request.opened",
+      threadId: "t-perm-plan",
+      requestId: "acp-perm-plan-0",
+      requestType: "tool_call_approval",
+      payload: {
+        summary: "Proposed plan",
+        details: {
+          toolName: "ExitPlanMode",
+          input: {
+            plan: "# KIMI_PLAN_SMOKE\n\n1. Step one\n2. Step two",
+            planFilePath: "/home/me/.kimi-code/sessions/ws/sid/agents/main/plans/p.md",
+          },
+        },
+        options: [
+          { optionId: "plan_approve", label: "Approve", description: undefined },
+          { optionId: "plan_revise", label: "Revise", description: undefined },
+          { optionId: "plan_reject_and_exit", label: "Reject and Exit", description: undefined },
+        ],
+      },
+    });
+  });
+
+  it("maps ExitPlanMode approvals without a saved-path prefix", () => {
+    const state = createAcpMapperState("t-perm-plan-bare");
+
+    const event = mapAcpPermissionRequest(
+      {
+        sessionId: "s1",
+        toolCall: {
+          toolCallId: "tool-plan-2",
+          title: "exit_plan_mode",
+          content: [
+            {
+              type: "content",
+              content: { type: "text", text: "Just the plan body" },
+            },
+          ],
+        },
+        options: [{ optionId: "plan_approve", name: "Approve", kind: "allow_once" }],
+      } as Parameters<typeof mapAcpPermissionRequest>[0],
+      state,
+      "acp-perm-plan-1",
+    );
+
+    expect(event.type).toBe("request.opened");
+    if (event.type !== "request.opened") return;
+    expect(event.payload.summary).toBe("Proposed plan");
+    expect(event.payload.details).toEqual({
+      toolName: "exit_plan_mode",
+      input: { plan: "Just the plan body" },
+    });
+  });
+
   it("unwraps command approval input instead of surfacing raw JSON details", () => {
     const state = createAcpMapperState("t-perm-command");
 

--- a/src/supervisor/agents/acp/canonicalMapping/contentExtraction.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/contentExtraction.ts
@@ -199,6 +199,49 @@ export function isAcpTodoWriteTool(
 }
 
 /**
+ * Detect ACP tool calls that represent the cross-provider `ExitPlanMode`
+ * plan-review convention (same names Claude and the renderer's plan-approval
+ * detection use).
+ */
+export function isAcpExitPlanModeTool(
+  title: string | null | undefined,
+  kind: string | null | undefined,
+): boolean {
+  const t = (title ?? "").trim().toLowerCase();
+  const k = (kind ?? "").trim().toLowerCase();
+  return (
+    t === "exitplanmode" || t === "exit_plan_mode" || k === "exitplanmode" || k === "exit_plan_mode"
+  );
+}
+
+export interface AcpPlanReviewContent {
+  plan: string;
+  planFilePath?: string;
+}
+
+/**
+ * Parse the plan body out of an ExitPlanMode approval's text content.
+ *
+ * ACP plan-review bridges (e.g. Kimi's acp-server) send the plan as a text
+ * block of the form `"Plan saved to: <path>\n\n<plan markdown>"` (the path
+ * prefix is optional) and append a trailing human summary line
+ * (`"Requesting approval to …"`). Returns `undefined` when no plan body
+ * remains after stripping that summary.
+ */
+export function parseAcpPlanReviewText(text: string | undefined): AcpPlanReviewContent | undefined {
+  if (!text) return undefined;
+  const body = text.replace(/\n+Requesting approval to [^\n]*$/i, "").trim();
+  if (!body || /^Requesting approval to /i.test(body)) return undefined;
+  const saved = /^Plan saved to:\s*(\S[^\n]*?)\s*\r?\n\r?\n([\s\S]*)$/.exec(body);
+  if (saved) {
+    const plan = saved[2]!.trim();
+    if (!plan) return undefined;
+    return { plan, planFilePath: saved[1]! };
+  }
+  return { plan: body };
+}
+
+/**
  * Extract canonical plan steps from a `todo_write` tool's `rawInput`.
  *
  * The input shape mirrors Claude's `TodoWrite`: `{ todos: [{ content, status }] }`.

--- a/src/supervisor/agents/acp/canonicalMapping/permissions.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/permissions.ts
@@ -9,11 +9,14 @@ import type {
   PermissionRequestDetails,
   RuntimeEvent,
 } from "@/shared/contracts";
+import { msg } from "@/shared/messages";
 import { readStringField } from "../../fileChangeSummary";
 import {
   extractToolCallContentText,
+  isAcpExitPlanModeTool,
   isApplyPatchToolName,
   normalizeToolText,
+  parseAcpPlanReviewText,
 } from "./contentExtraction";
 import type { AcpMapperState } from "./state";
 import { mapAcpQuestionPermissionRequest } from "../acpQuestionPermissions";
@@ -39,6 +42,31 @@ export function mapAcpPermissionRequest(
     rawInput?: unknown;
     content?: unknown;
   };
+  // Cross-provider plan review: an ExitPlanMode approval renders through the
+  // unified plan-review composer, so emit the same canonical shape Claude
+  // produces — "Proposed plan" summary plus `input.plan`/`input.planFilePath`
+  // recovered from the ACP text content block.
+  if (isAcpExitPlanModeTool(toolCall.title, toolCall.kind)) {
+    const planReview = parseAcpPlanReviewText(extractToolCallContentText(toolCall.content));
+    return {
+      type: "request.opened",
+      threadId: state.threadId,
+      requestId,
+      requestType: "tool_call_approval",
+      payload: {
+        summary: msg("supervisor.proposedPlan"),
+        details: {
+          toolName: normalizeToolText(toolCall.title) ?? "ExitPlanMode",
+          input: {
+            ...(planReview ? { plan: planReview.plan } : {}),
+            ...(planReview?.planFilePath ? { planFilePath: planReview.planFilePath } : {}),
+          },
+        },
+        options: mapPermissionOptions(req),
+      },
+    };
+  }
+
   const command =
     readStringField(toolCall.rawInput, "command") ??
     extractCommandFromApprovalContent(toolCall.content);
@@ -55,11 +83,7 @@ export function mapAcpPermissionRequest(
       : requestType === "tool_call_approval"
         ? buildToolCallPermissionDetails(toolCall.rawInput, title, kind)
         : toolCall.rawInput;
-  const options = req.options.map((opt) => ({
-    optionId: opt.optionId,
-    label: opt.name,
-    description: undefined,
-  }));
+  const options = mapPermissionOptions(req);
   return {
     type: "request.opened",
     threadId: state.threadId,
@@ -71,6 +95,14 @@ export function mapAcpPermissionRequest(
       options,
     },
   };
+}
+
+function mapPermissionOptions(req: RequestPermissionRequest) {
+  return req.options.map((opt) => ({
+    optionId: opt.optionId,
+    label: opt.name,
+    description: undefined,
+  }));
 }
 
 function buildCommandPermissionDetails(

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -9,6 +9,7 @@ import {
   AcpStructuredSession,
   resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
+  resolveAcpWritableHostFsPath,
   rewriteLoadSessionError,
   toAcpResourceUri,
 } from "./session";
@@ -578,6 +579,68 @@ describe("ACP resource path helpers", () => {
         },
         "/home/me/.agents/skills/../secret.txt",
       ),
+    ).toThrow("Invalid params");
+  });
+
+  const WINDOWS_LOCATION = { kind: "windows", path: "C:\\repo" } as const;
+  const WSL_LOCATION = {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/home/me/repo",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\repo",
+  } as const;
+  const KIMI_PLAN_WINDOWS = "C:\\Users\\me\\.kimi-code\\sessions\\ws\\sid\\agents\\a\\plans\\p.md";
+  const KIMI_PLAN_LINUX = "/home/me/.kimi-code/sessions/ws/sid/agents/a/plans/p.md";
+
+  it("allows read and write access to a declared agent home dir outside the project", () => {
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, KIMI_PLAN_WINDOWS, [".kimi-code"])).toBe(
+      KIMI_PLAN_WINDOWS,
+    );
+    expect(resolveAcpWritableHostFsPath(WINDOWS_LOCATION, KIMI_PLAN_WINDOWS, [".kimi-code"])).toBe(
+      KIMI_PLAN_WINDOWS,
+    );
+  });
+
+  it("maps agent home dir paths inside a WSL project to UNC host paths", () => {
+    const unc =
+      "\\\\wsl.localhost\\Ubuntu\\home\\me\\.kimi-code\\sessions\\ws\\sid\\agents\\a\\plans\\p.md";
+    expect(resolveAcpReadableHostFsPath(WSL_LOCATION, KIMI_PLAN_LINUX, [".kimi-code"])).toBe(unc);
+    expect(resolveAcpWritableHostFsPath(WSL_LOCATION, KIMI_PLAN_LINUX, [".kimi-code"])).toBe(unc);
+  });
+
+  it("still rejects agent home dir paths when no carve-out is declared", () => {
+    expect(() => resolveAcpReadableHostFsPath(WINDOWS_LOCATION, KIMI_PLAN_WINDOWS)).toThrow(
+      "Invalid params",
+    );
+    expect(() => resolveAcpWritableHostFsPath(WINDOWS_LOCATION, KIMI_PLAN_WINDOWS)).toThrow(
+      "Invalid params",
+    );
+  });
+
+  it("keeps user agent skills read-only even with agent home carve-outs", () => {
+    expect(() =>
+      resolveAcpWritableHostFsPath(WSL_LOCATION, "/home/me/.agents/skills/x/SKILL.md", [
+        ".kimi-code",
+      ]),
+    ).toThrow("Invalid params");
+  });
+
+  it("rejects agent home dir paths that escape through parent segments", () => {
+    expect(() =>
+      resolveAcpWritableHostFsPath(WSL_LOCATION, "/home/me/.kimi-code/../secret.txt", [
+        ".kimi-code",
+      ]),
+    ).toThrow("Invalid params");
+    expect(() =>
+      resolveAcpWritableHostFsPath(WINDOWS_LOCATION, "C:\\Users\\me\\.kimi-code\\..\\secret.txt", [
+        ".kimi-code",
+      ]),
+    ).toThrow("Invalid params");
+  });
+
+  it("does not match the agent home dir root itself", () => {
+    expect(() =>
+      resolveAcpWritableHostFsPath(WSL_LOCATION, "/home/me/.kimi-code", [".kimi-code"]),
     ).toThrow("Invalid params");
   });
 });

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -82,16 +82,21 @@ import { AcpSessionConfigSync } from "./sessionConfigSync";
 // ── Helpers ──────────────────────────────────────────────────────
 
 import {
-  resolveAcpHostFsPath,
   resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
+  resolveAcpWritableHostFsPath,
   resolveSessionCwd,
   resolveSpawnCwd,
   sliceTextFileContent,
   toAcpResourceUri,
 } from "./sessionPaths";
 
-export { resolveAcpReadableHostFsPath, resolveAcpResourcePath, toAcpResourceUri };
+export {
+  resolveAcpReadableHostFsPath,
+  resolveAcpResourcePath,
+  resolveAcpWritableHostFsPath,
+  toAcpResourceUri,
+};
 
 import { segmentsToContentBlocks } from "./sessionContentBlocks";
 import {
@@ -189,6 +194,13 @@ export interface AcpStructuredSessionOptions {
    */
   extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
   mcpServers?: readonly ResolvedMcpServer[];
+  /**
+   * Home-relative directories (posix-style, e.g. ".kimi-code") the agent may
+   * read and write through the ACP fs bridge even though they sit outside the
+   * project root. For providers that keep internal session state (plan files,
+   * profiles) under their own home dir and proxy all text IO to the client.
+   */
+  fsAgentHomeDirs?: readonly string[];
 }
 
 export class AcpStructuredSession implements StructuredSessionHandle {
@@ -212,6 +224,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly cwd: string;
   private readonly projectLocation: ProjectLocation;
   private readonly mcpServers: readonly ResolvedMcpServer[];
+  private readonly fsAgentHomeDirs: readonly string[];
   /** Poracode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
   private readonly stderrChunks: string[];
@@ -376,6 +389,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       this.extensionNotificationHandler = options.extensionNotificationHandler;
     }
     this.mcpServers = options?.mcpServers ?? [];
+    this.fsAgentHomeDirs = options?.fsAgentHomeDirs ?? [];
   }
 
   /** Initialize the canonical mapper once we have a stable thread id. */
@@ -1072,7 +1086,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
   private async handleReadTextFile(params: ReadTextFileRequest): Promise<ReadTextFileResponse> {
     this.assertRequestSession(params.sessionId);
-    const path = resolveAcpReadableHostFsPath(this.projectLocation, params.path);
+    const path = resolveAcpReadableHostFsPath(
+      this.projectLocation,
+      params.path,
+      this.fsAgentHomeDirs,
+    );
     const fullContent = await readFile(path, "utf8");
     const content = sliceTextFileContent(fullContent, params.line, params.limit);
     return { content };
@@ -1080,7 +1098,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
 
   private async handleWriteTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
     this.assertRequestSession(params.sessionId);
-    const path = resolveAcpHostFsPath(this.projectLocation, params.path);
+    const path = resolveAcpWritableHostFsPath(
+      this.projectLocation,
+      params.path,
+      this.fsAgentHomeDirs,
+    );
     await writeFile(path, params.content, "utf8");
     return {};
   }

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -60,5 +60,6 @@ export function createAcpStructuredSession(
       ? { extensionNotificationHandler: input.acpExtensionNotificationHandler }
       : {}),
     ...(input.mcpServers !== undefined ? { mcpServers: input.mcpServers } : {}),
+    ...(input.acpFsAgentHomeDirs ? { fsAgentHomeDirs: input.acpFsAgentHomeDirs } : {}),
   });
 }

--- a/src/supervisor/agents/acp/sessionPaths.ts
+++ b/src/supervisor/agents/acp/sessionPaths.ts
@@ -88,15 +88,48 @@ export function resolveAcpHostFsPath(location: ProjectLocation, rawPath: string)
     : win32.join(location.uncPath, ...relative.split("/").filter(Boolean));
 }
 
-export function resolveAcpReadableHostFsPath(location: ProjectLocation, rawPath: string): string {
+export function resolveAcpReadableHostFsPath(
+  location: ProjectLocation,
+  rawPath: string,
+  agentHomeDirs: readonly string[] = [],
+): string {
   const absolutePath = resolveAcpResourcePath(location, rawPath);
   if (isProjectRelativePath(location, absolutePath)) {
     return resolveAcpHostFsPath(location, rawPath);
   }
   const normalizedPath = normalizeAcpPath(location, absolutePath);
-  if (!isAgentSkillReadPath(location, normalizedPath)) {
+  if (
+    !isAgentSkillReadPath(location, normalizedPath) &&
+    !isAgentHomeDirPath(location, normalizedPath, agentHomeDirs)
+  ) {
     throw RequestError.invalidParams({ message: `Path is outside the project: ${rawPath}` });
   }
+  return toHostFsPathOutsideProject(location, normalizedPath);
+}
+
+/**
+ * Like {@link resolveAcpHostFsPath}, but with the provider's declared
+ * home-relative carve-outs (`agentHomeDirs`) writable in addition to the
+ * project root. `~/.agents/skills` stays read-only — it is deliberately NOT
+ * honored here.
+ */
+export function resolveAcpWritableHostFsPath(
+  location: ProjectLocation,
+  rawPath: string,
+  agentHomeDirs: readonly string[] = [],
+): string {
+  const absolutePath = resolveAcpResourcePath(location, rawPath);
+  if (isProjectRelativePath(location, absolutePath)) {
+    return resolveAcpHostFsPath(location, rawPath);
+  }
+  const normalizedPath = normalizeAcpPath(location, absolutePath);
+  if (!isAgentHomeDirPath(location, normalizedPath, agentHomeDirs)) {
+    throw RequestError.invalidParams({ message: `Path is outside the project: ${rawPath}` });
+  }
+  return toHostFsPathOutsideProject(location, normalizedPath);
+}
+
+function toHostFsPathOutsideProject(location: ProjectLocation, normalizedPath: string): string {
   if (location.kind === "wsl" && !isWindowsAbsolutePath(normalizedPath)) {
     return toWslUncPath(location.distro, normalizedPath);
   }
@@ -160,12 +193,39 @@ export function sliceTextFileContent(
 }
 
 function isAgentSkillReadPath(location: ProjectLocation, absolutePath: string): boolean {
+  return isUserHomeRelativePath(location, absolutePath, ".agents/skills");
+}
+
+function isAgentHomeDirPath(
+  location: ProjectLocation,
+  absolutePath: string,
+  agentHomeDirs: readonly string[],
+): boolean {
+  return agentHomeDirs.some((dir) => isUserHomeRelativePath(location, absolutePath, dir));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True when `absolutePath` points strictly inside `<user home>/<homeRelativeDir>`
+ * (posix-style relative dir, e.g. ".agents/skills" or ".kimi-code"). The home
+ * root itself does not match — only files/dirs beneath it.
+ */
+function isUserHomeRelativePath(
+  location: ProjectLocation,
+  absolutePath: string,
+  homeRelativeDir: string,
+): boolean {
+  const segments = homeRelativeDir.split("/").filter(Boolean).map(escapeRegExp);
   switch (location.kind) {
     case "windows": {
-      const match =
-        /^([A-Za-z]:[\\/]Users[\\/][^\\/]+[\\/]\\.agents[\\/]skills)(?:[\\/].*)?$/i.exec(
-          absolutePath,
-        );
+      const dirPattern = segments.join("[\\\\/]");
+      const match = new RegExp(
+        `^([A-Za-z]:[\\\\/]Users[\\\\/][^\\\\/]+[\\\\/]${dirPattern})(?:[\\\\/].*)?$`,
+        "i",
+      ).exec(absolutePath);
       if (!match) return false;
       const root = match[1]!;
       const relative = win32.relative(root, absolutePath);
@@ -173,7 +233,8 @@ function isAgentSkillReadPath(location: ProjectLocation, absolutePath: string): 
     }
     case "wsl":
     case "posix": {
-      const match = /^(\/(?:home\/[^/]+|Users\/[^/]+|root)\/\.agents\/skills)(?:\/.*)?$/.exec(
+      const dirPattern = segments.join("/");
+      const match = new RegExp(`^(/(?:home/[^/]+|Users/[^/]+|root)/${dirPattern})(?:/.*)?$`).exec(
         absolutePath,
       );
       if (!match) return false;

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -200,6 +200,15 @@ export interface CreateStructuredSessionInput {
    * that carry metadata absent from the standard `session/update` stream.
    */
   acpExtensionNotificationHandler?: AcpExtensionNotificationHandler;
+  /**
+   * Home-relative directories (posix-style, e.g. ".kimi-code") this provider
+   * may read and write through the ACP fs bridge even though they live outside
+   * the project root. For agents that keep internal session state (plan files,
+   * profiles) under their own home dir and route every text read/write through
+   * the client once fs capability is advertised — without a carve-out the
+   * bridge rejects those paths and provider features like plan mode break.
+   */
+  acpFsAgentHomeDirs?: readonly string[];
 }
 
 export type AcpEmptyResponseErrorResolver = (input: {

--- a/src/supervisor/agents/kimi/index.ts
+++ b/src/supervisor/agents/kimi/index.ts
@@ -134,6 +134,12 @@ export function createKimiAdapter(): AgentAdapter {
       );
       session = createAcpStructuredSession(command, {
         ...input,
+        // Kimi keeps per-session state (plan-mode plan files, profiles) under
+        // ~/.kimi-code and, once fs capability is advertised, routes those
+        // reads/writes through the ACP client too. Without this carve-out the
+        // bridge rejects them as outside-project and plan mode breaks
+        // (Write/Read of the plan file and ExitPlanMode all fail).
+        acpFsAgentHomeDirs: [".kimi-code"],
         acpEmptyResponseErrorResolver: resolveKimiEmptyResponseError,
         acpSessionUpdateTransform: createKimiAcpSessionUpdateTransform({
           subagents,


### PR DESCRIPTION
- Detect cross-provider `ExitPlanMode`/`exit_plan_mode` tool calls and surface the proposed plan (markdown body plus optional plan-file path) in the thread request panel with a localized "Proposed plan" summary.
- Let ACP providers read/write home-relative state directories (e.g. `~/.kimi-code`) through the fs bridge even though they live outside the project root, fixing broken plan mode for Kimi.
- Generalize the path resolvers to accept multiple agent-home carve-outs and harden them against parent-segment traversal escapes; covered by new unit tests.