### PR TITLE
Show project git badge on stacked thread rows

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.test.tsx
@@ -293,4 +293,52 @@ describe("GitBadge", () => {
     });
     expect(useGitStore.getState().prData[buildBranchPrKey("project-1")]?.number).toBe(2);
   });
+
+  it("shares one PR lookup across concurrent badges for the same project branch", async () => {
+    let resolvePr: (pr: PrData | null) => void = () => {};
+    ghGetPrForBranchMock.mockReturnValue(
+      new Promise<PrData | null>((resolve) => {
+        resolvePr = resolve;
+      }),
+    );
+    useAppStore.setState({
+      projects: [
+        {
+          id: "project-1",
+          name: "Project",
+          location: { kind: "posix", path: "/repo" },
+          createdAt: "2026-06-02T00:00:00.000Z",
+        },
+      ],
+    });
+    useGitStore.setState({
+      statuses: {
+        "project-1": makeStatus({
+          branch: "feature/current",
+          remoteInfo: { platform: "github", owner: "o", repo: "r", url: "https://github.com/o/r" },
+        }),
+      },
+      ghAvailable: { "project-1": true },
+    });
+
+    render(
+      <>
+        <GitBadge projectId="project-1" projectName="Project" />
+        <GitBadge projectId="project-1" projectName="Project" />
+      </>,
+    );
+
+    expect(ghGetPrForBranchMock).toHaveBeenCalledTimes(1);
+
+    resolvePr({ ...basePr, number: 2, title: "Current PR" });
+
+    await waitFor(() => {
+      const badges = screen.getAllByRole("button", { name: "Git status for Project" });
+      expect(badges).toHaveLength(2);
+      for (const badge of badges) {
+        expect(badge.querySelector(".lucide-git-pull-request")).not.toBeNull();
+      }
+    });
+    expect(useGitStore.getState().prData[buildBranchPrKey("project-1")]?.number).toBe(2);
+  });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/GitBadge.tsx
@@ -8,6 +8,7 @@ import { DiffStat } from "@/renderer/components/common/DiffStat";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
 import { buildBranchPrKey } from "@/renderer/state/gitSelectors";
