### PR TITLE
Group projects by workspace in the project switcher

### DIFF
--- a/src/mobile/styles.css
+++ b/src/mobile/styles.css
@@ -3226,6 +3226,17 @@ html[data-touch-device] .m-compose-bubble [data-composer-input-anchor]:not(:focu
   cursor: default;
 }
 
+/* Group heading between action rows (e.g. the project switcher's other-workspace
+   group). Same typography as the thread list's section labels. */
+.m-sheet-section {
+  padding: 0.375rem 0.625rem 0.125rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
 /* ── Git summaries (read-only, mirrored from the desktop) ─────────── */
 
 .m-git-badge,

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { waitFor } from "@testing-library/react";
-import type { RemoteThreadCommand, Thread, Workspace } from "@/shared/contracts";
+import type { Project, RemoteThreadCommand, Thread, Workspace } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
@@ -96,7 +96,7 @@ describe("threadActions", () => {
       newThreadMode: "page",
       workspaces: [],
     });
-    useWorkspaceStore.setState({ activeWorkspaceId: null });
+    useWorkspaceStore.setState({ activeWorkspaceId: null, lastProjectIdByWorkspace: {} });
   });
 
   it("does not restart an inactive thread before startup snapshots reconcile", async () => {
@@ -160,6 +160,48 @@ describe("threadActions", () => {
     expect(view.kind).toBe("thread");
     expect(view.kind === "thread" && view.panes).toContain(draftPaneId);
     expect(useAppStore.getState().draftContentDiscardRequests[firstProject.id]).toBeUndefined();
+  });
+
+  it("starts an untargeted new thread in the active workspace's last project", async () => {
+    const { alpha } = configureTwoWorkspaceProjects();
+    useWorkspaceStore.setState({
+      activeWorkspaceId: "workspace-alpha",
+      lastProjectIdByWorkspace: { "workspace-alpha": alpha.id },
+    });
+
+    openNewThread();
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: alpha.id });
+    });
+  });
+
+  it("ignores a remembered project that the active workspace hides", async () => {
+    const { alpha, beta } = configureTwoWorkspaceProjects();
+    // Remembered while another workspace was active: the fresh draft must land
+    // in a project this workspace actually shows.
+    useWorkspaceStore.setState({
+      activeWorkspaceId: "workspace-beta",
+      lastProjectIdByWorkspace: { "workspace-beta": alpha.id },
+    });
+
+    openNewThread();
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: beta.id });
+    });
+  });
+
+  it("leaves the on-screen project behind when it belongs to another workspace", async () => {
+    const { alpha, beta } = configureTwoWorkspaceProjects();
+    useWorkspaceStore.setState({ activeWorkspaceId: "workspace-beta" });
+    useAppStore.setState((state) => ({ ...state, view: { kind: "draft", projectId: alpha.id } }));
+
+    openNewThread();
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: beta.id });
+    });
   });
 
   it("hydrates a persisted GUI thread before opening the pane", async () => {
@@ -717,6 +759,28 @@ function makeThread(input: Partial<Thread> = {}): Thread {
     updatedAt: now,
     ...input,
   };
+}
+
+/** One project per workspace, so workspace scoping decides which one is picked. */
+function configureTwoWorkspaceProjects(): { alpha: Project; beta: Project } {
+  useSharedSettings.setState({
+    workspaces: [
+      {
+        id: "workspace-alpha",
+        name: "Alpha",
+        createdAt: "2026-07-29T00:00:00.000Z",
+        icon: "briefcase",
+      },
+      { id: "workspace-beta", name: "Beta", createdAt: "2026-07-29T00:00:00.000Z", icon: "rocket" },
+    ],
+  });
+  const alpha = useAppStore
+    .getState()
+    .addProject({ kind: "posix", path: "/repo-alpha" }, undefined, "workspace-alpha");
+  const beta = useAppStore
+    .getState()
+    .addProject({ kind: "posix", path: "/repo-beta" }, undefined, "workspace-beta");
+  return { alpha, beta };
 }
 
 function configureCrossWorkspaceThread(): {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -1,6 +1,11 @@
 import { startTransition } from "react";
 import { toast } from "@heroui/react";
-import { isProjectInWorkspace, type RemoteThreadCommand, type Thread } from "@/shared/contracts";
+import {
+  isProjectInWorkspace,
+  type Project,
+  type RemoteThreadCommand,
+  type Thread,
+} from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
 import { friendlyError } from "@/shared/messages";
 import { isDraftPaneId, parseDraftProjectId } from "@/shared/paneId";
@@ -16,7 +21,7 @@ import {
   hydrateThreadRuntimeItems,
 } from "@/renderer/state/chatRuntimePersister";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { getActiveWorkspaceId, useWorkspaceStore } from "@/renderer/state/workspaceStore";
+import { getActiveWorkspaceId, getLastWorkspaceProjectId } from "@/renderer/state/workspaceStore";
 import { useWorktreeDeleteStore } from "@/renderer/state/worktreeDeleteStore";
 import { readWorktreeDeletePref } from "@/renderer/views/MainView/parts/Sidebar/parts/DeleteWorktreeDialog";
 import { buildSidebarProjectRows } from "@/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows";
@@ -24,6 +29,7 @@ import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads } from "@/renderer/utils/shellUtils";
 import { closePanelsForUnloadedThread } from "./panelActions";
 import { getCurrentProjectId } from "./currentProject";
+import { switchWorkspaceForProject } from "./workspaceActions";
 import { deleteWorktreeGroup } from "./worktreeActions";
 
 let openThreadRequestId = 0;
@@ -64,16 +70,42 @@ function discardReplacedDraftContents(targetProjectId: string): void {
   }
 }
 
