### PR TITLE
Persist rotated browser login cookies

### DIFF
--- a/packages/agents-usage/src/collectors/qwen.test.ts
+++ b/packages/agents-usage/src/collectors/qwen.test.ts
@@ -211,6 +211,83 @@ describe("collectQwen", () => {
     });
   });
 
+  it("persists the console's rotated session ticket and replays it on later requests", async () => {
+    // Alibaba issues its `login_*` cookies as session cookies, so the browser jar
+    // loses them on quit and this sealed copy is all that survives a restart. If
+    // the rotation is dropped, the next launch replays a ticket the console has
+    // already retired and the provider reads as signed out.
+    const requests: HttpRequest[] = [];
+    const writes: { key: string; value: string }[] = [];
+    const rpcRoute = { body: TOKEN_PLAN_BODY, setCookies: ["login_aliyunid_ticket=rotated-2"] };
+    const host = createFakeHost({
+      secrets: {
+        qwen: { cookie: "login_aliyunid_ticket=captured; cna=anon" },
+      },
+      routes: {
+        [ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL]: {
+          body: '<html><script>window.config={SEC_TOKEN:"sec"}</script></html>',
+          setCookies: ["login_aliyunid_ticket=rotated-1; Path=/; HttpOnly"],
+        },
+        [ALIBABA_CODING_PLAN_INTL_CONSOLE_RPC_URL]: rpcRoute,
+      },
+      onRequest: (request) => {
+        requests.push(request);
+        if (request.url !== ALIBABA_CODING_PLAN_INTL_CONSOLE_RPC_URL) return;
+        const api = JSON.parse(new URLSearchParams(request.body).get("params") ?? "{}").Api;
+        rpcRoute.body =
+          api === "zeldaHttp.apikeyMgr./tokenplan/personal/api/v2/subscription"
+            ? TOKEN_PLAN_SUBSCRIPTION_BODY
+            : TOKEN_PLAN_BODY;
+      },
+      onSetSecret: (providerId, key, value) => {
+        expect(providerId).toBe("qwen");
+        writes.push({ key, value });
+      },
+    });
+
+    expect(await collectQwen(host)).toMatchObject({ status: "ok" });
+    // The dashboard's rotation is replayed on the RPC call, as a browser would.
+    expect(requests[1]?.headers?.Cookie).toBe("login_aliyunid_ticket=rotated-1; cna=anon");
+    expect(writes).toEqual([{ key: "cookie", value: "login_aliyunid_ticket=rotated-2; cna=anon" }]);
+  });
+
+  it("does not persist cookies when the console rejects the captured session", async () => {
+    // A rejected session's `Set-Cookie` lines are logout instructions, and a
+    // transient failure must not clobber a still-usable ticket.
+    const writes: string[] = [];
+    const host = createFakeHost({
+      secrets: { qwen: { cookie: "login_aliyunid_ticket=captured" } },
+      routes: {
+        [ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL]: {
+          status: 403,
+          setCookies: ["login_aliyunid_ticket=; Max-Age=0"],
+        },
+        "https://modelstudio.console.alibabacloud.com/tool/user/info.json": { status: 403 },
+      },
+      onSetSecret: (_providerId, key) => writes.push(key),
+    });
+
+    expect((await collectQwen(host)).status).toBe("auth-missing");
+    expect(writes).toEqual([]);
+  });
+
+  it("leaves the stored cookie untouched when the console rotates nothing", async () => {
+    const writes: string[] = [];
+    const host = createFakeHost({
+      secrets: { qwen: { cookie: "login_aliyunid_ticket=captured" } },
+      routes: {
+        [ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL]: {
+          body: '<html><script>window.config={SEC_TOKEN:"sec"}</script></html>',
+        },
+        [ALIBABA_CODING_PLAN_INTL_CONSOLE_RPC_URL]: { body: TOKEN_PLAN_BODY },
+      },
+      onSetSecret: (_providerId, key) => writes.push(key),
+    });
+
+    expect((await collectQwen(host)).status).toBe("ok");
+    expect(writes).toEqual([]);
+  });
+
   it("falls back to the API key when a captured console session is stale", async () => {
     const requests: string[] = [];
     const host = createFakeHost({

--- a/packages/agents-usage/src/collectors/qwen.ts
+++ b/packages/agents-usage/src/collectors/qwen.ts
@@ -1,3 +1,4 @@
+import { CookieJar } from "../cookieJar";
 import type { CollectOptions, HostPort, HttpResponse, OAuthToken } from "../host";
 import type { UsageSnapshot, UsageWindow } from "../types";
 
@@ -528,7 +529,7 @@ function requestQuota(
 
 async function resolveConsoleSecToken(
   host: HostPort,
-  cookieHeader: string,
+  jar: CookieJar,
   region: AlibabaCodingPlanRegion,
 ): Promise<string | undefined> {
   const config = REGION_CONFIG[region];
@@ -536,12 +537,15 @@ async function resolveConsoleSecToken(
     method: "GET",
     url: config.dashboardUrl,
     headers: {
-      Cookie: cookieHeader,
+      Cookie: jar.header,
       Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       "User-Agent": BROWSER_USER_AGENT,
     },
     timeoutMs: 15_000,
   });
+  // The console rotates its session ticket on the dashboard load, so absorb
+  // before issuing the next request — exactly what a browser would send.
+  jar.absorb(dashboard);
   if (dashboard.status === 200) {
     const fromHtml = consoleSecTokenFromHtml(dashboard.body);
     if (fromHtml) return fromHtml;
@@ -551,13 +555,14 @@ async function resolveConsoleSecToken(
     method: "GET",
     url: `${config.baseUrl}/tool/user/info.json`,
     headers: {
-      Cookie: cookieHeader,
+      Cookie: jar.header,
       Accept: "application/json, text/plain, */*",
       Referer: `${config.baseUrl}/`,
       "User-Agent": BROWSER_USER_AGENT,
     },
     timeoutMs: 15_000,
   });
+  jar.absorb(userInfo);
   if (userInfo.status === 200) {
     try {
       const fromUserInfo = firstString(expandEmbeddedJson(JSON.parse(userInfo.body)), [
@@ -569,7 +574,7 @@ async function resolveConsoleSecToken(
       // Continue to the cookie fallback.
     }
   }
-  return cookieValue(cookieHeader, "sec_token");
+  return cookieValue(jar.header, "sec_token");
 }
 
 function consoleRequestBody(
@@ -714,18 +719,41 @@ export async function collectQwen(host: HostPort, _opts?: CollectOptions): Promi
   const cookie = (await host.credentials.getSecret(QWEN_PROVIDER_ID, "cookie"))?.trim();
   let cookieSnapshot: UsageSnapshot | undefined;
   if (cookie) {
+    const jar = new CookieJar(cookie);
+    // Alibaba issues its `login_*` console cookies as session cookies, so the
+    // browser's own jar drops them when the app quits — this sealed copy is the
+    // only thing that survives a restart. Persist the rotated ticket the console
+    // just handed back, or the captured value goes stale and the provider reads
+    // as signed out until the user runs browser sign-in again. Only persist on a
+    // successful pass: a rejected session's `Set-Cookie` lines are logout
+    // instructions, and a transient failure must not clobber a good ticket.
+    const persistRotation = async (): Promise<void> => {
+      if (!jar.rotated || !host.credentials.setSecret) return;
+      try {
+        await host.credentials.setSecret(QWEN_PROVIDER_ID, "cookie", jar.header);
+      } catch {
+        // A failed write only costs freshness; never fail collection over it.
+      }
+    };
+
     // The in-app login captures cookies scoped to the international console.
     // Never replay those cookies to the China-mainland domain; API-key fallback
     // below may still try both official regions when no region is configured.
-    const secToken = await resolveConsoleSecToken(host, cookie, "intl");
+    const secToken = await resolveConsoleSecToken(host, jar, "intl");
     const [tokenPlanResponse, tokenPlanSubscriptionResponse] = secToken
       ? await Promise.all([
-          requestConsoleApi(host, cookie, "intl", secToken, TOKEN_PLAN_USAGE_ACTION),
-          requestConsoleApi(host, cookie, "intl", secToken, TOKEN_PLAN_SUBSCRIPTION_ACTION).catch(
-            () => undefined,
-          ),
+          requestConsoleApi(host, jar.header, "intl", secToken, TOKEN_PLAN_USAGE_ACTION),
+          requestConsoleApi(
+            host,
+            jar.header,
+            "intl",
+            secToken,
+            TOKEN_PLAN_SUBSCRIPTION_ACTION,
+          ).catch(() => undefined),
         ])
       : [undefined, undefined];
+    jar.absorb(tokenPlanResponse);
+    jar.absorb(tokenPlanSubscriptionResponse);
     const tokenPlanSnapshot = tokenPlanResponse
       ? responseSnapshot(tokenPlanResponse, now, "web-session")
       : {
@@ -736,14 +764,20 @@ export async function collectQwen(host: HostPort, _opts?: CollectOptions): Promi
           error: "Alibaba console session expired",
         };
     if (tokenPlanSnapshot.status === "ok" || tokenPlanSnapshot.status === "rate-limited") {
+      await persistRotation();
       const plan = tokenPlanSnapshot.plan ?? planFromResponse(tokenPlanSubscriptionResponse);
       return plan ? { ...tokenPlanSnapshot, plan } : tokenPlanSnapshot;
     }
 
-    const response = secToken ? await requestConsoleApi(host, cookie, "intl", secToken) : undefined;
+    const response = secToken
+      ? await requestConsoleApi(host, jar.header, "intl", secToken)
+      : undefined;
+    jar.absorb(response);
     cookieSnapshot = response ? responseSnapshot(response, now, "web-session") : tokenPlanSnapshot;
-    if (cookieSnapshot.status === "ok" || cookieSnapshot.status === "rate-limited")
+    if (cookieSnapshot.status === "ok" || cookieSnapshot.status === "rate-limited") {
+      await persistRotation();
       return cookieSnapshot;
+    }
   }
 
   const [pastedValue, token] = await Promise.all([

--- a/packages/agents-usage/src/cookieJar.test.ts
+++ b/packages/agents-usage/src/cookieJar.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { applySetCookies, CookieJar, parseCookieHeader, parseSetCookie } from "./cookieJar";
+
+describe("parseCookieHeader", () => {
+  it("keeps insertion order and tolerates padding and empty segments", () => {
+    expect([...parseCookieHeader(" a=1;; b = 2 ; c=3 ")]).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+      ["c", "3"],
+    ]);
+  });
+
+  it("skips segments with no name", () => {
+    expect([...parseCookieHeader("=orphan; a=1")]).toEqual([["a", "1"]]);
+  });
+
+  it("keeps a value containing '=' intact", () => {
+    expect(parseCookieHeader("t=abc==").get("t")).toBe("abc==");
+  });
+});
+
+describe("parseSetCookie", () => {
+  it("reads the name/value pair and ignores attributes", () => {
+    expect(parseSetCookie("login_aliyunid_ticket=fresh; Path=/; HttpOnly; Secure")).toEqual({
+      name: "login_aliyunid_ticket",
+      value: "fresh",
+      deleted: false,
+    });
+  });
+
+  it("treats an empty value or a non-positive Max-Age as a deletion", () => {
+    expect(parseSetCookie("sid=; Path=/")?.deleted).toBe(true);
+    expect(parseSetCookie("sid=x; Max-Age=0")?.deleted).toBe(true);
+    expect(parseSetCookie("sid=x; max-age=-1")?.deleted).toBe(true);
+    expect(parseSetCookie("sid=x; Max-Age=3600")?.deleted).toBe(false);
+  });
+
+  it("rejects malformed lines", () => {
+    expect(parseSetCookie("novalue")).toBeUndefined();
+    expect(parseSetCookie("=orphan")).toBeUndefined();
+  });
+});
+
+describe("applySetCookies", () => {
+  it("reports no change when the server repeats the value it was sent", () => {
+    const cookies = parseCookieHeader("a=1");
+    expect(applySetCookies(cookies, ["a=1; Path=/"])).toBe(false);
+  });
+
+  it("adds, replaces, and removes without disturbing untouched cookies", () => {
+    const cookies = parseCookieHeader("a=1; b=2");
+    expect(applySetCookies(cookies, ["b=3", "c=4", "a=; Max-Age=0"])).toBe(true);
+    expect([...cookies]).toEqual([
+      ["b", "3"],
+      ["c", "4"],
+    ]);
+  });
+
+  it("ignores a deletion for a cookie it never held", () => {
+    const cookies = parseCookieHeader("a=1");
+    expect(applySetCookies(cookies, ["gone=; Max-Age=0"])).toBe(false);
+  });
+});
+
+describe("CookieJar", () => {
+  it("starts unrotated and round-trips the captured header", () => {
+    const jar = new CookieJar("login_aliyunid_ticket=old; cna=anon");
+    expect(jar.rotated).toBe(false);
+    expect(jar.header).toBe("login_aliyunid_ticket=old; cna=anon");
+  });
+
+  it("absorbs a rotated ticket and reports it, leaving other cookies in place", () => {
+    const jar = new CookieJar("login_aliyunid_ticket=old; cna=anon");
+    jar.absorb({ setCookies: ["login_aliyunid_ticket=new; Path=/; HttpOnly"] });
+    expect(jar.rotated).toBe(true);
+    expect(jar.header).toBe("login_aliyunid_ticket=new; cna=anon");
+  });
+
+  it("stays unrotated for missing, empty, or echoed Set-Cookie values", () => {
+    const jar = new CookieJar("a=1");
+    jar.absorb(undefined);
+    jar.absorb({});
+    jar.absorb({ setCookies: [] });
+    jar.absorb({ setCookies: ["a=1"] });
+    expect(jar.rotated).toBe(false);
+    expect(jar.header).toBe("a=1");
+  });
+
+  it("stays rotated once a later response changes nothing", () => {
+    const jar = new CookieJar("a=1");
+    jar.absorb({ setCookies: ["a=2"] });
+    jar.absorb({ setCookies: ["a=2"] });
+    expect(jar.rotated).toBe(true);
+    expect(jar.header).toBe("a=2");
+  });
+});

--- a/packages/agents-usage/src/cookieJar.ts
+++ b/packages/agents-usage/src/cookieJar.ts
@@ -1,0 +1,116 @@
+import type { HttpResponse } from "./host";
+
+/**
+ * A minimal, in-memory cookie jar for collectors that authenticate with a
+ * captured browser session cookie.
+ *
+ * Providers whose console rotates its session ticket on every request (Alibaba's
+ * ModelStudio console is the motivating case) invalidate the header the in-app
+ * login captured. Without absorbing those rotations the stored secret goes stale
+ * and the provider reads as signed out until the user signs in again — so the jar
+ * tracks `Set-Cookie` across a collect pass and reports whether the header moved,
+ * letting the collector write the fresh value back through
+ * `CredentialStore.setSecret`.
+ *
+ * Deliberately not a full RFC 6265 store: every request in a collect pass targets
+ * one provider's own origin family, so `Domain`/`Path`/`Secure` scoping adds no
+ * signal here. Expiry is treated conservatively — only an explicit deletion
+ * (empty value or `Max-Age` <= 0) drops a cookie, because wrongly dropping a live
+ * ticket costs the user a re-login while keeping one the server tried to expire
+ * merely fails the next request.
+ */
+
+/** Parse a `Cookie` request header into an insertion-ordered name → value map. */
+export function parseCookieHeader(header: string): Map<string, string> {
+  const cookies = new Map<string, string>();
+  for (const segment of header.split(";")) {
+    const part = segment.trim();
+    if (!part) continue;
+    const separator = part.indexOf("=");
+    if (separator <= 0) continue;
+    const name = part.slice(0, separator).trim();
+    if (name) cookies.set(name, part.slice(separator + 1).trim());
+  }
+  return cookies;
+}
+
+/** Serialize a name → value map back into a `Cookie` request header. */
+export function serializeCookieHeader(cookies: Map<string, string>): string {
+  return [...cookies].map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+interface ParsedSetCookie {
+  name: string;
+  value: string;
+  deleted: boolean;
+}
+
+/** Pure: parse one raw `Set-Cookie` header line. */
+export function parseSetCookie(raw: string): ParsedSetCookie | undefined {
+  const [pair, ...attributes] = raw.split(";");
+  if (pair === undefined) return undefined;
+  const separator = pair.indexOf("=");
+  if (separator <= 0) return undefined;
+  const name = pair.slice(0, separator).trim();
+  if (!name) return undefined;
+  const value = pair.slice(separator + 1).trim();
+  const maxAge = attributes
+    .map((attribute) => /^\s*max-age\s*=\s*(-?\d+)\s*$/iu.exec(attribute)?.[1])
+    .find((match) => match !== undefined);
+  const deleted = !value || (maxAge !== undefined && Number(maxAge) <= 0);
+  return { name, value, deleted };
+}
+
+/**
+ * Apply raw `Set-Cookie` lines onto `cookies` in place. Returns true when the map
+ * changed, so callers can skip a no-op write to the sealed secret store.
+ */
+export function applySetCookies(
+  cookies: Map<string, string>,
+  setCookies: readonly string[],
+): boolean {
+  let changed = false;
+  for (const raw of setCookies) {
+    const parsed = parseSetCookie(raw);
+    if (!parsed) continue;
+    if (parsed.deleted) {
+      changed = cookies.delete(parsed.name) || changed;
+      continue;
+    }
+    if (cookies.get(parsed.name) === parsed.value) continue;
+    cookies.set(parsed.name, parsed.value);
+    changed = true;
+  }
+  return changed;
+}
+
+/**
+ * Tracks one provider's session cookie across a collect pass. Feed every response
+ * through {@link absorb}; when {@link rotated} is true the provider handed back a
+ * newer session and {@link header} should be persisted.
+ */
+export class CookieJar {
+  private cookies: Map<string, string>;
+  private changed = false;
+
+  constructor(header: string) {
+    this.cookies = parseCookieHeader(header);
+  }
+
+  /** The current `Cookie` request header. */
+  get header(): string {
+    return serializeCookieHeader(this.cookies);
+  }
+
+  /** True once any absorbed response changed the header. */
+  get rotated(): boolean {
+    return this.changed;
+  }
+
+  /** Absorb a response's `Set-Cookie` rotations. Missing/failed responses are no-ops. */
+  absorb(response: Pick<HttpResponse, "setCookies"> | undefined | null): void {
+    const setCookies = response?.setCookies;
+    if (!setCookies?.length) return;
+    if (applySetCookies(this.cookies, setCookies)) this.changed = true;
+  }
+}

--- a/packages/agents-usage/src/host.ts
+++ b/packages/agents-usage/src/host.ts
@@ -19,6 +19,15 @@ export interface HttpResponse {
   headers: Record<string, string>;
   body: string;
   bodyBytes?: Uint8Array;
+  /**
+   * Raw `Set-Cookie` values, one entry per header line. `headers` cannot carry
+   * them: the Headers API has no reliable generic multi-value read, so repeated
+   * `set-cookie` entries collapse into one comma-joined string that cannot be
+   * split back apart safely (cookie attributes contain commas). Hosts that can
+   * expose them populate this; collectors that rotate a stored session cookie
+   * read it (see `cookieJar.ts`) and degrade gracefully when it is absent.
+   */
+  setCookies?: string[];
 }
 
 export interface HttpClient {

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -14,6 +14,13 @@ export {
   LOCAL_USAGE_PROVIDER_DESCRIPTORS,
 } from "./providers";
 export { DEFAULT_CLIENT_VERSIONS } from "./clientVersions";
+export {
+  applySetCookies,
+  CookieJar,
+  parseCookieHeader,
+  parseSetCookie,
+  serializeCookieHeader,
+} from "./cookieJar";
 export { priceTokens, rateForModel, PRICING_TABLE_REVIEWED } from "./pricing";
 export type { ModelRate } from "./pricing";
 export { aggregateClaudeCost } from "./cost";

--- a/packages/agents-usage/src/testHost.ts
+++ b/packages/agents-usage/src/testHost.ts
@@ -10,6 +10,8 @@ export interface FakeRoute {
   body?: string;
   bodyBytes?: Uint8Array;
   headers?: Record<string, string>;
+  /** Raw `Set-Cookie` lines, for collectors that rotate a stored session cookie. */
+  setCookies?: string[];
 }
 
 export interface FakeHostConfig {
@@ -53,6 +55,7 @@ export function createFakeHost(config: FakeHostConfig = {}): HostPort {
           headers: route?.headers ?? {},
           body: route?.body ?? "{}",
           ...(route?.bodyBytes ? { bodyBytes: route.bodyBytes } : {}),
+          ...(route?.setCookies ? { setCookies: route.setCookies } : {}),
         });
       },
     },

--- a/src/main/browser/BrowserLoginCaptureCoordinator.ts
+++ b/src/main/browser/BrowserLoginCaptureCoordinator.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { session as electronSession } from "electron";
+import { BROWSER_SESSION_PARTITION } from "@/shared/browserPartition";
 import type { UsageLoginConfirmationAction, UsageLoginDeviceCode } from "@/shared/contracts";
 import type { BrowserEvent, BrowserTabInfo } from "@/shared/ipc";
 import type { BrowserTab } from "./BrowserTab";
@@ -323,7 +324,7 @@ export class BrowserLoginCaptureCoordinator {
   }
 
   async clearLoginCookies(opts: { cookieUrl: string; authCookiePattern: RegExp }): Promise<void> {
-    const ses = electronSession.fromPartition("persist:lightcode-browser");
+    const ses = electronSession.fromPartition(BROWSER_SESSION_PARTITION);
     const cookies = await ses.cookies.get({ url: opts.cookieUrl });
     await Promise.all(
       cookies

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -11,6 +11,7 @@ import {
   session as electronSession,
   type RenderProcessGoneDetails,
 } from "electron";
+import { BROWSER_SESSION_PARTITION } from "@/shared/browserPartition";
 import { resolveThemeMode } from "@/shared/themeMode";
 import { isThreadTurnActive, type RemoteThreadCommand } from "@/shared/contracts";
 import {
@@ -46,6 +47,7 @@ import {
   registerPickerProtocolScheme,
 } from "./browser";
 import { buildBrowserUserAgent } from "./browser/userAgent";
+import { startUsageLoginCookieMirror } from "./usageLogin/UsageLoginCookieMirror";
 import {
   ComputerUseDesktopOverlay,
   ComputerUseMcpIngress,
@@ -669,9 +671,14 @@ if (!hasSingleInstanceLock) {
       installLocalFileProtocolHandler();
       installPickerProtocolHandler();
       // Keep the pre-rebrand partition so browser cookies and sign-ins survive.
-      electronSession.fromPartition("persist:lightcode-browser").setUserAgent(browserUserAgent);
+      const browserSession = electronSession.fromPartition(BROWSER_SESSION_PARTITION);
+      browserSession.setUserAgent(browserUserAgent);
 
       const paths = requirePoracodePaths();
+      // Re-seal an already-signed-in provider's cookie whenever the live jar
+      // refreshes it, so providers with session-scoped auth cookies (Alibaba's
+      // console) don't age out of the one snapshot taken at sign-in.
+      startUsageLoginCookieMirror({ cacheDir: paths.cacheDir, session: browserSession });
       const initialSettings = readSharedSettingsFile(paths.settingsPath);
       syncStartupSettings(initialSettings);
       const showMainWindowOnReady = !shouldStartMinimized(

--- a/src/main/usageLogin/UsageLoginCookieMirror.test.ts
+++ b/src/main/usageLogin/UsageLoginCookieMirror.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Cookie } from "electron";
+import { getUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
+import { startUsageLoginCookieMirror } from "./UsageLoginCookieMirror";
+import type { CookieLoginConfig } from "./providerLoginConfigs";
+
+const CONSOLE_URL = "https://modelstudio.console.alibabacloud.com/";
+
+const TARGET_CONFIG: CookieLoginConfig = {
+  kind: "cookie",
+  loginUrl: CONSOLE_URL,
+  cookieUrl: CONSOLE_URL,
+  authCookiePattern: /^login_(?:aliyunid_ticket|aliyunid_pk)$/i,
+};
+
+function cookie(name: string, value: string): Cookie {
+  return { name, value } as Cookie;
+}
+
+interface Harness {
+  cacheDir: string;
+  jar: Cookie[];
+  emit(changed: Cookie, removed?: boolean): void;
+  stop(): void;
+  requestedUrls: string[];
+}
+
+let dirs: string[] = [];
+let stops: (() => void)[] = [];
+
+function harness(jar: Cookie[]): Harness {
+  const cacheDir = mkdtempSync(join(tmpdir(), "poracode-cookie-mirror-"));
+  dirs.push(cacheDir);
+  const requestedUrls: string[] = [];
+  let listener: ((...args: unknown[]) => void) | undefined;
+  const session = {
+    cookies: {
+      get: (filter: { url: string }) => {
+        requestedUrls.push(filter.url);
+        return Promise.resolve(jar);
+      },
+      on: (_event: string, handler: (...args: unknown[]) => void) => {
+        listener = handler;
+      },
+      removeListener: () => {
+        listener = undefined;
+      },
+    },
+  };
+  const stop = startUsageLoginCookieMirror({
+    cacheDir,
+    session: session as unknown as Parameters<typeof startUsageLoginCookieMirror>[0]["session"],
+    targets: [{ providerId: "qwen", config: TARGET_CONFIG }],
+    debounceMs: 0,
+  });
+  stops.push(stop);
+  return {
+    cacheDir,
+    jar,
+    emit: (changed, removed = false) => listener?.({}, changed, "explicit", removed),
+    stop,
+    requestedUrls,
+  };
+}
+
+/** The mirror re-seals on a debounce timer; let its callback and write settle. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+beforeEach(() => {
+  dirs = [];
+  stops = [];
+});
+
+afterEach(() => {
+  for (const stop of stops) stop();
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("startUsageLoginCookieMirror", () => {
+  it("re-seals the live jar when the browser refreshes an auth cookie", async () => {
+    // Alibaba's console cookies are session-scoped, so the snapshot taken at
+    // sign-in is the only copy that survives a restart — it has to track the jar.
+    const test = harness([cookie("login_aliyunid_ticket", "fresh"), cookie("cna", "anon")]);
+    setUsageSecret(test.cacheDir, "qwen", "cookie", "login_aliyunid_ticket=stale; cna=anon");
+
+    test.emit(cookie("login_aliyunid_ticket", "fresh"));
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBe(
+      "login_aliyunid_ticket=fresh; cna=anon",
+    );
+    expect(test.requestedUrls).toEqual([CONSOLE_URL]);
+  });
+
+  it("never captures a cookie for a provider the user has not signed into", async () => {
+    const test = harness([cookie("login_aliyunid_ticket", "fresh")]);
+
+    test.emit(cookie("login_aliyunid_ticket", "fresh"));
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBeUndefined();
+    expect(test.requestedUrls).toEqual([]);
+  });
+
+  it("ignores cookies outside the provider's auth pattern", async () => {
+    const test = harness([cookie("login_aliyunid_ticket", "fresh")]);
+    setUsageSecret(test.cacheDir, "qwen", "cookie", "login_aliyunid_ticket=stale");
+
+    test.emit(cookie("_ga", "analytics"));
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBe("login_aliyunid_ticket=stale");
+  });
+
+  it("ignores removals so a sign-out or expiry never writes a weaker header", async () => {
+    const test = harness([cookie("cna", "anon")]);
+    setUsageSecret(test.cacheDir, "qwen", "cookie", "login_aliyunid_ticket=stale");
+
+    test.emit(cookie("login_aliyunid_ticket", "stale"), true);
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBe("login_aliyunid_ticket=stale");
+  });
+
+  it("keeps the stored snapshot when no auth cookie applies to the provider URL", async () => {
+    // A same-named cookie on an unrelated host must not blank the stored header.
+    const test = harness([cookie("cna", "anon")]);
+    setUsageSecret(test.cacheDir, "qwen", "cookie", "login_aliyunid_ticket=stale; cna=anon");
+
+    test.emit(cookie("login_aliyunid_ticket", "elsewhere"));
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBe(
+      "login_aliyunid_ticket=stale; cna=anon",
+    );
+  });
+
+  it("stops mirroring after the returned stop function runs", async () => {
+    const test = harness([cookie("login_aliyunid_ticket", "fresh")]);
+    setUsageSecret(test.cacheDir, "qwen", "cookie", "login_aliyunid_ticket=stale");
+
+    test.stop();
+    test.emit(cookie("login_aliyunid_ticket", "fresh"));
+    await settle();
+
+    expect(getUsageSecret(test.cacheDir, "qwen", "cookie")).toBe("login_aliyunid_ticket=stale");
+  });
+});

--- a/src/main/usageLogin/UsageLoginCookieMirror.ts
+++ b/src/main/usageLogin/UsageLoginCookieMirror.ts
@@ -1,0 +1,103 @@
+import type { Cookie, Session } from "electron";
+import { getUsageSecret, hasUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
+import { type CookieLoginConfig, cookieLoginTargets } from "./providerLoginConfigs";
+
+/**
+ * Keeps the sealed session cookie of an already-signed-in provider in step with
+ * the in-app browser's live cookie jar.
+ *
+ * `UsageLoginManager` snapshots the `Cookie` header once, at sign-in. That is
+ * enough for providers whose auth cookie is persistent (Grok's `sso` carries a
+ * multi-month expiry, so Chromium writes it to disk), but Alibaba's ModelStudio
+ * console issues its `login_*` cookies as *session* cookies: they live only in
+ * memory, vanish when the app quits, and the console rotates the ticket whenever
+ * the user visits it. Without mirroring, the one sealed snapshot ages out and the
+ * provider reads as "Not signed in" — which is what made Alibaba Token Plan need
+ * a fresh browser sign-in far more often than the other providers.
+ *
+ * Consent: this only ever re-seals a provider that already has a stored secret,
+ * i.e. one the user explicitly signed into and confirmed. It never captures a
+ * cookie for a provider that was not signed in, and never logs cookie values.
+ */
+
+/** Coalesce the burst of `changed` events a single page load produces. */
+const RESEAL_DEBOUNCE_MS = 1_500;
+
+interface MirrorTarget {
+  providerId: string;
+  config: CookieLoginConfig;
+}
+
+export interface UsageLoginCookieMirrorOptions {
+  /** Directory holding the sealed provider-secrets file. */
+  cacheDir: string;
+  /** The in-app browser's session (the partition that owns the cookie jar). */
+  session: Pick<Session, "cookies">;
+  /** Override the mirrored providers; defaults to every cookie-login provider. */
+  targets?: MirrorTarget[];
+  /** Injected for tests so the debounce is observable without real timers. */
+  debounceMs?: number;
+}
+
+/**
+ * Start mirroring live browser cookies into the sealed store. Returns a stop
+ * function; safe to call more than once.
+ */
+export function startUsageLoginCookieMirror(options: UsageLoginCookieMirrorOptions): () => void {
+  const targets = options.targets ?? cookieLoginTargets();
+  const debounceMs = options.debounceMs ?? RESEAL_DEBOUNCE_MS;
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  let stopped = false;
+
+  const reseal = async (target: MirrorTarget): Promise<void> => {
+    // Only a provider the user already signed into may be mirrored.
+    if (!hasUsageSecret(options.cacheDir, target.providerId)) return;
+    const cookies = await options.session.cookies.get({ url: target.config.cookieUrl });
+    // No auth cookie applies to this URL — the jar holds nothing worth sealing
+    // (and an empty header would destroy the still-usable stored snapshot).
+    if (!cookies.some((cookie) => target.config.authCookiePattern.test(cookie.name))) return;
+    const header = cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+    if (!header) return;
+    if (getUsageSecret(options.cacheDir, target.providerId, "cookie") === header) return;
+    setUsageSecret(options.cacheDir, target.providerId, "cookie", header);
+  };
+
+  const schedule = (target: MirrorTarget): void => {
+    if (stopped) return;
+    const existing = timers.get(target.providerId);
+    if (existing) clearTimeout(existing);
+    timers.set(
+      target.providerId,
+      setTimeout(() => {
+        timers.delete(target.providerId);
+        void reseal(target).catch((error) => {
+          // Never include the cookie value.
+          console.warn(
+            `[usage-login] failed to mirror ${target.providerId} session cookie:`,
+            error instanceof Error ? error.message : String(error),
+          );
+        });
+      }, debounceMs),
+    );
+  };
+
+  const onChanged = (_event: unknown, cookie: Cookie, _cause: unknown, removed: boolean): void => {
+    // React only to cookies the browser gained/refreshed. A removal is either a
+    // sign-out (handled by `clearLogin`) or Chromium expiring a value, and
+    // re-sealing on it would only ever write a weaker header.
+    if (removed) return;
+    for (const target of targets) {
+      if (target.config.authCookiePattern.test(cookie.name)) schedule(target);
+    }
+  };
+
+  options.session.cookies.on("changed", onChanged);
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    options.session.cookies.removeListener("changed", onChanged);
+    for (const timer of timers.values()) clearTimeout(timer);
+    timers.clear();
+  };
+}

--- a/src/main/usageLogin/UsageLoginManager.ts
+++ b/src/main/usageLogin/UsageLoginManager.ts
@@ -1,13 +1,16 @@
 import { clipboard } from "electron";
-import {
-  ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL,
-  allUsageProviderDescriptors,
-} from "@poracode/agents-usage";
 import type { BrowserPanelManager } from "../browser";
 import type { PoracodePaths } from "@/shared/poracodePaths";
 import type { UsageLoginStateResponse } from "@/shared/contracts";
 import { clearUsageSecret, hasUsageSecret, setUsageSecret } from "@/shared/usageSecretStore";
-import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
+import {
+  PROVIDER_CONFIGS,
+  USAGE_PROVIDER_BY_ID,
+  usageProviderLabel,
+  type GitHubDeviceLoginConfig,
+  type LocalStorageLoginConfig,
+  type ProviderLoginConfig,
+} from "./providerLoginConfigs";
 
 /**
  * Consent-gated, user-initiated browser login that captures a provider's web
@@ -21,140 +24,6 @@ export interface UsageLoginResult {
   ok: boolean;
   cancelled?: boolean;
   error?: string;
-}
-
-interface CookieLoginConfig {
-  kind: "cookie";
-  /** Page the user signs in on. */
-  loginUrl: string;
-  /** URL whose applicable cookies are captured and sent as the API Cookie header. */
-  cookieUrl: string;
-  /** A captured cookie matching this signals a *candidate* login. */
-  authCookiePattern: RegExp;
-  /**
-   * Optional second gate run on the captured `Cookie` header before prompting.
-   * A matching cookie name is necessary but not sufficient — stale or
-   * mid-`/authorize` cookies can share the name — so providers that can cheaply
-   * verify a live session return false here to keep polling instead of falsely
-   * reporting "Found a signed-in session".
-   */
-  validateSession?: (cookieHeader: string) => Promise<boolean>;
-}
-
-interface GitHubDeviceLoginConfig {
-  kind: "github-device";
-  host: string;
-  clientId: string;
-  scope: string;
-}
-
-interface LocalStorageLoginConfig {
-  kind: "local-storage";
-  /** Page the user signs in on (whose localStorage holds the session tokens). */
-  loginUrl: string;
-  /** A non-empty value for this localStorage key signals a completed login. */
-  requiredKey: string;
-  /** localStorage key → stored secret key. All present keys are sealed on success. */
-  store: Record<string, string>;
-}
-
-/**
- * The provider authenticates its usage API with a long-lived key the user pastes
- * in (for example, z.ai or Kimi). There is no browser/OAuth step — the key is
- * sealed via {@link submitApiKey} and read back by the collector — but the
- * provider still lives in `PROVIDER_CONFIGS` so its stored-secret state surfaces
- * like any login.
- */
-interface ApiKeyLoginConfig {
-  kind: "api-key";
-}
-
-type ProviderLoginConfig =
-  | CookieLoginConfig
-  | GitHubDeviceLoginConfig
-  | LocalStorageLoginConfig
-  | ApiKeyLoginConfig;
-
-const USAGE_PROVIDER_BY_ID = new Map(
-  allUsageProviderDescriptors().map((descriptor) => [descriptor.id, descriptor]),
-);
-
-function usageProviderLabel(providerId: string): string {
-  return USAGE_PROVIDER_BY_ID.get(providerId)?.label ?? providerId;
-}
-
-function isAlibabaConsoleSessionCandidate(cookieHeader: string): boolean {
-  const names = new Set(
-    cookieHeader
-      .split(";")
-      .map((part) => part.slice(0, Math.max(0, part.indexOf("="))).trim())
-      .filter(Boolean),
-  );
-  return (
-    names.has("login_aliyunid_ticket") &&
-    (names.has("login_aliyunid_pk") || names.has("login_current_pk") || names.has("login_aliyunid"))
-  );
-}
-
-const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
-  copilot: {
-    kind: "github-device",
-    host: "github.com",
-    clientId: "Iv1.b507a08c87ecfe98",
-    scope: "read:user",
-  },
-  factory: {
-    kind: "local-storage",
-    loginUrl: "https://app.factory.ai/",
-    // app.factory.ai sets NO session cookie — it stores WorkOS AuthKit tokens in
-    // localStorage. Capture the rotating refresh token (the durable credential)
-    // plus the current access token; the collector exchanges/refreshes as needed.
-    // The refresh-token key only appears after a completed login, so its presence
-    // alone is a safe prompt gate (no private-endpoint probe — the Grok lesson).
-    requiredKey: "workos:refresh-token",
-    store: {
-      "workos:refresh-token": "refresh-token",
-      "workos:access-token": "access-token",
-    },
-  },
-  grok: {
-    kind: "cookie",
-    loginUrl: "https://grok.com/",
-    cookieUrl: "https://grok.com/",
-    // grok.com sets `sso` / `sso-rw` cookies after auth. Do not gate the
-    // confirmation dialog on Grok's private usage endpoint: when that endpoint
-    // drifts, a visibly signed-in browser session otherwise never prompts.
-    authCookiePattern: /^sso(?:-rw)?$/i,
-  },
-  opencode: {
-    kind: "cookie",
-    loginUrl: "https://opencode.ai/auth",
-    cookieUrl: "https://opencode.ai/",
-    authCookiePattern: /^(?:auth|__Host-auth)$/i,
-    // The OpenAuth `/authorize` page can set an `auth`-named cookie before the
-    // user signs in, and stale values linger in the jar — so confirm the cookie
-    // actually authenticates before prompting.
-    validateSession: isOpenCodeLoginCookieLive,
-  },
-  qwen: {
-    kind: "cookie",
-    loginUrl: ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL,
-    cookieUrl: "https://modelstudio.console.alibabacloud.com/",
-    authCookiePattern: /^login_(?:aliyunid_ticket|aliyunid_pk|current_pk|aliyunid)$/i,
-    validateSession: async (cookieHeader) => isAlibabaConsoleSessionCandidate(cookieHeader),
-  },
-};
-
-for (const descriptor of USAGE_PROVIDER_BY_ID.values()) {
-  if (descriptor.needsLogin && descriptor.mechanism === "api-key") {
-    PROVIDER_CONFIGS[descriptor.id] = { kind: "api-key" };
-  }
-}
-
-for (const providerId of Object.keys(PROVIDER_CONFIGS)) {
-  if (!USAGE_PROVIDER_BY_ID.has(providerId)) {
-    throw new Error(`Usage login config has no provider descriptor: ${providerId}`);
-  }
 }
 
 const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;

--- a/src/main/usageLogin/providerLoginConfigs.ts
+++ b/src/main/usageLogin/providerLoginConfigs.ts
@@ -1,0 +1,153 @@
+import {
+  ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL,
+  allUsageProviderDescriptors,
+} from "@poracode/agents-usage";
+import { isOpenCodeLoginCookieLive } from "./openCodeLoginProbe";
+
+/**
+ * The per-provider browser-login configuration table, split out of
+ * `UsageLoginManager` so that class stays focused on running a login and so the
+ * cookie mirror (`UsageLoginCookieMirror.ts`) can reuse the same cookie targets
+ * instead of duplicating URLs and cookie-name patterns.
+ */
+
+export interface CookieLoginConfig {
+  kind: "cookie";
+  /** Page the user signs in on. */
+  loginUrl: string;
+  /** URL whose applicable cookies are captured and sent as the API Cookie header. */
+  cookieUrl: string;
+  /** A captured cookie matching this signals a *candidate* login. */
+  authCookiePattern: RegExp;
+  /**
+   * Optional second gate run on the captured `Cookie` header before prompting.
+   * A matching cookie name is necessary but not sufficient — stale or
+   * mid-`/authorize` cookies can share the name — so providers that can cheaply
+   * verify a live session return false here to keep polling instead of falsely
+   * reporting "Found a signed-in session".
+   */
+  validateSession?: (cookieHeader: string) => Promise<boolean>;
+}
+
+export interface GitHubDeviceLoginConfig {
+  kind: "github-device";
+  host: string;
+  clientId: string;
+  scope: string;
+}
+
+export interface LocalStorageLoginConfig {
+  kind: "local-storage";
+  /** Page the user signs in on (whose localStorage holds the session tokens). */
+  loginUrl: string;
+  /** A non-empty value for this localStorage key signals a completed login. */
+  requiredKey: string;
+  /** localStorage key → stored secret key. All present keys are sealed on success. */
+  store: Record<string, string>;
+}
+
+/**
+ * The provider authenticates its usage API with a long-lived key the user pastes
+ * in (for example, z.ai or Kimi). There is no browser/OAuth step — the key is
+ * sealed via `UsageLoginManager.submitApiKey` and read back by the collector —
+ * but the provider still lives in {@link PROVIDER_CONFIGS} so its stored-secret
+ * state surfaces like any login.
+ */
+export interface ApiKeyLoginConfig {
+  kind: "api-key";
+}
+
+export type ProviderLoginConfig =
+  | CookieLoginConfig
+  | GitHubDeviceLoginConfig
+  | LocalStorageLoginConfig
+  | ApiKeyLoginConfig;
+
+export const USAGE_PROVIDER_BY_ID = new Map(
+  allUsageProviderDescriptors().map((descriptor) => [descriptor.id, descriptor]),
+);
+
+export function usageProviderLabel(providerId: string): string {
+  return USAGE_PROVIDER_BY_ID.get(providerId)?.label ?? providerId;
+}
+
+function isAlibabaConsoleSessionCandidate(cookieHeader: string): boolean {
+  const names = new Set(
+    cookieHeader
+      .split(";")
+      .map((part) => part.slice(0, Math.max(0, part.indexOf("="))).trim())
+      .filter(Boolean),
+  );
+  return (
+    names.has("login_aliyunid_ticket") &&
+    (names.has("login_aliyunid_pk") || names.has("login_current_pk") || names.has("login_aliyunid"))
+  );
+}
+
+export const PROVIDER_CONFIGS: Record<string, ProviderLoginConfig> = {
+  copilot: {
+    kind: "github-device",
+    host: "github.com",
+    clientId: "Iv1.b507a08c87ecfe98",
+    scope: "read:user",
+  },
+  factory: {
+    kind: "local-storage",
+    loginUrl: "https://app.factory.ai/",
+    // app.factory.ai sets NO session cookie — it stores WorkOS AuthKit tokens in
+    // localStorage. Capture the rotating refresh token (the durable credential)
+    // plus the current access token; the collector exchanges/refreshes as needed.
+    // The refresh-token key only appears after a completed login, so its presence
+    // alone is a safe prompt gate (no private-endpoint probe — the Grok lesson).
+    requiredKey: "workos:refresh-token",
+    store: {
+      "workos:refresh-token": "refresh-token",
+      "workos:access-token": "access-token",
+    },
+  },
+  grok: {
+    kind: "cookie",
+    loginUrl: "https://grok.com/",
+    cookieUrl: "https://grok.com/",
+    // grok.com sets `sso` / `sso-rw` cookies after auth. Do not gate the
+    // confirmation dialog on Grok's private usage endpoint: when that endpoint
+    // drifts, a visibly signed-in browser session otherwise never prompts.
+    authCookiePattern: /^sso(?:-rw)?$/i,
+  },
+  opencode: {
+    kind: "cookie",
+    loginUrl: "https://opencode.ai/auth",
+    cookieUrl: "https://opencode.ai/",
+    authCookiePattern: /^(?:auth|__Host-auth)$/i,
+    // The OpenAuth `/authorize` page can set an `auth`-named cookie before the
+    // user signs in, and stale values linger in the jar — so confirm the cookie
+    // actually authenticates before prompting.
+    validateSession: isOpenCodeLoginCookieLive,
+  },
+  qwen: {
+    kind: "cookie",
+    loginUrl: ALIBABA_TOKEN_PLAN_INTL_DASHBOARD_URL,
+    cookieUrl: "https://modelstudio.console.alibabacloud.com/",
+    authCookiePattern: /^login_(?:aliyunid_ticket|aliyunid_pk|current_pk|aliyunid)$/i,
+    validateSession: async (cookieHeader) => isAlibabaConsoleSessionCandidate(cookieHeader),
+  },
+};
+
+for (const descriptor of USAGE_PROVIDER_BY_ID.values()) {
+  if (descriptor.needsLogin && descriptor.mechanism === "api-key") {
+    PROVIDER_CONFIGS[descriptor.id] = { kind: "api-key" };
+  }
+}
+
+for (const providerId of Object.keys(PROVIDER_CONFIGS)) {
+  if (!USAGE_PROVIDER_BY_ID.has(providerId)) {
+    throw new Error(`Usage login config has no provider descriptor: ${providerId}`);
+  }
+}
+
+/** Every cookie-login provider, for consumers that mirror the live cookie jar. */
+export function cookieLoginTargets(): { providerId: string; config: CookieLoginConfig }[] {
+  return Object.entries(PROVIDER_CONFIGS).flatMap(([providerId, config]) =>
+    config.kind === "cookie" ? [{ providerId, config }] : [],
+  );
+}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -10,6 +10,7 @@ import {
   PictureInPicture2,
   X,
 } from "lucide-react";
+import { BROWSER_SESSION_PARTITION } from "@/shared/browserPartition";
 import { isMac, readBridge } from "@/renderer/bridge";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
@@ -379,7 +380,7 @@ function BrowserTabWebview(props: { tabId: string; initialSrc: string; visible: 
     <webview
       ref={ref}
       data-tab-id={props.tabId}
-      partition="persist:lightcode-browser"
+      partition={BROWSER_SESSION_PARTITION}
       src={initialSrcRef.current || "about:blank"}
       // Electron's React type says boolean, but React warns unless this custom
       // element attribute is serialized as a string.

--- a/src/shared/browserPartition.ts
+++ b/src/shared/browserPartition.ts
@@ -1,0 +1,7 @@
+/**
+ * Electron session partition for the in-app browser. Kept at the pre-rebrand name
+ * so browser cookies and provider sign-ins survive the Lightcode → Poracode
+ * rename; changing it silently signs the user out of every site. Shared so the
+ * renderer's `<webview>`, the login capture, and the cookie mirror cannot drift.
+ */
+export const BROWSER_SESSION_PARTITION = "persist:lightcode-browser";

--- a/src/supervisor/runtime/usageHttpClient.ts
+++ b/src/supervisor/runtime/usageHttpClient.ts
@@ -35,7 +35,18 @@ export function createNodeHttpClient(): HttpClient {
         });
         const bodyBytes = new Uint8Array(await res.arrayBuffer());
         const body = Buffer.from(bodyBytes).toString("utf8");
-        return { status: res.status, headers: headersToRecord(res.headers), body, bodyBytes };
+        // `headersToRecord` collapses repeated `set-cookie` into one comma-joined
+        // value that cannot be split back apart (attributes contain commas), so
+        // surface the raw lines separately for collectors that rotate a session
+        // cookie. Same pitfall the relay host documents.
+        const setCookies = res.headers.getSetCookie();
+        return {
+          status: res.status,
+          headers: headersToRecord(res.headers),
+          body,
+          bodyBytes,
+          ...(setCookies.length > 0 ? { setCookies } : {}),
+        };
       } finally {
         clearTimeout(timeout);
       }


### PR DESCRIPTION
- **Bugfix:** Keep browser-based usage logins active when providers rotate session cookies.
- Persist refreshed Qwen console cookies after usage requests and mirror live browser cookie updates.
- Share provider login configuration and browser partition handling to keep capture, browser, and usage flows aligned.
- Add coverage for cookie rotation, mirroring, and HTTP `Set-Cookie` handling.