### PR TITLE
Route set-worktree through host for remote threads

### DIFF
--- a/src/mobile/NarrowShell.tsx
+++ b/src/mobile/NarrowShell.tsx
@@ -194,6 +194,9 @@ export function NarrowShell(props: {
                   void remote.deleteWorktreeGroup(input);
                   void navigate({ to: "/threads" });
                 }}
+                onMoveThreadToWorktree={(target, withChanges) => {
+                  void remote.moveThreadToWorktree(target, withChanges);
+                }}
                 onOpenNotes={() =>
                   void navigate({
                     to: "/notes/$threadId",
@@ -272,6 +275,7 @@ export function NarrowShell(props: {
             onAction={() => undefined}
             onNewThreadInWorktree={() => undefined}
             onDeleteWorktreeGroup={() => undefined}
+            onMoveThreadToWorktree={() => undefined}
             onOpenNotes={() => undefined}
             onOpenTerminal={() => undefined}
           />

--- a/src/mobile/ThreadDetail.tsx
+++ b/src/mobile/ThreadDetail.tsx
@@ -158,6 +158,9 @@ export function ThreadDetail(props: {
           void remote.deleteWorktreeGroup(input);
           void navigate({ to: "/threads" });
         }}
+        onMoveThreadToWorktree={(target, withChanges) => {
+          void remote.moveThreadToWorktree(target, withChanges);
+        }}
       />
     </Suspense>
   );

--- a/src/mobile/ThreadTitleRow.test.tsx
+++ b/src/mobile/ThreadTitleRow.test.tsx
@@ -137,4 +137,45 @@ describe("ThreadTitleRow", () => {
     expect(screen.queryByText("Delete Worktree")).toBeNull();
     expect(screen.getByText("Delete Thread")).toBeInTheDocument();
   });
+
+  it("moves a project-root thread to a worktree from the thread actions", () => {
+    const onMoveThreadToWorktree = vi.fn<(thread: Thread, withChanges: boolean) => void>();
+
+    render(
+      <ThreadTitleRow
+        thread={makeThread()}
+        onAction={() => undefined}
+        onMoveThreadToWorktree={onMoveThreadToWorktree}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+    fireEvent.click(screen.getByText("Move to worktree with changes"));
+    expect(onMoveThreadToWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-1" }),
+      true,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+    fireEvent.click(screen.getByText("Move to clean worktree"));
+    expect(onMoveThreadToWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "thread-1" }),
+      false,
+    );
+  });
+
+  it("hides move-to-worktree for a thread already in a worktree", () => {
+    render(
+      <ThreadTitleRow
+        thread={makeThread({ worktreePath: "/repo/wt", worktreeBranch: "feature/x" })}
+        onAction={() => undefined}
+        onMoveThreadToWorktree={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+
+    expect(screen.queryByText("Move to worktree with changes")).toBeNull();
+    expect(screen.queryByText("Move to clean worktree")).toBeNull();
+  });
 });

--- a/src/mobile/ThreadTitleRow.tsx
+++ b/src/mobile/ThreadTitleRow.tsx
@@ -4,6 +4,7 @@ import {
   Archive,
   CircleCheck,
   Ellipsis,
+  GitFork,
   NotebookPen,
   Pencil,
   Plus,
@@ -60,6 +61,7 @@ function ThreadActionsMenu(props: {
   readonly onAction: (action: ThreadAction) => void;
   readonly onNewThreadInWorktree?: ((input: WorktreeThreadInput) => void) | undefined;
   readonly onDeleteWorktreeGroup?: ((input: WorktreeDeleteInput) => void) | undefined;
+  readonly onMoveThreadToWorktree?: ((thread: Thread, withChanges: boolean) => void) | undefined;
   readonly onOpenNotes?: (() => void) | undefined;
   readonly onOpenTerminal?: (() => void) | undefined;
 }) {
@@ -94,6 +96,20 @@ function ThreadActionsMenu(props: {
             id: "new-worktree-thread",
             label: t`New thread in worktree`,
             icon: <Plus className="size-4 text-muted" />,
+          },
+        ]
+      : []),
+    ...(!worktreePath && props.onMoveThreadToWorktree
+      ? [
+          {
+            id: "move-to-worktree-with-changes",
+            label: t`Move to worktree with changes`,
+            icon: <GitFork className="size-4 text-muted" />,
+          },
+          {
+            id: "move-to-worktree-clean",
+            label: t`Move to clean worktree`,
+            icon: <GitFork className="size-4 text-muted" />,
           },
         ]
       : []),
@@ -137,6 +153,8 @@ function ThreadActionsMenu(props: {
         worktreeBranch,
       });
     }
+    if (id === "move-to-worktree-with-changes") props.onMoveThreadToWorktree?.(thread, true);
+    if (id === "move-to-worktree-clean") props.onMoveThreadToWorktree?.(thread, false);
     if (id === "toggle-done") props.onAction({ kind: "set-done", done: !thread.done });
     if (id === "toggle-star")
       props.onAction({ kind: "set-starred", starred: !(thread.starred ?? false) });
@@ -187,6 +205,7 @@ export function ThreadTitleRow(props: {
   readonly onAction: (action: ThreadAction) => void;
   readonly onNewThreadInWorktree?: ((input: WorktreeThreadInput) => void) | undefined;
   readonly onDeleteWorktreeGroup?: ((input: WorktreeDeleteInput) => void) | undefined;
+  readonly onMoveThreadToWorktree?: ((thread: Thread, withChanges: boolean) => void) | undefined;
   /** Adds an "Open terminal" entry to the actions menu. */
   readonly onOpenTerminal?: (() => void) | undefined;
   /** Adds a project notes and to-dos entry to the actions menu. */
@@ -228,6 +247,7 @@ export function ThreadTitleRow(props: {
         onAction={props.onAction}
         onNewThreadInWorktree={props.onNewThreadInWorktree}
         onDeleteWorktreeGroup={props.onDeleteWorktreeGroup}
+        onMoveThreadToWorktree={props.onMoveThreadToWorktree}
         onOpenNotes={props.onOpenNotes}
         onOpenTerminal={props.onOpenTerminal}
       />

--- a/src/mobile/WideShell.tsx
+++ b/src/mobile/WideShell.tsx
@@ -232,6 +232,9 @@ export function WideShell(props: {
             onDeleteWorktreeGroup={(input) => {
               void remote.deleteWorktreeGroup(input);
             }}
+            onMoveThreadToWorktree={(thread, withChanges) => {
+              void remote.moveThreadToWorktree(thread, withChanges);
+            }}
             onNew={() => void navigate({ to: "/new" })}
             onNewThreadInWorktree={(input) => {
               void openWorktreeDraft(input, () => navigate({ to: "/new" }));

--- a/src/mobile/routeComponents.tsx
+++ b/src/mobile/routeComponents.tsx
@@ -224,6 +224,9 @@ export function ThreadsRoute() {
         onDeleteWorktreeGroup={(input) => {
           void remote.deleteWorktreeGroup(input);
         }}
+        onMoveThreadToWorktree={(thread, withChanges) => {
+          void remote.moveThreadToWorktree(thread, withChanges);
+        }}
         onNew={() => setComposeExpanded(true)}
         onNewThreadInWorktree={(input) => {
           preselectWorktreeDraft(input);

--- a/src/mobile/useRemoteDesktop.test.tsx
+++ b/src/mobile/useRemoteDesktop.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import { useAppStore } from "@/renderer/state/appStore";
 import type { RemoteShellSnapshot } from "@/shared/remote";
 import { RemoteClientError } from "@/shared/remote/client";
+import { useGitSummariesStore } from "./gitSummaries";
 import type { StoredDesktop } from "./storage";
 
 /** The RemoteDesktopClient surface the hook touches, each method a spy. */
@@ -78,6 +79,10 @@ const h = vi.hoisted(() => {
     updateDesktopPlatform: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
     gitAddWorktree: vi.fn<(...a: unknown[]) => Promise<{ path: string }>>(async () => ({
       path: "/repo/.poracode/worktrees/mobile-fix",
+    })),
+    bridgeCloseThread: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
+    bridgeStartThread: vi.fn<(...a: unknown[]) => Promise<unknown>>(async () => ({
+      threadId: "t",
     })),
     captureFileCheckpoint: vi.fn<(...a: unknown[]) => Promise<void>>(async () => {}),
     setRemoteBridgeClient: vi.fn<(...a: unknown[]) => void>(),
@@ -261,7 +266,11 @@ vi.mock("./settingsSync", () => ({
   resetDesktopSettings: (...a: unknown[]) => h.resetDesktopSettings(...a),
 }));
 vi.mock("@/renderer/bridge", () => ({
-  readBridge: () => ({ gitAddWorktree: h.gitAddWorktree }),
+  readBridge: () => ({
+    gitAddWorktree: h.gitAddWorktree,
+    closeThread: h.bridgeCloseThread,
+    startThread: h.bridgeStartThread,
+  }),
 }));
 vi.mock("./bridge", () => ({
   setRemoteBridgeClient: (...a: unknown[]) => h.setRemoteBridgeClient(...a),
@@ -388,11 +397,14 @@ describe("useRemoteDesktop", () => {
       h.updateDesktopEndpoint,
       h.updateDesktopPlatform,
       h.gitAddWorktree,
+      h.bridgeCloseThread,
+      h.bridgeStartThread,
       h.captureFileCheckpoint,
       h.setRemoteBridgeClient,
     ]) {
       fn.mockClear();
     }
+    useGitSummariesStore.getState().reset();
     h.applyShellSnapshot.mockImplementation(() => {});
     h.getSshCredential.mockResolvedValue(null);
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
@@ -707,6 +719,159 @@ describe("useRemoteDesktop", () => {
         isNewWorktree: true,
       }),
     );
+  });
+
+  describe("moveThreadToWorktree", () => {
+    const project = {
+      id: "p",
+      name: "Repo",
+      location: { kind: "posix" as const, path: "/repo" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    function makeMainThread(overrides: Record<string, unknown> = {}) {
+      return {
+        id: "t1",
+        projectId: "p",
+        title: "Thread",
+        agentKind: "codex" as const,
+        config: { model: "m" },
+        status: "inactive" as const,
+        attention: "none" as const,
+        canResumeWithConfig: false,
+        archived: false,
+        done: false,
+        starred: false,
+        presentationMode: "gui" as const,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("re-tags an inactive thread through the host set-worktree command", async () => {
+      const desktop = makeDesktop("d1");
+      const client = clientFor("d1");
+      const view = await mountWith([desktop], "d1");
+      const thread = makeMainThread();
+      client.sendThreadCommand.mockClear();
+
+      await act(async () => {
+        useAppStore.setState({ projects: [project as never], threads: [thread as never] });
+        await view.result.current.moveThreadToWorktree(thread as never, false);
+      });
+
+      // Inactive thread: no close, no restart.
+      expect(h.bridgeCloseThread).not.toHaveBeenCalled();
+      expect(h.bridgeStartThread).not.toHaveBeenCalled();
+      expect(h.gitAddWorktree).toHaveBeenCalledTimes(1);
+      const addPayload = h.gitAddWorktree.mock.calls[0]![0] as Record<string, unknown>;
+      expect(addPayload).toMatchObject({
+        projectLocation: project.location,
+        createBranch: true,
+        transferUncommitted: false,
+        keepChangesInSource: false,
+      });
+      expect(addPayload.branch).toEqual(expect.stringMatching(/^poracode\//));
+      // No git summary for the thread → no startPoint (host falls back to HEAD).
+      expect(addPayload.startPoint).toBeUndefined();
+      expect(client.sendThreadCommand).toHaveBeenCalledWith({
+        kind: "set-worktree",
+        threadId: "t1",
+        worktreePath: "/repo/.poracode/worktrees/mobile-fix",
+        worktreeBranch: addPayload.branch,
+        isNewWorktree: true,
+      });
+      // Optimistic local mirror tags the thread right away.
+      const stored = useAppStore.getState().threads.find((entry) => entry.id === "t1");
+      expect(stored?.worktreePath).toBe("/repo/.poracode/worktrees/mobile-fix");
+      expect(stored?.worktreeBranch).toBe(addPayload.branch);
+    });
+
+    it("closes an active thread, moves its changes, and restarts it in the worktree", async () => {
+      const desktop = makeDesktop("d1");
+      const client = clientFor("d1");
+      const view = await mountWith([desktop], "d1");
+      const thread = makeMainThread({ status: "idle", sessionRef: "ses-1" });
+
+      await act(async () => {
+        useAppStore.setState({ projects: [project as never], threads: [thread as never] });
+        useGitSummariesStore.getState().setThread("t1", {
+          isRepo: true,
+          branch: "main",
+          totalInsertions: 0,
+          totalDeletions: 0,
+          ahead: 0,
+          behind: 0,
+          pr: null,
+        } as never);
+        await view.result.current.moveThreadToWorktree(thread as never, true);
+      });
+
+      expect(h.bridgeCloseThread).toHaveBeenCalledWith({ threadId: "t1" });
+      const addPayload = h.gitAddWorktree.mock.calls[0]![0] as Record<string, unknown>;
+      expect(addPayload).toMatchObject({
+        startPoint: "main",
+        transferUncommitted: true,
+        keepChangesInSource: false,
+      });
+      expect(client.sendThreadCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "set-worktree", threadId: "t1", isNewWorktree: true }),
+      );
+      expect(h.bridgeStartThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "t1",
+          projectLocation: { kind: "posix", path: "/repo/.poracode/worktrees/mobile-fix" },
+          sessionRef: "ses-1",
+          presentationMode: "gui",
+        }),
+      );
+    });
+
+    it("reports the failure and refreshes without re-tagging when worktree creation fails", async () => {
+      const desktop = makeDesktop("d1");
+      const client = clientFor("d1");
+      const view = await mountWith([desktop], "d1");
+      const thread = makeMainThread();
+      client.sendThreadCommand.mockClear();
+      client.snapshot.mockClear();
+      h.gitAddWorktree.mockRejectedValueOnce(new Error("git boom"));
+
+      await act(async () => {
+        useAppStore.setState({ projects: [project as never], threads: [thread as never] });
+        await view.result.current.moveThreadToWorktree(thread as never, false);
+      });
+
+      expect(client.sendThreadCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "set-worktree" }),
+      );
+      expect(
+        useAppStore.getState().threads.find((entry) => entry.id === "t1")?.worktreePath,
+      ).toBeUndefined();
+      expect(view.result.current.message).toBe("git boom");
+      // The failure path re-pulls the desktop's truth.
+      await waitFor(() => expect(client.snapshot).toHaveBeenCalled());
+    });
+
+    it("refuses to move a thread that is still launching", async () => {
+      const desktop = makeDesktop("d1");
+      const client = clientFor("d1");
+      const view = await mountWith([desktop], "d1");
+      const thread = makeMainThread({ status: "launching" });
+      client.sendThreadCommand.mockClear();
+
+      await act(async () => {
+        useAppStore.setState({ projects: [project as never], threads: [thread as never] });
+        await view.result.current.moveThreadToWorktree(thread as never, false);
+      });
+
+      expect(h.gitAddWorktree).not.toHaveBeenCalled();
+      expect(h.bridgeCloseThread).not.toHaveBeenCalled();
+      expect(client.sendThreadCommand).not.toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "set-worktree" }),
+      );
+      expect(view.result.current.message).toContain("finish starting");
+    });
   });
 
   it("captures a pre-turn file checkpoint for a PWA prompt", async () => {

--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -11,6 +11,7 @@ import {
   type ThreadStatus,
 } from "@/shared/contracts";
 import { buildWorktreeLocation } from "@/shared/worktree";
+import { generateWorktreeBranch } from "@/shared/worktreeBranch";
 import { isHomeProjectId } from "@/shared/homeScope";
 import { buildRemoteGitTargetInterests } from "@/shared/gitStateInterestPolicy";
 import { waitForRemoteThreadAppearance } from "@/shared/remote/threadAppearance";
@@ -24,6 +25,7 @@ import {
   type RemoteThreadSnapshot,
 } from "@/shared/remote";
 import { performThreadInputSubmit } from "@/renderer/actions/threadRuntimeActions";
+import { worktreePlacementPayload } from "@/renderer/actions/worktreePlacement";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { useAppStore } from "@/renderer/state/appStore";
 import { seedOlderThreadRuntimeItemsCursor } from "@/renderer/state/chatRuntimePersister";
@@ -32,6 +34,7 @@ import type { DraftStartInput } from "@/renderer/components/thread/ThreadDraftCo
 import { i18n } from "@/renderer/i18n/i18n";
 import { setRemoteBridgeClient } from "./bridge";
 import { resetBrowserMirror } from "./browserMirror";
+import { useGitSummariesStore } from "./gitSummaries";
 import { buildGitAddWorktreePayload } from "./navHelpers";
 import { isNativeApp } from "./pwaInstall";
 import {
@@ -96,6 +99,9 @@ export interface WorktreeGroupDeleteInput {
   readonly worktreePath: string;
   readonly threadIds: readonly string[];
 }
+
+/** Threads currently being moved to a worktree — guards against double-taps. */
+const movingThreadIds = new Set<string>();
 
 function describeError(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
@@ -975,6 +981,81 @@ export function useRemoteDesktop() {
     }
   }
 
+  /**
+   * Move a main-checkout thread into a fresh worktree on the paired desktop.
+   * Mirrors the desktop's moveThreadToWorktree: the worktree is created through
+   * the bridge (host git), then the host's `set-worktree` command re-tags the
+   * durable row and — with isNewWorktree — primes git state and runs the setup
+   * script there. An active thread is restarted in the new directory.
+   * `withChanges` MOVES the main checkout's uncommitted changes along, leaving
+   * the current branch clean.
+   */
+  async function moveThreadToWorktree(thread: Thread, withChanges: boolean) {
+    const desktop = activeDesktop;
+    if (!desktop || thread.worktreePath || movingThreadIds.has(thread.id)) return;
+    const project = useAppStore.getState().projects.find((item) => item.id === thread.projectId);
+    if (!project) return;
+    if (thread.status === "launching") {
+      setOperationMessage(
+        i18n._(msg`Wait for the thread to finish starting before moving it to a worktree.`),
+      );
+      return;
+    }
+    const wasActive = thread.status !== "inactive";
+    const bridge = readBridge();
+    movingThreadIds.add(thread.id);
+    try {
+      // Re-tagging only sticks for a stopped thread — close any live runtime first.
+      if (wasActive) {
+        await bridge.closeThread({ threadId: thread.id });
+      }
+      const currentBranch = useGitSummariesStore.getState().byThread[thread.id]?.branch;
+      const branch = generateWorktreeBranch();
+      const created = await bridge.gitAddWorktree({
+        projectLocation: project.location,
+        branch,
+        ...(currentBranch ? { startPoint: currentBranch } : {}),
+        createBranch: true,
+        ...(project.scripts?.worktreeCopyPatterns?.length
+          ? { copyIgnoredPatterns: project.scripts.worktreeCopyPatterns }
+          : {}),
+        ...worktreePlacementPayload(project),
+        transferUncommitted: withChanges,
+        keepChangesInSource: false,
+      });
+      // Optimistic mirror; the host owns the durable row and confirms it via
+      // the next snapshot. On failure the refresh below restores its truth.
+      useAppStore.getState().setThreadWorktree(thread.id, created.path, branch);
+      await clientFor(desktop).sendThreadCommand({
+        kind: "set-worktree",
+        threadId: thread.id,
+        worktreePath: created.path,
+        worktreeBranch: branch,
+        isNewWorktree: true,
+      });
+      if (wasActive) {
+        await bridge.startThread({
+          threadId: thread.id,
+          projectLocation: buildWorktreeLocation(project.location, created.path),
+          agentKind: thread.agentKind,
+          ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
+          config: thread.config,
+          prompt: "",
+          initialSize: DEFAULT_TERMINAL_SIZE,
+          ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
+          ...(thread.presentationMode ? { presentationMode: thread.presentationMode } : {}),
+        });
+      }
+    } catch (error) {
+      setOperationMessage(
+        describeError(error, i18n._(msg`Couldn't move the thread to a worktree.`)),
+      );
+      void refresh(desktop, { refreshSelectedThread: true });
+    } finally {
+      movingThreadIds.delete(thread.id);
+    }
+  }
+
   async function switchDesktop(desktop: StoredDesktop) {
     const previous = activeDesktop;
     let restored: StoredDesktop;
@@ -1106,6 +1187,7 @@ export function useRemoteDesktop() {
     startThread,
     applyThreadAction,
     deleteWorktreeGroup,
+    moveThreadToWorktree,
     manageProject,
     switchDesktop,
     forget,

--- a/src/mobile/views/ThreadView.tsx
+++ b/src/mobile/views/ThreadView.tsx
@@ -83,6 +83,8 @@ export interface ThreadViewProps {
         readonly threadIds: readonly string[];
       }) => void)
     | undefined;
+  /** Moves a main-checkout thread into a fresh worktree on the paired desktop. */
+  readonly onMoveThreadToWorktree?: ((thread: Thread, withChanges: boolean) => void) | undefined;
 }
 
 /** Read-only scrollback shown while the live terminal snapshot is loading. */
@@ -361,6 +363,7 @@ export function ThreadView(props: ThreadViewProps) {
             onAction={props.onThreadAction}
             onNewThreadInWorktree={props.onNewThreadInWorktree}
             onDeleteWorktreeGroup={props.onDeleteWorktreeGroup}
+            onMoveThreadToWorktree={props.onMoveThreadToWorktree}
             onOpenNotes={props.onOpenNotes}
             onOpenTerminal={props.onOpenTerminal}
           />

--- a/src/mobile/views/ThreadsView.test.tsx
+++ b/src/mobile/views/ThreadsView.test.tsx
@@ -68,6 +68,7 @@ function renderView(
       worktreePath: string;
       threadIds: readonly string[];
     }) => void;
+    onMoveThreadToWorktree?: (thread: Thread, withChanges: boolean) => void;
     onOpenTerminal?: (input: {
       projectId: string;
       worktreePath?: string;
@@ -95,6 +96,7 @@ function renderView(
       onNew={() => {}}
       onNewThreadInWorktree={handlers?.onNewThreadInWorktree ?? (() => {})}
       onDeleteWorktreeGroup={handlers?.onDeleteWorktreeGroup ?? (() => {})}
+      onMoveThreadToWorktree={handlers?.onMoveThreadToWorktree ?? (() => {})}
       onOpenTerminal={handlers?.onOpenTerminal ?? (() => {})}
       onRunProjectAction={handlers?.onRunProjectAction ?? (() => {})}
       {...(handlers?.emptyStateOverride ? { emptyStateOverride: handlers.emptyStateOverride } : {})}
@@ -243,6 +245,59 @@ describe("ThreadsView grouping", () => {
     expect(input.projectId).toBe("p1");
     expect(input.worktreePath).toBe("/repo/wt");
     expect([...input.threadIds].sort()).toEqual(["a", "b"]);
+  });
+
+  it("moves a main-checkout thread with its changes from the row menu", () => {
+    const onMoveThreadToWorktree = vi.fn<(thread: Thread, withChanges: boolean) => void>();
+    renderView([makeThread({ id: "a", title: "Alpha" })], { onMoveThreadToWorktree });
+
+    fireEvent.contextMenu(screen.getByText("Alpha").closest("button")!);
+    fireEvent.click(screen.getByText("Move to Worktree"));
+    fireEvent.click(screen.getByText("Bring Uncommitted Changes"));
+
+    expect(onMoveThreadToWorktree).toHaveBeenCalledTimes(1);
+    expect(onMoveThreadToWorktree.mock.calls[0]![0].id).toBe("a");
+    expect(onMoveThreadToWorktree.mock.calls[0]![1]).toBe(true);
+  });
+
+  it("moves a main-checkout thread to a clean worktree from the row menu", () => {
+    const onMoveThreadToWorktree = vi.fn<(thread: Thread, withChanges: boolean) => void>();
+    renderView([makeThread({ id: "a", title: "Alpha" })], { onMoveThreadToWorktree });
+
+    fireEvent.contextMenu(screen.getByText("Alpha").closest("button")!);
+    fireEvent.click(screen.getByText("Move to Worktree"));
+    fireEvent.click(screen.getByText("Clean Worktree"));
+
+    expect(onMoveThreadToWorktree).toHaveBeenCalledTimes(1);
+    expect(onMoveThreadToWorktree.mock.calls[0]![0].id).toBe("a");
+    expect(onMoveThreadToWorktree.mock.calls[0]![1]).toBe(false);
+  });
+
+  it("omits Move to Worktree for threads already in a worktree", () => {
+    renderView([
+      makeThread({
+        id: "a",
+        title: "Alpha",
+        worktreePath: "/repo/wt",
+        worktreeBranch: "feature/x",
+      }),
+    ]);
+
+    fireEvent.contextMenu(screen.getByText("Alpha").closest("button")!);
+
+    expect(screen.queryByText("Move to Worktree")).toBeNull();
+  });
+
+  it("offers Move to Worktree as a desktop submenu entry", () => {
+    media.desktopPointer = true;
+    renderView([makeThread({ id: "a", title: "Alpha" })]);
+
+    fireEvent.contextMenu(screen.getByText("Alpha").closest("button")!, {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    expect(screen.getByRole("menuitem", { name: "Move to Worktree" })).toBeTruthy();
   });
 
   it("collapses and re-expands the group when its header is tapped", () => {
@@ -939,6 +994,7 @@ describe("ThreadsView header-driven (floating) search", () => {
         onNew={() => {}}
         onNewThreadInWorktree={() => {}}
         onDeleteWorktreeGroup={() => {}}
+        onMoveThreadToWorktree={() => {}}
         onOpenTerminal={() => {}}
         onRunProjectAction={() => {}}
       />,
@@ -1000,6 +1056,7 @@ describe("ThreadsView header-driven (floating) search", () => {
         onNew={() => {}}
         onNewThreadInWorktree={() => {}}
         onDeleteWorktreeGroup={() => {}}
+        onMoveThreadToWorktree={() => {}}
         onOpenTerminal={() => {}}
         onRunProjectAction={() => {}}
       />,
@@ -1030,6 +1087,7 @@ describe("ThreadsView header-driven (floating) search", () => {
           onNew={() => {}}
           onNewThreadInWorktree={() => {}}
           onDeleteWorktreeGroup={() => {}}
+          onMoveThreadToWorktree={() => {}}
           onOpenTerminal={() => {}}
           onRunProjectAction={() => {}}
         />,

--- a/src/mobile/views/ThreadsView.tsx
+++ b/src/mobile/views/ThreadsView.tsx
@@ -587,6 +587,7 @@ export function ThreadsView(props: ThreadsViewProps) {
         onThreadAction={props.onThreadAction}
         onNewThreadInWorktree={props.onNewThreadInWorktree}
         onDeleteWorktreeGroup={props.onDeleteWorktreeGroup}
+        onMoveThreadToWorktree={props.onMoveThreadToWorktree}
         onOpenTerminal={props.onOpenTerminal}
         onRunProjectAction={props.onRunProjectAction}
       >
@@ -669,6 +670,7 @@ export function ThreadsView(props: ThreadsViewProps) {
           onAction={(action) => props.onThreadAction(menuThread, action)}
           onNewThreadInWorktree={props.onNewThreadInWorktree}
           onDeleteWorktreeGroup={props.onDeleteWorktreeGroup}
+          onMoveThreadToWorktree={props.onMoveThreadToWorktree}
           onOpenTerminal={props.onOpenTerminal}
           onRunProjectAction={props.onRunProjectAction}
           onClose={threadMenu.close}

--- a/src/mobile/views/threadActionSurfaces.tsx
+++ b/src/mobile/views/threadActionSurfaces.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CircleCheck,
+  GitFork,
   Pencil,
   Play,
   Plus,
@@ -32,6 +33,8 @@ export interface ThreadActionCallbacks {
     readonly worktreePath: string;
     readonly threadIds: readonly string[];
   }) => void;
+  /** Move a main-checkout thread into a fresh worktree (optionally carrying uncommitted changes). */
+  readonly onMoveThreadToWorktree: (thread: Thread, withChanges: boolean) => void;
   readonly onOpenTerminal: (input: {
     readonly projectId: string;
     readonly worktreePath?: string;
@@ -78,6 +81,35 @@ function RunActionsPage(props: {
   );
 }
 
+function MoveToWorktreePage(props: {
+  readonly onBack: () => void;
+  readonly onPick: (withChanges: boolean) => void;
+}) {
+  const { t } = useLingui();
+
+  return (
+    <>
+      <div className="m-sheet-head">
+        <span className="truncate">{t`Move to Worktree`}</span>
+      </div>
+      <div className="m-sheet-list">
+        <button type="button" className="m-sheet-action" onClick={props.onBack}>
+          <ChevronLeft className="size-4 shrink-0 text-muted" />
+          <span>{t`Back`}</span>
+        </button>
+        <button type="button" className="m-sheet-action" onClick={() => props.onPick(true)}>
+          <GitFork className="size-4 shrink-0 text-muted" />
+          <span>{t`Bring Uncommitted Changes`}</span>
+        </button>
+        <button type="button" className="m-sheet-action" onClick={() => props.onPick(false)}>
+          <GitFork className="size-4 shrink-0 text-muted" />
+          <span>{t`Clean Worktree`}</span>
+        </button>
+      </div>
+    </>
+  );
+}
+
 function SheetSubmenuPages(props: {
   readonly submenuOpen: boolean;
   readonly main: ReactNode;
@@ -112,6 +144,7 @@ export function ThreadActionsSheet(props: {
   readonly onAction: (action: ThreadAction) => void;
   readonly onNewThreadInWorktree: ThreadActionCallbacks["onNewThreadInWorktree"];
   readonly onDeleteWorktreeGroup: ThreadActionCallbacks["onDeleteWorktreeGroup"];
+  readonly onMoveThreadToWorktree: ThreadActionCallbacks["onMoveThreadToWorktree"];
   readonly onOpenTerminal: ThreadActionCallbacks["onOpenTerminal"];
   readonly onRunProjectAction: ThreadActionCallbacks["onRunProjectAction"];
   readonly onClose: () => void;
@@ -119,7 +152,7 @@ export function ThreadActionsSheet(props: {
   const { thread } = props;
   const { t } = useLingui();
   const [renaming, setRenaming] = useState(props.initialRenaming ?? false);
-  const [showRunActions, setShowRunActions] = useState(false);
+  const [submenu, setSubmenu] = useState<"run" | "move" | null>(null);
   const runActions = props.project?.scripts?.actions ?? [];
 
   const act = (action: ThreadAction) => {
@@ -150,22 +183,31 @@ export function ThreadActionsSheet(props: {
       onClose={props.onClose}
     >
       <SheetSubmenuPages
-        submenuOpen={showRunActions}
+        submenuOpen={submenu !== null}
         submenu={
-          <RunActionsPage
-            actions={runActions}
-            onBack={() => setShowRunActions(false)}
-            onRun={(actionId) =>
-              runAndClose(() =>
-                props.onRunProjectAction({
-                  projectId: thread.projectId,
-                  actionId,
-                  ...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {}),
-                  sourceThreadId: thread.id,
-                }),
-              )
-            }
-          />
+          submenu === "move" ? (
+            <MoveToWorktreePage
+              onBack={() => setSubmenu(null)}
+              onPick={(withChanges) =>
+                runAndClose(() => props.onMoveThreadToWorktree(thread, withChanges))
+              }
+            />
+          ) : (
+            <RunActionsPage
+              actions={runActions}
+              onBack={() => setSubmenu(null)}
+              onRun={(actionId) =>
+                runAndClose(() =>
+                  props.onRunProjectAction({
+                    projectId: thread.projectId,
+                    actionId,
+                    ...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {}),
+                    sourceThreadId: thread.id,
+                  }),
+                )
+              }
+            />
+          )
         }
         main={
           <>
@@ -197,12 +239,15 @@ export function ThreadActionsSheet(props: {
                   </span>
                 </button>
               ) : null}
+              {!worktreePath ? (
+                <button type="button" className="m-sheet-action" onClick={() => setSubmenu("move")}>
+                  <GitFork className="size-4 shrink-0 text-muted" />
+                  <span className="flex-1">{t`Move to Worktree`}</span>
+                  <ChevronRight className="size-4 shrink-0 text-muted" />
+                </button>
+              ) : null}
               {runActions.length > 0 ? (
-                <button
-                  type="button"
-                  className="m-sheet-action"
-                  onClick={() => setShowRunActions(true)}
-                >
+                <button type="button" className="m-sheet-action" onClick={() => setSubmenu("run")}>
                   <Play className="size-4 shrink-0 text-muted" />
                   <span className="flex-1">{t`Run`}</span>
                   <ChevronRight className="size-4 shrink-0 text-muted" />

--- a/src/mobile/views/threadContextMenus.tsx
+++ b/src/mobile/views/threadContextMenus.tsx
@@ -1,6 +1,16 @@
 import type { ReactNode } from "react";
 import { useLingui } from "@lingui/react/macro";
-import { Archive, CircleCheck, Pencil, Play, Plus, Star, Terminal, Trash2 } from "lucide-react";
+import {
+  Archive,
+  CircleCheck,
+  GitFork,
+  Pencil,
+  Play,
+  Plus,
+  Star,
+  Terminal,
+  Trash2,
+} from "lucide-react";
 import type { Project, Thread } from "@/shared/contracts";
 import { ContextMenu, type ContextMenuEntry } from "@/renderer/components/common/ContextMenu";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
@@ -34,6 +44,26 @@ export function ThreadContextMenu(props: ThreadContextMenuProps) {
             id: "new-thread-in-worktree",
             label: t`New thread in worktree`,
             icon: <Plus className="size-3.5" />,
+          },
+        ]
+      : []),
+    ...(!worktreePath
+      ? [
+          {
+            type: "submenu" as const,
+            id: "move-to-worktree",
+            label: t`Move to Worktree`,
+            icon: <GitFork className="size-3.5" />,
+            items: [
+              {
+                id: "move-to-worktree-with-changes",
+                label: t`Bring Uncommitted Changes`,
+              },
+              {
+                id: "move-to-worktree-clean",
+                label: t`Clean Worktree`,
+              },
+            ],
           },
         ]
       : []),
@@ -101,6 +131,10 @@ export function ThreadContextMenu(props: ThreadContextMenuProps) {
         worktreePath,
         worktreeBranch,
       });
+    } else if (key === "move-to-worktree-with-changes") {
+      props.onMoveThreadToWorktree(thread, true);
+    } else if (key === "move-to-worktree-clean") {
+      props.onMoveThreadToWorktree(thread, false);
     } else if (key === "rename") {
       props.onRename();
     } else if (key === "toggle-done") {
@@ -137,7 +171,7 @@ export function ThreadContextMenu(props: ThreadContextMenuProps) {
   );
 }
 
-interface GroupContextMenuProps extends ThreadActionCallbacks {
+interface GroupContextMenuProps extends Omit<ThreadActionCallbacks, "onMoveThreadToWorktree"> {
   readonly entry: GroupEntry;
   readonly project?: Project | undefined;
   readonly children: ReactNode;

--- a/src/renderer/actions/moveThreadToWorktreeActions.test.ts
+++ b/src/renderer/actions/moveThreadToWorktreeActions.test.ts
@@ -5,7 +5,6 @@ const mocks = vi.hoisted(() => ({
   appState: {
     projects: [] as Project[],
     threads: [] as Thread[],
-    setThreadWorktree: vi.fn<(threadId: string, path: string, branch: string) => void>(),
   },
   createWorktree:
     vi.fn<
@@ -14,6 +13,15 @@ const mocks = vi.hoisted(() => ({
   primeWorktreeGitState: vi.fn<() => Promise<void>>(),
   refreshGitProject: vi.fn<() => Promise<void>>(),
   reopenStoredThread: vi.fn<(threadId: string) => void>(),
+  setThreadWorktree:
+    vi.fn<
+      (
+        threadId: string,
+        path: string,
+        branch: string,
+        options?: { isNewWorktree?: boolean },
+      ) => Promise<void>
+    >(),
   runWorktreeSetupScript: vi.fn<() => Promise<void>>(),
   unloadStoredThread: vi.fn<(threadId: string) => Promise<void>>(),
   toast: {
@@ -39,6 +47,7 @@ vi.mock("@/renderer/state/gitStore", () => ({
 }));
 vi.mock("./threadActions", () => ({
   reopenStoredThread: mocks.reopenStoredThread,
+  setThreadWorktree: mocks.setThreadWorktree,
   unloadStoredThread: mocks.unloadStoredThread,
 }));
 vi.mock("./worktreeLaunchActions", () => ({
@@ -56,11 +65,20 @@ const project = {
   createdAt: "2026-08-04T00:00:00.000Z",
 } satisfies Project;
 
-function thread(status: Thread["status"]): Thread {
+const remoteProject = {
+  ...project,
+  id: "remote:d1:project:project-1",
+  remoteServerId: "d1",
+  remoteId: "project-1",
+  location: { kind: "posix" as const, path: "/repo", remoteServerId: "d1" },
+} satisfies Project;
+
+function thread(status: Thread["status"], overrides: Partial<Thread> = {}): Thread {
   return {
     id: "thread-1",
     projectId: project.id,
     status,
+    ...overrides,
   } as Thread;
 }
 
@@ -73,6 +91,7 @@ describe("moveThreadToWorktree", () => {
     mocks.refreshGitProject.mockResolvedValue(undefined);
     mocks.runWorktreeSetupScript.mockResolvedValue(undefined);
     mocks.unloadStoredThread.mockResolvedValue(undefined);
+    mocks.setThreadWorktree.mockResolvedValue(undefined);
   });
 
   it("keeps an active thread open and relaunches it in the new worktree", async () => {
@@ -81,12 +100,14 @@ describe("moveThreadToWorktree", () => {
     await moveThreadToWorktree("thread-1", false);
 
     expect(mocks.unloadStoredThread).toHaveBeenCalledWith("thread-1");
-    expect(mocks.appState.setThreadWorktree).toHaveBeenCalledWith(
+    expect(mocks.setThreadWorktree).toHaveBeenCalledWith(
       "thread-1",
       "C:\\worktrees\\test",
       "poracode/test-branch",
+      { isNewWorktree: true },
     );
     expect(mocks.reopenStoredThread).toHaveBeenCalledWith("thread-1");
+    expect(mocks.primeWorktreeGitState).toHaveBeenCalled();
   });
 
   it("does not launch a thread that was already inactive", async () => {
@@ -96,5 +117,37 @@ describe("moveThreadToWorktree", () => {
 
     expect(mocks.unloadStoredThread).not.toHaveBeenCalled();
     expect(mocks.reopenStoredThread).not.toHaveBeenCalled();
+    expect(mocks.setThreadWorktree).toHaveBeenCalledWith(
+      "thread-1",
+      "C:\\worktrees\\test",
+      "poracode/test-branch",
+      { isNewWorktree: true },
+    );
+  });
+
+  it("uses the same setThreadWorktree path for remote threads (host routes)", async () => {
+    mocks.appState.projects = [remoteProject];
+    mocks.appState.threads = [
+      thread("idle", {
+        id: "remote:d1:thread:remote-thread",
+        projectId: remoteProject.id,
+        remoteServerId: "d1",
+        remoteId: "remote-thread",
+      }),
+    ];
+    mocks.createWorktree.mockResolvedValue({ path: "/repo/.poracode/worktrees/feature" });
+
+    await moveThreadToWorktree("remote:d1:thread:remote-thread", true);
+
+    expect(mocks.setThreadWorktree).toHaveBeenCalledWith(
+      "remote:d1:thread:remote-thread",
+      "/repo/.poracode/worktrees/feature",
+      "poracode/test-branch",
+      { isNewWorktree: true },
+    );
+    expect(mocks.reopenStoredThread).toHaveBeenCalledWith("remote:d1:thread:remote-thread");
+    // Host set-worktree isNewWorktree owns prime/setup — client must not double-run.
+    expect(mocks.primeWorktreeGitState).not.toHaveBeenCalled();
+    expect(mocks.runWorktreeSetupScript).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/actions/moveThreadToWorktreeActions.ts
+++ b/src/renderer/actions/moveThreadToWorktreeActions.ts
@@ -6,7 +6,8 @@ import { i18n } from "@/renderer/i18n/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { refreshGitProject } from "@/renderer/state/gitRefresh";
 import { useGitStore } from "@/renderer/state/gitStore";
-import { reopenStoredThread, unloadStoredThread } from "./threadActions";
+import { remoteOwner } from "@/renderer/state/remoteProjection";
+import { reopenStoredThread, setThreadWorktree, unloadStoredThread } from "./threadActions";
 import {
   createWorktree,
   primeWorktreeGitState,
@@ -20,6 +21,9 @@ const movingThreadIds = new Set<string>();
  * Active threads are relaunched there. `withChanges` MOVES the project's
  * uncommitted changes into the worktree, leaving the current branch clean.
  * Failures are toasted here.
+ *
+ * Local and remote share this path. Git create and thread metadata updates go
+ * through helpers that route to the host when the project is projected.
  */
 export async function moveThreadToWorktree(threadId: string, withChanges: boolean): Promise<void> {
   if (movingThreadIds.has(threadId)) return;
@@ -34,10 +38,14 @@ export async function moveThreadToWorktree(threadId: string, withChanges: boolea
     return;
   }
 
+  const wasActive = thread.status !== "inactive";
+  // Host-owned threads: `set-worktree` with isNewWorktree already primes git and
+  // runs setup on the desktop — do not double-run those from the client.
+  const hostFollowUp = remoteOwner(thread) !== undefined;
   movingThreadIds.add(threadId);
   try {
     // Re-tagging only sticks for a stopped thread — unload any live runtime first.
-    if (thread.status !== "inactive") {
+    if (wasActive) {
       await unloadStoredThread(threadId);
     }
     const currentBranch = useGitStore.getState().statuses[project.id]?.branch;
@@ -49,14 +57,16 @@ export async function moveThreadToWorktree(threadId: string, withChanges: boolea
       transferUncommitted: withChanges,
       keepChangesInSource: false,
     });
-    useAppStore.getState().setThreadWorktree(threadId, result.path, branch);
-    if (thread.status !== "inactive") reopenStoredThread(threadId);
-    void primeWorktreeGitState(project, result.path);
-    void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
-    const setupScript = project.scripts?.setupScript;
-    if (setupScript) {
-      void runWorktreeSetupScript(project, result.path, setupScript);
+    await setThreadWorktree(threadId, result.path, branch, { isNewWorktree: true });
+    if (wasActive) reopenStoredThread(threadId);
+    if (!hostFollowUp) {
+      void primeWorktreeGitState(project, result.path);
+      const setupScript = project.scripts?.setupScript;
+      if (setupScript) {
+        void runWorktreeSetupScript(project, result.path, setupScript);
+      }
     }
+    void refreshGitProject({ id: project.id, location: project.location }, "manual", "full");
 
     if (withChanges) {
       // `newBranch` keeps the msgid identical to the BranchSelector conflict

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -16,6 +16,7 @@ import {
   reopenPaneThreadsIfInactive,
   reopenStoredThread,
   setThreadRuntimeReopenEnabled,
+  setThreadWorktree,
   switchToAdjacentThread,
   toggleMarkThreadDone,
   toggleStarThread,
@@ -441,6 +442,37 @@ describe("threadActions", () => {
 
     resolveCommand();
     await waitFor(() => expect(useAppStore.getState().threads[0]?.archived).toBe(true));
+  });
+
+  it("tags a local thread with worktree metadata in the store", async () => {
+    const thread = makeThread();
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    await setThreadWorktree(thread.id, "/repo/wt", "feature/x", { isNewWorktree: true });
+
+    expect(sendThreadCommand).not.toHaveBeenCalled();
+    expect(useAppStore.getState().threads[0]?.worktreePath).toBe("/repo/wt");
+    expect(useAppStore.getState().threads[0]?.worktreeBranch).toBe("feature/x");
+  });
+
+  it("routes set-worktree through the host for remote threads before mirroring locally", async () => {
+    const thread = makeThread({
+      remoteServerId: "remote-server",
+      remoteId: "remote-thread",
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    await setThreadWorktree(thread.id, "/repo/wt", "feature/x", { isNewWorktree: true });
+
+    expect(sendThreadCommand).toHaveBeenCalledWith("remote-server", {
+      kind: "set-worktree",
+      threadId: "remote-thread",
+      worktreePath: "/repo/wt",
+      worktreeBranch: "feature/x",
+      isNewWorktree: true,
+    });
+    expect(useAppStore.getState().threads[0]?.worktreePath).toBe("/repo/wt");
+    expect(useAppStore.getState().threads[0]?.worktreeBranch).toBe("feature/x");
   });
 
   it("unloads a remote thread through the central bridge before refreshing its host", async () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -530,6 +530,39 @@ export function renameThread(threadId: string, title: string): void {
   store.renameThread(threadId, title);
 }
 
+/**
+ * Tag a thread with worktree metadata. Local threads update the store (and
+ * persist via the app DB); remote projected threads go through the host's
+ * existing `set-worktree` command so the durable row is updated on the machine
+ * that owns the project.
+ */
+export async function setThreadWorktree(
+  threadId: string,
+  worktreePath: string,
+  worktreeBranch?: string,
+  options?: { isNewWorktree?: boolean },
+): Promise<void> {
+  const store = useAppStore.getState();
+  const thread = store.threads.find((candidate) => candidate.id === threadId);
+  if (!thread) return;
+
+  const apply = () => {
+    useAppStore.getState().setThreadWorktree(threadId, worktreePath, worktreeBranch);
+  };
+
+  const owner = remoteOwner(thread);
+  if (owner) {
+    await useRemoteServersStore.getState().sendThreadCommand(owner.desktopId, {
+      kind: "set-worktree",
+      threadId: owner.remoteId,
+      worktreePath,
+      ...(worktreeBranch ? { worktreeBranch } : {}),
+      ...(options?.isNewWorktree ? { isNewWorktree: true } : {}),
+    });
+  }
+  apply();
+}
+
 /** Clear the unread completion marker without navigating the source desktop. */
 export function acknowledgeThread(threadId: string): void {
   const thread = useAppStore.getState().threads.find((item) => item.id === threadId);

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Zurück ins Panel holen"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Holen Sie ihn zurück in dieses Panel oder wechseln Sie zum Fenster, in dem er läuft."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Nicht festgeschriebene Änderungen mitbringen"
@@ -2223,6 +2225,8 @@ msgstr "Claude-Profilname"
 msgid "Claude profile removed."
 msgstr "Claude-Profil entfernt."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Sauberer Arbeitsbaum"
@@ -3151,6 +3155,10 @@ msgstr "Der Skill konnte nicht geladen werden."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Ihre Profilstatistiken konnten nicht geladen werden."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Thread konnte nicht in einen Arbeitsbaum verschoben werden."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Browser in Fenster verschieben"
 msgid "Move changes to a new worktree"
 msgstr "Änderungen in einen neuen Arbeitsbaum verschieben"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "In sauberen Arbeitsbaum verschieben"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "In Arbeitsbereich verschieben"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "In Arbeitsbaum verschieben"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Mit Änderungen in Arbeitsbaum verschieben"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Gewinner zu
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Warten Sie, bis alle Kandidaten fertig sind, bevor Sie einen Pull Request öffnen."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Warten Sie, bis der Thread vollständig gestartet ist, bevor Sie ihn in einen Arbeitsbaum verschieben."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1724,6 +1724,8 @@ msgstr "Bring back to panel"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bring it back into this panel, or jump to the window it’s running in."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Bring Uncommitted Changes"
@@ -2228,6 +2230,8 @@ msgstr "Claude profile name"
 msgid "Claude profile removed."
 msgstr "Claude profile removed."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Clean Worktree"
@@ -3156,6 +3160,10 @@ msgstr "Couldn't load the skill."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Couldn't load your profile stats."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Couldn't move the thread to a worktree."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6619,13 +6627,23 @@ msgstr "Move browser to window"
 msgid "Move changes to a new worktree"
 msgstr "Move changes to a new worktree"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Move to clean worktree"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Move to Workspace"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Move to Worktree"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Move to worktree with changes"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12446,6 +12464,7 @@ msgstr "Wait for every candidate to finish before merging a winner."
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Wait for every candidate to finish before opening a pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Wait for the thread to finish starting before moving it to a worktree."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Devolver al panel"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Devuélvelo a este panel o ve a la ventana en la que se está ejecutando."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Traer cambios sin confirmar"
@@ -2223,6 +2225,8 @@ msgstr "Nombre del perfil de Claude"
 msgid "Claude profile removed."
 msgstr "Perfil de Claude eliminado."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Worktree limpio"
@@ -3151,6 +3155,10 @@ msgstr "No se pudo cargar la skill."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "No se pudieron cargar las estadísticas de tu perfil."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "No se pudo mover el hilo a un worktree."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Mover navegador a una ventana"
 msgid "Move changes to a new worktree"
 msgstr "Mover cambios a un nuevo worktree"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Mover a worktree limpio"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover a espacio de trabajo"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Mover a worktree"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Mover a worktree con cambios"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Espera a que todos los candidatos terminen antes de fusionar a un ganado
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Espera a que todos los candidatos terminen antes de abrir una pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Espera a que el hilo termine de iniciarse antes de moverlo a un worktree."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Ramener dans le panneau"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Ramenez-le dans ce panneau ou accédez à la fenêtre dans laquelle il s’exécute."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Apporter les modifications non validées"
@@ -2223,6 +2225,8 @@ msgstr "Nom du profil Claude"
 msgid "Claude profile removed."
 msgstr "Profil de Claude supprimé."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Worktree propre"
@@ -3151,6 +3155,10 @@ msgstr "Impossible de charger la compétence."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Impossible de charger vos statistiques de profil."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Impossible de déplacer le fil de discussion vers un worktree."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6613,13 +6621,23 @@ msgstr "Déplacer le navigateur vers une fenêtre"
 msgid "Move changes to a new worktree"
 msgstr "Déplacer les modifications vers un nouvel arbre de travail"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Déplacer vers un worktree propre"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Déplacer vers un espace de travail"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Déplacer vers un worktree"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Déplacer vers un worktree avec les modifications"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12440,6 +12458,7 @@ msgstr "Attendez que tous les candidats aient terminé avant de fusionner un gag
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Attendez que tous les candidats aient terminé avant d’ouvrir une pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Attendez que le fil de discussion ait fini de démarrer avant de le déplacer vers un worktree."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1718,6 +1718,8 @@ msgstr "パネルに戻す"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "このパネルに戻すか、実行中のウィンドウに移動します。"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "コミットされていない変更を持ち込む"
@@ -2222,6 +2224,8 @@ msgstr "Claude プロファイル名"
 msgid "Claude profile removed."
 msgstr "Claude プロファイルが削除されました。"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "クリーンなワークツリー"
@@ -3150,6 +3154,10 @@ msgstr "スキルを読み込めませんでした。"
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "プロフィール統計を読み込めませんでした。"
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "スレッドをワークツリーに移動できませんでした。"
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6612,13 +6620,23 @@ msgstr "ブラウザーをウィンドウに移動"
 msgid "Move changes to a new worktree"
 msgstr "変更を新しいワークツリーに移動する"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "クリーンなワークツリーに移動"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "ワークスペースへ移動"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "ワークツリーに移動"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "変更を含めてワークツリーに移動"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12439,6 +12457,7 @@ msgstr "勝者をマージする前に、すべての候補が完了するまで
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "プルリクエストを開く前に、すべての候補が完了するまで待ってください。"
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "ワークツリーに移動する前に、スレッドの起動が完了するまでお待ちください。"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1719,6 +1719,8 @@ msgstr "패널로 되돌리기"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "이 패널로 되돌리거나 실행 중인 창으로 이동하세요."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "커밋되지 않은 변경 사항 가져오기"
@@ -2223,6 +2225,8 @@ msgstr "Claude 프로필 이름"
 msgid "Claude profile removed."
 msgstr "Claude 프로필이 삭제되었습니다."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "클린 작업 트리"
@@ -3151,6 +3155,10 @@ msgstr "스킬을 불러올 수 없습니다."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "프로필 통계를 불러오지 못했습니다."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "스레드를 작업 트리로 이동할 수 없습니다."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "브라우저를 창으로 이동"
 msgid "Move changes to a new worktree"
 msgstr "변경 사항을 새 작업 트리로 이동"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "클린 작업 트리로 이동"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "작업 영역으로 이동"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "작업 트리로 이동"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "변경 사항을 포함해 작업 트리로 이동"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "우승자를 병합하기 전에 모든 후보가 완료될 때까지 �
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "풀 리퀘스트를 열기 전에 모든 후보가 완료될 때까지 기다리세요."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "작업 트리로 이동하기 전에 스레드 시작이 완료될 때까지 기다리세요."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Przywróć do panelu"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Przywróć ją do tego panelu lub przejdź do okna, w którym działa."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Przenieś niezatwierdzone zmiany"
@@ -2223,6 +2225,8 @@ msgstr "Nazwa profilu Claude"
 msgid "Claude profile removed."
 msgstr "Usunięto profil Claude'a."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Czyste drzewo robocze"
@@ -3151,6 +3155,10 @@ msgstr "Nie udało się wczytać umiejętności."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Nie udało się wczytać statystyk profilu."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Nie udało się przenieść wątku do drzewa roboczego."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Przenieś przeglądarkę do okna"
 msgid "Move changes to a new worktree"
 msgstr "Przenieś zmiany do nowego drzewa roboczego"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Przenieś do czystego drzewa roboczego"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Przenieś do obszaru roboczego"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Przenieś do drzewa roboczego"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Przenieś do drzewa roboczego ze zmianami"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Przed scaleniem zmian zwycięzcy zaczekaj, aż wszyscy kandydaci zakońc
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Przed otwarciem pull requesta zaczekaj, aż wszyscy kandydaci zakończą pracę."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Poczekaj, aż wątek zakończy uruchamianie, przed przeniesieniem go do drzewa roboczego."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Trazer de volta ao painel"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Traga-o de volta para este painel ou vá para a janela em que ele está sendo executado."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Trazer alterações não commitadas"
@@ -2223,6 +2225,8 @@ msgstr "Nome do perfil de Claude"
 msgid "Claude profile removed."
 msgstr "Perfil de Claude removido."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Árvore de trabalho limpa"
@@ -3151,6 +3155,10 @@ msgstr "Não foi possível carregar a skill."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Não foi possível carregar as estatísticas do seu perfil."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Não foi possível mover o tópico para uma árvore de trabalho."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Mover navegador para uma janela"
 msgid "Move changes to a new worktree"
 msgstr "Mover alterações para uma nova árvore de trabalho"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Mover para árvore de trabalho limpa"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover para espaço de trabalho"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Mover para árvore de trabalho"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Mover para árvore de trabalho com alterações"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Aguarde todos os candidatos terminarem antes de mesclar um vencedor."
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Aguarde todos os candidatos terminarem antes de abrir uma pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Aguarde o tópico terminar de iniciar antes de movê-lo para uma árvore de trabalho."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Вернуть на панель"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Верните его на эту панель или перейдите к окну, в котором он запущен."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Перенести незакоммиченные изменения"
@@ -2223,6 +2225,8 @@ msgstr "Имя профиля Claude"
 msgid "Claude profile removed."
 msgstr "Профиль Claude удалён."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Чистый worktree"
@@ -3151,6 +3155,10 @@ msgstr "Не удалось загрузить навык."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Не удалось загрузить статистику профиля."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Не удалось переместить тред в worktree."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Переместить браузер в окно"
 msgid "Move changes to a new worktree"
 msgstr "Переместить изменения в новый worktree"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Переместить в чистый worktree"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Переместить в рабочую область"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Переместить в worktree"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Переместить в worktree с изменениями"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Дождитесь завершения работы всех канди
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Дождитесь завершения работы всех кандидатов перед созданием pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Дождитесь завершения запуска треда, прежде чем перемещать его в worktree."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Panele geri getir"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Bu panele geri getirin veya çalıştığı pencereye geçin."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Kaydedilmemiş değişiklikleri getir"
@@ -2223,6 +2225,8 @@ msgstr "Claude profil adı"
 msgid "Claude profile removed."
 msgstr "Claude profili kaldırıldı."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Temiz çalışma ağacı"
@@ -3151,6 +3155,10 @@ msgstr "Beceri yüklenemedi."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Profil istatistikleriniz yüklenemedi."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Konu çalışma ağacına taşınamadı."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Tarayıcıyı pencereye taşı"
 msgid "Move changes to a new worktree"
 msgstr "Değişiklikleri yeni bir çalışma ağacına taşı"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Temiz çalışma ağacına taşı"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Çalışma alanına taşı"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Çalışma ağacına taşı"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Değişikliklerle çalışma ağacına taşı"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Kazananı birleştirmeden önce tüm adayların çalışmasını tamamla
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Pull request açmadan önce tüm adayların çalışmasını tamamlamasını bekleyin."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Çalışma ağacına taşımadan önce konunun başlamasının bitmesini bekleyin."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Повернути на панель"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Поверніть його на цю панель або перейдіть до вікна, де він запущений."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Перенести незакомічені зміни"
@@ -2223,6 +2225,8 @@ msgstr "Ім'я профілю Claude"
 msgid "Claude profile removed."
 msgstr "Профіль Claude видалено."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Чистий worktree"
@@ -3151,6 +3155,10 @@ msgstr "Не вдалося завантажити навичку."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Не вдалося завантажити статистику профілю."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Не вдалося перемістити тред у worktree."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Перемістити браузер у вікно"
 msgid "Move changes to a new worktree"
 msgstr "Перемістити зміни в новий worktree"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Перемістити в чистий worktree"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Перемістити до робочої області"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Перемістити в worktree"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Перемістити в worktree зі змінами"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Зачекайте, доки всі кандидати завершат�
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Зачекайте, доки всі кандидати завершать роботу, перш ніж відкривати pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Дочекайтеся завершення запуску треда, перш ніж переміщувати його в worktree."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1719,6 +1719,8 @@ msgstr "Đưa về bảng điều khiển"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "Đưa trở lại bảng điều khiển này, hoặc chuyển đến cửa sổ đang chạy."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "Mang theo các thay đổi chưa được cam kết"
@@ -2223,6 +2225,8 @@ msgstr "Tên hồ sơ Claude"
 msgid "Claude profile removed."
 msgstr "Hồ sơ Claude đã bị xóa."
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "Cây làm việc sạch"
@@ -3151,6 +3155,10 @@ msgstr "Không thể tải skill."
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "Không thể tải thống kê hồ sơ của bạn."
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "Không thể chuyển chủ đề sang cây làm việc."
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6614,13 +6622,23 @@ msgstr "Chuyển trình duyệt sang cửa sổ"
 msgid "Move changes to a new worktree"
 msgstr "Di chuyển các thay đổi sang một cây làm việc mới"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "Chuyển sang cây làm việc sạch"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Chuyển tới không gian làm việc"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "Chuyển sang cây làm việc"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "Chuyển sang cây làm việc kèm thay đổi"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12441,6 +12459,7 @@ msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi hợp nhất
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "Hãy đợi tất cả ứng viên hoàn tất trước khi mở pull request."
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "Đợi luồng khởi động xong trước khi chuyển nó sang cây làm việc."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1719,6 +1719,8 @@ msgstr "移回面板"
 msgid "Bring it back into this panel, or jump to the window it’s running in."
 msgstr "将其移回此面板，或跳转到正在运行它的窗口。"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Bring Uncommitted Changes"
 msgstr "带上未提交的更改"
@@ -2223,6 +2225,8 @@ msgstr "Claude 配置文件名称"
 msgid "Claude profile removed."
 msgstr "Claude 配置文件已删除。"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Clean Worktree"
 msgstr "干净的工作树"
@@ -3151,6 +3155,10 @@ msgstr "无法加载技能。"
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "Couldn't load your profile stats."
 msgstr "无法加载你的资料统计。"
+
+#: src/mobile/useRemoteDesktop.ts
+msgid "Couldn't move the thread to a worktree."
+msgstr "无法将线程移至工作树。"
 
 #: src/mobile/routeComponents.tsx
 msgid "Couldn't reach the desktop from this HTTPS page."
@@ -6613,13 +6621,23 @@ msgstr "将浏览器移到窗口"
 msgid "Move changes to a new worktree"
 msgstr "将更改移至新工作树"
 
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to clean worktree"
+msgstr "移至干净的工作树"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "移动到工作区"
 
+#: src/mobile/views/threadActionSurfaces.tsx
+#: src/mobile/views/threadContextMenus.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 msgid "Move to Worktree"
 msgstr "移至工作树"
+
+#: src/mobile/ThreadTitleRow.tsx
+msgid "Move to worktree with changes"
+msgstr "连同更改移至工作树"
 
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #~ msgid "Move to Worktree…"
@@ -12440,6 +12458,7 @@ msgstr "请等待所有候选项完成后再合并优胜者。"
 msgid "Wait for every candidate to finish before opening a pull request."
 msgstr "请等待所有候选项完成后再创建拉取请求。"
 
+#: src/mobile/useRemoteDesktop.ts
 #: src/renderer/actions/moveThreadToWorktreeActions.ts
 msgid "Wait for the thread to finish starting before moving it to a worktree."
 msgstr "请等待线程启动完成，然后再将其移至工作树。"


### PR DESCRIPTION
- Add a shared `setThreadWorktree` helper so local and remote threads take one code path: local threads update store metadata directly, while remote projected threads send `set-worktree` through the owning host so the durable row updates on the machine that owns the project.
- Refactor `moveThreadToWorktree` to use the shared path; the host now owns git prime and setup-script handling for remote threads, removing double execution on the client.
- Add tests covering local store tagging and remote host routing (including `isNewWorktree` propagation).