### PR TITLE
fix(kimi): gate prompt readiness on 0.34 cache-expiry dialog

### DIFF
--- a/src/supervisor/agents/kimi/index.ts
+++ b/src/supervisor/agents/kimi/index.ts
@@ -22,7 +22,11 @@ import {
   makeKimiWatchSessionRef,
   snapshotKimiPreSpawnSessions,
 } from "./sessionFiles";
-import { detectKimiTerminalStatus, KIMI_TRUST_PROMPT_PATTERN } from "./terminal";
+import {
+  detectKimiTerminalStatus,
+  KIMI_CACHE_HINT_PATTERN,
+  KIMI_TRUST_PROMPT_PATTERN,
+} from "./terminal";
 
 // Kimi Code provider implementation (Moonshot AI).
 // Docs: https://www.kimi.com/code/docs/en/
@@ -207,9 +211,15 @@ export function createKimiAdapter(): AgentAdapter {
     },
 
     isReadyForInitialPrompt(text) {
-      // The trust dialog (shown if the pre-written marker ever misses) is not
-      // a composer — typing the prompt into it would just corrupt the choice.
+      // Modal dialogs are not a composer — typing the prompt into one would
+      // just corrupt the choice. The trust dialog shows if the pre-written
+      // marker ever misses; 0.34's cache-expiry dialog shows after a
+      // long-idle session is resumed (a queued resume prompt would otherwise
+      // be swallowed by the dialog and its Enter would pick "Compact and
+      // continue"). Once the user answers, the composer text returns and the
+      // gate re-passes on the next terminal update.
       if (KIMI_TRUST_PROMPT_PATTERN.test(text)) return false;
+      if (KIMI_CACHE_HINT_PATTERN.test(text)) return false;
       const t = text.toLowerCase();
       if (t.includes("kimi")) return true;
       if (/\?\s+for shortcuts|\/\s+for commands/i.test(text)) return true;

--- a/src/supervisor/agents/kimi/kimi.test.ts
+++ b/src/supervisor/agents/kimi/kimi.test.ts
@@ -192,6 +192,46 @@ describe("createKimiAdapter terminal heuristics", () => {
     expect(adapter.detectTerminalStatus?.("? for shortcuts")?.status).toBe("idle");
     expect(adapter.detectTerminalStatus?.("context: 10% (23.2k/256k)")?.status).toBe("idle");
   });
+
+  // Rendered verbatim by kimi 0.34.0's cache-hint-dialog.ts (verified against
+  // the released bundle): title, footer, body line, and the option list. The
+  // footer's "Enter select" does not match the generic "Enter to select"
+  // pattern, so this only passes through the dedicated cache-hint pattern.
+  const KIMI_034_CACHE_HINT_DIALOG = [
+    " This session has been idle for 3 hours and is ~48.2k tokens.",
+    " ↑↓ navigate · Enter select · Esc cancel",
+    "",
+    " Cache expired — the next message re-sends the entire history at full price.",
+    "",
+    "  ❯ Compact and continue    one-time compact cost · cheapest way to keep this topic",
+    "    Start a new session     zero context cost · best for a new task",
+    "    Continue as-is          full history kept · highest cost per turn",
+    "    Don't ask me again",
+  ].join("\n");
+
+  it("surfaces 0.34's cache-expiry dialog as needing a reply", () => {
+    expect(adapter.detectTerminalStatus?.(KIMI_034_CACHE_HINT_DIALOG)?.status).toBe("needs_reply");
+  });
+
+  it("refuses to type the initial prompt into modal dialogs", () => {
+    // 0.33's trust dialog (already gated) and 0.34's cache-expiry dialog both
+    // swallow keystrokes into a modal list; Enter would pick the default
+    // choice instead of submitting the prompt.
+    expect(adapter.isReadyForInitialPrompt?.("Trust this folder?")).toBe(false);
+    expect(adapter.isReadyForInitialPrompt?.(KIMI_034_CACHE_HINT_DIALOG)).toBe(false);
+  });
+
+  it("stays not-ready when the cache dialog floats over a kimi-branded transcript", () => {
+    // On resume the transcript renders before the dialog mounts, so the
+    // accumulated text can carry the "kimi" header that would otherwise pass
+    // the gate.
+    const text = `kimi code — resumed session\n\n${KIMI_034_CACHE_HINT_DIALOG}`;
+    expect(adapter.isReadyForInitialPrompt?.(text)).toBe(false);
+  });
+
+  it("passes the readiness gate on a normal composer", () => {
+    expect(adapter.isReadyForInitialPrompt?.("kimi\n? for shortcuts")).toBe(true);
+  });
 });
 
 describe("resolveKimiEmptyResponseError", () => {

--- a/src/supervisor/agents/kimi/terminal.ts
+++ b/src/supervisor/agents/kimi/terminal.ts
@@ -12,6 +12,19 @@ import { detectTerminalStatusFromHints, type TerminalStatusHint } from "../base"
  */
 export const KIMI_TRUST_PROMPT_PATTERN = /Trust this folder\?/i;
 
+/**
+ * Kimi 0.34's cache-expiry dialog (v2 engine): after a long-idle session is
+ * resumed — or a message is submitted after a long idle stretch — a modal
+ * list asks whether to compact, start a new session, or continue as-is. It
+ * is a real modal: keystrokes go to the dialog's list, not the composer, and
+ * Enter picks the default "Compact and continue", so both the status
+ * detector and the prompt gate must recognize it. Its footer ("Enter
+ * select") deliberately does not match the generic "Enter to select" pattern
+ * above. Strings verified against the released 0.34.0 bundle (dialog title
+ * and body line).
+ */
+export const KIMI_CACHE_HINT_PATTERN = /Cache expired|This session has been idle for/i;
+
 const KIMI_STRONG = [
   {
     re: /Enter to select|Choose an option/i,
@@ -24,6 +37,12 @@ const KIMI_STRONG = [
     re: KIMI_TRUST_PROMPT_PATTERN,
     status: "needs_reply" as const,
     attention: "needs_approval" as const,
+  },
+  // Same for the cache-expiry dialog: the thread is parked on a modal choice.
+  {
+    re: KIMI_CACHE_HINT_PATTERN,
+    status: "needs_reply" as const,
+    attention: "needs_reply" as const,
   },
   {
     re: /\[y\/n\]|\(y\/N\)|Allow\s+.*\?|Do you want to proceed|Continue\?|Approve\??/i,


### PR DESCRIPTION
- Kimi Code 0.34 shows a modal cache-expiry dialog ("Compact and continue" / "Start a new session" / "Continue as-is") when a long-idle session is resumed, so a queued resume prompt would be swallowed by the dialog's list.
- Detect the dialog in the terminal status scanner and treat it as `needs_reply`, so the thread surfaces as awaiting a user choice instead of idle.
- Gate prompt readiness on the dialog (alongside the existing trust-dialog gate) so Poracode never types into the modal; once the user answers, the composer text returns and the gate re-passes.
- Add unit tests covering detection, the readiness gate (including the dialog floating over a kimi-branded transcript), and the normal-composer pass-through.