### PR TITLE
Migrate Qwen 3.8 Max Preview to Qwen 3.8 Max

### DIFF
--- a/src/renderer/components/providers/qwen/index.test.tsx
+++ b/src/renderer/components/providers/qwen/index.test.tsx
@@ -40,7 +40,7 @@ describe("Qwen composer controls", () => {
     const onConfigChange = vi.fn<(patch: Partial<ThreadConfig>) => void>();
     const controls = getComposerControls("qwen")?.({
       capabilities,
-      config: { model: "qwen3.8-max-preview", mode: "agent", approvalPolicy: "auto" },
+      config: { model: "qwen3.8-max", mode: "agent", approvalPolicy: "auto" },
       isDisabled: false,
       onConfigChange,
       presentationMode: "gui",
@@ -58,7 +58,7 @@ describe("Qwen composer controls", () => {
   it("keeps Plan as the alternate mode", () => {
     const controls = getComposerControls("qwen")?.({
       capabilities,
-      config: { model: "qwen3.8-max-preview", mode: "plan", approvalPolicy: "auto" },
+      config: { model: "qwen3.8-max", mode: "plan", approvalPolicy: "auto" },
       isDisabled: false,
       onConfigChange: vi.fn<(patch: Partial<ThreadConfig>) => void>(),
       presentationMode: "gui",

--- a/src/renderer/components/providers/qwen/index.tsx
+++ b/src/renderer/components/providers/qwen/index.tsx
@@ -1,6 +1,7 @@
 export * from "./QwenIcon";
 
 import { msg } from "@lingui/core/macro";
+import { QWEN_DEFAULT_MODEL_ID } from "@/shared/agents/qwenModels";
 import { QwenIcon } from "./QwenIcon";
 import providerManifest from "./manifest";
 import { standardPlanApprovalControls } from "../composerControlBuilders";
@@ -13,8 +14,8 @@ import { registerTitleGenDefaults } from "../titleGen";
 const PROVIDER_KIND = providerManifest.kind;
 const QWEN_UTILITY_DEFAULTS = {
   label: "Qwen",
-  hint: "3.8 Max Preview",
-  model: "qwen3.8-max-preview",
+  hint: "3.8 Max",
+  model: QWEN_DEFAULT_MODEL_ID,
   effort: "",
 };
 

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
@@ -413,19 +413,27 @@ describe("ClaudeProfileProviderSettings", () => {
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue("ANTHROPIC_MODEL")).toBeInTheDocument();
     expect(screen.getByDisplayValue("CLAUDE_CODE_SUBAGENT_MODEL")).toBeInTheDocument();
-    expect(screen.getAllByLabelText("Model id").at(0)).toHaveValue("qwen3.8-max-preview");
+    expect(screen.getAllByLabelText("Model id").at(0)).toHaveValue("qwen3.8-max");
     const applied = settingsState.setAgentInstance.mock.calls.at(-1)?.[0];
     const config = applied?.config as ClaudeProfileInstanceConfig | undefined;
-    expect(config?.models).toHaveLength(15);
+    expect(config?.models?.map((model) => model.id)).toEqual([
+      "qwen3.8-max",
+      "qwen3.7-max",
+      "qwen3.7-plus",
+      "qwen3.6-flash",
+      "glm-5.2",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash-0731",
+    ]);
     expect(config).toMatchObject({
       configDir: "~/.poracode/claude-profiles/glm",
-      efforts: ["low", "high", "xHigh", "ultracode"],
+      efforts: ["low", "medium", "xHigh"],
       defaultEffort: "xHigh",
       modelEfforts: {
-        "qwen3.8-max-preview": ["low", "high", "xHigh", "ultracode"],
-        "qwen3.7-max": ["low", "high", "xHigh", "ultracode"],
-        "qwen3.7-plus": ["low", "high", "xHigh", "ultracode"],
-        "qwen3.6-flash": ["low", "high", "xHigh", "ultracode"],
+        "qwen3.8-max": ["low", "medium", "xHigh"],
+        "qwen3.7-max": ["low", "medium", "xHigh"],
+        "qwen3.7-plus": ["low", "medium", "xHigh"],
+        "qwen3.6-flash": ["low", "medium", "xHigh"],
       },
     });
   });

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
@@ -153,9 +153,10 @@ describe("ClaudeProfileSettingsModel", () => {
       expect(byKey.ANTHROPIC_BASE_URL).toBe(
         "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
       );
-      expect(byKey.ANTHROPIC_MODEL).toBe("qwen3.8-max-preview");
-      expect(byKey.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("qwen3.8-max-preview");
-      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("qwen3.8-max-preview");
+      expect(byKey.ANTHROPIC_MODEL).toBe("qwen3.8-max");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("qwen3.8-max");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("qwen3.8-max");
+      expect(byKey.ANTHROPIC_DEFAULT_FABLE_MODEL).toBeUndefined();
       expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("qwen3.6-flash");
       expect(byKey.CLAUDE_CODE_SUBAGENT_MODEL).toBe("qwen3.7-max");
       expect(byKey.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("983616");

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
@@ -78,25 +78,21 @@ export const KIMI_CODE_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
   { key: "CLAUDE_CODE_MAX_CONTEXT_TOKENS", value: "1048576", sensitive: false },
 ];
 
-/** Alibaba Token Plan uses a distinct endpoint; its key is invalid on the Coding Plan endpoint. */
-const QWEN_TOKEN_MODEL_ID = "qwen3.8-max-preview";
-const QWEN_38_EFFORTS = ["low", "high", "xHigh", "ultracode"] as const;
+/**
+ * QwenCloud Token Plan Individual uses the Singapore endpoint and an exact model allowlist.
+ * Keep this list in sync with the text-generation entries in:
+ * https://docs.qwencloud.com/token-plan/personal/token-plan-personal-overview#supported-models
+ */
+const QWEN_TOKEN_MODEL_ID = "qwen3.8-max";
+const QWEN_38_EFFORTS = ["low", "medium", "xHigh"] as const;
 const QWEN_TOKEN_PLAN_MODELS = [
-  { id: QWEN_TOKEN_MODEL_ID, label: "Qwen3.8 Max Preview" },
+  { id: QWEN_TOKEN_MODEL_ID, label: "Qwen3.8 Max" },
   { id: "qwen3.7-max", label: "Qwen3.7 Max" },
   { id: "qwen3.7-plus", label: "Qwen3.7 Plus" },
-  { id: "qwen3.6-plus", label: "Qwen3.6 Plus" },
   { id: "qwen3.6-flash", label: "Qwen3.6 Flash" },
-  { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
-  { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
-  { id: "deepseek-v3.2", label: "DeepSeek V3.2" },
-  { id: "kimi-k2.7-code", label: "Kimi K2.7 Code" },
-  { id: "kimi-k2.6", label: "Kimi K2.6" },
-  { id: "kimi-k2.5", label: "Kimi K2.5" },
   { id: "glm-5.2", label: "GLM-5.2" },
-  { id: "glm-5.1", label: "GLM-5.1" },
-  { id: "glm-5", label: "GLM-5" },
-  { id: "MiniMax-M2.5", label: "MiniMax M2.5" },
+  { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { id: "deepseek-v4-flash-0731", label: "DeepSeek V4 Flash 0731" },
 ] as const;
 
 export const QWEN_TOKEN_PLAN_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
@@ -107,10 +103,9 @@ export const QWEN_TOKEN_PLAN_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
   },
   { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
   { key: "ANTHROPIC_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_FABLE_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
   { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "qwen3.6-flash", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: QWEN_TOKEN_MODEL_ID, sensitive: false },
   { key: "CLAUDE_CODE_SUBAGENT_MODEL", value: "qwen3.7-max", sensitive: false },
   { key: "CLAUDE_CODE_MAX_CONTEXT_TOKENS", value: "983616", sensitive: false },
 ];

--- a/src/shared/agents/qwenModels.ts
+++ b/src/shared/agents/qwenModels.ts
@@ -1,0 +1,2 @@
+export const QWEN_DEFAULT_MODEL_ID = "qwen3.8-max";
+export const QWEN_RETIRED_PREVIEW_MODEL_ID = "qwen3.8-max-preview";

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -57,4 +57,63 @@ describe("shared settings defaults", () => {
       }).prAutomationDefault,
     ).toBe("off");
   });
+
+  it("migrates the retired Qwen 3.8 preview model without changing other providers", () => {
+    const migrated = normalizeSharedSettings({
+      providerConfigs: {
+        qwen: { model: "qwen3.8-max-preview", mode: "agent", approvalPolicy: "auto" },
+        "claude:qwen": { model: "qwen3.8-max-preview" },
+      },
+      commitGenProvider: "qwen",
+      commitGenModel: "qwen3.8-max-preview",
+      favoriteModels: [
+        { agentKind: "qwen", modelId: "qwen3.8-max-preview", presentationMode: "gui" },
+      ],
+      recentModels: [
+        { agentKind: "qwen", modelId: "qwen3.8-max-preview", presentationMode: "gui" },
+        { agentKind: "claude:qwen", modelId: "qwen3.8-max-preview", presentationMode: "gui" },
+      ],
+      agentSelectionUsage: [
+        {
+          agentKind: "qwen",
+          modelId: "qwen3.8-max-preview",
+          fast: false,
+          count: 2,
+          lastUsedAt: 1,
+        },
+      ],
+      crossagentSelectionUsage: [
+        {
+          agentKind: "qwen",
+          modelId: "qwen3.8-max-preview",
+          fast: false,
+          count: 1,
+          lastUsedAt: 1,
+        },
+      ],
+      crossagentRoutingOverrides: [
+        {
+          tags: ["review"],
+          agentKind: "qwen",
+          modelId: "qwen3.8-max-preview",
+          updatedAt: 1,
+        },
+      ],
+      hiddenModels: { qwen: ["qwen3.8-max-preview", "qwen3.8-max"] },
+    });
+
+    expect(migrated.providerConfigs.qwen?.model).toBe("qwen3.8-max");
+    expect(migrated.providerConfigs["claude:qwen"]?.model).toBe("qwen3.8-max-preview");
+    expect(migrated.commitGenModel).toBe("qwen3.8-max");
+    expect(migrated.favoriteModels).toEqual([
+      { agentKind: "qwen", modelId: "qwen3.8-max", presentationMode: "gui" },
+    ]);
+    expect(migrated.recentModels).toEqual([
+      { agentKind: "claude:qwen", modelId: "qwen3.8-max-preview", presentationMode: "gui" },
+    ]);
+    expect(migrated.agentSelectionUsage).toEqual([]);
+    expect(migrated.crossagentSelectionUsage).toEqual([]);
+    expect(migrated.crossagentRoutingOverrides[0]?.modelId).toBe("qwen3.8-max");
+    expect(migrated.hiddenModels.qwen).toEqual(["qwen3.8-max"]);
+  });
 });

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -23,6 +23,7 @@ import {
 } from "./contracts";
 import { DEFAULT_SEARCH_EXCLUDE } from "./searchExclude";
 import { AI_LANGUAGE_VALUES, LOCALE_SETTING_VALUES } from "./locale";
+import { QWEN_DEFAULT_MODEL_ID, QWEN_RETIRED_PREVIEW_MODEL_ID } from "./agents/qwenModels";
 
 const modelPickerEntrySchema = z.object({
   agentKind: z.string().min(1),
@@ -735,6 +736,88 @@ function normalizeObjectFromSchema<
   return normalized;
 }
 
+function migrateRetiredQwenPreviewModel(settings: SharedSettings): SharedSettings {
+  const isRetiredQwenSelection = (agentKind: string, modelId: string) =>
+    agentKind === "qwen" && modelId === QWEN_RETIRED_PREVIEW_MODEL_ID;
+  const migrateUtilityModel = (provider: string, model: string) =>
+    isRetiredQwenSelection(provider, model) ? QWEN_DEFAULT_MODEL_ID : model;
+  const qwenProviderConfig = settings.providerConfigs.qwen;
+  const providerConfigs =
+    qwenProviderConfig?.model === QWEN_RETIRED_PREVIEW_MODEL_ID
+      ? {
+          ...settings.providerConfigs,
+          qwen: { ...qwenProviderConfig, model: QWEN_DEFAULT_MODEL_ID },
+        }
+      : settings.providerConfigs;
+
+  const seenFavorites = new Set<string>();
+  const favoriteModels = settings.favoriteModels
+    .map((entry) =>
+      isRetiredQwenSelection(entry.agentKind, entry.modelId)
+        ? { ...entry, modelId: QWEN_DEFAULT_MODEL_ID }
+        : entry,
+    )
+    .filter((entry) => {
+      const key = `${entry.agentKind}\0${entry.modelId}\0${entry.presentationMode}`;
+      if (seenFavorites.has(key)) return false;
+      seenFavorites.add(key);
+      return true;
+    });
+
+  const hiddenModels = { ...settings.hiddenModels };
+  if (hiddenModels.qwen?.includes(QWEN_RETIRED_PREVIEW_MODEL_ID)) {
+    hiddenModels.qwen = [
+      ...new Set(
+        hiddenModels.qwen.map((modelId) =>
+          modelId === QWEN_RETIRED_PREVIEW_MODEL_ID ? QWEN_DEFAULT_MODEL_ID : modelId,
+        ),
+      ),
+    ];
+  }
+
+  return {
+    ...settings,
+    providerConfigs,
+    hiddenModels,
+    commitGenModel: migrateUtilityModel(settings.commitGenProvider, settings.commitGenModel),
+    titleGenModel: migrateUtilityModel(settings.titleGenProvider, settings.titleGenModel),
+    conflictResolverModel: migrateUtilityModel(
+      settings.conflictResolverProvider,
+      settings.conflictResolverModel,
+    ),
+    experimentJudgeModel: migrateUtilityModel(
+      settings.experimentJudgeProvider,
+      settings.experimentJudgeModel,
+    ),
+    wslCommitGenModel: migrateUtilityModel(
+      settings.wslCommitGenProvider,
+      settings.wslCommitGenModel,
+    ),
+    wslTitleGenModel: migrateUtilityModel(settings.wslTitleGenProvider, settings.wslTitleGenModel),
+    wslConflictResolverModel: migrateUtilityModel(
+      settings.wslConflictResolverProvider,
+      settings.wslConflictResolverModel,
+    ),
+    favoriteModels,
+    // Recents and learned usage are derived; discard retired entries instead of
+    // letting them continue to influence the picker or Crossagents routing.
+    recentModels: settings.recentModels.filter(
+      (entry) => !isRetiredQwenSelection(entry.agentKind, entry.modelId),
+    ),
+    agentSelectionUsage: settings.agentSelectionUsage.filter(
+      (entry) => !isRetiredQwenSelection(entry.agentKind, entry.modelId),
+    ),
+    crossagentSelectionUsage: settings.crossagentSelectionUsage.filter(
+      (entry) => !isRetiredQwenSelection(entry.agentKind, entry.modelId),
+    ),
+    crossagentRoutingOverrides: settings.crossagentRoutingOverrides.map((entry) =>
+      entry.agentKind === "qwen" && entry.modelId === QWEN_RETIRED_PREVIEW_MODEL_ID
+        ? { ...entry, modelId: QWEN_DEFAULT_MODEL_ID }
+        : entry,
+    ),
+  };
+}
+
 export function normalizeSharedSettings(value: unknown): SharedSettings {
   const normalized = normalizeObjectFromSchema(
     sharedSettingsSchema.shape,
@@ -757,7 +840,7 @@ export function normalizeSharedSettings(value: unknown): SharedSettings {
   const disabledProviders = usage.success
     ? z.array(z.string()).safeParse(usage.data.disabledProviders)
     : undefined;
-  return {
+  return migrateRetiredQwenPreviewModel({
     ...normalized,
     sidebarShortcutOrder: normalizeSidebarShortcutOrder(normalized.sidebarShortcutOrder),
     prAutomationDefault: hasAutomationMode ? normalized.prAutomationDefault : legacyAutomationMode,
@@ -769,5 +852,5 @@ export function normalizeSharedSettings(value: unknown): SharedSettings {
       ...defaultSharedSettings.enabledMcpServers,
       ...normalized.enabledMcpServers,
     },
-  };
+  });
 }

--- a/src/supervisor/agents/qwen/argv.ts
+++ b/src/supervisor/agents/qwen/argv.ts
@@ -1,6 +1,7 @@
 import type { ThreadConfig } from "@/shared/contracts";
+import { QWEN_DEFAULT_MODEL_ID } from "@/shared/agents/qwenModels";
 
-export const QWEN_DEFAULT_MODEL_ID = "qwen3.8-max-preview";
+export { QWEN_DEFAULT_MODEL_ID } from "@/shared/agents/qwenModels";
 
 function approvalModeFor(config: ThreadConfig): string {
   if (config.mode === "plan") return "plan";

--- a/src/supervisor/agents/qwen/detection.ts
+++ b/src/supervisor/agents/qwen/detection.ts
@@ -1,4 +1,5 @@
 import type { AgentCapability, AgentTerminalAuthMethod, ProjectLocation } from "@/shared/contracts";
+import { QWEN_RETIRED_PREVIEW_MODEL_ID } from "@/shared/agents/qwenModels";
 import { humanizeModelId, probeAcpCapabilities, type AcpProbeResult } from "../acp";
 import {
   buildAgentCommand,
@@ -11,7 +12,7 @@ import { getAgentProbeCwd, resolveProbeSpawnCwd } from "../probeCwd";
 import { QWEN_DEFAULT_MODEL_ID } from "./argv";
 
 export const qwenDefaultCapabilities: AgentCapability = {
-  models: [{ id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max Preview" }],
+  models: [{ id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max" }],
   efforts: [],
   modelEfforts: {},
   modes: ["agent", "plan"],
@@ -64,7 +65,7 @@ const MODEL_PROVIDER_TAG_RE = /^\[([^\]]+)\]\s*/u;
 const MODEL_PROVIDER_SUFFIX_RE = /\((openai|qwen-oauth)\)$/u;
 const QWEN_MODEL_LABELS: Readonly<Record<string, string>> = {
   "coder-model": "Coder Model",
-  "qwen3.8-max-preview": "Qwen3.8 Max Preview",
+  "qwen3.8-max": "Qwen3.8 Max",
   "glm-5.2": "GLM 5.2",
   "deepseek-v4-pro": "DeepSeek V4 Pro",
   "qwen3.5-plus": "Qwen3.5 Plus",
@@ -124,14 +125,25 @@ function normalizeQwenModel(model: NonNullable<AcpProbeResult["models"]>[number]
   };
 }
 
+function withoutRetiredPreview<T>(values: Record<string, T> | undefined): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(values ?? {}).filter(
+      ([modelId]) =>
+        modelId.replace(MODEL_PROVIDER_SUFFIX_RE, "") !== QWEN_RETIRED_PREVIEW_MODEL_ID,
+    ),
+  );
+}
+
 export function buildQwenProbeCapabilities(
   probe: AcpProbeResult | undefined,
 ): CapabilitiesProbeResult {
-  const normalizedModels = (probe?.models ?? []).map(normalizeQwenModel);
+  const normalizedModels = (probe?.models ?? [])
+    .map(normalizeQwenModel)
+    .filter((entry) => entry.model.id !== QWEN_RETIRED_PREVIEW_MODEL_ID);
   const probedModels = normalizedModels.map((entry) => entry.model);
   const defaultModel = probedModels.find((model) => model.id === QWEN_DEFAULT_MODEL_ID) ?? {
     id: QWEN_DEFAULT_MODEL_ID,
-    label: "Qwen3.8 Max Preview",
+    label: "Qwen3.8 Max",
   };
   const models = [
     defaultModel,
@@ -151,11 +163,15 @@ export function buildQwenProbeCapabilities(
   }
   const contextTokens = new Map<string, number>();
   for (const [modelId, metadata] of Object.entries(probe?.modelMetadata ?? {})) {
+    const normalizedModelId = modelId.replace(MODEL_PROVIDER_SUFFIX_RE, "");
+    if (normalizedModelId === QWEN_RETIRED_PREVIEW_MODEL_ID) continue;
     const contextLimit = metadata.contextLimit;
     if (typeof contextLimit === "number" && contextLimit > 0) {
-      contextTokens.set(modelId.replace(MODEL_PROVIDER_SUFFIX_RE, ""), contextLimit);
+      contextTokens.set(normalizedModelId, contextLimit);
     }
   }
+  const modelEfforts = withoutRetiredPreview(probe?.modelEfforts);
+  const modelDefaultEfforts = withoutRetiredPreview(probe?.modelDefaultEfforts);
 
   return {
     ...qwenDefaultCapabilities,
@@ -164,8 +180,8 @@ export function buildQwenProbeCapabilities(
     ...(Object.keys(modelSubProvider).length > 0 ? { modelSubProvider } : {}),
     ...(probe?.efforts?.length ? { efforts: probe.efforts } : {}),
     ...(probe?.defaultEffort ? { defaultEffort: probe.defaultEffort } : {}),
-    ...(probe?.modelEfforts ? { modelEfforts: probe.modelEfforts } : {}),
-    ...(probe?.modelDefaultEfforts ? { modelDefaultEfforts: probe.modelDefaultEfforts } : {}),
+    ...(Object.keys(modelEfforts).length > 0 ? { modelEfforts } : {}),
+    ...(Object.keys(modelDefaultEfforts).length > 0 ? { modelDefaultEfforts } : {}),
     modes: [...new Set([...qwenDefaultCapabilities.modes, ...(probe?.modes ?? [])])],
     ...(probe?.approvalPolicies?.length ? { approvalPolicies: probe.approvalPolicies } : {}),
     ...(probe?.slashCommands?.length ? { slashCommands: probe.slashCommands } : {}),

--- a/src/supervisor/agents/qwen/qwen.test.ts
+++ b/src/supervisor/agents/qwen/qwen.test.ts
@@ -99,7 +99,7 @@ describe("buildQwenProbeCapabilities", () => {
     const capabilities = buildQwenProbeCapabilities({
       models: [
         { id: "coder-model", label: "coder-model" },
-        { id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max Preview" },
+        { id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max" },
       ],
       modelMetadata: { "coder-model": { contextLimit: 1_000_000 } },
       authState: "authenticated",
@@ -116,8 +116,8 @@ describe("buildQwenProbeCapabilities", () => {
       models: [
         { id: "coder-model(qwen-oauth)", label: "coder-model" },
         {
-          id: "qwen3.8-max-preview(openai)",
-          label: "[ModelStudio Coding Plan for Global/Intl] qwen3.8-max-preview",
+          id: "qwen3.8-max(openai)",
+          label: "[ModelStudio Coding Plan for Global/Intl] qwen3.8-max",
         },
         {
           id: "glm-5.2(openai)",
@@ -129,12 +129,12 @@ describe("buildQwenProbeCapabilities", () => {
         },
       ],
       modelMetadata: {
-        "qwen3.8-max-preview(openai)": { contextLimit: 1_000_000 },
+        "qwen3.8-max(openai)": { contextLimit: 1_000_000 },
       },
     });
 
     expect(capabilities.models).toEqual([
-      { id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max Preview" },
+      { id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max" },
       { id: "coder-model", label: "Coder Model" },
       { id: "glm-5.2", label: "GLM 5.2" },
       { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
@@ -155,6 +155,23 @@ describe("buildQwenProbeCapabilities", () => {
     expect(capabilities.modelContextSizes).toEqual({
       [QWEN_DEFAULT_MODEL_ID]: ["1M"],
     });
+  });
+
+  it("excludes the retired Qwen 3.8 preview model reported by older CLIs", () => {
+    const capabilities = buildQwenProbeCapabilities({
+      models: [
+        { id: "qwen3.8-max-preview", label: "Qwen3.8 Max Preview" },
+        { id: QWEN_DEFAULT_MODEL_ID, label: "Qwen3.8 Max" },
+      ],
+      modelMetadata: { "qwen3.8-max-preview": { contextLimit: 1_000_000 } },
+      modelEfforts: { "qwen3.8-max-preview": ["high"] },
+      modelDefaultEfforts: { "qwen3.8-max-preview": "high" },
+    });
+
+    expect(capabilities.models?.map((model) => model.id)).toEqual([QWEN_DEFAULT_MODEL_ID]);
+    expect(capabilities.modelContextSizes).toBeUndefined();
+    expect(capabilities.modelEfforts).toEqual({});
+    expect(capabilities.modelDefaultEfforts).toBeUndefined();
   });
 
   it("keeps Agent and Plan modes when an authenticated ACP probe reports only Agent", () => {

--- a/tests/integration/providers-lifecycle.integration.test.ts
+++ b/tests/integration/providers-lifecycle.integration.test.ts
@@ -41,7 +41,7 @@ const PREFERRED_MODEL: Record<string, string> = {
   commandcode: "google/gemini-3.1-flash-lite",
   opencode: "opencode/big-pickle",
   kimi: "kimi-code/kimi-for-coding",
-  qwen: "qwen3.8-max-preview",
+  qwen: "qwen3.8-max",
   qoder: "lite",
 };
 


### PR DESCRIPTION
- **Bugfix:** replace the retired Qwen 3.8 Max Preview model with Qwen 3.8 Max across defaults, composer controls, provider detection, and lifecycle coverage.
- Migrate saved Qwen settings, utility-model selections, favorites, routing overrides, and hidden-model state while preserving non-Qwen provider selections.
- Filter the retired model from capabilities reported by older Qwen CLIs to prevent unavailable selections.