### PR TITLE
Add dedicated page size for flat sidebar thread list

### DIFF
--- a/src/renderer/state/sidebarUiStore.ts
+++ b/src/renderer/state/sidebarUiStore.ts
@@ -33,7 +33,7 @@ interface SidebarUiState {
   togglePinnedGitHubWorkflow: (projectId: string, workflowId: number) => void;
   setWorktreeCollapsed: (key: string, collapsed: boolean) => void;
   toggleWorktreeCollapsed: (key: string) => void;
-  revealMoreThreads: (projectId: string) => void;
+  revealMoreThreads: (projectId: string, pageSize?: number) => void;
   setFlatListProjectFilter: (projectIds: string[] | null) => void;
   setEditingThreadId: (id: string | null) => void;
 }
@@ -109,13 +109,13 @@ export const useSidebarUiStore = create<SidebarUiState>()(
             },
           };
         }),
-      revealMoreThreads: (projectId) =>
+      revealMoreThreads: (projectId, pageSize = SIDEBAR_THREAD_LIST_PAGE_SIZE) =>
         set((state) => {
-          const current = state.threadListLimits[projectId] ?? SIDEBAR_THREAD_LIST_PAGE_SIZE;
+          const current = state.threadListLimits[projectId] ?? pageSize;
           return {
             threadListLimits: {
               ...state.threadListLimits,
-              [projectId]: current + SIDEBAR_THREAD_LIST_PAGE_SIZE,
+              [projectId]: current + pageSize,
             },
           };
         }),
@@ -158,8 +158,11 @@ export function useIsProjectCollapsed(projectId: string): boolean {
   return useSidebarUiStore((s) => s.collapsedProjects[projectId] ?? false);
 }
 
-export function useThreadListLimit(projectId: string): number {
-  return useSidebarUiStore((s) => s.threadListLimits[projectId] ?? SIDEBAR_THREAD_LIST_PAGE_SIZE);
+export function useThreadListLimit(
+  projectId: string,
+  pageSize: number = SIDEBAR_THREAD_LIST_PAGE_SIZE,
+): number {
+  return useSidebarUiStore((s) => s.threadListLimits[projectId] ?? pageSize);
 }
 
 export function useIsWorktreeCollapsed(key: string): boolean {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -17,7 +17,11 @@ import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarU
 import { useWorkspaceProjectIds } from "@/renderer/state/workspaceSelectors";
 import { NewThreadButton } from "./NewThreadButton";
 import { SidebarProjectFilter } from "./SidebarProjectFilter";
-import { buildSidebarProjectRows, type SidebarRow } from "./sidebarProjectRows";
+import {
+  buildSidebarProjectRows,
+  SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE,
+  type SidebarRow,
+} from "./sidebarProjectRows";
 import type { ThreadSortMode } from "./sortMode";
 import { SeeMoreThreadsButton, SidebarThreadRow } from "./SidebarThreadRow";
 
@@ -55,7 +59,7 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
   const revealMoreThreads = useSidebarUiStore((s) => s.revealMoreThreads);
   const flatListProjectFilter = useSidebarUiStore((s) => s.flatListProjectFilter);
   const setFlatListProjectFilter = useSidebarUiStore((s) => s.setFlatListProjectFilter);
-  const visibleLimit = useThreadListLimit(FLAT_LIST_SCOPE);
+  const visibleLimit = useThreadListLimit(FLAT_LIST_SCOPE, SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE);
   const currentThreadCount = useCurrentThreadIdsCount();
   const source = useDragSource();
 
@@ -169,7 +173,9 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
             return (
               <SeeMoreThreadsButton
                 key={row.key}
-                onPress={() => revealMoreThreads(FLAT_LIST_SCOPE)}
+                onPress={() =>
+                  revealMoreThreads(FLAT_LIST_SCOPE, SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE)
+                }
               />
             );
           }

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
@@ -43,6 +43,12 @@ export type SidebarRow =
 /** Default number of list items shown per project before the "See more" row. */
 export const SIDEBAR_THREAD_LIST_PAGE_SIZE = 10;
 
+/**
+ * Page size for the flat (cross-project) list. It is the sidebar's only list,
+ * so it affords a taller first page than a per-project section.
+ */
+export const SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE = 20;
+
 const EMPTY_THREAD_ID_SET: ReadonlySet<string> = new Set();
 
 /**


### PR DESCRIPTION
- Introduce `SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE` (20) for the flat cross-project thread list, independent of the per-project section page size (10).
- Thread the page size through sidebar state (`revealMoreThreads`, `useThreadListLimit`) so reveal-more and the initial visible limit stay consistent.
- The flat list is the sidebar's only list, so it merits a taller first page than a per-project section.