### PR TITLE
Fix sub-agent event replay and remote running-state reconciliation

### DIFF
--- a/src/mobile/storeSync.applyThreadSnapshot.test.tsx
+++ b/src/mobile/storeSync.applyThreadSnapshot.test.tsx
@@ -571,4 +571,53 @@ describe("applyThreadSnapshot", () => {
 
     expect(useAppStore.getState().threads[0]?.status).toBe("finished");
   });
+
+  it("does not force-complete a running delegated-agent tile on an active remote snapshot", () => {
+    const runningCrossagent: PersistedRuntimeItem = {
+      id: "sub:run-1",
+      type: "tool_call",
+      state: "started",
+      payload: { name: "X", status: "running", isCrossagent: true },
+      streams: {},
+    };
+
+    applyThreadSnapshot(
+      makeSnapshot({
+        status: "working",
+        items: [runningCrossagent],
+      }),
+    );
+
+    const item = useAppStore.getState().runtimeItemsByIdByThread[THREAD_ID]?.["sub:run-1"];
+    expect(item?.state).toBe("started");
+    expect(item?.payload).toEqual({ name: "X", status: "running", isCrossagent: true });
+  });
+
+  it("reconciles a running delegated-agent tile when the remote thread is inactive", () => {
+    const runningCrossagent: PersistedRuntimeItem = {
+      id: "sub:run-1",
+      type: "tool_call",
+      state: "started",
+      payload: { name: "X", status: "running", isCrossagent: true },
+      streams: {},
+    };
+
+    applyThreadSnapshot(
+      makeSnapshot({
+        status: "idle",
+        items: [runningCrossagent],
+      }),
+    );
+
+    const item = useAppStore.getState().runtimeItemsByIdByThread[THREAD_ID]?.["sub:run-1"];
+    expect(item?.state).toBe("completed");
+    expect(item?.payload).toMatchObject({
+      name: "X",
+      status: "error",
+      isCrossagent: true,
+      result: {
+        error: "Interrupted: agent session ended before completion.",
+      },
+    });
+  });
 });

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.test.tsx
@@ -469,6 +469,57 @@ describe("SubAgentContent", () => {
     expect(useAppStore.getState().openSubAgentByThread[threadId]).toBeNull();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
+
+  it("still applies legacy-host subscribe history after the overlay unmounts", async () => {
+    const threadId = "thread-1";
+    const parentItem = makeSubAgentItem("parent-1");
+    let resolveSubscribe: ((value: { history: unknown[] }) => void) | undefined;
+    mockBridge.subagentSubscribe.mockReset().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSubscribe = resolve as (value: { history: unknown[] }) => void;
+        }),
+    );
+
+    useAppStore.setState({
+      runtimeItemIdsByThread: { [threadId]: [parentItem.id] },
+      runtimeItemsByIdByThread: { [threadId]: { [parentItem.id]: parentItem } },
+      runtimeStructuralVersionByThread: { [threadId]: 1 },
+    });
+
+    const view = render(
+      <SubAgentContent threadId={threadId} parentItemId={parentItem.id} hideHeader />,
+    );
+
+    await waitFor(() => expect(mockBridge.subagentSubscribe).toHaveBeenCalled());
+    view.unmount();
+
+    resolveSubscribe?.({
+      history: [
+        {
+          type: "item.started",
+          threadId,
+          itemId: "child-late",
+          itemType: "assistant_message",
+          parentItemId: parentItem.id,
+        },
+        {
+          type: "content.delta",
+          threadId,
+          itemId: "child-late",
+          stream: "assistant_text",
+          delta: "preserved after unmount",
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      const child = useAppStore.getState().runtimeItemsByIdByThread[threadId]?.["child-late"];
+      expect(child).toBeDefined();
+      expect(child?.streams.assistant_text).toBe("preserved after unmount");
+      expect(child?.parentItemId).toBe(parentItem.id);
+    });
+  });
 });
 
 function makeSubAgentItem(id: string): RuntimeChatItem {

--- a/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
@@ -82,25 +82,23 @@ export function SubAgentContent({
   const applyRuntimeEvents = useAppStore((s) => s.applyRuntimeEvents);
 
   // Subscribe to the supervisor's child-event stream for this sub-agent while
-  // the overlay is open. The supervisor buffers events when no renderer is
-  // subscribed (perf gate); on subscribe it drains the buffer as `history` and
-  // forwards the live tail through the regular runtime-event channels. Items
-  // already in the store are no-ops when replayed, so we keep the persisted
-  // child history intact and let any new events layer on top.
+  // the overlay is open. Current hosts drain the buffer and replay it onto the
+  // thread's regular runtime stream (events arrive via the standard channel);
+  // the RPC `history` payload is empty and is a fallback for older hosts that
+  // still return the drained buffer here. Late RPC responses are still applied
+  // so history is not lost if the panel remounts before the response arrives.
   useEffect(() => {
-    let cancelled = false;
     const bridge = readBridge();
     void bridge
       .subagentSubscribe({ threadId, parentItemId })
       .then((result) => {
-        if (cancelled || result.history.length === 0) return;
+        if (result.history.length === 0) return;
         applyRuntimeEvents(threadId, result.history);
       })
       .catch((err: unknown) => {
         console.warn("[subagent] subscribe failed", { threadId, parentItemId, err });
       });
     return () => {
-      cancelled = true;
       void bridge.subagentUnsubscribe({ threadId, parentItemId }).catch((err: unknown) => {
         console.warn("[subagent] unsubscribe failed", { threadId, parentItemId, err });
       });

--- a/src/renderer/state/remote/sync.ts
+++ b/src/renderer/state/remote/sync.ts
@@ -120,7 +120,12 @@ export function applyThreadSnapshot(
         [threadId]: (current.runtimeStructuralVersionByThread[threadId] ?? 0) + 1,
       },
     }));
-    state.reconcileStaleSubAgents(threadId);
+    // Active remote threads legitimately have running delegated-agent rows;
+    // terminating them paints a false "session ended" error while the host is
+    // still working. Inactive threads keep the reconcile (orphaned rows).
+    if (!threadActive) {
+      state.reconcileStaleSubAgents(threadId);
+    }
   } else if (options.fromServer) {
     mergeMissedOlderSnapshotItems(threadId, snapshotItems);
   }

--- a/src/supervisor/runtime/threadSession/runtimeEventRouter.test.ts
+++ b/src/supervisor/runtime/threadSession/runtimeEventRouter.test.ts
@@ -124,6 +124,97 @@ describe("RuntimeEventRouter", () => {
     ).toEqual([`item.started:${parentId}`, `item.completed:${parentId}`]);
     expect(router.subscribe(threadId, parentId)).toEqual([]);
   });
+
+  it("replays buffered child history onto the runtime stream on subscribe", () => {
+    const { router, emit } = makeRouter();
+    const threadId = "t1";
+    const parentId = "task-1";
+
+    router.append(threadId, {
+      type: "item.started",
+      threadId,
+      itemId: parentId,
+      itemType: "tool_call",
+      payload: { name: "Task", status: "running" },
+    });
+    router.append(threadId, {
+      type: "item.started",
+      threadId,
+      itemId: "child-1",
+      itemType: "assistant_message",
+      parentItemId: parentId,
+    });
+    router.append(threadId, {
+      type: "content.delta",
+      threadId,
+      itemId: "child-1",
+      stream: "assistant_text",
+      delta: "hi",
+    });
+    router.append(threadId, {
+      type: "item.started",
+      threadId,
+      itemId: "child-2",
+      itemType: "tool_call",
+      parentItemId: parentId,
+      payload: { name: "Read", status: "running" },
+    });
+    vi.runAllTimers();
+    emit.mockClear();
+
+    // Subscribe drains the buffer onto the normal stream and returns empty history.
+    expect(router.subscribe(threadId, parentId)).toEqual([]);
+    vi.runAllTimers();
+
+    const replayed = collectEmittedRuntimeEvents(emit);
+    expect(replayed).toEqual([
+      {
+        type: "item.started",
+        threadId,
+        itemId: "child-1",
+        itemType: "assistant_message",
+        parentItemId: parentId,
+      },
+      {
+        type: "content.delta",
+        threadId,
+        itemId: "child-1",
+        stream: "assistant_text",
+        delta: "hi",
+      },
+      {
+        type: "item.started",
+        threadId,
+        itemId: "child-2",
+        itemType: "tool_call",
+        parentItemId: parentId,
+        payload: { name: "Read", status: "running" },
+      },
+    ]);
+
+    // Subsequent child events stream live without re-buffering or duplicating
+    // the replayed history.
+    emit.mockClear();
+    router.append(threadId, {
+      type: "item.completed",
+      threadId,
+      itemId: "child-2",
+    });
+    vi.runAllTimers();
+    expect(collectEmittedRuntimeEvents(emit)).toEqual([
+      {
+        type: "item.completed",
+        threadId,
+        itemId: "child-2",
+      },
+    ]);
+
+    // Second subscribe returns empty and does not re-emit.
+    emit.mockClear();
+    expect(router.subscribe(threadId, parentId)).toEqual([]);
+    vi.runAllTimers();
+    expect(collectEmittedRuntimeEvents(emit)).toEqual([]);
+  });
 });
 
 describe("SubAgentRegistry", () => {

--- a/src/supervisor/runtime/threadSession/runtimeEventRouter.ts
+++ b/src/supervisor/runtime/threadSession/runtimeEventRouter.ts
@@ -37,8 +37,19 @@ export class RuntimeEventRouter {
     this.runtimeEvents.append(threadId, event);
   }
 
+  /**
+   * Subscribe a sub-agent overlay. Buffered child history is drained and
+   * re-emitted onto the normal runtime event channel (persisted + broadcast);
+   * the returned array is empty so clients receive history through that single
+   * ordered stream. The empty `history` return is intentional — older clients
+   * still accept an empty RPC history as a no-op.
+   */
   subscribe(threadId: string, parentItemId: string): RuntimeEvent[] {
-    return this.subAgents.subscribe(threadId, parentItemId);
+    const drained = this.subAgents.subscribe(threadId, parentItemId);
+    for (const event of drained) {
+      this.runtimeEvents.append(threadId, event);
+    }
+    return [];
   }
 
   unsubscribe(threadId: string, parentItemId: string): void {

--- a/src/supervisor/runtime/threadSessionManager.subAgentBuffer.test.ts
+++ b/src/supervisor/runtime/threadSessionManager.subAgentBuffer.test.ts
@@ -6,8 +6,9 @@ import { ThreadSessionManager } from "./threadSessionManager";
 /**
  * Focused tests for the sub-agent event gating + buffer-drain behavior in
  * `ThreadSessionManager`. The buffer holds child events while no overlay is
- * subscribed; the parent's completion drains it so the renderer can replay
- * every turn even if the overlay was never opened during the run.
+ * subscribed; subscribe (and parent completion) drain it onto the normal
+ * runtime stream so the renderer can replay every turn even if the overlay
+ * was never opened during the run.
  */
 
 function makeManager() {
@@ -191,7 +192,18 @@ describe("ThreadSessionManager sub-agent buffer", () => {
         payload: { progress: { stepCount: 1 } },
       },
     ]);
-    expect(manager.subagentSubscribe({ threadId, parentItemId: parentId }).history).toEqual([
+
+    // Subscribe drains the buffer onto the normal runtime stream and returns
+    // empty history (delivery is via the stream, not the RPC body).
+    expect(manager.subagentSubscribe({ threadId, parentItemId: parentId }).history).toEqual([]);
+    vi.runAllTimers();
+    expect(collectEmittedRuntimeEvents(emit)).toEqual([
+      {
+        type: "item.updated",
+        threadId,
+        itemId: parentId,
+        payload: { progress: { stepCount: 1 } },
+      },
       {
         type: "item.started",
         threadId,
@@ -201,5 +213,11 @@ describe("ThreadSessionManager sub-agent buffer", () => {
         payload: { name: "Read", status: "running" },
       },
     ]);
+
+    // Second subscribe returns empty and does not re-emit duplicates.
+    emit.mockClear();
+    expect(manager.subagentSubscribe({ threadId, parentItemId: parentId }).history).toEqual([]);
+    vi.runAllTimers();
+    expect(collectEmittedRuntimeEvents(emit)).toEqual([]);
   });
 });

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -388,9 +388,11 @@ export class ThreadSessionManager {
   }
 
   /**
-   * Renderer-facing: subscribe a sub-agent overlay. Returns the buffered
-   * child-event history so the renderer can hydrate the overlay; subsequent
-   * child events stream live via the regular runtime-event channels.
+   * Renderer-facing: subscribe a sub-agent overlay. Buffered child history is
+   * replayed onto the normal runtime event stream (persisted + broadcast to WS
+   * clients); subsequent child events continue on that same stream. The RPC
+   * returns `history: []` — the field remains for backward compatibility with
+   * older clients/hosts that still deliver drained buffer events in the body.
    */
   subagentSubscribe(payload: { threadId: string; parentItemId: string }): {
     history: RuntimeEvent[];


### PR DESCRIPTION
- Ensure buffered sub-agent events replay through the standard runtime stream when an overlay subscribes, preserving ordered history for renderer and remote clients.
- Retain compatibility with older hosts that return buffered history through the subscribe response, including late responses after an overlay unmounts.
- Prevent active remote snapshots from incorrectly marking running delegated agents as interrupted, while reconciling stale agents on inactive threads.
- Add coverage for event replay, duplicate prevention, overlay lifecycle handling, and remote snapshot reconciliation.