### PR TITLE
Refactor sidebar footer navigation into components

### DIFF
--- a/src/renderer/components/common/SidebarButton.tsx
+++ b/src/renderer/components/common/SidebarButton.tsx
@@ -19,6 +19,20 @@ export function sidebarRowClass(
   } text-left ${sizeClass} text-muted outline-none transition-colors hover:bg-[var(--row-hover)] hover:text-foreground focus-visible:focus-ring`;
 }
 
+/**
+ * The icon-only `SidebarButton` box, exported for trigger elements that must
+ * own their own element (menu triggers like the workspace switcher or an
+ * overflow kebab) and therefore can't be a `SidebarButton` themselves.
+ * `isActive` mirrors the `SidebarButton` active treatment so an overflow
+ * trigger can still show that the current destination lives behind it.
+ */
+export function sidebarIconButtonClass(options: { isActive?: boolean } = {}): string {
+  const stateClass = options.isActive
+    ? "bg-[var(--row-active)] text-foreground"
+    : "text-muted hover:bg-[var(--row-hover)] hover:text-foreground";
+  return `flex h-8 w-8 shrink-0 cursor-default items-center justify-center rounded-3xl outline-none transition-colors focus-visible:focus-ring ${stateClass}`;
+}
+
 export function SidebarButton(props: {
   ref?: React.Ref<HTMLDivElement>;
   icon: React.ReactNode;
@@ -42,6 +56,12 @@ export function SidebarButton(props: {
    */
   statusTone?: StatusTone;
   tooltip?: React.ReactNode;
+  /**
+   * Icon-only tooltip placement. Defaults to "right" for the vertical icon
+   * rail; bottom icon rows (e.g. the collapsed footer nav) pass "top" so the
+   * tooltip opens over the sidebar instead of covering neighbouring icons.
+   */
+  tooltipPlacement?: "right" | "top";
   suffix?: React.ReactNode;
   className?: string;
   onDoubleClick?: () => void;
@@ -63,6 +83,7 @@ export function SidebarButton(props: {
     density = "default",
     statusTone,
     tooltip,
+    tooltipPlacement = "right",
     suffix,
     className,
     onDoubleClick,
@@ -114,7 +135,11 @@ export function SidebarButton(props: {
             {icon}
           </button>
         </Tooltip.Trigger>
-        <Tooltip.Content placement="right">{tooltipContent}</Tooltip.Content>
+        {/* pointer-events-none: hovering the tooltip itself is a no-op, so it
+            can't block the neighbouring icons it overlaps. */}
+        <Tooltip.Content placement={tooltipPlacement} className="pointer-events-none">
+          {tooltipContent}
+        </Tooltip.Content>
       </Tooltip>
     );
   }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Fehler einklappen"
 #~ msgid "Collapse experiment"
 #~ msgstr "Experiment einklappen"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Fußzeile einklappen"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Herunterladen in „{0}“. Bei großen Repositories kann dies einen Moment dauern."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Update wird heruntergeladen"
@@ -4367,6 +4371,10 @@ msgstr "Fehler erweitern"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Experiment ausklappen"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Fußzeile ausklappen"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Git-Status für {0}: kein Git-Repository"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Laufzeit-Debug-Panel ausblenden"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Installiere das Paket, um seinen API-Schlüssel hinzuzufügen."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Update installieren"
@@ -5603,7 +5611,7 @@ msgstr "Update installieren"
 msgid "Install v{0}"
 msgstr "v{0} installieren"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "v{updateVersion} installieren"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Modi"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Mehr"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "aus"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Aus"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Einmalig"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Online"
@@ -8573,7 +8582,7 @@ msgstr "Pull Request zusammengeführt"
 msgid "Pull request options"
 msgstr "Pull-Request-Optionen"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Remote"
 msgid "Remote access"
 msgstr "Fernzugriff"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Geplante Aufgaben auf diesem Desktop"
 #~ msgstr "Geplante Aufgaben werden nur ausgeführt, solange dieses Gerät aktiv und Poracode geöffnet ist."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Zeitpläne"
@@ -10001,6 +10012,7 @@ msgstr "Beim Start dieser Sitzung festgelegt — starte einen neuen Thread, um S
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Thread {targetLabel} gestartet"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -2565,6 +2565,10 @@ msgstr "Collapse error"
 #~ msgid "Collapse experiment"
 #~ msgstr "Collapse experiment"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Collapse footer"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3967,7 +3971,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Downloading into “{0}”. This can take a moment for large repositories."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Downloading update"
@@ -4372,6 +4376,10 @@ msgstr "Expand error"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Expand experiment"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Expand footer"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5026,9 +5034,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Git status for {0}: not a Git repository"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5244,7 +5252,7 @@ msgstr "Hide runtime debug panel"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5598,7 +5606,7 @@ msgid "Install the package to add its API key."
 msgstr "Install the package to add its API key."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Install update"
@@ -5608,7 +5616,7 @@ msgstr "Install update"
 msgid "Install v{0}"
 msgstr "Install v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Install v{updateVersion}"
 
@@ -6531,6 +6539,7 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "More"
@@ -7424,7 +7433,7 @@ msgid "off"
 msgstr "off"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Off"
@@ -7480,7 +7489,7 @@ msgid "One time"
 msgstr "One time"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Online"
@@ -8578,7 +8587,7 @@ msgstr "Pull request merged"
 msgid "Pull request options"
 msgstr "Pull request options"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8845,6 +8854,8 @@ msgstr "Remote"
 msgid "Remote access"
 msgstr "Remote access"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9668,7 +9679,7 @@ msgstr "Scheduled tasks on this desktop"
 #~ msgstr "Scheduled tasks run only while this device is awake and Poracode is open."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Schedules"
@@ -10006,6 +10017,7 @@ msgstr "Set when this session started — start a new thread to change servers"
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10606,7 +10618,7 @@ msgstr "Started {targetLabel} thread"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Contraer error"
 #~ msgid "Collapse experiment"
 #~ msgstr "Contraer experimento"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Contraer el pie de la barra lateral"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Descargando en «{0}». Esto puede tardar un momento en repositorios grandes."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Descargando actualización"
@@ -4367,6 +4371,10 @@ msgstr "Expandir error"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Expandir experimento"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Expandir el pie de la barra lateral"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Estado de Git para {0}: no es un repositorio Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Ocultar panel de depuración del runtime"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Instala el paquete para añadir su clave API."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Instalar actualización"
@@ -5603,7 +5611,7 @@ msgstr "Instalar actualización"
 msgid "Install v{0}"
 msgstr "Instalar v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Instalar v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Más"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "desactivado"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Desactivado"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Una vez"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "En línea"
@@ -8573,7 +8582,7 @@ msgstr "Pull request fusionado"
 msgid "Pull request options"
 msgstr "Opciones de pull request"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Remoto"
 msgid "Remote access"
 msgstr "Acceso remoto"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Tareas programadas en este escritorio"
 #~ msgstr "Las tareas programadas solo se ejecutan mientras este dispositivo está activo y Poracode está abierto."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Programaciones"
@@ -10001,6 +10012,7 @@ msgstr "Se fijó al iniciar esta sesión — inicia un hilo nuevo para cambiar l
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Hilo {targetLabel} iniciado"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Réduire l'erreur"
 #~ msgid "Collapse experiment"
 #~ msgstr "Réduire l'expérience"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Réduire le bas de la barre latérale"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Téléchargement dans « {0} ». Cela peut prendre un certain temps pour les grands dépôts."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Téléchargement de la mise à jour"
@@ -4367,6 +4371,10 @@ msgstr "Développer l'erreur"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Développer l'expérience"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Développer le bas de la barre latérale"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Statut Git pour {0} : pas un dépôt Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Masquer le panneau de débogage d'exécution"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Installez le paquet pour ajouter sa clé API."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Installer la mise à jour"
@@ -5603,7 +5611,7 @@ msgstr "Installer la mise à jour"
 msgid "Install v{0}"
 msgstr "Installer v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Installer v{updateVersion}"
 
@@ -6525,6 +6533,7 @@ msgid "Modes"
 msgstr "Modes"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Plus"
@@ -7418,7 +7427,7 @@ msgid "off"
 msgstr "Désactivé"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Désactivé"
@@ -7474,7 +7483,7 @@ msgid "One time"
 msgstr "Une seule fois"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "En ligne"
@@ -8572,7 +8581,7 @@ msgstr "Pull request fusionnée"
 msgid "Pull request options"
 msgstr "Options de demande de tirage"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8839,6 +8848,8 @@ msgstr "À distance"
 msgid "Remote access"
 msgstr "Accès distant"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9662,7 +9673,7 @@ msgstr "Tâches planifiées sur cet ordinateur"
 #~ msgstr "Les tâches planifiées ne s’exécutent que lorsque cet appareil est actif et que Poracode est ouvert."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Planifications"
@@ -10000,6 +10011,7 @@ msgstr "Défini au démarrage de cette session — démarrez un nouveau fil pour
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10600,7 +10612,7 @@ msgstr "Fil de discussion {targetLabel} démarré"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -2559,6 +2559,10 @@ msgstr "エラーを折りたたむ"
 #~ msgid "Collapse experiment"
 #~ msgstr "実験を折りたたむ"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "フッターを折りたたむ"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3961,7 +3965,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "「{0}」にダウンロード中です。大規模なリポジトリの場合、これには時間がかかることがあります。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "アップデートをダウンロード中"
@@ -4366,6 +4370,10 @@ msgstr "エラーを展開"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "実験を展開する"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "フッターを展開する"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5020,9 +5028,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}の Git ステータス: Git リポジトリではありません"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5238,7 +5246,7 @@ msgstr "ランタイムデバッグパネルを非表示にする"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5592,7 +5600,7 @@ msgid "Install the package to add its API key."
 msgstr "パッケージをインストールしてAPIキーを追加してください。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "アップデートをインストールする"
@@ -5602,7 +5610,7 @@ msgstr "アップデートをインストールする"
 msgid "Install v{0}"
 msgstr "v{0}をインストール"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "v{updateVersion} をインストール"
 
@@ -6524,6 +6532,7 @@ msgid "Modes"
 msgstr "モード"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "多い"
@@ -7417,7 +7426,7 @@ msgid "off"
 msgstr "オフ"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "オフ"
@@ -7473,7 +7482,7 @@ msgid "One time"
 msgstr "1回のみ"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "オンライン"
@@ -8571,7 +8580,7 @@ msgstr "Pull request をマージしました"
 msgid "Pull request options"
 msgstr "プルリクエストのオプション"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8838,6 +8847,8 @@ msgstr "リモート"
 msgid "Remote access"
 msgstr "リモートアクセス"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9661,7 +9672,7 @@ msgstr "このデスクトップのスケジュールタスク"
 #~ msgstr "スケジュールタスクは、このデバイスが起動中でPoracodeが開いている間のみ実行されます。"
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "スケジュール"
@@ -9999,6 +10010,7 @@ msgstr "このセッションの開始時に確定されます — サーバー�
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10599,7 +10611,7 @@ msgstr "{targetLabel}スレッドを開始しました"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -2560,6 +2560,10 @@ msgstr "오류 접기"
 #~ msgid "Collapse experiment"
 #~ msgstr "실험 접기"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "바닥글 접기"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "“{0}”에 다운로드 중입니다. 대규모 리포지토리의 경우 시간이 걸릴 수 있습니다."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "업데이트 다운로드 중"
@@ -4367,6 +4371,10 @@ msgstr "확장 오류"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "실험 펼치기"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "바닥글 펼치기"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}에 대한 Git 상태: Git 저장소가 아닙니다."
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "런타임 디버그 패널 숨기기"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "패키지를 설치한 후 API 키를 추가하세요."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "업데이트 설치"
@@ -5603,7 +5611,7 @@ msgstr "업데이트 설치"
 msgid "Install v{0}"
 msgstr "v{0} 설치"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "v{updateVersion} 설치"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "모드"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "많음"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "꺼짐"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "꺼짐"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "한 번"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "온라인"
@@ -8573,7 +8582,7 @@ msgstr "Pull request가 병합되었습니다"
 msgid "Pull request options"
 msgstr "풀 요청 옵션"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "원격"
 msgid "Remote access"
 msgstr "원격 액세스"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "이 데스크톱의 예약 작업"
 #~ msgstr "예약 작업은 이 기기가 켜져 있고 Poracode가 열려 있을 때만 실행됩니다."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "일정"
@@ -10001,6 +10012,7 @@ msgstr "이 세션 시작 시 확정됨 — 서버를 변경하려면 새 스레
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "{targetLabel} 스레드를 시작했습니다."
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Zwiń błąd"
 #~ msgid "Collapse experiment"
 #~ msgstr "Zwiń eksperyment"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Zwiń stopkę"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Pobieranie do „{0}”. W przypadku dużych repozytoriów może to chwilę potrwać."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Pobieranie aktualizacji"
@@ -4367,6 +4371,10 @@ msgstr "Rozwiń błąd"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Rozwiń eksperyment"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Rozwiń stopkę"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Status Git dla {0}: to nie jest repozytorium Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Ukryj panel debugowania środowiska wykonawczego"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Zainstaluj pakiet, aby dodać jego klucz API."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Zainstaluj aktualizację"
@@ -5603,7 +5611,7 @@ msgstr "Zainstaluj aktualizację"
 msgid "Install v{0}"
 msgstr "Zainstaluj v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Zainstaluj v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Tryby"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Więcej"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "wyłączone"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Wył."
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Jednorazowo"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Online"
@@ -8573,7 +8582,7 @@ msgstr "Żądanie ściągnięcia scalone"
 msgid "Pull request options"
 msgstr "Opcje żądania ściągnięcia"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Zdalny"
 msgid "Remote access"
 msgstr "Dostęp zdalny"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Zaplanowane zadania na tym komputerze"
 #~ msgstr "Zaplanowane zadania są uruchamiane tylko wtedy, gdy urządzenie jest aktywne, a Poracode jest otwarty."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Harmonogramy"
@@ -10001,6 +10012,7 @@ msgstr "Ustalone przy starcie tej sesji — aby zmienić serwery, rozpocznij now
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Rozpoczęto wątek {targetLabel}"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Recolher erro"
 #~ msgid "Collapse experiment"
 #~ msgstr "Recolher experimento"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Recolher rodapé"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Baixando em “{0}”. Isso pode demorar um pouco para repositórios grandes."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Baixando atualização"
@@ -4367,6 +4371,10 @@ msgstr "Expandir erro"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Expandir experimento"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Expandir rodapé"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Status do Git para {0}: não é um repositório Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Ocultar painel de depuração de tempo de execução"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Instale o pacote para adicionar sua chave de API."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Instalar atualização"
@@ -5603,7 +5611,7 @@ msgstr "Instalar atualização"
 msgid "Install v{0}"
 msgstr "Instalar v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Instalar v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Modos"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Mais"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "desligado"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Desligado"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Uma vez"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Online"
@@ -8573,7 +8582,7 @@ msgstr "Pull request mesclado"
 msgid "Pull request options"
 msgstr "Opções de pull request"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Remoto"
 msgid "Remote access"
 msgstr "Acesso remoto"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Tarefas agendadas neste desktop"
 #~ msgstr "As tarefas agendadas só são executadas enquanto este dispositivo está ativo e o Poracode está aberto."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Agendamentos"
@@ -10001,6 +10012,7 @@ msgstr "Definido quando esta sessão começou — inicie uma nova thread para mu
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Tópico {targetLabel} iniciado"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Свернуть ошибку"
 #~ msgid "Collapse experiment"
 #~ msgstr "Свернуть эксперимент"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Свернуть нижнюю часть боковой панели"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Загрузка в «{0}». Для больших репозиториев это может занять некоторое время."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Загрузка обновления"
@@ -4367,6 +4371,10 @@ msgstr "Развернуть ошибку"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Развернуть эксперимент"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Развернуть нижнюю часть боковой панели"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Состояние Git для {0}: не репозиторий Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Скрыть панель отладки среды выполнения
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Установите пакет, чтобы добавить его API-ключ."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Установить обновление"
@@ -5603,7 +5611,7 @@ msgstr "Установить обновление"
 msgid "Install v{0}"
 msgstr "Установить v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Установить v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Режимы"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Больше"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "выкл"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Выкл."
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Один раз"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Онлайн"
@@ -8573,7 +8582,7 @@ msgstr "Pull request слит"
 msgid "Pull request options"
 msgstr "Параметры pull request"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Удалённый"
 msgid "Remote access"
 msgstr "Удалённый доступ"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Запланированные задачи на этом компьют
 #~ msgstr "Запланированные задачи выполняются только когда устройство активно и Poracode открыт."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Расписания"
@@ -10001,6 +10012,7 @@ msgstr "Зафиксировано при запуске этой сессии �
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Тред {targetLabel} запущен"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Hatayı daralt"
 #~ msgid "Collapse experiment"
 #~ msgstr "Deneyi daralt"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Altbilgiyi daralt"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "“{0}” içine indiriliyor. Büyük depolar için bu biraz zaman alabilir."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Güncelleme indiriliyor"
@@ -4367,6 +4371,10 @@ msgstr "Hatayı genişlet"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Deneyi genişlet"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Altbilgiyi genişlet"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0} için Git durumu: Git deposu değil"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Çalışma zamanı hata ayıklama panelini gizle"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "API anahtarını eklemek için paketi yükleyin."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Güncellemeyi yükle"
@@ -5603,7 +5611,7 @@ msgstr "Güncellemeyi yükle"
 msgid "Install v{0}"
 msgstr "v{0} sürümünü yükle"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "v{updateVersion} sürümünü yükle"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Modlar"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Çok"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "kapalı"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Kapalı"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Bir kez"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Çevrimiçi"
@@ -8573,7 +8582,7 @@ msgstr "Pull request birleştirildi"
 msgid "Pull request options"
 msgstr "Çekme isteği seçenekleri"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Uzak"
 msgid "Remote access"
 msgstr "Uzaktan erişim"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Bu masaüstündeki zamanlanmış görevler"
 #~ msgstr "Zamanlanmış görevler yalnızca bu cihaz açıkken ve Poracode çalışırken yürütülür."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Zamanlamalar"
@@ -10001,6 +10012,7 @@ msgstr "Bu oturum başlatıldığında sabitlendi — sunucuları değiştirmek 
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "{targetLabel} iş parçacığı başlatıldı"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Згорнути помилку"
 #~ msgid "Collapse experiment"
 #~ msgstr "Згорнути експеримент"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Згорнути нижню частину бічної панелі"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Завантаження до «{0}». Для великих репозиторіїв це може зайняти деякий час."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Завантаження оновлення"
@@ -4367,6 +4371,10 @@ msgstr "Розгорнути помилку"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Розгорнути експеримент"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Розгорнути нижню частину бічної панелі"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Стан Git для {0}: не репозиторій Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Сховати панель налагодження середовищ�
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Встановіть пакет, щоб додати його API-ключ."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Встановити оновлення"
@@ -5603,7 +5611,7 @@ msgstr "Встановити оновлення"
 msgid "Install v{0}"
 msgstr "Установити v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Встановити v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Режими"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Більше"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "вимк"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Вимк."
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Один раз"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Онлайн"
@@ -8573,7 +8582,7 @@ msgstr "Pull request злито"
 msgid "Pull request options"
 msgstr "Параметри pull request"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Віддалений"
 msgid "Remote access"
 msgstr "Віддалений доступ"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Заплановані завдання на цьому комп’ют�
 #~ msgstr "Заплановані завдання виконуються лише коли пристрій активний і Poracode відкрито."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Розклади"
@@ -10001,6 +10012,7 @@ msgstr "Зафіксовано під час запуску цієї сесії 
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Тред {targetLabel} запущено"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -2560,6 +2560,10 @@ msgstr "Thu gọn lỗi"
 #~ msgid "Collapse experiment"
 #~ msgstr "Thu gọn thí nghiệm"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "Thu gọn chân thanh bên"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "Đang tải xuống “{0}”. Việc này có thể mất một chút thời gian đối với các kho lưu trữ lớn."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "Đang tải xuống bản cập nhật"
@@ -4367,6 +4371,10 @@ msgstr "Mở rộng lỗi"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "Mở rộng thí nghiệm"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "Mở rộng chân thanh bên"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "Trạng thái Git cho {0}: không phải kho lưu trữ Git"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "Ẩn bảng gỡ lỗi thời gian chạy"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "Cài đặt gói để thêm khóa API của nó."
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "Cài đặt bản cập nhật"
@@ -5603,7 +5611,7 @@ msgstr "Cài đặt bản cập nhật"
 msgid "Install v{0}"
 msgstr "Cài đặt v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "Cài đặt v{updateVersion}"
 
@@ -6526,6 +6534,7 @@ msgid "Modes"
 msgstr "Chế độ"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "Nhiều"
@@ -7419,7 +7428,7 @@ msgid "off"
 msgstr "tắt"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "Tắt"
@@ -7475,7 +7484,7 @@ msgid "One time"
 msgstr "Một lần"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "Trực tuyến"
@@ -8573,7 +8582,7 @@ msgstr "Pull request đã được hợp nhất"
 msgid "Pull request options"
 msgstr "Tùy chọn pull request"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8840,6 +8849,8 @@ msgstr "Từ xa"
 msgid "Remote access"
 msgstr "Truy cập từ xa"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9663,7 +9674,7 @@ msgstr "Tác vụ đã lên lịch trên máy tính này"
 #~ msgstr "Tác vụ đã lên lịch chỉ chạy khi thiết bị này đang hoạt động và Poracode đang mở."
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "Lịch biểu"
@@ -10001,6 +10012,7 @@ msgstr "Được cố định khi phiên này bắt đầu — hãy tạo luồn
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10601,7 +10613,7 @@ msgstr "Đã bắt đầu chủ đề {targetLabel}"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -2560,6 +2560,10 @@ msgstr "折叠错误"
 #~ msgid "Collapse experiment"
 #~ msgstr "折叠实验"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Collapse footer"
+msgstr "折叠侧边栏底部"
+
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
 msgid "Collapse group"
@@ -3962,7 +3966,7 @@ msgid "Downloading into “{0}”. This can take a moment for large repositories
 msgstr "下载到“{0}”。对于大型存储库，这可能需要一些时间。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Downloading update"
 msgstr "正在下载更新"
@@ -4367,6 +4371,10 @@ msgstr "展开错误"
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadGroup.tsx
 #~ msgid "Expand experiment"
 #~ msgstr "展开实验"
+
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+msgid "Expand footer"
+msgstr "展开侧边栏底部"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabStrip.tsx
@@ -5021,9 +5029,9 @@ msgid "Git status for {0}: not a Git repository"
 msgstr "{0}的 Git 状态：不是 Git 存储库"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"
@@ -5239,7 +5247,7 @@ msgstr "隐藏运行时调试面板"
 
 #: src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
 #: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProjectSettingsOverlay/parts/SettingsSidebar.tsx
 #: src/renderer/views/PrReviewOverlay/parts/PrReviewSidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -5593,7 +5601,7 @@ msgid "Install the package to add its API key."
 msgstr "安装该包后即可添加其 API 密钥。"
 
 #: src/renderer/components/startup/StartupRecoveryScreen.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 #: src/renderer/views/SettingsOverlay/parts/AboutSettings.tsx
 msgid "Install update"
 msgstr "安装更新"
@@ -5603,7 +5611,7 @@ msgstr "安装更新"
 msgid "Install v{0}"
 msgstr "安装 v{0}"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
 msgid "Install v{updateVersion}"
 msgstr "安装 v{updateVersion}"
 
@@ -6525,6 +6533,7 @@ msgid "Modes"
 msgstr "模式"
 
 #: src/mobile/NarrowShell.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/ProfileOverlay/parts/ActivityHeatmap.tsx
 msgid "More"
 msgstr "多"
@@ -7418,7 +7427,7 @@ msgid "off"
 msgstr "关闭"
 
 #: src/renderer/components/git/PrAutomationSlider.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Off"
 msgstr "关闭"
@@ -7474,7 +7483,7 @@ msgid "One time"
 msgstr "仅一次"
 
 #: src/renderer/components/common/RemoteServerStatusDot.tsx
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Online"
 msgstr "在线"
@@ -8572,7 +8581,7 @@ msgstr "Pull request 已合并"
 msgid "Pull request options"
 msgstr "拉取请求选项"
 
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Pull requests"
@@ -8839,6 +8848,8 @@ msgstr "远程"
 msgid "Remote access"
 msgstr "远程访问"
 
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -9662,7 +9673,7 @@ msgstr "此桌面上的计划任务"
 #~ msgstr "计划任务仅在此设备处于唤醒状态且 Poracode 已打开时运行。"
 
 #: src/mobile/settingsSections.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "Schedules"
 msgstr "计划"
@@ -10000,6 +10011,7 @@ msgstr "在本会话启动时已固定 — 如需更改服务器，请开始新�
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
 #: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
 #: src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
 msgid "Settings"
@@ -10600,7 +10612,7 @@ msgstr "开始{targetLabel}线程"
 
 #. Button label while the microphone test is starting
 #: src/mobile/remoteConnectionState.ts
-#: src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteAccessSettings.tsx
 msgid "Starting"

--- a/src/renderer/state/sidebarUiStore.test.ts
+++ b/src/renderer/state/sidebarUiStore.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
     collapsedWorktrees: {},
     threadListLimits: {},
     flatListProjectFilter: null,
+    footerCollapsed: false,
     editingThreadId: null,
   });
 });
@@ -60,6 +61,42 @@ describe("sidebarUiStore persistence", () => {
     const merged = merge(newPayload, current) as State;
 
     expect(merged.flatListProjectFilter).toEqual(["a", "b"]);
+  });
+
+  it("persists footerCollapsed via partialize", () => {
+    useSidebarUiStore.setState({ footerCollapsed: true });
+    const partialize =
+      useSidebarUiStore.persist.getOptions().partialize ?? ((state: State) => state);
+    const partialized = partialize(useSidebarUiStore.getState());
+    expect(partialized).toHaveProperty("footerCollapsed", true);
+  });
+
+  it("rehydrates a v1 payload without footerCollapsed to the default false", () => {
+    // Simulates an upgrade: the persisted JSON was written by an older build
+    // that didn't know about footerCollapsed. The default merge
+    // ({ ...currentState, ...persistedState }) keeps the initial false for the
+    // absent key, so the footer keeps showing labeled rows.
+    const merge =
+      useSidebarUiStore.persist.getOptions().merge ??
+      ((persisted: unknown, current: State) => ({ ...current, ...(persisted as object) }));
+    const current = useSidebarUiStore.getState();
+    const oldPayload = {
+      collapsedProjects: { p1: true },
+      pinnedGitHubWorkflows: { p2: [1] },
+      flatListProjectFilter: null,
+    };
+    const merged = merge(oldPayload, current) as State;
+
+    expect(merged.footerCollapsed).toBe(false);
+  });
+});
+
+describe("toggleFooterCollapsed", () => {
+  it("flips the footer between labeled rows and the icon row", () => {
+    useSidebarUiStore.getState().toggleFooterCollapsed();
+    expect(useSidebarUiStore.getState().footerCollapsed).toBe(true);
+    useSidebarUiStore.getState().toggleFooterCollapsed();
+    expect(useSidebarUiStore.getState().footerCollapsed).toBe(false);
   });
 });
 

--- a/src/renderer/state/sidebarUiStore.ts
+++ b/src/renderer/state/sidebarUiStore.ts
@@ -27,6 +27,14 @@ interface SidebarUiState {
    * version stays 1.
    */
   flatListProjectFilter: string[] | null;
+  /**
+   * Footer nav (workspace switcher, shortcuts, Settings, Hide sidebar) shown
+   * as a compact icon row instead of labeled rows. Persisted; additive to the
+   * v1 envelope like `flatListProjectFilter` — older payloads lack the key and
+   * rehydrate to the default (false = labeled rows), older builds ignore the
+   * extra key, so the store version stays 1.
+   */
+  footerCollapsed: boolean;
   editingThreadId: string | null;
   setProjectCollapsed: (projectId: string, collapsed: boolean) => void;
   toggleProjectCollapsed: (projectId: string) => void;
@@ -35,6 +43,7 @@ interface SidebarUiState {
   toggleWorktreeCollapsed: (key: string) => void;
   revealMoreThreads: (projectId: string, pageSize?: number) => void;
   setFlatListProjectFilter: (projectIds: string[] | null) => void;
+  toggleFooterCollapsed: () => void;
   setEditingThreadId: (id: string | null) => void;
 }
 
@@ -62,6 +71,7 @@ export const useSidebarUiStore = create<SidebarUiState>()(
       collapsedWorktrees: {},
       threadListLimits: {},
       flatListProjectFilter: null,
+      footerCollapsed: false,
       editingThreadId: null,
 
       setProjectCollapsed: (projectId, collapsed) =>
@@ -137,6 +147,7 @@ export const useSidebarUiStore = create<SidebarUiState>()(
           }
           return { flatListProjectFilter: next };
         }),
+      toggleFooterCollapsed: () => set((state) => ({ footerCollapsed: !state.footerCollapsed })),
       setEditingThreadId: (editingThreadId) => set({ editingThreadId }),
     }),
     {
@@ -149,6 +160,7 @@ export const useSidebarUiStore = create<SidebarUiState>()(
         collapsedProjects: state.collapsedProjects,
         pinnedGitHubWorkflows: state.pinnedGitHubWorkflows,
         flatListProjectFilter: state.flatListProjectFilter,
+        footerCollapsed: state.footerCollapsed,
       }),
     },
   ),

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -1,35 +1,16 @@
-import { Tooltip } from "@heroui/react";
-import {
-  CalendarClock,
-  ChevronRight,
-  Download,
-  GitPullRequest,
-  Globe,
-  House,
-  PanelLeft,
-  PanelLeftClose,
-  Plus,
-  RefreshCw,
-  Search,
-  Settings2,
-  Smartphone,
-  Workflow,
-} from "lucide-react";
+import { ChevronRight, Globe, House, PanelLeft, Plus, Search, Settings2 } from "lucide-react";
 import { startTransition, useEffect, useLayoutEffect, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { AnimatedNumber } from "@/renderer/components/common/AnimatedNumber";
 import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { getAppName } from "@/shared/appName";
 import type { Thread } from "@/shared/contracts";
-import { formatBytes } from "@/shared/formatBytes";
 import { isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import { ThreadProviderIcon } from "@/renderer/components/providers/ThreadProviderIcon";
 import {
   sidebarBodyScrollClass,
   sidebarColumnLayoutClass,
-  sidebarFooterNavClass,
 } from "@/renderer/components/layout/sidebarChrome";
 import { useSidebar } from "@/renderer/views/MainView/parts/AppShell/AppShell";
 import { SIDEBAR_MIN_WIDTH } from "@/renderer/views/MainView/parts/AppShell/parts/useResizablePanels";
@@ -63,82 +44,21 @@ import {
   useProjectIdsHiddenByWorkspace,
   useWorkspaceProjectIds,
 } from "@/renderer/state/workspaceSelectors";
-import { useUpdateStore } from "@/renderer/state/updateStore";
-import { SidebarWorkspaceSwitcher } from "./parts/SidebarWorkspaceSwitcher";
 import { SidebarFlatThreadList } from "./parts/SidebarFlatThreadList";
+import { SidebarFooterNav } from "./parts/SidebarFooterNav";
 import { SidebarProjectThreadList } from "./parts/SidebarProjectThreadList";
+import { UpdateButtons } from "./parts/UpdateButtons";
+import { useSidebarShortcuts } from "./parts/sidebarShortcuts";
 import { WhatsNewButton } from "./parts/WhatsNewButton";
+import {
+  RemoteAccessSidebarIcon,
+  type RemoteAccessSidebarStatus,
+  RemoteAccessSidebarTooltip,
+} from "./parts/RemoteAccessSidebarIcon";
 import { DeferredSettingsOverlay } from "@/renderer/deferredFeatures";
 
 function prewarmSettings(): void {
   void DeferredSettingsOverlay.preload();
-}
-
-function UpdateButtons(props: { iconOnly?: boolean }) {
-  const { iconOnly = false } = props;
-  const { t } = useLingui();
-  const updatePhase = useUpdateStore((s) => s.phase);
-  const updateVersion = useUpdateStore((s) => s.version);
-  const downloadPercent = useUpdateStore((s) => s.downloadPercent);
-  const transferred = useUpdateStore((s) => s.downloadTransferred);
-  const total = useUpdateStore((s) => s.downloadTotal);
-
-  if (updatePhase !== "downloading" && updatePhase !== "downloaded") {
-    return null;
-  }
-
-  if (updatePhase === "downloading") {
-    const percent = Math.min(100, Math.max(0, Math.round(downloadPercent)));
-    const byteLine =
-      transferred != null && total != null && total > 0
-        ? `${formatBytes(transferred)} / ${formatBytes(total)}`
-        : null;
-
-    if (iconOnly) {
-      return (
-        <Tooltip delay={150}>
-          <Tooltip.Trigger>
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center">
-              <Download className="size-4 animate-pulse text-muted" />
-            </div>
-          </Tooltip.Trigger>
-          <Tooltip.Content placement="right">
-            <Trans>Downloading update</Trans> — {percent}%{byteLine ? ` · ${byteLine}` : ""}
-          </Tooltip.Content>
-        </Tooltip>
-      );
-    }
-
-    // Compact, fixed-height status: one line (bytes + percent) over a thin bar.
-    // The long target version is omitted — it overflowed/clipped and the About
-    // page already surfaces it. `tabular-nums` keeps the digits from reflowing.
-    return (
-      <div className="flex w-full items-center gap-2 rounded-3xl px-2 py-1.5 text-muted">
-        <Download className="size-4 shrink-0 animate-pulse text-muted" />
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <div className="flex min-w-0 items-center justify-between gap-2 text-xs tabular-nums">
-            <span className="truncate">{byteLine ?? <Trans>Downloading update</Trans>}</span>
-            <AnimatedNumber className="shrink-0" value={percent} suffix="%" />
-          </div>
-          <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--row-active)]">
-            <div
-              className="h-1 rounded-full bg-foreground transition-[width] duration-300"
-              style={{ width: `${percent}%` }}
-            />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <SidebarButton
-      iconOnly={iconOnly}
-      icon={<RefreshCw className="size-4" />}
-      label={updateVersion ? t`Install v${updateVersion}` : t`Install update`}
-      onPress={() => void readBridge().installUpdate()}
-    />
-  );
 }
 
 function HomeTerminalButton(props: { projectId: string; projectName: string }) {
@@ -167,19 +87,6 @@ function HomeTerminalButton(props: { projectId: string; projectName: string }) {
 
 function ThreadIcon(props: { thread: Thread }) {
   return <ThreadProviderIcon thread={props.thread} className="size-3.5" />;
-}
-
-type RemoteAccessSidebarStatus = "off" | "starting" | "online";
-
-function RemoteAccessSidebarIcon(props: { status: RemoteAccessSidebarStatus }) {
-  return (
-    <span className="relative flex size-4 items-center justify-center">
-      <Smartphone className="size-4" />
-      {props.status === "online" ? (
-        <span className="absolute -right-px -top-px size-1.5 rounded-full bg-emerald-400 ring-[1.5px] ring-[var(--sidebar-background)]" />
-      ) : null}
-    </span>
-  );
 }
 
 function CollapsedThreadRailButton(props: { thread: Thread; projectName?: string }) {
@@ -267,8 +174,6 @@ export function Sidebar() {
   const hiddenProjectCount = useProjectIdsHiddenByWorkspace().size;
   const homeProject = useAppStore((state) => state.projects.find(isHomeProject));
   const homeScopeEnabled = useSharedSettings((s) => s.homeScopeEnabled);
-  const sidebarHiddenShortcuts = useSharedSettings((s) => s.sidebarHiddenShortcuts);
-  const sidebarShortcutOrder = useSharedSettings((s) => s.sidebarShortcutOrder);
   const remoteAccessEnabled = useSharedSettings((s) => s.remoteAccessEnabled);
   const currentProjectId = useCurrentProjectId();
   const currentWorktreePath = useCurrentWorktreePath();
@@ -282,7 +187,6 @@ export function Sidebar() {
   const otherSettingsActive = settingsOpen && !remoteAccessSettingsActive;
   const threadSearchOpen = usePanelStore((s) => s.threadSearchOpen);
   const browserVisible = usePanelStore((s) => s.browserPanelOpen && s.rightPanelTab === "browser");
-  const githubActionsOpen = usePanelStore((s) => s.githubActionsContext !== null);
   const openThreadSearch = usePanelStore((s) => s.openThreadSearch);
   const isHomeProjectCollapsed = useSidebarUiStore((s) =>
     homeProject ? (s.collapsedProjects[homeProject.id] ?? false) : false,
@@ -290,69 +194,15 @@ export function Sidebar() {
   const setProjectCollapsed = useSidebarUiStore((s) => s.setProjectCollapsed);
   const toggleProjectCollapsed = useSidebarUiStore((s) => s.toggleProjectCollapsed);
   const setWorktreeCollapsed = useSidebarUiStore((s) => s.setWorktreeCollapsed);
-  const { isCollapsed, collapse, expand } = useSidebar();
+  const { isCollapsed, expand } = useSidebar();
   const openHome = useAppStore((s) => s.openHome);
-  const openPullRequests = useAppStore((s) => s.openPullRequests);
-  const openGitHubActions = useAppStore((s) => s.openGitHubActions);
-  const openSchedules = useAppStore((s) => s.openSchedules);
   const appView = useAppStore((s) => s.view);
   const appNameForHome = getAppName(readBridge().channel, import.meta.env.DEV);
   const [remoteAccessStatus, setRemoteAccessStatus] = useState<RemoteAccessSidebarStatus>("off");
   const { setScrollContainer, scrollFadeStyle } = useScrollFade<HTMLDivElement>({
     maxFadePx: 10,
   });
-  const remoteAccessStatusLabel =
-    remoteAccessStatus === "online"
-      ? t`Online`
-      : remoteAccessStatus === "starting"
-        ? t`Starting`
-        : t`Off`;
-  const remoteAccessTooltip = (
-    <span className="flex items-center gap-2">
-      <span>{t`Remote Access`}</span>
-      <span className="inline-flex items-center gap-1.5 text-muted">
-        {remoteAccessStatus === "online" ? (
-          <span className="size-1.5 rounded-full bg-emerald-400" />
-        ) : null}
-        {remoteAccessStatusLabel}
-      </span>
-    </span>
-  );
-  const sidebarShortcutsById = new Map([
-    [
-      "pullRequests" as const,
-      {
-        id: "pullRequests" as const,
-        icon: <GitPullRequest className="size-4" />,
-        label: t`Pull requests`,
-        onPress: () => startTransition(() => openPullRequests()),
-      },
-    ],
-    [
-      "githubActions" as const,
-      {
-        id: "githubActions" as const,
-        icon: <Workflow className="size-4" />,
-        label: t`GitHub Actions`,
-        onPress: () => startTransition(() => openGitHubActions(currentProjectId)),
-      },
-    ],
-    [
-      "schedules" as const,
-      {
-        id: "schedules" as const,
-        icon: <CalendarClock className="size-4" />,
-        label: t`Schedules`,
-        onPress: () => startTransition(() => openSchedules()),
-      },
-    ],
-  ]);
-  const sidebarShortcuts = sidebarShortcutOrder
-    .map((id) => sidebarShortcutsById.get(id))
-    .filter(
-      (shortcut): shortcut is NonNullable<typeof shortcut> =>
-        shortcut !== undefined && !sidebarHiddenShortcuts.includes(shortcut.id),
-    );
+  const sidebarShortcuts = useSidebarShortcuts();
 
   useEffect(() => {
     if (currentProjectId) {
@@ -458,9 +308,7 @@ export function Sidebar() {
                 iconOnly
                 icon={shortcut.icon}
                 label={shortcut.label}
-                isActive={
-                  shortcut.id === "githubActions" ? githubActionsOpen : appView.kind === shortcut.id
-                }
+                isActive={shortcut.isActive}
                 onPress={shortcut.onPress}
               />
             ))}
@@ -476,7 +324,7 @@ export function Sidebar() {
               iconOnly
               icon={<RemoteAccessSidebarIcon status={remoteAccessStatus} />}
               label={t`Remote Access`}
-              tooltip={remoteAccessTooltip}
+              tooltip={<RemoteAccessSidebarTooltip status={remoteAccessStatus} />}
               isActive={remoteAccessSettingsActive}
               onPreload={prewarmSettings}
               onPress={openRemoteAccessSettings}
@@ -495,8 +343,12 @@ export function Sidebar() {
         className={`${sidebarColumnLayoutClass} ${isCollapsed ? "invisible" : ""}`}
         style={{ minWidth: SIDEBAR_MIN_WIDTH }}
       >
-        <div ref={setScrollContainer} className={sidebarBodyScrollClass()} style={scrollFadeStyle}>
-          {projectIds.length === 0 && !(homeScopeEnabled && homeProject) ? (
+        {projectIds.length === 0 && !(homeScopeEnabled && homeProject) ? (
+          <div
+            ref={setScrollContainer}
+            className={sidebarBodyScrollClass()}
+            style={scrollFadeStyle}
+          >
             <div className="pt-4">
               <p className="text-center text-sm text-muted">
                 {hiddenProjectCount > 0 ? (
@@ -508,9 +360,17 @@ export function Sidebar() {
                 )}
               </p>
             </div>
-          ) : listLayout === "flat" ? (
-            <SidebarFlatThreadList sortMode={sortMode} />
-          ) : (
+          </div>
+        ) : listLayout === "flat" ? (
+          // The flat list pins its filter/new-thread head above the thread
+          // rows, so it renders its own scroll container instead of this one.
+          <SidebarFlatThreadList sortMode={sortMode} />
+        ) : (
+          <div
+            ref={setScrollContainer}
+            className={sidebarBodyScrollClass()}
+            style={scrollFadeStyle}
+          >
             <div className="space-y-4">
               {homeScopeEnabled && homeProject ? (
                 <section className="space-y-0.5">
@@ -553,51 +413,11 @@ export function Sidebar() {
                 />
               ))}
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         <ProviderUsageRail orientation="row" />
-        <div className={sidebarFooterNavClass}>
-          <SidebarWorkspaceSwitcher />
-          <UpdateButtons />
-          <WhatsNewButton />
-          {sidebarShortcuts.map((shortcut) => (
-            <SidebarButton
-              key={shortcut.id}
-              icon={shortcut.icon}
-              label={shortcut.label}
-              isActive={
-                shortcut.id === "githubActions" ? githubActionsOpen : appView.kind === shortcut.id
-              }
-              onPress={shortcut.onPress}
-            />
-          ))}
-          <div className="flex items-center gap-1">
-            <div className="min-w-0 flex-1">
-              <SidebarButton
-                icon={<Settings2 className="size-4" />}
-                label={t`Settings`}
-                isActive={otherSettingsActive}
-                onPreload={prewarmSettings}
-                onPress={openSettings}
-              />
-            </div>
-            <SidebarButton
-              iconOnly
-              icon={<RemoteAccessSidebarIcon status={remoteAccessStatus} />}
-              label={t`Remote Access`}
-              tooltip={remoteAccessTooltip}
-              isActive={remoteAccessSettingsActive}
-              onPreload={prewarmSettings}
-              onPress={openRemoteAccessSettings}
-            />
-          </div>
-          <SidebarButton
-            icon={<PanelLeftClose className="size-4" />}
-            label={t`Hide sidebar`}
-            onPress={collapse}
-          />
-        </div>
+        <SidebarFooterNav remoteAccessStatus={remoteAccessStatus} />
       </div>
     </div>
   );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon.tsx
@@ -1,0 +1,37 @@
+import { Smartphone } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+
+export type RemoteAccessSidebarStatus = "off" | "starting" | "online";
+
+export function RemoteAccessSidebarIcon(props: { status: RemoteAccessSidebarStatus }) {
+  return (
+    <span className="relative flex size-4 items-center justify-center">
+      <Smartphone className="size-4" />
+      {props.status === "online" ? (
+        <span className="absolute -right-px -top-px size-1.5 rounded-full bg-emerald-400 ring-[1.5px] ring-[var(--sidebar-background)]" />
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * Tooltip content for the Remote Access entry: the label plus the live
+ * pairing status. Shared by the collapsed icon rail and the footer nav so the
+ * two surfaces can never drift.
+ */
+export function RemoteAccessSidebarTooltip(props: { status: RemoteAccessSidebarStatus }) {
+  const { t } = useLingui();
+  const statusLabel =
+    props.status === "online" ? t`Online` : props.status === "starting" ? t`Starting` : t`Off`;
+  return (
+    <span className="flex items-center gap-2">
+      <span>{t`Remote Access`}</span>
+      <span className="inline-flex items-center gap-1.5 text-muted">
+        {props.status === "online" ? (
+          <span className="size-1.5 rounded-full bg-emerald-400" />
+        ) : null}
+        {statusLabel}
+      </span>
+    </span>
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
@@ -12,6 +12,9 @@ import { SidebarFlatThreadList } from "./SidebarFlatThreadList";
 
 vi.mock("@/renderer/bridge", () => ({
   readBridge: () => ({}),
+  // sidebarBodyScrollClass (scroll gutter classes) reads the platform.
+  isWindows: () => true,
+  isMac: () => false,
 }));
 
 vi.mock("@/renderer/dnd", () => ({
@@ -310,6 +313,23 @@ describe("SidebarFlatThreadList", () => {
     expect(head).toHaveTextContent("new-thread:local-1");
     expect(head?.querySelector('[data-testid="project-filter"]')).not.toBeNull();
     expect(newThreadCalls.at(-1)).toEqual({ projectId: "local-1", inline: true });
+  });
+
+  it("pins the filter/new-thread head above the scrolling rows", () => {
+    useAppStore.setState({
+      projects: [homeProject, localProject],
+      threads: [makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z")],
+    });
+
+    const { container } = render(<SidebarFlatThreadList sortMode="updated" />);
+
+    const head = container.querySelector(".poracode-flat-list-head");
+    const scroller = container.querySelector(".overflow-y-auto");
+    if (!head || !scroller) throw new Error("expected head row and scroll container");
+    // The head lives outside (above) the scroll container, so it stays put
+    // while the thread rows scroll underneath it.
+    expect(scroller.contains(head)).toBe(false);
+    expect(scroller).toHaveTextContent("thread:p1");
   });
 
   it("keeps the new-thread control as a full row when only one project is visible", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -13,11 +13,13 @@ import {
   useIsCurrentProjectDraft,
   useLiveBackgroundThreadIds,
 } from "@/renderer/hooks/uiSelectors";
+import { useScrollFade } from "@/renderer/hooks/useScrollFade";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentCandidateOrder } from "@/renderer/state/experimentStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useSidebarUiStore, useThreadListLimit } from "@/renderer/state/sidebarUiStore";
 import { useWorkspaceProjectIds } from "@/renderer/state/workspaceSelectors";
+import { sidebarBodyScrollClass } from "@/renderer/components/layout/sidebarChrome";
 import { NewThreadButton } from "./NewThreadButton";
 import { SidebarProjectFilter } from "./SidebarProjectFilter";
 import {
@@ -65,6 +67,11 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
   const visibleLimit = useThreadListLimit(FLAT_LIST_SCOPE, SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE);
   const currentThreadCount = useCurrentThreadIdsCount();
   const source = useDragSource();
+  // Own scroll container (the grouped/empty bodies use Sidebar's): the
+  // filter/new-thread head above it stays pinned while the rows scroll.
+  const { setScrollContainer, scrollFadeStyle } = useScrollFade<HTMLDivElement>({
+    maxFadePx: 10,
+  });
 
   // Same visibility rules as the grouped sidebar — workspace projects plus Home
   // (when enabled), minus disabled projects — except remote mirrors, which are
@@ -151,11 +158,11 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
     ) : null;
 
   return (
-    <div className="space-y-0.5">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       {visibleProjects.length > 1 ? (
         // Filter and new-thread share one head row; the new-thread control
         // collapses to an icon button (tooltip) when the row is narrow.
-        <div className="poracode-flat-list-head flex items-center gap-1">
+        <div className="poracode-flat-list-head flex shrink-0 items-center gap-1 pb-0.5">
           <div className="min-w-0 flex-1">
             <SidebarProjectFilter
               projects={visibleProjects}
@@ -167,56 +174,58 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
           {renderNewThreadButton(true)}
         </div>
       ) : (
-        renderNewThreadButton(false)
+        <div className="shrink-0 pb-0.5">{renderNewThreadButton(false)}</div>
       )}
 
-      <div>
-        {rows.map((row) => {
-          if (row.kind === "see-more") {
+      <div ref={setScrollContainer} className={sidebarBodyScrollClass()} style={scrollFadeStyle}>
+        <div>
+          {rows.map((row) => {
+            if (row.kind === "see-more") {
+              return (
+                <SeeMoreThreadsButton
+                  key={row.key}
+                  onPress={() =>
+                    revealMoreThreads(FLAT_LIST_SCOPE, SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE)
+                  }
+                />
+              );
+            }
+            const projectId = rowProjectId(row);
+            const project: Project | undefined = projectId
+              ? projectsById.get(projectId)
+              : visibleProjects[0];
+            if (!project) return null;
+            // Children under a group header omit the tag — the header carries it.
+            const tagged = !(row.kind === "thread" && row.inGroup) && row.kind !== "section-label";
+            // Thread rows and worktree headers stack the tag on a second line;
+            // provider/experiment group headers keep the inline trailing form.
+            const stackedTag = row.kind === "thread" || row.kind === "worktree-group";
+            // Remote mirrors carry the machine name so their rows read as
+            // non-local; mirrors the grouped project header's server chip.
+            const remote = remoteServerFor(project);
             return (
-              <SeeMoreThreadsButton
+              <SidebarThreadRow
                 key={row.key}
-                onPress={() =>
-                  revealMoreThreads(FLAT_LIST_SCOPE, SIDEBAR_FLAT_THREAD_LIST_PAGE_SIZE)
-                }
+                row={row}
+                project={project}
+                editingThreadId={editingThreadId}
+                setEditingThreadId={setEditingThreadId}
+                {...(tagged
+                  ? {
+                      projectTag: (
+                        <span
+                          className={`${stackedTag ? "min-w-0 flex-1" : "ml-auto max-w-[9rem] shrink-0 pl-1"} flex items-center gap-1 text-[10px] leading-4 text-muted/70`}
+                        >
+                          <span className="truncate">{project.name}</span>
+                          <ProjectRemoteServerChip info={remote} size="xs" />
+                        </span>
+                      ),
+                    }
+                  : {})}
               />
             );
-          }
-          const projectId = rowProjectId(row);
-          const project: Project | undefined = projectId
-            ? projectsById.get(projectId)
-            : visibleProjects[0];
-          if (!project) return null;
-          // Children under a group header omit the tag — the header carries it.
-          const tagged = !(row.kind === "thread" && row.inGroup) && row.kind !== "section-label";
-          // Thread rows and worktree headers stack the tag on a second line;
-          // provider/experiment group headers keep the inline trailing form.
-          const stackedTag = row.kind === "thread" || row.kind === "worktree-group";
-          // Remote mirrors carry the machine name so their rows read as
-          // non-local; mirrors the grouped project header's server chip.
-          const remote = remoteServerFor(project);
-          return (
-            <SidebarThreadRow
-              key={row.key}
-              row={row}
-              project={project}
-              editingThreadId={editingThreadId}
-              setEditingThreadId={setEditingThreadId}
-              {...(tagged
-                ? {
-                    projectTag: (
-                      <span
-                        className={`${stackedTag ? "min-w-0 flex-1" : "ml-auto max-w-[9rem] shrink-0 pl-1"} flex items-center gap-1 text-[10px] leading-4 text-muted/70`}
-                      >
-                        <span className="truncate">{project.name}</span>
-                        <ProjectRemoteServerChip info={remote} size="xs" />
-                      </span>
-                    ),
-                  }
-                : {})}
-            />
-          );
-        })}
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.test.tsx
@@ -1,0 +1,238 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { beginPanelResize, endPanelResize } from "@/renderer/state/panelResizeSignal";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
+import { SidebarFooterNav } from "./SidebarFooterNav";
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+/** The component under test re-measures via getBoundingClientRect, so firing
+ * the captured callbacks is enough to simulate a resize. */
+class MockResizeObserver {
+  static instances = new Set<MockResizeObserver>();
+
+  readonly callback: ResizeObserverCallback;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.add(this);
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {
+    MockResizeObserver.instances.delete(this);
+  }
+
+  static notifyAll() {
+    for (const instance of MockResizeObserver.instances) {
+      instance.callback([], {} as ResizeObserver);
+    }
+  }
+}
+
+describe("SidebarFooterNav", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSidebarUiStore.setState({ footerCollapsed: false });
+    usePanelStore.setState({ settingsOpen: false, settingsSection: "general" });
+    useSharedSettings.setState({
+      sidebarHiddenShortcuts: ["githubActions"],
+      sidebarShortcutOrder: ["pullRequests", "githubActions", "schedules"],
+    });
+  });
+
+  it("shows labeled rows with a collapse toggle by default", () => {
+    render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+    expect(screen.getByText("Pull requests")).toBeInTheDocument();
+    expect(screen.getByText("Schedules")).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Hide sidebar")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse footer" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand footer" })).not.toBeInTheDocument();
+  });
+
+  it("collapses to an icon row and back via the toggle", () => {
+    render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse footer" }));
+    expect(useSidebarUiStore.getState().footerCollapsed).toBe(true);
+
+    // Icon mode: labels leave the visible text but stay reachable as
+    // aria-labels on the icon buttons.
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hide sidebar")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pull requests" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Schedules" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remote Access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeInTheDocument();
+
+    // Hide sidebar anchors the left edge of the row, the expand toggle the
+    // right edge. (HeroUI's Tooltip.Trigger wrapper div also carries
+    // role="button", so filter down to the actual button elements.)
+    const buttons = screen.getAllByRole("button").filter((b) => b.tagName === "BUTTON");
+    expect(buttons[0]).toHaveAccessibleName("Hide sidebar");
+    expect(buttons.at(-1)).toHaveAccessibleName("Expand footer");
+    // The expand toggle is pinned to the row's right edge via an ml-auto
+    // wrapper, so it stays right-aligned even when nothing overflows.
+    expect(
+      screen.getByRole("button", { name: "Expand footer" }).closest(".ml-auto"),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand footer" }));
+    expect(useSidebarUiStore.getState().footerCollapsed).toBe(false);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("starts collapsed when the persisted flag is set", () => {
+    useSidebarUiStore.setState({ footerCollapsed: true });
+
+    render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand footer" })).toBeInTheDocument();
+  });
+
+  describe("overflow", () => {
+    beforeEach(() => {
+      // jsdom measures 0 everywhere (read as "unmeasured" → no overflow), so
+      // force a narrow row: 100px fits two 36px-pitch items, which the pinned
+      // Hide-sidebar / expand buttons already claim.
+      vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+        width: 100,
+        height: 32,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 32,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("moves actions that do not fit into a kebab menu", async () => {
+      useSidebarUiStore.setState({ footerCollapsed: true });
+
+      render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+      // Pinned buttons stay put; every action icon overflows.
+      expect(screen.getByRole("button", { name: "Hide sidebar" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Expand footer" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Pull requests" })).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+      const menu = await screen.findByRole("menu");
+      expect(menu).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Pull requests" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Schedules" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Remote Access" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("menuitem", { name: "Settings" }));
+      expect(usePanelStore.getState().settingsOpen).toBe(true);
+    });
+
+    it("marks the kebab active while a hidden destination is the current one", () => {
+      useSidebarUiStore.setState({ footerCollapsed: true });
+      // Settings (non-Remote-Access section) is open and overflowed, so the
+      // trigger has to stand in for the active icon it hides.
+      usePanelStore.setState({ settingsOpen: true, settingsSection: "general" });
+
+      render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+      const trigger = screen.getByRole("button", { name: "More" });
+      expect(trigger.className).toContain("bg-[var(--row-active)]");
+      expect(trigger.className).not.toContain("text-muted");
+    });
+
+    it("leaves the kebab inactive when nothing hidden is active", () => {
+      useSidebarUiStore.setState({ footerCollapsed: true });
+
+      render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+      const trigger = screen.getByRole("button", { name: "More" });
+      expect(trigger.className).toContain("text-muted");
+      expect(trigger.className).not.toContain("bg-[var(--row-active)]");
+    });
+  });
+
+  describe("resize responsiveness", () => {
+    let rowWidth = 350;
+
+    function mockRowWidth() {
+      // mockImplementation (not mockReturnValue) so tests can change rowWidth
+      // after setup and the next measurement picks it up.
+      vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+        () =>
+          ({
+            width: rowWidth,
+            height: 32,
+            top: 0,
+            left: 0,
+            right: rowWidth,
+            bottom: 32,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }) as DOMRect,
+      );
+    }
+
+    beforeEach(() => {
+      rowWidth = 350;
+      mockRowWidth();
+      globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    });
+
+    afterEach(() => {
+      endPanelResize();
+      globalThis.ResizeObserver = originalResizeObserver;
+      MockResizeObserver.instances.clear();
+      vi.restoreAllMocks();
+    });
+
+    it("hides overflowing actions immediately during a divider drag", () => {
+      useSidebarUiStore.setState({ footerCollapsed: true });
+      render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+      // 350px fits everything, so there is no kebab yet.
+      expect(screen.queryByRole("button", { name: "More" })).not.toBeInTheDocument();
+
+      beginPanelResize();
+      rowWidth = 100;
+      act(() => MockResizeObserver.notifyAll());
+
+      // No debounce while dragging: the kebab appears in the same frame.
+      expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
+    });
+
+    it("debounces width changes when no drag is in progress", async () => {
+      useSidebarUiStore.setState({ footerCollapsed: true });
+      render(<SidebarFooterNav remoteAccessStatus="off" />);
+
+      rowWidth = 100;
+      act(() => MockResizeObserver.notifyAll());
+
+      // Animation/window-resize path: the row keeps its settled layout until
+      // the width stops moving, so the kebab does not appear right away.
+      expect(screen.queryByRole("button", { name: "More" })).not.toBeInTheDocument();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      });
+      expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFooterNav.tsx
@@ -1,0 +1,320 @@
+import { Dropdown, Label } from "@heroui/react";
+import { ChevronsDown, ChevronsUp, Ellipsis, PanelLeftClose, Settings2 } from "lucide-react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { useLingui } from "@lingui/react/macro";
+import { SidebarButton, sidebarIconButtonClass } from "@/renderer/components/common/SidebarButton";
+import { sidebarFooterNavClass } from "@/renderer/components/layout/sidebarChrome";
+import { DeferredSettingsOverlay } from "@/renderer/deferredFeatures";
+import { openRemoteAccessSettings, openSettings } from "@/renderer/actions/panelActions";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { isPanelResizing } from "@/renderer/state/panelResizeSignal";
+import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
+import { useSidebar } from "@/renderer/views/MainView/parts/AppShell/AppShell";
+import {
+  RemoteAccessSidebarIcon,
+  type RemoteAccessSidebarStatus,
+  RemoteAccessSidebarTooltip,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/RemoteAccessSidebarIcon";
+import { useSidebarShortcuts } from "@/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts";
+import {
+  SidebarWorkspaceSwitcher,
+  useHasSwitchableWorkspaces,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher";
+import {
+  UpdateButtons,
+  useUpdateEntryVisible,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons";
+import {
+  WhatsNewButton,
+  useWhatsNewEntryVisible,
+} from "@/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton";
+
+function prewarmSettings(): void {
+  void DeferredSettingsOverlay.preload();
+}
+
+/** Icon buttons are 32px wide on a 4px gap. */
+const FOOTER_ITEM_PITCH_PX = 36;
+
+interface FooterActionItem {
+  key: string;
+  icon: ReactNode;
+  label: string;
+  isActive: boolean;
+  onPress: () => void;
+  onPreload?: () => void;
+  tooltip?: ReactNode;
+}
+
+/**
+ * Sticky footer nav of the expanded sidebar: workspace switcher, optional
+ * update/changelog entries, the configurable shortcuts, Settings/Remote
+ * Access, and Hide sidebar. `footerCollapsed` (persisted) swaps the labeled
+ * rows for a single icon row to give the thread list more vertical room; the
+ * chevron toggle on the Hide-sidebar row switches modes.
+ *
+ * The icon row never wraps (wrapping made icons jump rows during the sidebar
+ * expand animation). Items that stop fitting after a *settled* resize move
+ * into a trailing kebab menu; Hide sidebar anchors the left edge and the
+ * expand toggle the right.
+ */
+export function SidebarFooterNav(props: { remoteAccessStatus: RemoteAccessSidebarStatus }) {
+  const { remoteAccessStatus } = props;
+  const { t } = useLingui();
+  const settingsOpen = usePanelStore((s) => s.settingsOpen);
+  const settingsSection = usePanelStore((s) => s.settingsSection);
+  // Remote Access has its own sidebar entry, so the generic Settings button
+  // lights up for every other section.
+  const remoteAccessSettingsActive = settingsOpen && settingsSection === "remoteAccess";
+  const otherSettingsActive = settingsOpen && !remoteAccessSettingsActive;
+  const footerCollapsed = useSidebarUiStore((s) => s.footerCollapsed);
+  const toggleFooterCollapsed = useSidebarUiStore((s) => s.toggleFooterCollapsed);
+  const sidebarShortcuts = useSidebarShortcuts();
+  const { isCollapsed, collapse } = useSidebar();
+  const hasSwitchableWorkspaces = useHasSwitchableWorkspaces();
+  const updateEntryVisible = useUpdateEntryVisible();
+  const whatsNewEntryVisible = useWhatsNewEntryVisible();
+
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const enabledRef = useRef(!isCollapsed);
+  enabledRef.current = !isCollapsed;
+  const [settledWidth, setSettledWidth] = useState<number | null>(null);
+
+  // Two resize paths with different responsiveness needs: a divider drag
+  // (panelResizeSignal) should overflow live with the pointer, so it applies
+  // immediately; the sidebar expand/collapse *animation* (or a window resize)
+  // changes the width every frame without a drag, so it is debounced until
+  // the width settles and the row reshuffles exactly once. Updates are
+  // skipped while the sidebar is collapsed (the footer is invisible then, and
+  // keeping the pre-collapse layout means a re-expand starts with the icons
+  // exactly where they were). A zero width (jsdom, or a fully collapsed
+  // column) reads as "unmeasured" so the row shows everything.
+  useLayoutEffect(() => {
+    const el = rowRef.current;
+    if (!el) return;
+    const read = () => el.getBoundingClientRect().width;
+    // First measurement applies synchronously so the row never flashes
+    // un-overflowed before paint.
+    const initial = read();
+    if (initial > 0) {
+      setSettledWidth((current) => (current === initial ? current : initial));
+    }
+    if (typeof ResizeObserver === "undefined") return;
+    let timer: number | undefined;
+    const apply = () => {
+      if (!enabledRef.current) return;
+      const next = read();
+      if (next > 0) {
+        setSettledWidth((current) => (current === next ? current : next));
+      }
+    };
+    const observer = new ResizeObserver(() => {
+      window.clearTimeout(timer);
+      if (isPanelResizing()) {
+        apply();
+      } else {
+        timer = window.setTimeout(apply, 150);
+      }
+    });
+    observer.observe(el);
+    return () => {
+      window.clearTimeout(timer);
+      observer.disconnect();
+    };
+    // The row only exists while the footer is collapsed, so re-run when that
+    // toggles to attach (or detach) the observer.
+  }, [footerCollapsed]);
+
+  if (footerCollapsed) {
+    const hideSidebarButton = (
+      <SidebarButton
+        iconOnly
+        icon={<PanelLeftClose className="size-4" />}
+        label={t`Hide sidebar`}
+        tooltipPlacement="top"
+        onPress={collapse}
+      />
+    );
+    // ml-auto pins the expand toggle to the right edge of the row whenever
+    // there is free space (no overflow); the wrapper owns the margin because
+    // SidebarButton's className lands on the inner button, not the flex item.
+    const expandButton = (
+      <div className="ml-auto flex min-h-0 flex-col">
+        <SidebarButton
+          iconOnly
+          icon={<ChevronsUp className="size-4" />}
+          label={t`Expand footer`}
+          tooltipPlacement="top"
+          onPress={toggleFooterCollapsed}
+        />
+      </div>
+    );
+    // Leading entries with their own visibility rules and trigger semantics
+    // (dropdown, live status tooltip, unread badge); they never overflow.
+    const specialItems: ReactNode[] = [
+      hasSwitchableWorkspaces ? <SidebarWorkspaceSwitcher key="workspace" iconOnly /> : null,
+      updateEntryVisible ? <UpdateButtons key="update" iconOnly tooltipPlacement="top" /> : null,
+      whatsNewEntryVisible ? (
+        <WhatsNewButton key="whatsNew" iconOnly tooltipPlacement="top" />
+      ) : null,
+    ].filter(Boolean);
+    const actionItems: FooterActionItem[] = [
+      ...sidebarShortcuts.map((shortcut) => ({
+        key: shortcut.id,
+        icon: shortcut.icon,
+        label: shortcut.label,
+        isActive: shortcut.isActive,
+        onPress: shortcut.onPress,
+      })),
+      {
+        key: "settings",
+        icon: <Settings2 className="size-4" />,
+        label: t`Settings`,
+        isActive: otherSettingsActive,
+        onPress: openSettings,
+        onPreload: prewarmSettings,
+      },
+      {
+        key: "remoteAccess",
+        icon: <RemoteAccessSidebarIcon status={remoteAccessStatus} />,
+        label: t`Remote Access`,
+        isActive: remoteAccessSettingsActive,
+        onPress: openRemoteAccessSettings,
+        onPreload: prewarmSettings,
+        tooltip: <RemoteAccessSidebarTooltip status={remoteAccessStatus} />,
+      },
+    ];
+
+    // Hide + expand are pinned, so they always claim two slots; the kebab
+    // claims one more whenever anything overflows.
+    const capacity =
+      settledWidth === null
+        ? Number.POSITIVE_INFINITY
+        : Math.floor((settledWidth + 4) / FOOTER_ITEM_PITCH_PX);
+    const totalCount = 2 + specialItems.length + actionItems.length;
+    const needsOverflow = totalCount > capacity;
+    const visibleActionCount = needsOverflow
+      ? Math.max(0, capacity - 2 - specialItems.length - 1)
+      : actionItems.length;
+    const visibleActions = actionItems.slice(0, visibleActionCount);
+    const overflowedActions = actionItems.slice(visibleActionCount);
+
+    return (
+      <div className={sidebarFooterNavClass}>
+        <div ref={rowRef} className="flex flex-nowrap items-center gap-1 overflow-hidden">
+          {hideSidebarButton}
+          {specialItems}
+          {visibleActions.map((item) => (
+            <SidebarButton
+              key={item.key}
+              iconOnly
+              icon={item.icon}
+              label={item.label}
+              tooltipPlacement="top"
+              isActive={item.isActive}
+              {...(item.tooltip ? { tooltip: item.tooltip } : {})}
+              {...(item.onPreload ? { onPreload: item.onPreload } : {})}
+              onPress={item.onPress}
+            />
+          ))}
+          {needsOverflow && overflowedActions.length > 0 ? (
+            <Dropdown
+              onOpenChange={(open) => {
+                // Overflowed entries lose the row's hover/focus preload, so the
+                // menu opening is the earliest signal that one may be picked —
+                // it still buys the lazy Settings chunk a head start.
+                if (open) {
+                  for (const item of overflowedActions) item.onPreload?.();
+                }
+              }}
+            >
+              <Dropdown.Trigger
+                aria-label={t`More`}
+                // The trigger stands in for the icons it hides, so it carries
+                // their active state when the current destination is in there.
+                className={sidebarIconButtonClass({
+                  isActive: overflowedActions.some((item) => item.isActive),
+                })}
+              >
+                <Ellipsis className="size-4" />
+              </Dropdown.Trigger>
+              <Dropdown.Popover placement="top end">
+                <Dropdown.Menu
+                  aria-label={t`More`}
+                  className="poracode-menu min-w-48"
+                  onAction={(key) => {
+                    overflowedActions.find((item) => item.key === String(key))?.onPress();
+                  }}
+                >
+                  {overflowedActions.map((item) => (
+                    <Dropdown.Item key={item.key} id={item.key} textValue={item.label}>
+                      {/* Row icons inherit the button's color; menu entries
+                          follow the muted-icon convention instead. */}
+                      <span className="flex size-4 shrink-0 items-center justify-center text-muted">
+                        {item.icon}
+                      </span>
+                      <Label>{item.label}</Label>
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+              </Dropdown.Popover>
+            </Dropdown>
+          ) : null}
+          {expandButton}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={sidebarFooterNavClass}>
+      <SidebarWorkspaceSwitcher />
+      <UpdateButtons />
+      <WhatsNewButton />
+      {sidebarShortcuts.map((shortcut) => (
+        <SidebarButton
+          key={shortcut.id}
+          icon={shortcut.icon}
+          label={shortcut.label}
+          isActive={shortcut.isActive}
+          onPress={shortcut.onPress}
+        />
+      ))}
+      <div className="flex items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <SidebarButton
+            icon={<Settings2 className="size-4" />}
+            label={t`Settings`}
+            isActive={otherSettingsActive}
+            onPreload={prewarmSettings}
+            onPress={openSettings}
+          />
+        </div>
+        <SidebarButton
+          iconOnly
+          icon={<RemoteAccessSidebarIcon status={remoteAccessStatus} />}
+          label={t`Remote Access`}
+          tooltip={<RemoteAccessSidebarTooltip status={remoteAccessStatus} />}
+          isActive={remoteAccessSettingsActive}
+          onPreload={prewarmSettings}
+          onPress={openRemoteAccessSettings}
+        />
+      </div>
+      <div className="flex items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <SidebarButton
+            icon={<PanelLeftClose className="size-4" />}
+            label={t`Hide sidebar`}
+            onPress={collapse}
+          />
+        </div>
+        <SidebarButton
+          iconOnly
+          icon={<ChevronsDown className="size-4" />}
+          label={t`Collapse footer`}
+          onPress={toggleFooterCollapsed}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.test.tsx
@@ -67,4 +67,32 @@ describe("SidebarWorkspaceSwitcher", () => {
     expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("client");
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
+
+  describe("iconOnly", () => {
+    it("switches directly to the other workspace when there are exactly two", () => {
+      render(<SidebarWorkspaceSwitcher iconOnly />);
+
+      // Icon mode drops the visible workspace name; the aria-label stays.
+      expect(screen.queryByText("Work")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("side");
+
+      fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("work");
+    });
+
+    it("opens the workspace picker when there are more than two", async () => {
+      useSharedSettings.setState((state) => ({
+        workspaces: [...state.workspaces, workspace("client", "Client", "palette")],
+      }));
+
+      render(<SidebarWorkspaceSwitcher iconOnly />);
+      fireEvent.click(screen.getByRole("button", { name: "Switch workspace" }));
+
+      expect(await screen.findByRole("menu")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("menuitemradio", { name: "Client" }));
+      expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("client");
+    });
+  });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorkspaceSwitcher.tsx
@@ -11,9 +11,22 @@ import {
   parseWorkspaceMenuKey,
   workspaceMenuKey,
 } from "@/renderer/components/workspace/workspaceMenuKeys";
-import { sidebarRowClass } from "@/renderer/components/common/SidebarButton";
+import {
+  SidebarButton,
+  sidebarIconButtonClass,
+  sidebarRowClass,
+} from "@/renderer/components/common/SidebarButton";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useActiveWorkspaceId, useWorkspaceStore } from "@/renderer/state/workspaceStore";
+
+/**
+ * Whether the workspace switcher renders anything at all (it stays hidden
+ * with fewer than two workspaces). The collapsed footer nav reads this to
+ * keep its overflow math in sync with the switcher's own visibility rule.
+ */
+export function useHasSwitchableWorkspaces(): boolean {
+  return useSharedSettings((state) => state.workspaces.length >= 2);
+}
 
 interface MenuEntry {
   key: string;
@@ -28,7 +41,8 @@ interface MenuEntry {
  * is scoped to. Lives at the top of the sidebar footer nav so it reads as
  * ambient context for the navigation below it rather than another destination.
  */
-export function SidebarWorkspaceSwitcher() {
+export function SidebarWorkspaceSwitcher(props: { iconOnly?: boolean }) {
+  const { iconOnly = false } = props;
   const { t } = useLingui();
   const workspaces = useSharedSettings((state) => state.workspaces);
   const activeWorkspaceId = useActiveWorkspaceId();
@@ -58,7 +72,11 @@ export function SidebarWorkspaceSwitcher() {
     isSelected: workspace.id === active.id,
   }));
 
-  const triggerContent = (
+  // Icon mode (collapsed footer nav): just the active workspace's icon; the
+  // button chrome supplies the muted/hover color.
+  const triggerContent = iconOnly ? (
+    <WorkspaceIcon icon={active.icon} className="size-4" />
+  ) : (
     <>
       <span className="flex size-4 shrink-0 items-center justify-center">
         <WorkspaceIcon icon={active.icon} className="size-4 text-muted" />
@@ -76,12 +94,32 @@ export function SidebarWorkspaceSwitcher() {
 
   if (workspaces.length === 2) {
     const nextWorkspace = workspaces.find((workspace) => workspace.id !== active.id)!;
+    const switchToNext = () => useWorkspaceStore.getState().setActiveWorkspaceId(nextWorkspace.id);
+    if (iconOnly) {
+      // iconOnly exists for the collapsed footer nav (a bottom icon row), so
+      // the tooltip opens upward instead of over the neighbouring icons.
+      return (
+        <SidebarButton
+          iconOnly
+          icon={triggerContent}
+          label={t`Switch workspace`}
+          tooltip={
+            <span>
+              {active.name}
+              <span className="text-muted"> — {t`Switch workspace`}</span>
+            </span>
+          }
+          tooltipPlacement="top"
+          onPress={switchToNext}
+        />
+      );
+    }
     return (
       <button
         type="button"
         aria-label={t`Switch workspace`}
         className={sidebarRowClass()}
-        onClick={() => useWorkspaceStore.getState().setActiveWorkspaceId(nextWorkspace.id)}
+        onClick={switchToNext}
       >
         {triggerContent}
       </button>
@@ -93,7 +131,7 @@ export function SidebarWorkspaceSwitcher() {
       type="button"
       aria-label={t`Switch workspace`}
       aria-expanded={isOpen}
-      className={sidebarRowClass()}
+      className={iconOnly ? sidebarIconButtonClass() : sidebarRowClass()}
       // Desktop presses are wired by Popover.Trigger; the mobile sheet has no
       // trigger wiring of its own, so it opens the drawer directly.
       {...(mobile ? { onClick: () => setIsOpen(true) } : {})}
@@ -131,7 +169,10 @@ export function SidebarWorkspaceSwitcher() {
 
   return (
     <Dropdown isOpen={isOpen} onOpenChange={setIsOpen}>
-      <Dropdown.Trigger aria-label={t`Switch workspace`} className={sidebarRowClass()}>
+      <Dropdown.Trigger
+        aria-label={t`Switch workspace`}
+        className={iconOnly ? sidebarIconButtonClass() : sidebarRowClass()}
+      >
         {triggerContent}
       </Dropdown.Trigger>
       <Dropdown.Popover placement="top start">

--- a/src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/UpdateButtons.tsx
@@ -1,0 +1,88 @@
+import { Tooltip } from "@heroui/react";
+import { Download, RefreshCw } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { AnimatedNumber } from "@/renderer/components/common/AnimatedNumber";
+import { SidebarButton } from "@/renderer/components/common/SidebarButton";
+import { readBridge } from "@/renderer/bridge";
+import { formatBytes } from "@/shared/formatBytes";
+import { useUpdateStore } from "@/renderer/state/updateStore";
+
+/**
+ * Whether `UpdateButtons` renders anything. The collapsed footer nav reads
+ * this to keep its overflow math in sync with the component's own rule.
+ */
+export function useUpdateEntryVisible(): boolean {
+  return useUpdateStore((s) => s.phase === "downloading" || s.phase === "downloaded");
+}
+
+export function UpdateButtons(props: {
+  iconOnly?: boolean;
+  /** Icon-only tooltip placement; bottom icon rows pass "top". */
+  tooltipPlacement?: "right" | "top";
+}) {
+  const { iconOnly = false, tooltipPlacement = "right" } = props;
+  const { t } = useLingui();
+  const updatePhase = useUpdateStore((s) => s.phase);
+  const updateVersion = useUpdateStore((s) => s.version);
+  const downloadPercent = useUpdateStore((s) => s.downloadPercent);
+  const transferred = useUpdateStore((s) => s.downloadTransferred);
+  const total = useUpdateStore((s) => s.downloadTotal);
+
+  if (updatePhase !== "downloading" && updatePhase !== "downloaded") {
+    return null;
+  }
+
+  if (updatePhase === "downloading") {
+    const percent = Math.min(100, Math.max(0, Math.round(downloadPercent)));
+    const byteLine =
+      transferred != null && total != null && total > 0
+        ? `${formatBytes(transferred)} / ${formatBytes(total)}`
+        : null;
+
+    if (iconOnly) {
+      return (
+        <Tooltip delay={150}>
+          <Tooltip.Trigger>
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center">
+              <Download className="size-4 animate-pulse text-muted" />
+            </div>
+          </Tooltip.Trigger>
+          <Tooltip.Content placement={tooltipPlacement} className="pointer-events-none">
+            <Trans>Downloading update</Trans> — {percent}%{byteLine ? ` · ${byteLine}` : ""}
+          </Tooltip.Content>
+        </Tooltip>
+      );
+    }
+
+    // Compact, fixed-height status: one line (bytes + percent) over a thin bar.
+    // The long target version is omitted — it overflowed/clipped and the About
+    // page already surfaces it. `tabular-nums` keeps the digits from reflowing.
+    return (
+      <div className="flex w-full items-center gap-2 rounded-3xl px-2 py-1.5 text-muted">
+        <Download className="size-4 shrink-0 animate-pulse text-muted" />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex min-w-0 items-center justify-between gap-2 text-xs tabular-nums">
+            <span className="truncate">{byteLine ?? <Trans>Downloading update</Trans>}</span>
+            <AnimatedNumber className="shrink-0" value={percent} suffix="%" />
+          </div>
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[var(--row-active)]">
+            <div
+              className="h-1 rounded-full bg-foreground transition-[width] duration-300"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <SidebarButton
+      iconOnly={iconOnly}
+      icon={<RefreshCw className="size-4" />}
+      label={updateVersion ? t`Install v${updateVersion}` : t`Install update`}
+      tooltipPlacement={tooltipPlacement}
+      onPress={() => void readBridge().installUpdate()}
+    />
+  );
+}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WhatsNewButton.tsx
@@ -4,14 +4,29 @@ import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import { useChangelogStore, useHasUnseenChangelog } from "@/renderer/state/changelogStore";
 
 /**
+ * Whether `WhatsNewButton` renders anything (hidden by the user with nothing
+ * new to announce → it stays out). The collapsed footer nav reads this to
+ * keep its overflow math in sync with the component's own rule.
+ */
+export function useWhatsNewEntryVisible(): boolean {
+  const hasUnseen = useHasUnseenChangelog();
+  const hidden = useChangelogStore((s) => s.whatsNewHidden);
+  return !hidden || hasUnseen;
+}
+
+/**
  * Sidebar entry for the changelog. Clicking it opens the "What's New" dialog.
  * An accent dot marks an unread release. On expanded rows a hide (X) control —
  * revealed on hover — removes the entry from the sidebar; it comes back on its
  * own when a newer release is unread. The changelog also lives in Settings →
  * Changelog regardless.
  */
-export function WhatsNewButton(props: { iconOnly?: boolean }) {
-  const { iconOnly = false } = props;
+export function WhatsNewButton(props: {
+  iconOnly?: boolean;
+  /** Icon-only tooltip placement; bottom icon rows pass "top". */
+  tooltipPlacement?: "right" | "top";
+}) {
+  const { iconOnly = false, tooltipPlacement = "right" } = props;
   const { t } = useLingui();
   const hasUnseen = useHasUnseenChangelog();
   const hidden = useChangelogStore((s) => s.whatsNewHidden);
@@ -52,6 +67,7 @@ export function WhatsNewButton(props: { iconOnly?: boolean }) {
       iconOnly={iconOnly}
       icon={icon}
       label={t`What's New`}
