### PR TITLE
feat(sidebar): add project filters to flat thread list

### DIFF
--- a/src/renderer/components/common/ContextMenu.test.tsx
+++ b/src/renderer/components/common/ContextMenu.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { ContextMenu } from "./ContextMenu";
+import { ContextMenu, ContextMenuSurface } from "./ContextMenu";
 
 describe("ContextMenu", () => {
   it("does not wrap its child in an extra DOM element", () => {
@@ -12,5 +13,87 @@ describe("ContextMenu", () => {
 
     expect(container.firstElementChild?.tagName).toBe("BUTTON");
     expect(screen.getByRole("button", { name: "Row" })).toBe(container.firstElementChild);
+  });
+
+  describe("stacked ContextMenuSurface", () => {
+    // Mirrors the real structure: the thread-row ContextMenu and the filter
+    // subtree (overflow state + stacked surface) are siblings, so toggling
+    // the overflow re-renders only the filter subtree — the thread-row menu
+    // keeps its original closer registration, exactly like SortableThreadItem
+    // vs SidebarProjectFilter in the flat thread list.
+    function FilterHost() {
+      const [overflow, setOverflow] = useState<{ x: number; y: number } | null>(null);
+      return (
+        <div role="menu">
+          <button type="button" onClick={() => setOverflow({ x: 10, y: 10 })}>
+            open-overflow
+          </button>
+          <button type="button" onClick={() => setOverflow(null)}>
+            close-overflow
+          </button>
+          {overflow ? (
+            <ContextMenuSurface
+              position={overflow}
+              items={[{ id: "b", label: "B item" }]}
+              onAction={vi.fn<(key: string) => void>()}
+              onClose={() => setOverflow(null)}
+            />
+          ) : null}
+        </div>
+      );
+    }
+
+    function Harness() {
+      return (
+        <>
+          <ContextMenu
+            items={[{ id: "a", label: "A item" }]}
+            onAction={vi.fn<(key: string) => void>()}
+          >
+            <button type="button">row</button>
+          </ContextMenu>
+          <FilterHost />
+        </>
+      );
+    }
+
+    it("keeps a right-click menu dismissible after a stacked surface closes", async () => {
+      render(<Harness />);
+
+      fireEvent.contextMenu(screen.getByRole("button", { name: "row" }));
+      expect(await screen.findByRole("menuitem", { name: "A item" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "open-overflow" }));
+      expect(await screen.findByRole("menuitem", { name: "B item" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "A item" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "close-overflow" }));
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("menuitem", { name: "B item" })).not.toBeInTheDocument();
+      });
+
+      fireEvent.mouseDown(document.body);
+
+      // Dismissal runs through the window listener's setTimeout(0).
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("menuitem", { name: "A item" })).not.toBeInTheDocument();
+      });
+    });
+
+    it("dismisses a stacked surface when a new right-click menu opens", async () => {
+      render(<Harness />);
+
+      fireEvent.contextMenu(screen.getByRole("button", { name: "row" }));
+      expect(await screen.findByRole("menuitem", { name: "A item" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "open-overflow" }));
+      expect(await screen.findByRole("menuitem", { name: "B item" })).toBeInTheDocument();
+
+      fireEvent.contextMenu(screen.getByRole("button", { name: "row" }));
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("menuitem", { name: "B item" })).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole("menuitem", { name: "A item" })).toBeInTheDocument();
+    });
   });
 });

--- a/src/renderer/components/common/ContextMenu.tsx
+++ b/src/renderer/components/common/ContextMenu.tsx
@@ -2,8 +2,28 @@ import React, { type MouseEventHandler, type ReactNode, useEffect, useState } fr
 import { createPortal } from "react-dom";
 import { Dropdown, Label, Separator } from "@heroui/react";
 
