### PR TITLE
Consolidate sleep prevention controls

### DIFF
--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -128,8 +128,7 @@ describe("sharedSettingsFile", () => {
       agentTerminalFontSize: 12,
       guiChatFontSize: 13,
       terminalPanelFontSize: 12,
-      preventSleepWhileWorking: true,
-      remoteAccessPreventSleep: true,
+      preventSleep: "while-remote-access",
       launchAtStartup: true,
       startMinimized: true,
       closeToTray: true,
@@ -259,8 +258,7 @@ describe("sharedSettingsFile", () => {
       agentTerminalFontSize: 12,
       guiChatFontSize: 13,
       terminalPanelFontSize: 12,
-      preventSleepWhileWorking: true,
-      remoteAccessPreventSleep: true,
+      preventSleep: "while-remote-access",
       launchAtStartup: true,
       startMinimized: true,
       closeToTray: true,
@@ -348,6 +346,23 @@ describe("sharedSettingsFile", () => {
     expect(readSharedSettingsFile(settingsPath).usage.disabledProviders).toEqual([
       ...DEFAULT_USAGE_DISABLED_PROVIDER_IDS,
     ]);
+  });
+
+  it("migrates legacy prevent-sleep booleans from a previous released settings shape", () => {
+    const settingsPath = join(makeTempDir(), "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        preventSleepWhileWorking: true,
+        remoteAccessPreventSleep: false,
+      }),
+      "utf8",
+    );
+
+    const settings = readSharedSettingsFile(settingsPath);
+    expect(settings.preventSleep).toBe("while-working");
+    expect(settings).not.toHaveProperty("preventSleepWhileWorking");
+    expect(settings).not.toHaveProperty("remoteAccessPreventSleep");
   });
 
   it("defaults usage tracking to Claude and Codex only", () => {

--- a/src/main/sleepPolicy.test.ts
+++ b/src/main/sleepPolicy.test.ts
@@ -2,25 +2,32 @@ import { describe, expect, it } from "vitest";
 import { shouldPreventSystemSleep } from "./sleepPolicy";
 
 describe("shouldPreventSystemSleep", () => {
-  it("keeps the system awake for a working thread when enabled", () => {
+  it("always keeps the system awake regardless of remote access or thread activity", () => {
     expect(
       shouldPreventSystemSleep(
         {
-          preventSleepWhileWorking: true,
-          remoteAccessPreventSleep: false,
+          preventSleep: "always",
           remoteAccessEnabled: false,
         },
-        1,
+        0,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPreventSystemSleep(
+        {
+          preventSleep: "always",
+          remoteAccessEnabled: true,
+        },
+        2,
       ),
     ).toBe(true);
   });
 
-  it("keeps the system awake for enabled remote access independently of thread activity", () => {
+  it("while-remote-access keeps awake when remote access is enabled even with zero threads", () => {
     expect(
       shouldPreventSystemSleep(
         {
-          preventSleepWhileWorking: false,
-          remoteAccessPreventSleep: true,
+          preventSleep: "while-remote-access",
           remoteAccessEnabled: true,
         },
         0,
@@ -28,16 +35,48 @@ describe("shouldPreventSystemSleep", () => {
     ).toBe(true);
   });
 
-  it("allows sleep when each active reason is opted out", () => {
+  it("while-remote-access keeps awake when threads are working even if remote access is off", () => {
     expect(
       shouldPreventSystemSleep(
         {
-          preventSleepWhileWorking: false,
-          remoteAccessPreventSleep: false,
-          remoteAccessEnabled: true,
+          preventSleep: "while-remote-access",
+          remoteAccessEnabled: false,
         },
         1,
       ),
+    ).toBe(true);
+  });
+
+  it("while-remote-access allows sleep when remote access is off and no threads are working", () => {
+    expect(
+      shouldPreventSystemSleep(
+        {
+          preventSleep: "while-remote-access",
+          remoteAccessEnabled: false,
+        },
+        0,
+      ),
     ).toBe(false);
+  });
+
+  it("while-working only keeps awake when threads are working", () => {
+    expect(
+      shouldPreventSystemSleep(
+        {
+          preventSleep: "while-working",
+          remoteAccessEnabled: true,
+        },
+        0,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPreventSystemSleep(
+        {
+          preventSleep: "while-working",
+          remoteAccessEnabled: false,
+        },
+        1,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/main/sleepPolicy.ts
+++ b/src/main/sleepPolicy.ts
@@ -1,16 +1,17 @@
 import type { SharedSettings } from "@/shared/settings";
 
-type SleepPolicySettings = Pick<
-  SharedSettings,
-  "preventSleepWhileWorking" | "remoteAccessPreventSleep" | "remoteAccessEnabled"
->;
+type SleepPolicySettings = Pick<SharedSettings, "preventSleep" | "remoteAccessEnabled">;
 
 export function shouldPreventSystemSleep(
   settings: SleepPolicySettings,
   workingThreadCount: number,
 ): boolean {
-  const threadRequiresAwake = settings.preventSleepWhileWorking && workingThreadCount > 0;
-  const remoteAccessRequiresAwake =
-    settings.remoteAccessPreventSleep && settings.remoteAccessEnabled;
-  return threadRequiresAwake || remoteAccessRequiresAwake;
+  switch (settings.preventSleep) {
+    case "always":
+      return true;
+    case "while-remote-access":
+      return settings.remoteAccessEnabled || workingThreadCount > 0;
+    case "while-working":
+      return workingThreadCount > 0;
+  }
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Bereits von {conflict} verwendet"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Immer"
@@ -2167,6 +2168,11 @@ msgstr "Thread zum Anhängen auswählen"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Wähle, was Poracode bei neuen Pull Requests tut: nichts, Merge-Blocker beheben oder beheben und mergen."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Wählen Sie, wann dieser Rechner wach bleibt."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Poracode beim Start im Infobereich der Taskleiste belassen."
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Halten Sie das System wach, während ein Thread aktiv arbeitet."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Halten Sie das System wach, während ein Thread aktiv arbeitet."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Das System aktiv halten, solange der Fernzugriff aktiviert ist."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Das System aktiv halten, solange der Fernzugriff aktiviert ist."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Voreinstellungen"
 msgid "Press shortcut…"
 msgstr "Tastenkürzel drücken…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Ruhezustand verhindern"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Ruhezustand bei Fernzugriff verhindern"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Ruhezustand bei Fernzugriff verhindern"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Ruhezustand während der Arbeit verhindern"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Ruhezustand während der Arbeit verhindern"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Browserseite neu laden"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remote"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Fernzugriff"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Wo die Unterhaltung des Laufs erstellt wird."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Wo das Terminal-Panel erscheint."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Während der Arbeit"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1213,6 +1213,7 @@ msgid "Already used by {conflict}"
 msgstr "Already used by {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Always"
@@ -2172,6 +2173,11 @@ msgstr "Choose thread to attach to"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Choose when this machine stays awake."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5700,13 +5706,13 @@ msgstr "Keep Poracode in the system tray when it launches at startup."
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Keep the system awake while any thread is actively working."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Keep the system awake while any thread is actively working."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Keep the system awake while remote access is enabled."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Keep the system awake while remote access is enabled."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8281,15 +8287,20 @@ msgstr "Presets"
 msgid "Press shortcut…"
 msgstr "Press shortcut…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Prevent sleep"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Prevent sleep during remote access"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Prevent sleep during remote access"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Prevent sleep while working"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Prevent sleep while working"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8829,6 +8840,10 @@ msgstr "Reload browser page"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remote"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Remote access"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12619,6 +12634,10 @@ msgstr "Where the run's conversation is created."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Where the terminal panel appears."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "While working"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Ya lo usa {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Siempre"
@@ -2167,6 +2168,11 @@ msgstr "Elige el hilo al que adjuntar"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Elige qué hace Poracode con las nuevas solicitudes de cambios: nada, corregir los bloqueos de fusión o corregirlos y fusionar."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Elige cuándo esta máquina se mantiene activa."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Mantener Poracode en la bandeja del sistema cuando se inicie automática
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Mantener el sistema activo mientras cualquier hilo esté trabajando."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Mantener el sistema activo mientras cualquier hilo esté trabajando."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Mantén el sistema activo mientras el acceso remoto esté habilitado."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Mantén el sistema activo mientras el acceso remoto esté habilitado."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Preajustes"
 msgid "Press shortcut…"
 msgstr "Pulsa el atajo…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Evitar la suspensión"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Impedir la suspensión durante el acceso remoto"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Impedir la suspensión durante el acceso remoto"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Evitar la suspensión mientras se trabaja"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Evitar la suspensión mientras se trabaja"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Recargar página del navegador"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remoto"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Acceso remoto"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Dónde se crea la conversación de la ejecución."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Dónde aparece el panel del terminal."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Mientras se trabaja"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Déjà utilisé par {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Toujours"
@@ -2167,6 +2168,11 @@ msgstr "Choisissez le fil auquel attacher"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Choisissez ce que Poracode fait pour les nouvelles pull requests : ne rien faire, corriger les blocages de fusion, ou les corriger puis fusionner."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Choisissez quand cette machine reste éveillée."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Garder Poracode dans la zone de notification lors de son lancement au d�
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Gardez le système éveillé pendant qu'un thread fonctionne activement."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Gardez le système éveillé pendant qu'un thread fonctionne activement."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Garder le système éveillé tant que l’accès à distance est activé."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Garder le système éveillé tant que l’accès à distance est activé."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8275,15 +8281,20 @@ msgstr "Préréglages"
 msgid "Press shortcut…"
 msgstr "Appuyez sur le raccourci…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Empêcher la mise en veille"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Empêcher la mise en veille pendant l’accès à distance"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Empêcher la mise en veille pendant l’accès à distance"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Empêcher la mise en veille pendant le travail"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Empêcher la mise en veille pendant le travail"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8823,6 +8834,10 @@ msgstr "Recharger la page du navigateur"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "À distance"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Accès distant"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12613,6 +12628,10 @@ msgstr "Où la conversation de l’exécution est créée."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Où le panneau du terminal apparaît."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Pendant le travail"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1207,6 +1207,7 @@ msgid "Already used by {conflict}"
 msgstr "{conflict}で既に使用されています"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "いつも"
@@ -2166,6 +2167,11 @@ msgstr "接続するスレッドを選択してください"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "新しいプルリクエストに対するPoracodeの動作を選択します：何もしない、マージの妨げを修正する、または修正してマージする。"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "このマシンをスリープさせないタイミングを選びます。"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5694,13 +5700,13 @@ msgstr "スタートアップ時は Poracode をシステムトレイに格納�
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "スレッドがアクティブに動作している間は、システムを起動したままにします。"
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "スレッドがアクティブに動作している間は、システムを起動したままにします。"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "リモートアクセスが有効な間、システムをスリープさせません。"
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "リモートアクセスが有効な間、システムをスリープさせません。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8274,15 +8280,20 @@ msgstr "プリセット"
 msgid "Press shortcut…"
 msgstr "ショートカットを押してください…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "スリープを防止"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "リモートアクセス中のスリープを防止"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "リモートアクセス中のスリープを防止"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "作業中のスリープを防止する"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "作業中のスリープを防止する"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8822,6 +8833,10 @@ msgstr "ブラウザのページをリロード"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "リモート"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "リモートアクセス"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12612,6 +12627,10 @@ msgstr "実行の会話が作成される場所。"
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "ターミナルパネルが表示される場所。"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "作業中"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "이미 {conflict}에서 사용 중"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "항상"
@@ -2167,6 +2168,11 @@ msgstr "첨부할 스레드를 선택하세요."
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "새 풀 리퀘스트에서 Poracode가 수행할 작업을 선택하세요: 아무 작업 안 함, 병합 차단 문제 수정, 또는 수정 후 병합."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "이 기기가 깨어 있는 상태를 유지할 시점을 선택하세요."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "시작 시 Poracode를 시스템 트레이에 둡니다."
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "스레드가 활발하게 작동하는 동안 시스템을 활성 상태로 유지합니다."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "스레드가 활발하게 작동하는 동안 시스템을 활성 상태로 유지합니다."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "원격 액세스가 활성화된 동안 시스템이 절전 모드로 전환되지 않도록 합니다."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "원격 액세스가 활성화된 동안 시스템이 절전 모드로 전환되지 않도록 합니다."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "프리셋"
 msgid "Press shortcut…"
 msgstr "단축키를 누르세요…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "절전 모드 방지"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "원격 액세스 중 절전 모드 방지"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "원격 액세스 중 절전 모드 방지"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "작업 중 수면 방지"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "작업 중 수면 방지"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "브라우저 페이지 새로고침"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "원격"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "원격 액세스"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "실행의 대화가 생성되는 위치입니다."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "터미널 패널이 나타나는 위치."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "작업 중"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Już używany przez {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Zawsze"
@@ -2167,6 +2168,11 @@ msgstr "Wybierz wątek, do którego chcesz dołączyć"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Wybierz, co Poracode ma robić z nowymi pull requestami: nic, naprawiać blokady scalania albo naprawiać i scalać."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Wybierz, kiedy ten komputer pozostaje aktywny."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Po uruchomieniu przy starcie pozostaw Poracode w zasobniku systemowym."
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Utrzymuj system w stanie czuwania, gdy dowolny wątek aktywnie działa."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Utrzymuj system w stanie czuwania, gdy dowolny wątek aktywnie działa."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Utrzymuj system w stanie aktywnym, gdy dostęp zdalny jest włączony."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Utrzymuj system w stanie aktywnym, gdy dostęp zdalny jest włączony."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Ustawienia predefiniowane"
 msgid "Press shortcut…"
 msgstr "Naciśnij skrót…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Zapobiegaj zasypianiu"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Zapobiegaj uśpieniu podczas dostępu zdalnego"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Zapobiegaj uśpieniu podczas dostępu zdalnego"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Zapobiegaj zasypianiu podczas pracy"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Zapobiegaj zasypianiu podczas pracy"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Załaduj ponownie stronę przeglądarki"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Zdalny"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Dostęp zdalny"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Gdzie tworzona jest rozmowa uruchomienia."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Gdzie pojawia się panel terminali."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Podczas pracy"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Já usado por {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Sempre"
@@ -2167,6 +2168,11 @@ msgstr "Escolha o tópico ao qual anexar"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Escolha o que o Poracode faz com novos pull requests: nada, corrigir bloqueios de mesclagem ou corrigir e mesclar."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Escolha quando esta máquina permanece ativa."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Manter o Poracode na bandeja do sistema quando ele for iniciado com o Wi
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Mantém o sistema ativo enquanto qualquer thread estiver trabalhando ativamente."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Mantém o sistema ativo enquanto qualquer thread estiver trabalhando ativamente."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Mantenha o sistema ativo enquanto o acesso remoto estiver habilitado."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Mantenha o sistema ativo enquanto o acesso remoto estiver habilitado."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Predefinições"
 msgid "Press shortcut…"
 msgstr "Pressione o atalho…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Impedir suspensão"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Impedir suspensão durante o acesso remoto"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Impedir suspensão durante o acesso remoto"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Impedir suspensão durante o trabalho"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Impedir suspensão durante o trabalho"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Recarregar página do navegador"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Remoto"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Acesso remoto"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Onde a conversa da execução é criada."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Onde o painel do terminal aparece."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Durante o trabalho"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Уже используется командой {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Всегда"
@@ -2167,6 +2168,11 @@ msgstr "Выберите тред для прикрепления"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Выберите, что Poracode будет делать с новыми pull request: ничего, устранять препятствия для слияния или устранять их и выполнять слияние."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Выберите, когда этот компьютер остаётся активным."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "При запуске вместе с системой оставлят�
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Не давать системе засыпать, пока хотя бы один тред активно работает."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Не давать системе засыпать, пока хотя бы один тред активно работает."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Не переводить систему в спящий режим, пока включён удалённый доступ."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Не переводить систему в спящий режим, пока включён удалённый доступ."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Пресеты"
 msgid "Press shortcut…"
 msgstr "Нажмите сочетание клавиш…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Запрещать сон"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Запрещать спящий режим при удалённом доступе"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Запрещать спящий режим при удалённом доступе"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Запрещать сон во время работы"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Запрещать сон во время работы"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Перезагрузить страницу браузера"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Удалённый"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Удалённый доступ"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Где создаётся беседа запуска."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Где появляется панель терминала."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Во время работы"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Zaten {conflict} tarafından kullanılıyor"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Her zaman"
@@ -2167,6 +2168,11 @@ msgstr "Eklenecek konuyu seçin"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Poracode'un yeni pull request'lerde ne yapacağını seçin: hiçbir şey, birleştirme engellerini düzelt veya düzeltip birleştir."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Bu makinenin ne zaman uyanık kalacağını seçin."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Başlangıçta açıldığında Poracode'u sistem tepsisinde tutun."
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Herhangi bir konu aktif olarak çalışırken sistemi uyanık tutun."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Herhangi bir konu aktif olarak çalışırken sistemi uyanık tutun."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Uzaktan erişim etkinken sistemi uyanık tutun."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Uzaktan erişim etkinken sistemi uyanık tutun."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Hazır ayarlar"
 msgid "Press shortcut…"
 msgstr "Kısayola basın…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Uykuyu önle"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Uzaktan erişim sırasında uyku modunu engelle"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Uzaktan erişim sırasında uyku modunu engelle"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Çalışırken uykuyu önleyin"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Çalışırken uykuyu önleyin"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Tarayıcı sayfasını yeniden yükle"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Uzak"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Uzaktan erişim"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Çalıştırmanın konuşmasının oluşturulduğu yer."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Terminal panelinin göründüğü yer."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Çalışırken"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Уже використовується для {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Завжди"
@@ -2167,6 +2168,11 @@ msgstr "Виберіть тред для прикріплення"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Виберіть, що Poracode робитиме з новими pull request: нічого, усувати перешкоди для злиття або усувати їх і виконувати злиття."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Оберіть, коли цей комп’ютер залишається активним."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Під час запуску разом із системою залиш
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Не давати системі засинати, поки будь-який тред активно працює."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Не давати системі засинати, поки будь-який тред активно працює."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Не переводити систему в режим сну, доки ввімкнено віддалений доступ."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Не переводити систему в режим сну, доки ввімкнено віддалений доступ."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Пресети"
 msgid "Press shortcut…"
 msgstr "Натисніть комбінацію клавіш…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Запобігати засинанню"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Запобігати сну під час віддаленого доступу"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Запобігати сну під час віддаленого доступу"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Запобігати засинанню під час роботи"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Запобігати засинанню під час роботи"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Перезавантажити сторінку браузера"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Віддалений"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Віддалений доступ"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Де створюється розмова запуску."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Де з'являється панель термінала."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Під час роботи"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "Đã được dùng bởi {conflict}"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "Luôn luôn"
@@ -2167,6 +2168,11 @@ msgstr "Chọn chủ đề để đính kèm"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "Chọn việc Poracode sẽ làm với pull request mới: không làm gì, khắc phục các trở ngại hợp nhất, hoặc khắc phục rồi hợp nhất."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "Chọn khi máy này được giữ ở trạng thái hoạt động."
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "Giữ Poracode trong khay hệ thống khi ứng dụng khởi chạy c�
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "Giữ cho hệ thống luôn hoạt động trong khi bất kỳ luồng nào đang hoạt động tích cực."
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "Giữ cho hệ thống luôn hoạt động trong khi bất kỳ luồng nào đang hoạt động tích cực."
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "Giữ hệ thống luôn hoạt động khi truy cập từ xa được bật."
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "Giữ hệ thống luôn hoạt động khi truy cập từ xa được bật."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8276,15 +8282,20 @@ msgstr "Cấu hình sẵn"
 msgid "Press shortcut…"
 msgstr "Nhấn phím tắt…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "Ngăn chế độ ngủ"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "Ngăn chế độ ngủ khi truy cập từ xa"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "Ngăn chế độ ngủ khi truy cập từ xa"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "Ngăn chế độ ngủ khi đang làm việc"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "Ngăn chế độ ngủ khi đang làm việc"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8824,6 +8835,10 @@ msgstr "Tải lại trang trình duyệt"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "Từ xa"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "Truy cập từ xa"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12614,6 +12629,10 @@ msgstr "Nơi cuộc trò chuyện của lần chạy được tạo."
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "Nơi bảng điều khiển đầu cuối xuất hiện."
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "Khi đang làm việc"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1208,6 +1208,7 @@ msgid "Already used by {conflict}"
 msgstr "已被{conflict}使用"
 
 #. Notification filter: always notify
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/NotificationSettings.tsx
 msgid "Always"
 msgstr "总是"
@@ -2167,6 +2168,11 @@ msgstr "选择要附加到的线程"
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 msgid "Choose what Poracode does for new pull requests: nothing, fix merge blockers, or fix and merge."
 msgstr "选择 Poracode 对新拉取请求执行的操作：不执行任何操作、修复合并阻碍，或修复后合并。"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Choose when this machine stays awake."
+msgstr "选择这台机器保持唤醒的时机。"
 
 #: src/renderer/views/SettingsOverlay/parts/BrowserSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -5695,13 +5701,13 @@ msgstr "开机启动时将 Poracode 保持在系统托盘中。"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while any thread is actively working."
-msgstr "当任何线程正在工作时保持系统唤醒状态（不休眠）。"
+#~ msgid "Keep the system awake while any thread is actively working."
+#~ msgstr "当任何线程正在工作时保持系统唤醒状态（不休眠）。"
 
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Keep the system awake while remote access is enabled."
-msgstr "启用远程访问时保持系统唤醒。"
+#~ msgid "Keep the system awake while remote access is enabled."
+#~ msgstr "启用远程访问时保持系统唤醒。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
 msgid "Keep waiting"
@@ -8275,15 +8281,20 @@ msgstr "预设"
 msgid "Press shortcut…"
 msgstr "请按快捷键…"
 
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+msgid "Prevent sleep"
+msgstr "阻止休眠"
+
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep during remote access"
-msgstr "防止远程访问期间休眠"
+#~ msgid "Prevent sleep during remote access"
+#~ msgstr "防止远程访问期间休眠"
 
 #: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
-msgid "Prevent sleep while working"
-msgstr "工作时阻止系统休眠"
+#~ msgid "Prevent sleep while working"
+#~ msgstr "工作时阻止系统休眠"
 
 #. placeholder {0}: att.name
 #: src/renderer/components/composer/AttachmentBar.tsx
@@ -8823,6 +8834,10 @@ msgstr "重新加载浏览器页面"
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
 msgid "Remote"
 msgstr "远程"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "Remote access"
+msgstr "远程访问"
 
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -12613,6 +12628,10 @@ msgstr "运行的对话创建的位置。"
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Where the terminal panel appears."
 msgstr "终端面板出现的位置。"
+
+#: src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+msgid "While working"
+msgstr "工作时"
 
 #. placeholder {0}: env || t`this environment`
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/parts/AgentEnvironmentRow.tsx

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -5,6 +5,7 @@ import {
   normalizeSidebarShortcutOrder,
   normalizeSharedSettings,
   type CliPickerTarget,
+  type PreventSleep,
   type SidebarShortcutId,
   type SharedSettings,
   type SharedSettingsInput,
@@ -82,8 +83,7 @@ interface SharedSettingsState extends SharedSettings {
   setAgentTerminalFontSize: (value: number) => void;
   setGuiChatFontSize: (value: number) => void;
   setTerminalPanelFontSize: (value: number) => void;
-  setPreventSleepWhileWorking: (value: boolean) => void;
-  setRemoteAccessPreventSleep: (value: boolean) => void;
+  setPreventSleep: (value: PreventSleep) => void;
   setLaunchAtStartup: (value: boolean) => void;
   setStartMinimized: (value: boolean) => void;
   setCloseToTray: (value: boolean) => void;
@@ -452,12 +452,8 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({ terminalPanelFontSize });
     persistSettings(selectSharedSettings(get()));
   },
-  setPreventSleepWhileWorking: (preventSleepWhileWorking) => {
-    set({ preventSleepWhileWorking });
-    persistSettings(selectSharedSettings(get()));
-  },
-  setRemoteAccessPreventSleep: (remoteAccessPreventSleep) => {
-    set({ remoteAccessPreventSleep });
+  setPreventSleep: (preventSleep) => {
+    set({ preventSleep });
     persistSettings(selectSharedSettings(get()));
   },
   setLaunchAtStartup: (launchAtStartup) => {
@@ -902,8 +898,7 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     agentTerminalFontSize: state.agentTerminalFontSize,
     guiChatFontSize: state.guiChatFontSize,
     terminalPanelFontSize: state.terminalPanelFontSize,
-    preventSleepWhileWorking: state.preventSleepWhileWorking,
-    remoteAccessPreventSleep: state.remoteAccessPreventSleep,
+    preventSleep: state.preventSleep,
     launchAtStartup: state.launchAtStartup,
     startMinimized: state.startMinimized,
     closeToTray: state.closeToTray,

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.test.tsx
@@ -482,7 +482,7 @@ describe("SettingsOverlay", () => {
       target: { value: "sleep" },
     });
 
-    expect(screen.getByText("Prevent sleep while working")).toBeInTheDocument();
+    expect(screen.getByText("Prevent sleep")).toBeInTheDocument();
     // The section list is replaced — unrelated sections are gone.
     expect(screen.queryByRole("button", { name: "Audio" })).not.toBeInTheDocument();
   });
@@ -494,9 +494,7 @@ describe("SettingsOverlay", () => {
       target: { value: "awake" },
     });
 
-    expect(
-      screen.getByText("Keep the system awake while any thread is actively working."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Choose when this machine stays awake.")).toBeInTheDocument();
   });
 
   it("navigates to the section when a setting result is clicked", () => {
@@ -505,7 +503,7 @@ describe("SettingsOverlay", () => {
     fireEvent.change(screen.getByPlaceholderText("Search settings"), {
       target: { value: "sleep" },
     });
-    fireEvent.click(screen.getByText("Prevent sleep while working"));
+    fireEvent.click(screen.getByText("Prevent sleep"));
 
     expect(within(screen.getByRole("main")).getByText("General")).toBeInTheDocument();
   });

--- a/src/renderer/views/SettingsOverlay/parts/GeneralSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/GeneralSettings.test.tsx
@@ -31,6 +31,8 @@ describe("GeneralSettings", () => {
     expect(screen.getByText("Start minimized")).toBeInTheDocument();
     expect(screen.getByText("Editor LSP")).toBeInTheDocument();
     expect(screen.getByText("Sidebar shortcuts")).toBeInTheDocument();
+    expect(screen.getByText("Prevent sleep")).toBeInTheDocument();
+    expect(screen.getByRole("tablist", { name: "Prevent sleep" })).toBeInTheDocument();
     expect(screen.queryByText("Pull requests shortcut")).not.toBeInTheDocument();
   });
 
@@ -94,5 +96,6 @@ describe("GeneralSettings", () => {
     expect(screen.queryByText("Start minimized")).not.toBeInTheDocument();
     expect(screen.queryByText("Editor LSP")).not.toBeInTheDocument();
     expect(screen.queryByText("Sidebar shortcuts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Prevent sleep")).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/GeneralSettings.tsx
@@ -5,7 +5,8 @@ import { isRemoteSession, isWindows } from "@/renderer/bridge";
 import type { AiContentLanguage, LocaleSetting } from "@/shared/locale";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { aiLanguageOptions, localeOptions } from "@/renderer/i18n/locales";
-import { Select, ToggleSwitch } from "@/renderer/components/common";
+import { LightballTabs, Select, ToggleSwitch } from "@/renderer/components/common";
+import type { PreventSleep } from "@/shared/settings";
 import { SettingRow, SettingsPage } from "./SettingsForm";
 import { newThreadModeOptions, useLocalizedOptions } from "./settingsOptions";
 import { SidebarShortcutsSelector } from "./SidebarShortcutsSelector";
@@ -16,10 +17,8 @@ export function GeneralSettings() {
   const setLocale = useSharedSettings((state) => state.setLocale);
   const gitTextLanguage = useSharedSettings((state) => state.gitTextLanguage);
   const setGitTextLanguage = useSharedSettings((state) => state.setGitTextLanguage);
-  const preventSleepWhileWorking = useSharedSettings((state) => state.preventSleepWhileWorking);
-  const setPreventSleepWhileWorking = useSharedSettings(
-    (state) => state.setPreventSleepWhileWorking,
-  );
+  const preventSleep = useSharedSettings((state) => state.preventSleep);
+  const setPreventSleep = useSharedSettings((state) => state.setPreventSleep);
   const closeToTray = useSharedSettings((state) => state.closeToTray);
   const setCloseToTray = useSharedSettings((state) => state.setCloseToTray);
   const launchAtStartup = useSharedSettings((state) => state.launchAtStartup);
@@ -171,18 +170,23 @@ export function GeneralSettings() {
 
       {!remote && (
         <SettingRow
-          anchorId="general.preventSleepWhileWorking"
-          title={t`Prevent sleep while working`}
-          description={<Trans>Keep the system awake while any thread is actively working.</Trans>}
+          anchorId="general.preventSleep"
+          title={t`Prevent sleep`}
+          description={<Trans>Choose when this machine stays awake.</Trans>}
         >
-          <ToggleSwitch
-            aria-label={t`Prevent sleep while working`}
-            isSelected={preventSleepWhileWorking}
-            onChange={(selected) => {
+          <LightballTabs
+            tabs={[
+              { id: "while-working", label: t`While working` },
+              { id: "while-remote-access", label: t`Remote access` },
+              { id: "always", label: t`Always` },
+            ]}
+            active={preventSleep}
+            onChange={(value: PreventSleep) => {
               startTransition(() => {
-                setPreventSleepWhileWorking(selected);
+                setPreventSleep(value);
               });
             }}
+            ariaLabel={t`Prevent sleep`}
           />
         </SettingRow>
       )}

--- a/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.test.tsx
@@ -18,8 +18,6 @@ const { bridgeMock, pairingChangedState, sharedSettingsState, toDataURLMock } = 
     listener: null as ((info: RemoteAccessPairingInfo) => void) | null,
   },
   sharedSettingsState: {
-    remoteAccessPreventSleep: true,
-    setRemoteAccessPreventSleep: vi.fn<(enabled: boolean) => void>(),
     remoteAccessTailscaleHttps: true,
     remoteAccessAdvertisedUrl: "",
     remotePushEnabled: true,
@@ -88,14 +86,14 @@ describe("RemoteAccessSettings", () => {
     toDataURLMock.mockResolvedValue("data:image/png;base64,test");
   });
 
-  it("allows preventing sleep during remote access independently", () => {
+  it("does not render a prevent-sleep control in remote access settings", () => {
     render(<RemoteAccessSettings />);
 
-    const toggle = screen.getByRole("switch", { name: "Prevent sleep during remote access" });
-    expect(toggle).toBeChecked();
-    fireEvent.click(toggle);
-
-    expect(sharedSettingsState.setRemoteAccessPreventSleep).toHaveBeenCalledWith(false);
+    expect(
+      screen.queryByRole("switch", { name: "Prevent sleep during remote access" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Prevent sleep during remote access")).not.toBeInTheDocument();
+    expect(screen.queryByText("Prevent sleep")).not.toBeInTheDocument();
   });
 
   it("switches the displayed endpoint and QR code from Tailscale to local", async () => {

--- a/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
@@ -709,10 +709,6 @@ function RemotePushSection() {
 
 export function RemoteAccessSettings() {
   const { t } = useLingui();
-  const remoteAccessPreventSleep = useSharedSettings((state) => state.remoteAccessPreventSleep);
-  const setRemoteAccessPreventSleep = useSharedSettings(
-    (state) => state.setRemoteAccessPreventSleep,
-  );
   const [state, setState] = useState<PairingViewState>({
     info: null,
     error: null,
@@ -861,18 +857,6 @@ export function RemoteAccessSettings() {
         ) : null
       }
     >
-      <SettingRow
-        anchorId="remoteAccess.preventSleep"
-        title={t`Prevent sleep during remote access`}
-        description={<Trans>Keep the system awake while remote access is enabled.</Trans>}
-      >
-        <ToggleSwitch
-          aria-label={t`Prevent sleep during remote access`}
-          isSelected={remoteAccessPreventSleep}
-          onChange={setRemoteAccessPreventSleep}
-        />
-      </SettingRow>
-
       {isLoading ? (
         <div className="flex items-center gap-3 text-sm text-muted">
           <PixelLoader size="sm" />

--- a/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.test.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.test.ts
@@ -68,16 +68,16 @@ describe("searchSettings", () => {
 
   it("matches a setting title and shows no snippet (the title is the line)", () => {
     const results = searchSettings("prevent sleep", t);
-    const hit = results.find((r) => r.anchor === "general.preventSleepWhileWorking");
+    const hit = results.find((r) => r.anchor === "general.preventSleep");
     expect(hit).toBeDefined();
-    expect(hit?.title).toBe("Prevent sleep while working");
+    expect(hit?.title).toBe("Prevent sleep");
     expect(hit?.snippet).toBeNull();
   });
 
   it("matches description-only and surfaces the description snippet", () => {
     // "awake" is in the description, not the title.
     const results = searchSettings("awake", t);
-    const hit = results.find((r) => r.anchor === "general.preventSleepWhileWorking");
+    const hit = results.find((r) => r.anchor === "general.preventSleep");
     expect(hit).toBeDefined();
     expect(hit?.snippet).not.toBeNull();
     expect(hit?.snippet?.toLowerCase()).toContain("awake");

--- a/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
+++ b/src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -81,10 +81,10 @@ export const SETTINGS_SEARCH_INDEX: readonly SettingsSearchEntry[] = [
   },
   {
     section: "general",
-    anchor: "general.preventSleepWhileWorking",
-    title: msg`Prevent sleep while working`,
-    description: msg`Keep the system awake while any thread is actively working.`,
-    keywords: "sleep awake wake idle power system",
+    anchor: "general.preventSleep",
+    title: msg`Prevent sleep`,
+    description: msg`Choose when this machine stays awake.`,
+    keywords: "sleep awake wake idle power system server connection remote always",
     desktopOnly: true,
   },
   {
@@ -119,16 +119,6 @@ export const SETTINGS_SEARCH_INDEX: readonly SettingsSearchEntry[] = [
     title: msg`Editor LSP`,
     description: msg`Enable language server support for type checking, completions, and diagnostics. Requires a language server installed.`,
     keywords: "language server protocol type checking completion diagnostics intellisense",
-    desktopOnly: true,
-  },
-
-  // Remote Access
-  {
-    section: "remoteAccess",
-    anchor: "remoteAccess.preventSleep",
-    title: msg`Prevent sleep during remote access`,
-    description: msg`Keep the system awake while remote access is enabled.`,
-    keywords: "sleep awake wake idle power server connection",
     desktopOnly: true,
   },
 

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -20,12 +20,70 @@ describe("shared settings defaults", () => {
     expect(defaultSharedSettings.notificationFilter).toBe("all");
   });
 
-  it("prevents sleep during remote access by default and preserves opt-outs", () => {
-    expect(defaultSharedSettings.remoteAccessPreventSleep).toBe(true);
-    expect(normalizeSharedSettings({}).remoteAccessPreventSleep).toBe(true);
+  it("defaults preventSleep to while-remote-access", () => {
+    expect(defaultSharedSettings.preventSleep).toBe("while-remote-access");
+    expect(normalizeSharedSettings({}).preventSleep).toBe("while-remote-access");
+  });
+
+  it("migrates legacy sleep booleans into preventSleep", () => {
     expect(
-      normalizeSharedSettings({ remoteAccessPreventSleep: false }).remoteAccessPreventSleep,
-    ).toBe(false);
+      normalizeSharedSettings({
+        preventSleepWhileWorking: true,
+        remoteAccessPreventSleep: false,
+      }).preventSleep,
+    ).toBe("while-working");
+    expect(
+      normalizeSharedSettings({
+        preventSleepWhileWorking: false,
+        remoteAccessPreventSleep: true,
+      }).preventSleep,
+    ).toBe("while-remote-access");
+    expect(normalizeSharedSettings({ remoteAccessPreventSleep: true }).preventSleep).toBe(
+      "while-remote-access",
+    );
+    expect(
+      normalizeSharedSettings({
+        preventSleepWhileWorking: false,
+        remoteAccessPreventSleep: false,
+      }).preventSleep,
+    ).toBe("while-working");
+  });
+
+  it("lets an explicit preventSleep value win over legacy booleans", () => {
+    const migrated = normalizeSharedSettings({
+      preventSleep: "always",
+      preventSleepWhileWorking: true,
+      remoteAccessPreventSleep: true,
+    });
+    expect(migrated.preventSleep).toBe("always");
+    expect(migrated).not.toHaveProperty("preventSleepWhileWorking");
+    expect(migrated).not.toHaveProperty("remoteAccessPreventSleep");
+  });
+
+  it("falls back via migration when preventSleep is invalid", () => {
+    expect(
+      normalizeSharedSettings({
+        preventSleep: "never",
+        preventSleepWhileWorking: true,
+        remoteAccessPreventSleep: false,
+      }).preventSleep,
+    ).toBe("while-working");
+    expect(
+      normalizeSharedSettings({
+        preventSleep: "never",
+        remoteAccessPreventSleep: true,
+      }).preventSleep,
+    ).toBe("while-remote-access");
+  });
+
+  it("drops legacy sleep keys from the normalized output", () => {
+    const migrated = normalizeSharedSettings({
+      preventSleepWhileWorking: true,
+      remoteAccessPreventSleep: true,
+    });
+    expect(migrated.preventSleep).toBe("while-remote-access");
+    expect(migrated).not.toHaveProperty("preventSleepWhileWorking");
+    expect(migrated).not.toHaveProperty("remoteAccessPreventSleep");
   });
 
   it("enables Crossagents as the standing MCP default and preserves opt-outs", () => {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -321,10 +321,13 @@ export const sharedSettingsSchema = z.object({
   guiChatFontSize: z.number().int().min(8).max(20),
   /** Base font size for the dev terminal panel. Auto-shrinks in narrow/short panes. */
   terminalPanelFontSize: z.number().int().min(8).max(20),
-  /** Prevent OS sleep while any thread is actively working. */
-  preventSleepWhileWorking: z.boolean(),
-  /** Prevent OS sleep while the desktop remote access server is enabled. */
-  remoteAccessPreventSleep: z.boolean(),
+  /**
+   * When to prevent the OS from sleeping while Poracode is running.
+   * - "while-working": only while a thread is actively working
+   * - "while-remote-access": while remote access is enabled or a thread is working
+   * - "always": keep the machine awake whenever the app is running
+   */
+  preventSleep: z.enum(["while-working", "while-remote-access", "always"]),
   /** Register Poracode to launch automatically when the user signs in to Windows. */
   launchAtStartup: z.boolean(),
   /** Keep the main window hidden when Poracode is launched automatically at sign-in. */
@@ -571,6 +574,9 @@ export const sharedSettingsSchema = z.object({
 });
 export type SharedSettings = z.infer<typeof sharedSettingsSchema>;
 
+/** When to prevent the OS from sleeping while Poracode is running. */
+export type PreventSleep = SharedSettings["preventSleep"];
+
 /** Browser element-picker delivery target for terminal-native (CLI) threads. */
 export type CliPickerTarget = SharedSettings["cliPickerTarget"];
 
@@ -634,8 +640,7 @@ export const defaultSharedSettings: SharedSettings = {
   agentTerminalFontSize: 12,
   guiChatFontSize: 13,
   terminalPanelFontSize: 12,
-  preventSleepWhileWorking: true,
-  remoteAccessPreventSleep: true,
+  preventSleep: "while-remote-access",
   launchAtStartup: true,
   startMinimized: true,
   closeToTray: true,
@@ -836,6 +841,19 @@ export function normalizeSharedSettings(value: unknown): SharedSettings {
       : parsed.data.prWatchDefault === true
         ? "fix"
         : "off";
+  // Unversioned settings file: migrate the two legacy sleep booleans into
+  // the single `preventSleep` enum. An explicit valid value always wins.
+  const hasPreventSleep = sharedSettingsSchema.shape.preventSleep.safeParse(
+    parsed.data.preventSleep,
+  ).success;
+  const hasLegacyPreventSleepKeys =
+    "preventSleepWhileWorking" in parsed.data || "remoteAccessPreventSleep" in parsed.data;
+  const migratedPreventSleep =
+    !hasPreventSleep && hasLegacyPreventSleepKeys
+      ? parsed.data.remoteAccessPreventSleep === true
+        ? ("while-remote-access" as const)
+        : ("while-working" as const)
+      : normalized.preventSleep;
   const usage = z.record(z.string(), z.unknown()).safeParse(parsed.data.usage);
   const disabledProviders = usage.success
     ? z.array(z.string()).safeParse(usage.data.disabledProviders)
@@ -844,6 +862,7 @@ export function normalizeSharedSettings(value: unknown): SharedSettings {
     ...normalized,
     sidebarShortcutOrder: normalizeSidebarShortcutOrder(normalized.sidebarShortcutOrder),
     prAutomationDefault: hasAutomationMode ? normalized.prAutomationDefault : legacyAutomationMode,
+    preventSleep: migratedPreventSleep,
     usage: {
       ...normalized.usage,
       disabledProviders: disabledProviders?.success ? disabledProviders.data : [],


### PR DESCRIPTION
- **Feature:** Replace separate working-thread and remote-access sleep controls with one unified Prevent sleep setting.
- Offer clear modes for preventing sleep while working, during remote access, or always, so users can choose the right power behavior.
- Preserve existing preferences through migration and ensure system sleep policy follows the selected mode.
- Update settings search, tests, and all supported locale catalogs for the consolidated control.