### PR TITLE
fix(main-view): honor browser open flag for right panel tab

### DIFF
--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.test.tsx
@@ -18,8 +18,15 @@ vi.mock("@/renderer/state/gitRefresh", () => ({
   ),
 }));
 
+const unifiedRightPanelProps = vi.hoisted(() => ({
+  current: null as { activeTab: string } | null,
+}));
+
 vi.mock("@/renderer/components/layout/UnifiedRightPanel", () => ({
-  UnifiedRightPanel: () => null,
+  UnifiedRightPanel: (props: { activeTab: string }) => {
+    unifiedRightPanelProps.current = props;
+    return null;
+  },
 }));
 
 function makeThread(id: string, projectId: string, worktreePath: string): Thread {
@@ -57,6 +64,7 @@ function focusThread(threadId: string): void {
 describe("ProjectAuxiliaryPanel", () => {
   beforeEach(() => {
     localStorage.clear();
+    unifiedRightPanelProps.current = null;
     focusThread(threadA.id);
     usePanelStore.setState({
       gitReviewContext: {
@@ -96,6 +104,37 @@ describe("ProjectAuxiliaryPanel", () => {
         projectId: threadC.projectId,
         worktreePath: threadC.worktreePath!,
       });
+    });
+  });
+
+  it("leaves the browser tab when the browser panel was dismissed with it selected", async () => {
+    // Closing the last browser tab clears browserPanelOpen over IPC but leaves
+    // rightPanelTab on "browser"; the panel must fall back to an open panel
+    // instead of rendering an empty browser layer.
+    usePanelStore.setState({ rightPanelTab: "browser", browserPanelOpen: false });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectAuxiliaryPanel includeTerminal visible />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(unifiedRightPanelProps.current?.activeTab).toBe("git");
+    });
+  });
+
+  it("keeps the browser tab active while the browser panel is open", async () => {
+    usePanelStore.setState({ rightPanelTab: "browser", browserPanelOpen: true });
+
+    render(
+      <I18nProvider i18n={i18n}>
+        <ProjectAuxiliaryPanel includeTerminal visible />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(unifiedRightPanelProps.current?.activeTab).toBe("browser");
     });
   });
 });

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -190,11 +190,15 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   function requestedTabIsAvailable(): boolean {
     if (requestedTab === "subagent") return subAgentInCurrentThread;
     if (requestedTab === "plan") return planInCurrentThread;
+    // The browser panel is dismissed out-of-band when its last tab closes (the
+    // browser sync clears browserPanelOpen but leaves rightPanelTab pointing at
+    // "browser"), so it must honor its open flag even when no plan is present —
+    // otherwise the panel stays open on an empty browser layer.
+    if (requestedTab === "browser") return browserPanelOpen;
     if (!planInCurrentThread) return true;
     if (requestedTab === "terminal") return terminalOpen;
     if (requestedTab === "files") return filesPanelOpen;
     if (requestedTab === "git") return gitPanelOpen;
-    if (requestedTab === "browser") return browserPanelOpen;
     if (requestedTab === "usage") return usagePanelOpen;
     return requestedTab === "notes" && notesPanelOpen;
   }


### PR DESCRIPTION
- Fix the auxiliary right panel getting stuck on an empty browser tab after the last browser tab closes.
- Closing the last browser tab clears `browserPanelOpen` over IPC but leaves `rightPanelTab` on "browser"; the panel now falls back to an open panel instead of rendering an empty browser layer.
- The browser tab stays active while the browser panel is open.
- Add regression tests covering both the dismissed-with-browser-selected and open-browser states.