### PR TITLE
Fix idle project panel buttons collapsing to free sidebar row space

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -146,17 +146,21 @@ function HomeTerminalButton(props: { projectId: string; projectName: string }) {
   const hasTerminal = useIsProjectTerminalOpen(props.projectId);
   const isActiveTerminal = useIsProjectTerminalActive(props.projectId);
   const isBusy = useIsProjectTerminalBusy(props.projectId);
+  // Match thread / project-header collapse so idle home terminal does not
+  // reserve row width for the project title.
+  const hiddenPanelButtonClass =
+    "w-0 -mr-[3px] overflow-hidden p-0 opacity-0 pointer-events-none group-hover:w-[18px] group-hover:mr-0 group-hover:p-0.5 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:w-[18px] focus-visible:mr-0 focus-visible:p-0.5 focus-visible:opacity-100 focus-visible:pointer-events-auto";
   return (
     <SidebarPanelDragButton
       panel="terminal"
       projectId={props.projectId}
       ariaLabel={t`Terminal for ${props.projectName}`}
-      className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
+      className={`flex h-[18px] shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
         isActiveTerminal
-          ? "text-accent"
+          ? "w-[18px] p-0.5 text-accent"
           : hasTerminal
-            ? "text-foreground"
-            : "text-muted/60 opacity-0 group-hover:opacity-100"
+            ? "w-[18px] p-0.5 text-foreground"
+            : `text-muted/60 ${hiddenPanelButtonClass}`
       }`}
       onPress={() => openTerminal(props.projectId)}
     >

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import type { RemoteServerRecord } from "@/renderer/state/remoteServers/types";
 import { SidebarProjectHeader } from "./SidebarProjectHeader";
@@ -54,6 +56,16 @@ const server: RemoteServerRecord = {
   scopes: ["projects:manage"],
 };
 
+/** Thread-row collapse footprint — project icons must share this when idle. */
+const COLLAPSED_PANEL_CLASSES = [
+  "w-0",
+  "overflow-hidden",
+  "opacity-0",
+  "pointer-events-none",
+  "group-hover:w-[18px]",
+  "group-hover:opacity-100",
+] as const;
+
 function seedRemote(status: "online" | "offline") {
   useRemoteServersStore.setState({
     servers: [server],
@@ -61,35 +73,46 @@ function seedRemote(status: "online" | "offline") {
   });
 }
 
+function resetPanelAndTerminalState() {
+  usePanelStore.setState({
+    rightPanelTab: "git",
+    filesPanelContext: null,
+  });
+  useDevTerminalStore.setState({
+    isOpen: false,
+    explicitlyOpened: false,
+    activeProjectId: null,
+    activeWorktreePath: null,
+    tabs: [],
+    activeTabId: null,
+    focusRequestId: 0,
+    tabActivity: {},
+    streamingTabs: {},
+  });
+}
+
+function renderHeader() {
+  return render(
+    <SidebarProjectHeader project={project} isCollapsed isDragging={false} isUnreachable={false} />,
+  );
+}
+
 describe("SidebarProjectHeader", () => {
   beforeEach(() => {
     seedRemote("online");
     useAppStore.setState({ projects: [project], threads: [] });
+    resetPanelAndTerminalState();
   });
 
   it("shows the bare server name without the Poracode brand prefix", () => {
-    render(
-      <SidebarProjectHeader
-        project={project}
-        isCollapsed
-        isDragging={false}
-        isUnreachable={false}
-      />,
-    );
+    renderHeader();
 
     expect(screen.getByText("H1FCM6T4GX")).toBeInTheDocument();
     expect(screen.queryByText("Poracode on H1FCM6T4GX")).not.toBeInTheDocument();
   });
 
   it("lights the connection dot green while the remote server is online", () => {
-    render(
-      <SidebarProjectHeader
-        project={project}
-        isCollapsed
-        isDragging={false}
-        isUnreachable={false}
-      />,
-    );
+    renderHeader();
 
     expect(screen.getByTitle("Online")).toHaveClass("bg-success");
   });
@@ -119,5 +142,62 @@ describe("SidebarProjectHeader", () => {
     render(<SidebarProjectSection projectId={project.id} projectIndex={0} sortMode="updated" />);
 
     expect(screen.getByText("New thread")).toBeInTheDocument();
+  });
+
+  it("collapses idle files and terminal icons so they reserve no row width", () => {
+    renderHeader();
+
+    const files = screen.getByRole("button", { name: `Files for ${project.name}` });
+    const terminal = screen.getByRole("button", { name: `Terminal for ${project.name}` });
+
+    for (const className of COLLAPSED_PANEL_CLASSES) {
+      expect(files).toHaveClass(className);
+      expect(terminal).toHaveClass(className);
+    }
+    // Opacity-only hide would keep p-0.5 + fixed width; collapse must not.
+    expect(files.className).not.toMatch(/(?:^|\s)p-0\.5(?:\s|$)/);
+    expect(terminal.className).not.toMatch(/(?:^|\s)p-0\.5(?:\s|$)/);
+    expect(files).not.toHaveClass("w-[18px]");
+    expect(terminal).not.toHaveClass("w-[18px]");
+  });
+
+  it("keeps the files icon sized and accented while the files panel is active", () => {
+    usePanelStore.setState({
+      rightPanelTab: "files",
+      filesPanelContext: {
+        projectId: project.id,
+        projectName: project.name,
+        rootLabel: project.name,
+      },
+    });
+
+    renderHeader();
+
+    const files = screen.getByRole("button", { name: `Files for ${project.name}` });
+    expect(files).toHaveClass("w-[18px]", "p-0.5", "text-accent");
+    expect(files).not.toHaveClass("w-0");
+  });
+
+  it("keeps the terminal icon sized while a project terminal tab is open", () => {
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: project.id,
+      activeWorktreePath: null,
+      tabs: [
+        {
+          id: "term-1",
+          projectId: project.id,
+          title: "shell",
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+      activeTabId: "term-1",
+    });
+
+    renderHeader();
+
+    const terminal = screen.getByRole("button", { name: `Terminal for ${project.name}` });
+    expect(terminal).toHaveClass("w-[18px]", "p-0.5");
+    expect(terminal).not.toHaveClass("w-0");
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectHeader.tsx
@@ -50,6 +50,12 @@ export function SidebarProjectHeader(props: {
   const isUnavailable = isDisabled || isUnreachable;
   const showBody = !isCollapsed && !isUnavailable;
   const projectMenu = useProjectMenu(project, { isUnreachable });
+  // Same collapse footprint as thread / worktree panel buttons so idle icons
+  // free horizontal space for the project title.
+  const hiddenPanelButtonClass =
+    "w-0 -mr-[3px] overflow-hidden p-0 opacity-0 pointer-events-none group-hover:w-[18px] group-hover:mr-0 group-hover:p-0.5 group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:w-[18px] focus-visible:mr-0 focus-visible:p-0.5 focus-visible:opacity-100 focus-visible:pointer-events-auto";
+  const panelButtonBaseClass =
+    "flex h-[18px] shrink-0 cursor-grab items-center justify-center rounded transition-[opacity,color,background-color] hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing";
 
   return (
     <ContextMenu items={projectMenu.items} onAction={projectMenu.onAction}>
@@ -99,10 +105,10 @@ export function SidebarProjectHeader(props: {
                 panel="files"
                 projectId={project.id}
                 ariaLabel={t`Files for ${project.name}`}
-                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
+                className={`${panelButtonBaseClass} ${
                   isActiveFilesPanel
-                    ? "text-accent"
-                    : "text-muted/60 opacity-0 group-hover:opacity-100"
+                    ? "w-[18px] p-0.5 text-accent"
+                    : `text-muted/60 ${hiddenPanelButtonClass}`
                 }`}
                 onPress={() => openFilesPanel(project.id)}
               >
@@ -112,12 +118,12 @@ export function SidebarProjectHeader(props: {
                 panel="terminal"
                 projectId={project.id}
                 ariaLabel={t`Terminal for ${project.name}`}
-                className={`shrink-0 cursor-grab rounded p-0.5 transition-colors hover:bg-[var(--row-hover)] hover:text-foreground active:cursor-grabbing ${
+                className={`${panelButtonBaseClass} ${
                   isActiveTerminal
-                    ? "text-accent"
+                    ? "w-[18px] p-0.5 text-accent"
                     : hasTerminal
-                      ? "text-foreground"
-                      : "text-muted/60 opacity-0 group-hover:opacity-100"
+                      ? "w-[18px] p-0.5 text-foreground"
+                      : `text-muted/60 ${hiddenPanelButtonClass}`
                 }`}
                 onPress={() => openTerminal(project.id)}
               >


### PR DESCRIPTION
- Collapse idle Files and Terminal buttons in project headers (and the home row) to zero width so they no longer steal horizontal space from the project title, restoring row space when nothing is active.
- Idle icons now share the same collapse footprint as thread/worktree panel buttons and reveal on hover/focus, keeping interaction intact without layout cost.
- Active panels (files panel, open terminal tab) keep their fixed sized, accented state so state remains clearly visible.
- Add regression tests asserting the idle collapse footprint and that active panels stay expanded and accented.