### PR TITLE
Fix closed aside border layout shift

### DIFF
--- a/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
@@ -78,12 +78,13 @@ export function AsideSlot(props: {
     // `box-sizing: border-box`, a 0-width aside with a 1px border still occupies
     // 1px of the flex row, so `main` gained/lost that pixel whenever the panel
     // flipped to the fixed right overlay (which leaves the flow entirely) and
-    // the centered content column shifted by half a pixel.
+    // the centered content column shifted by half a pixel. The transparent
+    // closed color is kept alongside the 0 width so the hairline still fades in
+    // and out with `border-color` (see the transition list below) instead of
+    // popping to full strength the moment the border exists.
     const borderClass = isOpen
       ? `${isHorizontal ? "border-t" : "border-l"} border-[color:var(--border)]`
-      : isHorizontal
-        ? "border-t-0"
-        : "border-l-0";
+      : `${isHorizontal ? "border-t-0" : "border-l-0"} border-transparent`;
     asideClassName = `relative overflow-hidden bg-[var(--content-background)] ${
       isHorizontal ? "min-w-0" : "min-h-0"
     } ${borderClass}`;

--- a/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
+++ b/src/renderer/views/MainView/parts/AppShell/parts/AsideSlot.tsx
@@ -72,12 +72,21 @@ export function AsideSlot(props: {
     // The background layer (this <aside>) stays fully opaque while the panel
     // animates open, so the OS blur material (Windows acrylic / macOS vibrancy)
     // never shows through. Only the size animates here; the panel *content*
-    // cross-fades on the inner layer below. Collapse the border to transparent
-    // while closed so the 0-size panel leaves no 1px hairline at the edge.
-    const borderColorClass = isOpen ? "border-[color:var(--border)]" : "border-transparent";
+    // cross-fades on the inner layer below.
+    //
+    // Drop the border *width* (not just its color) while closed: with the global
+    // `box-sizing: border-box`, a 0-width aside with a 1px border still occupies
+    // 1px of the flex row, so `main` gained/lost that pixel whenever the panel
+    // flipped to the fixed right overlay (which leaves the flow entirely) and
+    // the centered content column shifted by half a pixel.
+    const borderClass = isOpen
+      ? `${isHorizontal ? "border-t" : "border-l"} border-[color:var(--border)]`
+      : isHorizontal
+        ? "border-t-0"
+        : "border-l-0";
     asideClassName = `relative overflow-hidden bg-[var(--content-background)] ${
-      isHorizontal ? `min-w-0 border-t ${borderColorClass}` : `min-h-0 border-l ${borderColorClass}`
-    }`;
+      isHorizontal ? "min-w-0" : "min-h-0"
+    } ${borderClass}`;
     asideStyle = {
       ...(isHorizontal
         ? { height: dockedDisplayHeight, minHeight: dockedDisplayHeight }


### PR DESCRIPTION
- **Bugfix:** remove the closed aside’s border width so it no longer reserves a pixel in the app layout.
- Prevent centered main content from shifting when the docked aside closes or switches to the right overlay.