### PR TITLE
fix(acp): deliver HTTP MCP servers to Factory Droid

### DIFF
--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -58,7 +58,8 @@ afterEach(() => {
 function makeConfigSyncSession(
   overrides: {
     currentConfig?: ThreadConfig;
-    agentMcpCapabilities?: { http?: boolean; sse?: boolean };
+    agentMcpCapabilities?: { http?: boolean; sse?: boolean } | undefined;
+    assumedMcpCapabilities?: { http?: boolean; sse?: boolean };
     mcpServers?: Array<{
       id: string;
       name: string;
@@ -140,7 +141,9 @@ function makeConfigSyncSession(
   // Default to advertising HTTP MCP support so the mcpServers-gating (added for
   // the Factory Droid bug) is a no-op for these pass-through tests. The gating
   // itself is covered by a dedicated test below.
-  session["agentMcpCapabilities"] = overrides.agentMcpCapabilities ?? { http: true };
+  session["agentMcpCapabilities"] =
+    "agentMcpCapabilities" in overrides ? overrides.agentMcpCapabilities : { http: true };
+  session["assumedMcpCapabilities"] = overrides.assumedMcpCapabilities;
   session["currentConfig"] = overrides.currentConfig ?? {
     model: "model-a",
     effort: "low",
@@ -1148,6 +1151,262 @@ describe("ACP client protocol helpers", () => {
       cwd: "C:\\repo",
       mcpServers: [],
     });
+  });
+
+  it("keeps HTTP MCP servers when the adapter assumes support and the agent advertises nothing", async () => {
+    // Factory Droid answers `initialize` with no mcpCapabilities block but
+    // connects HTTP MCP servers fine, so its adapter declares the transport.
+    // Without this, none of the built-in (all-HTTP) servers reach the agent.
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: undefined,
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "crossagents",
+          name: "crossagents",
+          timeoutMs: 300_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9200/mcp",
+            headers: { Authorization: "Bearer crossagent-token" },
+          },
+        },
+      ],
+    });
+
+    await expect(session.openThread({ model: "model-a", crossagentMcp: true })).resolves.toBe(
+      "session-1",
+    );
+
+    expect(connection.newSession).toHaveBeenCalledWith({
+      cwd: "C:\\repo",
+      mcpServers: [
+        {
+          type: "http",
+          name: "crossagents",
+          url: "http://127.0.0.1:9200/mcp",
+          headers: [{ name: "Authorization", value: "Bearer crossagent-token" }],
+        },
+      ],
+    });
+  });
+
+  it("retries without the assumed-transport MCP servers when session creation fails", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: undefined,
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp",
+            headers: { Authorization: "Bearer secret-token" },
+          },
+        },
+      ],
+    });
+    connection.newSession
+      .mockRejectedValueOnce(
+        RequestError.internalError({
+          message: "MCP server transport is unsupported",
+          Authorization: "Bearer must-not-reach-logs",
+        }),
+      )
+      .mockResolvedValueOnce({
+        sessionId: "session-1",
+        modes: { availableModes: [] },
+        configOptions: [],
+      });
+
+    try {
+      await expect(session.openThread({ model: "model-a", browserMcp: true })).resolves.toBe(
+        "session-1",
+      );
+
+      expect(connection.newSession).toHaveBeenCalledTimes(2);
+      expect(connection.newSession).toHaveBeenLastCalledWith({
+        cwd: "C:\\repo",
+        mcpServers: [],
+      });
+      expect(JSON.stringify(log.mock.calls)).not.toContain("must-not-reach-logs");
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("does not drop assumed-transport MCP servers after an unrelated session-open failure", async () => {
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: undefined,
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp",
+            headers: {},
+          },
+        },
+      ],
+    });
+    connection.newSession.mockRejectedValueOnce(new Error("transport closed"));
+
+    await expect(session.openThread({ model: "model-a", browserMcp: true })).rejects.toThrow(
+      "transport closed",
+    );
+    expect(connection.newSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries Droid's legacy bare internal error without broadening to detailed auth errors", async () => {
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: undefined,
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp",
+            headers: {},
+          },
+        },
+      ],
+    });
+    connection.newSession
+      .mockRejectedValueOnce(RequestError.internalError())
+      .mockResolvedValueOnce({
+        sessionId: "session-1",
+        modes: { availableModes: [] },
+        configOptions: [],
+      });
+
+    await expect(session.openThread({ model: "model-a", browserMcp: true })).resolves.toBe(
+      "session-1",
+    );
+    expect(connection.newSession).toHaveBeenCalledTimes(2);
+
+    connection.newSession.mockClear();
+    connection.newSession.mockRejectedValueOnce(
+      RequestError.internalError({ details: "401 invalid access token or token expired" }),
+    );
+    await expect(session.openThread({ model: "model-a", browserMcp: true })).rejects.toMatchObject({
+      code: -32603,
+    });
+    expect(connection.newSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves stale-session invalidParams instead of retrying load without MCP servers", async () => {
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: undefined,
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp",
+            headers: {},
+          },
+        },
+      ],
+    });
+    const sessionRef = {
+      providerSessionId: "stale-session",
+      discoveredAt: new Date().toISOString(),
+    };
+    connection.loadSession.mockRejectedValueOnce(
+      RequestError.invalidParams({ message: 'Session "stale-session" not found' }),
+    );
+
+    await expect(
+      session.openThread({ model: "model-a", browserMcp: true }, sessionRef),
+    ).rejects.toThrow("can't be resumed");
+    expect(connection.loadSession).toHaveBeenCalledTimes(1);
+    expect((session as unknown as Record<string, unknown>)["isReplayingHistory"]).toBe(false);
+  });
+
+  it.each([
+    ["resumeSession", true],
+    ["loadSession", false],
+  ] as const)(
+    "retries %s without assumed-transport MCP servers",
+    async (method, supportsResume) => {
+      const { connection, session } = makeConfigSyncSession({
+        agentMcpCapabilities: undefined,
+        assumedMcpCapabilities: { http: true },
+        mcpServers: [
+          {
+            id: "browser",
+            name: "browser",
+            timeoutMs: 30_000,
+            transport: {
+              type: "http",
+              url: "http://127.0.0.1:9123/mcp",
+              headers: {},
+            },
+          },
+        ],
+      });
+      if (supportsResume) {
+        (session as unknown as Record<string, unknown>)["agentSessionCapabilities"] = {
+          resume: {},
+        };
+      }
+      const open = connection[method];
+      open.mockRejectedValueOnce(RequestError.invalidParams({ field: "mcpServers" }));
+      const sessionRef = {
+        providerSessionId: `session-${supportsResume ? "resume" : "load"}`,
+        discoveredAt: new Date().toISOString(),
+      };
+
+      await expect(
+        session.openThread({ model: "model-a", browserMcp: true }, sessionRef),
+      ).resolves.toBe(sessionRef.providerSessionId);
+
+      expect(open).toHaveBeenCalledTimes(2);
+      expect(open).toHaveBeenLastCalledWith({
+        sessionId: sessionRef.providerSessionId,
+        cwd: "C:\\repo",
+        mcpServers: [],
+      });
+      expect((session as unknown as Record<string, unknown>)["isReplayingHistory"]).toBe(false);
+    },
+  );
+
+  it("does not assume transports the agent explicitly declined to advertise", async () => {
+    const { connection, session } = makeConfigSyncSession({
+      agentMcpCapabilities: { http: false },
+      assumedMcpCapabilities: { http: true },
+      mcpServers: [
+        {
+          id: "browser",
+          name: "browser",
+          timeoutMs: 30_000,
+          transport: {
+            type: "http",
+            url: "http://127.0.0.1:9123/mcp",
+            headers: { Authorization: "Bearer secret-token" },
+          },
+        },
+      ],
+    });
+
+    await expect(session.openThread({ model: "model-a", browserMcp: true })).resolves.toBe(
+      "session-1",
+    );
+
+    expect(connection.newSession).toHaveBeenCalledTimes(1);
+    expect(connection.newSession).toHaveBeenCalledWith({ cwd: "C:\\repo", mcpServers: [] });
   });
 
   it("appends both browser and Crossagents MCP servers when both are selected", async () => {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -118,7 +118,12 @@ import {
   shouldEmitAcpPromptRpcErrorItem,
 } from "./sessionErrors";
 import { AcpSessionRequests } from "./sessionRequests";
-import { buildAcpMcpServers, gateAcpMcpServers } from "../userMcp";
+import {
+  buildAcpMcpServers,
+  gateAcpMcpServers,
+  resolveAcpMcpCapabilities,
+  type AcpMcpCapabilities,
+} from "../userMcp";
 
 export { normalizeAcpStopReason, rewriteLoadSessionError };
 
@@ -131,6 +136,24 @@ export { normalizeAcpStopReason, rewriteLoadSessionError };
  * still open, which is what covers the multi-minute cases.
  */
 const ORPHAN_TURN_IDLE_MS = 20_000;
+
+/**
+ * Old Droid builds reject `session/new` with JSON-RPC invalid-params or
+ * internal-error when handed an HTTP MCP server. Retry only those protocol
+ * compatibility failures; transport, auth, and other session-open failures
+ * must remain visible instead of silently launching without requested MCPs.
+ */
+function isAssumedMcpCompatibilityError(error: unknown): error is RequestError {
+  if (!(error instanceof RequestError) || (error.code !== -32602 && error.code !== -32603)) {
+    return false;
+  }
+  const data = error.data as Record<string, unknown> | null | undefined;
+  const evidence = [error.message, data?.message, data?.details, data?.detail, data?.field]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+  if (/\bmcp(?:\s+server|servers)?\b/i.test(evidence)) return true;
+  return error.code === -32603 && error.message.trim().toLowerCase() === "internal error" && !data;
+}
 
 /**
  * Whether a `session/update` that arrives with no turn of ours open is the
@@ -195,6 +218,15 @@ export interface AcpStructuredSessionOptions {
   extensionNotificationHandler?: import("../base/types").AcpExtensionNotificationHandler;
   mcpServers?: readonly ResolvedMcpServer[];
   /**
+   * MCP transports the adapter knows this agent supports even though it
+   * advertises no `mcpCapabilities` in `initialize`. Poracode's built-in MCP
+   * servers (browser, Crossagents, computer use, app controls) are all HTTP,
+   * so an agent that stays silent about transports would otherwise get none of
+   * them. Applied only when the agent advertises nothing, and the session
+   * still falls back to the strictly gated set if opening fails.
+   */
+  assumedMcpCapabilities?: AcpMcpCapabilities;
+  /**
    * Home-relative directories (posix-style, e.g. ".kimi-code") the agent may
    * read and write through the ACP fs bridge even though they sit outside the
    * project root. For providers that keep internal session state (plan files,
@@ -224,6 +256,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
   private readonly cwd: string;
   private readonly projectLocation: ProjectLocation;
   private readonly mcpServers: readonly ResolvedMcpServer[];
+  private readonly assumedMcpCapabilities: AcpMcpCapabilities | undefined;
   private readonly fsAgentHomeDirs: readonly string[];
   /** Poracode thread id (stable identifier we report in RuntimeEvents). */
   private readonly threadId: string;
@@ -389,6 +422,7 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       this.extensionNotificationHandler = options.extensionNotificationHandler;
     }
     this.mcpServers = options?.mcpServers ?? [];
+    this.assumedMcpCapabilities = options?.assumedMcpCapabilities;
     this.fsAgentHomeDirs = options?.fsAgentHomeDirs ?? [];
   }
 
