### PR TITLE
feat(acp): support Factory droid's bare AskUser tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "smoke:integration": "node .agents/skills/interactive-testing/scripts/run-poracode-smoke.mjs",
     "update-server": "node scripts/update-server.mjs",
     "db:clone": "node scripts/clone-db.mjs",
+    "db:clone:nightly": "node scripts/clone-db.mjs nightly",
     "i18n:extract": "lingui extract",
     "i18n:extract:clean": "lingui extract --clean",
     "prepare": "husky"

--- a/scripts/clone-db.mjs
+++ b/scripts/clone-db.mjs
@@ -1,10 +1,11 @@
-// Clones the production Poracode SQLite DB into the dev base dir so dev runs
-// start from real data. One-way (prod -> dev) by design; never the reverse.
+// Clones a Poracode channel SQLite DB into the dev base dir so dev runs start
+// from real data. One-way (channel -> dev) by design; never the reverse.
 //
-// Source: ~/.poracode/state.sqlite
+// Source: ~/.poracode/state.sqlite       (default, stable)
+//         ~/.poracode-nightly/state.sqlite (with "nightly" argument)
 // Dest:   ~/.poracode-dev/state.sqlite
 //
-// Uses SQLite's online backup API so it is safe to run while the production app
+// Uses SQLite's online backup API so it is safe to run while the source app
 // is open (no WAL/SHM corruption). The dev DB is overwritten.
 
 import { spawnSync } from "node:child_process";
@@ -12,7 +13,8 @@ import { homedir } from "node:os";
 import { existsSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-const srcDir = join(homedir(), ".poracode");
+const channel = process.argv[2] === "nightly" ? "nightly" : "stable";
+const srcDir = join(homedir(), channel === "nightly" ? ".poracode-nightly" : ".poracode");
 const destDir = join(homedir(), ".poracode-dev");
 const srcPath = join(srcDir, "state.sqlite");
 const destPath = join(destDir, "state.sqlite");

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -339,7 +339,10 @@ describe("chatPaneSelectors", () => {
     ]);
   });
 