-// Only one context menu can be open at a time.
-let closeActiveMenu: (() => void) | null = null;
+// Context menus can stack (e.g. the flat-list filter stacks a project menu
+// over its own), so dismissal tracks a stack of closers: a new surface pushes
+// its closer, an outside press dismisses the top, and closing a surface pops
+// its own entry — an older menu underneath stays dismissible instead of being
+// orphaned when the top surface's cleanup runs.
+const menuCloseStack: Array<() => void> = [];
+
+function closeTopMenu(): void {
+  menuCloseStack.at(-1)?.();
+}
+
+function closeAllMenus(): void {
+  // Copy: closing surfaces may re-enter and mutate the stack while we walk it.
+  for (const close of [...menuCloseStack]) close();
+}
+
+/**
+ * Marks a {@link ContextMenuSurface} backdrop. Hosts that run their own
+ * outside-press dismissal can look for this to recognise a press that the menu
+ * on top already handled.
+ */
+export const MENU_BACKDROP_ATTR = "data-poracode-menu-backdrop";
 
 export interface ContextMenuItem {
   id: string;
@@ -83,7 +103,7 @@ function renderDropdownItem(item: ContextMenuItem) {
 
 function renderEntry(
   entry: ContextMenuItem | ContextMenuSubmenu,
-  setPosition: (pos: null) => void,
+  close: () => void,
   onAction: (key: string) => void,
 ) {
   if (isSubmenu(entry)) {
@@ -97,7 +117,7 @@ function renderEntry(
         <Dropdown.Popover>
           <Dropdown.Menu
             onAction={(key) => {
-              setPosition(null);
+              close();
               onAction(String(key));
             }}
           >
@@ -110,15 +130,39 @@ function renderEntry(
   return renderDropdownItem(entry);
 }
 
-export function ContextMenu(props: ContextMenuProps) {
-  const { items, onAction, children } = props;
-  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+/**
+ * The anchored menu itself, opened programmatically at fixed viewport
+ * coordinates. `ContextMenu` drives it from a right-click; other surfaces
+ * (e.g. an overflow button inside another menu) can drive it from any event.
+ */
+export function ContextMenuSurface(props: {
+  /** Anchor coordinates; null keeps the menu closed. */
+  position: { x: number; y: number } | null;
+  items: ContextMenuEntry[];
+  onAction: (key: string) => void;
+  onClose: () => void;
+  /**
+   * React Aria popovers close on blur by default (shouldCloseOnBlur is
+   * hardcoded in usePopover). When this menu stacks over another open menu —
+   * whose items take DOM focus on hover — pass a predicate that keeps the
+   * menu open while the interaction target lives inside any menu.
+   */
+  shouldCloseOnInteractOutside?: (element: Element) => boolean;
+  /**
+   * Render a full-viewport backdrop beneath the menu, so a press anywhere else
+   * dismisses it and does not reach whatever sits underneath. Opt-in: right-click
+   * menus dismiss through the global press listener above and let the press
+   * through, which is the behaviour their surfaces expect.
+   */
+  withBackdrop?: boolean;
+}) {
+  const { position, items, onAction, onClose } = props;
 
   useEffect(() => {
     if (!position) return;
 
-    const close = () => setPosition(null);
-    closeActiveMenu = close;
+    const close = () => onClose();
+    menuCloseStack.push(close);
 
     // Close on left-click anywhere. We use a capture listener to ensure we can catch it
     // but the dropdown components might also handle it.
@@ -131,23 +175,106 @@ export function ContextMenu(props: ContextMenuProps) {
           return;
         }
 
-        // If it's a left click outside, close the menu.
+        // If it's a left click outside, close the topmost menu.
         // We wait a tick to allow onAction to fire first if clicking an item that isn't caught by the roles above.
-        setTimeout(close, 0);
+        setTimeout(closeTopMenu, 0);
       }
     };
 
     window.addEventListener("mousedown", onGlobalMouseDown, true);
 
     return () => {
-      if (closeActiveMenu === close) closeActiveMenu = null;
+      const index = menuCloseStack.lastIndexOf(close);
+      if (index >= 0) menuCloseStack.splice(index, 1);
       window.removeEventListener("mousedown", onGlobalMouseDown, true);
     };
-  }, [position]);
+  }, [position, onClose]);
+
+  return position
+    ? createPortal(
+        <>
+          {props.withBackdrop ? (
+            // Shares the popover layer (see .poracode-menu-backdrop), so it
+            // covers the surface this menu was opened from — it comes later in
+            // the portal order — while the menu itself, portaled after it,
+            // still paints above. Marked so a host's own outside-press watcher
+            // can tell this apart from a press outside every menu.
+            <div
+              {...{ [MENU_BACKDROP_ATTR]: true }}
+              className="poracode-menu-backdrop fixed inset-0"
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onClose();
+              }}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                onClose();
+              }}
+            />
+          ) : null}
+          <Dropdown
+            isOpen
+            onOpenChange={(open) => {
+              if (!open) onClose();
+            }}
+          >
+            {/* Invisible anchor positioned at the opening coordinates */}
+            <Dropdown.Trigger className="fixed" style={{ left: position.x, top: position.y }}>
+              <div className="size-0" />
+            </Dropdown.Trigger>
+            <Dropdown.Popover
+              placement="bottom start"
+              isNonModal
+              {...(props.shouldCloseOnInteractOutside
+                ? { shouldCloseOnInteractOutside: props.shouldCloseOnInteractOutside }
+                : {})}
+            >
+              <Dropdown.Menu
+                autoFocus="first" // eslint-disable-line jsx-a11y/no-autofocus -- React Aria Menu prop, not HTML autofocus
+                disabledKeys={collectAllItems(items)
+                  .filter((item) => item.isDisabled)
+                  .map((item) => item.id)}
+                onAction={(key) => {
+                  onClose();
+                  onAction(String(key));
+                }}
+              >
+                {(() => {
+                  const sections = splitSections(items);
+                  if (sections.length <= 1) {
+                    return (sections[0] ?? []).map((entry) =>
+                      renderEntry(entry, onClose, onAction),
+                    );
+                  }
+                  return sections.flatMap((section, sIdx) => {
+                    const sectionEl = (
+                      <Dropdown.Section key={`section-${sIdx}`}>
+                        {section.map((entry) => renderEntry(entry, onClose, onAction))}
+                      </Dropdown.Section>
+                    );
+                    return sIdx > 0 ? [<Separator key={`sep-${sIdx}`} />, sectionEl] : [sectionEl];
+                  });
+                })()}
+              </Dropdown.Menu>
+            </Dropdown.Popover>
+          </Dropdown>
+        </>,
+        document.body,
+      )
+    : null;
+}
+
+export function ContextMenu(props: ContextMenuProps) {
+  const { items, onAction, children } = props;
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
 
   function handleContextMenu(e: React.MouseEvent) {
     e.preventDefault();
-    closeActiveMenu?.();
+    // A new right-click menu takes over: dismiss every already-open context
+    // menu (the filter surface below one of them is not a context menu and
+    // handles itself).
+    closeAllMenus();
     setPosition({ x: e.clientX, y: e.clientY });
   }
 
@@ -167,53 +294,12 @@ export function ContextMenu(props: ContextMenuProps) {
   return (
     <>
       {trigger}
-      {position
-        ? createPortal(
-            <Dropdown
-              isOpen
-              onOpenChange={(open) => {
-                if (!open) setPosition(null);
-              }}
-            >
-              {/* Invisible anchor positioned at the right-click coordinates */}
-              <Dropdown.Trigger className="fixed" style={{ left: position.x, top: position.y }}>
-                <div className="size-0" />
-              </Dropdown.Trigger>
-              <Dropdown.Popover placement="bottom start" isNonModal>
-                <Dropdown.Menu
-                  autoFocus="first" // eslint-disable-line jsx-a11y/no-autofocus -- React Aria Menu prop, not HTML autofocus
-                  disabledKeys={collectAllItems(items)
-                    .filter((item) => item.isDisabled)
-                    .map((item) => item.id)}
-                  onAction={(key) => {
-                    setPosition(null);
-                    onAction(String(key));
-                  }}
-                >
-                  {(() => {
-                    const sections = splitSections(items);
-                    if (sections.length <= 1) {
-                      return (sections[0] ?? []).map((entry) =>
-                        renderEntry(entry, setPosition, onAction),
-                      );
-                    }
-                    return sections.flatMap((section, sIdx) => {
-                      const sectionEl = (
-                        <Dropdown.Section key={`section-${sIdx}`}>
-                          {section.map((entry) => renderEntry(entry, setPosition, onAction))}
-                        </Dropdown.Section>
-                      );
-                      return sIdx > 0
-                        ? [<Separator key={`sep-${sIdx}`} />, sectionEl]
-                        : [sectionEl];
-                    });
-                  })()}
-                </Dropdown.Menu>
-              </Dropdown.Popover>
-            </Dropdown>,
-            document.body,
-          )
-        : null}
+      <ContextMenuSurface
+        position={position}
+        items={items}
+        onAction={onAction}
+        onClose={() => setPosition(null)}
+      />
     </>
   );
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# gekoppelter Desktop} other {# gekoppelte Desktops}}"
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# Projekt} other {# Projekte}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Alle Dateien"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Alle Projekte"
 
@@ -1157,7 +1160,7 @@ msgstr "Alle Projekte"
 msgid "All sources"
 msgstr "Alle Quellen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Alle Arbeitsbereiche"
@@ -3811,7 +3814,7 @@ msgstr "Computernutzung deaktivieren"
 msgid "Disable Crossagents"
 msgstr "Crossagents deaktivieren"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Projekt deaktivieren"
 
@@ -4137,7 +4140,7 @@ msgstr "Aktivieren Sie den Mikrofonzugriff in Ihren Systemeinstellungen und vers
 msgid "Enable notifications"
 msgstr "Benachrichtigungen aktivieren"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Projekt aktivieren"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Fülle alle erforderlichen Workflow-Eingaben aus."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Nach Projekt filtern"
 
@@ -4975,9 +4979,9 @@ msgstr "Aufgabe abrufen"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Git-Status für {0}: kein Git-Repository"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Browser in Fenster verschieben"
 msgid "Move changes to a new worktree"
 msgstr "Änderungen in einen neuen Arbeitsbaum verschieben"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "In Arbeitsbereich verschieben"
 
@@ -8347,6 +8352,11 @@ msgstr "Profile"
 msgid "Project"
 msgstr "Projekt"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Projektaktionen für {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Projektordner"
@@ -8372,7 +8382,7 @@ msgstr "Projekt nicht gefunden."
 msgid "Project notes"
 msgstr "Projektnotizen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Projekteinstellungen"
 
@@ -8393,6 +8403,7 @@ msgstr "Projektspezifische Überschreibungen zusätzlich zu den globalen Suchein
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Angeheftete Route für {tagLabel} entfernen"
 msgid "Remove project"
 msgstr "Projekt entfernen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Projekt entfernen"
 
@@ -9322,7 +9333,8 @@ msgstr "Änderungen von Kandidat {0} ({label}) überprüfen"
 msgid "Review changes"
 msgstr "Änderungen überprüfen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Änderungen überprüfen"
@@ -9386,9 +9398,9 @@ msgstr "Rechtsklicken, um den Ring zu wechseln"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Ausführen"
 
@@ -10648,7 +10660,7 @@ msgstr "Weiterleitung stoppen"
 msgid "Stop response"
 msgstr "Antwort stoppen"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Synchronisierung beenden"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Arbeitsbereich wechseln"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Synchronisieren"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# paired desktop} other {# paired desktops}}"
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# project} other {# projects}}"
@@ -1155,6 +1157,7 @@ msgid "All files"
 msgstr "All files"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "All projects"
 
@@ -1162,7 +1165,7 @@ msgstr "All projects"
 msgid "All sources"
 msgstr "All sources"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "All workspaces"
@@ -3816,7 +3819,7 @@ msgstr "Disable Computer Use"
 msgid "Disable Crossagents"
 msgstr "Disable Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Disable Project"
 
@@ -4142,7 +4145,7 @@ msgstr "Enable microphone access in your system settings, then try again."
 msgid "Enable notifications"
 msgstr "Enable notifications"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Enable Project"
 
@@ -4647,6 +4650,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Fill in all required workflow inputs."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Filter by project"
 
@@ -4980,9 +4984,9 @@ msgstr "Get task"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5016,7 +5020,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Git status for {0}: not a Git repository"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6608,7 +6613,7 @@ msgstr "Move browser to window"
 msgid "Move changes to a new worktree"
 msgstr "Move changes to a new worktree"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Move to Workspace"
 
@@ -8352,6 +8357,11 @@ msgstr "Profiles"
 msgid "Project"
 msgstr "Project"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Project actions for {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Project folder"
@@ -8377,7 +8387,7 @@ msgstr "Project not found."
 msgid "Project notes"
 msgstr "Project notes"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Project Settings"
 
@@ -8398,6 +8408,7 @@ msgstr "Project-specific overrides on top of the global search settings."
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8986,7 +8997,7 @@ msgstr "Remove pinned route for {tagLabel}"
 msgid "Remove project"
 msgstr "Remove project"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Remove Project"
 
@@ -9327,7 +9338,8 @@ msgstr "Review candidate {0} ({label}) changes"
 msgid "Review changes"
 msgstr "Review changes"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Review Changes"
@@ -9391,9 +9403,9 @@ msgstr "Right-click to switch ring"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Run"
 
@@ -10653,7 +10665,7 @@ msgstr "Stop forwarding"
 msgid "Stop response"
 msgstr "Stop response"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Stop syncing"
 
@@ -10839,7 +10851,8 @@ msgid "Switch workspace"
 msgstr "Switch workspace"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Sync"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# escritorio emparejado} other {# escritorios emparejad
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# proyecto} other {# proyectos}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Todos los archivos"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Todos los proyectos"
 
@@ -1157,7 +1160,7 @@ msgstr "Todos los proyectos"
 msgid "All sources"
 msgstr "Todas las fuentes"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Todos los espacios de trabajo"
@@ -3811,7 +3814,7 @@ msgstr "Deshabilitar el uso del ordenador"
 msgid "Disable Crossagents"
 msgstr "Deshabilitar Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Deshabilitar proyecto"
 
@@ -4137,7 +4140,7 @@ msgstr "Habilita el acceso al micrófono en los ajustes del sistema y vuelve a i
 msgid "Enable notifications"
 msgstr "Activar notificaciones"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Habilitar proyecto"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Completa todas las entradas obligatorias del workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Filtrar por proyecto"
 
@@ -4975,9 +4979,9 @@ msgstr "Obtener tarea"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Estado de Git para {0}: no es un repositorio Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Mover navegador a una ventana"
 msgid "Move changes to a new worktree"
 msgstr "Mover cambios a un nuevo worktree"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover a espacio de trabajo"
 
@@ -8347,6 +8352,11 @@ msgstr "Perfiles"
 msgid "Project"
 msgstr "Proyecto"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Acciones del proyecto para {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Carpeta del proyecto"
@@ -8372,7 +8382,7 @@ msgstr "No se encontró el proyecto."
 msgid "Project notes"
 msgstr "Notas del proyecto"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Ajustes del proyecto"
 
@@ -8393,6 +8403,7 @@ msgstr "Anulaciones específicas del proyecto sobre los ajustes de búsqueda glo
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Eliminar la ruta fijada para {tagLabel}"
 msgid "Remove project"
 msgstr "Eliminar proyecto"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Eliminar proyecto"
 
@@ -9322,7 +9333,8 @@ msgstr "Revisar los cambios del candidato {0} ({label})"
 msgid "Review changes"
 msgstr "Revisar cambios"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Revisar cambios"
@@ -9386,9 +9398,9 @@ msgstr "Haz clic derecho para cambiar de anillo"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Ejecutar"
 
@@ -10648,7 +10660,7 @@ msgstr "Detener reenvío"
 msgid "Stop response"
 msgstr "Detener respuesta"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Dejar de sincronizar"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Cambiar de espacio de trabajo"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Sincronizar"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# ordinateur associé} other {# ordinateurs associés}}
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# projet} other {# projets}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Tous les fichiers"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Tous les projets"
 
@@ -1157,7 +1160,7 @@ msgstr "Tous les projets"
 msgid "All sources"
 msgstr "Toutes les sources"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Tous les espaces de travail"
@@ -3811,7 +3814,7 @@ msgstr "Désactiver l'utilisation de l'ordinateur"
 msgid "Disable Crossagents"
 msgstr "Désactiver Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Désactiver le projet"
 
@@ -4137,7 +4140,7 @@ msgstr "Activez l'accès au microphone dans les paramètres de votre système, p
 msgid "Enable notifications"
 msgstr "Activer les notifications"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Activer le projet"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Renseignez toutes les entrées obligatoires du workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Filtrer par projet"
 
@@ -4975,9 +4979,9 @@ msgstr "Obtenir la tâche"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Statut Git pour {0} : pas un dépôt Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6602,7 +6607,7 @@ msgstr "Déplacer le navigateur vers une fenêtre"
 msgid "Move changes to a new worktree"
 msgstr "Déplacer les modifications vers un nouvel arbre de travail"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Déplacer vers un espace de travail"
 
@@ -8346,6 +8351,11 @@ msgstr "Profils"
 msgid "Project"
 msgstr "Projet"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Actions du projet pour {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Dossier du projet"
@@ -8371,7 +8381,7 @@ msgstr "Projet introuvable."
 msgid "Project notes"
 msgstr "Notes de projet"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Paramètres du projet"
 
@@ -8392,6 +8402,7 @@ msgstr "Remplacements spécifiques au projet en plus des paramètres de recherch
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8980,7 +8991,7 @@ msgstr "Supprimer la route épinglée pour {tagLabel}"
 msgid "Remove project"
 msgstr "Supprimer le projet"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Supprimer le projet"
 
@@ -9321,7 +9332,8 @@ msgstr "Examiner les modifications du candidat {0} ({label})"
 msgid "Review changes"
 msgstr "Examiner les changements"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Examiner les modifications"
@@ -9385,9 +9397,9 @@ msgstr "Clic droit pour changer d'anneau"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Exécuter"
 
@@ -10647,7 +10659,7 @@ msgstr "Arrêter le transfert"
 msgid "Stop response"
 msgstr "Arrêter la réponse"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Arrêter la synchronisation"
 
@@ -10833,7 +10845,8 @@ msgid "Switch workspace"
 msgstr "Changer d'espace de travail"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Synchroniser"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# 台のペアリング済みデスクトップ} other 
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {#件のプロジェクト} other {#件のプロジェクト}}"
@@ -1149,6 +1151,7 @@ msgid "All files"
 msgstr "すべてのファイル"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1156,7 +1159,7 @@ msgstr "すべてのプロジェクト"
 msgid "All sources"
 msgstr "すべてのソース"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "すべてのワークスペース"
@@ -3810,7 +3813,7 @@ msgstr "コンピュータ操作を無効にする"
 msgid "Disable Crossagents"
 msgstr "Crossagents を無効にする"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "プロジェクトを無効にする"
 
@@ -4136,7 +4139,7 @@ msgstr "システム設定でマイクへのアクセスを有効にしてから
 msgid "Enable notifications"
 msgstr "通知を有効にする"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "プロジェクトを有効にする"
 
@@ -4641,6 +4644,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "必須のワークフロー入力をすべて入力してください。"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "プロジェクトで絞り込み"
 
@@ -4974,9 +4978,9 @@ msgstr "タスクの取得"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5010,7 +5014,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}の Git ステータス: Git リポジトリではありません"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6601,7 +6606,7 @@ msgstr "ブラウザーをウィンドウに移動"
 msgid "Move changes to a new worktree"
 msgstr "変更を新しいワークツリーに移動する"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "ワークスペースへ移動"
 
@@ -8345,6 +8350,11 @@ msgstr "プロファイル"
 msgid "Project"
 msgstr "プロジェクト"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "{0}のプロジェクトアクション"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "プロジェクトフォルダー"
@@ -8370,7 +8380,7 @@ msgstr "プロジェクトが見つかりません。"
 msgid "Project notes"
 msgstr "プロジェクトノート"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "プロジェクト設定"
 
@@ -8391,6 +8401,7 @@ msgstr "グローバル検索設定に加えてプロジェクト固有のオー
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8979,7 +8990,7 @@ msgstr "{tagLabel} の固定ルートを削除"
 msgid "Remove project"
 msgstr "プロジェクトを削除"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "プロジェクトの削除"
 
@@ -9320,7 +9331,8 @@ msgstr "候補 {0}（{label}）の変更を確認"
 msgid "Review changes"
 msgstr "変更点をレビューする"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "変更の確認"
@@ -9384,9 +9396,9 @@ msgstr "右クリックでリングを切り替え"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "実行"
 
@@ -10646,7 +10658,7 @@ msgstr "転送を停止"
 msgid "Stop response"
 msgstr "応答停止"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "同期を停止"
 
@@ -10832,7 +10844,8 @@ msgid "Switch workspace"
 msgstr "ワークスペースを切り替え"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "同期"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {#개의 페어링된 데스크톱} other {#개의 페�
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {#개 프로젝트} other {#개 프로젝트}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "모든 파일"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "모든 프로젝트"
 
@@ -1157,7 +1160,7 @@ msgstr "모든 프로젝트"
 msgid "All sources"
 msgstr "모든 소스"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "모든 작업 영역"
@@ -3811,7 +3814,7 @@ msgstr "컴퓨터 사용 비활성화"
 msgid "Disable Crossagents"
 msgstr "Crossagents 비활성화"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "프로젝트 비활성화"
 
@@ -4137,7 +4140,7 @@ msgstr "시스템 설정에서 마이크 액세스를 활성화한 후 다시 �
 msgid "Enable notifications"
 msgstr "알림 활성화"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "프로젝트 활성화"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "필수 워크플로 입력을 모두 작성하세요."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "프로젝트별 필터"
 
@@ -4975,9 +4979,9 @@ msgstr "작업 가져오기"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}에 대한 Git 상태: Git 저장소가 아닙니다."
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "브라우저를 창으로 이동"
 msgid "Move changes to a new worktree"
 msgstr "변경 사항을 새 작업 트리로 이동"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "작업 영역으로 이동"
 
@@ -8347,6 +8352,11 @@ msgstr "프로필"
 msgid "Project"
 msgstr "프로젝트"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "{0}의 프로젝트 액션"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "프로젝트 폴더"
@@ -8372,7 +8382,7 @@ msgstr "프로젝트를 찾을 수 없습니다."
 msgid "Project notes"
 msgstr "프로젝트 노트"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "프로젝트 설정"
 
@@ -8393,6 +8403,7 @@ msgstr "전역 검색 설정 위에 프로젝트별 재정의가 적용됩니다
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "{tagLabel}의 고정 경로 제거"
 msgid "Remove project"
 msgstr "프로젝트 제거"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "프로젝트 제거"
 
@@ -9322,7 +9333,8 @@ msgstr "후보 {0}({label})의 변경 사항 검토"
 msgid "Review changes"
 msgstr "변경 사항 검토"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "변경사항 검토"
@@ -9386,9 +9398,9 @@ msgstr "마우스 오른쪽 버튼을 클릭해 링 전환"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "실행"
 
@@ -10648,7 +10660,7 @@ msgstr "전달 중지"
 msgid "Stop response"
 msgstr "응답 중지"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "동기화 중지"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "작업 영역 전환"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "동기화"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# sparowany desktop} few {# sparowane desktopy} many {#
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# projekt} few {# projekty} many {# projektów} other {# projektu}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Wszystkie pliki"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Wszystkie projekty"
 
@@ -1157,7 +1160,7 @@ msgstr "Wszystkie projekty"
 msgid "All sources"
 msgstr "Wszystkie źródła"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Wszystkie obszary robocze"
@@ -3811,7 +3814,7 @@ msgstr "Wyłącz obsługę komputera"
 msgid "Disable Crossagents"
 msgstr "Wyłącz Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Wyłącz projekt"
 
@@ -4137,7 +4140,7 @@ msgstr "Włącz dostęp do mikrofonu w ustawieniach systemu, a następnie sprób
 msgid "Enable notifications"
 msgstr "Włącz powiadomienia"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Włącz projekt"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Uzupełnij wszystkie wymagane dane wejściowe workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Filtruj według projektu"
 
@@ -4975,9 +4979,9 @@ msgstr "Pobierz zadanie"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Status Git dla {0}: to nie jest repozytorium Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Przenieś przeglądarkę do okna"
 msgid "Move changes to a new worktree"
 msgstr "Przenieś zmiany do nowego drzewa roboczego"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Przenieś do obszaru roboczego"
 
@@ -8347,6 +8352,11 @@ msgstr "Profile"
 msgid "Project"
 msgstr "Projekt"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Akcje projektu dla {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Folder projektu"
@@ -8372,7 +8382,7 @@ msgstr "Nie znaleziono projektu."
 msgid "Project notes"
 msgstr "Notatki projektowe"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Ustawienia projektu"
 
@@ -8393,6 +8403,7 @@ msgstr "Zastąpienia specyficzne dla projektu ponad globalnymi ustawieniami wysz
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Usuń przypiętą trasę dla {tagLabel}"
 msgid "Remove project"
 msgstr "Usuń projekt"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Usuń projekt"
 
@@ -9322,7 +9333,8 @@ msgstr "Przejrzyj zmiany kandydata {0} ({label})"
 msgid "Review changes"
 msgstr "Przejrzyj zmiany"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Przejrzyj zmiany"
@@ -9386,9 +9398,9 @@ msgstr "Kliknij prawym przyciskiem, aby przełączyć pierścień"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Uruchom"
 
@@ -10648,7 +10660,7 @@ msgstr "Zatrzymaj przekierowywanie"
 msgid "Stop response"
 msgstr "Zatrzymaj odpowiedź"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Zatrzymaj synchronizację"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Przełącz obszar roboczy"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Synchronizuj"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# desktop pareado} other {# desktops pareados}}"
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# projeto} other {# projetos}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Todos os arquivos"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Todos os projetos"
 
@@ -1157,7 +1160,7 @@ msgstr "Todos os projetos"
 msgid "All sources"
 msgstr "Todas as fontes"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Todos os espaços de trabalho"
@@ -3811,7 +3814,7 @@ msgstr "Desativar uso do computador"
 msgid "Disable Crossagents"
 msgstr "Desativar Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Desativar projeto"
 
@@ -4137,7 +4140,7 @@ msgstr "Ative o acesso ao microfone nas configurações do sistema e tente novam
 msgid "Enable notifications"
 msgstr "Habilitar notificações"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Habilitar Projeto"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Preencha todas as entradas obrigatórias do workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Filtrar por projeto"
 
@@ -4975,9 +4979,9 @@ msgstr "Obter tarefa"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Status do Git para {0}: não é um repositório Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Mover navegador para uma janela"
 msgid "Move changes to a new worktree"
 msgstr "Mover alterações para uma nova árvore de trabalho"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover para espaço de trabalho"
 
@@ -8347,6 +8352,11 @@ msgstr "Perfis"
 msgid "Project"
 msgstr "Projeto"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Ações do projeto para {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Pasta do projeto"
@@ -8372,7 +8382,7 @@ msgstr "Projeto não encontrado."
 msgid "Project notes"
 msgstr "Notas do projeto"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Configurações do projeto"
 
@@ -8393,6 +8403,7 @@ msgstr "Substituições específicas do projeto nas configurações de pesquisa 
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Remover a rota fixada para {tagLabel}"
 msgid "Remove project"
 msgstr "Remover projeto"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Remover projeto"
 
@@ -9322,7 +9333,8 @@ msgstr "Revisar as alterações do candidato {0} ({label})"
 msgid "Review changes"
 msgstr "Revisar mudanças"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Revisar alterações"
@@ -9386,9 +9398,9 @@ msgstr "Clique com o botão direito para trocar o anel"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Executar"
 
@@ -10648,7 +10660,7 @@ msgstr "Parar encaminhamento"
 msgid "Stop response"
 msgstr "Parar resposta"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Parar de sincronizar"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Trocar de espaço de trabalho"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Sincronizar"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# связанный десктоп} few {# связа�
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# проект} few {# проекта} many {# проектов} other {# проекта}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Все файлы"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Все проекты"
 
@@ -1157,7 +1160,7 @@ msgstr "Все проекты"
 msgid "All sources"
 msgstr "Все источники"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Все рабочие области"
@@ -3811,7 +3814,7 @@ msgstr "Отключить управление компьютером"
 msgid "Disable Crossagents"
 msgstr "Отключить Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Отключить проект"
 
@@ -4137,7 +4140,7 @@ msgstr "Включите доступ к микрофону в настройк�
 msgid "Enable notifications"
 msgstr "Включить уведомления"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Включить проект"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Заполните все обязательные параметры workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Фильтр по проекту"
 
@@ -4975,9 +4979,9 @@ msgstr "Получить задачу"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Состояние Git для {0}: не репозиторий Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Переместить браузер в окно"
 msgid "Move changes to a new worktree"
 msgstr "Переместить изменения в новый worktree"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Переместить в рабочую область"
 
@@ -8347,6 +8352,11 @@ msgstr "Профили"
 msgid "Project"
 msgstr "Проект"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Действия проекта для {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Папка проекта"
@@ -8372,7 +8382,7 @@ msgstr "Проект не найден."
 msgid "Project notes"
 msgstr "Заметки проекта"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Настройки проекта"
 
@@ -8393,6 +8403,7 @@ msgstr "Переопределения для конкретного проек�
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Удалить закреплённый маршрут для {tagLabel}
 msgid "Remove project"
 msgstr "Удалить проект"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Удалить проект"
 
@@ -9322,7 +9333,8 @@ msgstr "Просмотреть изменения кандидата {0} ({label
 msgid "Review changes"
 msgstr "Просмотреть изменения"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Просмотреть изменения"
@@ -9386,9 +9398,9 @@ msgstr "Щелкните правой кнопкой, чтобы переклю�
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Запустить"
 
@@ -10648,7 +10660,7 @@ msgstr "Остановить перенаправление"
 msgid "Stop response"
 msgstr "Остановить ответ"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Остановить синхронизацию"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Сменить рабочую область"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Синхронизировать"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# eşleştirilmiş masaüstü} other {# eşleştirilmi�
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# proje} other {# proje}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Tüm dosyalar"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Tüm projeler"
 
@@ -1157,7 +1160,7 @@ msgstr "Tüm projeler"
 msgid "All sources"
 msgstr "Tüm kaynaklar"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Tüm çalışma alanları"
@@ -3811,7 +3814,7 @@ msgstr "Bilgisayar Kullanımını Devre Dışı Bırak"
 msgid "Disable Crossagents"
 msgstr "Crossagents'i devre dışı bırak"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Projeyi Devre Dışı Bırak"
 
@@ -4137,7 +4140,7 @@ msgstr "Sistem ayarlarınızdan mikrofon erişimini etkinleştirin ve tekrar den
 msgid "Enable notifications"
 msgstr "Bildirimleri etkinleştir"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Projeyi Etkinleştir"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Tüm gerekli workflow girdilerini doldurun."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Projeye göre filtrele"
 
@@ -4975,9 +4979,9 @@ msgstr "Görev al"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0} için Git durumu: Git deposu değil"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Tarayıcıyı pencereye taşı"
 msgid "Move changes to a new worktree"
 msgstr "Değişiklikleri yeni bir çalışma ağacına taşı"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Çalışma alanına taşı"
 
@@ -8347,6 +8352,11 @@ msgstr "Profiller"
 msgid "Project"
 msgstr "Proje"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "{0} için proje eylemleri"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Proje klasörü"
@@ -8372,7 +8382,7 @@ msgstr "Proje bulunamadı."
 msgid "Project notes"
 msgstr "Proje notları"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Proje Ayarları"
 
@@ -8393,6 +8403,7 @@ msgstr "Genel arama ayarlarının yanı sıra projeye özel geçersiz kılmalar.
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "{tagLabel} için sabitlenmiş rotayı kaldır"
 msgid "Remove project"
 msgstr "Projeyi kaldır"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Projeyi Kaldır"
 
@@ -9322,7 +9333,8 @@ msgstr "Aday {0} ({label}) değişikliklerini incele"
 msgid "Review changes"
 msgstr "Değişiklikleri incele"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Değişiklikleri İncele"
@@ -9386,9 +9398,9 @@ msgstr "Halkayı değiştirmek için sağ tıklayın"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Çalıştır"
 
@@ -10648,7 +10660,7 @@ msgstr "Yönlendirmeyi durdur"
 msgid "Stop response"
 msgstr "Yanıtı durdur"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Senkronizasyonu durdur"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Çalışma alanını değiştir"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Senkronizasyon"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# підключений десктоп} few {# під�
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# проєкт} few {# проєкти} many {# проєктів} other {# проєкту}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Усі файли"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Усі проєкти"
 
@@ -1157,7 +1160,7 @@ msgstr "Усі проєкти"
 msgid "All sources"
 msgstr "Усі джерела"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Усі робочі області"
@@ -3811,7 +3814,7 @@ msgstr "Вимкнути керування комп'ютером"
 msgid "Disable Crossagents"
 msgstr "Вимкнути Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Вимкнути проект"
 
@@ -4137,7 +4140,7 @@ msgstr "Увімкніть доступ до мікрофона в налашт�
 msgid "Enable notifications"
 msgstr "Увімкнути сповіщення"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Увімкнути проєкт"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Заповніть усі обов’язкові параметри workflow."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Фільтр за проєктом"
 
@@ -4975,9 +4979,9 @@ msgstr "Отримати завдання"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Стан Git для {0}: не репозиторій Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Перемістити браузер у вікно"
 msgid "Move changes to a new worktree"
 msgstr "Перемістити зміни в новий worktree"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Перемістити до робочої області"
 
@@ -8347,6 +8352,11 @@ msgstr "Профілі"
 msgid "Project"
 msgstr "Проєкт"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Дії проєкта для {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Папка проєкту"
@@ -8372,7 +8382,7 @@ msgstr "Проєкт не знайдено."
 msgid "Project notes"
 msgstr "Нотатки проєкту"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Налаштування проєкту"
 
@@ -8393,6 +8403,7 @@ msgstr "Перевизначення для конкретного проєкт�
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Видалити закріплений маршрут для {tagLabel}
 msgid "Remove project"
 msgstr "Видалити проєкт"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Видалити проєкт"
 
@@ -9322,7 +9333,8 @@ msgstr "Переглянути зміни кандидата {0} ({label})"
 msgid "Review changes"
 msgstr "Переглянути зміни"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Переглянути зміни"
@@ -9386,9 +9398,9 @@ msgstr "Клацніть правою кнопкою, щоб перемкнут�
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Запустити"
 
@@ -10648,7 +10660,7 @@ msgstr "Зупинити переспрямування"
 msgid "Stop response"
 msgstr "Зупинити відповідь"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Припинити синхронізацію"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Змінити робочу область"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Синхронізувати"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# desktop đã ghép đôi} other {# desktop đã ghép
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# dự án} other {# dự án}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "Tất cả các tập tin"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "Tất cả dự án"
 
@@ -1157,7 +1160,7 @@ msgstr "Tất cả dự án"
 msgid "All sources"
 msgstr "Tất cả nguồn"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "Tất cả không gian làm việc"
@@ -3811,7 +3814,7 @@ msgstr "Tắt sử dụng máy tính"
 msgid "Disable Crossagents"
 msgstr "Tắt Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "Vô hiệu hóa dự án"
 
@@ -4137,7 +4140,7 @@ msgstr "Bật quyền truy cập micrô trong cài đặt hệ thống của b�
 msgid "Enable notifications"
 msgstr "Bật thông báo"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "Kích hoạt dự án"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "Điền tất cả đầu vào workflow bắt buộc."
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "Lọc theo dự án"
 
@@ -4975,9 +4979,9 @@ msgstr "Nhận nhiệm vụ"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Trạng thái Git cho {0}: không phải kho lưu trữ Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6603,7 +6608,7 @@ msgstr "Chuyển trình duyệt sang cửa sổ"
 msgid "Move changes to a new worktree"
 msgstr "Di chuyển các thay đổi sang một cây làm việc mới"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Chuyển tới không gian làm việc"
 
@@ -8347,6 +8352,11 @@ msgstr "Hồ sơ"
 msgid "Project"
 msgstr "dự án"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "Hành động dự án cho {0}"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "Thư mục dự án"
@@ -8372,7 +8382,7 @@ msgstr "Không tìm thấy dự án."
 msgid "Project notes"
 msgstr "ghi chú dự án"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "Cài đặt dự án"
 
@@ -8393,6 +8403,7 @@ msgstr "Ghi đè dành riêng cho dự án ở đầu cài đặt tìm kiếm ch
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8981,7 +8992,7 @@ msgstr "Xóa tuyến đã ghim cho {tagLabel}"
 msgid "Remove project"
 msgstr "Xóa dự án"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "Xóa dự án"
 
@@ -9322,7 +9333,8 @@ msgstr "Xem lại các thay đổi của ứng viên {0} ({label})"
 msgid "Review changes"
 msgstr "Xem xét thay đổi"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "Xem lại các thay đổi"
@@ -9386,9 +9398,9 @@ msgstr "Nhấp chuột phải để đổi vòng"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "Chạy"
 
@@ -10648,7 +10660,7 @@ msgstr "Dừng chuyển tiếp"
 msgid "Stop response"
 msgstr "Dừng phản hồi"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "Ngừng đồng bộ hóa"
 
@@ -10834,7 +10846,8 @@ msgid "Switch workspace"
 msgstr "Chuyển không gian làm việc"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "Đồng bộ hóa"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -82,7 +82,9 @@ msgstr "{0, plural, one {# 个已配对桌面} other {# 个已配对桌面}}"
 
 #. placeholder {0}: projectCounts.get(workspace.id) ?? 0
 #. placeholder {0}: props.projects.length
+#. placeholder {0}: selectedProjects.size
 #: src/mobile/views/ManageProjectsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "{0, plural, one {# project} other {# projects}}"
 msgstr "{0, plural, one {# 个项目} other {# 个项目}}"
@@ -1150,6 +1152,7 @@ msgid "All files"
 msgstr "所有文件"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "All projects"
 msgstr "所有项目"
 
@@ -1157,7 +1160,7 @@ msgstr "所有项目"
 msgid "All sources"
 msgstr "所有来源"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "All workspaces"
 msgstr "所有工作区"
@@ -3811,7 +3814,7 @@ msgstr "禁用计算机操作"
 msgid "Disable Crossagents"
 msgstr "禁用 Crossagents"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Disable Project"
 msgstr "禁用项目"
 
@@ -4137,7 +4140,7 @@ msgstr "在系统设置中启用麦克风访问，然后重试。"
 msgid "Enable notifications"
 msgstr "启用通知"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Enable Project"
 msgstr "启用项目"
 
@@ -4642,6 +4645,7 @@ msgid "Fill in all required workflow inputs."
 msgstr "请填写所有必需的工作流输入。"
 
 #: src/mobile/views/ThreadsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 msgid "Filter by project"
 msgstr "按项目筛选"
 
@@ -4975,9 +4979,9 @@ msgstr "获取任务"
 #: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/SettingsOverlay/parts/GitSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Git"
@@ -5011,7 +5015,8 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}的 Git 状态：不是 Git 存储库"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
@@ -6602,7 +6607,7 @@ msgstr "将浏览器移到窗口"
 msgid "Move changes to a new worktree"
 msgstr "将更改移至新工作树"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "移动到工作区"
 
@@ -8346,6 +8351,11 @@ msgstr "配置文件"
 msgid "Project"
 msgstr "项目"
 
+#. placeholder {0}: props.project.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+msgid "Project actions for {0}"
+msgstr "{0}的项目操作"
+
 #: src/renderer/views/ProjectSettingsOverlay/parts/GeneralSection.tsx
 msgid "Project folder"
 msgstr "项目文件夹"
@@ -8371,7 +8381,7 @@ msgstr "未找到项目。"
 msgid "Project notes"
 msgstr "项目笔记"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Project Settings"
 msgstr "项目设置"
 
@@ -8392,6 +8402,7 @@ msgstr "在全局搜索设置基础上的项目特定覆盖。"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx
 msgid "Projects"
@@ -8980,7 +8991,7 @@ msgstr "移除 {tagLabel} 的固定路由"
 msgid "Remove project"
 msgstr "移除项目"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Remove Project"
 msgstr "删除项目"
 
@@ -9321,7 +9332,8 @@ msgstr "查看候选 {0}（{label}）的更改"
 msgid "Review changes"
 msgstr "查看更改"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Review Changes"
 msgstr "审查变更"
@@ -9385,9 +9397,9 @@ msgstr "右键点击以切换环"
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 #: src/renderer/views/GitHubActionsView/GitHubActionsDispatchPopover.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Run"
 msgstr "运行"
 
@@ -10647,7 +10659,7 @@ msgstr "停止转发"
 msgid "Stop response"
 msgstr "停止响应"
 
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Stop syncing"
 msgstr "停止同步"
 
@@ -10833,7 +10845,8 @@ msgid "Switch workspace"
 msgstr "切换工作区"
 
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
-#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 msgid "Sync"
 msgstr "同步"

--- a/src/renderer/state/sidebarUiStore.test.ts
+++ b/src/renderer/state/sidebarUiStore.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSidebarUiStore } from "./sidebarUiStore";
+
+type State = ReturnType<typeof useSidebarUiStore.getState>;
+
+beforeEach(() => {
+  useSidebarUiStore.setState({
+    collapsedProjects: {},
+    pinnedGitHubWorkflows: {},
+    collapsedWorktrees: {},
+    threadListLimits: {},
+    flatListProjectFilter: null,
+    editingThreadId: null,
+  });
+});
+
+describe("sidebarUiStore persistence", () => {
+  it("keeps version 1 for the additive flatListProjectFilter field", () => {
+    expect(useSidebarUiStore.persist.getOptions().version).toBe(1);
+  });
+
+  it("persists flatListProjectFilter via partialize", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["a", "b"] });
+    const partialize =
+      useSidebarUiStore.persist.getOptions().partialize ?? ((state: State) => state);
+    const partialized = partialize(useSidebarUiStore.getState());
+    expect(partialized).toHaveProperty("flatListProjectFilter", ["a", "b"]);
+  });
+
+  it("rehydrates a v1 payload without flatListProjectFilter to the default null", () => {
+    // Simulates an upgrade: the persisted JSON was written by an older build
+    // that didn't know about flatListProjectFilter. The default merge
+    // ({ ...currentState, ...persistedState }) keeps the initial null for the
+    // absent key, so the filter rehydrates to "all projects".
+    const merge =
+      useSidebarUiStore.persist.getOptions().merge ??
+      ((persisted: unknown, current: State) => ({ ...current, ...(persisted as object) }));
+    const current = useSidebarUiStore.getState();
+    const oldPayload = {
+      collapsedProjects: { p1: true },
+      pinnedGitHubWorkflows: { p2: [1] },
+    };
+    const merged = merge(oldPayload, current) as State;
+
+    expect(merged.flatListProjectFilter).toBeNull();
+    expect(merged.collapsedProjects).toEqual({ p1: true });
+    expect(merged.pinnedGitHubWorkflows).toEqual({ p2: [1] });
+  });
+
+  it("rehydrates a v1 payload with flatListProjectFilter to the stored value", () => {
+    const merge =
+      useSidebarUiStore.persist.getOptions().merge ??
+      ((persisted: unknown, current: State) => ({ ...current, ...(persisted as object) }));
+    const current = useSidebarUiStore.getState();
+    const newPayload = {
+      collapsedProjects: {},
+      pinnedGitHubWorkflows: {},
+      flatListProjectFilter: ["a", "b"],
+    };
+    const merged = merge(newPayload, current) as State;
+
+    expect(merged.flatListProjectFilter).toEqual(["a", "b"]);
+  });
+});
+
+describe("setFlatListProjectFilter", () => {
+  it("normalizes an empty array to null", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["a"] });
+    useSidebarUiStore.getState().setFlatListProjectFilter([]);
+    expect(useSidebarUiStore.getState().flatListProjectFilter).toBeNull();
+  });
+
+  it("normalizes null to null", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["a"] });
+    useSidebarUiStore.getState().setFlatListProjectFilter(null);
+    expect(useSidebarUiStore.getState().flatListProjectFilter).toBeNull();
+  });
+
+  it("deduplicates project ids", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: null });
+    useSidebarUiStore.getState().setFlatListProjectFilter(["a", "a", "b", "b"]);
+    expect(useSidebarUiStore.getState().flatListProjectFilter).toEqual(["a", "b"]);
+  });
+
+  it("skips the update when the new value equals the current", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["a", "b"] });
+    const before = useSidebarUiStore.getState().flatListProjectFilter;
+    useSidebarUiStore.getState().setFlatListProjectFilter(["a", "b"]);
+    expect(useSidebarUiStore.getState().flatListProjectFilter).toBe(before);
+  });
+});