@@ -673,8 +707,11 @@ export class AcpStructuredSession implements StructuredSessionHandle {
    * ACP mode/model IDs (which vary per agent).
    */
   /** See {@link gateAcpMcpServers}; adds launch-time logging of what was dropped. */
-  private gateMcpServers(servers: ProtocolMcpServer[]): ProtocolMcpServer[] {
-    const kept = gateAcpMcpServers(servers, this.agentMcpCapabilities);
+  private gateMcpServers(
+    servers: ProtocolMcpServer[],
+    capabilities: AcpMcpCapabilities | undefined,
+  ): ProtocolMcpServer[] {
+    const kept = gateAcpMcpServers(servers, capabilities);
     if (kept.length < servers.length) {
       console.log(
         "[acp] dropping %d remote MCP server(s) — agent does not advertise the transport capability; launching without them: %s",
@@ -683,6 +720,40 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       );
     }
     return kept;
+  }
+
+  /**
+   * Run a session-open call with the MCP servers the adapter believes the
+   * agent supports, falling back once to the strictly advertised-capability
+   * set if that fails. Without the fallback an adapter's `assumedMcpCapabilities`
+   * would turn a future agent regression into an unopenable thread; with it the
+   * worst case is the old behaviour of launching without those servers.
+   */
+  private async openWithMcpServers<T>(
+    open: (mcpServers: ProtocolMcpServer[]) => Promise<T>,
+  ): Promise<T> {
+    const built = buildAcpMcpServers(this.mcpServers);
+    const assumed = this.gateMcpServers(
+      built,
+      resolveAcpMcpCapabilities(this.agentMcpCapabilities, this.assumedMcpCapabilities),
+    );
+    const advertised =
+      this.agentMcpCapabilities === undefined && this.assumedMcpCapabilities !== undefined
+        ? gateAcpMcpServers(built, this.agentMcpCapabilities)
+        : assumed;
+    if (advertised.length === assumed.length) return open(assumed);
+
+    try {
+      return await open(assumed);
+    } catch (error) {
+      if (!isAssumedMcpCompatibilityError(error)) throw error;
+      console.log(
+        "[acp] session open failed with %d assumed-transport MCP server(s) (ACP error %d); retrying without them",
+        assumed.length - advertised.length,
+        error.code,
+      );
+      return open(advertised);
+    }
   }
 
   /**
@@ -704,7 +775,6 @@ export class AcpStructuredSession implements StructuredSessionHandle {
     this.currentConfig = undefined;
     this.currentSlashCommands = undefined;
     this.sessionConfigSync.rememberOptions([], []);
-    const mcpServers = this.gateMcpServers(buildAcpMcpServers(this.mcpServers));
 
     if (sessionRef) {
       if (this.agentSessionCapabilities?.resume !== undefined) {
@@ -712,11 +782,13 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         this.isReplayingHistory = true;
         this.replayHistoryUntil = Infinity;
         try {
-          const result = await this.connection.resumeSession({
-            sessionId: sessionRef.providerSessionId,
-            cwd: this.cwd,
-            mcpServers,
-          });
+          const result = await this.openWithMcpServers((mcpServers) =>
+            this.connection.resumeSession({
+              sessionId: sessionRef.providerSessionId,
+              cwd: this.cwd,
+              mcpServers,
+            }),
+          );
           this.adoptSessionRef(sessionRef);
           this.trackUsageScope(sessionRef.providerSessionId, false);
           availableModeIds = result.modes?.availableModes?.map((m) => m.id) ?? [];
@@ -732,11 +804,13 @@ export class AcpStructuredSession implements StructuredSessionHandle {
         this.isReplayingHistory = true;
         this.replayHistoryUntil = Infinity;
         try {
-          const result = await this.connection.loadSession({
-            sessionId: sessionRef.providerSessionId,
-            cwd: this.cwd,
-            mcpServers,
-          });
+          const result = await this.openWithMcpServers((mcpServers) =>
+            this.connection.loadSession({
+              sessionId: sessionRef.providerSessionId,
+              cwd: this.cwd,
+              mcpServers,
+            }),
+          );
           this.adoptSessionRef(sessionRef);
           this.trackUsageScope(sessionRef.providerSessionId, false);
           availableModeIds = result.modes?.availableModes?.map((m) => m.id) ?? [];
@@ -750,10 +824,12 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       }
     } else {
       console.log("[acp] creating new session in", this.cwd);
-      const result = await this.connection.newSession({
-        cwd: this.cwd,
-        mcpServers,
-      });
+      const result = await this.openWithMcpServers((mcpServers) =>
+        this.connection.newSession({
+          cwd: this.cwd,
+          mcpServers,
+        }),
+      );
       this.sessionId = result.sessionId;
       this.stableSessionRef = createKnownSessionRef(result.sessionId);
       this.trackUsageScope(result.sessionId, true);

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -1,5 +1,5 @@
 import type { CommandSpec, CreateStructuredSessionInput } from "../base";
-import { AcpStructuredSession } from "./session";
+import { AcpStructuredSession, type AcpStructuredSessionOptions } from "./session";
 
 /**
  * Decide whether `createAcpStructuredSession` should actually spawn the ACP
@@ -34,10 +34,15 @@ export function shouldSpawnAcpSession(input: CreateStructuredSessionInput): bool
  * their own `if (input.sessionRef) return undefined` gate — that's what
  * produced the Copilot GUI-resume regression. Just call this factory
  * unconditionally and trust the shared decision.
+ *
+ * `overrides` carries the few session options an adapter states about its own
+ * agent rather than reading off the launch input (currently the MCP transports
+ * the agent supports without advertising them).
  */
 export function createAcpStructuredSession(
   acpCommand: CommandSpec,
   input: CreateStructuredSessionInput,
+  overrides?: Pick<AcpStructuredSessionOptions, "assumedMcpCapabilities">,
 ): AcpStructuredSession | undefined {
   if (!shouldSpawnAcpSession(input)) {
     return undefined;
@@ -61,5 +66,8 @@ export function createAcpStructuredSession(
       : {}),
     ...(input.mcpServers !== undefined ? { mcpServers: input.mcpServers } : {}),
     ...(input.acpFsAgentHomeDirs ? { fsAgentHomeDirs: input.acpFsAgentHomeDirs } : {}),
+    ...(overrides?.assumedMcpCapabilities
+      ? { assumedMcpCapabilities: overrides.assumedMcpCapabilities }
+      : {}),
   });
 }

--- a/src/supervisor/agents/factory/factory.test.ts
+++ b/src/supervisor/agents/factory/factory.test.ts
@@ -1,6 +1,7 @@
 import type { AuthMethod } from "@agentclientprotocol/sdk";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ProjectLocation } from "@/shared/contracts";
