### PR TITLE
Launch mirrored remote threads on host and reopen inactive ones

### DIFF
--- a/src/mobile/useRemoteDesktop.test.tsx
+++ b/src/mobile/useRemoteDesktop.test.tsx
@@ -2,6 +2,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { useAppStore } from "@/renderer/state/appStore";
+import { DEFAULT_TERMINAL_SIZE } from "@/shared/contracts";
 import type { RemoteShellSnapshot } from "@/shared/remote";
 import { RemoteClientError } from "@/shared/remote/client";
 import type { StoredDesktop } from "./storage";
@@ -365,7 +366,7 @@ describe("useRemoteDesktop", () => {
     h.storedThread.clear();
     h.isNativeApp = true;
     h.deviceId = "device-1";
-    useAppStore.setState({ threads: [] });
+    useAppStore.setState({ threads: [], projects: [] });
     for (const fn of [
       h.saveShellSnapshot,
       h.markDesktopConnected,
@@ -898,6 +899,109 @@ describe("useRemoteDesktop", () => {
     expect(client.startThread).not.toHaveBeenCalled();
     // The cached preload was applied conservatively (fromServer:false).
     expect(h.applyThreadSnapshot).toHaveBeenCalledWith(expect.anything(), { fromServer: false });
+  });
+
+  it("auto-starts an INACTIVE thread on open with the shared relaunch payload", async () => {
+    const d = makeDesktop("d1");
+    const inactiveThread = {
+      id: "t1",
+      projectId: "p",
+      title: "t1",
+      agentKind: "codex" as const,
+      agentInstanceId: "inst-9",
+      config: { model: "m" },
+      status: "inactive" as const,
+      attention: "none" as const,
+      canResumeWithConfig: false,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "terminal" as const,
+      sessionRef: { providerSessionId: "sess-1", discoveredAt: "2026-01-01T00:00:00.000Z" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const client = clientFor("d1");
+    client.threadHistory.mockResolvedValue({
+      snapshotSeq: 2,
+      thread: inactiveThread,
+      runtimeItems: [],
+      completedTurns: [],
+      contextUsage: null,
+      updatedAt: "",
+    });
+    const view = await mountWith([d], "d1");
+    await act(async () => {
+      useAppStore.setState({
+        projects: [{ id: "p", location: { kind: "posix", path: "/repo" }, name: "repo" }] as never,
+      });
+    });
+    client.startThread.mockClear();
+
+    await act(async () => {
+      await view.result.current.openThread(inactiveThread as never);
+    });
+
+    // The same empty-prompt relaunch payload the desktop renderer sends (see
+    // shared/threadRelaunch): agentInstanceId and sessionRef round-trip so the
+    // host resumes the same provider instance and session.
+    expect(client.startThread).toHaveBeenCalledTimes(1);
+    expect(client.startThread).toHaveBeenCalledWith({
+      threadId: "t1",
+      projectLocation: { kind: "posix", path: "/repo" },
+      agentKind: "codex",
+      agentInstanceId: "inst-9",
+      config: { model: "m" },
+      prompt: "",
+      initialSize: DEFAULT_TERMINAL_SIZE,
+      sessionRef: { providerSessionId: "sess-1", discoveredAt: "2026-01-01T00:00:00.000Z" },
+      presentationMode: "terminal",
+    });
+  });
+
+  it("does not auto-start a FINISHED terminal thread on open (the live session stays untouched)", async () => {
+    const d = makeDesktop("d1");
+    const finishedThread = {
+      id: "t2",
+      projectId: "p",
+      title: "t2",
+      agentKind: "codex" as const,
+      config: { model: "m" },
+      status: "finished" as const,
+      attention: "none" as const,
+      canResumeWithConfig: false,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "terminal" as const,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const client = clientFor("d1");
+    client.threadHistory.mockResolvedValue({
+      snapshotSeq: 2,
+      thread: finishedThread,
+      runtimeItems: [],
+      completedTurns: [],
+      contextUsage: null,
+      updatedAt: "",
+    });
+    const view = await mountWith([d], "d1");
+    await act(async () => {
+      useAppStore.setState({
+        projects: [{ id: "p", location: { kind: "posix", path: "/repo" }, name: "repo" }] as never,
+      });
+    });
+    client.startThread.mockClear();
+
+    await act(async () => {
+      await view.result.current.openThread(finishedThread as never);
+    });
+
+    // "finished" is the unwatched-completion badge over a LIVE host session;
+    // host-side startThread is close+restart, so an open-driven relaunch would
+    // kill the run. Only "inactive" relaunches (desktop parity).
+    expect(client.startThread).not.toHaveBeenCalled();
   });
 
   it("opening a DONE thread preserves done (no set-done command to the desktop)", async () => {

--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -8,8 +8,8 @@ import {
   type PromptSegment,
   type TerminalSize,
   type Thread,
-  type ThreadStatus,
 } from "@/shared/contracts";
+import { buildThreadRelaunchStartInput, shouldRelaunchThreadOnOpen } from "@/shared/threadRelaunch";
 import { buildWorktreeLocation } from "@/shared/worktree";
 import { isHomeProjectId } from "@/shared/homeScope";
 import { buildRemoteGitTargetInterests } from "@/shared/gitStateInterestPolicy";
@@ -125,22 +125,6 @@ async function restoreSshTransport(desktop: StoredDesktop): Promise<StoredDeskto
   await updateDesktopEndpoint(desktop.desktopId, result.endpoint);
   return { ...desktop, endpoint: result.endpoint };
 }
-
-const MOBILE_TERMINAL_START_STATUSES = new Set<ThreadStatus>([
-  "inactive",
-  "launching",
-  "finished",
-  "error",
-]);
-
-// For GUI threads "finished" (and "launching") mean the structured session is
-// still alive on the desktop — restarting would close+reopen a live session.
-// Only resume sessions that are actually gone, and only ones that ended
-// CLEANLY: a prompt-less resume of an "error" thread replays its broken turn,
-// which the agent session can keep re-entering on its own — an infinite
-// relaunch-into-working loop with no user input. Errored threads wait for an
-// explicit prompt instead.
-const MOBILE_GUI_START_STATUSES = new Set<ThreadStatus>(["inactive"]);
 
 /**
  * Owns the remote-desktop session: paired desktops, cached + live snapshots,
@@ -752,22 +736,19 @@ export function useRemoteDesktop() {
 
   /**
    * Activate an inactive thread on the desktop when the user opens it in the
-   * PWA. Terminal threads spawn a fresh PTY; GUI (native chat) threads resume
-   * their structured session via `sessionRef` (or open a new one when none was
-   * ever recorded). Both are driven with an empty prompt — the supervisor's
-   * `startThread` opens/resumes the session and leaves it idle, starting a turn
-   * only when a prompt is supplied. Only the presentation and terminal size
-   * differ between the two, so a single call covers both.
+   * PWA — the same reopen contract the desktop renderer applies (see
+   * shared/threadRelaunch). Terminal threads spawn a fresh PTY; GUI (native
+   * chat) threads resume their structured session via `sessionRef` (or open a
+   * new one when none was ever recorded). Both are driven with an empty
+   * prompt — the supervisor's `startThread` opens/resumes the session and
+   * leaves it idle, starting a turn only when a prompt is supplied.
    */
   async function ensureThreadRunning(
     thread: Thread,
     desktop: StoredDesktop,
     terminalSize?: TerminalSize,
   ): Promise<void> {
-    const presentation = thread.presentationMode ?? "terminal";
-    const startStatuses =
-      presentation === "terminal" ? MOBILE_TERMINAL_START_STATUSES : MOBILE_GUI_START_STATUSES;
-    if (!startStatuses.has(thread.status)) return;
+    if (!shouldRelaunchThreadOnOpen(thread)) return;
     const projectLocation = resolveThreadProjectLocation(thread);
     if (!projectLocation) {
       // The thread is startable but its project isn't in the current shell
@@ -776,17 +757,13 @@ export function useRemoteDesktop() {
       setOperationMessage(i18n._(msg`Unable to start the thread.`));
       return;
     }
-    await clientFor(desktop).startThread({
-      threadId: thread.id,
-      projectLocation,
-      agentKind: thread.agentKind,
-      ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
-      config: thread.config,
-      prompt: "",
-      initialSize: terminalSize ?? DEFAULT_TERMINAL_SIZE,
-      ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
-      presentationMode: presentation,
-    });
+    await clientFor(desktop).startThread(
+      buildThreadRelaunchStartInput({
+        thread,
+        projectLocation,
+        initialSize: terminalSize ?? DEFAULT_TERMINAL_SIZE,
+      }),
+    );
     void refresh(desktop, { refreshSelectedThread: true });
   }
 

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -390,6 +390,107 @@ describe("threadActions", () => {
     expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
   });
 
+  it("queues the same empty-prompt reopen for inactive remote threads as local", () => {
+    const thread = makeThread({
+      presentationMode: "gui",
+      status: "inactive",
+      remoteServerId: "desktop-1",
+      remoteId: "rt-1",
+      sessionRef: {
+        providerSessionId: "session-1",
+        discoveredAt: "2026-03-22T00:00:00.000Z",
+      },
+    });
+    useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+    reopenStoredThread(thread.id);
+
+    // Transport split is in performInitialThreadLaunch (remote client vs bridge).
+    expect(useAppStore.getState().threads[0]?.status).toBe("idle");
+    expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
+  });
+
+  it("reopens an inactive remote thread after history hydrates on open", async () => {
+    const previousOpenRemoteThread = useRemoteServersStore.getState().openRemoteThread;
+    const openRemoteThread = vi
+      .fn<(desktopId: string, threadId: string) => Promise<boolean>>()
+      .mockImplementation(async () => {
+        // Simulate history applying inactive status (same as openRemoteThread).
+        useAppStore.getState().updateThreadRuntime("thread-1", {
+          status: "inactive",
+          attention: "none",
+          canResumeWithConfig: true,
+          sessionRef: {
+            providerSessionId: "session-1",
+            discoveredAt: "2026-03-22T00:00:00.000Z",
+          },
+        });
+        return true;
+      });
+    useRemoteServersStore.setState({ openRemoteThread });
+    try {
+      const thread = makeThread({
+        presentationMode: "gui",
+        status: "inactive",
+        remoteServerId: "desktop-1",
+        remoteId: "rt-1",
+        canResumeWithConfig: true,
+        sessionRef: {
+          providerSessionId: "session-1",
+          discoveredAt: "2026-03-22T00:00:00.000Z",
+        },
+      });
+      useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+      openThread(thread.id);
+
+      await waitFor(() => {
+        expect(openRemoteThread).toHaveBeenCalledWith("desktop-1", "rt-1");
+      });
+      await waitFor(() => {
+        expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBe("");
+      });
+      expect(useAppStore.getState().threads[0]?.status).toBe("idle");
+    } finally {
+      useRemoteServersStore.setState({ openRemoteThread: previousOpenRemoteThread });
+    }
+  });
+
+  it("does not reopen when the remote open was superseded or failed", async () => {
+    const previousOpenRemoteThread = useRemoteServersStore.getState().openRemoteThread;
+    // openRemoteThread resolves false when it never applied a snapshot.
+    const openRemoteThread = vi
+      .fn<(desktopId: string, threadId: string) => Promise<boolean>>()
+      .mockResolvedValue(false);
+    useRemoteServersStore.setState({ openRemoteThread });
+    try {
+      const thread = makeThread({
+        presentationMode: "gui",
+        status: "inactive",
+        remoteServerId: "desktop-1",
+        remoteId: "rt-1",
+        canResumeWithConfig: true,
+        sessionRef: {
+          providerSessionId: "session-1",
+          discoveredAt: "2026-03-22T00:00:00.000Z",
+        },
+      });
+      useAppStore.setState((state) => ({ ...state, threads: [thread] }));
+
+      openThread(thread.id);
+
+      await waitFor(() => {
+        expect(openRemoteThread).toHaveBeenCalledWith("desktop-1", "rt-1");
+      });
+      // Flush the .then gate (microtasks) before asserting nothing was queued.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(useAppStore.getState().pendingThreadLaunches[thread.id]).toBeUndefined();
+      expect(useAppStore.getState().threads[0]?.status).toBe("inactive");
+    } finally {
+      useRemoteServersStore.setState({ openRemoteThread: previousOpenRemoteThread });
+    }
+  });
+
   it("closes a live CLI thread when marking done even before a session ref is known", async () => {
     const project = useAppStore.getState().addProject({
       kind: "posix",

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -9,6 +9,7 @@ import {
 import { isHomeProject } from "@/shared/homeScope";
 import { friendlyError } from "@/shared/messages";
 import { isDraftPaneId, parseDraftProjectId } from "@/shared/paneId";
+import { shouldRelaunchThreadOnOpen } from "@/shared/threadRelaunch";
 import { readBridge } from "@/renderer/bridge";
 import { useAppStore } from "@/renderer/state/appStore";
 import { findExperimentByThreadId, useExperimentStore } from "@/renderer/state/experimentStore";
@@ -327,7 +328,7 @@ export function reopenStoredThread(threadId: string): void {
   const store = useAppStore.getState();
   const thread = store.threads.find((item) => item.id === threadId);
   if (!thread) return;
-  if (thread.status !== "inactive" || store.pendingThreadLaunches[thread.id] !== undefined) {
+  if (!shouldRelaunchThreadOnOpen(thread) || store.pendingThreadLaunches[thread.id] !== undefined) {
     return;
   }
 

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -173,7 +173,19 @@ export function openThread(
       store.setPendingActiveThread(null);
       if (options?.focusComposer !== false) store.requestComposerFocus(threadId);
     });
-    void useRemoteServersStore.getState().openRemoteThread(owner.desktopId, owner.remoteId);
+    // Same open pipeline as local: hydrate remote history, then if still
+    // inactive queue the empty-prompt reopen. ThreadView runs
+    // performInitialThreadLaunch, which uses remote startThread instead of
+    // local IPC — the only intentional difference.
+    void useRemoteServersStore
+      .getState()
+      .openRemoteThread(owner.desktopId, owner.remoteId)
+      .then((opened) => {
+        // Reopen only when this open actually applied. A superseded open (the
+        // user already clicked another thread) or a failed one (host
+        // unreachable — the relaunch would fail noisily) resolves false.
+        if (opened && threadRuntimeReopenEnabled) reopenStoredThread(threadId);
+      });
     return;
   }
   const standalone = options?.standalone ?? findExperimentByThreadId(threadId) !== undefined;
@@ -328,6 +340,8 @@ export function reopenStoredThread(threadId: string): void {
       canResumeWithConfig: thread.canResumeWithConfig || thread.sessionRef !== undefined,
     });
   });
+  // Local and remote share this queue; performInitialThreadLaunch picks the
+  // host (local bridge vs remote client.startThread).
   store.queueThreadLaunch(thread.id, "");
 }
 

--- a/src/renderer/actions/threadLaunchActions.test.ts
+++ b/src/renderer/actions/threadLaunchActions.test.ts
@@ -5,9 +5,15 @@ const mocks = vi.hoisted(() => {
   const appState = {
     updateProjectDraftConfig: vi.fn<(projectId: string, config: unknown) => void>(),
     view: { kind: "home" as const },
+    projects: [] as Project[],
     threads: [] as Thread[],
     createThread: vi.fn<(input: unknown) => Thread>(),
     queueThreadLaunch: vi.fn<(threadId: string, prompt: string, segments?: unknown[]) => void>(),
+    setThreadMcpLaunchCustomServerNames:
+      vi.fn<(threadId: string, names: readonly string[]) => void>(),
+  };
+  const remoteClient = {
+    startThread: vi.fn<(input: unknown) => Promise<{ threadId: string }>>(),
   };
   const remoteState = {
     servers: [] as Array<{
@@ -17,10 +23,22 @@ const mocks = vi.hoisted(() => {
     }>,
     runtime: {} as Record<string, { status: string }>,
     launchRemoteThread: vi.fn<(input: unknown) => Promise<void>>(),
+    withClient:
+      vi.fn<
+        (
+          desktopId: string,
+          invoke: (client: typeof remoteClient) => Promise<unknown>,
+        ) => Promise<unknown>
+      >(),
+  };
+  const bridge = {
+    startThread: vi.fn<(input: unknown) => Promise<{ threadId: string }>>(),
   };
   return {
     appState,
     remoteState,
+    remoteClient,
+    bridge,
     createWorktree:
       vi.fn<
         (
@@ -70,8 +88,15 @@ vi.mock("@/renderer/state/sharedSettingsStore", () => ({
   useSharedSettings: {
     getState: () => ({
       pushRecentModel: vi.fn<(...args: unknown[]) => void>(),
+      mcpServers: [],
+      disabledBuiltInMcpServers: {},
+      disabledBuiltInMcpTools: {},
     }),
   },
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => mocks.bridge,
 }));
 
 vi.mock("@/renderer/analytics/posthog", () => ({
@@ -89,7 +114,7 @@ vi.mock("./worktreeLaunchActions", () => ({
   runWorktreeSetupScript: mocks.runWorktreeSetupScript,
 }));
 
-import { startThreadFromDraft } from "./threadLaunchActions";
+import { performInitialThreadLaunch, startThreadFromDraft } from "./threadLaunchActions";
 
 const localProject: Project = {
   id: "local-project",
@@ -116,6 +141,7 @@ describe("startThreadFromDraft host transport", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.appState.view = { kind: "home" };
+    mocks.appState.projects = [];
     mocks.appState.threads = [];
     mocks.appState.createThread.mockReturnValue({
       id: "local-thread",
@@ -128,6 +154,11 @@ describe("startThreadFromDraft host transport", () => {
     mocks.remoteState.servers = [];
     mocks.remoteState.runtime = { d1: { status: "online" } };
     mocks.remoteState.launchRemoteThread.mockResolvedValue(undefined);
+    mocks.remoteState.withClient.mockImplementation((desktopId, invoke) =>
+      invoke(mocks.remoteClient),
+    );
+    mocks.remoteClient.startThread.mockResolvedValue({ threadId: "rt-1" });
+    mocks.bridge.startThread.mockResolvedValue({ threadId: "local-thread" });
     mocks.primeWorktreeGitState.mockResolvedValue(undefined);
     mocks.runWorktreeSetupScript.mockResolvedValue(undefined);
   });
@@ -236,5 +267,81 @@ describe("startThreadFromDraft host transport", () => {
 
     expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledOnce();
     expect(mocks.runWorktreeSetupScript).not.toHaveBeenCalled();
+  });
+});
+
+describe("performInitialThreadLaunch host transport", () => {
+  const initialSize = { cols: 120, rows: 30 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.appState.projects = [];
+    mocks.remoteState.withClient.mockImplementation((desktopId, invoke) =>
+      invoke(mocks.remoteClient),
+    );
+    mocks.remoteClient.startThread.mockResolvedValue({ threadId: "rt-1" });
+    mocks.bridge.startThread.mockResolvedValue({ threadId: "local-thread" });
+  });
+
+  const localThread = {
+    id: "local-thread",
+    projectId: localProject.id,
+    agentKind: "codex",
+    config: { model: "" },
+    presentationMode: "terminal",
+    status: "launching",
+  } as Thread;
+
+  const remoteThread = {
+    id: "remote:d1:thread:rt-1",
+    projectId: remoteProject.id,
+    remoteServerId: "d1",
+    remoteId: "rt-1",
+    agentKind: "codex",
+    config: { model: "" },
+    presentationMode: "terminal",
+    status: "launching",
+  } as Thread;
+
+  it("launches a mirrored remote thread on its host without client MCP servers", async () => {
+    await performInitialThreadLaunch({
+      thread: remoteThread,
+      projectLocation: { kind: "posix", path: "/srv/repo", remoteServerId: "d1" },
+      prompt: "",
+      initialSize,
+    });
+
+    expect(mocks.remoteState.withClient).toHaveBeenCalledWith("d1", expect.any(Function));
+    const startInput = mocks.remoteClient.startThread.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(startInput).toMatchObject({
+      threadId: "rt-1",
+      // Projection marker stripped — the host receives its own native location.
+      projectLocation: { kind: "posix", path: "/srv/repo" },
+      agentKind: "codex",
+      prompt: "",
+      initialSize,
+    });
+    // The host resolves MCP from its own settings; clients must not inject any.
+    expect(startInput).not.toHaveProperty("mcpServers");
+    expect(mocks.bridge.startThread).not.toHaveBeenCalled();
+  });
+
+  it("launches a local thread over the bridge with the MCP launch snapshot", async () => {
+    await performInitialThreadLaunch({
+      thread: localThread,
+      projectLocation: localProject.location,
+      prompt: "",
+      initialSize,
+    });
+
+    expect(mocks.bridge.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "local-thread",
+        projectLocation: localProject.location,
+        mcpServers: [],
+        disabledBuiltInMcpServerIds: [],
+      }),
+    );
+    expect(mocks.remoteState.withClient).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -24,6 +24,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { findExperimentByGroupId } from "@/renderer/state/experimentStore";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { refreshGitProject } from "@/renderer/state/gitRefresh";
+import { unprojectProjectLocation } from "@/renderer/remoteProcedureRouter";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { isRemoteProjectUnreachable } from "@/renderer/state/remoteServers/reachability";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
@@ -97,9 +98,9 @@ export async function performInitialThreadLaunch(input: {
     thread.id,
     mcpLaunchSnapshot.mcpServers.map((server) => server.name),
   );
-  await readBridge().startThread({
-    threadId: thread.id,
-    projectLocation,
+
+  // Local and remote launches share one payload; only the transport differs.
+  const startInput = {
     agentKind: thread.agentKind,
     ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
     config: thread.config,
@@ -108,9 +109,31 @@ export async function performInitialThreadLaunch(input: {
     initialSize,
     ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
     ...(thread.presentationMode ? { presentationMode: thread.presentationMode } : {}),
-    ...mcpLaunchSnapshot,
     ...(optimisticUserMessageItemId ? { userMessageItemId: optimisticUserMessageItemId } : {}),
-  });
+  };
+
+  // Mirrored remote threads must launch on their host. Spawning locally would
+  // apply the remote projectLocation on this machine (posix path →
+  // `spawn /bin/bash ENOENT` on Windows) and never reach the remote supervisor.
+  const owner = remoteOwner(thread);
+  if (owner) {
+    // No mcpLaunchSnapshot here: the host ignores client-supplied MCP servers
+    // and resolves the launch snapshot from its own settings.
+    await useRemoteServersStore.getState().withClient(owner.desktopId, (client) =>
+      client.startThread({
+        threadId: owner.remoteId,
+        projectLocation: unprojectProjectLocation(projectLocation),
+        ...startInput,
+      }),
+    );
+  } else {
+    await readBridge().startThread({
+      threadId: thread.id,
+      projectLocation,
+      ...startInput,
+      ...mcpLaunchSnapshot,
+    });
+  }
   captureThreadStarted(thread);
   if (prompt.length > 0 || (segments?.length ?? 0) > 0) {
     captureThreadPromptSubmitted(thread, prompt, segments, "initial");

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -93,7 +93,14 @@ export interface RemoteServersState {
   launchRemoteThread(
     input: StartRemoteNewThreadInput & { readonly desktopId: string },
   ): Promise<void>;
-  openRemoteThread(desktopId: string, threadId: string): Promise<void>;
+  /**
+   * Hydrate a remote thread's history and focus it. Never rejects. Resolves
+   * `true` only when the snapshot was actually applied — `false` when the
+   * server is missing/unreachable or a newer open superseded this one, so
+   * callers can gate follow-up work (e.g. relaunching an inactive thread) on
+   * the open having taken effect.
+   */
+  openRemoteThread(desktopId: string, threadId: string): Promise<boolean>;
   closeRemoteThread(): void;
   sendThreadCommand(desktopId: string, command: RemoteThreadCommand): Promise<void>;
   pairServer(input: { endpoint: string; token: string }): Promise<RemoteServerRecord>;

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -201,6 +201,7 @@ function makeClient(opts?: {
   websocketUrl?: RemoteDesktopClient["websocketUrl"];
   sendThreadInput?: RemoteDesktopClient["sendThreadInput"];
   uploadAttachment?: RemoteDesktopClient["uploadAttachment"];
+  startThread?: RemoteDesktopClient["startThread"];
   startNewThread?: RemoteDesktopClient["startNewThread"];
   writeTerminal?: RemoteDesktopClient["writeTerminal"];
   resizeTerminal?: RemoteDesktopClient["resizeTerminal"];
@@ -254,6 +255,7 @@ function makeClient(opts?: {
     parseSocketMessage: (value: string) => JSON.parse(value),
     sendThreadInput: opts?.sendThreadInput ?? (async () => {}),
     uploadAttachment: opts?.uploadAttachment ?? (async () => "/remote/attachment.png"),
+    startThread: opts?.startThread ?? (async () => ({ threadId: remoteThread.id })),
     startNewThread: opts?.startNewThread ?? (async () => ({ threadId: crypto.randomUUID() })),
     writeTerminal: opts?.writeTerminal ?? (async () => {}),
     resizeTerminal: opts?.resizeTerminal ?? (async () => {}),
@@ -2015,11 +2017,13 @@ describe("useRemoteServersStore", () => {
     const firstOpen = useRemoteServersStore.getState().openRemoteThread("d1", "rt-slow");
     const secondOpen = useRemoteServersStore.getState().openRemoteThread("d1", "rt-fast");
     fast.resolve(remoteThreadSnapshot("rt-fast"));
-    await secondOpen;
+    // The applied open resolves true; the superseded one resolves false so
+    // callers can gate follow-up work (e.g. relaunching) on having applied.
+    expect(await secondOpen).toBe(true);
     expect(useRemoteServersStore.getState().openThread?.threadId).toBe("rt-fast");
 
     slow.resolve(remoteThreadSnapshot("rt-slow"));
-    await firstOpen;
+    expect(await firstOpen).toBe(false);
 
     expect(useRemoteServersStore.getState().openThread?.threadId).toBe("rt-fast");
     expect(sync.applyThreadSnapshot).toHaveBeenCalledTimes(applyCallsBefore + 1);
@@ -2390,10 +2394,11 @@ describe("useRemoteServersStore", () => {
       .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
 
     // Must resolve (not reject) so the caller's `void openRemoteThread(...)`
-    // never hits the renderer's global unhandledrejection crash screen.
-    await expect(
-      useRemoteServersStore.getState().openRemoteThread("d1", "rt-1"),
-    ).resolves.toBeUndefined();
+    // never hits the renderer's global unhandledrejection crash screen. It
+    // resolves false: no snapshot was applied, so no reopen should follow.
+    await expect(useRemoteServersStore.getState().openRemoteThread("d1", "rt-1")).resolves.toBe(
+      false,
+    );
     expect(toastDanger).toHaveBeenCalledWith("server offline");
     expect(useRemoteServersStore.getState().runtime.d1?.status).toBe("online");
     expect(useRemoteServersStore.getState().runtime.d1?.message).toBeUndefined();

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -888,7 +888,7 @@ export const useRemoteServersStore = create<RemoteServersState>()(
               new Error(i18n._(msg`Remote server not found.`)),
               i18n._(msg`Remote server not found.`),
             );
-            return;
+            return false;
           }
           // Hydrate the thread's history into the shared, threadId-keyed runtime
           // store so the desktop ChatPane renders it (coexists with local threads).
@@ -897,11 +897,11 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           try {
             snapshot = await withClient(desktopId, (client) => client.threadHistory(threadId));
           } catch (error) {
-            if (requestSeq !== openRemoteThreadRequestSeq) return;
+            if (requestSeq !== openRemoteThreadRequestSeq) return false;
             toast.danger(friendlyError(error) || i18n._(msg`Failed to open remote thread.`));
-            return;
+            return false;
           }
-          if (requestSeq !== openRemoteThreadRequestSeq) return;
+          if (requestSeq !== openRemoteThreadRequestSeq) return false;
           const projectedSnapshot = projectRemoteThreadSnapshot(desktopId, snapshot);
           const viewThreadId = projectedSnapshot.thread.id;
           const firstSnapshotItemId = projectedSnapshot.runtimeItems[0]?.id;
@@ -927,6 +927,7 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           startRemoteServerEventStream(server);
           const eventSocket = remoteServerEventSockets.get(desktopId)?.socket;
           if (eventSocket) activateRemoteTerminalFeed(desktopId, eventSocket);
+          return true;
         },
 
         closeRemoteThread: () => {

--- a/src/shared/threadRelaunch.test.ts
+++ b/src/shared/threadRelaunch.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadStatus } from "./contracts";
+import { buildThreadRelaunchStartInput, shouldRelaunchThreadOnOpen } from "./threadRelaunch";
+
+describe("shouldRelaunchThreadOnOpen", () => {
+  it("relaunches only inactive threads", () => {
+    const cases: Array<[ThreadStatus, boolean]> = [
+      ["inactive", true],
+      ["launching", false],
+      ["idle", false],
+      ["working", false],
+      ["finished", false],
+      ["error", false],
+    ];
+    for (const [status, expected] of cases) {
+      expect(shouldRelaunchThreadOnOpen({ status })).toBe(expected);
+    }
+  });
+});
+
+describe("buildThreadRelaunchStartInput", () => {
+  const projectLocation = { kind: "posix", path: "/repo" } as const;
+  const initialSize = { cols: 120, rows: 30 };
+
+  it("builds the empty-prompt relaunch payload with optional fields passed through", () => {
+    expect(
+      buildThreadRelaunchStartInput({
+        thread: {
+          id: "t1",
+          agentKind: "codex",
+          agentInstanceId: "inst-9",
+          config: { model: "m" },
+          sessionRef: { providerSessionId: "sess-1", discoveredAt: "2026-01-01T00:00:00.000Z" },
+          presentationMode: "gui",
+        },
+        projectLocation,
+        initialSize,
+      }),
+    ).toEqual({
+      threadId: "t1",
+      projectLocation: { kind: "posix", path: "/repo" },
+      agentKind: "codex",
+      agentInstanceId: "inst-9",
+      config: { model: "m" },
+      prompt: "",
+      initialSize: { cols: 120, rows: 30 },
+      sessionRef: { providerSessionId: "sess-1", discoveredAt: "2026-01-01T00:00:00.000Z" },
+      presentationMode: "gui",
+    });
+  });
+
+  it("omits optional fields the thread does not carry", () => {
+    const input = buildThreadRelaunchStartInput({
+      thread: {
+        id: "t2",
+        agentKind: "claude",
+        config: { model: "m" },
+      },
+      projectLocation,
+      initialSize,
+    });
+    expect(input).toEqual({
+      threadId: "t2",
+      projectLocation: { kind: "posix", path: "/repo" },
+      agentKind: "claude",
+      config: { model: "m" },
+      prompt: "",
+      initialSize: { cols: 120, rows: 30 },
+    });
+    expect("agentInstanceId" in input).toBe(false);
+    expect("sessionRef" in input).toBe(false);
+    expect("presentationMode" in input).toBe(false);
+  });
+});

--- a/src/shared/threadRelaunch.ts
+++ b/src/shared/threadRelaunch.ts
@@ -1,0 +1,48 @@
+import type { ProjectLocation, TerminalSize, Thread } from "./contracts";
+import type { StartRemoteThreadInput } from "./remote/client";
+
+/**
+ * Reopening a thread on its host relaunches it with an empty prompt. Only an
+ * INACTIVE thread qualifies: every other status means the host session is
+ * either alive (`launching`/`idle`/`working`/`finished` — and host-side
+ * startThread is close+restart, so firing it at a live session would kill the
+ * run) or intentionally stopped (`error` — a prompt-less relaunch would replay
+ * the broken turn, and a failed relaunch lands back on `error`, so the thread
+ * waits for an explicit prompt instead of an open-driven retry loop).
+ *
+ * Both clients gate on this one rule before relaunching: the desktop renderer
+ * in `reopenStoredThread`, the mobile PWA in `ensureThreadRunning`.
+ */
+export function shouldRelaunchThreadOnOpen(thread: Pick<Thread, "status">): boolean {
+  return thread.status === "inactive";
+}
+
+/**
+ * The empty-prompt relaunch payload both clients send for an inactive thread.
+ * The desktop renderer produces this same object in
+ * `performInitialThreadLaunch` (its reopen case carries an empty prompt and no
+ * segments/userMessageItemId); the mobile PWA builds it here directly. The
+ * host resolves the MCP launch snapshot itself, so no client snapshot is
+ * included.
+ */
+export function buildThreadRelaunchStartInput(input: {
+  readonly thread: Pick<
+    Thread,
+    "id" | "agentKind" | "agentInstanceId" | "config" | "sessionRef" | "presentationMode"
+  >;
+  readonly projectLocation: ProjectLocation;
+  readonly initialSize: TerminalSize;
+}): StartRemoteThreadInput {
+  const { thread } = input;
+  return {
+    threadId: thread.id,
+    projectLocation: input.projectLocation,
+    agentKind: thread.agentKind,
+    ...(thread.agentInstanceId ? { agentInstanceId: thread.agentInstanceId } : {}),
+    config: thread.config,
+    prompt: "",
+    initialSize: input.initialSize,
+    ...(thread.sessionRef ? { sessionRef: thread.sessionRef } : {}),
+    ...(thread.presentationMode ? { presentationMode: thread.presentationMode } : {}),
+  };
+}


### PR DESCRIPTION
- Remote mirrored threads now launch on the host via `client.startThread` instead of the local bridge, so the remote project location is never spawned on the local machine; projection markers are stripped and the host resolves its own MCP launch snapshot (clients inject none).
- `openRemoteThread` now resolves `true` only when a thread snapshot actually applied — `false` when the server is unreachable or a newer open superseded it — so callers can safely gate follow-up work.
- Reopening an inactive remote thread follows the local pipeline: after history hydrates on open, the empty-prompt reopen is queued, and it is skipped when the open did not apply.
- Tests added and updated across thread actions, launch actions, and the remote servers store covering host-side launch payloads, superseded opens, and inactive-thread reopen behavior.