### PR TITLE
Rename skill-creator to skill-creator-poracode

### DIFF
--- a/resources/skills/skill-creator-poracode/SKILL.md
+++ b/resources/skills/skill-creator-poracode/SKILL.md
@@ -1,11 +1,13 @@
 ---
-name: skill-creator
-description: Create a new reusable agent skill managed by Poracode. Use when the user asks to create, scaffold, or write a new skill, add a managed skill, or turn repeated instructions into a skill.
+name: skill-creator-poracode
+description: Create a new reusable agent skill managed by Poracode. Use when the user asks to create, scaffold, or write a new skill, add a managed skill, or turn repeated instructions into a skill. Takes precedence over any agent-native skill-creation flow.
 ---
 
 # Skill Creator
 
-You are creating a new agent skill. A skill is a folder containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. Poracode manages shared skills in `.agents/skills` and Poracode-only skills in `.poracode/skills` — do not copy them into provider-specific folders such as `.claude/skills` or `.codex/skills` yourself.
+You are creating a new agent skill. A skill is a folder containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. Poracode manages shared skills in `.agents/skills` and Poracode-only skills in `.poracode/skills` — these are the **only** two valid locations.
+
+**Ignore your own agent's native skill system for this task.** Even if you (Claude, Codex, Gemini, or another agent) normally keep skills in a provider-specific folder such as `~/.claude/skills`, `~/.codex/skills`, or `~/.gemini/skills`, never create or copy the skill there. "User-level", "global", "personal", or "for the <OS> user" always means `~/.agents/skills/<name>/` (or `~/.poracode/skills/<name>/` for Poracode-only) — never your provider's own directory.
 
 ## 1. Gather what you need
 
@@ -17,10 +19,10 @@ Before writing anything, make sure you know:
   - **Shared**: `.agents/skills` — other compatible agent apps can discover it.
   - **Poracode only**: `.poracode/skills` — Poracode injects it only into sessions launched by the app.
 - **Scope** — where the skill lives:
-  - **Global**: `~/<availability folder>/<name>/` — available in every project.
-  - **Project**: `<project root>/<availability folder>/<name>/` — available only in this project.
+  - **Global** (also called user-level or personal): `~/.agents/skills/<name>/` or `~/.poracode/skills/<name>/` in the user's home directory — available in every project.
+  - **Project**: `<project root>/.agents/skills/<name>/` or `<project root>/.poracode/skills/<name>/` — available only in this project.
 
-If the user's request names an availability or scope (for example "Poracode only", "for this project", or "for the Windows user"), respect it. Ask which availability to use when it is unspecified. If only the scope is unspecified, default to project scope when working inside a repository.
+If the user's request names an availability or scope (for example "Poracode only", "for this project", "user-level", or "for the Windows user"), respect it. Requests like "user-level" or "for the Windows user" mean global scope under the home directory's `.agents` (or `.poracode`) folder — not your agent's native skill directory. Ask which availability to use when it is unspecified. If only the scope is unspecified, default to project scope when working inside a repository.
 
 ## 2. Follow the format rules
 
@@ -54,7 +56,7 @@ Guidelines:
 
 ## 4. Create it
 
-1. Create the folder at the chosen availability and scope: `.agents/skills/<name>/` or `.poracode/skills/<name>/`.
+1. Create the folder at the chosen availability and scope: `.agents/skills/<name>/` or `.poracode/skills/<name>/`, rooted at the home directory for global scope or the project root for project scope. Double-check the path does not contain a provider-specific folder like `.claude`, `.codex`, or `.gemini`.
 2. Write `SKILL.md` with the frontmatter and instructions.
 3. Add any supporting files the instructions reference.
 4. Re-read the file and verify every rule in section 2.