+import { createAcpStructuredSession } from "../acp";
 import {
   buildFactoryCommand,
   buildFactoryProbeCapabilities,
@@ -10,6 +11,11 @@ import {
   normalizeFactoryModels,
 } from "./detection";
 import { createFactoryAdapter } from "./index";
+
+vi.mock("../acp", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../acp")>()),
+  createAcpStructuredSession: vi.fn<() => undefined>(() => undefined),
+}));
 
 describe("Factory Droid detection", () => {
   it("declares the native binary, updater, ACP defaults, and API-key fallback", () => {
@@ -146,5 +152,17 @@ describe("Factory Droid adapter", () => {
     });
     const authCommand = await adapter.buildAcpAuthCommand?.();
     expect(authCommand?.env).toEqual(expect.objectContaining(FACTORY_DISABLE_AUTO_UPDATE_ENV));
+  });
+
+  it("declares HTTP MCP support Droid never advertises so built-in servers reach it", async () => {
+    await createFactoryAdapter().createStructuredSession?.({
+      threadId: "thread-1",
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      config: { model: "auto" },
+    });
+
+    expect(vi.mocked(createAcpStructuredSession).mock.calls[0]?.[2]).toEqual({
+      assumedMcpCapabilities: { http: true },
+    });
   });
 });

