### PR TITLE
Improve Kimi ACP sessions, trust, and authentication

### DIFF
--- a/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
+++ b/.agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs
@@ -317,6 +317,52 @@ async function createFixture() {
   await writeFile(join(projectDir, "README.md"), "# Poracode smoke fixture\n");
   await writeFile(join(projectDir, "hello.txt"), "fixture data\n");
   await writeFile(
+    join(projectDir, "smoke-mcp-server.mjs"),
+    String.raw`let buffer = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  for (;;) {
+    const newline = buffer.indexOf("\n");
+    if (newline < 0) break;
+    const line = buffer.slice(0, newline);
+    buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const request = JSON.parse(line);
+    let result;
+    if (request.method === "initialize") {
+      result = {
+        protocolVersion: request.params?.protocolVersion ?? "2025-06-18",
+        capabilities: { tools: {} },
+        serverInfo: { name: "poracode-smoke", version: "1.0.0" },
+      };
+    } else if (request.method === "tools/list") {
+      result = {
+        tools: [
+          {
+            name: "smoke_echo",
+            description: "Return the supplied smoke-test text.",
+            inputSchema: {
+              type: "object",
+              properties: { text: { type: "string" } },
+              required: ["text"],
+            },
+          },
+        ],
+      };
+    } else if (request.method === "tools/call") {
+      result = {
+        content: [{ type: "text", text: String(request.params?.arguments?.text ?? "") }],
+      };
+    }
+    if (request.id !== undefined && result !== undefined) {
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\n");
+    }
+  }
+});
+`,
+  );
+  await writeFile(
     join(managedSkillDir, "SKILL.md"),
     "---\nname: smoke-review\ndescription: Deterministic managed smoke skill\n---\n\n# Smoke review\n",
   );

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -12,7 +12,7 @@ import { ChevronDown, Monitor } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
-import { agentStatusForPresentation } from "@/shared/agentSelection";
+import { agentStatusForPresentation, hasSelectableReasoning } from "@/shared/agentSelection";
 import {
   changeThreadConfig,
   clearThreadPendingSteer,
@@ -289,12 +289,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
       agentKind: thread.agentKind,
       presentationMode,
       runtimeLabel: effectiveAgentStatus?.capabilities.runtimeLabel,
-      hasEffort:
-        ((
-          effectiveAgentStatus?.capabilities.modelEfforts?.[thread.config?.model ?? ""] ??
-          effectiveAgentStatus?.capabilities.efforts ??
-          []
-        ).length ?? 0) > 0,
+      hasEffort: hasSelectableReasoning(
+        effectiveAgentStatus?.capabilities,
+        thread.config?.model ?? "",
+      ),
       supportsFast: effectiveAgentStatus
         ? supportsUsableFastMode(effectiveAgentStatus.capabilities, thread.config?.model ?? "")
         : false,

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -11,6 +11,7 @@ import type {
   ThreadPresentationMode,
 } from "@/shared/contracts";
 import { MAX_EXPERIMENT_CANDIDATES } from "@/shared/contracts";
+import { hasSelectableReasoning } from "@/shared/agentSelection";
 import { hookEnvForProject, hookEnvKey } from "@/shared/agentHookPluginEnv";
 import { mergeMcpServers } from "@/shared/contracts/mcpServer";
 import { isHomeProjectId } from "@/shared/homeScope";
@@ -377,12 +378,7 @@ export function ThreadDraftComposerArea(props: {
     props.selectedAgent.capabilities.slashCommands,
     {
       ...slashLookupContext,
-      hasEffort:
-        ((
-          props.selectedAgent.capabilities.modelEfforts?.[props.config.model] ??
-          props.selectedAgent.capabilities.efforts ??
-          []
-        ).length ?? 0) > 0,
+      hasEffort: hasSelectableReasoning(props.selectedAgent.capabilities, props.config.model),
       supportsFast: supportsUsableFastMode(props.selectedAgent.capabilities, props.config.model),
       skillCommands,
       disabledSkillNames: props.selectedAgent.capabilities.disabledSkillNames,

--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.test.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppProvider } from "@/renderer/components/ui/provider";
+import { asStructuredElicitationDetails, StructuredElicitationForm } from "./structuredElicitation";
+
+/**
+ * The form-mode request Kimi Code v2's acp-server builds for an
+ * AskUserQuestion: single-select questions become `type: "string"` + `oneOf`,
+ * multi-select ones `type: "array"` + `items.anyOf`, and every key is
+ * required. The `anyOf` half regressed once — the array rendered zero
+ * checkboxes, so the required key could never be filled and Submit stayed
+ * disabled forever.
+ */
+function kimiFormDetails() {
+  return {
+    acpElicitation: {
+      mode: "form",
+      message: "Which authentication method?\nWhich checks should run?",
+      agentName: "Kimi Code",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          q0: {
+            type: "string",
+            title: "Auth",
+            oneOf: [
+              { const: "Paste a token", title: "Paste a token" },
+              { const: "Log in via browser", title: "Log in via browser" },
+            ],
+          },
+          q1: {
+            type: "array",
+            title: "Checks",
+            minItems: 1,
+            items: {
+              anyOf: [
+                { const: "Tests", title: "Run tests" },
+                { const: "Lint", title: "Run lint" },
+              ],
+            },
+          },
+        },
+        required: ["q0", "q1"],
+      },
+    },
+  };
+}
+
+function renderKimiForm(details: unknown = kimiFormDetails()) {
+  const onSubmit = vi.fn<(response: unknown, outcome: string) => void>();
+  const params = asStructuredElicitationDetails(details);
+  expect(params).toBeDefined();
+  render(
+    <AppProvider>
+      <StructuredElicitationForm isDisabled={false} onSubmit={onSubmit} params={params!} />
+    </AppProvider>,
+  );
+  return { onSubmit };
+}
+
+describe("StructuredElicitationForm", () => {
+  it("renders a checkbox per anyOf choice of a multi-select array", () => {
+    renderKimiForm();
+
+    expect(screen.getByLabelText("Run tests")).toBeDefined();
+    expect(screen.getByLabelText("Run lint")).toBeDefined();
+  });
+
+  it("submits the picked anyOf values as the array answer", () => {
+    const { onSubmit } = renderKimiForm();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Log in via browser" } });
+    fireEvent.click(screen.getByLabelText("Run lint"));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      { action: "accept", content: { q0: "Log in via browser", q1: ["Lint"] } },
+      "answered",
+    );
+  });
+
+  it("keeps Submit disabled until every required key — array included — is filled", () => {
+    renderKimiForm();
+    const submit = screen.getByRole("button", { name: "Submit" });
+
+    expect(submit.getAttribute("data-disabled")).not.toBeNull();
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Paste a token" } });
+    expect(submit.getAttribute("data-disabled")).not.toBeNull();
+
+    fireEvent.click(screen.getByLabelText("Run tests"));
+    expect(submit.getAttribute("data-disabled")).toBeNull();
+  });
+
+  it("still reads oneOf item schemas and plain enums", () => {
+    renderKimiForm({
+      acpElicitation: {
+        mode: "form",
+        message: "Pick",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            legacy: {
+              type: "array",
+              title: "Legacy",
+              items: { oneOf: [{ const: "a", title: "Alpha" }] },
+            },
+            plain: { type: "string", title: "Plain", enum: ["x"], enumNames: ["Ex"] },
+          },
+        },
+      },
+    });
+
+    expect(screen.getByLabelText("Alpha")).toBeDefined();
+    expect(screen.getByRole("option", { name: "Ex" })).toBeDefined();
+  });
+});

--- a/src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
+++ b/src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
@@ -3,6 +3,13 @@ import { Button } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { RequestOutcome } from "@/shared/contracts";
 
+type StructuredElicitationChoice = { const: string; title?: string };
+
+type StructuredElicitationChoiceSource = {
+  oneOf?: StructuredElicitationChoice[];
+  anyOf?: StructuredElicitationChoice[];
+};
+
 type StructuredElicitationSchemaProperty =
   | {
       type: "string";
@@ -11,7 +18,11 @@ type StructuredElicitationSchemaProperty =
       default?: string;
       enum?: string[];
       enumNames?: string[];
-      oneOf?: Array<{ const: string; title?: string }>;
+      // JSON Schema choice lists arrive under either combinator: agents build
+      // single-select from `oneOf` and multi-select item schemas from `anyOf`
+      // (Kimi Code v2 does exactly that). Accept both wherever choices appear.
+      oneOf?: StructuredElicitationChoice[];
+      anyOf?: StructuredElicitationChoice[];
     }
   | {
       type: "integer" | "number";
@@ -33,7 +44,8 @@ type StructuredElicitationSchemaProperty =
       items?: {
         enum?: string[];
         enumNames?: string[];
-        oneOf?: Array<{ const: string; title?: string }>;
+        oneOf?: StructuredElicitationChoice[];
+        anyOf?: StructuredElicitationChoice[];
       };
     };
 