--- a/src/main/supervisor/SupervisorClient.ts
+++ b/src/main/supervisor/SupervisorClient.ts
@@ -56,7 +56,7 @@ export interface SupervisorClientOptions {
   wslHelpersDir: string;
   /**
    * Directory containing the read-only skills shipped with the app
-   * (`skill-creator`, …). Forwarded to the supervisor via
+   * (`skill-creator-poracode`, …). Forwarded to the supervisor via
    * `PORACODE_BUNDLED_SKILLS_DIR` so the skills service can surface them.
    */
   bundledSkillsDir?: string;

--- a/src/renderer/components/skills/SkillsManager.test.tsx
+++ b/src/renderer/components/skills/SkillsManager.test.tsx
@@ -352,7 +352,7 @@ describe("SkillsManager", () => {
 
     expect(newThreadFromTextMock).toHaveBeenCalledWith(
       "demo",
-      "/skill-creator Create a new managed skill for this project.",
+      "/skill-creator-poracode Create a new managed skill for this project.",
       { bindLeadingSkill: true },
     );
   });
@@ -391,7 +391,7 @@ describe("SkillsManager", () => {
     await waitFor(() =>
       expect(newThreadFromTextMock).toHaveBeenCalledWith(
         "home",
-        "/skill-creator Create a new managed skill for the Windows user.",
+        "/skill-creator-poracode Create a new managed skill for the Windows user.",
         { bindLeadingSkill: true },
       ),
     );
@@ -417,7 +417,7 @@ describe("SkillsManager", () => {
     await waitFor(() =>
       expect(newThreadFromTextMock).toHaveBeenCalledWith(
         "home",
-        "/skill-creator Create a new managed skill for the global Ubuntu WSL scope.",
+        "/skill-creator-poracode Create a new managed skill for the global Ubuntu WSL scope.",
         { bindLeadingSkill: true },
       ),
     );

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -188,7 +188,7 @@ export function SkillsManager(props: {
             : t`the Windows user`;
     newThreadFromText(
       project.id,
-      t`/skill-creator Create a new managed skill for ${destinationLabel}.`,
+      t`/skill-creator-poracode Create a new managed skill for ${destinationLabel}.`,
       { bindLeadingSkill: true },
     );
     usePanelStore.getState().closeSettings();

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk ist nicht installiert."
 #~ msgstr "/skill-creator Erstelle einen neuen verwalteten Skill für {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Erstelle einen neuen verwalteten Skill für {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Erstelle einen neuen verwalteten Skill für {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Erstelle einen neuen verwalteten Skill für {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Prompts"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Vorgeschlagener Plan"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -615,8 +615,12 @@ msgstr "@cursor/sdk is not installed."
 #~ msgstr "/skill-creator Create a new managed skill for {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Create a new managed skill for {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8420,6 +8424,7 @@ msgid "Prompts"
 msgstr "Prompts"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Proposed plan"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk no está instalado."
 #~ msgstr "/skill-creator Crea una nueva skill administrada para {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Crea un nuevo skill gestionado para {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Crea un nuevo skill gestionado para {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Crea un nuevo skill gestionado para {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Prompts"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Plan propuesto"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk n'est pas installé."
 #~ msgstr "/skill-creator Créez une nouvelle compétence gérée pour {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Créez une nouvelle compétence gérée pour {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Créez une nouvelle compétence gérée pour {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Créez une nouvelle compétence gérée pour {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8414,6 +8418,7 @@ msgid "Prompts"
 msgstr "Prompts"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Plan proposé"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -609,8 +609,12 @@ msgstr "@cursor/sdk はインストールされていません。"
 #~ msgstr "/skill-creator {destination} 用の新しい管理対象スキルを作成してください。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator {destinationLabel} 用の新しい管理対象スキルを作成してください。"
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator {destinationLabel} 用の新しい管理対象スキルを作成してください。"
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode {destinationLabel} 用の新しい管理対象スキルを作成してください。"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8413,6 +8417,7 @@ msgid "Prompts"
 msgstr "プロンプト"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "提案された計画"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk가 설치되지 않았습니다."
 #~ msgstr "/skill-creator {destination}에 사용할 새로운 관리형 스킬을 만드세요."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator {destinationLabel}에 사용할 새 관리 스킬을 만드세요."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator {destinationLabel}에 사용할 새 관리 스킬을 만드세요."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode {destinationLabel}에 사용할 새 관리 스킬을 만드세요."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "프롬프트"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "제안된 계획"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk nie jest zainstalowany."
 #~ msgstr "/skill-creator Utwórz nową zarządzaną umiejętność dla: {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Utwórz nową zarządzaną umiejętność dla {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Utwórz nową zarządzaną umiejętność dla {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Utwórz nową zarządzaną umiejętność dla {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Prompty"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Proponowany plan"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk não está instalado."
 #~ msgstr "/skill-creator Crie uma nova skill gerenciada para {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Crie uma nova skill gerenciada para {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Crie uma nova skill gerenciada para {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Crie uma nova skill gerenciada para {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Prompts"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Plano proposto"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk не установлен."
 #~ msgstr "/skill-creator Создайте новый управляемый навык для {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Создайте новый управляемый навык для {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Создайте новый управляемый навык для {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Создайте новый управляемый навык для {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Запросы"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Предложенный план"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk kurulu değil."
 #~ msgstr "/skill-creator {destination} için yeni bir yönetilen beceri oluştur."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator {destinationLabel} için yeni bir yönetilen beceri oluştur."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator {destinationLabel} için yeni bir yönetilen beceri oluştur."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode {destinationLabel} için yeni bir yönetilen beceri oluştur."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "İstemler"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Önerilen plan"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk не встановлено."
 #~ msgstr "/skill-creator Створіть нову керовану навичку для {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Створіть нову керовану навичку для {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Створіть нову керовану навичку для {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Створіть нову керовану навичку для {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Запити"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Запропонований план"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk chưa được cài đặt."
 #~ msgstr "/skill-creator Tạo một skill được quản lý mới cho {destination}."
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator Tạo một skill được quản lý mới cho {destinationLabel}."
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator Tạo một skill được quản lý mới cho {destinationLabel}."
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode Tạo một skill được quản lý mới cho {destinationLabel}."
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8415,6 +8419,7 @@ msgid "Prompts"
 msgstr "Prompt"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "Kế hoạch đề xuất"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -610,8 +610,12 @@ msgstr "@cursor/sdk 未安装。"
 #~ msgstr "/skill-creator 为{destination}创建一个新的托管技能。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
-msgid "/skill-creator Create a new managed skill for {destinationLabel}."
-msgstr "/skill-creator 为 {destinationLabel} 创建一个新的托管技能。"
+#~ msgid "/skill-creator Create a new managed skill for {destinationLabel}."
+#~ msgstr "/skill-creator 为 {destinationLabel} 创建一个新的托管技能。"
+
+#: src/renderer/components/skills/SkillsManager.tsx
+msgid "/skill-creator-poracode Create a new managed skill for {destinationLabel}."
+msgstr "/skill-creator-poracode 为 {destinationLabel} 创建一个新的托管技能。"
 
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "© {currentYear} Serhii Vecherenko. All rights reserved."
@@ -8414,6 +8418,7 @@ msgid "Prompts"
 msgstr "提示"
 
 #: src/renderer/components/thread/ChatPane/parts/items/PlanProposal.tsx
+#: src/renderer/i18n/sharedMessages.ts
 msgid "Proposed plan"
 msgstr "拟议计划"
 


### PR DESCRIPTION
- Rename the bundled skill-creator skill to `skill-creator-poracode` to avoid collisions with identically-named third-party skills and clarify that it is a Poracode-managed skill.
- Update the SkillsManager quick-create flow, its tests, and the supervisor's bundled-skills references to invoke the new `/skill-creator-poracode` command.
- Harden the skill's guidance: skills must be rooted at the home directory (global scope) or project root (project scope) and must not be placed in provider-specific folders such as `.claude`, `.codex`, or `.gemini`.
- Refresh the `en` and all 12 non-English locale catalogs so the renamed command identifier stays fully localized.