+      tooltipPlacement={tooltipPlacement}
       onPress={() => useChangelogStore.getState().openWhatsNew()}
       {...(suffix ? { suffix } : {})}
     />

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
@@ -1,0 +1,77 @@
+import { CalendarClock, GitPullRequest, Workflow } from "lucide-react";
+import { startTransition, type ReactNode } from "react";
+import { useLingui } from "@lingui/react/macro";
+import { useCurrentProjectId } from "@/renderer/hooks/uiSelectors";
+import { useAppStore } from "@/renderer/state/appStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+
+export interface SidebarShortcutEntry {
+  id: "pullRequests" | "githubActions" | "schedules";
+  icon: ReactNode;
+  label: string;
+  isActive: boolean;
+  onPress: () => void;
+}
+
+/**
+ * The configurable sidebar destinations (Settings → General can hide or
+ * reorder them). Shared by the expanded footer nav and the collapsed icon
+ * rail so both surfaces resolve order, visibility, and active state the same
+ * way.
+ */
+export function useSidebarShortcuts(): SidebarShortcutEntry[] {
+  const { t } = useLingui();
+  const currentProjectId = useCurrentProjectId();
+  const sidebarHiddenShortcuts = useSharedSettings((s) => s.sidebarHiddenShortcuts);
+  const sidebarShortcutOrder = useSharedSettings((s) => s.sidebarShortcutOrder);
+  const appView = useAppStore((s) => s.view);
+  const openPullRequests = useAppStore((s) => s.openPullRequests);
+  const openGitHubActions = useAppStore((s) => s.openGitHubActions);
+  const openSchedules = useAppStore((s) => s.openSchedules);
+  const githubActionsOpen = usePanelStore((s) => s.githubActionsContext !== null);
+
+  const sidebarShortcutsById = new Map<
+    SidebarShortcutEntry["id"],
+    Omit<SidebarShortcutEntry, "isActive">
+  >([
+    [
+      "pullRequests",
+      {
+        id: "pullRequests",
+        icon: <GitPullRequest className="size-4" />,
+        label: t`Pull requests`,
+        onPress: () => startTransition(() => openPullRequests()),
+      },
+    ],
+    [
+      "githubActions",
+      {
+        id: "githubActions",
+        icon: <Workflow className="size-4" />,
+        label: t`GitHub Actions`,
+        onPress: () => startTransition(() => openGitHubActions(currentProjectId)),
+      },
+    ],
+    [
+      "schedules",
+      {
+        id: "schedules",
+        icon: <CalendarClock className="size-4" />,
+        label: t`Schedules`,
+        onPress: () => startTransition(() => openSchedules()),
+      },
+    ],
+  ]);
+
+  return sidebarShortcutOrder
+    .map((id) => sidebarShortcutsById.get(id))
+    .filter(
+      (shortcut): shortcut is NonNullable<typeof shortcut> =>
+        shortcut !== undefined && !sidebarHiddenShortcuts.includes(shortcut.id),
+    )
+    .map((shortcut) => ({
+      ...shortcut,
+      isActive: shortcut.id === "githubActions" ? githubActionsOpen : appView.kind === shortcut.id,
+    }));
+}


### PR DESCRIPTION
- Split the monolithic Sidebar footer into focused components — `SidebarFooterNav`, `sidebarShortcuts`, `UpdateButtons`, and `RemoteAccessSidebarIcon` — with an icon-only mode for the workspace switcher, keeping `Sidebar.tsx` lean and reusable.
- Add a persistent footer collapse toggle (backed by `sidebarUiStore`) that swaps labeled rows for a compact icon row with a "More" kebab menu for overflow actions.
- Fix tooltips so they no longer block neighboring sidebar icons (non-interactive, configurable placement).
- Pin the flat thread list header above the scroll container so project headings stay visible while rows scroll.
- Localize all new strings in every catalog and add test coverage for footer nav, collapse behavior, and workspace switching.