--- a/src/renderer/state/sidebarUiStore.ts
+++ b/src/renderer/state/sidebarUiStore.ts
@@ -19,6 +19,14 @@ interface SidebarUiState {
   collapsedWorktrees: Record<string, boolean>;
   /** Per-project count of thread-list items revealed via "See more" (ephemeral). */
   threadListLimits: Record<string, number>;
+  /**
+   * Flat thread list's project filter: the project ids to show, or null for
+   * all projects. Persisted; additive to the v1 envelope — payloads written by
+   * older builds lack the key and rehydrate to the default (null = all, the
+   * pre-filter behavior), and older builds ignore the extra key, so the store
+   * version stays 1.
+   */
+  flatListProjectFilter: string[] | null;
   editingThreadId: string | null;
   setProjectCollapsed: (projectId: string, collapsed: boolean) => void;
   toggleProjectCollapsed: (projectId: string) => void;
@@ -26,6 +34,7 @@ interface SidebarUiState {
   setWorktreeCollapsed: (key: string, collapsed: boolean) => void;
   toggleWorktreeCollapsed: (key: string) => void;
   revealMoreThreads: (projectId: string) => void;
+  setFlatListProjectFilter: (projectIds: string[] | null) => void;
   setEditingThreadId: (id: string | null) => void;
 }
 
@@ -52,6 +61,7 @@ export const useSidebarUiStore = create<SidebarUiState>()(
       pinnedGitHubWorkflows: {},
       collapsedWorktrees: {},
       threadListLimits: {},
+      flatListProjectFilter: null,
       editingThreadId: null,
 
       setProjectCollapsed: (projectId, collapsed) =>
@@ -109,6 +119,24 @@ export const useSidebarUiStore = create<SidebarUiState>()(
             },
           };
         }),