@@ -139,21 +151,30 @@ function getAcpElicitationSourceText(obj: Record<string, unknown>): string {
 
 type StructuredFormValue = boolean | number | string | string[];
 
+function readChoiceOptions(source: StructuredElicitationChoiceSource): {
+  id: string;
+  label: string;
+}[] {
+  const choices = [source.oneOf, source.anyOf].find(Array.isArray) ?? [];
+  return choices.map((choice) => ({ id: choice.const, label: choice.title ?? choice.const }));
+}
+
 function getStructuredElicitationEnumOptions(
   property: StructuredElicitationSchemaProperty,
 ): { id: string; label: string }[] {
-  if ("oneOf" in property && Array.isArray(property.oneOf)) {
-    return property.oneOf.map((o) => ({ id: o.const, label: o.title ?? o.const }));
-  }
+  // A combinator can sit directly on the property (single-select) regardless of
+  // the declared `type`, which agents sometimes omit — so read it off every
+  // property shape rather than narrowing on `type === "string"`.
+  const direct = readChoiceOptions(property as StructuredElicitationChoiceSource);
+  if (direct.length > 0) return direct;
   if ("enum" in property && Array.isArray(property.enum)) {
     const names =
       "enumNames" in property && Array.isArray(property.enumNames) ? property.enumNames : [];
     return property.enum.map((v, i) => ({ id: v, label: names[i] ?? v }));
   }
   if (property.type === "array" && property.items) {
-    if (Array.isArray(property.items.oneOf)) {
-      return property.items.oneOf.map((o) => ({ id: o.const, label: o.title ?? o.const }));
-    }
+    const choices = readChoiceOptions(property.items);
+    if (choices.length > 0) return choices;
     if (Array.isArray(property.items.enum)) {
       const names = Array.isArray(property.items.enumNames) ? property.items.enumNames : [];
       return property.items.enum.map((v, i) => ({ id: v, label: names[i] ?? v }));

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -72,6 +72,32 @@ describe("patchConfigForModelChange", () => {
     });
   });
 
+  it("resets effort to the next model's declared default, not its first tier", () => {
+    const tiered = {
+      ...capabilities,
+      modelEfforts: { ...capabilities.modelEfforts, b: ["low", "high", "max"] },
+      modelDefaultEfforts: { b: "high" },
+    } as AgentCapability;
+    expect(patchConfigForModelChange(tiered, "b", { effort: "on" })).toMatchObject({
+      model: "b",
+      effort: "high",
+    });
+  });
+
+  // Kimi's K2.7 models advertise no tiers; keeping K3's tier would send an
+  // effort the model does not support instead of letting the agent decide.
+  it("clears effort when the next model has no tiers of its own", () => {
+    const untiered = {
+      ...capabilities,
+      efforts: [],
+      modelEfforts: { ...capabilities.modelEfforts, b: [] },
+    } as unknown as AgentCapability;
+    expect(patchConfigForModelChange(untiered, "b", { effort: "high" })).toMatchObject({
+      model: "b",
+      effort: "",
+    });
+  });
+
   it("forces fast off when the account can't use fast mode", () => {
     const gated = { ...capabilities, fastDisabledReason: "disabled" } as AgentCapability;
     expect(patchConfigForModelChange(gated, "a", { fast: true })).toMatchObject({

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -170,13 +170,17 @@ export function patchConfigForModelChange(
     thinking?: boolean;
   },
 ): ModelPickerConfigPatch {
-  const nextEfforts = capabilities.modelEfforts?.[model] ?? capabilities.efforts ?? [];
-  const effortValid = current.effort ? nextEfforts.includes(current.effort) : true;
+  const nextReasoning = modelSelectionFor(capabilities, model).reasoning;
+  const effortValid = current.effort ? nextReasoning.values.includes(current.effort) : true;
   const nextContextIds = capabilities.modelContextSizes?.[model];
   const nextContextDefault = nextContextIds?.[0] ?? capabilities.defaultContextSize;
   return {
     model,
-    ...(!effortValid && nextEfforts.length > 0 ? { effort: nextEfforts[0] } : {}),
+    // Reset to the new model's declared default, not the first tier in its
+    // list. A model with no tiers at all clears the effort rather than
+    // inheriting the previous model's — an effort it does not support would
+    // otherwise be sent to the agent, which is free to apply its own default.
+    ...(effortValid ? {} : { effort: nextReasoning.default ?? "" }),
     ...(nextContextDefault ? { contextSize: nextContextDefault } : {}),
     ...(supportsUsableFastMode(capabilities, model) ? {} : { fast: false }),
     thinking: capabilities.thinkingModels?.includes(model) ?? false,

--- a/src/shared/agentSelection.ts
+++ b/src/shared/agentSelection.ts
@@ -222,6 +222,21 @@ export function modelSelectionFor(
   };
 }
 
+/**
+ * True when a model offers more than one reasoning level — i.e. there is
+ * something for the user to pick. A single advertised level (Kimi's untiered
+ * `on`) is still sent to the agent, but no picker is drawn for it, so surfaces
+ * that gate on "has an effort control" must use this rather than a non-empty
+ * check.
+ */
+export function hasSelectableReasoning(
+  capabilities: AgentCapability | undefined,
+  model: string,
+): boolean {
+  if (!capabilities) return false;
+  return modelSelectionFor(capabilities, model).reasoning.values.length > 1;
+}
+
 export function resolveModelSelection(capabilities: AgentCapability, preferred?: string): string {
   return preferred && capabilities.models.some((model) => model.id === preferred)
     ? preferred

--- a/src/supervisor/agents/acp/acpQuestionPermissions.test.ts
+++ b/src/supervisor/agents/acp/acpQuestionPermissions.test.ts
@@ -1,0 +1,194 @@
+import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  buildAcpQuestionPermissionAnswerEvents,
+  isAcpAskUserQuestionToolCall,
+  normalizeAcpQuestionPermissionResponse,
+  parseAcpPermissionQuestions,
+} from "./acpQuestionPermissions";
+
+/**
+ * The exact v2 fallback shape (`AcpInteractionBridge.handleQuestion` when
+ * `elicitation/create` is unavailable or fails): no rawInput, the question
+ * text in `toolCall.content`, `q0_opt_<i>` allow_once options carrying the
+ * answer labels, and one trailing `q0_skip` reject_once option. Only those
+ * ids are valid back — legacy `approve`/`approve_for_session` are not.
+ */
+function kimiV2QuestionRequest(): RequestPermissionRequest {
+  return {
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "7:tool-ask",
+      title: "AskUserQuestion",
+      content: [
+        { type: "content", content: { type: "text", text: "Which authentication method?" } },
+      ],
+    },
+    options: [
+      { optionId: "q0_opt_0", name: "Paste a token", kind: "allow_once" },
+      { optionId: "q0_opt_1", name: "Log in via browser", kind: "allow_once" },
+      { optionId: "q0_skip", name: "Skip", kind: "reject_once" },
+    ],
+  };
+}
+
+describe("parseAcpPermissionQuestions (Kimi v2 content shape)", () => {
+  it("parses the question text and answer options, dropping the skip option", () => {
+    expect(parseAcpPermissionQuestions(kimiV2QuestionRequest())).toEqual([
+      {
+        id: "0",
+        header: "Which authentication method?",
+        question: "Which authentication method?",
+        options: [
+          { optionId: "q0_opt_0", label: "Paste a token" },
+          { optionId: "q0_opt_1", label: "Log in via browser" },
+        ],
+        multiSelect: false,
+        // The ACP options are the answer choices in this shape.
+        optionsAreAnswers: true,
+      },
+    ]);
+  });
+
+  it("recognizes the AskUserQuestion tool call by title without rawInput", () => {
+    expect(isAcpAskUserQuestionToolCall({ title: "AskUserQuestion" })).toBe(true);
+    expect(isAcpAskUserQuestionToolCall({ title: "Ask user 2 questions" })).toBe(true);
+    expect(isAcpAskUserQuestionToolCall({ title: "Bash" })).toBe(false);
+  });
+
+  it("does not reinterpret ordinary approvals as questions", () => {
+    const approval: RequestPermissionRequest = {
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "7:tool-bash",
+        title: "Run tests",
+        kind: "execute",
+        content: [{ type: "content", content: { type: "text", text: "pnpm test" } }],
+      },
+      options: [{ optionId: "approve_once", name: "Approve once", kind: "allow_once" }],
+    };
+    expect(parseAcpPermissionQuestions(approval)).toEqual([]);
+  });
+});
+
+describe("normalizeAcpQuestionPermissionResponse (Kimi v2 ids)", () => {
+  it("promotes the picked answer to the server-provided option id", () => {
+    const request = kimiV2QuestionRequest();
+    expect(
+      normalizeAcpQuestionPermissionResponse(request, { answers: { "0": "q0_opt_1" } }),
+    ).toEqual({
+      outcome: { outcome: "selected", optionId: "q0_opt_1" },
+      answers: { "0": "Log in via browser" },
+    });
+  });
+
+  it("echoes a directly resolved server option id", () => {
+    const request = kimiV2QuestionRequest();
+    expect(normalizeAcpQuestionPermissionResponse(request, { optionId: "q0_opt_0" })).toEqual({
+      outcome: { outcome: "selected", optionId: "q0_opt_0" },
+    });
+  });
+
+  it("round-trips the explicit skip option as a selection the server dismisses", () => {
+    const request = kimiV2QuestionRequest();
+    expect(normalizeAcpQuestionPermissionResponse(request, { optionId: "q0_skip" })).toEqual({
+      outcome: { outcome: "selected", optionId: "q0_skip" },
+    });
+  });
+
+  it("cancels on explicit cancel/decline actions", () => {
+    const request = kimiV2QuestionRequest();
+    expect(normalizeAcpQuestionPermissionResponse(request, { action: "cancel" })).toEqual({
+      outcome: { outcome: "cancelled" },
+    });
+    expect(normalizeAcpQuestionPermissionResponse(request, { action: "decline" })).toEqual({
+      outcome: { outcome: "cancelled" },
+    });
+  });
+
+  it("routes unmatched free text to the skip option instead of fabricating the first answer", () => {
+    const request = kimiV2QuestionRequest();
+    expect(
+      normalizeAcpQuestionPermissionResponse(request, { answers: { "0": "use OAuth instead" } }),
+    ).toEqual({
+      outcome: { outcome: "selected", optionId: "q0_skip" },
+      answers: { "0": "use OAuth instead" },
+    });
+  });
+
+  it("keeps the Qwen rawInput shape answering through the allow_once fallback", () => {
+    const request: RequestPermissionRequest = {
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "tool-q",
+        title: "Ask user 1 question",
+        kind: "other",
+        rawInput: {
+          questions: [
+            {
+              header: "Scope",
+              question: "Which scope?",
+              options: [{ label: "Focused" }, { label: "Broad" }],
+            },
+          ],
+        },
+      },
+      options: [
+        { optionId: "proceed_once", name: "Submit", kind: "allow_once" },
+        { optionId: "cancel", name: "Cancel", kind: "reject_once" },
+      ],
+    };
+    expect(
+      normalizeAcpQuestionPermissionResponse(request, { answers: { "0": "Focused" } }),
+    ).toEqual({
+      outcome: { outcome: "selected", optionId: "proceed_once" },
+      answers: { "0": "Focused" },
+    });
+  });
+});
+
+describe("buildAcpQuestionPermissionAnswerEvents (Kimi v2 ids)", () => {
+  it("records the picked answer label as a question_answer item", () => {
+    const events = buildAcpQuestionPermissionAnswerEvents({
+      threadId: "thread-1",
+      itemId: "acp-question-answer-acp-perm-0",
+      request: kimiV2QuestionRequest(),
+      response: { answers: { "0": "q0_opt_1" } },
+    });
+    expect(events).toEqual([
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "acp-question-answer-acp-perm-0",
+        itemType: "question_answer",
+        payload: {
+          questions: [
+            {
+              header: "Which authentication method?",
+              question: "Which authentication method?",
+              selected: [{ label: "Log in via browser" }],
+            },
+          ],
+        },
+      },
+      {
+        type: "item.completed",
+        threadId: "thread-1",
+        itemId: "acp-question-answer-acp-perm-0",
+      },
+    ]);
+  });
+
+  it("emits nothing for skipped or cancelled replies", () => {
+    for (const response of [{ optionId: "q0_skip" }, { action: "cancel" }]) {
+      expect(
+        buildAcpQuestionPermissionAnswerEvents({
+          threadId: "thread-1",
+          itemId: "item-1",
+          request: kimiV2QuestionRequest(),
+          response,
+        }),
+      ).toEqual([]);
+    }
+  });
+});

--- a/src/supervisor/agents/acp/acpQuestionPermissions.ts
+++ b/src/supervisor/agents/acp/acpQuestionPermissions.ts
@@ -15,6 +15,13 @@ interface AcpPermissionQuestion {
   question: string;
   options: Array<{ optionId: string; label: string; description?: string }>;
   multiSelect: boolean;
+  /**
+   * True when the ACP requestPermission `options` themselves are this
+   * question's answer choices (the content shape below). The response side
+   * needs it to know that an unmatched reply cannot be expressed as an
+   * approval, so request and response must not re-derive it independently.
+   */
+  optionsAreAnswers?: boolean;
 }
 
 type AcpQuestionPermissionResponse = RequestPermissionResponse & {
@@ -108,7 +115,9 @@ function parseContentPermissionQuestion(
     return [{ optionId: option.optionId, label }];
   });
   if (options.length === 0) return [];
-  return [{ id: "0", header: question, question, options, multiSelect: false }];
+  return [
+    { id: "0", header: question, question, options, multiSelect: false, optionsAreAnswers: true },
+  ];
 }
 
 export function mapAcpQuestionPermissionRequest(
@@ -150,9 +159,10 @@ export function normalizeAcpQuestionPermissionResponse(
 ): AcpQuestionPermissionResponse {
   if (isCancelledResponse(response)) return { outcome: { outcome: "cancelled" } };
 
-  const optionId = selectedPermissionOptionId(request, response);
+  const questions = parseAcpPermissionQuestions(request);
+  const optionId = selectedPermissionOptionId(request, response, questions);
   if (!optionId) return { outcome: { outcome: "cancelled" } };
-  const answers = normalizeQuestionAnswers(request, response);
+  const answers = normalizeQuestionAnswers(questions, response);
   return {
     outcome: { outcome: "selected", optionId },
     ...(Object.keys(answers).length > 0 ? { answers } : {}),
@@ -198,12 +208,12 @@ export function isAcpAskUserQuestionToolCall(toolCall: {
 }
 
 function normalizeQuestionAnswers(
-  request: RequestPermissionRequest,
+  questions: readonly AcpPermissionQuestion[],
   response: unknown,
 ): Record<string, string> {
   const rawAnswers = responseAnswers(response);
   const answers: Record<string, string> = {};
-  for (const question of parseAcpPermissionQuestions(request)) {
+  for (const question of questions) {
     const raw =
       rawAnswers[question.id] ?? rawAnswers[question.question] ?? rawAnswers[question.header];
     const selected = chosenOptionIds(raw);
@@ -226,6 +236,7 @@ function responseAnswers(response: unknown): Record<string, unknown> {
 function selectedPermissionOptionId(
   request: RequestPermissionRequest,
   response: unknown,
+  questions: readonly AcpPermissionQuestion[],
 ): string | undefined {
   const requested =
     isRecord(response) && typeof response.optionId === "string" ? response.optionId : undefined;
@@ -233,6 +244,14 @@ function selectedPermissionOptionId(
     return requested;
   const answered = answerSelectedOptionId(request, response);
   if (answered) return answered;
+  if (questions.some((question) => question.optionsAreAnswers)) {
+    // The ACP options of a content-shape question ARE the answer choices,
+    // so an unmatched reply (free text, no selection) cannot be expressed:
+    // falling back to the first option would fabricate an answer. Route to
+    // the server's skip/reject option — the ask-user tool resolves it as
+    // dismissed — and cancel when there is none.
+    return request.options.find((option) => isRejectionOptionKind(option.kind))?.optionId;
+  }
   return (
     request.options.find((option) => option.kind === "allow_once") ??
     request.options.find((option) => !isRejectionOptionKind(option.kind))

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -2499,6 +2499,57 @@ describe("mapAcpPermissionRequest", () => {
     });
   });
 
+  it("echoes Kimi v2 plan_review option ids (plan_opt_*) verbatim", () => {
+    const state = createAcpMapperState("t-perm-plan-opts");
+
+    const event = mapAcpPermissionRequest(
+      {
+        sessionId: "s1",
+        toolCall: {
+          toolCallId: "3:tool-plan",
+          title: "ExitPlanMode",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "Plan saved to: /repo/.kimi-code/plans/p.md\n\n# Plan\n\n1. Step one",
+              },
+            },
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "Requesting approval to Presenting plan and exiting plan mode",
+              },
+            },
+          ],
+        },
+        options: [
+          { optionId: "plan_opt_0", name: "Use REST", kind: "allow_once" },
+          { optionId: "plan_opt_1", name: "Use GraphQL", kind: "allow_once" },
+          { optionId: "plan_revise", name: "Revise", kind: "reject_once" },
+          { optionId: "plan_reject_and_exit", name: "Reject and Exit", kind: "reject_once" },
+        ],
+      } as Parameters<typeof mapAcpPermissionRequest>[0],
+      state,
+      "acp-perm-plan-2",
+    );
+
+    expect(event.type).toBe("request.opened");
+    if (event.type !== "request.opened") return;
+    expect(event.payload.details).toEqual({
+      toolName: "ExitPlanMode",
+      input: { plan: "# Plan\n\n1. Step one", planFilePath: "/repo/.kimi-code/plans/p.md" },
+    });
+    expect(event.payload.options).toEqual([
+      { optionId: "plan_opt_0", label: "Use REST", description: undefined },
+      { optionId: "plan_opt_1", label: "Use GraphQL", description: undefined },
+      { optionId: "plan_revise", label: "Revise", description: undefined },
+      { optionId: "plan_reject_and_exit", label: "Reject and Exit", description: undefined },
+    ]);
+  });
+
   it("unwraps command approval input instead of surfacing raw JSON details", () => {
     const state = createAcpMapperState("t-perm-command");
 

--- a/src/supervisor/agents/acp/dispatch.test.ts
+++ b/src/supervisor/agents/acp/dispatch.test.ts
@@ -168,6 +168,75 @@ describe("dispatchAcpLogout", () => {
     });
   });
 
+  describe("preferAcpLogoutRpc", () => {
+    function makeRpcFirstAdapter(): AgentAdapter {
+      return makeAdapter(
+        { command: "kimi", args: ["acp"] },
+        {
+          preferAcpLogoutRpc: true,
+          async buildAcpLogoutCommand() {
+            return { command: "sh", args: ["-c", "rm -f -- creds.json"] };
+          },
+        },
+      );
+    }
+
+    it("runs the ACP logout RPC before the adapter's logout command", async () => {
+      const order: string[] = [];
+      logoutAcpAgentMock.mockImplementationOnce(async () => {
+        order.push("rpc");
+      });
+      readCommandOutputAsyncMock.mockImplementationOnce(async () => {
+        order.push("command");
+        return { ok: true, stdout: "", stderr: "" };
+      });
+
+      await dispatchAcpLogout({ adapter: makeRpcFirstAdapter(), envKind: "posix" });
+
+      expect(order).toEqual(["rpc", "command"]);
+      expect(logoutAcpAgentMock.mock.calls[0]?.[0]).toBe("kimi");
+      expect(logoutAcpAgentMock.mock.calls[0]?.[1]).toEqual(["acp"]);
+    });
+
+    it("skips the RPC for adapters that do not opt in", async () => {
+      await dispatchAcpLogout({
+        adapter: makeAdapter(
+          { command: "cursor-agent", args: ["acp"] },
+          {
+            async buildAcpLogoutCommand() {
+              return { command: "cursor-agent", args: ["logout"] };
+            },
+          },
+        ),
+        envKind: "posix",
+      });
+
+      expect(logoutAcpAgentMock).not.toHaveBeenCalled();
+      expect(readCommandOutputAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still runs the logout command when the agent has no logout RPC", async () => {
+      logoutAcpAgentMock.mockRejectedValueOnce(
+        new Error("ACP logout is not supported by this agent."),
+      );
+
+      await dispatchAcpLogout({ adapter: makeRpcFirstAdapter(), envKind: "posix" });
+
+      expect(readCommandOutputAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    // A stalled or unspawnable ACP server must not strand the user signed in:
+    // the credential-file command is what the adapter relied on before the RPC
+    // existed, so it runs regardless of why the RPC failed.
+    it("still runs the logout command when the RPC fails unexpectedly", async () => {
+      logoutAcpAgentMock.mockRejectedValueOnce(new Error("ACP logout timed out"));
+
+      await dispatchAcpLogout({ adapter: makeRpcFirstAdapter(), envKind: "posix" });
+
+      expect(readCommandOutputAsyncMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("throws when the adapter returns no logout command", async () => {
     await expect(
       dispatchAcpLogout({

--- a/src/supervisor/agents/acp/dispatch.ts
+++ b/src/supervisor/agents/acp/dispatch.ts
@@ -11,6 +11,7 @@
  * the caller's responsibility — this module only owns the spawn handshake.
  */
 
+import type { ProjectLocation } from "@/shared/contracts";
 import type { AgentAdapter, AgentEnvContext } from "../base";
 import { detectProbeLocation, injectWslEnv, readCommandOutputAsync } from "../base";
 import { resolveProbeSpawnCwd } from "../probeCwd";
@@ -75,6 +76,9 @@ export async function dispatchAcpLogout(input: {
   const ctx = envContextFromPayload(input.envKind, input.wslDistro);
   const location = detectProbeLocation(ctx);
   if (input.adapter.buildAcpLogoutCommand) {
+    if (input.adapter.preferAcpLogoutRpc) {
+      await tryAcpLogoutRpc(input.adapter, ctx, location);
+    }
     const command = await input.adapter.buildAcpLogoutCommand(ctx);
     if (!command) {
       throw new Error(`Agent did not return an ACP logout command: ${input.adapter.kind}`);
@@ -103,16 +107,57 @@ export async function dispatchAcpLogout(input: {
   if (!input.adapter.buildAcpAuthCommand) {
     throw new Error(`Agent does not support ACP logout: ${input.adapter.kind}`);
   }
-  const command = await input.adapter.buildAcpAuthCommand(ctx);
-  if (!command) {
+  if (!(await runAcpLogoutRpc(input.adapter, ctx, location))) {
     throw new Error(`Agent did not return an ACP logout command: ${input.adapter.kind}`);
   }
+}
+
+/**
+ * Run the ACP `logout` RPC over the adapter's auth command. Returns false when
+ * the adapter has no auth command to spawn. Errors propagate — callers that
+ * treat the RPC as best-effort swallow them via {@link tryAcpLogoutRpc}.
+ */
+async function runAcpLogoutRpc(
+  adapter: AgentAdapter,
+  ctx: AgentEnvContext | undefined,
+  location: ProjectLocation,
+): Promise<boolean> {
+  const command = await adapter.buildAcpAuthCommand?.(ctx);
+  if (!command) return false;
   const processCwd = resolveProbeSpawnCwd(location, command.cwd);
   await logoutAcpAgent(command.command, command.args, {
     ...(processCwd ? { processCwd } : {}),
-    ...(command.env ? { env: command.env } : {}),
-    label: input.adapter.label,
+    // WSL specs bake their env exports into the wsl.exe script already.
+    ...(location.kind !== "wsl" && command.env ? { env: command.env } : {}),
+    label: adapter.label,
   });
+  return true;
+}
+
+/**
+ * Best-effort ACP `logout` RPC ahead of an adapter's logout command.
+ *
+ * Never throws: an agent that predates the RPC answers "logout is not
+ * supported", and a stalled or unspawnable ACP server must not strand the
+ * user signed in when the command fallback would have cleared the credential
+ * on its own. Both cases fall through to the command; only the unexpected one
+ * is logged.
+ */
+async function tryAcpLogoutRpc(
+  adapter: AgentAdapter,
+  ctx: AgentEnvContext | undefined,
+  location: ProjectLocation,
+): Promise<void> {
+  try {
+    await runAcpLogoutRpc(adapter, ctx, location);
+  } catch (error) {
+    if (isUnsupportedAcpLogoutError(error)) return;
+    console.log(
+      "%s ACP logout RPC failed, falling back to the logout command: %s",
+      adapter.label,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
 }
 
 export function isUnsupportedAcpLogoutError(error: unknown): boolean {

--- a/src/supervisor/agents/acp/probe.ts
+++ b/src/supervisor/agents/acp/probe.ts
@@ -134,6 +134,9 @@ const INITIAL_SLASH_COMMANDS_TIMEOUT_MS = 2_000;
 const MODE_MAP: Record<string, { mode: ThreadMode; approvalPolicyId?: string }> = {
   default: { mode: "agent", approvalPolicyId: "default" },
   autoEdit: { mode: "agent", approvalPolicyId: "auto_edit" },
+  // Kimi's `auto` mode (auto-approve safe operations) and Qwen's `auto`
+  // approval policy share the canonical `auto` policy id.
+  auto: { mode: "agent", approvalPolicyId: "auto" },
   yolo: { mode: "agent", approvalPolicyId: "never" },
   plan: { mode: "plan" },
   agent: { mode: "agent" },

--- a/src/supervisor/agents/acp/sessionElicitation.test.ts
+++ b/src/supervisor/agents/acp/sessionElicitation.test.ts
@@ -1,0 +1,160 @@
+import type { CreateElicitationRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import {
+  buildAcpElicitationAnswerEvents,
+  normalizeAcpElicitationResponse,
+} from "./sessionElicitation";
+
+/**
+ * The exact form-mode request Kimi Code v2's acp-server builds for an
+ * AskUserQuestion with one single-select and one multi-select question
+ * (`questionRequestToElicitationParams`): single-select becomes
+ * `type: "string"` + `oneOf`, multi-select `type: "array"` + `items.anyOf`,
+ * properties keyed `q<i>`, every key required.
+ */
+function kimiFormElicitation(): CreateElicitationRequest {
+  return {
+    mode: "form",
+    sessionId: "session-1",
+    toolCallId: "3:tool-ask",
+    message: "Which authentication method?\nWhich checks should run?",
+    requestedSchema: {
+      type: "object",
+      properties: {
+        q0: {
+          type: "string",
+          title: "Auth",
+          description: "Choose how to authenticate.",
+          oneOf: [
+            {
+              const: "Paste a token",
+              title: "Paste a token",
+              description: "Use a precreated token.",
+            },
+            { const: "Log in via browser", title: "Log in via browser" },
+          ],
+        },
+        q1: {
+          type: "array",
+          title: "Checks",
+          description: "Select the checks to run.",
+          minItems: 1,
+          items: {
+            anyOf: [
+              { const: "Tests", title: "Tests", description: "Run focused tests." },
+              { const: "Lint", title: "Lint" },
+            ],
+          },
+        },
+      },
+      required: ["q0", "q1"],
+    },
+  };
+}
+
+describe("normalizeAcpElicitationResponse", () => {
+  it("round-trips Kimi's single-select and multi-select answers", () => {
+    const response = normalizeAcpElicitationResponse(
+      {
+        action: "accept",
+        content: { q0: "Log in via browser", q1: ["Tests", "Lint"] },
+      },
+      kimiFormElicitation(),
+    );
+    expect(response).toEqual({
+      action: "accept",
+      content: { q0: "Log in via browser", q1: ["Tests", "Lint"] },
+    });
+  });
+
+  it("drops content keys and values outside the requested schema", () => {
+    const response = normalizeAcpElicitationResponse(
+      {
+        action: "accept",
+        content: {
+          q0: "Paste a token",
+          q1: "Tests", // not an array — schema says array
+          q2: ["unknown question"],
+        },
+      },
+      kimiFormElicitation(),
+    );
+    expect(response).toEqual({ action: "accept", content: { q0: "Paste a token" } });
+  });
+
+  it("maps decline, cancel, and unrecognizable responses to terminal actions", () => {
+    const request = kimiFormElicitation();
+    expect(normalizeAcpElicitationResponse({ action: "decline" }, request)).toEqual({
+      action: "decline",
+    });
+    expect(normalizeAcpElicitationResponse({ action: "cancel" }, request)).toEqual({
+      action: "cancel",
+    });
+    expect(normalizeAcpElicitationResponse({ action: "something" }, request)).toEqual({
+      action: "cancel",
+    });
+    expect(normalizeAcpElicitationResponse(undefined, request)).toEqual({ action: "cancel" });
+  });
+
+  it("preserves response _meta when present", () => {
+    const response = normalizeAcpElicitationResponse(
+      { action: "accept", content: { q0: "Paste a token", q1: ["Lint"] }, _meta: { via: "test" } },
+      kimiFormElicitation(),
+    );
+    expect(response).toMatchObject({ action: "accept", _meta: { via: "test" } });
+  });
+});
+
+describe("buildAcpElicitationAnswerEvents", () => {
+  it("maps Kimi's form answers — including anyOf multi-select — to a question_answer item", () => {
+    const events = buildAcpElicitationAnswerEvents({
+      threadId: "thread-1",
+      itemId: "acp-question-answer-acp-elicit-0",
+      request: kimiFormElicitation(),
+      response: {
+        action: "accept",
+        content: { q0: "Log in via browser", q1: ["Tests", "Lint"] },
+      },
+    });
+    expect(events).toEqual([
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "acp-question-answer-acp-elicit-0",
+        itemType: "question_answer",
+        payload: {
+          questions: [
+            {
+              header: "Auth",
+              question: "Choose how to authenticate.",
+              selected: [{ label: "Log in via browser" }],
+            },
+            {
+              header: "Checks",
+              question: "Select the checks to run.",
+              selected: [{ label: "Tests", description: "Run focused tests." }, { label: "Lint" }],
+            },
+          ],
+        },
+      },
+      {
+        type: "item.completed",
+        threadId: "thread-1",
+        itemId: "acp-question-answer-acp-elicit-0",
+      },
+    ]);
+  });
+
+  it("emits nothing for cancelled or declined responses", () => {
+    for (const response of [{ action: "cancel" }, { action: "decline" }]) {
+      expect(
+        buildAcpElicitationAnswerEvents({
+          threadId: "thread-1",
+          itemId: "item-1",
+          request: kimiFormElicitation(),
+          response,
+        }),
+      ).toEqual([]);
+    }
+  });
+});

--- a/src/supervisor/agents/acp/sessionElicitation.ts
+++ b/src/supervisor/agents/acp/sessionElicitation.ts
@@ -81,13 +81,12 @@ function acpSchemaOptions(schema: ElicitationPropertySchema): QuestionAnswerSour
 }
 
 function readEnumLikeOptions(source: Record<string, unknown>): QuestionAnswerSourceOption[] {
-  if (Array.isArray(source.oneOf)) {
-    return source.oneOf.flatMap((entry) => {
-      if (!entry || typeof entry !== "object") return [];
-      const o = entry as { const?: unknown; title?: unknown };
-      if (typeof o.const !== "string") return [];
-      return [{ optionId: o.const, label: typeof o.title === "string" ? o.title : o.const }];
-    });
+  // JSON Schema choice lists arrive under either combinator: `oneOf` (e.g.
+  // single-select questions) or `anyOf` (e.g. the `items` schema of a
+  // multi-select array). Both carry `{ const, title }` entries.
+  for (const entries of [source.oneOf, source.anyOf]) {
+    const combinator = readConstTitleOptions(entries);
+    if (combinator.length > 0) return combinator;
   }
   if (Array.isArray(source.enum)) {
     const names = Array.isArray(source.enumNames) ? source.enumNames : [];
@@ -98,6 +97,24 @@ function readEnumLikeOptions(source: Record<string, unknown>): QuestionAnswerSou
     });
   }
   return [];
+}
+
+function readConstTitleOptions(entries: unknown): QuestionAnswerSourceOption[] {
+  if (!Array.isArray(entries)) return [];
+  return entries.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") return [];
+    const o = entry as { const?: unknown; title?: unknown; description?: unknown };
+    if (typeof o.const !== "string") return [];
+    return [
+      {
+        optionId: o.const,
+        label: typeof o.title === "string" ? o.title : o.const,
+        ...(typeof o.description === "string" && o.description.length > 0
+          ? { description: o.description }
+          : {}),
+      },
+    ];
+  });
 }
 
 function acpResponseAnswers(response: unknown): Record<string, unknown> {

--- a/src/supervisor/agents/acp/sessionRequests.test.ts
+++ b/src/supervisor/agents/acp/sessionRequests.test.ts
@@ -306,6 +306,38 @@ describe("AcpSessionRequests permissions", () => {
     });
   });
 
+  it("echoes Kimi v2 plan-review option ids back to the server verbatim", async () => {
+    const { requests } = makeRequests();
+    const response = requests.requestPermission({
+      sessionId: "session-1",
+      toolCall: {
+        toolCallId: "3:tool-plan",
+        title: "ExitPlanMode",
+        content: [
+          {
+            type: "content",
+            content: { type: "text", text: "Plan saved to: /p.md\n\n# Plan" },
+          },
+          {
+            type: "content",
+            content: { type: "text", text: "Requesting approval to Presenting plan" },
+          },
+        ],
+      },
+      options: [
+        { optionId: "plan_opt_0", name: "Use REST", kind: "allow_once" },
+        { optionId: "plan_opt_1", name: "Use GraphQL", kind: "allow_once" },
+        { optionId: "plan_revise", name: "Revise", kind: "reject_once" },
+        { optionId: "plan_reject_and_exit", name: "Reject and Exit", kind: "reject_once" },
+      ],
+    });
+
+    requests.resolve("acp-perm-0", { optionId: "plan_opt_1" });
+    await expect(response).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "plan_opt_1" },
+    });
+  });
+
   it("reports when a permission request is no longer pending", () => {
     const { emitRuntimeEvents, requests } = makeRequests();
 

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -388,7 +388,21 @@ export interface AgentDetector {
  */
 export interface AgentAcpAuth {
   buildAcpAuthCommand(ctx?: AgentEnvContext): Promise<CommandSpec | undefined>;
+  /**
+   * Build the CLI fallback that signs the agent out. Must stay side-effect
+   * free — callers inspect the spec without running it, so a builder that
+   * logs out on its own would sign the user out just for being asked.
+   */
   buildAcpLogoutCommand?(ctx?: AgentEnvContext): Promise<CommandSpec | undefined>;
+  /**
+   * Try the ACP `logout` RPC (over `buildAcpAuthCommand`) before running
+   * `buildAcpLogoutCommand`. For agents whose engine owns the credential but
+   * whose older releases only ever wrote a token file: the RPC is the native
+   * path, the command is the fallback, and both are safe to run in sequence.
+   * A failing RPC never blocks the command — the command is what the adapter
+   * relied on before the RPC existed.
+   */
+  preferAcpLogoutRpc?: boolean;
 }
 
 export interface AgentPromptFormatter {

--- a/src/supervisor/agents/kimi/acpTransform.test.ts
+++ b/src/supervisor/agents/kimi/acpTransform.test.ts
@@ -27,12 +27,23 @@ function toolCall(overrides: Record<string, unknown>): SessionNotification {
   } as unknown as SessionNotification;
 }
 
-function transformedRawInput(input: SessionNotification): Record<string, unknown> {
-  return (transformKimiAcpSessionUpdate(input).update as { rawInput?: unknown }).rawInput as Record<
-    string,
-    unknown
-  >;
+function textContent(text: string) {
+  return { type: "content", content: { type: "text", text } };
 }
+
+/** Casts a session-update payload to a plain record so tests can read whichever fields they need without a bespoke inline interface. */
+function asRecord(value: unknown): Record<string, unknown> {
+  return value as Record<string, unknown>;
+}
+
+function transformedRawInput(input: SessionNotification): Record<string, unknown> {
+  return asRecord(transformKimiAcpSessionUpdate(input).update).rawInput as Record<string, unknown>;
+}
+
+// Verbatim shape of Kimi's detached-launch receipt: identical text arrives as
+// both `rawOutput` and the `content[0].content.text` echo.
+const DETACHED_LAUNCH_RECEIPT =
+  "task_id: agent-1a2b3c4d\nstatus: running\nagent_id: agent-0\nactual_subagent_type: explore\nautomatic_notification: true\n\ndescription: Inspect files";
 
 describe("transformKimiAcpSessionUpdate", () => {
   it("recovers subagent_type and description from a Kimi launch title", () => {
@@ -80,7 +91,7 @@ describe("transformKimiAcpSessionUpdate", () => {
       rawOutput:
         "agent_id: agent-0\nactual_subagent_type: explore\nstatus: completed\n\n[summary]\nThe useful result",
     });
-    expect((transformKimiAcpSessionUpdate(input).update as { rawOutput?: unknown }).rawOutput).toBe(
+    expect(asRecord(transformKimiAcpSessionUpdate(input).update).rawOutput).toBe(
       "The useful result",
     );
   });
@@ -123,14 +134,11 @@ describe("transformKimiAcpSessionUpdate", () => {
   it("classifies the initial empty Agent call and hides streamed JSON input", () => {
     const transform = createKimiAcpSessionUpdateTransform();
     const initial = transform(toolCall({ title: "Agent", content: [] }));
-    const initialUpdate = initial.update as {
-      rawInput?: Record<string, unknown>;
-      _meta?: Record<string, unknown>;
-      content?: unknown;
-    };
+    const initialUpdate = asRecord(initial.update);
+    const initialMeta = initialUpdate._meta as Record<string, unknown> | undefined;
     expect(initialUpdate.rawInput).toMatchObject({ subagent_type: "agent" });
-    expect(initialUpdate._meta?.[PORACODE_ACP_DETACHED_SUBAGENT_META_KEY]).toBeUndefined();
-    expect(initialUpdate._meta?.[PORACODE_ACP_TOP_LEVEL_TOOL_CALL_META_KEY]).toBe(true);
+    expect(initialMeta?.[PORACODE_ACP_DETACHED_SUBAGENT_META_KEY]).toBeUndefined();
+    expect(initialMeta?.[PORACODE_ACP_TOP_LEVEL_TOOL_CALL_META_KEY]).toBe(true);
     expect(initialUpdate).not.toHaveProperty("content");
 
     const streamed = transform(
@@ -138,18 +146,10 @@ describe("transformKimiAcpSessionUpdate", () => {
         sessionUpdate: "tool_call_update",
         status: "in_progress",
         title: undefined,
-        content: [
-          {
-            type: "content",
-            content: {
-              type: "text",
-              text: '{"description":"Inspect files","subagent_type":"explore"}',
-            },
-          },
-        ],
+        content: [textContent('{"description":"Inspect files","subagent_type":"explore"}')],
       }),
     );
-    expect((streamed.update as { rawInput?: unknown }).rawInput).toMatchObject({
+    expect(asRecord(streamed.update).rawInput).toMatchObject({
       description: "Inspect files",
       subagent_type: "explore",
     });
@@ -200,12 +200,12 @@ describe("transformKimiAcpSessionUpdate", () => {
         title: undefined,
         rawOutput:
           "task_id: agent-task\nstatus: running\nagent_id: agent-0\nautomatic_notification: true",
-        content: [{ type: "content", content: { type: "text", text: "launch receipt" } }],
+        content: [textContent("launch receipt")],
       }),
     );
-    expect((receipt.update as { status?: unknown }).status).toBe("in_progress");
+    expect(asRecord(receipt.update).status).toBe("in_progress");
     expect(
-      (receipt.update as { _meta?: Record<string, unknown> })._meta?.[
+      (asRecord(receipt.update)._meta as Record<string, unknown> | undefined)?.[
         PORACODE_ACP_DETACHED_SUBAGENT_META_KEY
       ],
     ).toBe(true);
@@ -237,7 +237,7 @@ describe("transformKimiAcpSessionUpdate", () => {
           status: "in_progress",
           title: "Launching explore agent: Inspect files",
           rawInput: { description: "Inspect files", subagent_type: "explore" },
-          content: [{ type: "content", content: { type: "text", text: "input JSON" } }],
+          content: [textContent("input JSON")],
         }),
       ),
       state,
@@ -301,6 +301,262 @@ describe("transformKimiAcpSessionUpdate", () => {
     expect(state.toolCallItems.get("tc-agent")?.detached).toBe(true);
   });
 
+  it("normalizes the v2 streamed sequence: pending create, cumulative deltas, started upgrade, receipt", () => {
+    const launches: KimiBackgroundLaunch[] = [];
+    const transform = createKimiAcpSessionUpdateTransform({
+      onBackgroundLaunch: (launch) => launches.push(launch),
+    });
+
+    // v2 lazily CREATEs the tool_call from the first `tool.call.delta`: the
+    // raw tool name as title, status `pending`, and a PARTIAL args fragment
+    // as content.
+    const create = transform(
+      toolCall({
+        status: "pending",
+        title: "Agent",
+        kind: "other",
+        content: [textContent('{"description":"Insp')],
+      }),
+    );
+    const createUpdate = asRecord(create.update);
+    expect(createUpdate.status).toBe("pending");
+    expect(createUpdate.rawInput).toMatchObject({ subagent_type: "agent" });
+    expect(
+      (createUpdate._meta as Record<string, unknown> | undefined)?.[
+        PORACODE_ACP_TOP_LEVEL_TOOL_CALL_META_KEY
+      ],
+    ).toBe(true);
+    expect(createUpdate).not.toHaveProperty("content");
+
+    // Later deltas REPLACE the content with the CUMULATIVE args text; the
+    // partial fragment must not leak into the normalized input.
+    const partial = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "in_progress",
+        content: [textContent('{"description":"Inspect files","subagent')],
+      }),
+    );
+    expect(asRecord(partial.update).rawInput).toMatchObject({
+      subagent_type: "agent",
+    });
+    expect(partial.update).not.toHaveProperty("content");
+
+    const delta = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "in_progress",
+        content: [
+          textContent(
+            '{"description":"Inspect files","subagent_type":"explore","run_in_background":true}',
+          ),
+        ],
+      }),
+    );
+    expect(asRecord(delta.update).rawInput).toMatchObject({
+      description: "Inspect files",
+      subagent_type: "explore",
+      background: true,
+    });
+    expect(delta.update).not.toHaveProperty("content");
+
+    // `tool.call.started` upgrades the lazy create: rewrites the title,
+    // carries kind/rawInput/locations.
+    const fullArgs =
+      '{"description":"Inspect files","subagent_type":"explore","run_in_background":true}';
+    const upgrade = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "in_progress",
+        title: "Launching background explore agent: Inspect files",
+        kind: "other",
+        rawInput: {
+          description: "Inspect files",
+          subagent_type: "explore",
+          run_in_background: true,
+        },
+        locations: [],
+        content: [textContent(fullArgs)],
+      }),
+    );
+    const upgradeUpdate = asRecord(upgrade.update);
+    expect(upgradeUpdate.rawInput).toMatchObject({
+      subagent_type: "explore",
+      description: "Inspect files",
+      background: true,
+    });
+    expect(
+      (upgradeUpdate._meta as Record<string, unknown> | undefined)?.[
+        PORACODE_ACP_DETACHED_SUBAGENT_META_KEY
+      ],
+    ).toBe(true);
+    expect(upgradeUpdate).not.toHaveProperty("content");
+
+    // `tool.result` delivers the detached launch receipt; the call stays
+    // open for the session-file bridge.
+    const receipt = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "completed",
+        rawOutput: DETACHED_LAUNCH_RECEIPT,
+        content: [textContent(DETACHED_LAUNCH_RECEIPT)],
+      }),
+    );
+    expect(asRecord(receipt.update).status).toBe("in_progress");
+    expect(receipt.update).not.toHaveProperty("rawOutput");
+    expect(receipt.update).not.toHaveProperty("content");
+    expect(launches).toEqual([
+      {
+        sessionId: "ses-1",
+        toolCallId: "tc-agent",
+        taskId: "agent-1a2b3c4d",
+        agentId: "agent-0",
+        subagentType: "explore",
+        description: "Inspect files",
+      },
+    ]);
+  });
+
+  it("normalizes a v2 non-streamed create and strips the transport header from its result", () => {
+    const transform = createKimiAcpSessionUpdateTransform();
+
+    // No streamed deltas: `tool.call.started` emits a plain CREATE with
+    // status `in_progress` + rawInput and the descriptive title.
+    const create = transform(
+      toolCall({
+        status: "in_progress",
+        title: "Launching explore agent: Inspect files",
+        kind: "other",
+        rawInput: { description: "Inspect files", subagent_type: "explore" },
+        content: [textContent('{"description":"Inspect files","subagent_type":"explore"}')],
+      }),
+    );
+    const createUpdate = asRecord(create.update);
+    expect(createUpdate.rawInput).toMatchObject({
+      subagent_type: "explore",
+      description: "Inspect files",
+    });
+    expect(
+      (createUpdate._meta as Record<string, unknown> | undefined)?.[
+        PORACODE_ACP_DETACHED_SUBAGENT_META_KEY
+      ],
+    ).toBeUndefined();
+    expect(createUpdate).not.toHaveProperty("content");
+
+    const done = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "completed",
+        rawOutput:
+          "agent_id: agent-0\nactual_subagent_type: explore\nstatus: completed\n\n[summary]\nThe useful result",
+      }),
+    );
+    expect(asRecord(done.update).rawOutput).toBe("The useful result");
+  });
+
+  it("detaches a v2 foreground call whose tool result is a late background receipt", () => {
+    const launches: KimiBackgroundLaunch[] = [];
+    const transform = createKimiAcpSessionUpdateTransform({
+      onBackgroundLaunch: (launch) => launches.push(launch),
+    });
+    transform(toolCall({ status: "pending", title: "Agent", content: [] }));
+    transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "in_progress",
+        title: "Launching explore agent: Inspect files",
+        rawInput: { description: "Inspect files", subagent_type: "explore" },
+      }),
+    );
+
+    // v2 detaches a foreground call mid-run: the terminal tool result is
+    // the launch receipt even though nothing was marked background.
+    const receipt = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "completed",
+        rawOutput:
+          "task_id: agent-9f8e7d6c\nstatus: running\nagent_id: agent-1\nactual_subagent_type: explore\nautomatic_notification: true",
+      }),
+    );
+    const receiptUpdate = asRecord(receipt.update);
+    expect(receiptUpdate.status).toBe("in_progress");
+    expect(receiptUpdate.rawInput).toMatchObject({ background: true });
+    expect(
+      (receiptUpdate._meta as Record<string, unknown> | undefined)?.[
+        PORACODE_ACP_DETACHED_SUBAGENT_META_KEY
+      ],
+    ).toBe(true);
+    expect(receiptUpdate).not.toHaveProperty("rawOutput");
+    expect(launches).toEqual([
+      {
+        sessionId: "ses-1",
+        toolCallId: "tc-agent",
+        taskId: "agent-9f8e7d6c",
+        agentId: "agent-1",
+        subagentType: "explore",
+        description: "Inspect files",
+      },
+    ]);
+  });
+
+  it("keeps the canonical input across v2 title-only progress updates", () => {
+    const transform = createKimiAcpSessionUpdateTransform();
+    transform(toolCall({ status: "pending", title: "Agent", content: [] }));
+    transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        status: "in_progress",
+        title: "Launching explore agent: Inspect files",
+        rawInput: { description: "Inspect files", subagent_type: "explore" },
+      }),
+    );
+
+    // `tool.progress` (kind: status) refreshes only the card title.
+    const progress = transform(
+      toolCall({
+        sessionUpdate: "tool_call_update",
+        title: "Exploring the repository",
+      }),
+    );
+    const progressUpdate = asRecord(progress.update);
+    expect(progressUpdate.title).toBe("Exploring the repository");
+    expect(progressUpdate.rawInput).toMatchObject({
+      subagent_type: "explore",
+      description: "Inspect files",
+    });
+  });
+
+  it("maps a v2 pending create to a running top-level subagent item", () => {
+    const transform = createKimiAcpSessionUpdateTransform();
+    const state = createAcpMapperState("thread-1");
+
+    const started = mapAcpSessionUpdate(
+      transform(toolCall({ status: "pending", title: "Agent", content: [] })),
+      state,
+    );
+    const item = started.find((event) => event.type === "item.started") as {
+      itemId: string;
+      payload?: Record<string, unknown>;
+    };
+    expect(item.payload).toMatchObject({ isSubAgent: true, status: "running" });
+    expect(item).not.toHaveProperty("parentItemId");
+
+    // The started-upgrade flips the tracked item to detached.
+    mapAcpSessionUpdate(
+      transform(
+        toolCall({
+          sessionUpdate: "tool_call_update",
+          status: "in_progress",
+          title: "Launching background explore agent: Inspect files",
+          rawInput: { subagent_type: "explore", run_in_background: true },
+        }),
+      ),
+      state,
+    );
+    expect(state.toolCallItems.get("tc-agent")?.detached).toBe(true);
+  });
+
   it("separates recovered background output from the automatic parent reply", () => {
     const transform = createKimiAcpSessionUpdateTransform();
     const state = createAcpMapperState("thread-1");
@@ -350,5 +606,101 @@ describe("transformKimiAcpSessionUpdate", () => {
       "content.delta",
     ]);
     expect(parentReply[1]).not.toHaveProperty("parentItemId");
+  });
+});
+
+describe("transformKimiAcpSessionUpdate (thought level)", () => {
+  // Probed from kimi 0.33.0: the `thinking` select lists the untiered `on`
+  // after K3's real tiers and reports it as `currentValue` even there.
+  function configOptionUpdate(thinking: {
+    currentValue?: string;
+    options: { value: string; name: string }[];
+  }): SessionNotification {
+    return {
+      sessionId: "s1",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            id: "model",
+            category: "model",
+            type: "select",
+            currentValue: "kimi-code/k3-256k",
+            options: [{ value: "kimi-code/k3-256k", name: "K3-256k" }],
+          },
+          { id: "thinking", category: "thought_level", type: "select", ...thinking },
+        ],
+      },
+    } as unknown as SessionNotification;
+  }
+
+  function thoughtLevelOf(notification: SessionNotification) {
+    const options = (notification.update as { configOptions?: unknown[] }).configOptions ?? [];
+    return options.find((option) => (option as { id?: unknown }).id === "thinking") as {
+      currentValue?: string;
+      options: { value: string }[];
+    };
+  }
+
+  it("drops the untiered `on` level and its stale current value for a tiered model", () => {
+    const result = transformKimiAcpSessionUpdate(
+      configOptionUpdate({
+        currentValue: "on",
+        options: [
+          { value: "low", name: "Thinking Low" },
+          { value: "high", name: "Thinking High" },
+          { value: "max", name: "Thinking Max" },
+          { value: "on", name: "Thinking On" },
+        ],
+      }),
+    );
+    const thinking = thoughtLevelOf(result);
+    expect(thinking.options.map((option) => option.value)).toEqual(["low", "high", "max"]);
+    // `on` is not one of the model's efforts, so the session must not adopt it.
+    expect(thinking).not.toHaveProperty("currentValue");
+  });
+
+  it("keeps a real tier as the current value", () => {
+    const thinking = thoughtLevelOf(
+      transformKimiAcpSessionUpdate(
+        configOptionUpdate({
+          currentValue: "max",
+          options: [
+            { value: "low", name: "Thinking Low" },
+            { value: "max", name: "Thinking Max" },
+            { value: "on", name: "Thinking On" },
+          ],
+        }),
+      ),
+    );
+    expect(thinking.options.map((option) => option.value)).toEqual(["low", "max"]);
+    expect(thinking.currentValue).toBe("max");
+  });
+
+  // Verified against kimi 0.33.0: after K3 `max` -> K2.7 the session still
+  // reports `max`, and lists it as a K2.7 option. Adopting it would run the
+  // untiered model at a tier it does not offer.
+  it("drops the previous model's tier after switching to an untiered model", () => {
+    const thinking = thoughtLevelOf(
+      transformKimiAcpSessionUpdate(
+        configOptionUpdate({
+          currentValue: "max",
+          options: [
+            { value: "on", name: "Thinking On" },
+            { value: "max", name: "Thinking Max" },
+          ],
+        }),
+      ),
+    );
+    expect(thinking.options.map((option) => option.value)).toEqual(["on"]);
+    expect(thinking).not.toHaveProperty("currentValue");
+  });
+
+  it("leaves an on-only selector untouched (K2.7 has no tier to choose)", () => {
+    const notification = configOptionUpdate({
+      currentValue: "on",
+      options: [{ value: "on", name: "Thinking On" }],
+    });
+    expect(transformKimiAcpSessionUpdate(notification)).toBe(notification);
   });
 });

--- a/src/supervisor/agents/kimi/acpTransform.ts
+++ b/src/supervisor/agents/kimi/acpTransform.ts
@@ -1,21 +1,44 @@
 /**
  * Kimi-specific ACP `session/update` normalization.
  *
- * Kimi streams Agent tool input over several `tool_call_update`s. The initial
- * call is only `{ title: "Agent", rawInput: undefined }`; the descriptive
- * `Launching … agent` title and structured input arrive later. Canonical ACP
- * mapping classifies a tool when it starts, so this stateful normalizer marks
- * the initial call immediately and carries the eventual input across updates.
+ * Two wire shapes of the `Agent` tool must normalize into the shared
+ * subagent shape — the v2 engine (0.33.0+, `kimi acp` default) and the
+ * legacy engine (still selectable via `KIMI_CODE_LEGACY_FLAG=1`):
  *
- * Kimi does not stream a child agent's internal events over ACP. The canonical
- * `detached` nesting marker prevents parallel sibling launches from being
- * inferred as parent/child calls. Background Agent calls also report the
- * launch receipt as `status: completed` even though the detached task is still
- * running; those receipts stay `in_progress` until the Kimi session-file bridge
- * observes the automatic follow-up turn.
+ * Legacy engine: a bare `{ title: "Agent" }` CREATE first; the descriptive
+ * `Launching … agent` title and structured input arrive on later
+ * `tool_call_update`s.
+ *
+ * v2 engine: the first `tool.call.delta` lazily CREATEs the `tool_call`
+ * with the raw tool name as title (`"Agent"` again), status `pending`, and
+ * a PARTIAL args-text fragment as content. Later deltas send
+ * `tool_call_update`s whose content is the CUMULATIVE (REPLACE) args text.
+ * `tool.call.started` then finalizes the call with a `tool_call_update`
+ * that rewrites the title to `Launching (background )?<profile> agent:
+ * <description>` and carries kind/rawInput/locations. When the args were
+ * never streamed, the started event emits a plain CREATE with status
+ * `in_progress` + rawInput instead. `tool.progress` emits title-only
+ * updates; `tool.result` emits the terminal completed/failed update.
+ *
+ * In both shapes the shared mapper must classify the call as a subagent
+ * from its first notification, so this stateful normalizer marks the bare
+ * initial call immediately and carries the eventual input across updates.
+ * Kimi does not stream a child agent's internal events over ACP; the
+ * canonical `detached` nesting marker prevents parallel sibling launches
+ * from being inferred as parent/child calls.
+ *
+ * A detached launch reports `task_id: …\nstatus: running\n…
+ * automatic_notification: true` as its tool result and keeps running even
+ * though the tool call "completed". Such receipts stay `in_progress` until
+ * the Kimi session-file bridge observes the task settle (the follow-up
+ * notification turn is only ever visible on disk, never over ACP). Since
+ * v2 can also detach a call mid-run that started in the foreground
+ * (`waitForForegroundRelease` → `detached`), the receipt is recognized on
+ * ANY terminal Agent update, not only ones already known to be background.
  */
 
 import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { findThoughtLevelConfigOption } from "../acp/thoughtLevel";
 import {
   createAcpSubagentCoordinator,
   normalizeAcpSubagentToolCall,
@@ -23,6 +46,7 @@ import {
   type AcpBackgroundSubagentLaunch,
   type AcpSubagentCoordinator,
 } from "../acp/subagentCoordinator";
+import { normalizeKimiThoughtLevelOption } from "./thoughtLevels";
 
 const KIMI_SUBAGENT_TITLE = /^Launching\s+(background\s+)?([\w-]+)\s+agent:\s*(.*)$/i;
 const KIMI_AGENT_TITLE = /^Agent$/i;
@@ -41,6 +65,9 @@ export function createKimiAcpSessionUpdateTransform(
 
   return (notification) => {
     const update = notification.update;
+    if (update.sessionUpdate === "config_option_update") {
+      return normalizeKimiConfigOptionUpdate(notification);
+    }
     if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
       return notification;
     }
@@ -68,21 +95,25 @@ export function createKimiAcpSessionUpdateTransform(
 
     const titleType = titleMatch?.[2]?.toLowerCase();
     const titleDescription = titleMatch?.[3]?.trim();
+    const terminal = tool.status === "completed" || tool.status === "failed";
+    // The detached-launch receipt can arrive on a call never marked
+    // background (v2 detaches foreground calls mid-run), so parse it on
+    // every terminal update and let it flip the descriptor.
+    const launch = terminal ? parseBackgroundLaunch(tool.rawOutput, tool.content) : undefined;
+
     const descriptor = subagents.updateCall(toolCallId, {
       ...(incomingInput ? { rawInput: incomingInput } : {}),
       ...(titleType ? { subagentType: titleType } : {}),
       ...(titleDescription ? { description: titleDescription } : {}),
-      ...(titleMatch?.[1] !== undefined || incomingInput?.run_in_background === true
+      ...(titleMatch?.[1] !== undefined ||
+      incomingInput?.run_in_background === true ||
+      launch !== undefined
         ? { background: true }
         : {}),
     });
 
-    const terminal = tool.status === "completed" || tool.status === "failed";
     const normalizedInput = subagents.canonicalInput(toolCallId);
 
-    const launch = descriptor.background
-      ? parseBackgroundLaunch(tool.rawOutput, tool.content)
-      : undefined;
     if (launch) {
       const registered = subagents.registerBackgroundLaunch({
         sessionId: notification.sessionId,
@@ -93,8 +124,7 @@ export function createKimiAcpSessionUpdateTransform(
       if (registered) callbacks.onBackgroundLaunch?.(registered);
     }
 
-    const backgroundLaunchReceipt =
-      descriptor.background && tool.status === "completed" && launch !== undefined;
+    const backgroundLaunchReceipt = launch !== undefined && tool.status === "completed";
 
     const hideInputStream = !terminal || backgroundLaunchReceipt;
     const normalizedOutput = normalizeKimiAgentOutput(tool.rawOutput);
@@ -128,6 +158,38 @@ export function transformKimiAcpSessionUpdate(
   return createKimiAcpSessionUpdateTransform()(notification);
 }
 
+/**
+ * Strip the untiered `on` thought level out of a live `config_option_update`.
+ *
+ * The session's config sync adopts the thought-level `currentValue` verbatim as
+ * the thread's effort, and Kimi reports `on` even for the tiered K3 models —
+ * which the capability probe deliberately does not surface as a tier. Without
+ * this, a K3 thread's reasoning would read `On` while its picker offers only
+ * `Low`/`High`/`Max`.
+ */
+function normalizeKimiConfigOptionUpdate(notification: SessionNotification): SessionNotification {
+  const update = notification.update as { configOptions?: unknown };
+  if (!Array.isArray(update.configOptions)) return notification;
+  const thoughtLevel = findThoughtLevelConfigOption(update.configOptions);
+  if (!thoughtLevel) return notification;
+  const normalized = normalizeKimiThoughtLevelOption(thoughtLevel);
+  if (normalized === thoughtLevel) return notification;
+  return {
+    ...notification,
+    update: {
+      ...notification.update,
+      configOptions: update.configOptions.map((option) =>
+        option === thoughtLevel ? normalized : option,
+      ),
+    } as SessionNotification["update"],
+  };
+}
+
+/**
+ * Parse the cumulative args text Kimi streams as tool-call content. Legacy
+ * deltas stream the same JSON text; v2 starts from a partial fragment, so
+ * incomplete JSON simply yields `undefined` until the args assemble.
+ */
 function parseKimiAgentInput(content: unknown): Record<string, unknown> | undefined {
   const text = extractContentText(content)?.trim();
   if (!text?.startsWith("{") || !text.endsWith("}")) return undefined;

--- a/src/supervisor/agents/kimi/backgroundBridge.test.ts
+++ b/src/supervisor/agents/kimi/backgroundBridge.test.ts
@@ -6,14 +6,62 @@ import {
   PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY,
   PORACODE_ACP_PARENT_TOOL_CALL_ID_META_KEY,
 } from "../acp/canonicalMapping";
-import {
-  createKimiBackgroundBridge,
-  parseCompletedKimiWireTurns,
-  parseKimiTaskRecord,
-} from "./backgroundBridge";
+import { createKimiBackgroundBridge } from "./backgroundBridge";
+import { parseCompletedKimiWireTurns, parseKimiTaskRecord } from "./kimiWireJournal";
 
 function wireLine(time: number, event: Record<string, unknown>): string {
   return JSON.stringify({ type: "context.append_loop_event", event, time });
+}
+
+type ReadTextFake = ReturnType<
+  typeof vi.fn<
+    (location: ProjectLocation, path: string, maxBytes?: number) => Promise<string | undefined>
+  >
+>;
+
+/**
+ * Builds the `readText` dependency fake shared by the wire-polling tests.
+ * `wire` answers `/wire.jsonl` reads — pass a function to flip from the
+ * launch wire to the completed wire on a later poll, keyed by the 1-based
+ * read count. `task` answers any `*.json` task-record read. `output` maps
+ * output-log path suffixes to their contents.
+ */
+function makeReadText({
+  wire,
+  task,
+  output,
+}: {
+  wire: string | ((reads: number) => string);
+  task: string;
+  output: Record<string, string>;
+}): ReadTextFake {
+  let wireReads = 0;
+  return vi.fn<
+    (location: ProjectLocation, path: string, maxBytes?: number) => Promise<string | undefined>
+  >(async (_location, path) => {
+    if (path.endsWith("/wire.jsonl")) {
+      wireReads += 1;
+      return typeof wire === "function" ? wire(wireReads) : wire;
+    }
+    if (path.endsWith(".json")) return task;
+    return Object.entries(output).find(([suffix]) => path.endsWith(suffix))?.[1];
+  });
+}
+
+/** Starts a bridge wired to `readText` and collects every emitted notification. */
+function startBridge(readText: ReadTextFake, overrides: { now?: () => number } = {}) {
+  const updates: SessionNotification[] = [];
+  const bridge = createKimiBackgroundBridge(
+    { kind: "posix", path: "/repo" },
+    (notification) => updates.push(notification),
+    {
+      readText,
+      resolveSessionDir: async () => "/kimi/session",
+      pollIntervalMs: 1,
+      ...(overrides.now ? { now: overrides.now } : {}),
+    },
+  );
+  return { bridge, updates };
 }
 
 describe("Kimi background subagent bridge", () => {
@@ -24,6 +72,78 @@ describe("Kimi background subagent bridge", () => {
     });
     expect(parseKimiTaskRecord("not-json")).toBeUndefined();
     expect(parseKimiTaskRecord('{"endedAt":42}')).toBeUndefined();
+  });
+
+  it("reads every v2 terminal status plus legacy snake_case timestamps", () => {
+    expect(parseKimiTaskRecord('{"status":"killed","endedAt":7}')).toEqual({
+      status: "killed",
+      endedAt: 7,
+    });
+    expect(parseKimiTaskRecord('{"status":"timed_out","endedAt":null}')).toEqual({
+      status: "timed_out",
+    });
+    expect(parseKimiTaskRecord('{"status":"lost"}')).toEqual({ status: "lost" });
+    expect(parseKimiTaskRecord('{"status":"failed","ended_at":9}')).toEqual({
+      status: "failed",
+      endedAt: 9,
+    });
+  });
+
+  it("ignores v2 metadata and task lifecycle wire records", () => {
+    const wire = [
+      JSON.stringify({ type: "metadata", protocol_version: "1", created_at: 1, time: 1 }),
+      JSON.stringify({
+        type: "task.terminated",
+        info: { taskId: "agent-task", status: "completed", endedAt: 12 },
+        outputTail: "tail",
+        time: 12,
+      }),
+      wireLine(10, {
+        type: "content.part",
+        turnId: "1",
+        part: { type: "text", text: "reply" },
+      }),
+      wireLine(11, { type: "step.end", turnId: "1", finishReason: "end_turn" }),
+    ].join("\n");
+    expect(parseCompletedKimiWireTurns(wire)).toEqual([
+      {
+        turnId: "1",
+        completionId: "1:10:11",
+        firstTime: 10,
+        lastTime: 11,
+        text: "reply",
+        taskIds: [],
+      },
+    ]);
+  });
+
+  it("links a numeric v2 notification turn to its originating background task", () => {
+    const wire = [
+      JSON.stringify({
+        type: "turn.prompt",
+        input: [{ type: "text", text: "<notification>completed</notification>" }],
+        origin: { kind: "task", taskId: "agent-task", status: "completed" },
+        time: 20,
+      }),
+      wireLine(21, { type: "step.begin", turnId: 1 }),
+      wireLine(22, {
+        type: "content.part",
+        turnId: 1,
+        part: { type: "text", text: "automatic reply" },
+      }),
+      wireLine(23, { type: "step.end", turnId: 1, finishReason: "end_turn" }),
+    ].join("\n");
+
+    expect(parseCompletedKimiWireTurns(wire)).toEqual([
+      {
+        turnId: "1",
+        completionId: "1:21:23",
+        firstTime: 21,
+        lastTime: 23,
+        text: "automatic reply",
+        taskIds: ["agent-task"],
+      },
+    ]);
   });
 
   it("collects text from completed Kimi wire turns", () => {
@@ -157,30 +277,12 @@ describe("Kimi background subagent bridge", () => {
       }),
       wireLine(202, { type: "step.end", turnId: "1", finishReason: "end_turn" }),
     ].join("\n");
-    let wireReads = 0;
-    const readText = vi.fn<
-      (location: ProjectLocation, path: string, maxBytes?: number) => Promise<string | undefined>
-    >(async (_location, path) => {
-      if (path.endsWith("/wire.jsonl")) {
-        wireReads += 1;
-        return wireReads === 1 ? initialWire : completedWire;
-      }
-      if (path.endsWith("/agent-task.json")) {
-        return '{"status":"completed","endedAt":200}';
-      }
-      if (path.endsWith("/agent-task/output.log")) return "child result";
-      return undefined;
+    const readText = makeReadText({
+      wire: (reads) => (reads === 1 ? initialWire : completedWire),
+      task: '{"status":"completed","endedAt":200}',
+      output: { "/agent-task/output.log": "child result" },
     });
-    const updates: SessionNotification[] = [];
-    const bridge = createKimiBackgroundBridge(
-      { kind: "posix", path: "/repo" },
-      (notification) => updates.push(notification),
-      {
-        readText,
-        resolveSessionDir: async () => "/kimi/session",
-        pollIntervalMs: 1,
-      },
-    );
+    const { bridge, updates } = startBridge(readText);
 
     bridge.onBackgroundLaunch({
       sessionId: "session-1",
@@ -208,6 +310,57 @@ describe("Kimi background subagent bridge", () => {
       status: "completed",
       rawOutput: "child result",
       _meta: { [PORACODE_ACP_DETACHED_SUBAGENT_ACTIVITY_META_KEY]: "tool-1" },
+    });
+  });
+
+  it("accepts Kimi v2 completion segments that resume the launch turn id", async () => {
+    const launchWire = [
+      wireLine(100, {
+        type: "tool.call",
+        turnId: "10",
+        name: "Agent",
+        args: { run_in_background: true },
+      }),
+      wireLine(101, { type: "step.end", turnId: "10", finishReason: "tool_use" }),
+    ].join("\n");
+    const completedWire = [
+      launchWire,
+      wireLine(201, {
+        type: "tool.call",
+        turnId: "10",
+        name: "TaskOutput",
+        args: { task_id: "agent-task" },
+      }),
+      wireLine(202, {
+        type: "content.part",
+        turnId: "10",
+        part: { type: "text", text: "same-turn automatic reply" },
+      }),
+      wireLine(203, { type: "step.end", turnId: "10", finishReason: "end_turn" }),
+    ].join("\n");
+    const readText = makeReadText({
+      wire: (reads) => (reads === 1 ? launchWire : completedWire),
+      task: '{"status":"completed","endedAt":200}',
+      output: { "/agent-task/output.log": "child result" },
+    });
+    const { bridge, updates } = startBridge(readText);
+
+    bridge.onBackgroundLaunch({
+      sessionId: "session-1",
+      toolCallId: "tool-1",
+      taskId: "agent-task",
+    });
+    await vi.waitFor(() => expect(updates).toHaveLength(3));
+    bridge.dispose();
+
+    expect(updates[1]?.update).toMatchObject({
+      content: { type: "text", text: "same-turn automatic reply" },
+      _meta: { [PORACODE_ACP_NEW_ASSISTANT_ITEM_META_KEY]: true },
+    });
+    expect(updates[2]?.update).toMatchObject({
+      toolCallId: "tool-1",
+      status: "completed",
+      rawOutput: "child result",
     });
   });
 
@@ -241,29 +394,15 @@ describe("Kimi background subagent bridge", () => {
       }),
       wireLine(204, { type: "step.end", turnId: "1", finishReason: "end_turn" }),
     ].join("\n");
-    let wireReads = 0;
-    const readText = vi.fn<
-      (location: ProjectLocation, path: string, maxBytes?: number) => Promise<string | undefined>
-    >(async (_location, path) => {
-      if (path.endsWith("/wire.jsonl")) {
-        wireReads += 1;
-        return wireReads <= 2 ? initialWire : completedWire;
-      }
-      if (path.endsWith(".json")) return '{"status":"completed","endedAt":200}';
-      if (path.endsWith("/agent-alpha/output.log")) return "alpha result";
-      if (path.endsWith("/agent-beta/output.log")) return "beta result";
-      return undefined;
-    });
-    const updates: SessionNotification[] = [];
-    const bridge = createKimiBackgroundBridge(
-      { kind: "posix", path: "/repo" },
-      (notification) => updates.push(notification),
-      {
-        readText,
-        resolveSessionDir: async () => "/kimi/session",
-        pollIntervalMs: 1,
+    const readText = makeReadText({
+      wire: (reads) => (reads <= 2 ? initialWire : completedWire),
+      task: '{"status":"completed","endedAt":200}',
+      output: {
+        "/agent-alpha/output.log": "alpha result",
+        "/agent-beta/output.log": "beta result",
       },
-    );
+    });
+    const { bridge, updates } = startBridge(readText);
 
     bridge.onBackgroundLaunch({
       sessionId: "session-1",
@@ -309,4 +448,61 @@ describe("Kimi background subagent bridge", () => {
       )?.update,
     ).toMatchObject({ content: { type: "text", text: "combined automatic reply" } });
   });
+
+  it.each([
+    { status: "killed", expected: "failed" },
+    { status: "timed_out", expected: "failed" },
+    { status: "lost", expected: "failed" },
+    { status: "failed", expected: "failed" },
+    { status: "completed", expected: "completed" },
+  ])(
+    "completes $status tasks without a parent reply when no wire turn references them",
+    async ({ status, expected }) => {
+      const initialWire = [
+        wireLine(100, {
+          type: "content.part",
+          turnId: "0",
+          part: { type: "text", text: "launched" },
+        }),
+        wireLine(101, { type: "step.end", turnId: "0", finishReason: "end_turn" }),
+      ].join("\n");
+      // v2 notification turns are invisible over ACP; when the model's reply
+      // turn never references the task, the wire poll expires its grace
+      // window and the completion must still be emitted. Fast-forward the
+      // injected clock past the window once the wire polling starts.
+      let clock = 1_000;
+      const readText = makeReadText({
+        wire: (reads) => {
+          if (reads >= 2) clock = 1_000 + 15 * 60 * 1_000 + 1_000;
+          return initialWire;
+        },
+        task: `{"status":"${status}","endedAt":200}`,
+        output: { "/agent-task/output.log": "child result" },
+      });
+      const { bridge, updates } = startBridge(readText, { now: () => clock });
+
+      bridge.onBackgroundLaunch({
+        sessionId: "session-1",
+        toolCallId: "tool-1",
+        taskId: "agent-task",
+      });
+      await vi.waitFor(() => expect(updates).toHaveLength(2));
+      bridge.dispose();
+
+      expect(updates.map((notification) => notification.update.sessionUpdate)).toEqual([
+        "agent_message_chunk",
+        "tool_call_update",
+      ]);
+      expect(updates[0]?.update).toMatchObject({
+        content: { type: "text", text: "child result" },
+        _meta: { [PORACODE_ACP_PARENT_TOOL_CALL_ID_META_KEY]: "tool-1" },
+      });
+      expect(updates[1]?.update).toMatchObject({
+        toolCallId: "tool-1",
+        status: expected,
+        rawOutput: "child result",
+        _meta: { [PORACODE_ACP_DETACHED_SUBAGENT_ACTIVITY_META_KEY]: "tool-1" },
+      });
+    },
+  );
 });

--- a/src/supervisor/agents/kimi/backgroundBridge.ts
+++ b/src/supervisor/agents/kimi/backgroundBridge.ts
@@ -6,26 +6,31 @@ import {
   type AcpSubagentCoordinator,
 } from "../acp/subagentCoordinator";
 import type { KimiBackgroundLaunch } from "./acpTransform";
+import {
+  isTerminalTaskStatus,
+  parseCompletedKimiWireTurns,
+  parseKimiTaskRecord,
+  type KimiCompletedWireTurn,
+} from "./kimiWireJournal";
 import { resolveKimiSessionDir } from "./sessionFiles";
 
 const POLL_INTERVAL_MS = 500;
 const SESSION_DIR_TIMEOUT_MS = 30_000;
+/**
+ * How long to poll the session's wire journal for the model's follow-up
+ * reply turn after the task file reports a terminal status.
+ *
+ * With the v2 engine (0.33.0+) a detached task settling while the session
+ * is idle makes the engine start a spontaneous notification turn — but the
+ * acp-server forwards events of client-initiated turns ONLY, so that turn
+ * never reaches us over ACP. The on-disk wire journal is the sole place it
+ * can be observed, and disk polling is the only completion signal. When no
+ * turn references the task within this window (e.g. the model acknowledges
+ * a killed task without calling TaskOutput), the completion is emitted
+ * without a parent reply.
+ */
 const AUTOMATIC_TURN_GRACE_MS = 15 * 60 * 1_000;
 const TASK_TIMEOUT_MS = 2 * 60 * 60 * 1_000;
-
-interface KimiTaskRecord {
-  status: string;
-  endedAt?: number;
-}
-
-export interface KimiCompletedWireTurn {
-  turnId: string;
-  completionId: string;
-  firstTime: number;
-  lastTime: number;
-  text: string;
-  taskIds: string[];
-}
 
 export interface KimiBackgroundBridge {
   onBackgroundLaunch(launch: KimiBackgroundLaunch): void;
@@ -97,8 +102,6 @@ async function monitorBackgroundLaunch(input: MonitorBackgroundLaunchInput): Pro
   if (!sessionDir || input.signal.aborted) return;
 
   const wirePath = `${sessionDir}/agents/main/wire.jsonl`;
-  const initialWire = await input.readText(input.location, wirePath, 8_000_000);
-  const launchTurnId = findLatestKimiWireTurnId(initialWire);
   const taskPath = `${sessionDir}/agents/main/tasks/${input.launch.taskId}`;
 
   while (!input.signal.aborted && input.now() - startedAt < TASK_TIMEOUT_MS) {
@@ -113,7 +116,7 @@ async function monitorBackgroundLaunch(input: MonitorBackgroundLaunchInput): Pro
     const output = (
       await input.readText(input.location, `${taskPath}/output.log`, 4_000_000)
     )?.trim();
-    const automaticTurn = await waitForAutomaticTurn(input, wirePath, launchTurnId, task.endedAt);
+    const automaticTurn = await waitForAutomaticTurn(input, wirePath, task.endedAt);
     const emitAutomaticReply =
       automaticTurn !== undefined && !input.claimedAutomaticTurns.has(automaticTurn.completionId);
     if (automaticTurn) input.claimedAutomaticTurns.add(automaticTurn.completionId);
@@ -144,7 +147,6 @@ async function waitForSessionDir(
 async function waitForAutomaticTurn(
   input: MonitorBackgroundLaunchInput,
   wirePath: string,
-  launchTurnId: string | undefined,
   taskEndedAt: number | undefined,
 ): Promise<KimiCompletedWireTurn | undefined> {
   const startedAt = input.now();
@@ -153,7 +155,6 @@ async function waitForAutomaticTurn(
     const candidate = parseCompletedKimiWireTurns(wire)
       .filter(
         (turn) =>
-          turn.turnId !== launchTurnId &&
           turn.taskIds.includes(input.launch.taskId) &&
           (taskEndedAt === undefined || turn.lastTime >= taskEndedAt),
       )
@@ -173,6 +174,8 @@ function emitBackgroundCompletion(
   automaticText: string | undefined,
 ): void {
   const finalText = automaticText?.trim();
+  // Only `completed` is a success; `failed`, `killed`, `timed_out`, `lost`
+  // (and legacy `cancelled`) all surface the subagent card as failed.
   for (const notification of subagents.complete({
     sessionId: launch.sessionId,
     toolCallId: launch.toolCallId,
@@ -182,109 +185,6 @@ function emitBackgroundCompletion(
   })) {
     emit(notification);
   }
-}
-
-export function parseKimiTaskRecord(text: string | undefined): KimiTaskRecord | undefined {
-  if (!text) return undefined;
-  try {
-    const parsed: unknown = JSON.parse(text);
-    if (!isPlainRecord(parsed) || typeof parsed.status !== "string") return undefined;
-    return {
-      status: parsed.status,
-      ...(typeof parsed.endedAt === "number" ? { endedAt: parsed.endedAt } : {}),
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-export function parseCompletedKimiWireTurns(text: string | undefined): KimiCompletedWireTurn[] {
-  if (!text) return [];
-  const activeTurns = new Map<
-    string,
-    {
-      firstTime: number;
-      lastTime: number;
-      textParts: string[];
-      taskIds: Set<string>;
-    }
-  >();
-  const completedTurns: KimiCompletedWireTurn[] = [];
-  for (const line of text.split("\n")) {
-    if (!line.trim()) continue;
-    let record: unknown;
-    try {
-      record = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!isPlainRecord(record) || record.type !== "context.append_loop_event") continue;
-    const event = record.event;
-    if (!isPlainRecord(event) || typeof event.turnId !== "string") continue;
-    const time = typeof record.time === "number" ? record.time : 0;
-    const turn = activeTurns.get(event.turnId) ?? {
-      firstTime: time,
-      lastTime: time,
-      textParts: [],
-      taskIds: new Set<string>(),
-    };
-    turn.firstTime = Math.min(turn.firstTime, time);
-    turn.lastTime = Math.max(turn.lastTime, time);
-    if (event.type === "content.part" && isPlainRecord(event.part)) {
-      if (event.part.type === "text" && typeof event.part.text === "string") {
-        turn.textParts.push(event.part.text);
-      }
-    }
-    if (event.type === "tool.call" && isPlainRecord(event.args)) {
-      const path = event.args.path;
-      if (typeof path === "string") {
-        const taskId = /[/\\]tasks[/\\]([^/\\]+)[/\\]output\.log$/i.exec(path)?.[1];
-        if (taskId) turn.taskIds.add(taskId);
-      }
-      if (event.name === "TaskOutput" && typeof event.args.task_id === "string") {
-        turn.taskIds.add(event.args.task_id);
-      }
-    }
-    if (event.type === "step.end" && event.finishReason === "end_turn") {
-      completedTurns.push({
-        turnId: event.turnId,
-        completionId: `${event.turnId}:${turn.firstTime}:${turn.lastTime}`,
-        firstTime: turn.firstTime,
-        lastTime: turn.lastTime,
-        text: turn.textParts.join("").trim(),
-        taskIds: [...turn.taskIds],
-      });
-      activeTurns.delete(event.turnId);
-    } else {
-      activeTurns.set(event.turnId, turn);
-    }
-  }
-  return completedTurns;
-}
-
-function findLatestKimiWireTurnId(text: string | undefined): string | undefined {
-  return parseKimiWireTurnIds(text).at(-1);
-}
-
-function parseKimiWireTurnIds(text: string | undefined): string[] {
-  if (!text) return [];
-  const turnIds: string[] = [];
-  for (const line of text.split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const record: unknown = JSON.parse(line);
-      if (!isPlainRecord(record) || !isPlainRecord(record.event)) continue;
-      const turnId = record.event.turnId;
-      if (typeof turnId === "string" && turnIds.at(-1) !== turnId) turnIds.push(turnId);
-    } catch {
-      // A partial last line is expected while Kimi is appending to the wire.
-    }
-  }
-  return turnIds;
-}
-
-function isTerminalTaskStatus(status: string): boolean {
-  return status === "completed" || status === "failed" || status === "cancelled";
 }
 
 function waitForNextPoll(signal: AbortSignal, timeoutMs: number): Promise<boolean> {
@@ -300,8 +200,4 @@ function waitForNextPoll(signal: AbortSignal, timeoutMs: number): Promise<boolea
     };
     signal.addEventListener("abort", onAbort, { once: true });
   });
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/supervisor/agents/kimi/detection.test.ts
+++ b/src/supervisor/agents/kimi/detection.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildKimiProbeCapabilities,
   hasKimiCredential,
   hasKimiOAuthCredential,
   kimiDefaultCapabilities,
   kimiDetectionSpec,
+  kimiTerminalAuthMethod,
+  normalizeKimiProbeEfforts,
 } from "./detection";
 
 describe("hasKimiCredential", () => {
@@ -70,7 +73,7 @@ describe("kimiDetectionSpec", () => {
         location: { kind: "windows", path: "C:\\repo" },
         executablePath: "C:\\Users\\demo\\.kimi-code\\bin\\kimi.exe",
       }),
-    ).toBe("& 'C:\\Users\\demo\\.kimi-code\\bin\\kimi.exe' login");
+    ).toBe("& 'C:\\Users\\demo\\.kimi-code\\bin\\kimi.exe' acp --login");
     expect(
       kimiDetectionSpec.loginCommand({
         location: {
@@ -81,7 +84,7 @@ describe("kimiDetectionSpec", () => {
         },
         executablePath: "/home/demo/.kimi-code/bin/kimi",
       }),
-    ).toBe("'/home/demo/.kimi-code/bin/kimi' login");
+    ).toBe("'/home/demo/.kimi-code/bin/kimi' acp --login");
   });
 
   it("ships a non-interactive installer update and the npm version probe", () => {
@@ -126,5 +129,202 @@ describe("kimiDefaultCapabilities", () => {
   it("supports both terminal and GUI presentation", () => {
     expect(kimiDefaultCapabilities.presentationModes).toEqual(["terminal", "gui"]);
     expect(kimiDefaultCapabilities.modes).toEqual(["agent", "plan"]);
+  });
+});
+
+describe("normalizeKimiProbeEfforts", () => {
+  it("returns nothing without a probe", () => {
+    expect(normalizeKimiProbeEfforts(undefined)).toEqual({});
+  });
+
+  // K2.7 offers thinking as a state, not a ladder. Keeping the single `on`
+  // (rather than reporting no levels) is what lets Poracode put the session back
+  // into that state — Kimi otherwise keeps the previous model's tier across a
+  // model switch. The composer draws no picker for a one-option list.
+  it("keeps the untiered `on` as an untiered model's only level", () => {
+    expect(normalizeKimiProbeEfforts({ efforts: ["on"], defaultEffort: "on" })).toEqual({
+      efforts: ["on"],
+      defaultEffort: "on",
+    });
+  });
+
+  // Kimi's own picker shows K2.7 as `On` / `Off (Unsupported)`; `off` is not a
+  // level the model can actually run at.
+  it("reduces an on/off thinking switch to `on`", () => {
+    expect(
+      normalizeKimiProbeEfforts({ modelEfforts: { "kimi-for-coding": ["on", "off"] } }),
+    ).toEqual({ modelEfforts: { "kimi-for-coding": ["on"] } });
+  });
+
+  it("keeps multi-value effort tiers with their default", () => {
+    expect(
+      normalizeKimiProbeEfforts({
+        efforts: ["low", "medium", "high"],
+        defaultEffort: "medium",
+      }),
+    ).toEqual({ efforts: ["low", "medium", "high"], defaultEffort: "medium" });
+  });
+
+  it("drops the untiered `on` from a real tier ladder", () => {
+    expect(
+      normalizeKimiProbeEfforts({ efforts: ["low", "high", "max", "on"], defaultEffort: "on" }),
+    ).toEqual({
+      efforts: ["low", "high", "max"],
+      // `on` is not a tier, so the probed default cannot stand — prefer `high`.
+      defaultEffort: "high",
+    });
+  });
+
+  it("resolves each model's default against its own levels", () => {
+    expect(
+      normalizeKimiProbeEfforts({
+        modelEfforts: {
+          "kimi-for-coding": ["on"],
+          k3: ["low", "medium", "high"],
+        },
+        modelDefaultEfforts: { "kimi-for-coding": "on", k3: "on", orphan: "on" },
+      }),
+    ).toEqual({
+      modelEfforts: { "kimi-for-coding": ["on"], k3: ["low", "medium", "high"] },
+      // K2.7 keeps `on`; K3's untiered default becomes `high`; a model with
+      // neither its own levels nor a global list gets nothing.
+      modelDefaultEfforts: { "kimi-for-coding": "on", k3: "high" },
+    });
+  });
+
+  it("keeps a probed model default that is valid for its levels", () => {
+    expect(
+      normalizeKimiProbeEfforts({
+        modelEfforts: { k3: ["low", "high"] },
+        modelDefaultEfforts: { k3: "low" },
+      }),
+    ).toEqual({
+      modelEfforts: { k3: ["low", "high"] },
+      modelDefaultEfforts: { k3: "low" },
+    });
+  });
+
+  // Probed from kimi 0.33.0 with the CLI's persisted model on K2.7: the baseline
+  // is `["on"]` and only the K3 models carry their own list.
+  it("normalizes the real Kimi 0.33 payload probed from K2.7", () => {
+    expect(
+      normalizeKimiProbeEfforts({
+        efforts: ["on"],
+        defaultEffort: "on",
+        modelEfforts: {
+          "kimi-code/k3": ["low", "high", "max", "on"],
+          "kimi-code/k3-256k": ["low", "high", "max", "on"],
+        },
+        modelDefaultEfforts: {
+          "kimi-code/kimi-for-coding": "on",
+          "kimi-code/kimi-for-coding-highspeed": "on",
+          "kimi-code/k3": "on",
+          "kimi-code/k3-256k": "on",
+        },
+      }),
+    ).toEqual({
+      // The K2.7 models have no list of their own and inherit this one.
+      efforts: ["on"],
+      defaultEffort: "on",
+      modelEfforts: {
+        "kimi-code/k3": ["low", "high", "max"],
+        "kimi-code/k3-256k": ["low", "high", "max"],
+      },
+      modelDefaultEfforts: {
+        "kimi-code/kimi-for-coding": "on",
+        "kimi-code/kimi-for-coding-highspeed": "on",
+        "kimi-code/k3": "high",
+        "kimi-code/k3-256k": "high",
+      },
+    });
+  });
+
+  // `session/new` starts on whichever model the Kimi CLI last persisted, so the
+  // baseline can just as easily be K3's ladder. K2.7 must not inherit it.
+  it("normalizes the same payload probed from a K3 model", () => {
+    expect(
+      normalizeKimiProbeEfforts({
+        efforts: ["low", "high", "max", "on"],
+        defaultEffort: "on",
+        modelEfforts: {
+          "kimi-code/kimi-for-coding": ["on"],
+          "kimi-code/kimi-for-coding-highspeed": ["on"],
+        },
+        modelDefaultEfforts: {
+          "kimi-code/kimi-for-coding": "on",
+          "kimi-code/kimi-for-coding-highspeed": "on",
+          "kimi-code/k3": "on",
+          "kimi-code/k3-256k": "on",
+        },
+      }),
+    ).toEqual({
+      efforts: ["low", "high", "max"],
+      defaultEffort: "high",
+      modelEfforts: {
+        "kimi-code/kimi-for-coding": ["on"],
+        "kimi-code/kimi-for-coding-highspeed": ["on"],
+      },
+      modelDefaultEfforts: {
+        "kimi-code/kimi-for-coding": "on",
+        "kimi-code/kimi-for-coding-highspeed": "on",
+        "kimi-code/k3": "high",
+        "kimi-code/k3-256k": "high",
+      },
+    });
+  });
+});
+
+describe("buildKimiProbeCapabilities", () => {
+  const noCredentials = { hasAnyCredential: false, hasManagedOAuthCredential: false };
+
+  it("passes models through from the probe", () => {
+    const models = [{ id: "k3", label: "Kimi for Coding" }];
+    expect(buildKimiProbeCapabilities({ models }, noCredentials).models).toEqual(models);
+    expect(buildKimiProbeCapabilities(undefined, noCredentials).models).toBeUndefined();
+  });
+
+  it("advertises the static terminal login method and prefers it", () => {
+    const caps = buildKimiProbeCapabilities(undefined, noCredentials);
+    expect(caps.authMethods).toEqual([kimiTerminalAuthMethod]);
+    expect(caps.authMethods?.[0]?.id).toBe("kimi-terminal-login");
+    expect(caps.preferTerminalLogin).toBe(true);
+  });
+
+  it("prefers the probe's authState over the credential fallback", () => {
+    expect(
+      buildKimiProbeCapabilities(
+        { authState: "missing" },
+        { hasAnyCredential: true, hasManagedOAuthCredential: false },
+      ).authState,
+    ).toBe("missing");
+    expect(
+      buildKimiProbeCapabilities({ authState: "authenticated" }, noCredentials).authState,
+    ).toBe("authenticated");
+  });
+
+  it("falls back to credential files when the probe could not decide", () => {
+    expect(
+      buildKimiProbeCapabilities(undefined, {
+        hasAnyCredential: true,
+        hasManagedOAuthCredential: false,
+      }).authState,
+    ).toBe("authenticated");
+    expect(buildKimiProbeCapabilities(undefined, noCredentials).authState).toBe("missing");
+    expect(buildKimiProbeCapabilities({}, noCredentials).authState).toBe("missing");
+  });
+
+  it("reports logout support from the probe or a managed OAuth credential", () => {
+    expect(
+      buildKimiProbeCapabilities({ authLogoutSupported: true }, noCredentials).authLogoutSupported,
+    ).toBe(true);
+    expect(
+      buildKimiProbeCapabilities(undefined, {
+        hasAnyCredential: false,
+        hasManagedOAuthCredential: true,
+      }).authLogoutSupported,
+    ).toBe(true);
+    expect(
+      buildKimiProbeCapabilities(undefined, noCredentials).authLogoutSupported,
+    ).toBeUndefined();
   });
 });

--- a/src/supervisor/agents/kimi/detection.ts
+++ b/src/supervisor/agents/kimi/detection.ts
@@ -1,9 +1,8 @@
 import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { parse as parseToml } from "smol-toml";
-import type { AgentCapability, ProjectLocation } from "@/shared/contracts";
-import { dedupeAcpAuthMethods, probeAcpCapabilities } from "../acp";
+import type { AgentCapability, AgentTerminalAuthMethod, ProjectLocation } from "@/shared/contracts";
+import { probeAcpCapabilities, type AcpProbeResult } from "../acp";
 import {
   batchWslCommandsAsync,
   buildAgentCommand,
@@ -14,6 +13,9 @@ import {
 } from "../base";
 import { buildContextSizeCapabilities } from "../contextWindowLabel";
 import { getAgentProbeCwd, resolveProbeSpawnCwd } from "../probeCwd";
+import { kimiThoughtLevelChoices, preferredKimiThoughtTier } from "./thoughtLevels";
+import { ensureKimiWorkspaceTrust } from "./kimiTrust";
+import { nativeKimiHomePath, nativeKimiOAuthCredentialPath } from "./paths";
 
 // Kimi Code exposes three permission modes: manual (the CLI default), auto,
 // and yolo. Poracode starts fresh threads in auto mode.
@@ -52,24 +54,73 @@ export function buildKimiCommand(location: ProjectLocation, args: string[], wslE
   return buildAgentCommand(location, "kimi", args, wslExecPath);
 }
 
-async function probeCapabilities(
-  location: ProjectLocation,
-  executablePath?: string,
-): Promise<CapabilitiesProbeResult> {
-  const spec = buildKimiCommand(location, ["acp"], executablePath);
-  const sessionCwd = getAgentProbeCwd(location);
-  const processCwd = resolveProbeSpawnCwd(location, spec.cwd);
-  // No `authenticateMethodIds`: Kimi's only ACP method is "login" (OAuth device
-  // flow), which is interactive — probing must never trigger a browser flow.
-  const [probe, credentialState] = await Promise.all([
-    probeAcpCapabilities(spec.command, spec.args, sessionCwd, {
-      ...(processCwd ? { processCwd } : {}),
-      timeoutMs: 20_000,
-      label: location.kind === "wsl" ? `kimi:wsl:${location.distro}` : `kimi:${location.kind}`,
-    }),
-    readKimiCredentialState(location),
-  ]);
+// 0.33.0's agent-core-v2 ACP server no longer drives the OAuth device flow
+// from `authenticate` — it only re-validates auth state. Sign-in happens in a
+// terminal instead, through `kimiDetectionSpec.loginCommand`. Advertise a
+// static terminal method (the Qwen pattern) so the Login button survives even
+// when the ACP probe itself fails. The method carries no `args`: the renderer
+// runs `status.loginCommand` and reads only `env` off the method, so anything
+// else here would be inert.
+export const kimiTerminalAuthMethod: AgentTerminalAuthMethod = {
+  id: "kimi-terminal-login",
+  name: "Login",
+  type: "terminal",
+};
 
+/**
+ * Turn Kimi's `thought_level` selector into real effort tiers.
+ *
+ * Each model keeps the levels it actually offers (see thoughtLevels.ts for the
+ * probed payloads): the `low`/`high`/`max` ladder for K3, and the lone untiered
+ * `on` for K2.7 — which the composer renders as no picker at all, since there is
+ * nothing to choose, while still giving the thread a level to send.
+ *
+ * Kimi reports `currentValue: "on"` even for the tiered K3 models, so defaults
+ * resolve through {@link preferredKimiThoughtTier} (`high`) rather than adopting
+ * a level the model does not offer.
+ */
+export function normalizeKimiProbeEfforts(probe: AcpProbeResult | undefined): {
+  efforts?: string[];
+  defaultEffort?: string;
+  modelEfforts?: Record<string, string[]>;
+  modelDefaultEfforts?: Record<string, string>;
+} {
+  const efforts = kimiThoughtLevelChoices(probe?.efforts ?? []);
+  const defaultEffort = preferredKimiThoughtTier(efforts, probe?.defaultEffort);
+  const modelEfforts: Record<string, string[]> = {};
+  for (const [modelId, levels] of Object.entries(probe?.modelEfforts ?? {})) {
+    // Record every probed model, including the untiered ones: consumers resolve
+    // `modelEfforts[model] ?? efforts`, so omitting a model makes it inherit the
+    // global list — and that list holds only the levels of whichever model the
+    // probe started on, which is whatever the Kimi CLI last persisted.
+    modelEfforts[modelId] = kimiThoughtLevelChoices(levels);
+  }
+  // Kimi's probed default (`on`) names no tier for the tiered models, so resolve
+  // every model's default against the levels that model actually offers.
+  const modelDefaultEfforts: Record<string, string> = {};
+  const probedModelIds = new Set([
+    ...Object.keys(modelEfforts),
+    ...Object.keys(probe?.modelDefaultEfforts ?? {}),
+  ]);
+  for (const modelId of probedModelIds) {
+    const levels = modelEfforts[modelId] ?? efforts;
+    const level = preferredKimiThoughtTier(levels, probe?.modelDefaultEfforts?.[modelId]);
+    if (level) modelDefaultEfforts[modelId] = level;
+  }
+  return {
+    ...(efforts.length > 0 ? { efforts, ...(defaultEffort ? { defaultEffort } : {}) } : {}),
+    ...(Object.keys(modelEfforts).length > 0 ? { modelEfforts } : {}),
+    ...(Object.keys(modelDefaultEfforts).length > 0 ? { modelDefaultEfforts } : {}),
+  };
+}
+
+export function buildKimiProbeCapabilities(
+  probe: AcpProbeResult | undefined,
+  credentialState: {
+    hasAnyCredential: boolean;
+    hasManagedOAuthCredential: boolean;
+  },
+): CapabilitiesProbeResult {
   let contextCaps: Pick<AgentCapability, "contextSizes" | "modelContextSizes"> = {};
   if (probe?.modelMetadata) {
     const sizes = new Map<string, number>();
@@ -82,26 +133,54 @@ async function probeCapabilities(
     }
   }
 
-  const dedupedAuth = probe?.authMethods?.length
-    ? dedupeAcpAuthMethods(probe.authMethods)
-    : undefined;
-
   return {
+    // 0.33.0 carries no model list on `initialize`; models arrive on
+    // `session/new` configOptions, which the shared probe already maps.
     ...(probe?.models?.length ? { models: probe.models } : {}),
-    ...(probe?.efforts?.length ? { efforts: probe.efforts } : {}),
-    ...(probe?.defaultEffort ? { defaultEffort: probe.defaultEffort } : {}),
-    ...(probe?.modelEfforts ? { modelEfforts: probe.modelEfforts } : {}),
-    ...(probe?.modelDefaultEfforts ? { modelDefaultEfforts: probe.modelDefaultEfforts } : {}),
+    ...normalizeKimiProbeEfforts(probe),
     ...(probe?.modes?.length ? { modes: probe.modes } : {}),
     ...(probe?.approvalPolicies?.length ? { approvalPolicies: probe.approvalPolicies } : {}),
     ...(probe?.slashCommands?.length ? { slashCommands: probe.slashCommands } : {}),
     ...contextCaps,
-    ...(dedupedAuth?.length ? { authMethods: dedupedAuth } : {}),
-    authState: credentialState.hasAnyCredential ? "authenticated" : "missing",
-    ...(credentialState.hasManagedOAuthCredential ? { authLogoutSupported: true } : {}),
-    // Kimi's supported sign-in path is its CLI login flow (`kimi login`).
+    authMethods: [kimiTerminalAuthMethod],
+    // Prefer the ACP-native auth signal (session/new succeeded → authenticated,
+    // `auth_required` → missing); fall back to the credential files when the
+    // probe couldn't decide.
+    authState: probe?.authState ?? (credentialState.hasAnyCredential ? "authenticated" : "missing"),
+    // v2 advertises `agentCapabilities.auth.logout` (the ACP logout RPC); the
+    // legacy engine has no RPC but its managed OAuth token file can be
+    // removed directly — the adapter's logout command handles both.
+    ...(probe?.authLogoutSupported || credentialState.hasManagedOAuthCredential
+      ? { authLogoutSupported: true }
+      : {}),
     preferTerminalLogin: true,
   };
+}
+
+async function probeCapabilities(
+  location: ProjectLocation,
+  executablePath?: string,
+): Promise<CapabilitiesProbeResult> {
+  const spec = buildKimiCommand(location, ["acp"], executablePath);
+  const sessionCwd = getAgentProbeCwd(location);
+  const processCwd = resolveProbeSpawnCwd(location, spec.cwd);
+  // `session/new` is what decides `authState`, models and modes, so the probe
+  // must not be the one call that trips over 0.33's workspace-trust gate.
+  // Trust the probe's own cwd (a scratch dir on posix hosts, the project
+  // elsewhere) rather than the project path a launch would use.
+  // Only the ACP probe depends on the trust marker, so read the credential
+  // files (another WSL round trip) alongside the marker write instead of after.
+  const credentialStatePromise = readKimiCredentialState(location);
+  await ensureKimiWorkspaceTrust(location, sessionCwd);
+  // No `authenticateMethodIds`: on the legacy engine `authenticate` triggers
+  // the interactive OAuth device flow, and on 0.33.0's v2 server it only
+  // re-validates — probing must never invoke either.
+  const probe = await probeAcpCapabilities(spec.command, spec.args, sessionCwd, {
+    ...(processCwd ? { processCwd } : {}),
+    timeoutMs: 20_000,
+    label: location.kind === "wsl" ? `kimi:wsl:${location.distro}` : `kimi:${location.kind}`,
+  });
+  return buildKimiProbeCapabilities(probe, await credentialStatePromise);
 }
 
 /**
@@ -159,15 +238,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function nativeKimiHomePath(): string {
-  const kimiHome = process.env["KIMI_CODE_HOME"];
-  return kimiHome && kimiHome.trim().length > 0 ? kimiHome : join(homedir(), ".kimi-code");
-}
-
-export function nativeKimiOAuthCredentialPath(): string {
-  return join(nativeKimiHomePath(), "credentials", "kimi-code.json");
-}
-
 async function readKimiCredentialState(location: ProjectLocation): Promise<{
   hasAnyCredential: boolean;
   hasManagedOAuthCredential: boolean;
@@ -208,11 +278,15 @@ export const kimiDetectionSpec: DetectionSpec = {
     env: "KIMI_CODE_HOME",
     defaultSubpath: ".kimi-code",
   },
+  // The v2 terminal-auth entry point: `kimi acp --login` runs the device-code
+  // login flow in the terminal and exits. This is the only thing that drives a
+  // Kimi sign-in — the renderer's Login button runs exactly this string.
+  // Works on the legacy engine too.
   loginCommand: ({ location, executablePath }) => {
     if (!executablePath) return undefined;
     return location.kind === "windows"
-      ? `& ${quotePowerShellLiteral(executablePath)} login`
-      : `${quotePosixShellArg(executablePath)} login`;
+      ? `& ${quotePowerShellLiteral(executablePath)} acp --login`
+      : `${quotePosixShellArg(executablePath)} acp --login`;
   },
   capabilities: kimiDefaultCapabilities,
   // `kimi upgrade` is an interactive TUI (arrow-key chooser, no headless flag),

--- a/src/supervisor/agents/kimi/index.ts
+++ b/src/supervisor/agents/kimi/index.ts
@@ -9,24 +9,20 @@ import {
   type AgentAdapter,
   type AgentEnvContext,
   type CreateStructuredSessionInput,
-  quotePowerShellLiteral,
 } from "../base";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import { createKimiAcpSessionUpdateTransform } from "./acpTransform";
 import { buildKimiAcpArgs, buildKimiArgs, buildKimiContinueArgs } from "./argv";
 import { createKimiBackgroundBridge } from "./backgroundBridge";
-import {
-  buildKimiCommand,
-  kimiDefaultCapabilities,
-  kimiDetectionSpec,
-  nativeKimiOAuthCredentialPath,
-} from "./detection";
+import { buildKimiCommand, kimiDefaultCapabilities, kimiDetectionSpec } from "./detection";
+import { buildKimiLogoutCommand } from "./kimiLogout";
+import { ensureKimiWorkspaceTrust } from "./kimiTrust";
 import {
   makeKimiDiscoverSessionRef,
   makeKimiWatchSessionRef,
   snapshotKimiPreSpawnSessions,
 } from "./sessionFiles";
-import { detectKimiTerminalStatus } from "./terminal";
+import { detectKimiTerminalStatus, KIMI_TRUST_PROMPT_PATTERN } from "./terminal";
 
 // Kimi Code provider implementation (Moonshot AI).
 // Docs: https://www.kimi.com/code/docs/en/
@@ -118,7 +114,17 @@ export function createKimiAdapter(): AgentAdapter {
       return { binary: "kimi", args };
     },
 
+    // The only async hook that runs ahead of every PTY spawn — used to
+    // pre-write Kimi 0.33's workspace-trust marker so the TUI's interactive
+    // "Trust this folder?" dialog never blocks a launch (the args pass
+    // through untouched).
+    async rewriteLaunchArgsForConfig(args, _config, projectLocation) {
+      await ensureKimiWorkspaceTrust(projectLocation);
+      return args;
+    },
+
     async createStructuredSession(input: CreateStructuredSessionInput) {
+      await ensureKimiWorkspaceTrust(input.projectLocation);
       const acpArgs = buildKimiAcpArgs(input.config);
       const command = buildKimiCommand(
         input.projectLocation,
@@ -158,37 +164,22 @@ export function createKimiAdapter(): AgentAdapter {
       return session;
     },
 
-    // Kimi ACP advertises a single "login" auth method; the auth command is the
-    // same `kimi acp` stdio process.
+    // The `kimi acp` stdio process that dispatch uses for the ACP
+    // `authenticate`/`logout` handshake. On 0.33.0's v2 server `authenticate`
+    // only re-validates auth state (interactive sign-in is the terminal
+    // `kimi acp --login` flow), while `logout` drives the real RPC logout.
     async buildAcpAuthCommand(ctx?: AgentEnvContext) {
       const location = detectProbeLocation(ctx);
       return buildKimiCommand(location, ["acp"], resolveAgentBinaryPath(location, "kimi"));
     },
 
-    // Kimi has no `kimi logout` subcommand and ACP logout is unimplemented.
-    // Its own `/logout` handler removes this managed OAuth token through
-    // FileTokenStorage, so do the same here without launching an interactive
-    // TUI provider picker.
+    // Logout is ACP-RPC-first (v2 advertises `agentCapabilities.auth.logout`)
+    // with the managed-OAuth credential file as the legacy fallback. dispatch
+    // runs the RPC; this builder only describes the file cleanup, so asking
+    // the adapter for its logout spec never signs anyone out.
+    preferAcpLogoutRpc: true,
     async buildAcpLogoutCommand(ctx?: AgentEnvContext) {
-      const location = detectProbeLocation(ctx);
-      if (location.kind === "windows") {
-        return {
-          command: "powershell.exe",
-          args: [
-            "-NoLogo",
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `Remove-Item -LiteralPath ${quotePowerShellLiteral(nativeKimiOAuthCredentialPath())} -Force -ErrorAction SilentlyContinue`,
-          ],
-          cwd: location.path,
-        };
-      }
-      return buildKimiCommand(
-        location,
-        ["-c", 'rm -f -- "${KIMI_CODE_HOME:-$HOME/.kimi-code}/credentials/kimi-code.json"'],
-        "sh",
-      );
+      return buildKimiLogoutCommand(ctx);
     },
 
     createInitialSessionRef() {
@@ -209,6 +200,9 @@ export function createKimiAdapter(): AgentAdapter {
     },
 
     isReadyForInitialPrompt(text) {
+      // The trust dialog (shown if the pre-written marker ever misses) is not
+      // a composer — typing the prompt into it would just corrupt the choice.
+      if (KIMI_TRUST_PROMPT_PATTERN.test(text)) return false;
       const t = text.toLowerCase();
       if (t.includes("kimi")) return true;
       if (/\?\s+for shortcuts|\/\s+for commands/i.test(text)) return true;

--- a/src/supervisor/agents/kimi/kimi.test.ts
+++ b/src/supervisor/agents/kimi/kimi.test.ts
@@ -3,6 +3,7 @@ import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import { resolveSharedUpdateCommand } from "@/shared/agents/updateResolver";
 import { createKnownSessionRef } from "../base";
 import { createKimiAdapter, resolveKimiEmptyResponseError } from "./index";
+import { buildKimiLogoutCommand } from "./kimiLogout";
 
 const location = { kind: "windows", path: "C:\\repo" } as ProjectLocation;
 const config = { mode: "agent" } as ThreadConfig;
@@ -67,26 +68,9 @@ describe("createKimiAdapter shape", () => {
     expect(typeof adapter.createStructuredSession).toBe("function");
   });
 
-  it("provides ACP auth and managed OAuth logout commands", async () => {
+  it("provides ACP auth and managed OAuth logout commands", () => {
     expect(typeof adapter.buildAcpAuthCommand).toBe("function");
     expect(typeof adapter.buildAcpLogoutCommand).toBe("function");
-    const isWindows = process.platform === "win32";
-    const envKind = isWindows ? "windows" : "posix";
-    const logout = await adapter.buildAcpLogoutCommand?.({ envKind });
-    expect(logout?.args).toContain(isWindows ? "-NoLogo" : "-c");
-    expect(logout?.args.join(" ")).toContain(
-      isWindows ? "credentials\\kimi-code.json" : "credentials/kimi-code.json",
-    );
-  });
-
-  it("removes the managed OAuth token inside the selected WSL distro", async () => {
-    const logout = await adapter.buildAcpLogoutCommand?.({
-      envKind: "wsl",
-      wslDistro: "Ubuntu",
-    });
-    expect(logout?.command.toLowerCase()).toContain("wsl");
-    expect(logout?.args).toContain("Ubuntu");
-    expect(logout?.args.join(" ")).toContain("credentials/kimi-code.json");
   });
 
   it("neutralizes the browser for the WSL OAuth flow", () => {
@@ -115,6 +99,38 @@ describe("createKimiAdapter shape", () => {
         projectPath: ".agents/skills",
       },
     ]);
+  });
+});
+
+describe("buildKimiLogoutCommand", () => {
+  const isWindows = process.platform === "win32";
+  const hostEnvKind = isWindows ? "windows" : "posix";
+
+  it("builds the credential-file cleanup spec without any side effect", () => {
+    const logout = buildKimiLogoutCommand({ envKind: hostEnvKind });
+    expect(logout.args).toContain(isWindows ? "-NoLogo" : "-c");
+    expect(logout.args.join(" ")).toContain(isWindows ? "Remove-Item" : "rm -f");
+    expect(logout.args.join(" ")).toContain(
+      isWindows ? "credentials\\kimi-code.json" : "credentials/kimi-code.json",
+    );
+  });
+
+  it("removes the managed OAuth token inside the selected WSL distro", () => {
+    const logout = buildKimiLogoutCommand({ envKind: "wsl", wslDistro: "Ubuntu" });
+    expect(logout.command.toLowerCase()).toContain("wsl");
+    expect(logout.args).toContain("Ubuntu");
+    expect(logout.args.join(" ")).toContain("credentials/kimi-code.json");
+  });
+
+  // Regression: an earlier revision ran the ACP logout RPC inside this
+  // builder, so merely asking the adapter for its logout spec signed the user
+  // out. dispatchAcpLogout owns the RPC now; the adapter opts in with
+  // `preferAcpLogoutRpc`.
+  it("is safe to call straight off the adapter, and the RPC is opt-in via dispatch", async () => {
+    const adapter = createKimiAdapter();
+    expect(adapter.preferAcpLogoutRpc).toBe(true);
+    const logout = await adapter.buildAcpLogoutCommand?.({ envKind: hostEnvKind });
+    expect(logout?.args.join(" ")).toContain(isWindows ? "Remove-Item" : "rm -f");
   });
 });
 

--- a/src/supervisor/agents/kimi/kimiLogout.ts
+++ b/src/supervisor/agents/kimi/kimiLogout.ts
@@ -1,0 +1,41 @@
+import { detectProbeLocation, quotePowerShellLiteral, type AgentEnvContext } from "../base";
+import { buildKimiCommand } from "./detection";
+import { nativeKimiOAuthCredentialPath } from "./paths";
+
+/**
+ * The credential-file half of a Kimi logout.
+ *
+ * Logout is ACP-first: 0.33.0's v2 server advertises
+ * `agentCapabilities.auth.logout`, and the RPC is the engine-native path. The
+ * adapter opts into it with `preferAcpLogoutRpc`, and `dispatchAcpLogout` runs
+ * that RPC before executing the spec built here. The legacy engine has no
+ * logout RPC — its own `/logout` handler just removes the managed OAuth token
+ * through FileTokenStorage — so this command IS the logout there, and stays a
+ * harmless cleanup (`rm -f` / `-ErrorAction SilentlyContinue`) after a
+ * successful RPC.
+ *
+ * This function is a pure builder on purpose. It used to perform the RPC
+ * itself, which meant merely asking the adapter for its logout spec signed the
+ * user out — a unit test doing exactly that wiped a real session.
+ */
+export function buildKimiLogoutCommand(ctx?: AgentEnvContext) {
+  const location = detectProbeLocation(ctx);
+  if (location.kind === "windows") {
+    return {
+      command: "powershell.exe",
+      args: [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Remove-Item -LiteralPath ${quotePowerShellLiteral(nativeKimiOAuthCredentialPath())} -Force -ErrorAction SilentlyContinue`,
+      ],
+      cwd: location.path,
+    };
+  }
+  return buildKimiCommand(
+    location,
+    ["-c", 'rm -f -- "${KIMI_CODE_HOME:-$HOME/.kimi-code}/credentials/kimi-code.json"'],
+    "sh",
+  );
+}

--- a/src/supervisor/agents/kimi/kimiTrust.test.ts
+++ b/src/supervisor/agents/kimi/kimiTrust.test.ts
@@ -1,0 +1,182 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  encodeKimiWorkDirKey,
+  ensureKimiWorkspaceTrust,
+  resetKimiWorkspaceTrustCache,
+  slugifyKimiWorkDirName,
+} from "./kimiTrust";
+
+function sha256Prefix(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
+}
+
+describe("slugifyKimiWorkDirName", () => {
+  it("lowercases the name and maps special characters to dashes", () => {
+    expect(slugifyKimiWorkDirName("My Project")).toBe("my-project");
+    expect(slugifyKimiWorkDirName("Hello, World! (v2)")).toBe("hello-world-v2");
+  });
+
+  it("keeps dots, underscores, and dashes", () => {
+    expect(slugifyKimiWorkDirName("my_app.v2-fix")).toBe("my_app.v2-fix");
+  });
+
+  it("trims leading and trailing dashes", () => {
+    expect(slugifyKimiWorkDirName("--demo--")).toBe("demo");
+  });
+
+  it("caps the slug at 40 characters and re-trims dashes exposed by the cut", () => {
+    expect(slugifyKimiWorkDirName("a".repeat(60))).toBe("a".repeat(40));
+    expect(slugifyKimiWorkDirName(`${"a".repeat(39)} ${"b".repeat(20)}`)).toBe("a".repeat(39));
+  });
+
+  it("falls back to workspace for empty or dot-only names", () => {
+    expect(slugifyKimiWorkDirName("")).toBe("workspace");
+    expect(slugifyKimiWorkDirName("///")).toBe("workspace");
+    expect(slugifyKimiWorkDirName(".")).toBe("workspace");
+    expect(slugifyKimiWorkDirName("..")).toBe("workspace");
+  });
+});
+
+describe("encodeKimiWorkDirKey", () => {
+  it("combines wd_, the slug of the last path segment, and the 12-char sha256 prefix", () => {
+    const key = encodeKimiWorkDirKey("/home/demo/project");
+    expect(key).toBe(`wd_project_${sha256Prefix("/home/demo/project")}`);
+  });
+
+  it("normalizes backslashes before hashing", () => {
+    const key = encodeKimiWorkDirKey("C:\\Users\\demo\\repo");
+    expect(key).toBe(`wd_repo_${sha256Prefix("C:/Users/demo/repo")}`);
+  });
+
+  it("strips trailing slashes so equivalent paths share a key", () => {
+    expect(encodeKimiWorkDirKey("/home/demo/repo/")).toBe(encodeKimiWorkDirKey("/home/demo/repo"));
+    expect(encodeKimiWorkDirKey("C:\\demo\\repo\\\\")).toBe(encodeKimiWorkDirKey("C:\\demo\\repo"));
+  });
+});
+
+describe("ensureKimiWorkspaceTrust (native)", () => {
+  const tempDirs: string[] = [];
+
+  function makeTempDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  beforeEach(() => {
+    resetKimiWorkspaceTrustCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes the marker JSON under KIMI_CODE_HOME/workspace-trust", async () => {
+    const home = makeTempDir("kimi-home-");
+    const project = makeTempDir("kimi-project-");
+    vi.stubEnv("KIMI_CODE_HOME", home);
+    const root = realpathSync(project);
+
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+
+    const markerPath = join(home, "workspace-trust", encodeKimiWorkDirKey(root));
+    expect(existsSync(markerPath)).toBe(true);
+    const record = JSON.parse(readFileSync(markerPath, "utf8")) as {
+      root: unknown;
+      trustedAt: unknown;
+    };
+    expect(record.root).toBe(root);
+    expect(typeof record.trustedAt).toBe("number");
+  });
+
+  it("does not overwrite an existing marker", async () => {
+    const home = makeTempDir("kimi-home-");
+    const project = makeTempDir("kimi-project-");
+    vi.stubEnv("KIMI_CODE_HOME", home);
+    const root = realpathSync(project);
+    const markerPath = join(home, "workspace-trust", encodeKimiWorkDirKey(root));
+    mkdirSync(dirname(markerPath), { recursive: true });
+    writeFileSync(markerPath, '{"root":"sentinel","trustedAt":1}');
+
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+
+    expect(readFileSync(markerPath, "utf8")).toBe('{"root":"sentinel","trustedAt":1}');
+  });
+
+  it("honors an explicit workDir over the project path (the ACP probe's cwd)", async () => {
+    const home = makeTempDir("kimi-home-");
+    const project = makeTempDir("kimi-project-");
+    const probeCwd = makeTempDir("kimi-probe-");
+    vi.stubEnv("KIMI_CODE_HOME", home);
+
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project }, probeCwd);
+
+    const trustDir = join(home, "workspace-trust");
+    expect(existsSync(join(trustDir, encodeKimiWorkDirKey(realpathSync(probeCwd))))).toBe(true);
+    expect(existsSync(join(trustDir, encodeKimiWorkDirKey(realpathSync(project))))).toBe(false);
+  });
+
+  // The marker is write-once, so re-checking it on every launch buys nothing —
+  // on WSL it would cost two bridge round trips per spawn.
+  it("stops touching the marker once a folder is known trusted", async () => {
+    const home = makeTempDir("kimi-home-");
+    const project = makeTempDir("kimi-project-");
+    vi.stubEnv("KIMI_CODE_HOME", home);
+    const markerPath = join(home, "workspace-trust", encodeKimiWorkDirKey(realpathSync(project)));
+
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+    rmSync(markerPath, { force: true });
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it("retries after a failure instead of caching it", async () => {
+    const homeDir = makeTempDir("kimi-home-");
+    const homeFile = join(homeDir, "blocked");
+    const project = makeTempDir("kimi-project-");
+    writeFileSync(homeFile, "not a directory");
+    vi.stubEnv("KIMI_CODE_HOME", homeFile);
+
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+
+    // Same folder, but the home is writable now — the first failure must not
+    // have been memoized as "already trusted".
+    vi.stubEnv("KIMI_CODE_HOME", homeDir);
+    await ensureKimiWorkspaceTrust({ kind: "posix", path: project });
+
+    const markerPath = join(
+      homeDir,
+      "workspace-trust",
+      encodeKimiWorkDirKey(realpathSync(project)),
+    );
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  it("never throws when the trust directory is unwritable", async () => {
+    // Pointing KIMI_CODE_HOME at a plain file makes the workspace-trust mkdir
+    // fail with ENOTDIR — the launch must not be blocked by that.
+    const homeFile = join(makeTempDir("kimi-home-"), "blocked");
+    writeFileSync(homeFile, "not a directory");
+    vi.stubEnv("KIMI_CODE_HOME", homeFile);
+
+    await expect(
+      ensureKimiWorkspaceTrust({ kind: "posix", path: makeTempDir("kimi-project-") }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/kimi/kimiTrust.ts
+++ b/src/supervisor/agents/kimi/kimiTrust.ts
@@ -1,0 +1,146 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ProjectLocation } from "@/shared/contracts";
+import { batchWslCommandsAsync, quotePosixShellArg } from "../base";
+import { nativeKimiHomePath } from "./paths";
+
+/**
+ * Kimi Code 0.33's agent-core-v2 engine gates first launch in a folder behind
+ * a TUI "Trust this folder?" dialog (no CLI flag skips it). The engine
+ * pre-trusts a folder when a marker document exists under
+ * `$KIMI_CODE_HOME/workspace-trust/<workDirKey>`, so we write that marker
+ * before spawning Kimi and the dialog never appears.
+ *
+ * The workDirKey encoding matches Kimi's `encodeWorkDirKey`
+ * (`wd_<slug>_<sha256(normalizedRoot)[0:12]>`) — the same key its session
+ * dirs use — and the marker body is the JSON record its trust service reads:
+ * `{"root": <absolute path>, "trustedAt": <epoch ms>}`.
+ *
+ * This encoding is a best-effort mirror of an upstream implementation we do
+ * not control: a drift only costs us the marker (Kimi then shows its own
+ * dialog, which terminal.ts surfaces). Session discovery in sessionFiles.ts
+ * therefore keeps treating the workDirKey as opaque and scans every dir
+ * rather than deriving the key from here — do not "optimize" it to use this.
+ */
+
+const MAX_WORKDIR_SLUG_LENGTH = 40;
+const WORKDIR_KEY_PREFIX = "wd_";
+const HASH_LENGTH = 12;
+
+export function slugifyKimiWorkDirName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9._-]+/g, "-")
+    .replaceAll(/^-+|-+$/g, "")
+    .slice(0, MAX_WORKDIR_SLUG_LENGTH)
+    .replaceAll(/^-+|-+$/g, "");
+  return slug === "" || slug === "." || slug === ".." ? "workspace" : slug;
+}
+
+/**
+ * Derive Kimi's opaque workspace key for a working directory. The hash input
+ * is the slash-normalized, trailing-slash-stripped path — Kimi hashes its own
+ * post-`chdir` cwd, so callers should pass the resolved (realpath) path.
+ */
+export function encodeKimiWorkDirKey(workDir: string): string {
+  const normalized = workDir.replaceAll("\\", "/").replace(/\/+$/, "");
+  const base = normalized.split("/").pop() ?? normalized;
+  const slug = slugifyKimiWorkDirName(base);
+  const hash = createHash("sha256").update(normalized).digest("hex").slice(0, HASH_LENGTH);
+  return `${WORKDIR_KEY_PREFIX}${slug}_${hash}`;
+}
+
+function resolveTrustRoot(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+function trustMarkerRecord(root: string): string {
+  return JSON.stringify({ root, trustedAt: Date.now() });
+}
+
+function ensureNativeKimiWorkspaceTrust(projectPath: string): boolean {
+  const root = resolveTrustRoot(projectPath);
+  const markerPath = join(nativeKimiHomePath(), "workspace-trust", encodeKimiWorkDirKey(root));
+  try {
+    if (existsSync(markerPath)) return true;
+    mkdirSync(dirname(markerPath), { recursive: true });
+    // `wx` fails instead of overwriting a marker a racing process just wrote.
+    writeFileSync(markerPath, trustMarkerRecord(root), { flag: "wx" });
+    return true;
+  } catch {
+    // Best effort: a missed marker only means the TUI shows its own trust
+    // dialog, which the terminal status heuristics surface to the user.
+    return existsSync(markerPath);
+  }
+}
+
+// WSL: the marker lives inside the distro, and a profile-set KIMI_CODE_HOME
+// only exists in the distro's login env — expand it there (the same way
+// sessionFiles.ts honors it) instead of reading the Windows process env.
+async function ensureWslKimiWorkspaceTrust(distro: string, linuxPath: string): Promise<boolean> {
+  // Kimi hashes its own post-chdir cwd, which resolves symlinks — mirror that
+  // with readlink before deriving the key.
+  const [resolved] = await batchWslCommandsAsync(distro, [
+    `readlink -f -- ${quotePosixShellArg(linuxPath)} 2>/dev/null || printf %s ${quotePosixShellArg(linuxPath)}`,
+  ]);
+  const trimmed = resolved?.ok ? resolved.stdout.trim() : "";
+  const root = trimmed.length > 0 ? trimmed : linuxPath;
+  const markerName = encodeKimiWorkDirKey(root);
+  const script = [
+    'lc_home="${KIMI_CODE_HOME:-$HOME/.kimi-code}"',
+    'lc_dir="$lc_home/workspace-trust"',
+    `lc_marker="$lc_dir/${markerName}"`,
+    // Never overwrite an existing marker; its presence alone is the trusted bit.
+    `if [ ! -e "$lc_marker" ]; then mkdir -p "$lc_dir" && printf %s ${quotePosixShellArg(trustMarkerRecord(root))} > "$lc_marker"; fi`,
+    // Echoed so the caller can cache the result and stop paying two bridge
+    // round trips on every subsequent launch of the same folder.
+    'if [ -e "$lc_marker" ]; then printf trusted; fi',
+  ].join("; ");
+  const [written] = await batchWslCommandsAsync(distro, [script]);
+  return written?.ok === true && written.stdout.trim() === "trusted";
+}
+
+// Folders whose marker we have already confirmed this session. The marker is
+// write-once and nothing in Poracode removes it, so re-checking it costs two
+// WSL bridge round trips per launch for no new information. Only successful
+// runs are recorded, so a transient failure is retried on the next launch.
+const trustedWorkDirs = new Set<string>();
+
+function trustCacheKey(location: ProjectLocation, workDir: string): string {
+  return location.kind === "wsl" ? `wsl:${location.distro}:${workDir}` : `native:${workDir}`;
+}
+
+/**
+ * Ensure the workspace-trust marker exists before a Kimi launch (PTY, ACP
+ * session, or capabilities probe). `workDir` defaults to the location's own
+ * path; pass it explicitly when the process runs somewhere else (the ACP
+ * probe spawns in a scratch dir, not the project). Best effort — failures
+ * never block the launch.
+ */
+export async function ensureKimiWorkspaceTrust(
+  location: ProjectLocation,
+  workDir?: string,
+): Promise<void> {
+  const target = workDir ?? (location.kind === "wsl" ? location.linuxPath : location.path);
+  const cacheKey = trustCacheKey(location, target);
+  if (trustedWorkDirs.has(cacheKey)) return;
+  try {
+    const trusted =
+      location.kind === "wsl"
+        ? await ensureWslKimiWorkspaceTrust(location.distro, target)
+        : ensureNativeKimiWorkspaceTrust(target);
+    if (trusted) trustedWorkDirs.add(cacheKey);
+  } catch {
+    // Best effort (see ensureNativeKimiWorkspaceTrust).
+  }
+}
+
+/** Test-only: drop the memoized markers so each case starts from a clean slate. */
+export function resetKimiWorkspaceTrustCache(): void {
+  trustedWorkDirs.clear();
+}

--- a/src/supervisor/agents/kimi/kimiWireJournal.ts
+++ b/src/supervisor/agents/kimi/kimiWireJournal.ts
@@ -1,0 +1,147 @@
+/**
+ * Readers for the on-disk state Kimi's engine writes next to a session: the
+ * per-task `<taskId>.json` record and the `wire.jsonl` journal. Kept separate
+ * from the polling bridge (backgroundBridge.ts) so the engine's file formats —
+ * which differ between the legacy and v2 engines — can change and be tested
+ * without touching the poll/emit orchestration.
+ */
+
+export interface KimiTaskRecord {
+  status: string;
+  endedAt?: number;
+}
+
+export interface KimiCompletedWireTurn {
+  turnId: string;
+  completionId: string;
+  firstTime: number;
+  lastTime: number;
+  text: string;
+  taskIds: string[];
+}
+
+/**
+ * Terminal v2 task statuses: `completed | failed | killed | timed_out |
+ * lost` (the v2 engine's TERMINAL_STATUSES). `cancelled` is retained for
+ * older task records written by previous engines.
+ */
+const TERMINAL_TASK_STATUSES = new Set([
+  "completed",
+  "failed",
+  "killed",
+  "timed_out",
+  "lost",
+  "cancelled",
+]);
+
+export function isTerminalTaskStatus(status: string): boolean {
+  return TERMINAL_TASK_STATUSES.has(status);
+}
+
+/**
+ * Parse a `<taskId>.json` task record. v2 writes camelCase (`endedAt`,
+ * possibly `null`); legacy snake_case records (`ended_at`) can still be on
+ * disk mid-migration, so both spellings are read.
+ */
+export function parseKimiTaskRecord(text: string | undefined): KimiTaskRecord | undefined {
+  if (!text) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(text);
+    if (!isPlainRecord(parsed) || typeof parsed.status !== "string") return undefined;
+    const endedAt =
+      typeof parsed.endedAt === "number"
+        ? parsed.endedAt
+        : typeof parsed.ended_at === "number"
+          ? parsed.ended_at
+          : undefined;
+    return {
+      status: parsed.status,
+      ...(endedAt !== undefined ? { endedAt } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseCompletedKimiWireTurns(text: string | undefined): KimiCompletedWireTurn[] {
+  if (!text) return [];
+  const activeTurns = new Map<
+    string,
+    {
+      firstTime: number;
+      lastTime: number;
+      textParts: string[];
+      taskIds: Set<string>;
+    }
+  >();
+  const completedTurns: KimiCompletedWireTurn[] = [];
+  const pendingTaskIds = new Set<string>();
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainRecord(record)) continue;
+    if (record.type === "turn.prompt" && isPlainRecord(record.origin)) {
+      if (record.origin.kind === "task" && typeof record.origin.taskId === "string") {
+        pendingTaskIds.add(record.origin.taskId);
+      }
+      continue;
+    }
+    if (record.type !== "context.append_loop_event") continue;
+    const event = record.event;
+    if (
+      !isPlainRecord(event) ||
+      (typeof event.turnId !== "string" && typeof event.turnId !== "number")
+    ) {
+      continue;
+    }
+    const turnId = String(event.turnId);
+    const time = typeof record.time === "number" ? record.time : 0;
+    let turn = activeTurns.get(turnId);
+    if (!turn) {
+      // A turn's first event claims the task ids announced by the
+      // `turn.prompt` records seen since the previous turn started.
+      turn = { firstTime: time, lastTime: time, textParts: [], taskIds: new Set(pendingTaskIds) };
+      pendingTaskIds.clear();
+    }
+    turn.firstTime = Math.min(turn.firstTime, time);
+    turn.lastTime = Math.max(turn.lastTime, time);
+    if (event.type === "content.part" && isPlainRecord(event.part)) {
+      if (event.part.type === "text" && typeof event.part.text === "string") {
+        turn.textParts.push(event.part.text);
+      }
+    }
+    if (event.type === "tool.call" && isPlainRecord(event.args)) {
+      const path = event.args.path;
+      if (typeof path === "string") {
+        const taskId = /[/\\]tasks[/\\]([^/\\]+)[/\\]output\.log$/i.exec(path)?.[1];
+        if (taskId) turn.taskIds.add(taskId);
+      }
+      if (event.name === "TaskOutput" && typeof event.args.task_id === "string") {
+        turn.taskIds.add(event.args.task_id);
+      }
+    }
+    if (event.type === "step.end" && event.finishReason === "end_turn") {
+      completedTurns.push({
+        turnId,
+        completionId: `${turnId}:${turn.firstTime}:${turn.lastTime}`,
+        firstTime: turn.firstTime,
+        lastTime: turn.lastTime,
+        text: turn.textParts.join("").trim(),
+        taskIds: [...turn.taskIds],
+      });
+      activeTurns.delete(turnId);
+    } else {
+      activeTurns.set(turnId, turn);
+    }
+  }
+  return completedTurns;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/supervisor/agents/kimi/paths.ts
+++ b/src/supervisor/agents/kimi/paths.ts
@@ -1,0 +1,20 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Native (non-WSL) Kimi Code home and credential paths.
+ *
+ * Kept in its own leaf module — `detection.ts`, `sessionFiles.ts`,
+ * `kimiTrust.ts` and the supervisor's credential reader all need them, and
+ * detection now depends on kimiTrust, so a shared import here is what keeps
+ * that from becoming an import cycle.
+ */
+
+export function nativeKimiHomePath(): string {
+  const kimiHome = process.env["KIMI_CODE_HOME"];
+  return kimiHome && kimiHome.trim().length > 0 ? kimiHome : join(homedir(), ".kimi-code");
+}
+
+export function nativeKimiOAuthCredentialPath(): string {
+  return join(nativeKimiHomePath(), "credentials", "kimi-code.json");
+}

--- a/src/supervisor/agents/kimi/sessionFiles.ts
+++ b/src/supervisor/agents/kimi/sessionFiles.ts
@@ -10,7 +10,7 @@ import {
   statSessionPaths,
   watchSessionPaths,
 } from "../base";
-import { nativeKimiHomePath } from "./detection";
+import { nativeKimiHomePath } from "./paths";
 
 // Honor the KIMI_CODE_HOME override the CLI supports (default ~/.kimi-code).
 // Sessions live under $KIMI_CODE_HOME/sessions/<workDirKey>/<sessionId>/. The

--- a/src/supervisor/agents/kimi/terminal.ts
+++ b/src/supervisor/agents/kimi/terminal.ts
@@ -4,11 +4,26 @@ import { detectTerminalStatusFromHints, type TerminalStatusHint } from "../base"
 // conservative — only generic, high-confidence interactive/working/idle
 // signals shared across CLI agents. Kimi emits no OSC, so there is no
 // OSC-based signal to corroborate against.
+/**
+ * Kimi 0.33's first-launch workspace-trust dialog. Launches pre-write the
+ * trust marker (kimiTrust.ts), so every consumer of this pattern is handling
+ * the rare miss: the status detector surfaces it, and the prompt gate refuses
+ * to type into it.
+ */
+export const KIMI_TRUST_PROMPT_PATTERN = /Trust this folder\?/i;
+
 const KIMI_STRONG = [
   {
     re: /Enter to select|Choose an option/i,
     status: "needs_reply" as const,
     attention: "needs_reply" as const,
+  },
+  // Surface the trust dialog so the user can answer it instead of staring at
+  // a hung thread.
+  {
+    re: KIMI_TRUST_PROMPT_PATTERN,
+    status: "needs_reply" as const,
+    attention: "needs_approval" as const,
   },
   {
     re: /\[y\/n\]|\(y\/N\)|Allow\s+.*\?|Do you want to proceed|Continue\?|Approve\??/i,

--- a/src/supervisor/agents/kimi/thoughtLevels.ts
+++ b/src/supervisor/agents/kimi/thoughtLevels.ts
@@ -1,0 +1,95 @@
+/**
+ * Kimi's `thought_level` selector (config id `thinking`) advertises `on` for
+ * every model, but it is not an effort tier — it means "thinking enabled, tier
+ * unspecified". Verified against kimi 0.33.0 (`session/new` followed by
+ * `session/set_config_option` per model):
+ *
+ *   kimi-code/kimi-for-coding            -> ["on"]
+ *   kimi-code/kimi-for-coding-highspeed  -> ["on"]
+ *   kimi-code/k3                         -> ["low", "high", "max", "on"]
+ *   kimi-code/k3-256k                    -> ["low", "high", "max", "on"]
+ *
+ * `currentValue` is `on` for all four, including the tiered K3 models. Kimi's
+ * own picker never offers `on` next to the tiers (it shows `Low High Max` for
+ * K3 and `On` / `Off (Unsupported)` for K2.7), so passing the raw list through
+ * draws a fourth pseudo-tier and reports `On` as the selected reasoning level
+ * for a K3 thread.
+ *
+ * ACP has no per-option "unsupported"/"disabled" marker (`SessionConfigSelectOption`
+ * carries only `value`/`name`/`description`/`_meta`), so the untiered value can
+ * only be recognized by its id.
+ */
+export const KIMI_UNTIERED_THOUGHT_LEVEL = "on";
+
+/**
+ * Default tier for a model whose probed default is the untiered `on`. Kimi
+ * reports `on` for K3 too, so its probed default names no tier; falling back to
+ * the list order would start K3 threads at `low`, the weakest thinking budget,
+ * where Kimi's untiered `on` is not a floor at all.
+ */
+export const KIMI_PREFERRED_THOUGHT_TIER = "high";
+
+/**
+ * Resolve the default tier for a model: the probed default when it is a real
+ * tier of that model, else {@link KIMI_PREFERRED_THOUGHT_TIER}. Returns
+ * `undefined` when neither is available, leaving the choice to the caller.
+ */
+export function preferredKimiThoughtTier(
+  tiers: readonly string[],
+  probedDefault: string | undefined,
+): string | undefined {
+  if (probedDefault && tiers.includes(probedDefault)) return probedDefault;
+  return tiers.includes(KIMI_PREFERRED_THOUGHT_TIER) ? KIMI_PREFERRED_THOUGHT_TIER : undefined;
+}
+
+/**
+ * Reduce a probed thought-level list to the levels Poracode should offer.
+ *
+ * Two or more real tiers → the tier ladder, with `on` dropped. Kimi itself
+ * removes `on` from the list as soon as a tier is selected (`thinking=max` on
+ * K3 leaves `["low","high","max"]`), confirming it is the "no tier chosen yet"
+ * placeholder rather than a level.
+ *
+ * Otherwise → just `on`. Keeping the single level, instead of reporting no
+ * levels at all, is what lets Poracode put an untiered model back into its only
+ * state: Kimi carries the previous model's tier across a model switch, so after
+ * K3 `max` → K2.7 the session stays on `max` (and even lists it as a K2.7
+ * option) until `thinking=on` is sent explicitly.
+ */
+export function kimiThoughtLevelChoices(levels: readonly string[]): string[] {
+  const tiers = levels.filter((level) => level !== KIMI_UNTIERED_THOUGHT_LEVEL);
+  if (tiers.length > 1) return tiers;
+  return levels.includes(KIMI_UNTIERED_THOUGHT_LEVEL) ? [KIMI_UNTIERED_THOUGHT_LEVEL] : tiers;
+}
+
+type KimiThoughtLevelOption = { value?: unknown };
+
+/**
+ * Apply {@link kimiThoughtLevelChoices} to a live ACP thought-level select, and
+ * clear a `currentValue` that is not one of the surviving choices. Returns the
+ * option unchanged when every advertised value survives.
+ *
+ * The session's config sync adopts `currentValue` verbatim as the thread's
+ * effort, and Kimi reports values that are not choices of the selected model:
+ * `on` for the tiered K3 models, and the previous model's tier for a whole turn
+ * after switching to an untiered one.
+ */
+export function normalizeKimiThoughtLevelOption<
+  T extends { currentValue?: string; options?: unknown },
+>(option: T): T {
+  if (!Array.isArray(option.options)) return option;
+  const values = option.options.flatMap((entry: unknown) => {
+    const value = (entry as KimiThoughtLevelOption | null)?.value;
+    return typeof value === "string" ? [value] : [];
+  });
+  const tiers = new Set(kimiThoughtLevelChoices(values));
+  if (tiers.size === values.length) return option;
+  const options = option.options.filter((entry: unknown) => {
+    const value = (entry as KimiThoughtLevelOption | null)?.value;
+    return typeof value !== "string" || tiers.has(value);
+  });
+  const dropCurrentValue = option.currentValue !== undefined && !tiers.has(option.currentValue);
+  const normalized = { ...option, options };
+  if (dropCurrentValue) delete normalized.currentValue;
+  return normalized;
+}

--- a/src/supervisor/runtime/kimiCredentials.ts
+++ b/src/supervisor/runtime/kimiCredentials.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { OAuthToken } from "@poracode/agents-usage";
-import { nativeKimiHomePath, nativeKimiOAuthCredentialPath } from "../agents/kimi/detection";
+import { nativeKimiHomePath, nativeKimiOAuthCredentialPath } from "../agents/kimi/paths";
 
 /**
  * Kimi For Coding credential resolution, mirroring CodexBar: an explicit API


### PR DESCRIPTION
- **Feature:** improve Kimi ACP login, logout, credential handling, and workspace trust so structured sessions authenticate and start reliably.
- Normalize Kimi ACP session updates, thinking levels, mode selection, permissions, elicitation forms, and detached subagent activity for clearer controls and responses.
- Preserve valid reasoning settings across model changes and expose effort controls only when models support selectable levels.
- Add targeted coverage and smoke fixtures for Kimi flows, ACP request handling, and structured elicitation rendering.