### PR TITLE
Read Cursor context-window usage from SDK checkpoint store

### DIFF
--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
@@ -225,10 +225,14 @@ describe("GitHubActionsView", () => {
     render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
 
     expect(await screen.findByRole("heading", { name: "Alpha" })).toBeInTheDocument();
-    expect(bridge.ghListWorkflowRuns).toHaveBeenCalledWith({
-      projectLocation: project.location,
-      workflowId: 33,
-    });
+    // The runs fetch is kicked off by an effect after the selection commits, so
+    // under CI load it can lag the heading by a tick.
+    await waitFor(() =>
+      expect(bridge.ghListWorkflowRuns).toHaveBeenCalledWith({
+        projectLocation: project.location,
+        workflowId: 33,
+      }),
+    );
   });
 
   it("deep-links directly to a PR check run", async () => {

--- a/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMapping.test.ts
@@ -1185,6 +1185,7 @@ describe("Cursor SDK canonical mapping — auxiliary updates and usage", () => {
         },
       },
     ]);
+    expect(events.some((event) => event.type === "context.updated")).toBe(false);
     expectCanonical(events);
   });
 

--- a/src/supervisor/agents/cursor/sdkCanonicalMapping.ts
+++ b/src/supervisor/agents/cursor/sdkCanonicalMapping.ts
@@ -468,8 +468,7 @@ function mapUsage(
   const runId = state.currentRunId ?? state.currentTurnId ?? state.threadId;
   const sampleId = `${runId}:turn-${state.usageSequence}`;
   // Cursor documents this as per-turn spend, which can aggregate several
-  // model/tool-loop calls. It is not current context-window occupancy, so the
-  // exact mapping is `usage.spent` only.
+  // model/tool-loop calls. It is not current context-window occupancy.
   return [
     {
       type: "usage.spent",

--- a/src/supervisor/agents/cursor/sdkContextUsage.test.ts
+++ b/src/supervisor/agents/cursor/sdkContextUsage.test.ts
@@ -1,0 +1,162 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cursorSdkStateRoot, readCursorSdkContextUsage } from "./sdkContextUsage";
+
+const fakeStores = new Map<
+  string,
+  { agents: Map<string, string>; blobs: Map<string, Uint8Array> }
+>();
+
+vi.mock("../../runtime/sqliteRead", () => ({
+  withReadonlyDb: async (dbPath: string, fn: (db: unknown) => unknown) => {
+    const store = fakeStores.get(dbPath);
+    if (!store) return undefined;
+    return fn({
+      prepare(sql: string) {
+        return {
+          get(param: unknown) {
+            if (sql.includes("FROM agents")) {
+              const ref = store.agents.get(String(param));
+              return ref === undefined ? undefined : { latest_checkpoint_ref_json: ref };
+            }
+            const data = store.blobs.get(String(param));
+            return data === undefined ? undefined : { data };
+          },
+        };
+      },
+    });
+  },
+}));
+
+function varint(value: number): Buffer {
+  const bytes: number[] = [];
+  let remaining = BigInt(value);
+  for (;;) {
+    const byte = Number(remaining & 0x7fn);
+    remaining >>= 7n;
+    if (remaining === 0n) {
+      bytes.push(byte);
+      break;
+    }
+    bytes.push(byte | 0x80);
+  }
+  return Buffer.from(bytes);
+}
+
+function field(fieldNo: number, value: number | string | Buffer): Buffer {
+  if (typeof value === "number") {
+    return Buffer.concat([varint((fieldNo << 3) | 0), varint(value)]);
+  }
+  const bytes = typeof value === "string" ? Buffer.from(value, "utf8") : value;
+  return Buffer.concat([varint((fieldNo << 3) | 2), varint(bytes.length), bytes]);
+}
+
+function category(id: string, label: string, tokens: number): Buffer {
+  return field(3, Buffer.concat([field(1, id), field(2, label), field(3, tokens)]));
+}
+
+function conversationStateBlob(used: number, max: number, categories: Buffer[]): Buffer {
+  const breakdown = field(3, Buffer.concat(categories));
+  const tokenDetails = Buffer.concat([field(1, used), field(2, max), breakdown]);
+  return field(5, tokenDetails);
+}
+
+const AGENT_ID = "agent-12345678-9abc-def0-1234-56789abcdef0";
+
+function installStore(stateRoot: string, blob: Uint8Array): string {
+  const blobId = createHash("sha256").update(blob).digest("hex");
+  fakeStores.set(join(stateRoot, "index.db"), {
+    agents: new Map([[AGENT_ID, JSON.stringify({ blobId, storeKind: "local-agent-store" })]]),
+    blobs: new Map(),
+  });
+  const agentDir = `agent-${createHash("sha256").update(AGENT_ID).digest("hex")}`;
+  fakeStores.set(join(stateRoot, "agents", agentDir, "store.db"), {
+    agents: new Map(),
+    blobs: new Map([[blobId, blob]]),
+  });
+  return blobId;
+}
+
+describe("cursorSdkStateRoot", () => {
+  it("mirrors the SDK default store layout for a workspace ref", () => {
+    const root = cursorSdkStateRoot("E:\\work\\lightcode", "C:\\home\\tester");
+    expect(root).toBe(
+      join(
+        "C:\\home\\tester",
+        ".cursor",
+        "projects",
+        "E-work-lightcode",
+        "sdk-agent-store",
+        createHash("md5").update("E:\\work\\lightcode").digest("hex"),
+      ),
+    );
+  });
+});
+
+describe("readCursorSdkContextUsage", () => {
+  beforeEach(() => {
+    fakeStores.clear();
+  });
+
+  it("decodes token details and categories from the checkpoint blob", async () => {
+    const stateRoot = join("C:\\home\\tester", "store");
+    const blob = conversationStateBlob(22_364, 200_000, [
+      category("system_prompt", "System prompt", 468),
+      category("tools", "Tool definitions", 7049),
+      category("summarized_conversation", "Summarized conversation", 0),
+      category("conversation", "Conversation", 14_847),
+    ]);
+    installStore(stateRoot, blob);
+
+    const usage = await readCursorSdkContextUsage({
+      cwd: "E:\\work\\lightcode",
+      agentId: AGENT_ID,
+      stateRoot,
+    });
+
+    expect(usage).toEqual({
+      usedTokens: 22_364,
+      maxTokens: 200_000,
+      categories: [
+        { id: "system_prompt", label: "System prompt", tokens: 468 },
+        { id: "tools", label: "Tool definitions", tokens: 7049 },
+        { id: "conversation", label: "Conversation", tokens: 14_847 },
+      ],
+    });
+  });
+
+  it("reads a WSL store from the caller-provided UNC home directory", async () => {
+    const cwd = "/home/demo/repo";
+    const homeDir = "\\\\wsl.localhost\\Ubuntu\\home\\demo";
+    const stateRoot = cursorSdkStateRoot(cwd, homeDir);
+    installStore(stateRoot, conversationStateBlob(120, 200_000, []));
+
+    await expect(readCursorSdkContextUsage({ cwd, agentId: AGENT_ID, homeDir })).resolves.toEqual({
+      usedTokens: 120,
+      maxTokens: 200_000,
+      categories: [],
+    });
+  });
+
+  it("returns undefined when no checkpoint store exists", async () => {
+    const usage = await readCursorSdkContextUsage({
+      cwd: "E:\\work\\nowhere",
+      agentId: AGENT_ID,
+      stateRoot: join("C:\\home\\tester", "missing"),
+    });
+    expect(usage).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed blob instead of throwing", async () => {
+    const stateRoot = join("C:\\home\\tester", "broken");
+    installStore(stateRoot, new Uint8Array([0x2a, 0xff, 0xff, 0xff, 0x7f, 0x01]));
+
+    const usage = await readCursorSdkContextUsage({
+      cwd: "E:\\work\\lightcode",
+      agentId: AGENT_ID,
+      stateRoot,
+    });
+    expect(usage).toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/cursor/sdkContextUsage.ts
+++ b/src/supervisor/agents/cursor/sdkContextUsage.ts
@@ -1,0 +1,182 @@
+/**
+ * Best-effort reader for the Cursor SDK's local checkpoint store.
+ *
+ * The public `@cursor/sdk` API only reports billed per-turn token usage. The
+ * context-window occupancy the Cursor app shows (used/max plus the
+ * system-prompt/tools/rules/skills/MCP/subagents/conversation breakdown) lives
+ * in the SDK's private local store: `~/.cursor/projects/<ref>/sdk-agent-store/
+ * <md5(ref)>/` with one SQLite DB per agent holding protobuf checkpoint blobs
+ * (`agent.v1.ConversationState.token_details`, observed in SDK 1.0.2x).
+ *
+ * This reader mirrors that layout read-only. Every step is guarded — a
+ * missing directory, a locked WAL database, or a reshaped protobuf degrades to
+ * `undefined`; the session continues with public spend events and leaves
+ * context occupancy unavailable.
+ */
+
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { withReadonlyDb } from "../../runtime/sqliteRead";
+
+export interface CursorSdkContextCategory {
+  id: string;
+  label: string;
+  tokens: number;
+}
+
+export interface CursorSdkContextUsage {
+  usedTokens: number;
+  maxTokens?: number | undefined;
+  categories: CursorSdkContextCategory[];
+}
+
+export interface CursorSdkContextUsageInput {
+  cwd: string;
+  agentId: string;
+  stateRoot?: string | undefined;
+  homeDir?: string | undefined;
+}
+
+export function cursorSdkStateRoot(cwd: string, homeDir: string = homedir()): string {
+  // Mirrors the SDK's default store location for a workspace ref (raw cwd).
+  const sanitized = cwd
+    .replace(/[^a-zA-Z0-9]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const digest = createHash("md5").update(cwd).digest("hex");
+  return join(homeDir, ".cursor", "projects", sanitized, "sdk-agent-store", digest);
+}
+
+export async function readCursorSdkContextUsage(
+  input: CursorSdkContextUsageInput,
+): Promise<CursorSdkContextUsage | undefined> {
+  const stateRoot = input.stateRoot ?? cursorSdkStateRoot(input.cwd, input.homeDir);
+  const blobId = await withReadonlyDb(join(stateRoot, "index.db"), (db) => {
+    const row = db
+      .prepare("SELECT latest_checkpoint_ref_json FROM agents WHERE agent_id = ?")
+      .get(input.agentId) as { latest_checkpoint_ref_json?: string | null } | undefined;
+    if (!row?.latest_checkpoint_ref_json) return undefined;
+    const parsed = JSON.parse(row.latest_checkpoint_ref_json) as { blobId?: string };
+    return parsed.blobId;
+  }).catch(() => undefined);
+  if (!blobId) return undefined;
+
+  const agentDir = `agent-${createHash("sha256").update(input.agentId).digest("hex")}`;
+  const blob = await withReadonlyDb(join(stateRoot, "agents", agentDir, "store.db"), (db) => {
+    const row = db.prepare("SELECT data FROM blobs WHERE id = ?").get(blobId) as
+      | { data?: Uint8Array | null }
+      | undefined;
+    return row?.data ? new Uint8Array(row.data) : undefined;
+  }).catch(() => undefined);
+  if (!blob) return undefined;
+
+  try {
+    return decodeConversationStateContextUsage(blob);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeConversationStateContextUsage(blob: Uint8Array): CursorSdkContextUsage | undefined {
+  for (const field of protoFields(blob)) {
+    // ConversationState.token_details
+    if (field.fieldNo !== 5 || !field.bytes) continue;
+    return decodeTokenDetails(field.bytes);
+  }
+  return undefined;
+}
+
+function decodeTokenDetails(bytes: Uint8Array): CursorSdkContextUsage | undefined {
+  let usedTokens: number | undefined;
+  let maxTokens: number | undefined;
+  const categories: CursorSdkContextCategory[] = [];
+  for (const field of protoFields(bytes)) {
+    if (field.fieldNo === 1 && field.value !== undefined) usedTokens = field.value;
+    else if (field.fieldNo === 2 && field.value !== undefined) maxTokens = field.value;
+    else if (field.fieldNo === 3 && field.bytes) {
+      for (const category of protoFields(field.bytes)) {
+        if (category.fieldNo === 3 && category.bytes) {
+          const decoded = decodeCategory(category.bytes);
+          if (decoded && decoded.tokens > 0) categories.push(decoded);
+        }
+      }
+    }
+  }
+  if (usedTokens === undefined || usedTokens <= 0) return undefined;
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined && maxTokens > 0 ? { maxTokens } : {}),
+    categories,
+  };
+}
+
+function decodeCategory(bytes: Uint8Array): CursorSdkContextCategory | undefined {
+  let id = "";
+  let label = "";
+  let tokens = 0;
+  for (const field of protoFields(bytes)) {
+    if (field.fieldNo === 1 && field.bytes) id = utf8(field.bytes);
+    else if (field.fieldNo === 2 && field.bytes) label = utf8(field.bytes);
+    else if (field.fieldNo === 3 && field.value !== undefined) tokens = field.value;
+  }
+  if (!id && !label) return undefined;
+  return { id: id || label, label: label || id, tokens };
+}
+
+interface ProtoField {
+  fieldNo: number;
+  value?: number | undefined;
+  bytes?: Uint8Array | undefined;
+}
+
+/** Lenient protobuf walker: varint (wire 0) and length-delimited (wire 2) only. */
+function protoFields(bytes: Uint8Array): ProtoField[] {
+  const fields: ProtoField[] = [];
+  let offset = 0;
+  while (offset < bytes.length) {
+    const [key, afterKey] = readVarint(bytes, offset);
+    offset = afterKey;
+    const fieldNo = Number(key >> 3n);
+    const wireType = Number(key & 7n);
+    if (wireType === 0) {
+      const [value, afterValue] = readVarint(bytes, offset);
+      offset = afterValue;
+      fields.push({ fieldNo, value: Number(value) });
+    } else if (wireType === 2) {
+      const [length, afterLength] = readVarint(bytes, offset);
+      offset = afterLength;
+      const size = Number(length);
+      if (offset + size > bytes.length) throw new Error("Truncated protobuf field.");
+      fields.push({ fieldNo, bytes: bytes.subarray(offset, offset + size) });
+      offset += size;
+    } else if (wireType === 1) {
+      offset += 8;
+    } else if (wireType === 5) {
+      offset += 4;
+    } else {
+      throw new Error(`Unsupported protobuf wire type ${wireType}.`);
+    }
+  }
+  return fields;
+}
+
+function readVarint(bytes: Uint8Array, offset: number): [bigint, number] {
+  let result = 0n;
+  let shift = 0n;
+  let index = offset;
+  for (;;) {
+    const byte = bytes[index];
+    if (byte === undefined) throw new Error("Truncated varint.");
+    index += 1;
+    result |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) break;
+    shift += 7n;
+    if (shift > 63n) throw new Error("Varint overflow.");
+  }
+  return [result, index];
+}
+
+function utf8(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("utf8");
+}

--- a/src/supervisor/agents/cursor/sdkSession.ts
+++ b/src/supervisor/agents/cursor/sdkSession.ts
@@ -9,6 +9,7 @@ import type {
   ThreadConfig,
   ThreadStatus,
 } from "@/shared/contracts";
+import { toWslUncPath } from "@/shared/wsl";
 import {
   createKnownSessionRef,
   type AgentLaunchOptions,
@@ -20,6 +21,8 @@ import {
   type ThreadHistory,
 } from "../base";
 import { resolveSessionCwd } from "../acp/sessionPaths";
+import { resolveWslHomeDirectoryAsync } from "../base/processRuntime";
+import { createContextUsageEvent } from "../contextUsage";
 import { buildCursorSdkMcpServers } from "../userMcp";
 import {
   closeCursorSdkOpenItems,
@@ -30,6 +33,7 @@ import {
   startCursorSdkTurn,
   type CursorSdkMapperState,
 } from "./sdkCanonicalMapping";
+import { readCursorSdkContextUsage } from "./sdkContextUsage";
 import {
   buildCursorSdkModelSelection,
   type CursorSdkModel,
@@ -239,6 +243,7 @@ export class CursorSdkSession implements StructuredSessionHandle {
   private closeReported = false;
   private activated = false;
   private disposed = false;
+  private contextUsageRefreshGeneration = 0;
 
   private get apiKey(): string | undefined {
     // The shared GUI session factory normally leaves `input.env` absent and
@@ -375,6 +380,7 @@ export class CursorSdkSession implements StructuredSessionHandle {
       config,
       sessionRef: this.stableSessionRef,
     });
+    void this.refreshContextUsage();
     return prefixedId;
   }
 
@@ -800,6 +806,7 @@ export class CursorSdkSession implements StructuredSessionHandle {
     } else {
       this.emitUpdate({ status: "idle", attention: "none" });
     }
+    void this.refreshContextUsage();
     turn.resolveCompletion();
   }
 
@@ -890,6 +897,45 @@ export class CursorSdkSession implements StructuredSessionHandle {
       return;
     }
     for (const event of events) this.listener.onRuntimeEvent(event);
+  }
+
+  /**
+   * The public SDK only reports billed per-turn spend; the context-window
+   * occupancy the Cursor app displays is read best-effort from the SDK's
+   * private checkpoint store. Failures leave context usage unavailable.
+   */
+  private async refreshContextUsage(): Promise<void> {
+    const agentId = this.sessionId;
+    if (!agentId || this.disposed) return;
+    const generation = ++this.contextUsageRefreshGeneration;
+    const cwd = resolveSessionCwd(this.input.projectLocation);
+    try {
+      const projectLocation = this.input.projectLocation;
+      const wslDistro = projectLocation.kind === "wsl" ? projectLocation.distro : undefined;
+      const wslHome = wslDistro ? await resolveWslHomeDirectoryAsync(wslDistro) : undefined;
+      if (wslDistro && !wslHome) return;
+      const usage = await readCursorSdkContextUsage({
+        cwd,
+        agentId,
+        ...(wslDistro && wslHome ? { homeDir: toWslUncPath(wslDistro, wslHome) } : {}),
+      });
+      if (
+        !usage ||
+        this.disposed ||
+        this.sessionId !== agentId ||
+        generation !== this.contextUsageRefreshGeneration
+      ) {
+        return;
+      }
+      const event = createContextUsageEvent(this.input.threadId, {
+        usedTokens: usage.usedTokens,
+        ...(usage.maxTokens !== undefined ? { maxTokens: usage.maxTokens } : {}),
+        ...(usage.categories.length > 0 ? { breakdown: usage.categories } : {}),
+      });
+      if (event) this.emitRuntimeEvents([event]);
+    } catch {
+      // Context usage is supplemental; the public per-turn spend stream remains authoritative.
+    }
   }
 
   private requireWorker(): CursorSdkWorkerHandle {


### PR DESCRIPTION
- Add a best-effort reader that surfaces context-window occupancy (used/max tokens plus system-prompt/tools/conversation breakdown) by parsing the SDK's private local SQLite checkpoint store, since the public SDK API only reports billed per-turn spend.
- Wire the reader into the Cursor SDK session so context occupancy refreshes and emits `context.updated` events during runs.
- Guard every step so a missing directory, locked WAL database, or reshaped protobuf degrades to no context usage instead of breaking the session; per-turn spend events remain authoritative.
- Add unit tests covering store layout resolution (including WSL UNC home directories) and malformed-input fallbacks.