### PR TITLE
Sort project switcher: Home, local, then remote

### DIFF
--- a/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
@@ -129,6 +129,67 @@ describe("ProjectSwitchMenu", () => {
     expect(items.map((item) => item.textContent)).toEqual(["Alpha", "AlphaMacBook 16"]);
   });
 
+  it("pins Home first, then local projects, then remote mirrors regardless of store order", async () => {
+    const remoteAlpha = {
+      ...project("r1", "RemoteAlpha"),
+      remoteServerId: "desktop-1",
+      remoteId: "rp-1",
+    } as Project;
+    const remoteGamma = {
+      ...project("r2", "RemoteGamma"),
+      remoteServerId: "desktop-1",
+      remoteId: "rp-2",
+    } as Project;
+    useRemoteServersStore.setState({
+      servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+      runtime: { "desktop-1": { status: "online", projects: [], threads: [] } },
+    } as never);
+    // Store order interleaves remote mirrors among local projects — the
+    // selector must ignore it and bucket Home, local, then remote.
+    useAppStore.setState({
+      projects: [
+        remoteAlpha,
+        homeProject,
+        project("l1", "LocalBeta"),
+        remoteGamma,
+        project("l2", "LocalDelta"),
+      ],
+    });
+
+    render(<ProjectSwitchMenu currentProjectId="l1" variant="compact" />);
+    const menu = await openMenu();
+    const items = within(menu).getAllByRole("menuitemradio");
+    expect(items.map((item) => item.textContent)).toEqual([
+      HOME_PROJECT_NAME,
+      "LocalBeta",
+      "LocalDelta",
+      "RemoteAlphaMacBook 16",
+      "RemoteGammaMacBook 16",
+    ]);
+  });
+
+  it("omits Home from the selector when the Home scope setting is off", async () => {
+    useSharedSettings.setState({ homeScopeEnabled: false });
+    render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
+    const menu = await openMenu();
+
+    expect(
+      within(menu).queryByRole("menuitemradio", { name: HOME_PROJECT_NAME }),
+    ).not.toBeInTheDocument();
+    // Active workspace still leads, then the other workspace's projects.
+    const groups = within(menu).getAllByRole("group");
+    expect(
+      within(groups[0]!)
+        .getAllByRole("menuitemradio")
+        .map((item) => item.textContent),
+    ).toEqual(["Alpha", "Gamma"]);
+    expect(
+      within(groups[1]!)
+        .getAllByRole("menuitemradio")
+        .map((item) => item.textContent),
+    ).toEqual(["BetaSide Hustle"]);
+  });
+
   it("labels the trigger with a draft that outlived a workspace switch", async () => {
     render(<ProjectSwitchMenu currentProjectId="b" variant="compact" />);
 

--- a/src/renderer/components/thread/projectSwitchGroups.ts
+++ b/src/renderer/components/thread/projectSwitchGroups.ts
@@ -13,12 +13,29 @@ export interface ProjectSwitchEntry {
 }
 
 export interface ProjectSwitchGroups {
-  /** Active-workspace projects first, then the rest — the flat fallback order. */
+  /**
+   * Home first (while the Home scope setting is on), then local projects,
+   * then projects mirrored from a remote server — the flat fallback order.
+   */
   all: readonly ProjectSwitchEntry[];
   inWorkspace: readonly ProjectSwitchEntry[];
   /** Projects filed to another workspace; picking one switches the workspace. */
   others: readonly ProjectSwitchEntry[];
   activeWorkspaceName: string | undefined;
+}
+
+/**
+ * Preferred selector order: the Home scope first, then local projects, then
+ * remote-mirrored ones. Store order alone would scatter newly added remote
+ * mirrors between local projects. Stable, so projects keep their store order
+ * within each bucket.
+ */
+function compareSelectorOrder(a: Project, b: Project): number {
+  const rank = (project: Project) => {
+    if (isHomeProject(project)) return 0;
+    return project.remoteServerId ? 2 : 1;
+  };
+  return rank(a) - rank(b);
 }
 
 /**
@@ -31,12 +48,16 @@ export interface ProjectSwitchGroups {
 export function useProjectSwitchGroups(): ProjectSwitchGroups {
   const isInWorkspace = useWorkspaceProjectFilter();
   const workspaces = useSharedSettings((state) => state.workspaces);
+  const homeScopeEnabled = useSharedSettings((state) => state.homeScopeEnabled);
   const activeWorkspaceId = useActiveWorkspaceId();
   // Home is persisted with `disabled: true` as an internal marker (it is not a
-  // user-disabled project), so it has to survive the disabled filter.
+  // user-disabled project), so it has to survive the disabled filter — but it
+  // is only offered while the Home scope setting is on.
   const projects = useAppStore(
     useShallow((state) =>
-      state.projects.filter((project) => isHomeProject(project) || !project.disabled),
+      state.projects
+        .filter((project) => (isHomeProject(project) ? homeScopeEnabled : !project.disabled))
+        .sort(compareSelectorOrder),
     ),
   );
 


### PR DESCRIPTION
- Projects in the switcher now follow a stable order — Home scope first, then local projects, then remote mirrors — instead of raw store insertion order, which could scatter newly added remote mirrors among local ones.
- Each bucket keeps store order internally, so ordering is only enforced at the group boundary.
- Home is now shown only while the Home scope setting is enabled; turning it off removes Home from the selector.
- Adds tests covering the bucket ordering with interleaved store input and the Home setting on/off behavior.