+import { coalesceByKey } from "@/shared/coalesce";
 import { useShallow } from "zustand/shallow";
 import { handleKeyActivate } from "@/renderer/utils/a11y";
 import {
@@ -42,6 +43,15 @@ const gitBadgeTextPaddingClass = "px-1 py-0.5";
 const activeGitBadgeClass = "bg-accent/15 hover:bg-accent/25";
 const hiddenGitBadgeClass =
   "opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
+
+/**
+ * In-flight project-branch PR verifications, keyed by project PR key + branch. Every
+ * mounted project badge verifies on mount, and a flat thread list mounts one
+ * badge per main-branch thread of the same project — without sharing, each
+ * would clear the shared prData entry and fire its own `gh` lookup. Followers
+ * for the same branch await the leader's lookup instead of starting another.
+ */
+const projectPrVerifications = new Map<string, Promise<void>>();
 
 export function GitBadge(props: {
   projectId: string;
@@ -138,17 +148,20 @@ export function GitBadge(props: {
     if (remotePlatform !== "github" && remotePlatform !== "unknown") return;
 
     let isActive = true;
-    readBridge()
-      .ghGetPrForBranch({ projectLocation, branch })
-      .then((pr) => {
-        if (!isActive) return;
-        if (useGitStore.getState().statuses[props.projectId]?.branch !== branch) return;
-        useGitStore.getState().setPrData(projectPrKey, pr);
-        setVerifiedProjectPrBranch(branch);
-      })
-      .catch(() => {
-        if (isActive) setVerifiedProjectPrBranch(branch);
-      });
+    const markVerified = () => {
+      if (!isActive) return;
+      if (useGitStore.getState().statuses[props.projectId]?.branch !== branch) return;
+      setVerifiedProjectPrBranch(branch);
+    };
+    void coalesceByKey(projectPrVerifications, `${projectPrKey}\0${branch}`, () =>
+      readBridge()
+        .ghGetPrForBranch({ projectLocation, branch })
+        .then((pr) => {
+          if (useGitStore.getState().statuses[props.projectId]?.branch !== branch) return;
+          useGitStore.getState().setPrData(projectPrKey, pr);
+        })
+        .catch(() => undefined),
+    ).then(markVerified);
     return () => {
       isActive = false;
     };

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project, Thread } from "@/shared/contracts";
@@ -46,11 +47,22 @@ vi.mock("@/renderer/components/common/ContextMenu", () => ({
 }));
 
 vi.mock("@/renderer/components/common/SidebarButton", () => ({
-  SidebarButton: (props: { label: ReactNode }) => <button type="button">{props.label}</button>,
+  SidebarButton: (props: { label: ReactNode; suffix?: ReactNode }) => (
+    <button type="button">
+      {props.label}
+      {props.suffix}
+    </button>
+  ),
 }));
 
 vi.mock("@/renderer/components/providers/ThreadProviderIcon", () => ({
   ThreadProviderIcon: () => null,
+}));
+
+vi.mock("@/renderer/views/MainView/parts/Sidebar/parts/GitBadge", () => ({
+  GitBadge: (props: { projectName: string }) => (
+    <button type="button" aria-label={`Git status for ${props.projectName}`} />
+  ),
 }));
 
 vi.mock("@/renderer/components/providers/statusTone", () => ({
@@ -64,6 +76,7 @@ vi.mock("@/renderer/hooks/uiSelectors", () => ({
   useThreadHasBackgroundActivity: (threadId: string) =>
     useThreadHasBackgroundActivityMock(threadId),
   useThreadHasDraft: (threadId: string) => useThreadHasDraftMock(threadId),
+  useIsProjectGitPanelActive: () => false,
   useIsWorktreeFilesPanelActive: () => false,
   useIsWorktreeGitPanelActive: () => false,
   useIsWorktreeTerminalActive: () => false,
@@ -107,9 +120,14 @@ vi.mock("@/renderer/bridge", () => ({
   readBridge: () => ({ openExternal: vi.fn<(url: string) => void>() }),
 }));
 
-vi.mock("@/renderer/state/gitStore", () => ({
-  useGitStore: { getState: () => ({ prData: {} }) },
-}));
+vi.mock("@/renderer/state/gitStore", () => {
+  const state = { prData: {} };
+  return {
+    useGitStore: Object.assign((selector: (value: typeof state) => unknown) => selector(state), {
+      getState: () => state,
+    }),
+  };
+});
 
 function makeThread(): Thread {
   return {
@@ -288,5 +306,40 @@ describe("SortableThreadItem", () => {
       isDisabled: true,
       disabledReason: "Thread is already unloaded.",
     });
+  });
+
+  it("shows the project git badge on a flat-list main-branch thread row", () => {
+    render(
+      <SortableThreadItem
+        thread={makeThread()}
+        threadIndex={1}
+        project={project}
+        showWorktreeBadge={false}
+        editingThreadId={null}
+        setEditingThreadId={vi.fn<(id: string | null) => void>()}
+        group="flat:__flat__"
+        projectTag={<span>{project.name}</span>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Git status for Project" })).toBeInTheDocument();
+  });
+
+  it("omits the project git badge in grouped lists, where the project header carries it", () => {
+    render(
+      <SortableThreadItem
+        thread={makeThread()}
+        threadIndex={1}
+        project={project}
+        showWorktreeBadge={false}
+        editingThreadId={null}
+        setEditingThreadId={vi.fn<(id: string | null) => void>()}
+        group="project-entries:project-1"
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Git status for Project" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -83,6 +83,10 @@ export function SortableThreadItem(props: {
     showWorktreeBadge,
     showWorktreeFilesButton,
     isExperimentCandidate,
+    // Stacked rows are flat cross-project list rows: no project header carries
+    // the main branch's git state, so a main-branch thread shows it inline.
+    showProjectBadge: stacked,
+    projectName: project.name,
   };
 
   return (

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/parts/ThreadItemSuffix.tsx
@@ -11,6 +11,7 @@ import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
 import { openWorktreeTerminal } from "@/renderer/actions/terminalActions";
 import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import {
+  useIsProjectGitPanelActive,
   useIsWorktreeFilesPanelActive,
   useIsWorktreeGitPanelActive,
   useIsWorktreeTerminalActive,
@@ -25,6 +26,14 @@ interface ThreadItemSuffixProps {
   showWorktreeBadge: boolean;
   showWorktreeFilesButton: boolean;
   isExperimentCandidate: boolean;
+  /**
+   * Flat cross-project lists have no project header to carry the project's git
+   * state, so a main-branch thread row shows the project-level badge itself
+   * (mirrors the PWA row). Off in grouped lists, where the header has it.
+   */
+  showProjectBadge?: boolean;
+  /** Project display name for the project-level badge's accessibility label. */
+  projectName: string;
 }
 
 const iconSizeClass = "size-3.5";
@@ -32,6 +41,18 @@ const buttonHeightClass = "h-[18px]";
 const buttonVisibleClass = "w-[18px] p-0.5";
 const hiddenPanelButtonClass =
   "w-0 -mr-[3px] overflow-hidden p-0 opacity-0 pointer-events-none group-hover:w-[18px] group-hover:mr-0 group-hover:p-0.5 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:w-[18px] focus-visible:mr-0 focus-visible:p-0.5 focus-visible:opacity-100 focus-visible:pointer-events-auto";
+
+function ProjectGitBadge(props: { projectId: string; projectName: string; threadId: string }) {
+  const isActive = useIsProjectGitPanelActive(props.projectId);
+  return (
+    <GitBadge
+      projectId={props.projectId}
+      projectName={props.projectName}
+      onPress={() => openGitReview(props.projectId, undefined, props.threadId)}
+      isActive={isActive}
+    />
+  );
+}
 
 function ThreadItemWorktreeActions(props: ThreadItemSuffixProps) {
   const { thread, showWorktreeBadge, showWorktreeFilesButton } = props;
@@ -121,6 +142,12 @@ function ThreadItemStatusBadges(props: ThreadItemSuffixProps) {
           onPress={() => openGitReview(thread.projectId, worktreePath, thread.id)}
           isActive={isGitActive}
           fallbackToWorktreeIcon
+        />
+      ) : !thread.worktreePath && props.showProjectBadge ? (
+        <ProjectGitBadge
+          projectId={thread.projectId}
+          projectName={props.projectName}
+          threadId={thread.id}
         />
       ) : null}
     </>


### PR DESCRIPTION
- Display the project git badge on main-branch thread rows in flat/stacked sidebar lists, where no project header is present to carry git state.
- Keep the badge off grouped lists, whose project headers already carry it.
- Deduplicate in-flight PR verifications per project branch so concurrent badges share a single GitHub lookup instead of firing duplicate requests.
- Add tests covering badge placement in flat vs grouped lists and the shared-lookup behavior.