--- a/src/supervisor/agents/factory/index.ts
+++ b/src/supervisor/agents/factory/index.ts
@@ -82,7 +82,14 @@ export function createFactoryAdapter(): AgentAdapter {
         input.projectLocation,
         resolveAgentBinaryPath(input.projectLocation, "droid"),
       );
-      return createAcpStructuredSession(command, input);
+      // Droid answers `initialize` without an `mcpCapabilities` block even
+      // though `session/new` connects HTTP MCP servers fine (verified against
+      // droid 0.188.0, `exec --output-format acp`). Left to the advertised
+      // capabilities alone it would receive none of Poracode's built-in MCP
+      // servers, which are all HTTP.
+      return createAcpStructuredSession(command, input, {
+        assumedMcpCapabilities: { http: true },
+      });
     },
     async buildAcpAuthCommand(ctx?: AgentEnvContext) {
       const location = detectProbeLocation(ctx);

--- a/src/supervisor/agents/userMcp/translate.ts
+++ b/src/supervisor/agents/userMcp/translate.ts
@@ -254,6 +254,21 @@ export interface AcpMcpCapabilities {
   sse?: boolean;
 }
 
+/**
+ * Effective MCP transport support for an ACP agent.
+ *
+ * `advertised` is what the agent returned in `initialize`. `assumed` is what
+ * the adapter knows the agent actually supports; it only applies when the
+ * agent advertises no `mcpCapabilities` at all, so an agent that explicitly
+ * states its transports is always taken at its word.
+ */
+export function resolveAcpMcpCapabilities(
+  advertised: AcpMcpCapabilities | undefined,
+  assumed: AcpMcpCapabilities | undefined,
+): AcpMcpCapabilities | undefined {
+  return advertised ?? assumed;
+}
+
 export function gateAcpMcpServers<T extends object>(
   servers: T[],
   capabilities: AcpMcpCapabilities | undefined,


### PR DESCRIPTION
- Factory Droid advertises no `mcpCapabilities` in `initialize` despite supporting HTTP MCP on `session/new`, so Poracode's built-in HTTP MCP servers were being filtered out for Droid sessions.
- Adapters can now declare `assumedMcpCapabilities` via the ACP session factory; the Factory adapter declares HTTP support so built-in servers reach it.
- `resolveAcpMcpCapabilities` applies assumed capabilities only when the agent advertises none — agents that explicitly declare transports are always taken at their word.
- Session open retries only protocol compatibility failures (invalid-params/internal-error) with HTTP MCP servers dropped, keeping transport/auth errors visible rather than silently launching without requested MCPs.
- Adds test coverage for capability resolution, the open-with-MCP retry path, and the Factory Droid override.