+      setFlatListProjectFilter: (projectIds) =>
+        set((state) => {
+          // An empty selection reads the same as no filter — normalize to
+          // null; dedup so a stale or hand-edited payload can't double-count
+          // an id and trip the complete-selection collapse downstream.
+          const next = projectIds && projectIds.length > 0 ? [...new Set(projectIds)] : null;
+          const current = state.flatListProjectFilter;
+          if (current === next) return {};
+          if (
+            current !== null &&
+            next !== null &&
+            current.length === next.length &&
+            current.every((id, index) => id === next[index])
+          ) {
+            return {};
+          }
+          return { flatListProjectFilter: next };
+        }),
       setEditingThreadId: (editingThreadId) => set({ editingThreadId }),
     }),
     {
@@ -120,6 +148,7 @@ export const useSidebarUiStore = create<SidebarUiState>()(
       partialize: (state) => ({
         collapsedProjects: state.collapsedProjects,
         pinnedGitHubWorkflows: state.pinnedGitHubWorkflows,
+        flatListProjectFilter: state.flatListProjectFilter,
       }),
     },
   ),

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2321,6 +2321,36 @@ html[data-app-unfocused] .poracode-provider-icon--finished {
   display: none;
 }
 
+/* Clickaway layer for a context menu stacked over another overlay. HeroUI
+   popovers render at z-index 100000, so the backdrop joins that layer: it comes
+   later in the portal order than the surface below it, and the menu it belongs
+   to is portaled later still, so the paint order is surface → backdrop → menu. */
+.poracode-menu-backdrop {
+  z-index: 100000;
+}
+
+/* Flat-list head row (project filter + new-thread control): when the row is
+   too narrow for the labelled new-thread button, swap it for the icon-only
+   button whose tooltip carries the name. The selectors nest under the head
+   row so they outrank the buttons' Tailwind display utilities. */
+.poracode-flat-list-head {
+  container-type: inline-size;
+}
+
+.poracode-flat-list-head .poracode-flat-new-thread-icon {
+  display: none;
+}
+
+@container (max-width: 260px) {
+  .poracode-flat-list-head .poracode-flat-new-thread-full {
+    display: none;
+  }
+
+  .poracode-flat-list-head .poracode-flat-new-thread-icon {
+    display: flex;
+  }
+}
+
 .poracode-composer-shell:focus-within {
   border-color: color-mix(in oklab, var(--focus) 70%, transparent);
   outline: none !important;

--- a/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { NewThreadButton } from "./NewThreadButton";
+
+vi.mock("@dnd-kit/react", () => ({
+  useDraggable: () => ({}),
+}));
+
+function renderButton(overrides: Partial<Parameters<typeof NewThreadButton>[0]> = {}) {
+  const onPress = vi.fn<() => void>();
+  const onOpenAsPanel = vi.fn<() => void>();
+  render(
+    <NewThreadButton
+      projectId="p1"
+      hasDraft={false}
+      isActive={false}
+      isDraggingAnything={false}
+      canOpenAsPanel={true}
+      onPress={onPress}
+      onOpenAsPanel={onOpenAsPanel}
+      {...overrides}
+    />,
+  );
+  return { onPress, onOpenAsPanel };
+}
+
+describe("NewThreadButton", () => {
+  it("renders a single labelled row by default", () => {
+    renderButton();
+
+    expect(screen.getByRole("button", { name: "New thread" })).toBeInTheDocument();
+  });
+
+  it("renders both the labelled and the icon-only control when inline", () => {
+    renderButton({ inline: true });
+
+    // The head row's container query keeps exactly one of these visible;
+    // jsdom applies no stylesheet, so both sit in the accessibility tree.
+    expect(screen.getAllByRole("button", { name: "New thread" })).toHaveLength(2);
+  });
+
+  it("creates a thread from either inline control", () => {
+    const { onPress } = renderButton({ inline: true });
+
+    for (const button of screen.getAllByRole("button", { name: "New thread" })) {
+      fireEvent.click(button);
+    }
+
+    expect(onPress).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the Open as Panel context menu when inline", async () => {
+    const { onOpenAsPanel } = renderButton({ inline: true });
+
+    fireEvent.contextMenu(screen.getAllByRole("button", { name: "New thread" })[0]!);
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Open as Panel" }));
+
+    expect(onOpenAsPanel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -15,6 +15,14 @@ export function NewThreadButton(props: {
   canOpenAsPanel: boolean;
   onPress: () => void;
   onOpenAsPanel: () => void;
+  /**
+   * Docked into the flat list's head row next to the project filter instead
+   * of taking a full-width row. Renders both a labelled button and an
+   * icon-only button; the `.poracode-flat-list-head` container query keeps
+   * exactly one visible — label when the row is wide, icon (tooltip carries
+   * the name) when it is tight.
+   */
+  inline?: boolean;
 }) {
   const { t } = useLingui();
   const newThreadRef = useRef<HTMLDivElement>(null);
@@ -25,23 +33,54 @@ export function NewThreadButton(props: {
     element: newThreadRef,
   });
 
+  const contextMenuItems = [
+    {
+      id: "open-as-panel",
+      label: t({
+        message: "Open as Panel",
+        comment: "Context menu action: open the new thread in a side-by-side panel",
+      }),
+      icon: <Columns2 className="size-3.5" />,
+      isDisabled: !props.canOpenAsPanel,
+    },
+  ];
+  const handleContextMenuAction = (key: string) => {
+    if (key === "open-as-panel") props.onOpenAsPanel();
+  };
+
+  if (props.inline) {
+    const stateClass =
+      props.isActive && !props.isDraggingAnything
+        ? "bg-[var(--row-active)] text-foreground"
+        : `text-foreground/85 ${props.isDraggingAnything ? "" : "hover:bg-[var(--row-hover)] hover:text-foreground"}`;
+    return (
+      <ContextMenu items={contextMenuItems} onAction={handleContextMenuAction}>
+        <div ref={newThreadRef} className="flex shrink-0 items-center">
+          <button
+            type="button"
+            className={`poracode-flat-new-thread-full flex h-8 shrink-0 cursor-default items-center gap-1.5 rounded-3xl px-2 text-xs outline-none transition-colors focus-visible:focus-ring ${stateClass}`}
+            onClick={props.onPress}
+          >
+            <Plus className="size-3.5" />
+            <span className="whitespace-nowrap">{t`New thread`}</span>
+            {props.hasDraft ? <DraftIndicator /> : null}
+          </button>
+          <SidebarButton
+            iconOnly
+            className="poracode-flat-new-thread-icon"
+            icon={<Plus className="size-4" />}
+            label={t`New thread`}
+            isActive={props.isActive}
+            isDraggingAnything={props.isDraggingAnything}
+            onPress={props.onPress}
+          />
+        </div>
+      </ContextMenu>
+    );
+  }
+
   return (
-    <ContextMenu
-      items={[
-        {
-          id: "open-as-panel",
-          label: t({
-            message: "Open as Panel",
-            comment: "Context menu action: open the new thread in a side-by-side panel",
-          }),
-          icon: <Columns2 className="size-3.5" />,
-          isDisabled: !props.canOpenAsPanel,
-        },
-      ]}
-      onAction={(key) => {
-        if (key === "open-as-panel") props.onOpenAsPanel();
-      }}
-    >
+    <ContextMenu items={contextMenuItems} onAction={handleContextMenuAction}>
       <SidebarButton
         size="xs"
         liveText

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
@@ -6,6 +6,7 @@ import { HOME_PROJECT_ID, HOME_PROJECT_NAME } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { useWorkspaceStore } from "@/renderer/state/workspaceStore";
 import { SidebarFlatThreadList } from "./SidebarFlatThreadList";
 
@@ -17,10 +18,16 @@ vi.mock("@/renderer/dnd", () => ({
   useDragSource: () => null,
 }));
 
+// Records every render so tests can assert where the button was docked.
+const newThreadCalls = vi.hoisted(
+  () => [] as Array<{ projectId: string; inline: boolean | undefined }>,
+);
+
 vi.mock("./NewThreadButton", () => ({
-  NewThreadButton: (props: { projectId: string }) => (
-    <button type="button">new-thread:{props.projectId}</button>
-  ),
+  NewThreadButton: (props: { projectId: string; inline?: boolean }) => {
+    newThreadCalls.push({ projectId: props.projectId, inline: props.inline });
+    return <button type="button">new-thread:{props.projectId}</button>;
+  },
 }));
 
 vi.mock("./SidebarThreadRow", () => ({
@@ -33,6 +40,16 @@ vi.mock("./SidebarThreadRow", () => ({
     <div data-testid="row">
       {props.row.key} in {props.project.name}
       {props.projectTag}
+    </div>
+  ),
+}));
+
+// Filter interaction is covered by SidebarProjectFilter.test.tsx; here a stub
+// exposes the effective (normalized) filter the list passes down.
+vi.mock("./SidebarProjectFilter", () => ({
+  SidebarProjectFilter: (props: { value: ReadonlySet<string> | null }) => (
+    <div data-testid="project-filter">
+      {props.value === null ? "all" : [...props.value].join(",")}
     </div>
   ),
 }));
@@ -70,6 +87,14 @@ const localProject: Project = {
   workspaceId: "w1",
 } as Project;
 
+const secondLocalProject: Project = {
+  id: "local-2",
+  name: "Side Project",
+  location: { kind: "windows", path: "C:\\side" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  workspaceId: "w1",
+} as Project;
+
 const unreachableRemoteProject: Project = {
   id: "remote-1",
   name: "Mac Poracode",
@@ -88,6 +113,8 @@ describe("SidebarFlatThreadList", () => {
       workspaces: [{ id: "w1", name: "Side Hustle" }],
     } as never);
     useWorkspaceStore.setState({ activeWorkspaceId: "w1" });
+    useSidebarUiStore.setState({ flatListProjectFilter: null });
+    newThreadCalls.length = 0;
   });
 
   it("shows Home threads alongside project threads with the new-thread row", () => {
@@ -165,5 +192,138 @@ describe("SidebarFlatThreadList", () => {
     expect(screen.queryByText(/thread:h1/)).not.toBeInTheDocument();
     expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
     expect(screen.getByText("new-thread:local-1")).toBeInTheDocument();
+  });
+
+  it("filters threads to the selected projects and targets new threads there", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["local-1"] });
+    useAppStore.setState({
+      projects: [homeProject, localProject, secondLocalProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-03T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+        makeThread("s1", "local-2", "2026-08-02T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("local-1");
+    expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
+    expect(screen.queryByText(/thread:h1/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/thread:s1/)).not.toBeInTheDocument();
+    // The most recently updated thread overall is h1 (Home), but the filtered
+    // list must not offer creating a thread in a hidden project.
+    expect(screen.getByText("new-thread:local-1")).toBeInTheDocument();
+  });
+
+  it("treats a persisted selection covering every visible project as no filter", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: [HOME_PROJECT_ID, "local-1"] });
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("all");
+    expect(screen.getByText(/thread:h1/)).toBeInTheDocument();
+    expect(screen.getByText(/thread:p1/)).toBeInTheDocument();
+  });
+
+  it("ignores stale project ids in the persisted filter", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["deleted-project"] });
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("all");
+    expect(screen.getByText(/thread:h1/)).toBeInTheDocument();
+    expect(screen.getByText(/thread:p1/)).toBeInTheDocument();
+  });
+
+  it("falls back to the first filtered project for new threads when the filter has none", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: ["local-1"] });
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z")],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.queryByText(/thread:h1/)).not.toBeInTheDocument();
+    expect(screen.getByText("new-thread:local-1")).toBeInTheDocument();
+  });
+
+  it("omits the project filter when only one project is visible", () => {
+    useSharedSettings.setState({ homeScopeEnabled: false } as never);
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z")],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.queryByTestId("project-filter")).not.toBeInTheDocument();
+    expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
+  });
+
+  it("docks the new-thread control into the filter head row when several projects are visible", () => {
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z")],
+    });
+
+    const { container } = render(<SidebarFlatThreadList sortMode="updated" />);
+
+    const head = container.querySelector(".poracode-flat-list-head");
+    expect(head).not.toBeNull();
+    expect(head).toHaveTextContent("new-thread:local-1");
+    expect(head?.querySelector('[data-testid="project-filter"]')).not.toBeNull();
+    expect(newThreadCalls.at(-1)).toEqual({ projectId: "local-1", inline: true });
+  });
+
+  it("keeps the new-thread control as a full row when only one project is visible", () => {
+    useSharedSettings.setState({ homeScopeEnabled: false } as never);
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z")],
+    });
+
+    const { container } = render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(container.querySelector(".poracode-flat-list-head")).toBeNull();
+    expect(newThreadCalls.at(-1)).toEqual({ projectId: "local-1", inline: undefined });
+  });
+
+  it("drops Home from the active filter when home scope is disabled, keeping the rest", () => {
+    useSidebarUiStore.setState({ flatListProjectFilter: [HOME_PROJECT_ID, "local-1"] });
+    useSharedSettings.setState({ homeScopeEnabled: false } as never);
+    useAppStore.setState({
+      projects: [homeProject, localProject, secondLocalProject],
+      threads: [
+        makeThread("h1", HOME_PROJECT_ID, "2026-08-02T10:00:00.000Z"),
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+        makeThread("s1", "local-2", "2026-08-03T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    // Home is invisible (homeScope off), so the stale Home id is dropped from
+    // the filter — but with local-2 still visible the selection stays active
+    // rather than collapsing to "all".
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("local-1");
+    expect(screen.getByText(/thread:p1/)).toBeInTheDocument();
+    expect(screen.queryByText(/thread:h1/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/thread:s1/)).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -16,6 +16,7 @@ import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarUiStore";
 import { useWorkspaceProjectIds } from "@/renderer/state/workspaceSelectors";
 import { NewThreadButton } from "./NewThreadButton";
+import { SidebarProjectFilter } from "./SidebarProjectFilter";
 import { buildSidebarProjectRows, type SidebarRow } from "./sidebarProjectRows";
 import type { ThreadSortMode } from "./sortMode";
 import { SeeMoreThreadsButton, SidebarThreadRow } from "./SidebarThreadRow";
@@ -52,6 +53,8 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
   const editingThreadId = useSidebarUiStore((s) => s.editingThreadId);
   const setEditingThreadId = useSidebarUiStore((s) => s.setEditingThreadId);
   const revealMoreThreads = useSidebarUiStore((s) => s.revealMoreThreads);
+  const flatListProjectFilter = useSidebarUiStore((s) => s.flatListProjectFilter);
+  const setFlatListProjectFilter = useSidebarUiStore((s) => s.setFlatListProjectFilter);
   const visibleLimit = useThreadListLimit(FLAT_LIST_SCOPE);
   const currentThreadCount = useCurrentThreadIdsCount();
   const source = useDragSource();
@@ -75,14 +78,33 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
   });
   const projectsById = new Map(visibleProjects.map((project) => [project.id, project]));
 
+  // The persisted filter can name projects that are gone or currently hidden
+  // (workspace switch, home scope off, dead remote server); only ids
+  // intersecting the visible set can match, and a selection covering every
+  // visible project reads — and behaves — the same as no filter.
+  const filteredVisibleIds = flatListProjectFilter?.filter((id) => projectsById.has(id)) ?? [];
+  const activeProjectFilter: ReadonlySet<string> | null =
+    filteredVisibleIds.length === 0 || filteredVisibleIds.length >= visibleProjects.length
+      ? null
+      : new Set(filteredVisibleIds);
+
   const allThreads = useAppStore((s) => s.threads);
-  const threads = allThreads.filter(
+  const visibleThreads = allThreads.filter(
     (thread) => !thread.archived && projectsById.has(thread.projectId),
   );
+  const threadCounts = new Map<string, number>();
+  for (const thread of visibleThreads) {
+    threadCounts.set(thread.projectId, (threadCounts.get(thread.projectId) ?? 0) + 1);
+  }
+  const threads =
+    activeProjectFilter === null
+      ? visibleThreads
+      : visibleThreads.filter((thread) => activeProjectFilter.has(thread.projectId));
   const liveBackgroundThreadIds = useLiveBackgroundThreadIds(threads);
 
   // "New thread" targets the most recently active project (latest thread
-  // update), falling back to the first visible project on a fresh workspace.
+  // update), falling back to the first project in the filter — or the first
+  // visible project when unfiltered — on a fresh workspace.
   let latestProjectId: string | undefined;
   let latestUpdatedAt = "";
   for (const thread of threads) {
@@ -91,7 +113,9 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
       latestProjectId = thread.projectId;
     }
   }
-  latestProjectId ??= visibleProjects[0]?.id;
+  latestProjectId ??= activeProjectFilter
+    ? visibleProjects.find((project) => activeProjectFilter.has(project.id))?.id
+    : visibleProjects[0]?.id;
   const hasDraft = useHasDraft(latestProjectId ?? "");
   const isDraftActive = useIsCurrentProjectDraft(latestProjectId ?? "");
 
@@ -105,19 +129,39 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
     ...(experimentCandidateOrder.size > 0 ? { experimentCandidateOrder } : {}),
   });
 
+  const renderNewThreadButton = (inline: boolean) =>
+    latestProjectId ? (
+      <NewThreadButton
+        {...(inline ? { inline: true } : {})}
+        projectId={latestProjectId}
+        hasDraft={hasDraft}
+        isActive={isDraftActive}
+        isDraggingAnything={!!source}
+        canOpenAsPanel={currentThreadCount > 0 && currentThreadCount < 3}
+        onPress={() => openNewThread(latestProjectId)}
+        onOpenAsPanel={() => openNewThreadSideBySide(latestProjectId)}
+      />
+    ) : null;
+
   return (
     <div className="space-y-0.5">
-      {latestProjectId ? (
-        <NewThreadButton
-          projectId={latestProjectId}
-          hasDraft={hasDraft}
-          isActive={isDraftActive}
-          isDraggingAnything={!!source}
-          canOpenAsPanel={currentThreadCount > 0 && currentThreadCount < 3}
-          onPress={() => openNewThread(latestProjectId)}
-          onOpenAsPanel={() => openNewThreadSideBySide(latestProjectId)}
-        />
-      ) : null}
+      {visibleProjects.length > 1 ? (
+        // Filter and new-thread share one head row; the new-thread control
+        // collapses to an icon button (tooltip) when the row is narrow.
+        <div className="poracode-flat-list-head flex items-center gap-1">
+          <div className="min-w-0 flex-1">
+            <SidebarProjectFilter
+              projects={visibleProjects}
+              threadCounts={threadCounts}
+              value={activeProjectFilter}
+              onChange={setFlatListProjectFilter}
+            />
+          </div>
+          {renderNewThreadButton(true)}
+        </div>
+      ) : (
+        renderNewThreadButton(false)
+      )}
 
       <div>
         {rows.map((row) => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
@@ -1,0 +1,306 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project } from "@/shared/contracts";
+import { HOME_PROJECT_ID } from "@/shared/homeScope";
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { SidebarProjectFilter } from "./SidebarProjectFilter";
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({}),
+  isRemoteSession: () => false,
+}));
+
+function project(id: string, name: string): Project {
+  return {
+    id,
+    name,
+    location: { kind: "windows", path: `C:\\${id}` },
+    createdAt: "2026-07-01T00:00:00.000Z",
+  } as Project;
+}
+
+const projects = [project("a", "Alpha"), project("b", "Beta"), project("c", "Gamma")];
+const homeProject = project(HOME_PROJECT_ID, "Home");
+const threadCounts = new Map([
+  ["a", 2],
+  ["b", 1],
+  ["c", 0],
+]);
+
+function renderFilter(
+  value: ReadonlySet<string> | null,
+  onChange = vi.fn<(next: string[] | null) => void>(),
+  list: readonly Project[] = projects,
+) {
+  render(
+    <SidebarProjectFilter
+      projects={list}
+      threadCounts={threadCounts}
+      value={value}
+      onChange={onChange}
+    />,
+  );
+  return onChange;
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "Filter by project" }));
+  return screen.findByRole("menu");
+}
+
+describe("SidebarProjectFilter", () => {
+  it("labels the trigger with the current selection", () => {
+    renderFilter(null);
+    expect(screen.getByRole("button", { name: "Filter by project" })).toHaveTextContent(
+      "All projects",
+    );
+  });
+
+  it("labels the trigger with the project name when one project is selected", () => {
+    renderFilter(new Set(["b"]));
+    expect(screen.getByRole("button", { name: "Filter by project" })).toHaveTextContent("Beta");
+  });
+
+  it("labels the trigger with the count when several projects are selected", () => {
+    renderFilter(new Set(["a", "c"]));
+    expect(screen.getByRole("button", { name: "Filter by project" })).toHaveTextContent(
+      "2 projects",
+    );
+  });
+
+  it("unchecking a project in the all state filters to the remaining projects", async () => {
+    const onChange = renderFilter(null);
+    await openMenu();
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Beta/ }));
+
+    expect(onChange).toHaveBeenCalledWith(["a", "c"]);
+  });
+
+  it("toggling a project adds it to an active filter", async () => {
+    const onChange = renderFilter(new Set(["a"]));
+    await openMenu();
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Gamma/ }));
+
+    expect(onChange).toHaveBeenCalledWith(["a", "c"]);
+  });
+
+  it("resetting via All projects clears the filter", async () => {
+    const onChange = renderFilter(new Set(["a"]));
+    await openMenu();
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: "All projects" }));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("deselecting the last selected project collapses back to all projects", async () => {
+    const onChange = renderFilter(new Set(["b"]));
+    await openMenu();
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Beta/ }));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("selecting every project individually collapses back to all projects", async () => {
+    const onChange = renderFilter(new Set(["a", "b"]));
+    await openMenu();
+
+    fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Gamma/ }));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("closes when the trigger is pressed again", async () => {
+    renderFilter(null);
+    await openMenu();
+
+    // The popover is non-modal, so it renders no underlay to swallow this press
+    // and React Aria's trigger would only ever re-open the menu.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Filter by project" }));
+
+    expect(screen.queryByRole("menuitemcheckbox")).not.toBeInTheDocument();
+  });
+
+  it("shows per-project thread counts in the menu", async () => {
+    renderFilter(null);
+    await openMenu();
+
+    expect(screen.getByRole("menuitemcheckbox", { name: /Alpha/ })).toHaveTextContent("2");
+    expect(screen.getByRole("menuitemcheckbox", { name: /Gamma/ })).toHaveTextContent("0");
+  });
+
+  describe("project overflow menu", () => {
+    beforeEach(() => {
+      usePanelStore.setState({ settingsOpen: false, projectSettingsId: null });
+      useAppStore.setState({ projects: [...projects], threads: [] });
+    });
+
+    it("stacks the project context menu on top of the open filter menu", async () => {
+      const onChange = renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+
+      // The overflow menu opens while the filter menu stays open beneath it.
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Disable Project" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Remove Project" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitemcheckbox", { name: "All projects" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("closes both menus once an action is picked", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Project Settings" }));
+
+      // The project settings overlay is keyed off projectSettingsId alone.
+      expect(usePanelStore.getState().projectSettingsId).toBe("b");
+      expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+      expect(screen.queryByRole("menuitemcheckbox")).not.toBeInTheDocument();
+    });
+
+    it("dismisses the overflow menu when a filter checkbox is toggled", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("menuitemcheckbox", { name: /Alpha/ }));
+
+      expect(screen.queryByRole("menuitem", { name: "Project Settings" })).not.toBeInTheDocument();
+      // The filter menu itself stays open — selection changes never close it.
+      expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
+    });
+
+    it("does not blur-close the overflow menu when hover moves focus into the filter menu", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      const projectSettings = await screen.findByRole("menuitem", { name: "Project Settings" });
+
+      // React Aria menu items take DOM focus on hover, and RAC popovers close
+      // on blur by default — without the interact-outside guard, wandering
+      // back over the filter menu dismisses the project menu. (jsdom: real
+      // .focus() so React Aria's focus-within tracking engages before blur.)
+      projectSettings.focus();
+      fireEvent.blur(projectSettings, {
+        relatedTarget: screen.getByRole("menuitemcheckbox", { name: /Alpha/ }),
+      });
+
+      expect(screen.getByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+    });
+
+    it("blur-closes the overflow menu when focus leaves all menus", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      const projectSettings = await screen.findByRole("menuitem", { name: "Project Settings" });
+
+      projectSettings.focus();
+      fireEvent.blur(projectSettings, {
+        // The open filter is modal, so aria-hidden covers the trigger behind it.
+        relatedTarget: screen.getByRole("button", { name: "Filter by project", hidden: true }),
+      });
+
+      expect(screen.queryByRole("menuitem", { name: "Project Settings" })).not.toBeInTheDocument();
+    });
+
+    it("dismisses both menus on a press outside them", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+      fireEvent.pointerDown(document.body, { button: 0, pointerType: "mouse" });
+      fireEvent.mouseUp(document.body);
+      await vi.waitFor(() => {
+        expect(screen.queryByRole("menuitemcheckbox")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByRole("menuitem", { name: "Project Settings" })).not.toBeInTheDocument();
+    });
+
+    it("swallows the overflow press so the row neither toggles nor takes focus", async () => {
+      const onChange = renderFilter(null);
+      await openMenu();
+
+      const button = screen.getByRole("button", { name: "Project actions for Beta" });
+      // The press-down defaults are cancelled, which is what stops the row from
+      // taking DOM focus and rendering as focus-visible. React Aria menu items
+      // also select on press *up*, so the whole gesture is dispatched here; that
+      // half only shows up against real React Aria press handling, not in jsdom.
+      const pointerDown = new PointerEvent("pointerdown", { bubbles: true, cancelable: true });
+      const mouseDown = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+      button.dispatchEvent(pointerDown);
+      button.dispatchEvent(mouseDown);
+      fireEvent.pointerUp(button);
+      fireEvent.mouseUp(button);
+      fireEvent.click(button);
+
+      expect(pointerDown.defaultPrevented).toBe(true);
+      expect(mouseDown.defaultPrevented).toBe(true);
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+      expect(button).not.toHaveFocus();
+    });
+
+    it("dismisses through its backdrop without disturbing the filter", async () => {
+      const onChange = renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+
+      const backdrop = document.querySelector("[data-poracode-menu-backdrop]");
+      expect(backdrop).not.toBeNull();
+      fireEvent.pointerDown(backdrop!);
+
+      // Only the menu on top goes; the filter it stacked over stays open and
+      // unchanged, because the backdrop absorbed the press.
+      expect(screen.queryByRole("menuitem", { name: "Project Settings" })).not.toBeInTheDocument();
+      expect(document.querySelector("[data-poracode-menu-backdrop]")).toBeNull();
+      expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("peels the stack top-down on Escape, wherever focus sits", async () => {
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+
+      // A non-modal popover never takes focus on a mouse press, so Escape is
+      // handled at the window rather than by React Aria's popover.
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByRole("menuitem", { name: "Project Settings" })).not.toBeInTheDocument();
+      expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(screen.queryByRole("menuitemcheckbox")).not.toBeInTheDocument();
+    });
+
+    it("offers no overflow button for the Home project", async () => {
+      renderFilter(null, vi.fn<(next: string[] | null) => void>(), [homeProject, projects[0]!]);
+      await openMenu();
+
+      expect(screen.getByRole("button", { name: "Project actions for Alpha" })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Project actions for Home" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -1,0 +1,460 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { Selection } from "@heroui/react";
+import { Dropdown, Label, Separator } from "@heroui/react";
+import { Check, ChevronsUpDown, ListFilter, MoreHorizontal } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { plural } from "@lingui/core/macro";
+import type { Project } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
+import { ContextMenuSurface, MENU_BACKDROP_ATTR } from "@/renderer/components/common/ContextMenu";
+import {
+  ResponsiveMenuSurface,
+  useResponsiveMenu,
+} from "@/renderer/components/common/ResponsiveMenuSurface";
+import { sidebarRowClass } from "@/renderer/components/common/SidebarButton";
+import { handleKeyActivate } from "@/renderer/utils/a11y";
+import { useProjectMenu } from "./useProjectMenu";
+
+/**
+ * Menu id of the "All projects" reset row. Real project ids are generated and
+ * can't collide with this sentinel (mirrors `FLAT_LIST_SCOPE = "__flat__"`).
+ */
+const ALL_PROJECTS_KEY = "__all__";
+
+/**
+ * Interact-outside predicate shared by the two stacked overlays: neither may
+ * dismiss while the target stays inside any open menu. React Aria menu items
+ * take DOM focus on hover and RAC popovers close on blur (`shouldCloseOnBlur`
+ * is hardcoded in `usePopover`), so without this the pointer moving between the
+ * filter menu and the project menu on top of it collapses one of them. Same
+ * rule RAC applies to its own submenus. Real outside presses still dismiss.
+ */
+const closeOnlyOutsideMenus = (element: Element) => element.closest('[role="menu"]') === null;
+
+/** Marks the filter trigger so the dismissal paths below can ignore it. */
+const TRIGGER_ATTR = "data-poracode-project-filter-trigger";
+
+/**
+ * Dismiss the open filter on a press outside every menu overlay, and on Escape.
+ *
+ * The filter popover has to be `isNonModal` so the stacked project menu can own
+ * focus — a modal popover contains focus in its own scope, leaving the menu on
+ * top unreachable by hover and keyboard. Non-modal costs both dismissal paths
+ * React Aria would otherwise provide, so they are restored here (modelled on
+ * {@link BrowserTabGroupMenu}):
+ *
+ * - `usePopover` derives `isDismissable: !isNonModal`, so no outside-press
+ *   handling is attached at all.
+ * - Only a modal popover renders as a dialog and takes focus on open, so after a
+ *   mouse press focus stays on the trigger and the popover's own Escape handler
+ *   never sees the key. Escape is handled at the window instead, which also
+ *   makes it peel the stack top-down from wherever focus happens to sit.
+ *
+ * Presses on the trigger are skipped; it toggles through its own capture
+ * handlers below.
+ */
+function useFilterDismissal(args: {
+  isOpen: boolean;
+  /** Closes the stacked project menu only; null when none is open. */
+  closeStacked: (() => void) | null;
+  closeAll: () => void;
+}) {
+  const { isOpen, closeStacked, closeAll } = args;
+  useEffect(() => {
+    if (!isOpen) return;
+    const onDown = (event: Event) => {
+      const target = event.target as Element | null;
+      if (
+        target?.closest(
+          `[role="menu"], [role="menuitem"], [data-heroui-overlay], [${TRIGGER_ATTR}], [${MENU_BACKDROP_ATTR}]`,
+        )
+      ) {
+        // The stacked menu's backdrop included: that press dismisses only the
+        // menu on top, leaving this one open like a submenu would.
+        return;
+      }
+      closeAll();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (closeStacked) closeStacked();
+      else closeAll();
+    };
+    // Both press events: React Aria presses start on pointerdown where
+    // available, and fall back to mousedown otherwise.
+    window.addEventListener("pointerdown", onDown, true);
+    window.addEventListener("mousedown", onDown, true);
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("pointerdown", onDown, true);
+      window.removeEventListener("mousedown", onDown, true);
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [isOpen, closeStacked, closeAll]);
+}
+
+/**
+ * Trailing overflow button on a project row: reports where the project context
+ * menu should open. The press must not reach the enclosing multi-select menu
+ * item — that would toggle the filter instead — so the whole gesture stops here.
+ *
+ * Every step matters: React Aria menu items select on press *up*, so stopping
+ * only the press down still toggles the row. And the default focus has to be
+ * prevented too, since `useSelectableCollection` focuses the row whenever focus
+ * enters it, leaving the row outlined as focus-visible.
+ */
+function ProjectRowMenuButton(props: {
+  project: Project;
+  onOpenMenu: (anchor: { x: number; y: number }) => void;
+}) {
+  const { t } = useLingui();
+
+  const open = (element: HTMLElement) => {
+    const rect = element.getBoundingClientRect();
+    props.onOpenMenu({ x: rect.left, y: rect.bottom });
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={t`Project actions for ${props.project.name}`}
+      className="-mr-1 flex size-5 shrink-0 items-center justify-center rounded text-muted/60 hover:bg-[var(--row-hover)] hover:text-foreground"
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onPointerUp={(event) => event.stopPropagation()}
+      onMouseUp={(event) => event.stopPropagation()}
+      onClick={(event) => {
+        event.stopPropagation();
+        open(event.currentTarget);
+      }}
+      onKeyDown={(event) =>
+        handleKeyActivate(event, () => open(event.currentTarget), { stopPropagation: true })
+      }
+    >
+      <MoreHorizontal className="size-3.5" />
+    </div>
+  );
+}
+
+/**
+ * The full project context menu (the same entries the grouped sidebar's
+ * project header offers on right-click) anchored at a filter row's overflow
+ * button. The flat list has no project headers, so this is the only route to
+ * project settings/git/run/workspace actions.
+ *
+ * Rendered *inside* the filter's popover so React Aria treats it as a nested
+ * overlay: its focus scope registers as a child of the filter menu's, which is
+ * what lets it take focus (arrow keys and Escape address the top menu, not the
+ * one underneath). It also means the filter closing tears this menu down with
+ * it, which is the behaviour we want.
+ */
+function ProjectOverflowMenu(props: {
+  project: Project;
+  anchor: { x: number; y: number };
+  onClose: () => void;
+  /** Fired before dispatching a picked action, so the filter menu can close. */
+  onAction: () => void;
+}) {
+  // Flat-list projects are visible by construction: enabled, local or backed
+  // by an online server — nothing here is host-unreachable.
+  const projectMenu = useProjectMenu(props.project, { isUnreachable: false });
+  return (
+    <ContextMenuSurface
+      position={props.anchor}
+      items={projectMenu.items}
+      onAction={(key) => {
+        props.onAction();
+        projectMenu.onAction(key);
+      }}
+      onClose={props.onClose}
+      shouldCloseOnInteractOutside={closeOnlyOutsideMenus}
+      // Its own clickaway layer: a press anywhere but this menu dismisses it
+      // without reaching the filter menu underneath, so the first click after
+      // opening it never toggles a project by accident.
+      withBackdrop
+    />
+  );
+}
+
+/**
+ * Project filter for the flat thread list: a multi-select of which projects'
+ * threads to show, defaulting to all of them. Selecting every project — or
+ * deselecting the last selected one — collapses back to "All projects" (null),
+ * since a filter matching everything or nothing is meaningless.
+ *
+ * The trigger is a sidebar row labelled with the current selection; the menu
+ * is a desktop dropdown and a bottom sheet in the mobile PWA, mirroring
+ * {@link SidebarWorkspaceSwitcher}.
+ */
+export function SidebarProjectFilter(props: {
+  /** Projects offered in the menu (already visibility-filtered by the caller). */
+  projects: readonly Project[];
+  /** Unarchived thread counts per project id, shown as row hints. */
+  threadCounts: ReadonlyMap<string, number>;
+  /**
+   * Selected project ids, pre-intersected with `projects` by the caller;
+   * null = all projects.
+   */
+  value: ReadonlySet<string> | null;
+  onChange: (next: string[] | null) => void;
+}) {
+  const { t } = useLingui();
+  const { mobile } = useResponsiveMenu();
+  const [isOpen, setIsOpen] = useState(false);
+  // Which project the overflow menu is open for, and where.
+  const [overflowTarget, setOverflowTarget] = useState<{
+    project: Project;
+    anchor: { x: number; y: number };
+  } | null>(null);
+
+  const close = () => {
+    setIsOpen(false);
+    setOverflowTarget(null);
+  };
+  useFilterDismissal({
+    isOpen,
+    closeStacked: overflowTarget ? () => setOverflowTarget(null) : null,
+    closeAll: close,
+  });
+
+  // `useMenuTrigger` only ever *opens* on a mouse press: a modal dropdown closes
+  // on a second trigger click because its underlay swallows that press, and this
+  // popover is non-modal (see useDismissOnOutsidePress), so it renders none.
+  // Close here instead and swallow the whole gesture — both the press and the
+  // click React Aria falls back to — so it can't re-open behind us.
+  const swallowTriggerClick = useRef(false);
+  const onTriggerPointerDownCapture = (event: React.PointerEvent) => {
+    if (!isOpen) return;
+    event.preventDefault();
+    event.stopPropagation();
+    swallowTriggerClick.current = true;
+    close();
+  };
+  const onTriggerClickCapture = (event: React.MouseEvent) => {
+    if (!swallowTriggerClick.current) return;
+    swallowTriggerClick.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const visibleIds = props.projects.map((project) => project.id);
+  const isAll = props.value === null;
+  // In the all state every project reads as selected — unchecking one then
+  // filters it out, matching checkbox expectations.
+  const selectedProjects: ReadonlySet<string> = props.value ?? new Set(visibleIds);
+
+  const label = isAll
+    ? t`All projects`
+    : selectedProjects.size === 1
+      ? (props.projects.find((project) => selectedProjects.has(project.id))?.name ??
+        t`All projects`)
+      : t`${plural(selectedProjects.size, { one: `# project`, other: `# projects` })}`;
+
+  const selectAll = () => props.onChange(null);
+
+  const toggleProject = (projectId: string) => {
+    const next = new Set(selectedProjects);
+    if (next.has(projectId)) next.delete(projectId);
+    else next.add(projectId);
+    // Empty and complete selections are both just "all projects".
+    props.onChange(next.size === 0 || next.size >= visibleIds.length ? null : [...next]);
+  };
+
+  const triggerContent = (
+    <>
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        <ListFilter className="size-3.5 text-muted" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <span className="block truncate text-left">{label}</span>
+      </div>
+      <span className="flex shrink-0 items-center">
+        <ChevronsUpDown className="size-3.5 text-muted" />
+      </span>
+    </>
+  );
+
+  if (mobile) {
+    return (
+      <ResponsiveMenuSurface
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        label={t`Filter by project`}
+        trigger={
+          <button
+            type="button"
+            aria-label={t`Filter by project`}
+            aria-expanded={isOpen}
+            className={sidebarRowClass()}
+            onClick={() => setIsOpen(true)}
+          >
+            {triggerContent}
+          </button>
+        }
+      >
+        <div className="m-sheet-list">
+          <button
+            type="button"
+            className="m-sheet-action"
+            aria-pressed={isAll || undefined}
+            onClick={selectAll}
+          >
+            <span className="flex-1 truncate">
+              <Trans>All projects</Trans>
+            </span>
+            {isAll ? <Check className="size-4 shrink-0 text-accent" /> : null}
+          </button>
+          {props.projects.map((project) => {
+            const selected = selectedProjects.has(project.id);
+            return (
+              <button
+                key={project.id}
+                type="button"
+                className="m-sheet-action"
+                aria-pressed={selected || undefined}
+                onClick={() => toggleProject(project.id)}
+              >
+                <span className="flex-1 truncate">{project.name}</span>
+                <span className="shrink-0 text-xs text-muted">
+                  {props.threadCounts.get(project.id) ?? 0}
+                </span>
+                {selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
+              </button>
+            );
+          })}
+        </div>
+      </ResponsiveMenuSurface>
+    );
+  }
+
+  // Controlled multi-selection menu: a press flips one key, so diff the new
+  // selection against the rendered one to find it, then route through the same
+  // toggle/reset logic as the sheet. Selection changes never close the menu.
+  const menuSelectedKeys = new Set<string>([
+    ...(isAll ? [ALL_PROJECTS_KEY] : []),
+    ...selectedProjects,
+  ]);
+  const handleSelectionChange = (keys: Selection) => {
+    // Interacting with the filter again dismisses a stacked overflow menu,
+    // matching how clicking elsewhere closes a context menu.
+    setOverflowTarget(null);
+    if (keys === "all") {
+      selectAll();
+      return;
+    }
+    const next = new Set([...keys].map(String));
+    let pressed: string | undefined;
+    for (const key of next) {
+      if (!menuSelectedKeys.has(key)) {
+        pressed = key;
+        break;
+      }
+    }
+    if (pressed === undefined) {
+      for (const key of menuSelectedKeys) {
+        if (!next.has(key)) {
+          pressed = key;
+          break;
+        }
+      }
+    }
+    if (pressed === undefined) return;
+    if (pressed === ALL_PROJECTS_KEY) {
+      selectAll();
+      return;
+    }
+    toggleProject(pressed);
+  };
+
+  return (
+    <Dropdown
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (open) setIsOpen(true);
+        // The stacked menu lives in this popover's subtree, so it goes away with
+        // the filter — drop its target too, or it would reappear on the next open.
+        else close();
+      }}
+    >
+      {/* display:contents keeps the head row's layout while giving the trigger
+          press a capture-phase handler React Aria's Button never exposes. */}
+      <div
+        className="contents"
+        onPointerDownCapture={onTriggerPointerDownCapture}
+        onClickCapture={onTriggerClickCapture}
+      >
+        <Dropdown.Trigger
+          {...{ [TRIGGER_ATTR]: true }}
+          aria-label={t`Filter by project`}
+          className={sidebarRowClass()}
+        >
+          {triggerContent}
+        </Dropdown.Trigger>
+      </div>
+      {/* Non-modal so the project menu stacked on top can hold focus: a modal
+          popover contains focus in its own scope, which leaves that menu
+          unreachable by hover and keyboard. Dismissal therefore runs through
+          useFilterDismissal above. The guard here only exempts targets inside
+          another menu, so hover-driven focus moves between the two stacked
+          menus don't dismiss this one. */}
+      <Dropdown.Popover
+        placement="bottom start"
+        isNonModal
+        shouldCloseOnInteractOutside={closeOnlyOutsideMenus}
+      >
+        <Dropdown.Menu
+          aria-label={t`Projects`}
+          className="poracode-menu min-w-56"
+          selectionMode="multiple"
+          selectedKeys={menuSelectedKeys}
+          onSelectionChange={handleSelectionChange}
+        >
+          <Dropdown.Item key={ALL_PROJECTS_KEY} id={ALL_PROJECTS_KEY} textValue={t`All projects`}>
+            <Label className="flex-1 truncate">
+              <Trans>All projects</Trans>
+            </Label>
+            <Dropdown.ItemIndicator />
+          </Dropdown.Item>
+          <Separator />
+          {props.projects.map((project) => (
+            <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+              <Label className="flex-1 truncate">{project.name}</Label>
+              <span className="ms-auto shrink-0 text-xs text-muted">
+                {props.threadCounts.get(project.id) ?? 0}
+              </span>
+              <Dropdown.ItemIndicator />
+              {isHomeProject(project) ? null : (
+                <ProjectRowMenuButton
+                  project={project}
+                  onOpenMenu={(anchor) => {
+                    // The filter menu stays open; the overflow menu stacks
+                    // on top like a submenu and closes it once an action is
+                    // picked (see ProjectOverflowMenu's onAction).
+                    setOverflowTarget({ project, anchor });
+                  }}
+                />
+              )}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+        {overflowTarget ? (
+          <ProjectOverflowMenu
+            project={overflowTarget.project}
+            anchor={overflowTarget.anchor}
+            onClose={() => setOverflowTarget(null)}
+            onAction={close}
+          />
+        ) : null}
+      </Dropdown.Popover>
+    </Dropdown>
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
@@ -1,19 +1,4 @@
-import {
-  ChevronRight,
-  EyeOff,
-  FileDiff,
-  FolderOpen,
-  GitFork,
-  Layers,
-  Play,
-  Power,
-  PowerOff,
-  RefreshCw,
-  Server,
-  Settings2,
-  Trash2,
-  Workflow,
-} from "lucide-react";
+import { ChevronRight, FolderOpen, Server } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { Project } from "@/shared/contracts";
 import { desktopTitle } from "@/shared/remote/desktopLabel";
@@ -24,22 +9,8 @@ import {
 } from "@/renderer/components/common/RemoteServerStatusDot";
 import { ContextMenu } from "@/renderer/components/common/ContextMenu";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
-import { setProjectDisabled, deleteProject } from "@/renderer/actions/projectActions";
-import {
-  openFilesPanel,
-  openGitReview,
-  openProjectSettings,
-} from "@/renderer/actions/panelActions";
-import { gitSync } from "@/renderer/actions/gitActions";
-import {
-  WORKSPACE_UNFILED_KEY,
-  parseWorkspaceMenuKey,
-  workspaceMenuKey,
-} from "@/renderer/components/workspace/workspaceMenuKeys";
-import { WorkspaceIcon } from "@/renderer/components/workspace/WorkspaceIcon";
-import { useAppStore } from "@/renderer/state/appStore";
-import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { openTerminal, runProjectAction } from "@/renderer/actions/terminalActions";
+import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
+import { openTerminal } from "@/renderer/actions/terminalActions";
 import {
   useIsProjectFilesPanelActive,
   useIsProjectGitPanelActive,
@@ -48,12 +19,12 @@ import {
   useIsProjectTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
-import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { formatProjectLocation } from "./formatProjectLocation";
 import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { GitBadge } from "./GitBadge";
 import { SidebarPanelDragButton } from "./SidebarPanelDragButton";
 import { SyncBadge } from "./SyncBadge";
+import { useProjectMenu } from "./useProjectMenu";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import type { RemoteServerStatus } from "@/renderer/state/remoteServers/types";
 
@@ -67,7 +38,6 @@ export function SidebarProjectHeader(props: {
   const { project, isCollapsed, isDragging, remoteStatus, isUnreachable } = props;
   const { t } = useLingui();
   const toggleProjectCollapsed = useSidebarUiStore((s) => s.toggleProjectCollapsed);
-  const workspaces = useSharedSettings((s) => s.workspaces);
   const hasTerminal = useIsProjectTerminalOpen(project.id);
   const isActiveTerminal = useIsProjectTerminalActive(project.id);
   const isBusyTerminal = useIsProjectTerminalBusy(project.id);
@@ -80,7 +50,6 @@ export function SidebarProjectHeader(props: {
       ? state.servers.find((server) => server.desktopId === project.remoteServerId)
       : undefined,
   );
-  const setRemoteProjectSynced = useRemoteServersStore((state) => state.setRemoteProjectSynced);
   const remoteServerName = remoteServer ? desktopTitle(remoteServer.label) : undefined;
   const remoteStatusLabel = useRemoteServerStatusLabel(remoteStatus ?? "offline");
   const isRemote = project.remoteServerId !== undefined && project.remoteId !== undefined;
@@ -89,133 +58,10 @@ export function SidebarProjectHeader(props: {
   // tooltip carries the status, so the greyed-out items read as explained.
   const isUnavailable = isDisabled || isUnreachable;
   const showBody = !isCollapsed && !isUnavailable;
+  const projectMenu = useProjectMenu(project, { isUnreachable });
 
   return (
-    <ContextMenu
-      items={[
-        {
-          id: "project-settings",
-          label: t`Project Settings`,
-          icon: <Settings2 className="size-3.5" />,
-        },
-        ...(isDisabled
-          ? []
-          : [
-              {
-                type: "submenu" as const,
-                id: "git",
-                label: t`Git`,
-                icon: <GitFork className="size-3.5" />,
-                items: [
-                  {
-                    id: "git-review",
-                    label: t`Review Changes`,
-                    icon: <FileDiff className="size-3.5" />,
-                    isDisabled: isUnreachable,
-                  },
-                  {
-                    id: "github-actions",
-                    label: t`GitHub Actions`,
-                    icon: <Workflow className="size-3.5" />,
-                    isDisabled: isUnreachable,
-                  },
-                  {
-                    id: "git-sync",
-                    label: t`Sync`,
-                    icon: <RefreshCw className="size-3.5" />,
-                    isDisabled: isUnreachable,
-                  },
-                ],
-              },
-              ...(project.scripts?.actions?.length
-                ? [
-                    {
-                      type: "submenu" as const,
-                      id: "run-action",
-                      label: t`Run`,
-                      icon: <Play className="size-3.5" />,
-                      items: project.scripts.actions.map((action) => ({
-                        id: `action:${action.id}`,
-                        label: action.name,
-                        icon: resolveActionIcon(action.icon),
-                        isDisabled: isUnreachable,
-                      })),
-                    },
-                  ]
-                : []),
-            ]),
-        ...(workspaces.length > 1
-          ? [
-              {
-                type: "submenu" as const,
-                id: "move-to-workspace",
-                label: t`Move to Workspace`,
-                icon: <Layers className="size-3.5" />,
-                items: [
-                  ...workspaces.map((workspace) => ({
-                    id: workspaceMenuKey(workspace.id),
-                    label: workspace.name,
-                    icon: <WorkspaceIcon icon={workspace.icon} className="size-3.5" />,
-                    isDisabled: workspace.id === project.workspaceId,
-                  })),
-                  {
-                    id: WORKSPACE_UNFILED_KEY,
-                    label: t`All workspaces`,
-                    icon: <Layers className="size-3.5" />,
-                    isDisabled: !project.workspaceId,
-                  },
-                ],
-              },
-            ]
-          : []),
-        {
-          id: "toggle-disabled",
-          label: isDisabled ? t`Enable Project` : t`Disable Project`,
-          icon: isDisabled ? <Power className="size-3.5" /> : <PowerOff className="size-3.5" />,
-        },
-        // Dropping a mirrored project from this client is local state, so it
-        // stays available while the server is offline — unlike Remove Project,
-        // which deletes it on the host.
-        ...(isRemote
-          ? [
-              {
-                id: "stop-syncing",
-                label: t`Stop syncing`,
-                icon: <EyeOff className="size-3.5" />,
-              },
-            ]
-          : []),
-        {
-          id: "remove-project",
-          label: t`Remove Project`,
-          icon: <Trash2 className="size-3.5" />,
-          variant: "danger" as const,
-          isDisabled: isUnreachable,
-        },
-      ]}
-      onAction={(key) => {
-        if (key === "project-settings") openProjectSettings(project.id);
-        if (key === "stop-syncing" && project.remoteServerId && project.remoteId) {
-          setRemoteProjectSynced(project.remoteServerId, project.remoteId, false);
-        }
-        if (key === "remove-project") deleteProject(project.id);
-        if (key === "toggle-disabled") setProjectDisabled(project.id, !isDisabled);
-        if (key === "git-review") openGitReview(project.id);
-        if (key === "github-actions") {
-          useAppStore.getState().openGitHubActions(project.id);
-        }
-        if (key === "git-sync") gitSync(project.id);
-        if (key.startsWith("action:")) {
-          runProjectAction(project.id, key.slice("action:".length));
-        }
-        const workspaceChoice = parseWorkspaceMenuKey(key);
-        if (workspaceChoice?.kind === "unfiled") {
-          useAppStore.getState().setProjectWorkspace(project.id, undefined);
-        } else if (workspaceChoice?.kind === "workspace") {
-          useAppStore.getState().setProjectWorkspace(project.id, workspaceChoice.workspaceId);
-        }
-      }}
-    >
+    <ContextMenu items={projectMenu.items} onAction={projectMenu.onAction}>
       <SidebarButton
         icon={
           <ChevronRight

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -95,6 +95,7 @@ export function SortableThreadItem(props: {
         thread={thread}
         project={project}
         onRename={() => props.setEditingThreadId(thread.id)}
+        showProjectActions={stacked}
       >
         <SidebarButton
           size="xs"

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project, Thread } from "@/shared/contracts";
+import { HOME_PROJECT_ID } from "@/shared/homeScope";
+import { ThreadContextMenu } from "./ThreadContextMenu";
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({}),
+}));
+
+const project: Project = {
+  id: "p1",
+  name: "Poracode",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  scripts: { actions: [{ id: "build", name: "Build" }] },
+} as Project;
+
+const homeProject: Project = {
+  id: HOME_PROJECT_ID,
+  name: "Home",
+  location: { kind: "windows", path: "C:\\Users\\me" },
+  createdAt: "2026-07-01T00:00:00.000Z",
+} as Project;
+
+function thread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "t1",
+    projectId: project.id,
+    title: "Thread",
+    status: "inactive",
+    done: false,
+    starred: false,
+    archived: false,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    agentKind: "claude",
+    ...overrides,
+  } as unknown as Thread;
+}
+
+function renderMenu(
+  target: Thread,
+  owner: Project = project,
+  options: { showProjectActions?: boolean } = {},
+) {
+  render(
+    <ThreadContextMenu thread={target} project={owner} {...options}>
+      <button type="button">row</button>
+    </ThreadContextMenu>,
+  );
+  fireEvent.contextMenu(screen.getByRole("button", { name: "row" }));
+  return screen.findByRole("menu");
+}
+
+describe("ThreadContextMenu project actions", () => {
+  it("offers project Git and Run submenus on flat main-branch rows", async () => {
+    await renderMenu(thread(), project, { showProjectActions: true });
+
+    expect(screen.getByRole("menuitem", { name: "Move to Worktree" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Git" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Run" })).toBeInTheDocument();
+  });
+
+  it("omits project actions without the flat-row flag (grouped layout)", async () => {
+    await renderMenu(thread(), project);
+
+    expect(screen.getByRole("menuitem", { name: "Move to Worktree" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Git" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+  });
+
+  it("omits project actions for the Home project", async () => {
+    await renderMenu(thread({ projectId: HOME_PROJECT_ID }), homeProject, {
+      showProjectActions: true,
+    });
+
+    expect(screen.queryByRole("menuitem", { name: "Git" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+  });
+
+  it("keeps a single Git submenu for worktree threads", async () => {
+    await renderMenu(thread({ worktreePath: "C:\\repo\\wt" }), project, {
+      showProjectActions: true,
+    });
+
+    expect(screen.getAllByRole("menuitem", { name: "Git" })).toHaveLength(1);
+    expect(screen.getByRole("menuitem", { name: "Run" })).toBeInTheDocument();
+  });
+
+  it("omits the Run submenu when the project defines no scripts", async () => {
+    const scriptless = { ...project, scripts: undefined } as unknown as Project;
+    await renderMenu(thread(), scriptless, { showProjectActions: true });
+
+    expect(screen.getByRole("menuitem", { name: "Git" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
@@ -4,17 +4,21 @@ import {
   ArrowRightLeft,
   CircleCheck,
   Columns2,
+  FileDiff,
   FlaskConical,
   GitFork,
   Pencil,
   Play,
   Plus,
+  RefreshCw,
   Star,
   Trash2,
+  Workflow,
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useLingui } from "@lingui/react/macro";
 import type { Project, Thread } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentStore } from "@/renderer/state/experimentStore";
 import { useGitStore } from "@/renderer/state/gitStore";
@@ -59,6 +63,12 @@ export function ThreadContextMenu(props: {
   thread: Thread;
   project: Project;
   onRename?: () => void;
+  /**
+   * Flat cross-project rows only: add the project-level Git and Run submenus.
+   * The grouped layout already offers them on the project header's own menu;
+   * the flat list has no project headers, so main-branch threads carry them.
+   */
+  showProjectActions?: boolean;
   children: ReactNode;
 }) {
   const { thread, project, onRename } = props;
@@ -81,6 +91,9 @@ export function ThreadContextMenu(props: {
       : thread.status === "launching"
         ? t`Wait for the thread to finish starting.`
         : undefined;
+  // Home has no project menu even in the grouped layout (its sidebar section
+  // is a plain header), so flat Home threads don't get project actions either.
+  const showProjectActions = props.showProjectActions === true && !isHomeProject(project);
 
   return (
     <ContextMenu
@@ -119,9 +132,39 @@ export function ThreadContextMenu(props: {
                   },
                 ],
               },
+              // Project-level git, running against the main checkout the
+              // thread lives in (mirrors the project header's Git submenu).
+              ...(showProjectActions
+                ? [
+                    {
+                      type: "submenu" as const,
+                      id: "git",
+                      label: t`Git`,
+                      icon: <GitFork className="size-3.5" />,
+                      items: [
+                        {
+                          id: "git-review",
+                          label: t`Review Changes`,
+                          icon: <FileDiff className="size-3.5" />,
+                        },
+                        {
+                          id: "github-actions",
+                          label: t`GitHub Actions`,
+                          icon: <Workflow className="size-3.5" />,
+                        },
+                        {
+                          id: "git-sync",
+                          label: t`Sync`,
+                          icon: <RefreshCw className="size-3.5" />,
+                        },
+                      ],
+                    },
+                  ]
+                : []),
             ]
           : []),
-        ...(thread.worktreePath && project.scripts?.actions?.length
+        ...((thread.worktreePath || (showProjectActions && !isExperimentCandidate)) &&
+        project.scripts?.actions?.length
           ? [
               {
                 type: "submenu" as const,
@@ -242,8 +285,12 @@ export function ThreadContextMenu(props: {
         if (key === "move-to-worktree-with-changes") void moveThreadToWorktree(thread.id, true);
         if (key === "move-to-worktree-clean") void moveThreadToWorktree(thread.id, false);
         if (key === "git-review") openGitReview(thread.projectId, thread.worktreePath, thread.id);
-        if (key === "git-sync" && thread.worktreePath)
-          gitSync(thread.projectId, thread.worktreePath);
+        // Non-worktree flat rows offer project-level sync (no path argument).
+        if (key === "git-sync") {
+          if (thread.worktreePath) gitSync(thread.projectId, thread.worktreePath);
+          else gitSync(thread.projectId);
+        }
+        if (key === "github-actions") useAppStore.getState().openGitHubActions(thread.projectId);
         if (key === "git-push" && thread.worktreePath)
           gitPush(thread.projectId, thread.worktreePath);
         if (key === "git-pull" && thread.worktreePath)

--- a/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
@@ -1,0 +1,176 @@
+import {
+  EyeOff,
+  FileDiff,
+  GitFork,
+  Layers,
+  Play,
+  Power,
+  PowerOff,
+  RefreshCw,
+  Settings2,
+  Trash2,
+  Workflow,
+} from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { Project } from "@/shared/contracts";
+import type { ContextMenuEntry } from "@/renderer/components/common/ContextMenu";
+import { setProjectDisabled, deleteProject } from "@/renderer/actions/projectActions";
+import { openGitReview, openProjectSettings } from "@/renderer/actions/panelActions";
+import { gitSync } from "@/renderer/actions/gitActions";
+import { runProjectAction } from "@/renderer/actions/terminalActions";
+import {
+  WORKSPACE_UNFILED_KEY,
+  parseWorkspaceMenuKey,
+  workspaceMenuKey,
+} from "@/renderer/components/workspace/workspaceMenuKeys";
+import { WorkspaceIcon } from "@/renderer/components/workspace/WorkspaceIcon";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import { resolveActionIcon } from "@/renderer/utils/actionIcons";
+
+/**
+ * The project context menu: entries plus their action dispatcher, shared by
+ * every surface that offers project actions — the grouped sidebar's project
+ * header (right-click) and the flat list's project filter rows (overflow
+ * button). `isUnreachable` greys out entries that execute on the project's
+ * host (git, run-scripts, removal) while a mirrored project's server is down.
+ */
+export function useProjectMenu(
+  project: Project,
+  options: { isUnreachable: boolean },
+): { items: ContextMenuEntry[]; onAction: (key: string) => void } {
+  const { t } = useLingui();
+  const { isUnreachable } = options;
+  const workspaces = useSharedSettings((s) => s.workspaces);
+  const setRemoteProjectSynced = useRemoteServersStore((state) => state.setRemoteProjectSynced);
+  const isDisabled = !!project.disabled;
+  const isRemote = project.remoteServerId !== undefined && project.remoteId !== undefined;
+
+  const items: ContextMenuEntry[] = [
+    {
+      id: "project-settings",
+      label: t`Project Settings`,
+      icon: <Settings2 className="size-3.5" />,
+    },
+    ...(isDisabled
+      ? []
+      : [
+          {
+            type: "submenu" as const,
+            id: "git",
+            label: t`Git`,
+            icon: <GitFork className="size-3.5" />,
+            items: [
+              {
+                id: "git-review",
+                label: t`Review Changes`,
+                icon: <FileDiff className="size-3.5" />,
+                isDisabled: isUnreachable,
+              },
+              {
+                id: "github-actions",
+                label: t`GitHub Actions`,
+                icon: <Workflow className="size-3.5" />,
+                isDisabled: isUnreachable,
+              },
+              {
+                id: "git-sync",
+                label: t`Sync`,
+                icon: <RefreshCw className="size-3.5" />,
+                isDisabled: isUnreachable,
+              },
+            ],
+          },
+          ...(project.scripts?.actions?.length
+            ? [
+                {
+                  type: "submenu" as const,
+                  id: "run-action",
+                  label: t`Run`,
+                  icon: <Play className="size-3.5" />,
+                  items: project.scripts.actions.map((action) => ({
+                    id: `action:${action.id}`,
+                    label: action.name,
+                    icon: resolveActionIcon(action.icon),
+                    isDisabled: isUnreachable,
+                  })),
+                },
+              ]
+            : []),
+        ]),
+    ...(workspaces.length > 1
+      ? [
+          {
+            type: "submenu" as const,
+            id: "move-to-workspace",
+            label: t`Move to Workspace`,
+            icon: <Layers className="size-3.5" />,
+            items: [
+              ...workspaces.map((workspace) => ({
+                id: workspaceMenuKey(workspace.id),
+                label: workspace.name,
+                icon: <WorkspaceIcon icon={workspace.icon} className="size-3.5" />,
+                isDisabled: workspace.id === project.workspaceId,
+              })),
+              {
+                id: WORKSPACE_UNFILED_KEY,
+                label: t`All workspaces`,
+                icon: <Layers className="size-3.5" />,
+                isDisabled: !project.workspaceId,
+              },
+            ],
+          },
+        ]
+      : []),
+    {
+      id: "toggle-disabled",
+      label: isDisabled ? t`Enable Project` : t`Disable Project`,
+      icon: isDisabled ? <Power className="size-3.5" /> : <PowerOff className="size-3.5" />,
+    },
+    // Dropping a mirrored project from this client is local state, so it
+    // stays available while the server is offline — unlike Remove Project,
+    // which deletes it on the host.
+    ...(isRemote
+      ? [
+          {
+            id: "stop-syncing",
+            label: t`Stop syncing`,
+            icon: <EyeOff className="size-3.5" />,
+          },
+        ]
+      : []),
+    {
+      id: "remove-project",
+      label: t`Remove Project`,
+      icon: <Trash2 className="size-3.5" />,
+      variant: "danger" as const,
+      isDisabled: isUnreachable,
+    },
+  ];
+
+  const onAction = (key: string) => {
+    if (key === "project-settings") openProjectSettings(project.id);
+    if (key === "stop-syncing" && project.remoteServerId && project.remoteId) {
+      setRemoteProjectSynced(project.remoteServerId, project.remoteId, false);
+    }
+    if (key === "remove-project") deleteProject(project.id);
+    if (key === "toggle-disabled") setProjectDisabled(project.id, !isDisabled);
+    if (key === "git-review") openGitReview(project.id);
+    if (key === "github-actions") {
+      useAppStore.getState().openGitHubActions(project.id);
+    }
+    if (key === "git-sync") gitSync(project.id);
+    if (key.startsWith("action:")) {
+      runProjectAction(project.id, key.slice("action:".length));
+    }
+    const workspaceChoice = parseWorkspaceMenuKey(key);
+    if (workspaceChoice?.kind === "unfiled") {
+      useAppStore.getState().setProjectWorkspace(project.id, undefined);
+    } else if (workspaceChoice?.kind === "workspace") {
+      useAppStore.getState().setProjectWorkspace(project.id, workspaceChoice.workspaceId);
+    }
+  };
+
+  return { items, onAction };
+}


### PR DESCRIPTION
## What changed

- add a localized project filter popover to the flat thread list
- persist the selected project filter and keep filtered thread/new-thread actions project-aware
- share project context-menu behavior between stacked and flat sidebar views
- expand context-menu, sidebar state, filter, new-thread, and flat-list coverage

## Why

The flat sidebar listed threads across every project without a way to narrow the view. This adds a project-scoped workflow while retaining the all-projects flat list.

## Validation

- `pnpm i18n:extract` (0 missing in all 12 non-English catalogs)
- `pnpm exec vitest run src/renderer/components/common/ContextMenu.test.tsx src/renderer/state/sidebarUiStore.test.ts src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.test.tsx src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx --maxWorkers=4` (53 passed)
- `pnpm run typecheck`
- `pnpm run lint`