-export function openNewThread(projectId?: string): void {
-  openThreadRequestId += 1;
+/**
+ * Which project a new thread starts in when the caller names none. Every
+ * candidate is checked against the active workspace: a workspace switch has to
+ * change what "new thread" means, or the fresh draft lands in work the user just
+ * navigated away from. The remembered pick comes second so returning to a
+ * workspace resumes its last project, while the project currently on screen
+ * still wins when it belongs to this workspace.
+ */
+function resolveNewThreadProjectId(): string | undefined {
   const store = useAppStore.getState();
-  const targetProjectId =
-    projectId ??
-    getCurrentProjectId() ??
+  const knownWorkspaceIds = new Set(
+    (useSharedSettings.getState().workspaces ?? []).map((workspace) => workspace.id),
+  );
+  const activeWorkspaceId = getActiveWorkspaceId();
+  const isVisible = (project: Project) =>
+    (isHomeProject(project) || !project.disabled) &&
+    isProjectInWorkspace(project, activeWorkspaceId, knownWorkspaceIds);
+  const visibleId = (projectId: string | undefined) =>
+    store.projects.find((project) => project.id === projectId && isVisible(project))?.id;
+
+  return (
+    visibleId(getCurrentProjectId()) ??
+    visibleId(getLastWorkspaceProjectId()) ??
     (useSharedSettings.getState().homeScopeEnabled
       ? store.projects.find(isHomeProject)?.id
       : undefined) ??
-    store.projects.find((project) => !project.disabled && !isHomeProject(project))?.id;
+    store.projects.find((project) => !isHomeProject(project) && isVisible(project))?.id ??
+    // Nothing in this workspace: better a draft in another workspace's project
+    // than dropping the user back on Home with no way to type.
+    store.projects.find((project) => !project.disabled && !isHomeProject(project))?.id
+  );
+}
+
+export function openNewThread(projectId?: string): void {
+  openThreadRequestId += 1;
+  const targetProjectId = projectId ?? resolveNewThreadProjectId();
   startTransition(() => {
     if (!targetProjectId) {
       useAppStore.getState().openHome();
@@ -129,18 +161,7 @@ export function openThread(
   const store = useAppStore.getState();
   const thread = store.threads.find((item) => item.id === threadId);
   if (thread && options?.switchWorkspace) {
-    const project = store.projects.find((item) => item.id === thread.projectId);
-    const targetWorkspaceId = project?.workspaceId;
-    const knownWorkspaceIds = new Set(
-      (useSharedSettings.getState().workspaces ?? []).map((workspace) => workspace.id),
-    );
-    if (
-      project &&
-      targetWorkspaceId &&
-      !isProjectInWorkspace(project, getActiveWorkspaceId(), knownWorkspaceIds)
-    ) {
-      useWorkspaceStore.getState().setActiveWorkspaceId(targetWorkspaceId);
-    }
+    switchWorkspaceForProject(thread.projectId);
   }
   const owner = remoteOwner(thread);
   if (owner) {

--- a/src/renderer/actions/workspaceActions.test.ts
+++ b/src/renderer/actions/workspaceActions.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useWorkspaceStore } from "@/renderer/state/workspaceStore";
-import { createWorkspace, deleteWorkspace, renameWorkspace } from "./workspaceActions";
+import {
+  createWorkspace,
+  deleteWorkspace,
+  renameWorkspace,
+  switchWorkspaceForProject,
+} from "./workspaceActions";
 
 vi.mock("@heroui/react", () => ({
   toast: {
@@ -53,6 +58,30 @@ describe("workspaceActions", () => {
 
     renameWorkspace(workspace.id, "  Client  ");
     expect(useSharedSettings.getState().workspaces[0]!.name).toBe("Client");
+  });
+
+  it("follows a project filed in another workspace", () => {
+    const work = createWorkspace("Work")!;
+    const side = createWorkspace("Side Hustle")!;
+    const project = addProject("beta", side.id);
+    useWorkspaceStore.setState({ activeWorkspaceId: work.id });
+
+    switchWorkspaceForProject(project.id);
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(side.id);
+  });
+
+  it("stays put for projects the active workspace already shows", () => {
+    const work = createWorkspace("Work")!;
+    const filed = addProject("alpha", work.id);
+    const unfiled = addProject("gamma");
+    useWorkspaceStore.setState({ activeWorkspaceId: work.id });
+
+    switchWorkspaceForProject(filed.id);
+    switchWorkspaceForProject(unfiled.id);
+    switchWorkspaceForProject("missing-project");
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(work.id);
   });
 
   it("moves projects to another workspace when one is deleted", () => {

--- a/src/renderer/actions/workspaceActions.ts
+++ b/src/renderer/actions/workspaceActions.ts
@@ -1,6 +1,6 @@
 import { toast } from "@heroui/react";
 import { msg, plural } from "@lingui/core/macro";
-import type { Workspace } from "@/shared/contracts";
+import { isProjectInWorkspace, type Workspace } from "@/shared/contracts";
 import { i18n } from "@/renderer/i18n/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -13,6 +13,24 @@ export function createWorkspace(name: string): Workspace | null {
   const workspace = useSharedSettings.getState().addWorkspace(trimmed);
   useWorkspaceStore.getState().setActiveWorkspaceId(workspace.id);
   return workspace;
+}
+
+/**
+ * Follow a project into its own workspace when it lives outside the active one.
+ * Opening work the current workspace hides would otherwise leave the user
+ * staring at a sidebar that does not contain the thread they just started, so
+ * the view moves to where the work is. No-op for projects the active workspace
+ * already shows (including unfiled ones and Home).
+ */
+export function switchWorkspaceForProject(projectId: string): void {
+  const project = useAppStore.getState().projects.find((item) => item.id === projectId);
+  const targetWorkspaceId = project?.workspaceId;
+  if (!project || !targetWorkspaceId) return;
+  const knownWorkspaceIds = new Set(
+    (useSharedSettings.getState().workspaces ?? []).map((workspace) => workspace.id),
+  );
+  if (isProjectInWorkspace(project, getActiveWorkspaceId(), knownWorkspaceIds)) return;
+  useWorkspaceStore.getState().setActiveWorkspaceId(targetWorkspaceId);
 }
 
 export function renameWorkspace(workspaceId: string, name: string): void {

--- a/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project } from "@/shared/contracts";
+import { HOME_PROJECT_ID, HOME_PROJECT_NAME } from "@/shared/homeScope";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useWorkspaceStore } from "@/renderer/state/workspaceStore";
+import { ProjectSwitchMenu } from "./ProjectSwitchMenu";
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => ({}),
+  isRemoteSession: () => false,
+}));
+
+function project(id: string, name: string, workspaceId?: string): Project {
+  return {
+    id,
+    name,
+    location: { kind: "windows", path: `C:\\${id}` },
+    createdAt: "2026-07-01T00:00:00.000Z",
+    ...(workspaceId ? { workspaceId } : {}),
+  } as Project;
+}
+
+// Mirrors production: the synthetic Home row is persisted with `disabled: true`
+// and must still be offered by every workspace.
+const homeProject = { ...project(HOME_PROJECT_ID, HOME_PROJECT_NAME), disabled: true } as Project;
+
+const workProject = project("a", "Alpha", "w1");
+const sideHustleProject = project("b", "Beta", "w2");
+const unfiledProject = project("c", "Gamma");
+
+async function openMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "Switch project" }));
+  return screen.findByRole("menu");
+}
+
+describe("ProjectSwitchMenu", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSharedSettings.setState({
+      workspaces: [
+        { id: "w1", name: "Work", icon: "briefcase", createdAt: "2026-07-27T00:00:00.000Z" },
+        { id: "w2", name: "Side Hustle", icon: "rocket", createdAt: "2026-07-27T00:00:00.000Z" },
+      ],
+    });
+    useWorkspaceStore.setState({ activeWorkspaceId: "w1", lastProjectIdByWorkspace: {} });
+    useAppStore.setState({
+      projects: [homeProject, workProject, sideHustleProject, unfiledProject],
+      view: { kind: "draft", projectId: "a" },
+    });
+  });
+
+  it("groups other workspaces' projects under their own heading instead of hiding them", async () => {
+    render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
+    const menu = await openMenu();
+
+    const groups = within(menu).getAllByRole("group");
+    expect(groups).toHaveLength(2);
+    // Active workspace first: Home and unfiled projects belong to every workspace.
+    expect(
+      within(groups[0]!)
+        .getAllByRole("menuitemradio")
+        .map((item) => item.textContent),
+    ).toEqual([HOME_PROJECT_NAME, "Alpha", "Gamma"]);
+    // The out-of-workspace group names the workspace the project would move to.
+    const other = within(groups[1]!).getByRole("menuitemradio", { name: /Beta/ });
+    expect(other).toHaveTextContent("Side Hustle");
+    expect(within(menu).getByText("Other workspaces")).toBeInTheDocument();
+  });
+
+  it("keeps a flat list when every project belongs to the active workspace", async () => {
+    useAppStore.setState({ projects: [homeProject, workProject, unfiledProject] });
+    render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
+    const menu = await openMenu();
+
+    expect(within(menu).queryByRole("group")).not.toBeInTheDocument();
+    expect(within(menu).getAllByRole("menuitemradio")).toHaveLength(3);
+  });
+
+  it("follows an out-of-workspace pick into its workspace and remembers it there", async () => {
+    render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitemradio", { name: /Beta/ }));
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: "b" });
+    });
+    // Otherwise the new thread would be started in a project the sidebar hides.
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("w2");
+    expect(useWorkspaceStore.getState().lastProjectIdByWorkspace).toEqual({ w2: "b" });
+  });
+
+  it("stays in the active workspace when the pick is already visible there", async () => {
+    render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
+    const menu = await openMenu();
+
+    fireEvent.click(within(menu).getByRole("menuitemradio", { name: "Gamma" }));
+
+    await waitFor(() => {
+      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: "c" });
+    });
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("w1");
+    expect(useWorkspaceStore.getState().lastProjectIdByWorkspace).toEqual({ w1: "c" });
+  });
+
+  it("labels the trigger with a draft that outlived a workspace switch", async () => {
+    render(<ProjectSwitchMenu currentProjectId="b" variant="compact" />);
+
+    expect(screen.getByRole("button", { name: "Switch project" })).toHaveTextContent("Beta");
+
+    const menu = await openMenu();
+    expect(within(menu).getByRole("menuitemradio", { name: /Beta/ })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitemradio", { name: "Alpha" })).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -1,17 +1,19 @@
 import { startTransition, useState } from "react";
 import { Check, ChevronDown, FolderOpen, House, Monitor } from "lucide-react";
-import { Dropdown, Label } from "@heroui/react";
-import { useLingui } from "@lingui/react/macro";
-import { useShallow } from "zustand/shallow";
+import { Description, Dropdown, Header, Label } from "@heroui/react";
+import { Trans, useLingui } from "@lingui/react/macro";
 import type { Project } from "@/shared/contracts";
 import { HOME_PROJECT_NAME, isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { makeDraftPaneId } from "@/shared/paneId";
+import { switchWorkspaceForProject } from "@/renderer/actions/workspaceActions";
 import { useAppStore } from "@/renderer/state/appStore";
+import { rememberWorkspaceProject } from "@/renderer/state/workspaceStore";
 import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
 } from "@/renderer/components/common/ResponsiveMenuSurface";
 import { TuxIcon } from "@/renderer/components/common/TuxIcon";
+import { useProjectSwitchGroups, type ProjectSwitchEntry } from "./projectSwitchGroups";
 
 function LocationIcon(props: { kind: Project["location"]["kind"]; className?: string }) {
   if (props.kind === "wsl") {
@@ -38,20 +40,21 @@ export function ProjectSwitchMenu(props: {
 }) {
   const { currentProjectId, variant, paneId, onSelectProject } = props;
   const { t } = useLingui();
-  // Show every selectable project. Home is intentionally stored with
-  // `disabled: true` as an internal marker (it's not a user-disabled
-  // project), so we let it through the filter and only exclude
-  // user-disabled regular projects.
-  const projects = useAppStore(
-    useShallow((state) => state.projects.filter((p) => isHomeProject(p) || !p.disabled)),
-  );
+  // Projects the active workspace hides are grouped under their own heading
+  // rather than dropped: switching workspaces should not make a project
+  // unreachable from the composer, and picking one moves the workspace along
+  // with the draft (see `handleSelect`).
+  const { all, inWorkspace, others, activeWorkspaceName } = useProjectSwitchGroups();
   const openDraft = useAppStore((state) => state.openDraft);
   const replacePaneId = useAppStore((state) => state.replacePaneId);
   const discardDraftContent = useAppStore((state) => state.discardDraftContent);
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
 
-  const current = projects.find((p) => p.id === currentProjectId);
+  // Sectioned only when there is something to separate; a single-workspace
+  // install keeps the plain list it has always had.
+  const sectioned = others.length > 0 && activeWorkspaceName !== undefined;
+  const current = all.find((entry) => entry.project.id === currentProjectId)?.project;
   const isHomeCurrent = isHomeProjectId(currentProjectId);
   const label = isHomeCurrent ? HOME_PROJECT_NAME : (current?.name ?? t`Select project`);
   const triggerIcon = isHomeCurrent ? (
@@ -59,10 +62,15 @@ export function ProjectSwitchMenu(props: {
   ) : current ? (
     <LocationIcon kind={current.location.kind} className="size-3.5" />
   ) : null;
-  const isDisabled = projects.length <= 1;
+  const isDisabled = all.length <= 1;
 
   function handleSelect(nextProjectId: string) {
     if (nextProjectId === currentProjectId) return;
+    // Follow the project into its workspace, otherwise the thread the user is
+    // about to start lands in a sidebar that does not list it. Done for the
+    // embedded surfaces too (Quick Composer) for the same reason.
+    switchWorkspaceForProject(nextProjectId);
+    rememberWorkspaceProject(nextProjectId);
     if (onSelectProject) {
       onSelectProject(nextProjectId);
       return;
@@ -74,6 +82,56 @@ export function ProjectSwitchMenu(props: {
       } else {
         openDraft(nextProjectId);
       }
+    });
+  }
+
+  /** Finger-sized rows for the mobile bottom drawer. */
+  function sheetRows(entries: readonly ProjectSwitchEntry[]) {
+    return entries.map(({ project, otherWorkspaceName }) => {
+      const isHome = isHomeProject(project);
+      const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
+      const selected = project.id === currentProjectId;
+      return (
+        <button
+          key={project.id}
+          type="button"
+          className="m-sheet-action"
+          aria-pressed={selected || undefined}
+          onClick={() => {
+            setIsOpen(false);
+            handleSelect(project.id);
+          }}
+        >
+          {isHome ? (
+            <House className="size-4 shrink-0 text-muted" />
+          ) : (
+            <LocationIcon kind={project.location.kind} />
+          )}
+          <span className="flex-1 truncate">{itemLabel}</span>
+          {otherWorkspaceName ? (
+            <span className="shrink-0 truncate text-xs text-muted">{otherWorkspaceName}</span>
+          ) : null}
+          {selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
+        </button>
+      );
+    });
+  }
+
+  function menuItems(entries: readonly ProjectSwitchEntry[]) {
+    return entries.map(({ project, otherWorkspaceName }) => {
+      const isHome = isHomeProject(project);
+      const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
+      return (
+        <Dropdown.Item key={project.id} id={project.id} textValue={itemLabel}>
+          {isHome ? (
+            <House className="size-4 shrink-0 text-muted" />
+          ) : (
+            <LocationIcon kind={project.location.kind} />
+          )}
+          <Label>{itemLabel}</Label>
+          {otherWorkspaceName ? <Description>{otherWorkspaceName}</Description> : null}
+        </Dropdown.Item>
+      );
     });
   }
 
@@ -116,31 +174,18 @@ export function ProjectSwitchMenu(props: {
         }
       >
         <div className="m-sheet-list">
-          {projects.map((project) => {
-            const isHome = isHomeProject(project);
-            const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
-            const selected = project.id === currentProjectId;
-            return (
-              <button
-                key={project.id}
-                type="button"
-                className="m-sheet-action"
-                aria-pressed={selected || undefined}
-                onClick={() => {
-                  setIsOpen(false);
-                  handleSelect(project.id);
-                }}
-              >
-                {isHome ? (
-                  <House className="size-4 shrink-0 text-muted" />
-                ) : (
-                  <LocationIcon kind={project.location.kind} />
-                )}
-                <span className="flex-1 truncate">{itemLabel}</span>
-                {selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
-              </button>
-            );
-          })}
+          {sectioned ? (
+            <>
+              <div className="m-sheet-section">{activeWorkspaceName}</div>
+              {sheetRows(inWorkspace)}
+              <div className="m-sheet-section">
+                <Trans>Other workspaces</Trans>
+              </div>
+              {sheetRows(others)}
+            </>
+          ) : (
+            sheetRows(all)
+          )}
         </div>
       </ResponsiveMenuSurface>
     );
@@ -154,20 +199,20 @@ export function ProjectSwitchMenu(props: {
       onAction={(key) => handleSelect(String(key))}
       className="poracode-menu min-w-56"
     >
-      {projects.map((project) => {
-        const isHome = isHomeProject(project);
-        const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
-        return (
-          <Dropdown.Item key={project.id} id={project.id} textValue={itemLabel}>
-            {isHome ? (
-              <House className="size-4 shrink-0 text-muted" />
-            ) : (
-              <LocationIcon kind={project.location.kind} />
-            )}
-            <Label>{itemLabel}</Label>
-          </Dropdown.Item>
-        );
-      })}
+      {sectioned
+        ? [
+            <Dropdown.Section key="active-workspace">
+              <Header>{activeWorkspaceName}</Header>
+              {menuItems(inWorkspace)}
+            </Dropdown.Section>,
+            <Dropdown.Section key="other-workspaces">
+              <Header>
+                <Trans>Other workspaces</Trans>
+              </Header>
+              {menuItems(others)}
+            </Dropdown.Section>,
+          ]
+        : menuItems(all)}
     </Dropdown.Menu>
   );
 

--- a/src/renderer/components/thread/projectSwitchGroups.ts
+++ b/src/renderer/components/thread/projectSwitchGroups.ts
@@ -1,0 +1,60 @@
+import { useShallow } from "zustand/shallow";
+import type { Project } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
+import { useAppStore } from "@/renderer/state/appStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useActiveWorkspaceId } from "@/renderer/state/workspaceStore";
+import { useWorkspaceProjectFilter } from "@/renderer/state/workspaceSelectors";
+
+export interface ProjectSwitchEntry {
+  project: Project;
+  /** Workspace this project is filed in, set only for out-of-workspace entries. */
+  otherWorkspaceName?: string;
+}
+
+export interface ProjectSwitchGroups {
+  /** Active-workspace projects first, then the rest — the flat fallback order. */
+  all: readonly ProjectSwitchEntry[];
+  inWorkspace: readonly ProjectSwitchEntry[];
+  /** Projects filed to another workspace; picking one switches the workspace. */
+  others: readonly ProjectSwitchEntry[];
+  activeWorkspaceName: string | undefined;
+}
+
+/**
+ * Splits the project list the way the project switcher presents it: the active
+ * workspace's projects, then everything filed elsewhere. Out-of-workspace
+ * projects stay reachable rather than being hidden — a project the user cannot
+ * see is worse than one shown under a heading — and the workspace membership
+ * rule stays the shared one in `@/shared/contracts/workspace`.
+ */
+export function useProjectSwitchGroups(): ProjectSwitchGroups {
+  const isInWorkspace = useWorkspaceProjectFilter();
+  const workspaces = useSharedSettings((state) => state.workspaces);
+  const activeWorkspaceId = useActiveWorkspaceId();
+  // Home is persisted with `disabled: true` as an internal marker (it is not a
+  // user-disabled project), so it has to survive the disabled filter.
+  const projects = useAppStore(
+    useShallow((state) =>
+      state.projects.filter((project) => isHomeProject(project) || !project.disabled),
+    ),
+  );
+
+  const inWorkspace: ProjectSwitchEntry[] = [];
+  const others: ProjectSwitchEntry[] = [];
+  for (const project of projects) {
+    if (isInWorkspace(project)) {
+      inWorkspace.push({ project });
+      continue;
+    }
+    const name = workspaces.find((workspace) => workspace.id === project.workspaceId)?.name;
+    others.push({ project, ...(name ? { otherWorkspaceName: name } : {}) });
+  }
+
+  return {
+    all: [...inWorkspace, ...others],
+    inWorkspace,
+    others,
+    activeWorkspaceName: workspaces.find((workspace) => workspace.id === activeWorkspaceId)?.name,
+  };
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Oder schreiben Sie eine individuelle Antwort"
 msgid "Other"
 msgstr "Andere"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Andere Arbeitsbereiche"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Ergebnis"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -7809,6 +7809,10 @@ msgstr "Or write a custom answer"
 msgid "Other"
 msgstr "Other"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Other workspaces"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Outcome"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -7804,6 +7804,10 @@ msgstr "O escribe una respuesta personalizada"
 msgid "Other"
 msgstr "Otras"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Otros espacios de trabajo"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Resultado"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -7803,6 +7803,10 @@ msgstr "Ou écrivez une réponse personnalisée"
 msgid "Other"
 msgstr "Autres"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Autres espaces de travail"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Résultat"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -7802,6 +7802,10 @@ msgstr "またはカスタムの回答を作成します"
 msgid "Other"
 msgstr "その他"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "他のワークスペース"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "結果"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -7804,6 +7804,10 @@ msgstr "또는 맞춤 답변을 작성하세요."
 msgid "Other"
 msgstr "기타"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "다른 작업 영역"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "결과"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Lub napisz niestandardową odpowiedź"
 msgid "Other"
 msgstr "Inne"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Inne obszary robocze"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Wynik"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Ou escreva uma resposta personalizada"
 msgid "Other"
 msgstr "Outros"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Outros espaços de trabalho"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Resultado"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Или напишите свой ответ"
 msgid "Other"
 msgstr "Прочие"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Другие рабочие области"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Результат"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Veya özel bir cevap yazın"
 msgid "Other"
 msgstr "Diğer"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Diğer çalışma alanları"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Sonuç"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Або напишіть власну відповідь"
 msgid "Other"
 msgstr "Інші"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Інші робочі області"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Результат"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -7804,6 +7804,10 @@ msgstr "Hoặc viết một câu trả lời tùy chỉnh"
 msgid "Other"
 msgstr "Khác"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "Không gian làm việc khác"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "Kết quả"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -7803,6 +7803,10 @@ msgstr "或者写一个自定义答案"
 msgid "Other"
 msgstr "其他"
 
+#: src/renderer/components/thread/ProjectSwitchMenu.tsx
+msgid "Other workspaces"
+msgstr "其他工作区"
+
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"
 msgstr "结果"

--- a/src/renderer/state/workspaceStore.test.ts
+++ b/src/renderer/state/workspaceStore.test.ts
@@ -3,7 +3,13 @@ import { DEFAULT_WORKSPACE_ICONS, DEFAULT_WORKSPACE_NAMES } from "@/shared/contr
 import { HOME_PROJECT_ID } from "@/shared/homeScope";
 import { useAppStore } from "./appStore";
 import { useSharedSettings } from "./sharedSettingsStore";
-import { bootstrapWorkspaces, resolveActiveWorkspaceId, useWorkspaceStore } from "./workspaceStore";
+import {
+  bootstrapWorkspaces,
+  getLastWorkspaceProjectId,
+  rememberWorkspaceProject,
+  resolveActiveWorkspaceId,
+  useWorkspaceStore,
+} from "./workspaceStore";
 
 function addProject(name: string) {
   return useAppStore.getState().addProject({ kind: "posix", path: `/repos/${name}` }, name);
@@ -21,6 +27,48 @@ describe("resolveActiveWorkspaceId", () => {
 
   it("returns null when there are no workspaces at all", () => {
     expect(resolveActiveWorkspaceId([], "a")).toBeNull();
+  });
+});
+
+describe("last project per workspace", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSharedSettings.setState({
+      workspaces: [
+        { id: "w1", name: "Work", createdAt: "2026-07-29T00:00:00.000Z", icon: "briefcase" },
+        { id: "w2", name: "Side", createdAt: "2026-07-29T00:00:00.000Z", icon: "rocket" },
+      ],
+    });
+    useWorkspaceStore.setState({ activeWorkspaceId: "w1", lastProjectIdByWorkspace: {} });
+  });
+
+  it("keeps a pick per workspace", () => {
+    rememberWorkspaceProject("p1");
+    useWorkspaceStore.setState({ activeWorkspaceId: "w2" });
+    rememberWorkspaceProject("p2");
+
+    expect(getLastWorkspaceProjectId()).toBe("p2");
+    useWorkspaceStore.setState({ activeWorkspaceId: "w1" });
+    expect(getLastWorkspaceProjectId()).toBe("p1");
+  });
+
+  it("reads nothing for a workspace with no pick yet", () => {
+    expect(getLastWorkspaceProjectId()).toBeUndefined();
+  });
+
+  it("rehydrates a payload written before the field existed", async () => {
+    // Regression for the released v1 shape: `lastProjectIdByWorkspace` is
+    // additive, so the stored active workspace must survive rather than reset.
+    localStorage.setItem(
+      "poracode-active-workspace",
+      JSON.stringify({ state: { activeWorkspaceId: "w2" }, version: 1 }),
+    );
+
+    await useWorkspaceStore.persist.rehydrate();
+
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("w2");
+    expect(useWorkspaceStore.getState().lastProjectIdByWorkspace).toEqual({});
+    expect(typeof useWorkspaceStore.getState().rememberProjectForWorkspace).toBe("function");
   });
 });
 

--- a/src/renderer/state/workspaceStore.ts
+++ b/src/renderer/state/workspaceStore.ts
@@ -10,6 +10,9 @@ import { useSharedSettings, whenSharedSettingsHydrated } from "./sharedSettingsS
 
 const PERSIST_KEY = "poracode-active-workspace";
 
+/** Key for projects picked while no workspace exists yet (fresh install). */
+const NO_WORKSPACE_KEY = "";
+
 interface WorkspaceUiState {
   /**
    * Which workspace this window is looking at. Deliberately *not* part of
@@ -18,6 +21,16 @@ interface WorkspaceUiState {
    */
   activeWorkspaceId: string | null;
   setActiveWorkspaceId: (workspaceId: string | null) => void;
+  /**
+   * The project last deliberately picked while each workspace was active, keyed
+   * by workspace id, so a new thread started with no explicit target resumes
+   * that workspace's own work instead of whatever project happens to sit first
+   * in the store. Entries for deleted workspaces/projects are left in place;
+   * readers validate the id against the live project list, which is cheaper and
+   * safer than pruning on every deletion path.
+   */
+  lastProjectIdByWorkspace: Record<string, string>;
+  rememberProjectForWorkspace: (workspaceId: string | null, projectId: string) => void;
 }
 
 export const useWorkspaceStore = create<WorkspaceUiState>()(
@@ -25,14 +38,37 @@ export const useWorkspaceStore = create<WorkspaceUiState>()(
     (set) => ({
       activeWorkspaceId: null,
       setActiveWorkspaceId: (activeWorkspaceId) => set({ activeWorkspaceId }),
+      lastProjectIdByWorkspace: {},
+      rememberProjectForWorkspace: (workspaceId, projectId) =>
+        set((state) => ({
+          lastProjectIdByWorkspace: {
+            ...state.lastProjectIdByWorkspace,
+            [workspaceId ?? NO_WORKSPACE_KEY]: projectId,
+          },
+        })),
     }),
     {
       name: PERSIST_KEY,
+      // Still version 1: `lastProjectIdByWorkspace` is purely additive, and
+      // persist's shallow merge leaves the `{}` default in place for payloads
+      // written before it existed. A v1 payload stays valid, so bumping would
+      // only throw away the user's active workspace for no gain.
       version: 1,
       storage: createJSONStorage(() => localStorage),
     },
   ),
 );
+
+/** Record a deliberate project pick as the active workspace's default target. */
+export function rememberWorkspaceProject(projectId: string): void {
+  useWorkspaceStore.getState().rememberProjectForWorkspace(getActiveWorkspaceId(), projectId);
+}
+
+/** The project a fresh draft should prefer for the active workspace, if any. */
+export function getLastWorkspaceProjectId(): string | undefined {
+  const byWorkspace = useWorkspaceStore.getState().lastProjectIdByWorkspace ?? {};
+  return byWorkspace[getActiveWorkspaceId() ?? NO_WORKSPACE_KEY];
+}
 
 /**
  * The workspace actually in effect: the stored id when it still resolves,


### PR DESCRIPTION
- Feature: organize project choices into the active workspace and other workspaces for clearer navigation.
- Preserve workspace context by remembering each workspace’s most recently selected project.
- Switch to the appropriate workspace when opening or selecting a project, including drafts and threads.
- Add localized section labels, mobile styling, and coverage for workspace and menu behavior.