-  it("hides AskUserQuestion tool rows after a late ACP name update", () => {
+  it.each([
+    { name: "AskUserQuestion", title: "AskUserQuestion" },
+    { name: "AskUser", title: "AskUser" },
+  ])("hides $name tool rows after a late ACP name update", ({ name, title }) => {
     const itemIds = ["assistant-1", "tool-question", "answer-1"];
     const state = {
       runtimeItemIdsByThread: { question: itemIds },
@@ -355,7 +358,7 @@ describe("chatPaneSelectors", () => {
             id: "tool-question",
             type: "tool_call",
             state: "completed",
-            payload: { name: "AskUserQuestion", title: "AskUserQuestion", status: "success" },
+            payload: { name, title, status: "success" },
             streams: {},
           },
           "answer-1": {

--- a/src/shared/toolCallClassification.ts
+++ b/src/shared/toolCallClassification.ts
@@ -26,12 +26,16 @@ export function isWorkflowTool(payload: ToolCallPayload | undefined): boolean {
  * Question tools are interaction plumbing: the canonical request form and the
  * resulting question_answer item are their user-facing surfaces. Some ACP
  * agents name the tool only in a later update, so this check also protects
- * persisted transcripts that already contain the redundant tool row.
+ * persisted transcripts that already contain the redundant tool row. Covers
+ * the ACP spellings in the wild: "AskUserQuestion", "Ask user N questions",
+ * and Factory droid's bare "AskUser" / "ask_user" (no "question" suffix).
  */
 export function isAskUserQuestionToolName(candidate: unknown): boolean {
   return (
     typeof candidate === "string" &&
-    /^(?:ask[_ ]?user[_ ]?question|ask user \d+ questions?)(?::|\b)/iu.test(candidate.trim())
+    /^(?:ask[_ ]?user[_ ]?question|ask[_ ]?user\b|ask user \d+ questions?)(?::|\b)/iu.test(
+      candidate.trim(),
+    )
   );
 }
 

--- a/src/supervisor/agents/acp/acpQuestionPermissions.test.ts
+++ b/src/supervisor/agents/acp/acpQuestionPermissions.test.ts
@@ -56,6 +56,14 @@ describe("parseAcpPermissionQuestions (Kimi v2 content shape)", () => {
     expect(isAcpAskUserQuestionToolCall({ title: "Bash" })).toBe(false);
   });
 
+  it("recognizes Factory droid's bare AskUser tool call by title and name", () => {
+    expect(isAcpAskUserQuestionToolCall({ title: "AskUser" })).toBe(true);
+    expect(isAcpAskUserQuestionToolCall({ name: "ask_user" })).toBe(true);
+    expect(isAcpAskUserQuestionToolCall({ title: "AskUser", name: "ask_user" })).toBe(true);
+    expect(isAcpAskUserQuestionToolCall({ title: "TodoWrite" })).toBe(false);
+    expect(isAcpAskUserQuestionToolCall({ title: "Execute" })).toBe(false);
+  });
+
   it("does not reinterpret ordinary approvals as questions", () => {
     const approval: RequestPermissionRequest = {
       sessionId: "session-1",
@@ -68,6 +76,129 @@ describe("parseAcpPermissionQuestions (Kimi v2 content shape)", () => {
       options: [{ optionId: "approve_once", name: "Approve once", kind: "allow_once" }],
     };
     expect(parseAcpPermissionQuestions(approval)).toEqual([]);
+  });
+});
+
+/**
+ * The exact shape Factory droid 0.189.0 emits over ACP for its AskUser tool:
+ * the tool identity is the bare `AskUser` title, the question payload is a
+ * single plain-text `rawInput.questionnaire` string in the format from
+ * droid's AskUser tool description, and the ACP permission options are plain
+ * proceed/cancel choices (the answers are NOT the options).
+ */
+function droidQuestionnaireRequest(): RequestPermissionRequest {
+  return {
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "tool-ask-droid",
+      title: "AskUser",
+      kind: "other",
+      rawInput: {
+        questionnaire: [
+          "1. [question] Which features do you want to enable? (multi)",
+          "[topic] Features",
+          "[option] Auth handling",
+          "[option] Login Page",
+          "2. [question] Which library should we use for date formatting?",
+          "[topic] Library",
+          "[option] Library ABC",
+          "[option] Library BlaBla",
+        ].join("\n"),
+      },
+    },
+    options: [
+      { optionId: "proceed_once", name: "Submit", kind: "allow_once" },
+      { optionId: "cancel", name: "Cancel", kind: "reject_once" },
+    ],
+  };
+}
+
+describe("parseAcpPermissionQuestions (droid questionnaire shape)", () => {
+  it("parses numbered questions, topics, options, and the (multi) flag", () => {
+    expect(parseAcpPermissionQuestions(droidQuestionnaireRequest())).toEqual([
+      {
+        id: "0",
+        header: "Features",
+        question: "Which features do you want to enable?",
+        options: [
+          { optionId: "Auth handling", label: "Auth handling" },
+          { optionId: "Login Page", label: "Login Page" },
+        ],
+        multiSelect: true,
+      },
+      {
+        id: "1",
+        header: "Library",
+        question: "Which library should we use for date formatting?",
+        options: [
+          { optionId: "Library ABC", label: "Library ABC" },
+          { optionId: "Library BlaBla", label: "Library BlaBla" },
+        ],
+        multiSelect: false,
+      },
+    ]);
+  });
+
+  it("falls back to the question text as header when no topic line is present", () => {
+    const request = droidQuestionnaireRequest();
+    (request.toolCall!.rawInput as { questionnaire: string }).questionnaire = [
+      "1. [question] Which scope?",
+      "[option] Focused",
+      "[option] Broad",
+    ].join("\n");
+    expect(parseAcpPermissionQuestions(request)).toEqual([
+      {
+        id: "0",
+        header: "Which scope?",
+        question: "Which scope?",
+        options: [
+          { optionId: "Focused", label: "Focused" },
+          { optionId: "Broad", label: "Broad" },
+        ],
+        multiSelect: false,
+      },
+    ]);
+  });
+
+  it("ignores notes and trailing prose lines outside the format", () => {
+    const request = droidQuestionnaireRequest();
+    (request.toolCall!.rawInput as { questionnaire: string }).questionnaire = [
+      "1. [question] Confirm the plan?",
+      "[topic] Plan",
+      "[option] Approve",
+      "[option] Adjust",
+      "Notes:",
+      "- Keep it short",
+    ].join("\n");
+    expect(parseAcpPermissionQuestions(request).map((q) => q.question)).toEqual([
+      "Confirm the plan?",
+    ]);
+  });
+});
+
+describe("normalizeAcpQuestionPermissionResponse (droid questionnaire ids)", () => {
+  it("answers through the allow_once fallback since droid options are not the choices", () => {
+    const request = droidQuestionnaireRequest();
+    expect(
+      normalizeAcpQuestionPermissionResponse(request, {
+        answers: { "0": "Auth handling", "1": "Library ABC" },
+      }),
+    ).toEqual({
+      outcome: { outcome: "selected", optionId: "proceed_once" },
+      answers: { "0": "Auth handling", "1": "Library ABC" },
+    });
+  });
+
+  it("joins multiple picked choices and keeps free-text custom answers verbatim", () => {
+    const request = droidQuestionnaireRequest();
+    expect(
+      normalizeAcpQuestionPermissionResponse(request, {
+        answers: { "0": ["Auth handling", "Login Page"], "1": "a bespoke library" },
+      }),
+    ).toEqual({
+      outcome: { outcome: "selected", optionId: "proceed_once" },
+      answers: { "0": "Auth handling, Login Page", "1": "a bespoke library" },
+    });
   });
 });
 

--- a/src/supervisor/agents/acp/acpQuestionPermissions.ts
+++ b/src/supervisor/agents/acp/acpQuestionPermissions.ts
@@ -29,8 +29,8 @@ type AcpQuestionPermissionResponse = RequestPermissionResponse & {
 };
 
 /**
- * AskUserQuestion is carried over ACP's requestPermission method in two
- * provider-native shapes, both normalized to the same AcpPermissionQuestion
+ * AskUserQuestion is carried over ACP's requestPermission method in three
+ * provider-native shapes, all normalized to the same AcpPermissionQuestion
  * contract so shared runtime and renderer code stays provider-agnostic:
  *  - Qwen Code sends a structured `rawInput.questions` array (header, question,
  *    options) — the same signal Qwen's own ACP clients use.
@@ -38,6 +38,10 @@ type AcpQuestionPermissionResponse = RequestPermissionResponse & {
  *    `toolCall.content` and the answer choices are the standard requestPermission
  *    `options`. Detection stays semantic (tool identity + payload shape) rather
  *    than keyed on the provider kind.
+ *  - Factory droid sends a single plain-text `rawInput.questionnaire` string
+ *    (`"1. [question] ..."`, `"[topic] ..."`, `"[option] ..."` lines, with
+ *    `(multi)` on the question line opting into multi-select) that is parsed
+ *    back into the same question list.
  */
 export function parseAcpPermissionQuestions(
   request: RequestPermissionRequest,
@@ -45,6 +49,9 @@ export function parseAcpPermissionQuestions(
   const rawInput = request.toolCall?.rawInput;
   if (isRecord(rawInput) && Array.isArray(rawInput.questions)) {
     return parseRawInputQuestions(rawInput.questions);
+  }
+  if (isRecord(rawInput) && typeof rawInput.questionnaire === "string") {
+    return parseQuestionnairePermissionQuestions(rawInput.questionnaire);
   }
   return parseContentPermissionQuestion(request);
 }
@@ -93,6 +100,65 @@ function parseRawInputQuestions(rawQuestions: readonly unknown[]): AcpPermission
       },
     ];
   });
+}
+
+/**
+ * Droid shape: a single plain-text questionnaire. The format is documented in
+ * droid's AskUser tool description — one numbered `[question]` line per
+ * question, followed by one `[topic]` label and 2-4 `[option]` lines; a
+ * trailing `(multi)` on the question line opts into multi-select. Options
+ * carry no ids in the wire format, so the label doubles as the optionId (the
+ * Qwen fallback convention) — answer echoes and label lookups round-trip.
+ */
+const DROID_QUESTION_LINE =
+  /^\s*(?:[0-9]+[.)]\s*)?\[question\]\s*(.+?)\s*(?:\((multi(?:ple)?(?:[-_ ]select)?)\))?$/iu;
+const DROID_TOPIC_LINE = /^\s*\[topic\]\s*(.+?)\s*$/iu;
+const DROID_OPTION_LINE = /^\s*\[option\]\s*(.+?)\s*$/iu;
+
+function parseQuestionnairePermissionQuestions(raw: string): AcpPermissionQuestion[] {
+  interface ParsedDroidQuestion {
+    question: string;
+    topic: string;
+    options: string[];
+    multiSelect: boolean;
+  }
+  const parsed: ParsedDroidQuestion[] = [];
+  let current: ParsedDroidQuestion | undefined;
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    const questionMatch = DROID_QUESTION_LINE.exec(line);
+    if (questionMatch) {
+      if (current) parsed.push(current);
+      current = {
+        question: questionMatch[1]!.trim(),
+        topic: "",
+        options: [],
+        multiSelect: questionMatch[2] !== undefined,
+      };
+      continue;
+    }
+    if (!current) continue;
+    const topicMatch = DROID_TOPIC_LINE.exec(line);
+    if (topicMatch) {
+      current.topic = topicMatch[1]!.trim();
+      continue;
+    }
+    const optionMatch = DROID_OPTION_LINE.exec(line);
+    if (optionMatch) {
+      current.options.push(optionMatch[1]!.trim());
+    }
+  }
+  if (current) parsed.push(current);
+  return parsed
+    .filter((question) => question.question.length > 0)
+    .map((question, index) => ({
+      id: String(index),
+      header: question.topic.length > 0 ? question.topic : question.question,
+      question: question.question,
+      options: question.options.map((label) => ({ optionId: label, label })),
+      multiSelect: question.multiSelect,
+    }));
 }
 
 /**
@@ -193,18 +259,20 @@ export function buildAcpQuestionPermissionAnswerEvents(input: {
 }
 
 /**
- * Detect an AskUserQuestion tool call by its identity (tool name / title), used
- * both to gate the Kimi content-shape parser and to suppress the redundant tool
- * row once the same call is presented as a form. Kept independent of `rawInput`
- * so it recognizes providers (Kimi Code) that omit structured input.
+ * Detect an AskUserQuestion tool call by its identity (tool name / title /
+ * programmatic name), used both to gate the Kimi content-shape parser and to
+ * suppress the redundant tool row once the same call is presented as a form.
+ * Kept independent of `rawInput` so it recognizes providers (Kimi Code, droid)
+ * that carry the question outside structured input.
  */
 export function isAcpAskUserQuestionToolCall(toolCall: {
   title?: unknown;
+  name?: unknown;
   rawInput?: unknown;
   _meta?: unknown;
 }): boolean {
   const metaName = isRecord(toolCall._meta) ? toolCall._meta.toolName : undefined;
-  return [metaName, toolCall.title].some(isAskUserQuestionToolName);
+  return [metaName, toolCall.title, toolCall.name].some(isAskUserQuestionToolName);
 }
 
 function normalizeQuestionAnswers(

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -389,6 +389,35 @@ describe("mapAcpSessionUpdate", () => {
     expect(state.suppressedToolCallIds.has("tc-question")).toBe(false);
   });
 
+  it("suppresses Factory droid's bare AskUser tool rows presented as reply forms", () => {
+    const state = createAcpMapperState("t-question-droid");
+
+    const started = mapAcpSessionUpdate(
+      {
+        sessionId: "s1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-question-droid",
+          title: "AskUser",
+          kind: "other",
+          status: "pending",
+          rawInput: {
+            questionnaire: [
+              "1. [question] Which features do you want to enable? (multi)",
+              "[topic] Features",
+              "[option] Auth handling",
+              "[option] Login Page",
+            ].join("\n"),
+          },
+        },
+      } as Parameters<typeof mapAcpSessionUpdate>[0],
+      state,
+    );
+
+    expect(started).toEqual([]);
+    expect(state.suppressedToolCallIds.has("tc-question-droid")).toBe(true);
+  });
+
   it("omits `name` on a bare tool_call so the renderer defers the unnamed row", () => {
     const state = createAcpMapperState("t-bare");
     const started = mapAcpSessionUpdate(

--- a/src/supervisor/agents/acp/sessionRequests.test.ts
+++ b/src/supervisor/agents/acp/sessionRequests.test.ts
@@ -74,6 +74,33 @@ function kimiQuestionPermissionRequest(): RequestPermissionRequest {
   };
 }
 
+function droidQuestionnairePermissionRequest(): RequestPermissionRequest {
+  return {
+    sessionId: "session-1",
+    toolCall: {
+      toolCallId: "tool-ask-droid",
+      title: "AskUser",
+      kind: "other",
+      rawInput: {
+        questionnaire: [
+          "1. [question] Which features do you want to enable? (multi)",
+          "[topic] Features",
+          "[option] Auth handling",
+          "[option] Login Page",
+          "2. [question] Which library should we use for date formatting?",
+          "[topic] Library",
+          "[option] Library ABC",
+          "[option] Library BlaBla",
+        ].join("\n"),
+      },
+    },
+    options: [
+      { optionId: "proceed_once", name: "Submit", kind: "allow_once" },
+      { optionId: "cancel", name: "Cancel", kind: "reject_once" },
+    ],
+  };
+}
+
 function formElicitation(): CreateElicitationRequest {
   return {
     mode: "form",
@@ -304,6 +331,67 @@ describe("AcpSessionRequests permissions", () => {
       outcome: { outcome: "selected", optionId: "q0_opt_1" },
       answers: { "0": "Log in via browser" },
     });
+  });
+
+  it("maps droid AskUser questionnaires to a reply form instead of auto-approving them", async () => {
+    // `never` + no native mode is the exact config under which unrecognized
+    // permissions are silently auto-approved — the droid questionnaire must
+    // still open as a form.
+    const { emitRuntimeEvents, requests, setRequestAttention } = makeRequests({
+      config: { model: "model-a", mode: "agent", approvalPolicy: "never" },
+      availableModeIds: ["agent"],
+    });
+
+    const response = requests.requestPermission(droidQuestionnairePermissionRequest());
+
+    expect(setRequestAttention).toHaveBeenCalledExactlyOnceWith("needs_reply");
+    expect(emitRuntimeEvents).toHaveBeenCalledWith([
+      {
+        type: "request.opened",
+        threadId: "thread-1",
+        requestId: "acp-perm-0",
+        requestType: "tool_user_input",
+        payload: {
+          summary: "Which features do you want to enable?",
+          details: {
+            userInputForm: {
+              questions: [
+                {
+                  id: "0",
+                  header: "Features",
+                  question: "Which features do you want to enable?",
+                  options: [
+                    { optionId: "Auth handling", label: "Auth handling" },
+                    { optionId: "Login Page", label: "Login Page" },
+                  ],
+                  multiSelect: true,
+                },
+                {
+                  id: "1",
+                  header: "Library",
+                  question: "Which library should we use for date formatting?",
+                  options: [
+                    { optionId: "Library ABC", label: "Library ABC" },
+                    { optionId: "Library BlaBla", label: "Library BlaBla" },
+                  ],
+                  multiSelect: false,
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    requests.resolve("acp-perm-0", {
+      answers: { "0": ["Auth handling", "Login Page"], "1": "Library ABC" },
+    });
+
+    await expect(response).resolves.toEqual({
+      outcome: { outcome: "selected", optionId: "proceed_once" },
+      answers: { "0": "Auth handling, Login Page", "1": "Library ABC" },
+    });
+    expect(setRequestAttention).toHaveBeenLastCalledWith("working");
   });
 
   it("echoes Kimi v2 plan-review option ids back to the server verbatim", async () => {


### PR DESCRIPTION
- Recognize Factory droid's bare `AskUser`/`ask_user` tool identity over ACP so its sessions present reply forms instead of auto-approving the request.
- Parse droid's plain-text `rawInput.questionnaire` payload into the standard question list, including multi-select options and verbatim free-text answers on submission.
- Extend question-tool classification and tool-row suppression so persisted transcripts and renderer selectors cover all provider spellings of the AskUser tool.
- Add `pnpm db:clone:nightly`, which clones the nightly channel DB into the dev base dir for dev runs against nightly data.