### PR TITLE
feat(panel-dock): add bottom dock and split panel docking

### DIFF
--- a/src/renderer/actions/panelActions.test.ts
+++ b/src/renderer/actions/panelActions.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { usePanelStore } from "@/renderer/state/panelStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { dockPanelTab, openGitReview, openUsagePanel, undockPanelTab } from "./panelActions";
+
+function resetDockState() {
+  useSharedSettings.setState({ terminalPosition: "bottom", gitReviewMode: "panel" });
+  usePanelStore.setState({
+    rightPanelTab: "git",
+    rightPanelSplit: null,
+    bottomPanelDocks: { left: null, right: null },
+    usagePanelOpen: false,
+    notesPanelOpen: false,
+    browserPanelOpen: false,
+    gitReviewContext: null,
+    gitReviewAsPanel: false,
+  });
+  useDevTerminalStore.setState({
+    isOpen: false,
+    explicitlyOpened: false,
+    activeProjectId: null,
+    activeWorktreePath: null,
+  });
+}
+
+describe("dockPanelTab", () => {
+  beforeEach(resetDockState);
+  afterEach(resetDockState);
+
+  it("docks a tab into a bottom slot and opens its content", () => {
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "right" });
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: "usage" });
+    expect(usePanelStore.getState().usagePanelOpen).toBe(true);
+  });
+
+  it("fills both bottom slots with different tabs", () => {
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "left" });
+    dockPanelTab("notes", { zone: "bottom-panel", placement: "right" });
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: "notes" });
+  });
+
+  it("moves a right-panel split tab into the bottom dock", () => {
+    usePanelStore.getState().setRightPanelSplit({ tab: "usage", placement: "bottom" });
+
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "left" });
+
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: null });
+  });
+
+  it("splits the right panel without switching the active tab", () => {
+    dockPanelTab("usage", { zone: "right-panel", placement: "bottom" });
+
+    expect(usePanelStore.getState().rightPanelTab).toBe("git");
+    expect(usePanelStore.getState().rightPanelSplit).toEqual({
+      tab: "usage",
+      placement: "bottom",
+    });
+    expect(usePanelStore.getState().usagePanelOpen).toBe(true);
+  });
+
+  it("moves a bottom-docked tab back into the right panel as a split", () => {
+    usePanelStore.getState().setBottomPanelDock("right", "usage");
+
+    dockPanelTab("usage", { zone: "right-panel", placement: "top" });
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+    expect(usePanelStore.getState().rightPanelSplit).toEqual({
+      tab: "usage",
+      placement: "top",
+    });
+  });
+
+  it("does not split the active tab with itself", () => {
+    usePanelStore.setState({ rightPanelTab: "usage", usagePanelOpen: true });
+
+    dockPanelTab("usage", { zone: "right-panel", placement: "bottom" });
+
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+  });
+
+  it("ignores the terminal in the bottom row — it already owns the middle", () => {
+    dockPanelTab("terminal", { zone: "bottom-panel", placement: "right" });
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+  });
+
+  it("keeps the terminal on the free side when a panel is dropped into the left slot", () => {
+    useDevTerminalStore.setState({ isOpen: true, explicitlyOpened: true });
+
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "left" });
+
+    expect(useDevTerminalStore.getState().isOpen).toBe(true);
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: null });
+  });
+
+  it("keeps the terminal when a panel is dropped into the right slot", () => {
+    useDevTerminalStore.setState({ isOpen: true, explicitlyOpened: true });
+
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "right" });
+
+    expect(useDevTerminalStore.getState().isOpen).toBe(true);
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: "usage" });
+  });
+
+  it("closes the terminal when a panel is dropped into the free slot beside an existing dock", () => {
+    useDevTerminalStore.setState({ isOpen: true, explicitlyOpened: true });
+    usePanelStore.getState().setBottomPanelDock("right", "notes");
+
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "left" });
+
+    expect(useDevTerminalStore.getState().isOpen).toBe(false);
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: "notes" });
+  });
+
+  it("closes the terminal when a panel fills the remaining free slot on the right", () => {
+    useDevTerminalStore.setState({ isOpen: true, explicitlyOpened: true });
+    usePanelStore.getState().setBottomPanelDock("left", "notes");
+
+    dockPanelTab("usage", { zone: "bottom-panel", placement: "right" });
+
+    expect(useDevTerminalStore.getState().isOpen).toBe(false);
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "notes", right: "usage" });
+  });
+
+  it("ignores non-dockable tabs", () => {
+    dockPanelTab("plan", { zone: "right-panel", placement: "bottom" });
+
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+  });
+});
+
+// The toggle entry points close the right panel when their tab is already
+// active. A bottom-docked tab is not what the right panel is showing, so that
+// close is invisible — the toggle has to pull the panel back instead.
+describe("toggling a bottom-docked tab", () => {
+  beforeEach(resetDockState);
+  afterEach(resetDockState);
+
+  it("brings a docked Usage back into the right panel", () => {
+    usePanelStore.getState().setUsagePanelOpen(true);
+    usePanelStore.getState().setBottomPanelDock("right", "usage");
+    usePanelStore.setState({ rightPanelTab: "usage" });
+
+    openUsagePanel();
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+    expect(usePanelStore.getState().usagePanelOpen).toBe(true);
+    expect(usePanelStore.getState().rightPanelTab).toBe("usage");
+  });
+
+  it("brings a docked Git back into the right panel", () => {
+    usePanelStore.getState().setGitReviewContext({ projectId: "p1" });
+    usePanelStore.getState().setGitReviewAsPanel(true);
+    usePanelStore.getState().setBottomPanelDock("left", "git");
+    usePanelStore.setState({ rightPanelTab: "git" });
+
+    openGitReview("p1");
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+    expect(usePanelStore.getState().gitReviewContext).not.toBeNull();
+    expect(usePanelStore.getState().rightPanelTab).toBe("git");
+  });
+
+  it("still closes the panel when the tab is not docked", () => {
+    usePanelStore.getState().setUsagePanelOpen(true);
+    usePanelStore.setState({ rightPanelTab: "usage" });
+
+    openUsagePanel();
+
+    expect(usePanelStore.getState().usagePanelOpen).toBe(false);
+  });
+});
+
+describe("undockPanelTab", () => {
+  beforeEach(resetDockState);
+  afterEach(resetDockState);
+
+  it("pulls a tab out of the split half and the bottom row", () => {
+    usePanelStore.getState().setRightPanelSplit({ tab: "notes", placement: "top" });
+    usePanelStore.getState().setBottomPanelDock("left", "usage");
+
+    undockPanelTab("notes");
+    undockPanelTab("usage");
+
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+  });
+
+  it("leaves other placements untouched", () => {
+    usePanelStore.getState().setBottomPanelDock("left", "usage");
+
+    undockPanelTab("notes");
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: null });
+  });
+});

--- a/src/renderer/actions/panelActions.ts
+++ b/src/renderer/actions/panelActions.ts
@@ -6,7 +6,13 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { hasDirtyEditorBuffers } from "@/renderer/state/fileEditorSelectors";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
-import { usePanelStore } from "@/renderer/state/panelStore";
+import { isTabBottomDocked } from "@/renderer/state/panelDockSelectors";
+import {
+  DOCKABLE_PANEL_TABS,
+  usePanelStore,
+  type PanelDockTarget,
+  type RightPanelTab,
+} from "@/renderer/state/panelStore";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -17,6 +23,7 @@ import {
 import { buildFileEditorContext, resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { closeThreads } from "@/renderer/utils/shellUtils";
 import { resolveActivePaneId } from "./currentProject";
+import { showTerminalPanel } from "./terminalActions";
 
 function panelContextMatchesThread(
   projectId: string,
@@ -102,20 +109,32 @@ export function openWorkspaceSettings(): void {
 /** Open the docked usage panel, or close all right-side panels if it is already active. */
 export function openUsagePanel(): void {
   const panelStore = usePanelStore.getState();
-  if (panelStore.usagePanelOpen && panelStore.rightPanelTab === "usage") {
+  // A docked Usage is not what the right panel is showing, so closing it here
+  // would be a no-op the user can see; bring it back instead.
+  if (
+    panelStore.usagePanelOpen &&
+    panelStore.rightPanelTab === "usage" &&
+    !isTabBottomDocked("usage")
+  ) {
     closeAllPanels();
     return;
   }
+  undockPanelTab("usage");
   panelStore.openUsagePanel();
 }
 
 /** Open the docked notes panel, or close all right-side panels if it is already active. */
 export function openNotesPanel(): void {
   const panelStore = usePanelStore.getState();
-  if (panelStore.notesPanelOpen && panelStore.rightPanelTab === "notes") {
+  if (
+    panelStore.notesPanelOpen &&
+    panelStore.rightPanelTab === "notes" &&
+    !isTabBottomDocked("notes")
+  ) {
     closeAllPanels();
     return;
   }
+  undockPanelTab("notes");
   panelStore.openNotesPanel();
 }
 
@@ -130,6 +149,7 @@ export function toggleBrowserPanel(): void {
   if (panelStore.browserPanelOpen && panelStore.rightPanelTab === "browser") {
     panelStore.setBrowserPanelOpen(false);
   } else {
+    undockPanelTab("browser");
     panelStore.setBrowserPanelOpen(true);
     panelStore.setRightPanelTab("browser");
   }
@@ -162,6 +182,12 @@ export function closeAllPanels(): void {
       resolveActivePaneId(appState.view.panes, appState.focusedPaneId),
       "composer",
     );
+  }
+  // Bottom docks survive this (they are their own surface), but only while
+  // there is a bottom row to hold them — drop stale slots first so they cannot
+  // pin a panel's open flag from a row that no longer renders.
+  if (useSharedSettings.getState().terminalPosition !== "bottom") {
+    usePanelStore.getState().clearBottomPanelDocks();
   }
   usePanelStore.getState().closeAllPanels();
 }
@@ -228,11 +254,16 @@ function applyFilesPanel(
       isSameContext &&
       filesPanelContext?.projectId === context.projectId &&
       filesPanelContext?.worktreePath === context.worktreePath &&
-      rightPanelTab === "files"
+      rightPanelTab === "files" &&
+      // A docked Files renders elsewhere, so `rightPanelTab` saying "files"
+      // does not mean the user is looking at it here — toggling would close
+      // nothing they can see. Pull it back into this panel instead.
+      !isTabBottomDocked("files")
     ) {
       closeAllPanels();
       return;
     }
+    undockPanelTab("files");
   }
 
   panelStore.setFilesPanelContext(context);
@@ -269,7 +300,8 @@ export function openGitReview(
       gitReviewContext?.projectId === projectId &&
       gitReviewContext?.worktreePath === worktreePath;
 
-    if (isSameContext && rightPanelTab === "git") {
+    // See `applyFilesPanel`: a docked Git is not what this panel is showing.
+    if (isSameContext && rightPanelTab === "git" && !isTabBottomDocked("git")) {
       closeAllPanels();
       return;
     }
@@ -277,6 +309,7 @@ export function openGitReview(
 
   panelStore.setGitReviewContext(nextContext);
   if (mode === "panel") {
+    undockPanelTab("git");
     panelStore.setGitReviewAsPanel(true);
     panelStore.setRightPanelTab("git");
   } else {
@@ -295,6 +328,116 @@ export function showGitReviewPanel(projectId: string, worktreePath?: string): vo
 
 export function openGitOverlay(): void {
   usePanelStore.getState().setGitOverlayOpen(true);
+}
+
+/** Project/worktree scope of the focused thread, falling back to the first project. */
+function resolveCurrentThreadScope(): { projectId: string; worktreePath?: string } | null {
+  const appState = useAppStore.getState();
+  if (appState.view.kind === "thread") {
+    const paneId = resolveActivePaneId(appState.view.panes, appState.focusedPaneId);
+    const thread = appState.threads.find((item) => item.id === paneId);
+    if (thread) {
+      return {
+        projectId: thread.projectId,
+        ...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {}),
+      };
+    }
+  }
+  if (appState.view.kind === "draft" || appState.view.kind === "experiment") {
+    return { projectId: appState.view.projectId };
+  }
+  const firstProject = appState.projects[0];
+  return firstProject ? { projectId: firstProject.id } : null;
+}
+
+/**
+ * Open the given tab's content without stealing the active right-panel tab.
+ * The `show*` actions activate the tab they open; a drag-and-drop dock must
+ * leave the active tab alone, so the pre-call tab is restored afterwards.
+ */
+function ensurePanelTabContent(tab: RightPanelTab): void {
+  const panelStore = usePanelStore.getState();
+  const previousTab = panelStore.rightPanelTab;
+  switch (tab) {
+    case "usage":
+      panelStore.setUsagePanelOpen(true);
+      return;
+    case "notes":
+      panelStore.setNotesPanelOpen(true);
+      return;
+    case "browser":
+      panelStore.setBrowserPanelOpen(true);
+      return;
+    case "git": {
+      if (panelStore.gitReviewContext) {
+        panelStore.setGitReviewAsPanel(true);
+        panelStore.setGitOverlayOpen(false);
+        return;
+      }
+      const scope = resolveCurrentThreadScope();
+      if (!scope) return;
+      showGitReviewPanel(scope.projectId, scope.worktreePath);
+      usePanelStore.getState().setRightPanelTab(previousTab);
+      return;
+    }
+    case "files": {
+      if (panelStore.filesPanelContext) return;
+      const scope = resolveCurrentThreadScope();
+      if (!scope) return;
+      showFilesPanel(scope.projectId, scope.worktreePath);
+      usePanelStore.getState().setRightPanelTab(previousTab);
+      return;
+    }
+    case "terminal": {
+      if (useDevTerminalStore.getState().isOpen) return;
+      const scope = resolveCurrentThreadScope();
+      if (!scope) return;
+      showTerminalPanel(scope.projectId, scope.worktreePath);
+      usePanelStore.getState().setRightPanelTab(previousTab);
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+/** Take a tab out of the right-panel split and any bottom dock slot holding it. */
+export function undockPanelTab(tab: RightPanelTab): void {
+  const panelStore = usePanelStore.getState();
+  if (panelStore.rightPanelSplit?.tab === tab) panelStore.setRightPanelSplit(null);
+  panelStore.clearBottomPanelDockTab(tab);
+}
+
+/** Apply a drag-and-drop dock of a right-panel tab icon onto a dock zone. */
+export function dockPanelTab(tab: RightPanelTab, target: PanelDockTarget): void {
+  if (!DOCKABLE_PANEL_TABS.has(tab)) return;
+  if (target.zone === "bottom-panel") {
+    // The terminal already owns the middle of the bottom row.
+    if (tab === "terminal") return;
+    const terminalStore = useDevTerminalStore.getState();
+    const { left, right } = usePanelStore.getState().bottomPanelDocks;
+    // Terminal can sit beside one dock (`left | terminal` or `terminal | right`),
+    // but not both. When the opposite slot is free the terminal keeps the
+    // remaining space; only close it when the other side is already filled.
+    if (terminalStore.isOpen) {
+      const oppositeOccupied = target.placement === "left" ? right !== null : left !== null;
+      if (oppositeOccupied) terminalStore.closePanel();
+    }
+    ensurePanelTabContent(tab);
+    const panelStore = usePanelStore.getState();
+    if (panelStore.rightPanelSplit?.tab === tab) panelStore.setRightPanelSplit(null);
+    panelStore.setBottomPanelDock(target.placement, tab);
+    return;
+  }
+  ensurePanelTabContent(tab);
+  const panelStore = usePanelStore.getState();
+  panelStore.clearBottomPanelDockTab(tab);
+  // The active tab cannot split with itself — pulling it back out is enough.
+  if (panelStore.rightPanelTab === tab) {
+    panelStore.setRightPanelSplit(null);
+    return;
+  }
+  panelStore.setRightPanelSplit({ tab, placement: target.placement });
 }
 
 export function closeGitPanel(): void {

--- a/src/renderer/components/layout/PanelDock/PanelDockDropZone.tsx
+++ b/src/renderer/components/layout/PanelDock/PanelDockDropZone.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode, useEffect, useId, useRef } from "react";
+import { useDroppable } from "@dnd-kit/react";
+import { setPanelDockZoneElement, usePanelDockPlacement } from "@/renderer/dnd";
+import type { PanelDockZone } from "@/renderer/state/panelStore";
+
+const HIGHLIGHT_INSET = {
+  top: "inset-x-0 top-0 h-1/2",
+  bottom: "inset-x-0 bottom-0 h-1/2",
+  left: "inset-y-0 left-0 w-1/2",
+  right: "inset-y-0 right-0 w-1/2",
+} as const;
+
+/**
+ * Drop target for dragged panel-tab icons. Highlights the half of the zone the
+ * tab would occupy. The dnd-kit registration only keeps the drag from
+ * cancelling as "no valid target"; hit-testing runs in the dnd module against
+ * the element registered below (see `setPanelDockZoneElement`).
+ */
+export function PanelDockDropZone(props: {
+  zone: PanelDockZone;
+  /** Must establish a positioning context — the default already does. */
+  className?: string;
+  /** Set false when the zone paints its own target affordance (see `BottomDockDropStrip`). */
+  highlight?: boolean;
+  children?: ReactNode;
+}) {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const instanceId = useId();
+  useDroppable({
+    id: `panel-dock-zone:${props.zone}:${instanceId}`,
+    accept: "panel-tab",
+    data: { type: "panel-dock-zone", zone: props.zone },
+    element: elementRef,
+  });
+  const placement = usePanelDockPlacement(props.zone);
+
+  useEffect(() => {
+    setPanelDockZoneElement(instanceId, props.zone, elementRef.current);
+    return () => setPanelDockZoneElement(instanceId, props.zone, null);
+  }, [instanceId, props.zone]);
+
+  return (
+    <div ref={elementRef} className={props.className ?? "relative h-full min-h-0"}>
+      {props.children}
+      {placement && props.highlight !== false ? (
+        <div
+          aria-hidden="true"
+          className={`pointer-events-none absolute z-20 rounded border border-accent/70 bg-accent/10 ${HIGHLIGHT_INSET[placement]}`}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+++ b/src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
@@ -1,0 +1,59 @@
+import { useId, useRef } from "react";
+import type { LucideIcon } from "lucide-react";
+import { X } from "lucide-react";
+import { useDraggable } from "@dnd-kit/react";
+import { useLingui } from "@lingui/react/macro";
+import { panelHeaderIconButtonClass } from "@/renderer/components/layout/sidebarChrome";
+import type { DragSourceData } from "@/renderer/dnd";
+import type { RightPanelTab } from "@/renderer/state/panelStore";
+
+/**
+ * Title row of a docked panel section (right-panel split half or bottom dock
+ * slot). The label area is a drag handle carrying the same `panel-tab` source
+ * as the toolbar icons, so an already-placed section can be moved between dock
+ * zones. The close button stays outside the draggable element so a click on it
+ * never starts a drag.
+ */
+export function PanelSectionHeader(props: {
+  tab: RightPanelTab;
+  label: string;
+  icon: LucideIcon;
+  onClose?: () => void;
+}) {
+  const { t } = useLingui();
+  const elementRef = useRef<HTMLDivElement>(null);
+  const dragId = useId();
+  useDraggable({
+    id: `panel-section:${props.tab}:${dragId}`,
+    type: "panel-tab",
+    data: { type: "panel-tab", tab: props.tab } satisfies DragSourceData,
+    element: elementRef,
+  });
+  const Icon = props.icon;
+
+  return (
+    <div className="flex h-6 shrink-0 items-center gap-1.5 border-b border-[color:var(--border)] px-2">
+      <div
+        ref={elementRef}
+        role="button"
+        tabIndex={0}
+        aria-label={t`Move panel`}
+        title={props.label}
+        className="flex min-w-0 flex-1 cursor-grab items-center gap-1.5 active:cursor-grabbing"
+      >
+        <Icon className="size-3 shrink-0 text-muted" />
+        <span className="min-w-0 truncate text-xs text-muted">{props.label}</span>
+      </div>
+      {props.onClose ? (
+        <button
+          type="button"
+          className={panelHeaderIconButtonClass}
+          title={t`Close Split`}
+          onClick={props.onClose}
+        >
+          <X className="size-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/components/layout/PanelDock/PanelTabDragButton.tsx
+++ b/src/renderer/components/layout/PanelDock/PanelTabDragButton.tsx
@@ -1,0 +1,53 @@
+import { type ReactNode, useId, useRef } from "react";
+import { useDraggable } from "@dnd-kit/react";
+import type { DragSourceData } from "@/renderer/dnd";
+import type { RightPanelTab } from "@/renderer/state/panelStore";
+
+/**
+ * Right-panel toolbar icon that both activates its tab on click and can be
+ * dragged into a `PanelDockDropZone` to split the right panel or dock beside
+ * the bottom terminal. Mirrors `SidebarPanelDragButton` (div + role="button"
+ * so dnd-kit's 5px activation distance keeps plain clicks working).
+ */
+export function PanelTabDragButton(props: {
+  tab: RightPanelTab;
+  label: string;
+  className: string;
+  "aria-pressed"?: boolean;
+  onPress: () => void;
+  children: ReactNode;
+}) {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const dragId = useId();
+  useDraggable({
+    id: `panel-tab:${props.tab}:${dragId}`,
+    type: "panel-tab",
+    data: { type: "panel-tab", tab: props.tab } satisfies DragSourceData,
+    element: elementRef,
+  });
+
+  return (
+    <div
+      ref={elementRef}
+      role="button"
+      tabIndex={0}
+      aria-label={props.label}
+      {...(props["aria-pressed"] === undefined ? {} : { "aria-pressed": props["aria-pressed"] })}
+      title={props.label}
+      className={props.className}
+      onClick={(event) => {
+        event.stopPropagation();
+        props.onPress();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          event.stopPropagation();
+          props.onPress();
+        }
+      }}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/renderer/components/layout/PanelDock/panelTabMeta.ts
+++ b/src/renderer/components/layout/PanelDock/panelTabMeta.ts
@@ -1,0 +1,42 @@
+import {
+  Bot,
+  FileDiff,
+  FolderOpen,
+  Gauge,
+  Globe,
+  ListChecks,
+  NotebookPen,
+  TerminalSquare,
+  Waypoints,
+  type LucideIcon,
+} from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
+import type { RightPanelTab } from "@/renderer/state/panelStore";
+
+/** Single source of truth for panel-tab chrome, shared by the toolbar and every dock section. */
+export const PANEL_TAB_ICONS: Record<RightPanelTab, LucideIcon> = {
+  plan: ListChecks,
+  subagent: Bot,
+  terminal: TerminalSquare,
+  files: FolderOpen,
+  git: FileDiff,
+  usage: Gauge,
+  notes: NotebookPen,
+  ports: Waypoints,
+  browser: Globe,
+};
+
+export function usePanelTabLabels(): Record<RightPanelTab, string> {
+  const { t } = useLingui();
+  return {
+    plan: t`Plan`,
+    subagent: t`Subagent`,
+    terminal: t`Terminal`,
+    files: t`Files`,
+    git: t`Git`,
+    usage: t`Usage`,
+    notes: t`Notes`,
+    ports: t`Ports`,
+    browser: t`Browser`,
+  };
+}

--- a/src/renderer/components/layout/PanelDock/useSplitPercent.ts
+++ b/src/renderer/components/layout/PanelDock/useSplitPercent.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+} from "react";
+import { readStoredNumber, writeStoredNumber } from "@/renderer/utils/localStorage";
+
+const KEY_RESIZE_STEP_PERCENT = 2;
+
+/**
+ * Percent-based two-pane split resize (drag + keyboard), persisted per
+ * `storageKey`. During a drag the percent is written straight to the sized
+ * pane's `flexBasis`; React state (and localStorage) only commit on release,
+ * like the terminal split in `TerminalSurfaces`.
+ */
+export function useSplitPercent(options: {
+  storageKey: string;
+  /** "row": panes sit side by side (drag along X). "column": panes stack (drag along Y). */
+  orientation: "row" | "column";
+  /** Element whose size converts pointer deltas into percent. */
+  containerRef: RefObject<HTMLElement | null>;
+  /** Pane that receives the live `flexBasis` writes; its size is `percent`. */
+  paneRef: RefObject<HTMLElement | null>;
+  /** Flip drag direction when the sized pane sits after the divider. */
+  invert?: boolean;
+  defaultPercent?: number;
+  minPercent?: number;
+}) {
+  const {
+    storageKey,
+    orientation,
+    containerRef,
+    paneRef,
+    invert = false,
+    defaultPercent = 50,
+    minPercent = 15,
+  } = options;
+  const maxPercent = 100 - minPercent;
+
+  function clampPercent(value: number): number {
+    if (!Number.isFinite(value)) return defaultPercent;
+    return Math.min(maxPercent, Math.max(minPercent, value));
+  }
+
+  const [percent, setPercent] = useState(() =>
+    clampPercent(readStoredNumber(storageKey, defaultPercent)),
+  );
+  const percentRef = useRef(percent);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    return () => cleanupRef.current?.();
+  }, []);
+
+  // Re-sync the pane after commits and after the pane remounts on
+  // placement/tab changes (flexBasis lives on the element, not in JSX).
+  useEffect(() => {
+    percentRef.current = percent;
+    if (paneRef.current) paneRef.current.style.flexBasis = `${percent}%`;
+  });
+
+  function applyPercent(value: number): number {
+    const next = clampPercent(value);
+    percentRef.current = next;
+    if (paneRef.current) paneRef.current.style.flexBasis = `${next}%`;
+    return next;
+  }
+
+  function commitPercent(value: number) {
+    const next = applyPercent(value);
+    setPercent(next);
+    writeStoredNumber(storageKey, next);
+  }
+
+  function handleResizeStart(event: ReactPointerEvent<HTMLDivElement>) {
+    event.preventDefault();
+    cleanupRef.current?.();
+
+    // Keep receiving moves even when the pointer crosses a webview/iframe
+    // (browser panel, terminal) that would otherwise swallow the events.
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      /* ignore */
+    }
+
+    const startCoord = orientation === "row" ? event.clientX : event.clientY;
+    const startPercent = percentRef.current;
+
+    function onPointerMove(pointerEvent: PointerEvent) {
+      const container = containerRef.current;
+      if (!container) return;
+      const totalSize = orientation === "row" ? container.offsetWidth : container.offsetHeight;
+      if (totalSize <= 0) return;
+      const pointerCoord = orientation === "row" ? pointerEvent.clientX : pointerEvent.clientY;
+      const deltaPercent = ((pointerCoord - startCoord) / totalSize) * 100 * (invert ? -1 : 1);
+      applyPercent(startPercent + deltaPercent);
+    }
+
+    function cleanup() {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+      cleanupRef.current = null;
+    }
+
+    function onPointerUp() {
+      cleanup();
+      commitPercent(percentRef.current);
+    }
+
+    cleanupRef.current = cleanup;
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+  }
+
+  function handleResizeKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    const decreaseKey = orientation === "row" ? "ArrowLeft" : "ArrowUp";
+    const increaseKey = orientation === "row" ? "ArrowRight" : "ArrowDown";
+    const step = KEY_RESIZE_STEP_PERCENT * (invert ? -1 : 1);
+    let next: number;
+    switch (event.key) {
+      case decreaseKey:
+        next = percentRef.current - step;
+        break;
+      case increaseKey:
+        next = percentRef.current + step;
+        break;
+      case "Home":
+        next = minPercent;
+        break;
+      case "End":
+        next = maxPercent;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    commitPercent(next);
+  }
+
+  return { percent, minPercent, maxPercent, handleResizeStart, handleResizeKeyDown };
+}

--- a/src/renderer/components/layout/UnifiedRightPanel.tsx
+++ b/src/renderer/components/layout/UnifiedRightPanel.tsx
@@ -1,29 +1,21 @@
-import { type CSSProperties, type ReactNode } from "react";
-import {
-  Bot,
-  FileDiff,
-  FolderOpen,
-  Gauge,
-  Globe,
-  ListChecks,
-  Lock,
-  LockOpen,
-  Maximize2,
-  NotebookPen,
-  PanelRightClose,
-  PictureInPicture2,
-  TerminalSquare,
-  Waypoints,
-  X,
-} from "lucide-react";
+import { type CSSProperties, type ReactNode, useRef } from "react";
+import { Lock, LockOpen, Maximize2, PanelRightClose, PictureInPicture2, X } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { PanelHeaderProjectName } from "@/renderer/components/layout/PanelHeaderProjectName";
+import { PanelDockDropZone } from "@/renderer/components/layout/PanelDock/PanelDockDropZone";
+import { PanelSectionHeader } from "@/renderer/components/layout/PanelDock/PanelSectionHeader";
+import { PanelTabDragButton } from "@/renderer/components/layout/PanelDock/PanelTabDragButton";
+import {
+  PANEL_TAB_ICONS,
+  usePanelTabLabels,
+} from "@/renderer/components/layout/PanelDock/panelTabMeta";
+import { useSplitPercent } from "@/renderer/components/layout/PanelDock/useSplitPercent";
 import {
   panelHeaderIconButtonClass,
   panelHeaderRowClass,
   panelHeaderTabIconButtonClass,
 } from "@/renderer/components/layout/sidebarChrome";
-import type { RightPanelTab } from "@/renderer/state/panelStore";
+import { DOCKABLE_PANEL_TABS, type RightPanelTab } from "@/renderer/state/panelStore";
 
 export type { RightPanelTab };
 
@@ -68,6 +60,13 @@ export function UnifiedRightPanel(props: {
   /** Whether the panel re-scopes itself to whichever thread is open. */
   followsThread?: boolean;
   onToggleFollowsThread?: () => void;
+  /** Second tab rendered stacked with the active one (drag-and-drop split). */
+  splitTab?: RightPanelTab;
+  /** Which half of the panel the split tab occupies. */
+  splitPlacement?: "top" | "bottom";
+  onCloseSplit?: () => void;
+  /** Tabs painted in the bottom row; their icons stay lit even though this panel skips them. */
+  dockedTabs?: readonly RightPanelTab[];
   onClose: () => void;
 }) {
   const {
@@ -109,9 +108,29 @@ export function UnifiedRightPanel(props: {
     onOpenPorts,
     followsThread = false,
     onToggleFollowsThread,
+    splitTab,
+    splitPlacement = "bottom",
+    onCloseSplit,
+    dockedTabs = [],
     onClose,
   } = props;
   const { t } = useLingui();
+  const splitContainerRef = useRef<HTMLDivElement>(null);
+  const splitFirstPaneRef = useRef<HTMLDivElement>(null);
+  const {
+    percent: splitPercent,
+    minPercent: splitMinPercent,
+    maxPercent: splitMaxPercent,
+    handleResizeStart: handleSplitResizeStart,
+    handleResizeKeyDown: handleSplitResizeKeyDown,
+  } = useSplitPercent({
+    storageKey: "poracode-right-panel-split-percent",
+    orientation: "column",
+    containerRef: splitContainerRef,
+    paneRef: splitFirstPaneRef,
+    defaultPercent: 50,
+    minPercent: 20,
+  });
   const hasSubagentModel = activeTab === "subagent" && subagentModel !== undefined;
   const hasSubagentTitle = activeTab === "subagent" && subagentTitle !== undefined;
 
@@ -127,80 +146,89 @@ export function UnifiedRightPanel(props: {
   };
 
   const dragCtl = "poracode-overlay-header__controls";
+  const labels = usePanelTabLabels();
   const tabs = [
     {
       id: "plan",
-      label: t`Plan`,
-      icon: ListChecks,
+      label: labels.plan,
+      icon: PANEL_TAB_ICONS.plan,
       content: planContent,
       visible: showPlanTab,
       onOpen: undefined,
     },
     {
       id: "subagent",
-      label: t`Subagent`,
-      icon: Bot,
+      label: labels.subagent,
+      icon: PANEL_TAB_ICONS.subagent,
       content: subagentContent,
       visible: showSubagentTab,
       onOpen: undefined,
     },
     {
       id: "terminal",
-      label: t`Terminal`,
-      icon: TerminalSquare,
+      label: labels.terminal,
+      icon: PANEL_TAB_ICONS.terminal,
       content: terminalContent,
       visible: showTerminalTab,
       onOpen: onOpenTerminal,
     },
     {
       id: "files",
-      label: t`Files`,
-      icon: FolderOpen,
+      label: labels.files,
+      icon: PANEL_TAB_ICONS.files,
       content: filesContent,
       visible: showFilesTab,
       onOpen: onOpenFiles,
     },
     {
       id: "git",
-      label: t`Git`,
-      icon: FileDiff,
+      label: labels.git,
+      icon: PANEL_TAB_ICONS.git,
       content: gitContent,
       visible: showGitTab,
       onOpen: onOpenGit,
     },
     {
       id: "usage",
-      label: t`Usage`,
-      icon: Gauge,
+      label: labels.usage,
+      icon: PANEL_TAB_ICONS.usage,
       content: usageContent,
       visible: showUsageTab,
       onOpen: onOpenUsage,
     },
     {
       id: "notes",
-      label: t`Notes`,
-      icon: NotebookPen,
+      label: labels.notes,
+      icon: PANEL_TAB_ICONS.notes,
       content: notesContent,
       visible: showNotesTab,
       onOpen: onOpenNotes,
     },
     {
       id: "ports",
-      label: t`Ports`,
-      icon: Waypoints,
+      label: labels.ports,
+      icon: PANEL_TAB_ICONS.ports,
       content: portsContent,
       visible: showPortsTab,
       onOpen: onOpenPorts,
     },
     {
       id: "browser",
-      label: t`Browser`,
-      icon: Globe,
+      label: labels.browser,
+      icon: PANEL_TAB_ICONS.browser,
       content: browserContent,
       visible: showBrowserTab,
       onOpen: onOpenBrowser,
     },
   ] as const;
+
+  const splitEntry =
+    splitTab && splitTab !== activeTab
+      ? tabs.find((tab) => tab.id === splitTab && tab.visible && tab.content !== undefined)
+      : undefined;
+  /** Painted right now: the active layer, the split section, or a bottom dock slot. */
+  const isTabOnScreen = (tab: RightPanelTab) =>
+    tab === activeTab || tab === splitEntry?.id || dockedTabs.includes(tab);
 
   return (
     <div
@@ -263,16 +291,36 @@ export function UnifiedRightPanel(props: {
         {tabs.map((tab) => {
           if (!tab.visible) return null;
           const Icon = tab.icon;
+          // Lit whenever the panel is painted somewhere — the active layer, the
+          // split half, or a bottom dock slot.
+          const onScreen = isTabOnScreen(tab.id);
+          const buttonClass = `${dragCtl} ${panelHeaderTabIconButtonClass(onScreen)}`;
+          const handlePress = () => {
+            if (tab.onOpen) tab.onOpen();
+            else onTabChange(tab.id);
+          };
+          if (DOCKABLE_PANEL_TABS.has(tab.id)) {
+            return (
+              <PanelTabDragButton
+                key={tab.id}
+                tab={tab.id}
+                label={tab.label}
+                className={buttonClass}
+                aria-pressed={onScreen}
+                onPress={handlePress}
+              >
+                <Icon className="size-3.5" />
+              </PanelTabDragButton>
+            );
+          }
           return (
             <button
               key={tab.id}
               type="button"
-              className={`${dragCtl} ${panelHeaderTabIconButtonClass(activeTab === tab.id)}`}
+              className={buttonClass}
               title={tab.label}
-              onClick={() => {
-                if (tab.onOpen) tab.onOpen();
-                else onTabChange(tab.id);
-              }}
+              aria-pressed={onScreen}
+              onClick={handlePress}
             >
               <Icon className="size-3.5" />
             </button>
@@ -318,20 +366,73 @@ export function UnifiedRightPanel(props: {
         </div>
       ) : null}
 
-      {/* Content — stacked layers cross-fade on tab change */}
-      <div className="relative min-h-0 flex-1 overflow-hidden">
-        {tabs.map((tab) =>
-          tab.visible ? (
-            <div
-              key={tab.id}
-              className="absolute inset-0 flex min-h-0 flex-col overflow-hidden"
-              style={tabLayerStyle(tab.id)}
-            >
-              {tab.content}
+      {/* Content — stacked layers cross-fade on tab change; a dropped panel-tab
+          splits this area into two stacked sections. */}
+      <PanelDockDropZone
+        zone="right-panel"
+        className="relative flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        {(() => {
+          const layerStack = (
+            <div className="relative min-h-0 flex-1 overflow-hidden">
+              {tabs.map((tab) =>
+                tab.visible && tab.id !== splitEntry?.id ? (
+                  <div
+                    key={tab.id}
+                    className="absolute inset-0 flex min-h-0 flex-col overflow-hidden"
+                    style={tabLayerStyle(tab.id)}
+                  >
+                    {tab.content}
+                  </div>
+                ) : null,
+              )}
             </div>
-          ) : null,
-        )}
-      </div>
+          );
+
+          if (!splitEntry) return layerStack;
+
+          const splitSection = (
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <PanelSectionHeader
+                tab={splitEntry.id}
+                label={splitEntry.label}
+                icon={splitEntry.icon}
+                {...(onCloseSplit ? { onClose: onCloseSplit } : {})}
+              />
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                {splitEntry.content}
+              </div>
+            </div>
+          );
+
+          return (
+            <div ref={splitContainerRef} className="flex h-full min-h-0 flex-col">
+              <div
+                ref={splitFirstPaneRef}
+                className="flex min-h-0 flex-col overflow-hidden"
+                style={{ flexBasis: `${splitPercent}%`, flexGrow: 0, flexShrink: 0 }}
+              >
+                {splitPlacement === "top" ? splitSection : layerStack}
+              </div>
+              <div
+                className="poracode-pane-divider-horizontal"
+                onPointerDown={handleSplitResizeStart}
+                onKeyDown={handleSplitResizeKeyDown}
+                role="separator"
+                tabIndex={0}
+                aria-orientation="horizontal"
+                aria-label={t`Resize split`}
+                aria-valuenow={Math.round(splitPercent)}
+                aria-valuemin={splitMinPercent}
+                aria-valuemax={splitMaxPercent}
+              />
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                {splitPlacement === "top" ? layerStack : splitSection}
+              </div>
+            </div>
+          );
+        })()}
+      </PanelDockDropZone>
     </div>
   );
 }

--- a/src/renderer/dnd.tsx
+++ b/src/renderer/dnd.tsx
@@ -1,10 +1,22 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { Plugins } from "@dnd-kit/abstract";
-import { Feedback, PointerActivationConstraints } from "@dnd-kit/dom";
-import { DragDropProvider, DragOverlay, KeyboardSensor, PointerSensor } from "@dnd-kit/react";
+import {
+  AutoScroller,
+  Feedback,
+  PointerActivationConstraints,
+  type DragDropManager,
+} from "@dnd-kit/dom";
+import {
+  DragDropProvider,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  useDragDropManager,
+} from "@dnd-kit/react";
 import { isSortable } from "@dnd-kit/react/sortable";
 import type { PaneLayout, PaneLayoutAxis, PaneLayoutInsertTarget } from "@/shared/paneLayout";
 import { findPanePath } from "@/shared/paneLayout";
+import type { PanelDockTarget, PanelDockZone, RightPanelTab } from "./state/panelStore";
 import { useFileEditorStore } from "./state/fileEditorStore";
 import { useThread } from "./state/useThread";
 
@@ -27,7 +39,8 @@ export type DragSourceData =
       projectId: string;
       worktreePath?: string;
     }
-  | { type: "editor-tab"; path: string };
+  | { type: "editor-tab"; path: string }
+  | { type: "panel-tab"; tab: RightPanelTab };
 
 export type PaneDropIndicator =
   | { kind: "replace"; paneId: string }
@@ -38,11 +51,13 @@ type DndSnapshot = {
   source: DragSourceData | null;
   paneIndicator: PaneDropIndicator | null;
   mainPanelDropActive: boolean;
+  panelDockIndicator: PanelDockTarget | null;
 };
 const EMPTY_DND_SNAPSHOT: DndSnapshot = {
   source: null,
   paneIndicator: null,
   mainPanelDropActive: false,
+  panelDockIndicator: null,
 };
 
 let dndSnapshot: DndSnapshot = EMPTY_DND_SNAPSHOT;
@@ -63,7 +78,8 @@ function updateDndSnapshot(nextSnapshot: DndSnapshot) {
   if (
     dndSnapshot.source === nextSnapshot.source &&
     dndSnapshot.paneIndicator === nextSnapshot.paneIndicator &&
-    dndSnapshot.mainPanelDropActive === nextSnapshot.mainPanelDropActive
+    dndSnapshot.mainPanelDropActive === nextSnapshot.mainPanelDropActive &&
+    dndSnapshot.panelDockIndicator === nextSnapshot.panelDockIndicator
   ) {
     return;
   }
@@ -81,6 +97,10 @@ function setPaneIndicatorState(paneIndicator: PaneDropIndicator | null) {
 
 function setMainPanelDropActive(mainPanelDropActive: boolean) {
   updateDndSnapshot({ ...dndSnapshot, mainPanelDropActive });
+}
+
+function setPanelDockIndicatorState(panelDockIndicator: PanelDockTarget | null) {
+  updateDndSnapshot({ ...dndSnapshot, panelDockIndicator });
 }
 
 function useDndSelector<T>(selector: (snapshot: DndSnapshot) => T) {
@@ -128,6 +148,13 @@ export function useIsDraggingEditorTab(path: string) {
 
 export function useIsMainPanelDropActive() {
   return useDndSelector((snapshot) => snapshot.mainPanelDropActive);
+}
+
+/** The dragged panel-tab's projected placement in this zone, or null when not hovering it. */
+export function usePanelDockPlacement(zone: PanelDockZone) {
+  return useDndSelector((snapshot) =>
+    snapshot.panelDockIndicator?.zone === zone ? snapshot.panelDockIndicator.placement : null,
+  );
 }
 
 export function usePaneDropIndicatorState(paneId: string) {
@@ -189,6 +216,49 @@ type PaneDragSource = Extract<DragSourceData, { type: "pane" }>;
 
 function isPaneDragSource(source: DragSourceData | undefined): source is PaneDragSource {
   return source?.type === "pane";
+}
+
+export type PanelTabDragSource = Extract<DragSourceData, { type: "panel-tab" }>;
+
+const panelDockZoneElements = new Map<string, { zone: PanelDockZone; element: HTMLElement }>();
+
+/** Below this the zone is a collapsed panel (or an exit animation) — not a real target. */
+const MIN_DOCK_ZONE_SIZE_PX = 24;
+
+/**
+ * Registered by `PanelDockDropZone` via a ref callback, keyed per instance so a
+ * collapsing panel and the drag-time drop strip can both be registered for the
+ * same zone. Like the main-panel drop zone, panel-tab drags are hit-tested
+ * manually against the live rects so droppables nested inside panel content
+ * (usage sortables, editor tabs, …) cannot steal the drop target.
+ */
+export function setPanelDockZoneElement(
+  id: string,
+  zone: PanelDockZone,
+  element: HTMLElement | null,
+): void {
+  if (element) panelDockZoneElements.set(id, { zone, element });
+  else panelDockZoneElements.delete(id);
+}
+
+function hitTestPanelDockZones(pointerX: number, pointerY: number): PanelDockTarget | null {
+  for (const { zone, element } of panelDockZoneElements.values()) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width < MIN_DOCK_ZONE_SIZE_PX || rect.height < MIN_DOCK_ZONE_SIZE_PX) continue;
+    if (
+      pointerX < rect.left ||
+      pointerX > rect.right ||
+      pointerY < rect.top ||
+      pointerY > rect.bottom
+    ) {
+      continue;
+    }
+    if (zone === "right-panel") {
+      return { zone, placement: pointerY < rect.top + rect.height / 2 ? "top" : "bottom" };
+    }
+    return { zone, placement: pointerX < rect.left + rect.width / 2 ? "left" : "right" };
+  }
+  return null;
 }
 
 function isPointerInMainPanelDropZone(pointerX: number, pointerY: number): boolean {
@@ -310,6 +380,23 @@ function resolveSiblingInsertTarget(
   return null;
 }
 
+/**
+ * Publishes the manager instance so drag handlers can reach its plugin registry
+ * synchronously. `useDragDropManager` only resolves inside the provider, so this
+ * runs as a child of it.
+ */
+function DndManagerBridge(props: { managerRef: React.RefObject<DragDropManager | null> }) {
+  const manager = useDragDropManager();
+  const managerRef = props.managerRef;
+  useEffect(() => {
+    managerRef.current = (manager as DragDropManager | null) ?? null;
+    return () => {
+      managerRef.current = null;
+    };
+  }, [manager, managerRef]);
+  return null;
+}
+
 export function AppDndProvider(props: {
   children: React.ReactNode;
   onSidebarSortEnd: (
@@ -322,12 +409,28 @@ export function AppDndProvider(props: {
   ) => void;
   onPaneDrop: (source: DragSourceData, target: PaneDropIndicator | null) => void;
   onMainPanelDrop: (source: MainPanelDropSource) => void;
+  onPanelDockDrop: (source: PanelTabDragSource, target: PanelDockTarget) => void;
   paneLayout: PaneLayout;
 }) {
   const pointer = useRef({ x: 0, y: 0 });
   const paneIndicatorRef = useRef<PaneDropIndicator | null>(null);
   const mainPanelDropActiveRef = useRef(false);
+  const panelDockIndicatorRef = useRef<PanelDockTarget | null>(null);
   const sidebarSortTargetRef = useRef<DragSourceData | null>(null);
+  const managerRef = useRef<DragDropManager | null>(null);
+
+  /**
+   * Panel-tab drops target whole panes, not positions inside a list, so
+   * dnd-kit's edge auto-scrolling only jerks the chat and panel scrollers out
+   * from under the pointer. Sortable drags (sidebar threads, editor tabs) still
+   * need it, so it is toggled per drag instead of configured away.
+   */
+  function setAutoScrollEnabled(enabled: boolean) {
+    const autoScroller = managerRef.current?.registry.plugins.get(AutoScroller);
+    if (!autoScroller) return;
+    if (enabled) autoScroller.enable();
+    else autoScroller.disable();
+  }
 
   const activePaneTarget = useRef<{
     paneId: string;
@@ -359,6 +462,14 @@ export function AppDndProvider(props: {
     );
     setPaneIndicatorState(next);
     paneIndicatorRef.current = next;
+  }
+
+  function updatePanelDockIndicator() {
+    const next = hitTestPanelDockZones(pointer.current.x, pointer.current.y);
+    const prev = panelDockIndicatorRef.current;
+    if (prev && next && prev.zone === next.zone && prev.placement === next.placement) return;
+    panelDockIndicatorRef.current = next;
+    setPanelDockIndicatorState(next);
   }
 
   function updateMainPanelDropState(source: DragSourceData | undefined) {
@@ -400,11 +511,16 @@ export function AppDndProvider(props: {
         if (data) setDragSource(data);
         sidebarSortTargetRef.current = null;
         mainPanelDropActiveRef.current = false;
+        setAutoScrollEnabled(data?.type !== "panel-tab");
         // Lets CSS opt chat scrollers out of dnd-kit's AutoScroller ancestor scan.
         document.documentElement.dataset.poracodeDragActive = "true";
       }}
       onDragMove={(event) => {
         const data = event.operation.source?.data as DragSourceData | undefined;
+        if (data?.type === "panel-tab") {
+          updatePanelDockIndicator();
+          return;
+        }
         if (isMainPanelDropSource(data)) {
           updateMainPanelDropState(data);
           return;
@@ -416,6 +532,10 @@ export function AppDndProvider(props: {
       onDragOver={(event) => {
         const target = event.operation.target;
         const data = event.operation.source?.data as DragSourceData | undefined;
+        if (data?.type === "panel-tab") {
+          updatePanelDockIndicator();
+          return;
+        }
         if (isMainPanelDropSource(data) && updateMainPanelDropState(data)) {
           activePaneTarget.current = null;
           setPaneIndicatorState(null);
@@ -519,7 +639,11 @@ export function AppDndProvider(props: {
         const data = src?.data as DragSourceData | undefined;
 
         if (!event.canceled && data) {
-          if (
+          if (data.type === "panel-tab") {
+            if (panelDockIndicatorRef.current) {
+              props.onPanelDockDrop(data, panelDockIndicatorRef.current);
+            }
+          } else if (
             (data.type === "pane" || data.type === "thread" || data.type === "new-thread") &&
             paneIndicatorRef.current
           ) {
@@ -544,12 +668,16 @@ export function AppDndProvider(props: {
         setDragSource(null);
         setPaneIndicatorState(null);
         setMainPanelDropActive(false);
+        setPanelDockIndicatorState(null);
         paneIndicatorRef.current = null;
         mainPanelDropActiveRef.current = false;
+        panelDockIndicatorRef.current = null;
         sidebarSortTargetRef.current = null;
+        setAutoScrollEnabled(true);
         delete document.documentElement.dataset.poracodeDragActive;
       }}
     >
+      <DndManagerBridge managerRef={managerRef} />
       {props.children}
       <DragOverlay
         disabled={(source) => !isPaneDragSource(source?.data as DragSourceData | undefined)}

--- a/src/renderer/hooks/useDndHandlers.ts
+++ b/src/renderer/hooks/useDndHandlers.ts
@@ -4,9 +4,15 @@ import { makeDraftPaneId } from "@/shared/paneId";
 import type { Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { findExperimentByThreadId } from "@/renderer/state/experimentStore";
-import type { DragSourceData, MainPanelDropSource, PaneDropIndicator } from "@/renderer/dnd";
+import type {
+  DragSourceData,
+  MainPanelDropSource,
+  PaneDropIndicator,
+  PanelTabDragSource,
+} from "@/renderer/dnd";
+import type { PanelDockTarget } from "@/renderer/state/panelStore";
 import type { ReorderPlacement } from "@/renderer/state/reorder";
-import { showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
+import { dockPanelTab, showFilesPanel, showGitReviewPanel } from "@/renderer/actions/panelActions";
 import { showTerminalPanel } from "@/renderer/actions/terminalActions";
 
 type ThreadDragSource = Extract<DragSourceData, { type: "thread" }>;
@@ -186,6 +192,10 @@ export function useDndHandlers() {
     }
   }
 
+  function handlePanelDockDrop(source: PanelTabDragSource, target: PanelDockTarget) {
+    startTransition(() => dockPanelTab(source.tab, target));
+  }
+
   function handleMainPanelDrop(source: MainPanelDropSource) {
     if (source.type === "project") {
       showFilesPanel(source.projectId);
@@ -200,5 +210,5 @@ export function useDndHandlers() {
     }
   }
 
-  return { handleSortEnd, handlePaneDrop, handleMainPanelDrop };
+  return { handleSortEnd, handlePaneDrop, handleMainPanelDrop, handlePanelDockDrop };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Durchsuchen Sie Ihre GitHub-Repositorys oder fügen Sie eine Klon-URL ei
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Scanner schließen"
 msgid "Close search"
 msgstr "Suche schließen"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Split schließen"
@@ -3922,6 +3923,14 @@ msgstr "Anzeigename (optional)"
 msgid "Display name in the sidebar."
 msgstr "Anzeigename in der Seitenleiste."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Links andocken"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Rechts andocken"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Doku"
@@ -4003,6 +4012,10 @@ msgstr "Laufwerke"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Zum Anhängen hier ablegen"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Links oder rechts ablegen, um unten anzudocken"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Die Datei verwendet eine nicht unterstützte Codierung."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Dateien"
@@ -4982,7 +4995,7 @@ msgstr "Aufgabe abrufen"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Browser in Fenster verschieben"
 msgid "Move changes to a new worktree"
 msgstr "Änderungen in einen neuen Arbeitsbaum verschieben"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Panel verschieben"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "In Arbeitsbereich verschieben"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Nicht synchronisiert"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Angeheftete Aufgabenrouten"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Portweiterleitung ist nicht aktiviert"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Ports"
 
@@ -9209,7 +9226,9 @@ msgstr "Größe der Laufdetails ändern"
 msgid "Resize sidebar"
 msgstr "Größe der Seitenleiste ändern"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Größe der Teilung ändern"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Strukturierte Laufzeit"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Subagent"
@@ -10992,7 +11011,7 @@ msgstr "Sagen Sie dem Zielanbieter, was als nächstes zu tun ist ..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "URL ist erforderlich."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1747,7 +1747,7 @@ msgstr "Browse your GitHub repositories or paste a clone URL."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2467,6 +2467,7 @@ msgstr "Close scanner"
 msgid "Close search"
 msgstr "Close search"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Close Split"
@@ -3927,6 +3928,14 @@ msgstr "Display name (optional)"
 msgid "Display name in the sidebar."
 msgstr "Display name in the sidebar."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Dock left"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Dock right"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Docs"
@@ -4008,6 +4017,10 @@ msgstr "Drives"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Drop here to attach"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Drop left or right to dock at the bottom"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4632,7 +4645,7 @@ msgstr "File uses an unsupported encoding."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Files"
@@ -4987,7 +5000,7 @@ msgstr "Get task"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6619,6 +6632,10 @@ msgstr "Move browser to window"
 msgid "Move changes to a new worktree"
 msgstr "Move changes to a new worktree"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Move panel"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Move to Workspace"
@@ -7385,7 +7402,7 @@ msgid "Not synced"
 msgstr "Not synced"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8111,7 +8128,7 @@ msgid "Pinned task routes"
 msgstr "Pinned task routes"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8227,7 +8244,7 @@ msgstr "Port forwarding isn't enabled"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Ports"
 
@@ -9214,7 +9231,9 @@ msgstr "Resize run details"
 msgid "Resize sidebar"
 msgstr "Resize sidebar"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Resize split"
 
@@ -10727,7 +10746,7 @@ msgid "Structured runtime"
 msgstr "Structured runtime"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Subagent"
@@ -10997,7 +11016,7 @@ msgstr "Tell the target provider what to do next..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12221,7 +12240,7 @@ msgstr "URL is required."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Explora tus repositorios de GitHub o pega una URL de clonación."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Cerrar escáner"
 msgid "Close search"
 msgstr "Cerrar búsqueda"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Cerrar división"
@@ -3922,6 +3923,14 @@ msgstr "Nombre para mostrar (opcional)"
 msgid "Display name in the sidebar."
 msgstr "Nombre que se muestra en la barra lateral."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Acoplar a la izquierda"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Acoplar a la derecha"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Documentación"
@@ -4003,6 +4012,10 @@ msgstr "Unidades"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Suelta aquí para adjuntar"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Suelta a la izquierda o a la derecha para acoplar abajo"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "El archivo usa una codificación no compatible."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Archivos"
@@ -4982,7 +4995,7 @@ msgstr "Obtener tarea"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Mover navegador a una ventana"
 msgid "Move changes to a new worktree"
 msgstr "Mover cambios a un nuevo worktree"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Mover panel"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover a espacio de trabajo"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Sin sincronizar"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Rutas de tarea fijadas"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "El reenvío de puertos no está habilitado"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Puertos"
 
@@ -9209,7 +9226,9 @@ msgstr "Cambiar el tamaño de los detalles de la ejecución"
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Redimensionar división"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Entorno de ejecución estructurado"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Subagente"
@@ -10992,7 +11011,7 @@ msgstr "Indica al proveedor de destino qué hacer a continuación..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "La URL es obligatoria."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Parcourez vos référentiels GitHub ou collez une URL de clonage."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Fermer le scanner"
 msgid "Close search"
 msgstr "Fermer la recherche"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Fermer la division"
@@ -3922,6 +3923,14 @@ msgstr "Nom d’affichage (facultatif)"
 msgid "Display name in the sidebar."
 msgstr "Afficher le nom dans la barre latérale."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Ancrer à gauche"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Ancrer à droite"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Docs"
@@ -4003,6 +4012,10 @@ msgstr "Lecteurs"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Déposez ici pour joindre"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Déposez à gauche ou à droite pour ancrer en bas"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Le fichier utilise un encodage non pris en charge."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Fichiers"
@@ -4982,7 +4995,7 @@ msgstr "Obtenir la tâche"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6613,6 +6626,10 @@ msgstr "Déplacer le navigateur vers une fenêtre"
 msgid "Move changes to a new worktree"
 msgstr "Déplacer les modifications vers un nouvel arbre de travail"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Déplacer le panneau"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Déplacer vers un espace de travail"
@@ -7379,7 +7396,7 @@ msgid "Not synced"
 msgstr "Non synchronisé"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8105,7 +8122,7 @@ msgid "Pinned task routes"
 msgstr "Routes de tâche épinglées"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8221,7 +8238,7 @@ msgstr "Le transfert de port n'est pas activé"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Ports"
 
@@ -9208,7 +9225,9 @@ msgstr "Redimensionner les détails de l’exécution"
 msgid "Resize sidebar"
 msgstr "Redimensionner la barre latérale"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Redimensionner la division"
 
@@ -10721,7 +10740,7 @@ msgid "Structured runtime"
 msgstr "Environnement d’exécution structuré"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Sous-agent"
@@ -10991,7 +11010,7 @@ msgstr "Dites au fournisseur cible quoi faire ensuite..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12215,7 +12234,7 @@ msgstr "L’URL est obligatoire."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1741,7 +1741,7 @@ msgstr "GitHub リポジトリを参照するか、クローン URL を貼り付
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2461,6 +2461,7 @@ msgstr "スキャナーを閉じる"
 msgid "Close search"
 msgstr "検索を閉じる"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "分割を閉じる"
@@ -3921,6 +3922,14 @@ msgstr "表示名（任意）"
 msgid "Display name in the sidebar."
 msgstr "サイドバーに名前を表示します。"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "左にドッキング"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "右にドッキング"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "ドキュメント"
@@ -4002,6 +4011,10 @@ msgstr "ドライブ"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "ここにドロップして添付します"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "左または右にドロップして下部にドッキング"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4626,7 +4639,7 @@ msgstr "ファイルはサポートされていないエンコーディングを
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "ファイル"
@@ -4981,7 +4994,7 @@ msgstr "タスクの取得"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6612,6 +6625,10 @@ msgstr "ブラウザーをウィンドウに移動"
 msgid "Move changes to a new worktree"
 msgstr "変更を新しいワークツリーに移動する"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "パネルを移動"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "ワークスペースへ移動"
@@ -7378,7 +7395,7 @@ msgid "Not synced"
 msgstr "未同期"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8104,7 +8121,7 @@ msgid "Pinned task routes"
 msgstr "固定されたタスクルート"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8220,7 +8237,7 @@ msgstr "ポート転送が有効になっていません"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "ポート"
 
@@ -9207,7 +9224,9 @@ msgstr "実行詳細のサイズを変更"
 msgid "Resize sidebar"
 msgstr "サイドバーのサイズを変更する"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "分割のサイズ変更"
 
@@ -10720,7 +10739,7 @@ msgid "Structured runtime"
 msgstr "構造化ランタイム"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "サブエージェント"
@@ -10990,7 +11009,7 @@ msgstr "ターゲットプロバイダーに次に何をすべきかを伝えま
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12214,7 +12233,7 @@ msgstr "URLは必須です。"
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1742,7 +1742,7 @@ msgstr "GitHub 리포지토리를 찾아보거나 복제 URL을 붙여넣으세�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "스캐너 닫기"
 msgid "Close search"
 msgstr "검색 닫기"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "분할 닫기"
@@ -3922,6 +3923,14 @@ msgstr "표시 이름(선택 사항)"
 msgid "Display name in the sidebar."
 msgstr "사이드바에 이름을 표시합니다."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "왼쪽에 고정"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "오른쪽에 고정"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "문서"
@@ -4003,6 +4012,10 @@ msgstr "드라이브"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "첨부하려면 여기에 드롭하세요."
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "왼쪽 또는 오른쪽에 놓아 아래에 고정"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "파일이 지원되지 않는 인코딩을 사용합니다."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "파일"
@@ -4982,7 +4995,7 @@ msgstr "작업 가져오기"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "브라우저를 창으로 이동"
 msgid "Move changes to a new worktree"
 msgstr "변경 사항을 새 작업 트리로 이동"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "패널 이동"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "작업 영역으로 이동"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "동기화되지 않음"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "고정된 작업 경로"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "포트 포워딩이 활성화되지 않았습니다"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "포트"
 
@@ -9209,7 +9226,9 @@ msgstr "실행 세부 정보 크기 조절"
 msgid "Resize sidebar"
 msgstr "사이드바 크기 조정"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "분할 크기 조정"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "구조화 런타임"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "하위 에이전트"
@@ -10992,7 +11011,7 @@ msgstr "대상 공급자에게 다음에 무엇을 해야 할지 알려주세요
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "URL을 입력해야 합니다."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Przeglądaj swoje repozytoria GitHub lub wklej adres URL do klonowania."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Zamknij skaner"
 msgid "Close search"
 msgstr "Zamknij wyszukiwanie"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Zamknij podział"
@@ -3922,6 +3923,14 @@ msgstr "Nazwa wyświetlana (opcjonalnie)"
 msgid "Display name in the sidebar."
 msgstr "Nazwa wyświetlana na pasku bocznym."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Zadokuj po lewej"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Zadokuj po prawej"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Dokumentacja"
@@ -4003,6 +4012,10 @@ msgstr "Dyski"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Upuść tutaj, aby dołączyć"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Upuść po lewej lub prawej, aby zadokować na dole"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Plik używa nieobsługiwanego kodowania."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Pliki"
@@ -4982,7 +4995,7 @@ msgstr "Pobierz zadanie"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Przenieś przeglądarkę do okna"
 msgid "Move changes to a new worktree"
 msgstr "Przenieś zmiany do nowego drzewa roboczego"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Przenieś panel"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Przenieś do obszaru roboczego"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Niezsynchronizowany"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Przypięte trasy zadań"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Przekierowywanie portów nie jest włączone"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Porty"
 
@@ -9209,7 +9226,9 @@ msgstr "Zmień rozmiar szczegółów uruchomienia"
 msgid "Resize sidebar"
 msgstr "Zmień rozmiar paska bocznego"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Zmień rozmiar podziału"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Środowisko strukturalne"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Subagent"
@@ -10992,7 +11011,7 @@ msgstr "Powiedz dostawcy docelowemu, co ma dalej robić..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "Adres URL jest wymagany."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Navegue pelos seus repositórios do GitHub ou cole uma URL de clonagem."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Fechar scanner"
 msgid "Close search"
 msgstr "Fechar pesquisa"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Fechar divisão"
@@ -3922,6 +3923,14 @@ msgstr "Nome de exibição (opcional)"
 msgid "Display name in the sidebar."
 msgstr "Nome de exibição na barra lateral."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Encaixar à esquerda"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Encaixar à direita"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Documentação"
@@ -4003,6 +4012,10 @@ msgstr "Unidades"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Solte aqui para anexar"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Solte à esquerda ou à direita para encaixar embaixo"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "O arquivo usa uma codificação não suportada."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Arquivos"
@@ -4982,7 +4995,7 @@ msgstr "Obter tarefa"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Mover navegador para uma janela"
 msgid "Move changes to a new worktree"
 msgstr "Mover alterações para uma nova árvore de trabalho"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Mover painel"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Mover para espaço de trabalho"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Não sincronizado"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Rotas de tarefa fixadas"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "O encaminhamento de portas não está ativado"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Portas"
 
@@ -9209,7 +9226,9 @@ msgstr "Redimensionar detalhes da execução"
 msgid "Resize sidebar"
 msgstr "Redimensionar barra lateral"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Redimensionar divisão"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Runtime estruturado"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Subagente"
@@ -10992,7 +11011,7 @@ msgstr "Diga ao provedor alvo o que fazer a seguir..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "A URL é obrigatória."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Просмотрите свои репозитории GitHub или в�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Закрыть сканер"
 msgid "Close search"
 msgstr "Закрыть поиск"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Закрыть разделение"
@@ -3922,6 +3923,14 @@ msgstr "Отображаемое имя (необязательно)"
 msgid "Display name in the sidebar."
 msgstr "Отображаемое имя в боковой панели."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Закрепить слева"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Закрепить справа"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Документация"
@@ -4003,6 +4012,10 @@ msgstr "Диски"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Перетащите сюда, чтобы прикрепить"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Перетащите влево или вправо, чтобы закрепить снизу"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Файл использует неподдерживаемую коди�
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Файлы"
@@ -4982,7 +4995,7 @@ msgstr "Получить задачу"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Переместить браузер в окно"
 msgid "Move changes to a new worktree"
 msgstr "Переместить изменения в новый worktree"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Переместить панель"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Переместить в рабочую область"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Не синхронизируется"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Закреплённые маршруты задач"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Перенаправление портов не включено"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Порты"
 
@@ -9209,7 +9226,9 @@ msgstr "Изменить размер области сведений о зап�
 msgid "Resize sidebar"
 msgstr "Изменить размер боковой панели"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Изменить размер разделения"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Структурированная среда выполнения"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Субагент"
@@ -10992,7 +11011,7 @@ msgstr "Укажите целевому провайдеру, что делат�
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "URL обязателен."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1742,7 +1742,7 @@ msgstr "GitHub depolarınıza göz atın veya bir klon URL'si yapıştırın."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Tarayıcıyı kapat"
 msgid "Close search"
 msgstr "Aramayı kapat"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Bölmeyi Kapat"
@@ -3922,6 +3923,14 @@ msgstr "Görünen ad (isteğe bağlı)"
 msgid "Display name in the sidebar."
 msgstr "Kenar çubuğunda görünen ad."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Sola sabitle"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Sağa sabitle"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Dokümanlar"
@@ -4003,6 +4012,10 @@ msgstr "Sürücüler"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Eklemek için buraya bırakın"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Alta sabitlemek için sola veya sağa bırakın"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Dosya desteklenmeyen bir kodlama kullanıyor."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Dosyalar"
@@ -4982,7 +4995,7 @@ msgstr "Görev al"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Tarayıcıyı pencereye taşı"
 msgid "Move changes to a new worktree"
 msgstr "Değişiklikleri yeni bir çalışma ağacına taşı"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Paneli taşı"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Çalışma alanına taşı"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Senkronize değil"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Sabitlenmiş görev rotaları"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Port yönlendirme etkin değil"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Portlar"
 
@@ -9209,7 +9226,9 @@ msgstr "Çalıştırma ayrıntılarını yeniden boyutlandır"
 msgid "Resize sidebar"
 msgstr "Kenar çubuğunu yeniden boyutlandır"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Bölmeyi yeniden boyutlandır"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Yapılandırılmış çalışma zamanı"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Alt aracı"
@@ -10992,7 +11011,7 @@ msgstr "Hedef sağlayıcıya bundan sonra ne yapacağını söyleyin..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "URL gereklidir."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Перегляньте свої репозиторії GitHub або в�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Закрити сканер"
 msgid "Close search"
 msgstr "Закрити пошук"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Закрити розділення"
@@ -3922,6 +3923,14 @@ msgstr "Відображуване ім’я (необов’язково)"
 msgid "Display name in the sidebar."
 msgstr "Відображуване ім'я в бічній панелі."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Закріпити ліворуч"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Закріпити праворуч"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Документація"
@@ -4003,6 +4012,10 @@ msgstr "Диски"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Перетягніть сюди, щоб прикріпити"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Перетягніть ліворуч або праворуч, щоб закріпити знизу"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Файл використовує непідтримуване коду�
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Файли"
@@ -4982,7 +4995,7 @@ msgstr "Отримати завдання"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Перемістити браузер у вікно"
 msgid "Move changes to a new worktree"
 msgstr "Перемістити зміни в новий worktree"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Перемістити панель"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Перемістити до робочої області"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Не синхронізується"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Закріплені маршрути завдань"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Переспрямування портів не увімкнено"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Порти"
 
@@ -9209,7 +9226,9 @@ msgstr "Змінити розмір відомостей про запуск"
 msgid "Resize sidebar"
 msgstr "Змінити розмір бічної панелі"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Змінити розмір розділення"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Структуроване середовище виконання"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Субагент"
@@ -10992,7 +11011,7 @@ msgstr "Укажіть цільовому провайдеру, що робит�
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "Потрібно вказати URL."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1742,7 +1742,7 @@ msgstr "Duyệt qua kho GitHub của bạn hoặc dán URL nhân bản."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "Đóng trình quét"
 msgid "Close search"
 msgstr "Đóng tìm kiếm"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "Đóng Chia tách"
@@ -3922,6 +3923,14 @@ msgstr "Tên hiển thị (không bắt buộc)"
 msgid "Display name in the sidebar."
 msgstr "Hiển thị tên ở thanh bên."
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "Gắn bên trái"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "Gắn bên phải"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "Tài liệu"
@@ -4003,6 +4012,10 @@ msgstr "Ổ đĩa"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "Thả vào đây để đính kèm"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "Thả sang trái hoặc phải để gắn ở dưới cùng"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "Tệp sử dụng mã hóa không được hỗ trợ."
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "Tập tin"
@@ -4982,7 +4995,7 @@ msgstr "Nhận nhiệm vụ"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6614,6 +6627,10 @@ msgstr "Chuyển trình duyệt sang cửa sổ"
 msgid "Move changes to a new worktree"
 msgstr "Di chuyển các thay đổi sang một cây làm việc mới"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "Di chuyển bảng điều khiển"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "Chuyển tới không gian làm việc"
@@ -7380,7 +7397,7 @@ msgid "Not synced"
 msgstr "Chưa đồng bộ"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8106,7 +8123,7 @@ msgid "Pinned task routes"
 msgstr "Tuyến tác vụ đã ghim"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8222,7 +8239,7 @@ msgstr "Chưa bật chuyển tiếp cổng"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "Cổng"
 
@@ -9209,7 +9226,9 @@ msgstr "Thay đổi kích thước chi tiết lượt chạy"
 msgid "Resize sidebar"
 msgstr "Thay đổi kích thước thanh bên"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "Thay đổi kích thước phần chia"
 
@@ -10722,7 +10741,7 @@ msgid "Structured runtime"
 msgstr "Môi trường chạy có cấu trúc"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "Tác nhân phụ"
@@ -10992,7 +11011,7 @@ msgstr "Cho nhà cung cấp mục tiêu biết phải làm gì tiếp theo..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12216,7 +12235,7 @@ msgstr "Bắt buộc phải có URL."
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1742,7 +1742,7 @@ msgstr "浏览您的 GitHub 存储库或粘贴克隆 URL。"
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/composer/composerMcpServers.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/mcp/McpServersManager.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserPanel.tsx
@@ -2462,6 +2462,7 @@ msgstr "关闭扫描器"
 msgid "Close search"
 msgstr "关闭搜索"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
 msgid "Close Split"
 msgstr "关闭分割"
@@ -3922,6 +3923,14 @@ msgstr "显示名称（可选）"
 msgid "Display name in the sidebar."
 msgstr "在侧边栏中显示名称。"
 
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock left"
+msgstr "停靠到左侧"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+msgid "Dock right"
+msgstr "停靠到右侧"
+
 #: src/renderer/views/SettingsOverlay/parts/AcpRegistrySettings.tsx
 msgid "Docs"
 msgstr "文档"
@@ -4003,6 +4012,10 @@ msgstr "驱动器"
 #: src/renderer/components/thread/ThreadComposer.tsx
 msgid "Drop here to attach"
 msgstr "拖放到此处以附加"
+
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+#~ msgid "Drop left or right to dock at the bottom"
+#~ msgstr "拖放到左侧或右侧以停靠在底部"
 
 #: src/renderer/views/SettingsOverlay/parts/DevSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
@@ -4627,7 +4640,7 @@ msgstr "文件使用不受支持的编码。"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/WorkspaceView.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 msgid "Files"
 msgstr "文件"
@@ -4982,7 +4995,7 @@ msgstr "获取任务"
 #: src/mobile/settingsSections.ts
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/commandSummary.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -6613,6 +6626,10 @@ msgstr "将浏览器移到窗口"
 msgid "Move changes to a new worktree"
 msgstr "将更改移至新工作树"
 
+#: src/renderer/components/layout/PanelDock/PanelSectionHeader.tsx
+msgid "Move panel"
+msgstr "移动面板"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Move to Workspace"
 msgstr "移动到工作区"
@@ -7379,7 +7396,7 @@ msgid "Not synced"
 msgstr "未同步"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
 msgid "Notes"
@@ -8105,7 +8122,7 @@ msgid "Pinned task routes"
 msgstr "已固定的任务路由"
 
 #: src/mobile/ComposerInfoChips.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/composerControlBuilders.tsx
 #: src/renderer/components/thread/ThreadTodoDock.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -8221,7 +8238,7 @@ msgstr "未启用端口转发"
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/views/PortsView.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 msgid "Ports"
 msgstr "端口"
 
@@ -9208,7 +9225,9 @@ msgstr "调整运行详情大小"
 msgid "Resize sidebar"
 msgstr "调整侧边栏大小"
 
+#: src/renderer/components/layout/UnifiedRightPanel.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
 msgid "Resize split"
 msgstr "调整分割大小"
 
@@ -10721,7 +10740,7 @@ msgid "Structured runtime"
 msgstr "结构化运行时"
 
 #: src/mobile/views/DesktopWorkspacePanel.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentOverlay.tsx
 msgid "Subagent"
 msgstr "子代理"
@@ -10991,7 +11010,7 @@ msgstr "告诉目标提供商下一步该做什么..."
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -12215,7 +12234,7 @@ msgstr "URL 为必填项。"
 #: src/mobile/ThreadUsageIndicator.tsx
 #: src/mobile/views/DesktopWorkspacePanel.tsx
 #: src/mobile/WideShell.tsx
-#: src/renderer/components/layout/UnifiedRightPanel.tsx
+#: src/renderer/components/layout/PanelDock/panelTabMeta.ts
 #: src/renderer/components/providers/ProviderUsageRail.tsx
 #: src/renderer/components/thread/ThreadContextDock.tsx
 #: src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx

--- a/src/renderer/state/panelDockSelectors.ts
+++ b/src/renderer/state/panelDockSelectors.ts
@@ -1,0 +1,41 @@
+import {
+  EMPTY_BOTTOM_PANEL_DOCKS,
+  usePanelStore,
+  type BottomPanelDocks,
+  type RightPanelTab,
+} from "./panelStore";
+import { useSharedSettings } from "./sharedSettingsStore";
+
+/**
+ * Bottom docks only render while the terminal owns the bottom edge; with the
+ * terminal on the right there is no bottom row to dock into, so stale slots are
+ * reported as empty instead of hiding the tab from the right panel.
+ */
+export function useBottomDockedTabs(): BottomPanelDocks {
+  const docks = usePanelStore((s) => s.bottomPanelDocks);
+  const isBottom = useSharedSettings((s) => s.terminalPosition === "bottom");
+  return isBottom ? docks : EMPTY_BOTTOM_PANEL_DOCKS;
+}
+
+export function getBottomDockedTabs(): BottomPanelDocks {
+  return useSharedSettings.getState().terminalPosition === "bottom"
+    ? usePanelStore.getState().bottomPanelDocks
+    : EMPTY_BOTTOM_PANEL_DOCKS;
+}
+
+export function isTabBottomDocked(tab: RightPanelTab): boolean {
+  const docks = getBottomDockedTabs();
+  return docks.left === tab || docks.right === tab;
+}
+
+/**
+ * Whether a tab is currently painted somewhere on screen — as the right
+ * panel's active layer, as its split section, or in a bottom dock slot.
+ * Surfaces positioned from the outside (the browser webview) key off this.
+ */
+export function useIsPanelTabVisible(tab: RightPanelTab): boolean {
+  const isActiveTab = usePanelStore((s) => s.rightPanelTab === tab);
+  const isSplitTab = usePanelStore((s) => s.rightPanelSplit?.tab === tab);
+  const docks = useBottomDockedTabs();
+  return isActiveTab || isSplitTab || docks.left === tab || docks.right === tab;
+}

--- a/src/renderer/state/panelStore.test.ts
+++ b/src/renderer/state/panelStore.test.ts
@@ -163,6 +163,98 @@ describe("subagent panel lifecycle", () => {
   });
 });
 
+describe("panel dock state", () => {
+  beforeEach(() => {
+    resetPanelStore();
+    usePanelStore.setState({
+      rightPanelSplit: null,
+      bottomPanelDocks: { left: null, right: null },
+    });
+  });
+  afterEach(() => {
+    resetPanelStore();
+    usePanelStore.setState({
+      rightPanelSplit: null,
+      bottomPanelDocks: { left: null, right: null },
+    });
+  });
+
+  it("stores and clears the right-panel split", () => {
+    usePanelStore.getState().setRightPanelSplit({ tab: "usage", placement: "bottom" });
+    expect(usePanelStore.getState().rightPanelSplit).toEqual({
+      tab: "usage",
+      placement: "bottom",
+    });
+
+    usePanelStore.getState().setRightPanelSplit(null);
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+  });
+
+  it("bails out when setting an identical split", () => {
+    usePanelStore.getState().setRightPanelSplit({ tab: "usage", placement: "top" });
+    const before = usePanelStore.getState().rightPanelSplit;
+    usePanelStore.getState().setRightPanelSplit({ tab: "usage", placement: "top" });
+    expect(usePanelStore.getState().rightPanelSplit).toBe(before);
+  });
+
+  it("fills and clears the two bottom slots independently", () => {
+    usePanelStore.getState().setBottomPanelDock("left", "usage");
+    usePanelStore.getState().setBottomPanelDock("right", "git");
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: "usage", right: "git" });
+
+    usePanelStore.getState().setBottomPanelDock("left", null);
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: "git" });
+  });
+
+  it("moves a tab rather than rendering it in both slots", () => {
+    usePanelStore.getState().setBottomPanelDock("left", "usage");
+    usePanelStore.getState().setBottomPanelDock("right", "usage");
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: "usage" });
+  });
+
+  it("clears a docked tab from whichever slot holds it", () => {
+    usePanelStore.getState().setBottomPanelDock("right", "notes");
+    usePanelStore.getState().clearBottomPanelDockTab("notes");
+
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+  });
+
+  it("releases a dock slot when the docked panel closes its own content", () => {
+    usePanelStore.getState().setUsagePanelOpen(true);
+    usePanelStore.getState().setBottomPanelDock("right", "usage");
+
+    usePanelStore.getState().setUsagePanelOpen(false);
+
+    // Otherwise an empty "Usage" section keeps the bottom row on screen.
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual({ left: null, right: null });
+  });
+
+  it("releases the right-panel split when its content closes", () => {
+    usePanelStore.getState().setGitReviewContext({ projectId: "p1" });
+    usePanelStore.getState().setRightPanelSplit({ tab: "git", placement: "bottom" });
+
+    usePanelStore.getState().setGitReviewContext(null);
+
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+  });
+
+  it("keeps a docked tab's content open when the right panel is hidden", () => {
+    usePanelStore.getState().setUsagePanelOpen(true);
+    usePanelStore.getState().setNotesPanelOpen(true);
+    usePanelStore.getState().setBottomPanelDock("right", "usage");
+    usePanelStore.getState().setRightPanelSplit({ tab: "notes", placement: "bottom" });
+
+    usePanelStore.getState().closeAllPanels();
+
+    // The bottom row is a separate surface, so its panel stays alive; the
+    // right panel's own split does not.
+    expect(usePanelStore.getState().usagePanelOpen).toBe(true);
+    expect(usePanelStore.getState().notesPanelOpen).toBe(false);
+    expect(usePanelStore.getState().rightPanelSplit).toBeNull();
+  });
+});
+
 describe("create project modal", () => {
   beforeEach(() => {
     resetPanelStore();

--- a/src/renderer/state/panelStore.ts
+++ b/src/renderer/state/panelStore.ts
@@ -57,6 +57,44 @@ export type RightPanelTab =
   | "plan"
   | "subagent";
 
+/** Tabs that can be dragged into a dock zone. Thread-transient tabs (plan, subagent) and ports stay fixed. */
+export const DOCKABLE_PANEL_TABS: ReadonlySet<RightPanelTab> = new Set([
+  "git",
+  "files",
+  "terminal",
+  "browser",
+  "usage",
+  "notes",
+]);
+
+/** A second panel section stacked above or below the active right-panel tab. */
+export interface RightPanelSplit {
+  tab: RightPanelTab;
+  /** Which half of the right panel the split tab occupies. */
+  placement: "top" | "bottom";
+}
+
+export type BottomDockPlacement = "left" | "right";
+
+/**
+ * Panels docked in the bottom row, one per side. The terminal (when open) sits
+ * between them, so the row reads `left | terminal | right`; with the terminal
+ * closed the docks own the row on their own.
+ */
+export interface BottomPanelDocks {
+  left: RightPanelTab | null;
+  right: RightPanelTab | null;
+}
+
+export const EMPTY_BOTTOM_PANEL_DOCKS: BottomPanelDocks = { left: null, right: null };
+
+export type PanelDockZone = "right-panel" | "bottom-panel";
+
+/** Resolved drop location for a dragged panel-tab icon. */
+export type PanelDockTarget =
+  | { zone: "right-panel"; placement: "top" | "bottom" }
+  | { zone: "bottom-panel"; placement: BottomDockPlacement };
+
 interface PanelState {
   gitReviewContext: GitReviewContext | null;
   gitReviewAsPanel: boolean;
@@ -67,6 +105,13 @@ interface PanelState {
   subAgentPanelContext: SubAgentPanelContext | null;
   subAgentPanelOpen: boolean;
   rightPanelTab: RightPanelTab;
+  /**
+   * Session-scoped like `rightPanelTab`: a second tab rendered stacked with the
+   * active one in the right panel, or null when the panel is unsplit.
+   */
+  rightPanelSplit: RightPanelSplit | null;
+  /** Panels rendered in the bottom row. Only meaningful with terminalPosition "bottom". */
+  bottomPanelDocks: BottomPanelDocks;
   /**
    * When true, the open right-panel tools re-scope to whichever thread is
    * focused instead of staying on the project/worktree they were opened from.
@@ -102,6 +147,12 @@ interface PanelState {
   setFilesPanelContext: (ctx: FilesPanelContext | null) => void;
   setSubAgentPanelContext: (ctx: SubAgentPanelContext | null) => void;
   setRightPanelTab: (tab: RightPanelTab) => void;
+  setRightPanelSplit: (split: RightPanelSplit | null) => void;
+  /** Put a tab in one bottom slot (or clear it); a tab never occupies two slots. */
+  setBottomPanelDock: (placement: BottomDockPlacement, tab: RightPanelTab | null) => void;
+  /** Remove a tab from whichever bottom slot holds it. */
+  clearBottomPanelDockTab: (tab: RightPanelTab) => void;
+  clearBottomPanelDocks: () => void;
   toggleRightPanelFollowsThread: () => void;
   setThreadToolRailOffset: (offset: number) => void;
   setBrowserPanelOpen: (v: boolean) => void;
@@ -198,6 +249,27 @@ function sanitizeThreadListLayout(value: unknown): ThreadListLayout {
   return value === "grouped" || value === "flat" ? value : "grouped";
 }
 
+/**
+ * A dock placement may only hold a tab whose content is still open. When a
+ * panel closes itself (its close button, a removed worktree, a project going
+ * away) the slot has to be released too — otherwise an empty section keeps its
+ * header, and the bottom row it lives in, on screen with nothing inside.
+ */
+function releaseClosedTab(state: PanelState, tab: RightPanelTab): Partial<PanelState> {
+  const { left, right } = state.bottomPanelDocks;
+  return {
+    ...(left === tab || right === tab
+      ? {
+          bottomPanelDocks: {
+            left: left === tab ? null : left,
+            right: right === tab ? null : right,
+          },
+        }
+      : {}),
+    ...(state.rightPanelSplit?.tab === tab ? { rightPanelSplit: null } : {}),
+  };
+}
+
 /** Default rail offset: below the pane header, near the top of the conversation. */
 const DEFAULT_THREAD_TOOL_RAIL_OFFSET = 56;
 
@@ -218,6 +290,8 @@ export const usePanelStore = create<PanelState>()((set) => ({
   subAgentPanelContext: null,
   subAgentPanelOpen: false,
   rightPanelTab: "git",
+  rightPanelSplit: null,
+  bottomPanelDocks: EMPTY_BOTTOM_PANEL_DOCKS,
   rightPanelFollowsThread: initialPersisted?.rightPanelFollowsThread ?? false,
   threadToolRailOffset: sanitizeRailOffset(
     initialPersisted?.threadToolRailOffset ?? DEFAULT_THREAD_TOOL_RAIL_OFFSET,
@@ -251,7 +325,10 @@ export const usePanelStore = create<PanelState>()((set) => ({
     ) {
       return;
     }
-    set({ gitReviewContext: ctx });
+    set((state) => ({
+      gitReviewContext: ctx,
+      ...(ctx === null ? releaseClosedTab(state, "git") : {}),
+    }));
   },
   setGitReviewAsPanel: (v) =>
     set((state) => (state.gitReviewAsPanel === v ? {} : { gitReviewAsPanel: v })),
@@ -302,7 +379,10 @@ export const usePanelStore = create<PanelState>()((set) => ({
       ) {
         return {};
       }
-      return { filesPanelContext: ctx };
+      return {
+        filesPanelContext: ctx,
+        ...(ctx === null ? releaseClosedTab(state, "files") : {}),
+      };
     }),
   setSubAgentPanelContext: (ctx) =>
     set((state) => {
@@ -329,6 +409,57 @@ export const usePanelStore = create<PanelState>()((set) => ({
         ...(reopenSubAgent ? { subAgentPanelOpen: true } : {}),
       };
     }),
+  setRightPanelSplit: (split) =>
+    set((state) => {
+      const prev = state.rightPanelSplit;
+      if (
+        (prev === null && split === null) ||
+        (prev !== null &&
+          split !== null &&
+          prev.tab === split.tab &&
+          prev.placement === split.placement)
+      ) {
+        return {};
+      }
+      return { rightPanelSplit: split };
+    }),
+  setBottomPanelDock: (placement, tab) =>
+    set((state) => {
+      const other = placement === "left" ? "right" : "left";
+      // A tab lives in exactly one place: dropping it in the opposite slot moves
+      // it rather than rendering the same surface twice.
+      const otherTab =
+        tab !== null && state.bottomPanelDocks[other] === tab
+          ? null
+          : state.bottomPanelDocks[other];
+      if (state.bottomPanelDocks[placement] === tab && state.bottomPanelDocks[other] === otherTab) {
+        return {};
+      }
+      return {
+        bottomPanelDocks: {
+          ...EMPTY_BOTTOM_PANEL_DOCKS,
+          [placement]: tab,
+          [other]: otherTab,
+        },
+      };
+    }),
+  clearBottomPanelDockTab: (tab) =>
+    set((state) => {
+      const { left, right } = state.bottomPanelDocks;
+      if (left !== tab && right !== tab) return {};
+      return {
+        bottomPanelDocks: {
+          left: left === tab ? null : left,
+          right: right === tab ? null : right,
+        },
+      };
+    }),
+  clearBottomPanelDocks: () =>
+    set((state) =>
+      state.bottomPanelDocks.left === null && state.bottomPanelDocks.right === null
+        ? {}
+        : { bottomPanelDocks: EMPTY_BOTTOM_PANEL_DOCKS },
+    ),
   toggleRightPanelFollowsThread: () =>
     set((state) => ({ rightPanelFollowsThread: !state.rightPanelFollowsThread })),
   setThreadToolRailOffset: (offset) =>
@@ -344,7 +475,11 @@ export const usePanelStore = create<PanelState>()((set) => ({
   // would make the fullscreen page vanish. Callers that genuinely want to
   // dismiss both (e.g. the last tab closing) close the overlay explicitly.
   setBrowserPanelOpen: (v) =>
-    set((state) => (state.browserPanelOpen === v ? {} : { browserPanelOpen: v })),
+    set((state) =>
+      state.browserPanelOpen === v
+        ? {}
+        : { browserPanelOpen: v, ...(v ? {} : releaseClosedTab(state, "browser")) },
+    ),
   // NOTE: overlay state is intentionally independent of the right-panel
   // browser in both directions. Opening the overlay does NOT enable the
   // right-panel browser tab, and closing the overlay leaves the right panel in
@@ -374,7 +509,11 @@ export const usePanelStore = create<PanelState>()((set) => ({
         : { browserPanelOpen: true, rightPanelTab: "browser" as const },
     ),
   setUsagePanelOpen: (v) =>
-    set((state) => (state.usagePanelOpen === v ? {} : { usagePanelOpen: v })),
+    set((state) =>
+      state.usagePanelOpen === v
+        ? {}
+        : { usagePanelOpen: v, ...(v ? {} : releaseClosedTab(state, "usage")) },
+    ),
   openUsagePanel: () =>
     set((state) =>
       state.usagePanelOpen && state.rightPanelTab === "usage"
@@ -382,7 +521,11 @@ export const usePanelStore = create<PanelState>()((set) => ({
         : { usagePanelOpen: true, rightPanelTab: "usage" as const },
     ),
   setNotesPanelOpen: (v) =>
-    set((state) => (state.notesPanelOpen === v ? {} : { notesPanelOpen: v })),
+    set((state) =>
+      state.notesPanelOpen === v
+        ? {}
+        : { notesPanelOpen: v, ...(v ? {} : releaseClosedTab(state, "notes")) },
+    ),
   openNotesPanel: () =>
     set((state) =>
       state.notesPanelOpen && state.rightPanelTab === "notes"
@@ -427,24 +570,30 @@ export const usePanelStore = create<PanelState>()((set) => ({
       // that fires when the window shrinks — must not tear down a standalone
       // browser overlay or the temporary subagent target. The latter has its own
       // explicit close control in the panel header.
-      if (
-        state.gitReviewContext === null &&
-        state.filesPanelContext === null &&
-        !state.subAgentPanelOpen &&
-        !state.browserPanelOpen &&
-        !state.usagePanelOpen &&
-        !state.notesPanelOpen
-      ) {
-        return {};
-      }
-      return {
-        gitReviewContext: null,
-        filesPanelContext: null,
+      //
+      // Bottom-docked tabs are likewise a separate surface: hiding the right
+      // panel must leave them (and the open flag that feeds their content)
+      // alone, otherwise a docked Usage/Git would blank out beside the terminal.
+      const { left, right } = state.bottomPanelDocks;
+      const isDocked = (tab: RightPanelTab) => left === tab || right === tab;
+      const next = {
+        ...(isDocked("git") ? {} : { gitReviewContext: null }),
+        ...(isDocked("files") ? {} : { filesPanelContext: null }),
+        ...(isDocked("browser") ? {} : { browserPanelOpen: false }),
+        ...(isDocked("usage") ? {} : { usagePanelOpen: false }),
+        ...(isDocked("notes") ? {} : { notesPanelOpen: false }),
         subAgentPanelOpen: false,
-        browserPanelOpen: false,
-        usagePanelOpen: false,
-        notesPanelOpen: false,
+        rightPanelSplit: null,
       };
+      const alreadyClosed =
+        (next.gitReviewContext === undefined || state.gitReviewContext === null) &&
+        (next.filesPanelContext === undefined || state.filesPanelContext === null) &&
+        !state.subAgentPanelOpen &&
+        (next.browserPanelOpen === undefined || !state.browserPanelOpen) &&
+        (next.usagePanelOpen === undefined || !state.usagePanelOpen) &&
+        (next.notesPanelOpen === undefined || !state.notesPanelOpen) &&
+        state.rightPanelSplit === null;
+      return alreadyClosed ? {} : next;
     });
   },
 }));

--- a/src/renderer/views/MainView/MainView.tsx
+++ b/src/renderer/views/MainView/MainView.tsx
@@ -54,7 +54,8 @@ export function MainView(props: {
   useRightPanelThreadLock();
   useBrowserSync();
 
-  const { handleSortEnd, handlePaneDrop, handleMainPanelDrop } = useDndHandlers();
+  const { handleSortEnd, handlePaneDrop, handleMainPanelDrop, handlePanelDockDrop } =
+    useDndHandlers();
 
   useEffect(() => {
     if (!storeHydrated || !sharedSettingsHydrated || !homeScopeEnabled) {
@@ -115,6 +116,7 @@ export function MainView(props: {
         onSidebarSortEnd={handleSortEnd}
         onPaneDrop={handlePaneDrop}
         onMainPanelDrop={handleMainPanelDrop}
+        onPanelDockDrop={handlePanelDockDrop}
         paneLayout={
           view.kind === "thread"
             ? (view.paneLayout ?? buildPaneLayoutFromLegacy(view.panes, view.rowLayout))

--- a/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
+++ b/src/renderer/views/MainView/parts/AppShell/parts/usePanelVisibility.ts
@@ -1,24 +1,22 @@
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
-import { usePanelStore } from "@/renderer/state/panelStore";
+import { useBottomDockedTabs } from "@/renderer/state/panelDockSelectors";
+import { usePanelStore, type RightPanelTab } from "@/renderer/state/panelStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { selectThreadTodoDockState } from "@/renderer/components/thread/threadTodoState";
 import { useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 
-export function usePanelVisibility() {
+/**
+ * Whether the dev terminal panel is currently shown to the user. An explicitly
+ * opened terminal shows regardless of the focused thread — the user asked for
+ * it. Once the follow lock re-scopes it (setPanelScope clears the marker),
+ * visibility depends on matching the focused thread's scope.
+ */
+export function useBottomTerminalVisible(): boolean {
   const devTerminalOpen = useDevTerminalStore((s) => s.isOpen);
   const devTerminalExplicitlyOpened = useDevTerminalStore((s) => s.explicitlyOpened);
-  const gitReviewContext = usePanelStore((s) => s.gitReviewContext);
-  const gitReviewAsPanel = usePanelStore((s) => s.gitReviewAsPanel);
-  const filesPanelContext = usePanelStore((s) => s.filesPanelContext);
-  const subAgentPanelContext = usePanelStore((s) => s.subAgentPanelContext);
-  const subAgentPanelOpen = usePanelStore((s) => s.subAgentPanelOpen);
-  const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
-  const usagePanelOpen = usePanelStore((s) => s.usagePanelOpen);
-  const notesPanelOpen = usePanelStore((s) => s.notesPanelOpen);
   const rightPanelFollowsThread = usePanelStore((s) => s.rightPanelFollowsThread);
-  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   const currentThreadId = useFocusedThreadId();
   const currentThreadScope = useAppStore((state) => {
     if (currentThreadId === null) return null;
@@ -37,6 +35,29 @@ export function usePanelVisibility() {
       )
     );
   });
+
+  return (
+    devTerminalOpen &&
+    (!rightPanelFollowsThread ||
+      devTerminalExplicitlyOpened ||
+      (currentThreadId !== null && activeTerminalScopeHasTabs))
+  );
+}
+
+export function usePanelVisibility() {
+  const devTerminalOpen = useDevTerminalStore((s) => s.isOpen);
+  const gitReviewContext = usePanelStore((s) => s.gitReviewContext);
+  const gitReviewAsPanel = usePanelStore((s) => s.gitReviewAsPanel);
+  const filesPanelContext = usePanelStore((s) => s.filesPanelContext);
+  const subAgentPanelContext = usePanelStore((s) => s.subAgentPanelContext);
+  const subAgentPanelOpen = usePanelStore((s) => s.subAgentPanelOpen);
+  const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
+  const usagePanelOpen = usePanelStore((s) => s.usagePanelOpen);
+  const notesPanelOpen = usePanelStore((s) => s.notesPanelOpen);
+  const bottomDocks = useBottomDockedTabs();
+  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
+  const currentThreadId = useFocusedThreadId();
+  const bottomTerminalOpen = useBottomTerminalVisible();
   const todoDockPlacement = useThreadTodoDockStore((state) =>
     currentThreadId
       ? (state.byThreadId[currentThreadId]?.placement ?? state.defaultPlacement)
@@ -71,15 +92,10 @@ export function usePanelVisibility() {
     todoDockPlacement === "right" &&
     todoDockState !== null &&
     todoDockState.sourceItemId !== retiredTodoSourceItemId;
-  // An explicitly opened terminal shows regardless of the focused thread — the
-  // user asked for it. Once the follow lock re-scopes it (setPanelScope clears
-  // the marker), visibility depends on matching the focused thread's scope.
-  const bottomTerminalOpen =
-    devTerminalOpen &&
-    (!rightPanelFollowsThread ||
-      devTerminalExplicitlyOpened ||
-      (currentThreadId !== null && activeTerminalScopeHasTabs));
 
+  // Docked panels keep the bottom row open on their own, so a dropped Usage or
+  // Git stays on screen after the terminal is closed.
+  const hasBottomDocks = bottomDocks.left !== null || bottomDocks.right !== null;
   const rightPanelOpen = isTerminalRight
     ? devTerminalOpen ||
       gitPanelOpen ||
@@ -89,16 +105,19 @@ export function usePanelVisibility() {
       browserPanelOpen ||
       usagePanelOpen ||
       notesPanelOpen
-    : bottomTerminalOpen;
+    : bottomTerminalOpen || hasBottomDocks;
+  // A bottom-docked tab must not keep the right aside open on its own — it is
+  // already rendered in the bottom row.
+  const isDocked = (tab: RightPanelTab) => bottomDocks.left === tab || bottomDocks.right === tab;
   const sideGitPanelOpen =
     !isTerminalRight &&
-    (gitPanelOpen ||
-      filesPanelOpen ||
+    ((gitPanelOpen && !isDocked("git")) ||
+      (filesPanelOpen && !isDocked("files")) ||
       planPanelOpen ||
       scopedSubAgentPanelOpen ||
-      browserPanelOpen ||
-      usagePanelOpen ||
-      notesPanelOpen);
+      (browserPanelOpen && !isDocked("browser")) ||
+      (usagePanelOpen && !isDocked("usage")) ||
+      (notesPanelOpen && !isDocked("notes")));
   const sidePanelOpen = isTerminalRight ? rightPanelOpen : sideGitPanelOpen;
 
   return { rightPanelOpen, gitPanelOpen: sideGitPanelOpen, sidePanelOpen };

--- a/src/renderer/views/MainView/parts/MainPageLayout.tsx
+++ b/src/renderer/views/MainView/parts/MainPageLayout.tsx
@@ -9,6 +9,7 @@ import { AppContent } from "@/renderer/views/MainView/parts/AppContent/AppConten
 import { SidebarHeaderControls } from "@/renderer/views/MainView/parts/SidebarHeaderControls";
 import { MainRightPanel } from "@/renderer/views/MainView/parts/MainRightPanel";
 import { MainGitPanel } from "@/renderer/views/MainView/parts/MainGitPanel";
+import { BottomDockDropStrip } from "@/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip";
 import { useFileEditorStore } from "@/renderer/state/fileEditorStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useProjectIds } from "@/renderer/state/useThread";
@@ -79,6 +80,7 @@ function MainPanelDropZone(props: { children: ReactNode }) {
   return (
     <div ref={elementRef} className="relative h-full min-h-0">
       {props.children}
+      <BottomDockDropStrip />
       {isActive ? (
         <div
           aria-hidden="true"

--- a/src/renderer/views/MainView/parts/MainRightPanel.tsx
+++ b/src/renderer/views/MainView/parts/MainRightPanel.tsx
@@ -1,6 +1,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { usePanelVisibility } from "./AppShell/parts/usePanelVisibility";
+import { useBottomTerminalVisible, usePanelVisibility } from "./AppShell/parts/usePanelVisibility";
+import { BottomPanelDockContainer } from "./RightPanel/parts/PanelDock/BottomPanelDockContainer";
 import {
   DeferredDevTerminalPanel,
   DeferredProjectAuxiliaryPanel,
@@ -9,6 +10,7 @@ import {
 export function MainRightPanel() {
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
   const { rightPanelOpen } = usePanelVisibility();
+  const terminalVisible = useBottomTerminalVisible();
   const [enabled, setEnabled] = useState(rightPanelOpen);
 
   useEffect(() => {
@@ -24,7 +26,9 @@ export function MainRightPanel() {
   return (
     <Suspense>
       {!isTerminalRight ? (
-        <DeferredDevTerminalPanel />
+        <BottomPanelDockContainer terminalVisible={terminalVisible}>
+          <DeferredDevTerminalPanel />
+        </BottomPanelDockContainer>
       ) : (
         <DeferredProjectAuxiliaryPanel includeTerminal visible={rightPanelOpen} />
       )}

--- a/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
+++ b/src/renderer/views/MainView/parts/ProjectAuxiliaryPanel.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from "react";
 import { useLingui } from "@lingui/react/macro";
-import type { Project } from "@/shared/contracts";
 import { isHomeProjectId } from "@/shared/homeScope";
 import {
   productSurfaceView,
@@ -30,11 +29,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { useFileEditorStore, type FileEditorRootContext } from "@/renderer/state/fileEditorStore";
-import {
-  usePanelStore,
-  type FilesPanelContext,
-  type GitReviewContext,
-} from "@/renderer/state/panelStore";
+import { usePanelStore, type GitReviewContext } from "@/renderer/state/panelStore";
 import { useThreadTodoDockStore } from "@/renderer/state/threadTodoDockStore";
 import { watchRemoteTerminal } from "@/renderer/state/remoteTerminalFeed";
 import { prefetchVisibleGitPanelPrData } from "@/renderer/state/gitRefresh";
@@ -43,14 +38,16 @@ import {
   moveThreadTodoDock,
   showFilesPanel,
   showGitReviewPanel,
+  undockPanelTab,
 } from "@/renderer/actions/panelActions";
 import { showTerminalPanel } from "@/renderer/actions/terminalActions";
 import { getCurrentProjectId } from "@/renderer/actions/currentProject";
 import { selectFocusedThreadId, useFocusedThreadId } from "@/renderer/hooks/uiSelectors";
 import { syncRightPanelTabToFocusedThread } from "@/renderer/hooks/useRightPanelThreadLock";
-import { buildFileEditorContext } from "@/renderer/utils/gitHelpers";
 import { formatProjectScopeLabel } from "@/renderer/utils/projectScopeLabel";
+import { useBottomDockedTabs } from "@/renderer/state/panelDockSelectors";
 import { GitReviewPanelContent } from "./RightPanel/parts/GitReviewPanelContent";
+import { resolveFilesRootContext } from "./RightPanel/parts/resolveFilesRootContext";
 
 interface PanelProjectScope {
   projectId: string;
@@ -73,19 +70,6 @@ function scopeFromFilesContext(context: FileEditorRootContext | null): PanelProj
   };
 }
 
-function resolveFilesRootContext(
-  context: FilesPanelContext | null,
-  projects: Project[],
-): FileEditorRootContext | null {
-  if (!context) return null;
-  const project = projects.find((p) => p.id === context.projectId);
-  if (!project) return null;
-  return {
-    ...buildFileEditorContext(project, context.worktreePath),
-    rootLabel: context.rootLabel,
-  };
-}
-
 export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible: boolean }) {
   const { t } = useLingui();
   const projects = useAppStore((s) => s.projects);
@@ -94,6 +78,12 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   const filesPanelContext = usePanelStore((s) => s.filesPanelContext);
   const subAgentPanelContext = usePanelStore((s) => s.subAgentPanelContext);
   const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
+  const rightPanelSplit = usePanelStore((s) => s.rightPanelSplit);
+  const bottomDocks = useBottomDockedTabs();
+  const dockedTabs = [bottomDocks.left, bottomDocks.right].filter(
+    (tab): tab is RightPanelTab => tab !== null,
+  );
+  const isBottomDocked = (tab: RightPanelTab) => dockedTabs.includes(tab);
   const setRightPanelTab = usePanelStore((s) => s.setRightPanelTab);
   const rightPanelFollowsThread = usePanelStore((s) => s.rightPanelFollowsThread);
   const toggleRightPanelFollowsThread = usePanelStore((s) => s.toggleRightPanelFollowsThread);
@@ -188,6 +178,8 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       : "git";
 
   function requestedTabIsAvailable(): boolean {
+    // A bottom-docked tab already renders in the bottom row.
+    if (isBottomDocked(requestedTab)) return false;
     if (requestedTab === "subagent") return subAgentInCurrentThread;
     if (requestedTab === "plan") return planInCurrentThread;
     if (!planInCurrentThread) return true;
@@ -202,11 +194,11 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
   function fallbackActiveTab(): RightPanelTab {
     if (planInCurrentThread) return "plan";
     if (subAgentInCurrentThread) return "subagent";
-    if (filesPanelOpen) return "files";
-    if (gitPanelOpen) return "git";
-    if (browserPanelOpen) return "browser";
-    if (usagePanelOpen) return "usage";
-    if (notesPanelOpen) return "notes";
+    if (filesPanelOpen && !isBottomDocked("files")) return "files";
+    if (gitPanelOpen && !isBottomDocked("git")) return "git";
+    if (browserPanelOpen && !isBottomDocked("browser")) return "browser";
+    if (usagePanelOpen && !isBottomDocked("usage")) return "usage";
+    if (notesPanelOpen && !isBottomDocked("notes")) return "notes";
     if (props.includeTerminal && terminalOpen) return "terminal";
     return "git";
   }
@@ -310,6 +302,16 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     return activeProjectScope() ?? fallbackScope();
   }
 
+  /**
+   * Clicking a toolbar icon always lands the tab in this panel, so a tab that
+   * currently lives in the split half or the bottom row is pulled back first —
+   * otherwise the click would have no visible effect.
+   */
+  function pressTab(tab: RightPanelTab, open: () => void) {
+    undockPanelTab(tab);
+    open();
+  }
+
   function handleOpenGit() {
     const scope = resolveNextProjectScope();
     if (!scope) return;
@@ -340,12 +342,15 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
     handleClose();
   }
 
+  // A bottom-docked tab renders in the bottom row; keep it out of this panel so
+  // singleton surfaces (the browser webview) are never mounted twice.
   const renderTerminalContent = props.includeTerminal && terminalOpen;
-  const renderGitContent = gitPanelOpen;
-  const renderFilesContent = filesPanelOpen;
-  const renderBrowserContent = browserPanelOpen;
-  const renderUsageContent = usagePanelOpen;
-  const renderNotesContent = notesPanelOpen && notesProjectId !== undefined;
+  const renderGitContent = gitPanelOpen && !isBottomDocked("git");
+  const renderFilesContent = filesPanelOpen && !isBottomDocked("files");
+  const renderBrowserContent = browserPanelOpen && !isBottomDocked("browser");
+  const renderUsageContent = usagePanelOpen && !isBottomDocked("usage");
+  const renderNotesContent =
+    notesPanelOpen && notesProjectId !== undefined && !isBottomDocked("notes");
   const renderPlanContent = planInCurrentThread;
   const renderSubAgentContent = subAgentInCurrentThread;
 
@@ -355,7 +360,7 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
       onTabChange={(tab) => {
         if (tab === "subagent" && !renderSubAgentContent) return;
         if (tab === "plan" && !renderPlanContent) return;
-        setRightPanelTab(tab);
+        pressTab(tab, () => setRightPanelTab(tab));
       }}
       {...(renderTerminalContent
         ? {
@@ -472,27 +477,43 @@ export function ProjectAuxiliaryPanel(props: { includeTerminal: boolean; visible
         setBrowserOverlayOpen(true);
       }}
       onExtractBrowserToWindow={extractBrowserToWindow}
-      onOpenGit={handleOpenGit}
-      onOpenFiles={handleOpenFiles}
-      {...(props.includeTerminal ? { onOpenTerminal: handleOpenTerminal } : {})}
-      onOpenBrowser={() => {
-        if (browserExtracted) {
-          extractBrowserToWindow();
-          return;
-        }
-        setBrowserPanelOpen(true);
-        setRightPanelTab("browser");
-      }}
-      onOpenUsage={() => {
-        setUsagePanelOpen(true);
-        setRightPanelTab("usage");
-      }}
-      onOpenNotes={() => {
-        setNotesPanelOpen(true);
-        setRightPanelTab("notes");
-      }}
+      onOpenGit={() => pressTab("git", handleOpenGit)}
+      onOpenFiles={() => pressTab("files", handleOpenFiles)}
+      {...(props.includeTerminal
+        ? { onOpenTerminal: () => pressTab("terminal", handleOpenTerminal) }
+        : {})}
+      onOpenBrowser={() =>
+        pressTab("browser", () => {
+          if (browserExtracted) {
+            extractBrowserToWindow();
+            return;
+          }
+          setBrowserPanelOpen(true);
+          setRightPanelTab("browser");
+        })
+      }
+      onOpenUsage={() =>
+        pressTab("usage", () => {
+          setUsagePanelOpen(true);
+          setRightPanelTab("usage");
+        })
+      }
+      onOpenNotes={() =>
+        pressTab("notes", () => {
+          setNotesPanelOpen(true);
+          setRightPanelTab("notes");
+        })
+      }
       followsThread={rightPanelFollowsThread}
       onToggleFollowsThread={toggleRightPanelFollowsThread}
+      dockedTabs={dockedTabs}
+      {...(rightPanelSplit && !isBottomDocked(rightPanelSplit.tab)
+        ? {
+            splitTab: rightPanelSplit.tab,
+            splitPlacement: rightPanelSplit.placement,
+            onCloseSplit: () => usePanelStore.getState().setRightPanelSplit(null),
+          }
+        : {})}
       onClose={handleClose}
     />
   );

--- a/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserHost.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/BrowserHost.tsx
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import { useLingui } from "@lingui/react/macro";
 import { usePanelStore } from "@/renderer/state/panelStore";
+import { useIsPanelTabVisible } from "@/renderer/state/panelDockSelectors";
 import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
 import { pushEscapeHandler } from "@/renderer/components/layout/overlayEscapeStack";
 import { BrowserPanel } from "./BrowserPanel";
@@ -48,7 +49,6 @@ export function BrowserHost() {
   const browserOverlayMaximized = usePanelStore((s) => s.browserOverlayMaximized);
   const drawerWidth = usePanelStore((s) => s.browserOverlayDrawerWidth);
   const setDrawerWidth = usePanelStore((s) => s.setBrowserOverlayDrawerWidth);
-  const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
   const setBrowserOverlayOpen = usePanelStore((s) => s.setBrowserOverlayOpen);
   const setBrowserOverlayMaximized = usePanelStore((s) => s.setBrowserOverlayMaximized);
   const setRightPanelTab = usePanelStore((s) => s.setRightPanelTab);
@@ -56,13 +56,19 @@ export function BrowserHost() {
   const hasTabs = useBrowserPanelStore((s) => s.tabs.length > 0);
   const automationActive = useBrowserPanelStore((s) => s.automationActive);
 
+  // The browser is painted wherever its dock slot lives: the right panel's
+  // active layer, a right-panel split section, or a bottom dock slot. Keying
+  // this off `rightPanelTab` alone would drop a split/docked browser into
+  // off-screen background mode, leaving an empty section behind.
+  const dockedVisible = useIsPanelTabVisible("browser");
+
   const mode: BrowserHostMode = extracted
     ? "hidden"
     : browserOverlayOpen
       ? browserOverlayMaximized
         ? "fullscreen"
         : "drawer"
-      : browserPanelOpen && rightPanelTab === "browser"
+      : browserPanelOpen && dockedVisible
         ? "docked"
         : // Panel + overlay both closed: keep tabs alive off-screen so the agent
           // can drive them headless (no forced panel reveal).
@@ -70,8 +76,6 @@ export function BrowserHost() {
 
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [isResizing, setIsResizing] = useState(false);
-
-  const dockedVisible = rightPanelTab === "browser";
   useBrowserHostPositioning({ wrapperRef, mode, drawerWidth, dockedVisible });
 
   useLayoutEffect(() => {

--- a/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockDropStrip.tsx
@@ -1,0 +1,46 @@
+import { Trans } from "@lingui/react/macro";
+import { PanelDockDropZone } from "@/renderer/components/layout/PanelDock/PanelDockDropZone";
+import { useDragSource, usePanelDockPlacement } from "@/renderer/dnd";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { usePanelVisibility } from "../../../AppShell/parts/usePanelVisibility";
+
+/**
+ * Landing pad along the bottom edge of the main area, shown only while a panel
+ * tab is being dragged and the bottom row is closed. Without it there is no
+ * bottom drop target to aim at until a terminal happens to be open.
+ *
+ * The two halves are painted as real siblings rather than an overlay so each
+ * target is exactly the size of the slot it creates.
+ */
+export function BottomDockDropStrip() {
+  const dragSource = useDragSource();
+  const isTerminalBottom = useSharedSettings((s) => s.terminalPosition === "bottom");
+  const { rightPanelOpen: bottomRowOpen } = usePanelVisibility();
+  const placement = usePanelDockPlacement("bottom-panel");
+
+  if (!isTerminalBottom || bottomRowOpen || dragSource?.type !== "panel-tab") return null;
+
+  function halfClass(side: "left" | "right") {
+    const active = placement === side;
+    return `flex flex-1 items-center justify-center rounded-lg border border-dashed text-xs transition-colors ${
+      active
+        ? "border-accent bg-accent/10 text-foreground"
+        : "border-[color:var(--hairline-strong)] text-muted"
+    }`;
+  }
+
+  return (
+    <PanelDockDropZone
+      zone="bottom-panel"
+      highlight={false}
+      className="absolute inset-x-0 bottom-0 z-30 flex h-32 gap-2 p-2"
+    >
+      <div className={halfClass("left")}>
+        <Trans>Dock left</Trans>
+      </div>
+      <div className={halfClass("right")}>
+        <Trans>Dock right</Trans>
+      </div>
+    </PanelDockDropZone>
+  );
+}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockPanelContent.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomDockPanelContent.tsx
@@ -1,0 +1,60 @@
+import { useAppStore } from "@/renderer/state/appStore";
+import { useBrowserPanelStore } from "@/renderer/state/browserPanelStore";
+import { usePanelStore, type RightPanelTab } from "@/renderer/state/panelStore";
+import { getCurrentProjectId } from "@/renderer/actions/currentProject";
+import { ProjectFilesPanel } from "@/renderer/views/FileEditorOverlay/parts/ProjectFilesPanel";
+import { BrowserDockSlot } from "../BrowserPanel/BrowserDockSlot";
+import { extractBrowserToWindow, injectBrowserToMain } from "../BrowserPanel/browserWindowActions";
+import { NotesPanel } from "../NotesPanel/NotesPanel";
+import { UsagePanel } from "../UsagePanel/UsagePanel";
+import { GitReviewPanelContent } from "../GitReviewPanelContent";
+import { resolveFilesRootContext } from "../resolveFilesRootContext";
+
+/**
+ * Body of a panel docked beside the bottom terminal. Reuses the same content
+ * components the right panel mounts for each tab; `ProjectAuxiliaryPanel`
+ * skips a bottom-docked tab so singleton surfaces (the browser webview) are
+ * only ever mounted once.
+ */
+export function BottomDockPanelContent(props: { tab: RightPanelTab }) {
+  const projects = useAppStore((s) => s.projects);
+  const gitReviewContext = usePanelStore((s) => s.gitReviewContext);
+  const filesPanelContext = usePanelStore((s) => s.filesPanelContext);
+  const setGitReviewContext = usePanelStore((s) => s.setGitReviewContext);
+  const setGitOverlayOpen = usePanelStore((s) => s.setGitOverlayOpen);
+  const browserExtracted = useBrowserPanelStore((s) => s.extracted);
+  // Reactive id of the project the notes panel should show — recomputed as the
+  // user navigates between threads/drafts/projects.
+  const currentProjectId = useAppStore(() => getCurrentProjectId());
+
+  switch (props.tab) {
+    case "usage":
+      return <UsagePanel />;
+    case "notes": {
+      const notesProjectId = currentProjectId ?? projects[0]?.id;
+      return notesProjectId ? <NotesPanel key={notesProjectId} projectId={notesProjectId} /> : null;
+    }
+    case "browser":
+      return (
+        <BrowserDockSlot
+          extracted={browserExtracted}
+          onBringBack={injectBrowserToMain}
+          onFocusWindow={extractBrowserToWindow}
+        />
+      );
+    case "git":
+      return gitReviewContext ? (
+        <GitReviewPanelContent
+          gitPanelContext={gitReviewContext}
+          onClose={() => setGitReviewContext(null)}
+          onExpandToOverlay={() => setGitOverlayOpen(true)}
+        />
+      ) : null;
+    case "files": {
+      const rootContext = resolveFilesRootContext(filesPanelContext, projects);
+      return rootContext ? <ProjectFilesPanel rootContext={rootContext} /> : null;
+    }
+    default:
+      return null;
+  }
+}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/PanelDock/BottomPanelDockContainer.tsx
@@ -1,0 +1,216 @@
+import { Suspense, lazy, useEffect, useRef, type ReactNode } from "react";
+import { useLingui } from "@lingui/react/macro";
+import { PanelDockDropZone } from "@/renderer/components/layout/PanelDock/PanelDockDropZone";
+import { PanelSectionHeader } from "@/renderer/components/layout/PanelDock/PanelSectionHeader";
+import {
+  PANEL_TAB_ICONS,
+  usePanelTabLabels,
+} from "@/renderer/components/layout/PanelDock/panelTabMeta";
+import { useSplitPercent } from "@/renderer/components/layout/PanelDock/useSplitPercent";
+import { useBottomDockedTabs } from "@/renderer/state/panelDockSelectors";
+import {
+  usePanelStore,
+  type BottomDockPlacement,
+  type RightPanelTab,
+} from "@/renderer/state/panelStore";
+
+/** Floor for whichever segment absorbs the leftover width (terminal or empty slot). */
+const MIN_FLEX_SEGMENT = "15%";
+
+const DeferredBottomDockPanelContent = lazy(() =>
+  import("./BottomDockPanelContent").then((module) => ({
+    default: module.BottomDockPanelContent,
+  })),
+);
+
+/**
+ * The bottom row: `left slot | terminal | right slot`. Each side holds at most
+ * one dropped panel; with the terminal closed the slots own the row on their
+ * own. When both slots are occupied, opening the terminal replaces and closes
+ * the left slot while the right dock remains visible. A lone dock keeps an
+ * empty (resizable) slot opposite rather than swallowing the whole row, so the
+ * drop target the user aimed at is the space they get.
+ *
+ * Also the drop zone for the docking gesture — its left and right halves map
+ * onto the two slots.
+ */
+export function BottomPanelDockContainer(props: {
+  /**
+   * The terminal stays mounted even while hidden so its xterm surfaces (and
+   * their scrollback) survive a dock-only bottom row.
+   */
+  terminalVisible: boolean;
+  children: ReactNode;
+}) {
+  const { t } = useLingui();
+  const labels = usePanelTabLabels();
+  const docks = useBottomDockedTabs();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const leftPaneRef = useRef<HTMLDivElement>(null);
+  const rightPaneRef = useRef<HTMLDivElement>(null);
+  const previousDocksRef = useRef(docks);
+  const flexibleDockRef = useRef<BottomDockPlacement | null>(null);
+
+  const { left: leftTab, right: rightTab } = docks;
+  const terminalReplacesLeft = props.terminalVisible && leftTab !== null && rightTab !== null;
+  // With the terminal hidden, a lone dock keeps the opposite slot as empty
+  // space so the row still reads as left/right.
+  const showSpacer = !props.terminalVisible && (leftTab === null) !== (rightTab === null);
+  const hasLeftDockSlot = leftTab !== null || (showSpacer && rightTab !== null);
+  const hasRightSlot = rightTab !== null || (showSpacer && leftTab !== null);
+
+  useEffect(() => {
+    if (!terminalReplacesLeft || leftTab === null || rightTab === null) return;
+
+    const panelStore = usePanelStore.getState();
+    panelStore.setBottomPanelDock("left", null);
+    if (panelStore.rightPanelTab === leftTab) panelStore.setRightPanelTab(rightTab);
+
+    switch (leftTab) {
+      case "git":
+        panelStore.setGitOverlayOpen(false);
+        panelStore.setGitReviewContext(null);
+        break;
+      case "files":
+        panelStore.setFilesPanelContext(null);
+        break;
+      case "browser":
+        panelStore.setBrowserPanelOpen(false);
+        break;
+      case "usage":
+        panelStore.setUsagePanelOpen(false);
+        break;
+      case "notes":
+        panelStore.setNotesPanelOpen(false);
+        break;
+    }
+  }, [leftTab, rightTab, terminalReplacesLeft]);
+
+  // Keep the existing dock's stored width when a second panel is added. The
+  // newly occupied slot absorbs the remaining space beside it (and the
+  // terminal, when visible), instead of shrinking the panel already on screen.
+  const previousDocks = previousDocksRef.current;
+  if (previousDocks.left !== leftTab || previousDocks.right !== rightTab) {
+    const addedPlacement =
+      leftTab !== null && previousDocks.left === null
+        ? "left"
+        : rightTab !== null && previousDocks.right === null
+          ? "right"
+          : null;
+    if (addedPlacement !== null) flexibleDockRef.current = addedPlacement;
+    previousDocksRef.current = docks;
+  }
+
+  const flexibleDock =
+    leftTab !== null && rightTab !== null
+      ? (flexibleDockRef.current ?? "right")
+      : leftTab === null && rightTab !== null
+        ? "left"
+        : rightTab === null && leftTab !== null
+          ? "right"
+          : null;
+  const effectiveFlexibleDock = terminalReplacesLeft ? "left" : flexibleDock;
+  const leftSized = !terminalReplacesLeft && hasLeftDockSlot && effectiveFlexibleDock !== "left";
+  const rightSized = hasRightSlot && effectiveFlexibleDock !== "right";
+
+  // Key names carry the meaning of the stored number: the width of the docked
+  // panel on that side. Renamed from `poracode-bottom-row-*`, which briefly
+  // stored the empty slot's width instead — a stale value under the old name
+  // would be read as a dock width and place the panel wrong.
+  const leftSplit = useSplitPercent({
+    storageKey: "poracode-bottom-slot-left-percent",
+    orientation: "row",
+    containerRef,
+    paneRef: leftSized ? leftPaneRef : { current: null },
+    defaultPercent: 50,
+    minPercent: 15,
+  });
+  const rightSplit = useSplitPercent({
+    storageKey: "poracode-bottom-slot-right-percent",
+    orientation: "row",
+    containerRef,
+    paneRef: rightSized ? rightPaneRef : { current: null },
+    invert: true,
+    defaultPercent: 50,
+    minPercent: 15,
+  });
+
+  function slotStyle(placement: BottomDockPlacement, sized: boolean) {
+    const split = placement === "left" ? leftSplit : rightSplit;
+    // A stored dock width is authoritative. The other live segment absorbs the
+    // divider and remaining width, so panel content cannot resize this dock.
+    return sized
+      ? { flexBasis: `${split.percent}%`, flexGrow: 0, flexShrink: 0 }
+      : { flexBasis: "0%", flexGrow: 1, flexShrink: 1, minWidth: MIN_FLEX_SEGMENT };
+  }
+
+  function slot(placement: BottomDockPlacement) {
+    const tab: RightPanelTab | null = placement === "left" ? leftTab : rightTab;
+    const sized = placement === "left" ? leftSized : rightSized;
+    return (
+      <div
+        ref={sized ? (placement === "left" ? leftPaneRef : rightPaneRef) : undefined}
+        className="flex min-h-0 min-w-0 flex-col overflow-hidden"
+        style={slotStyle(placement, sized)}
+      >
+        {tab ? (
+          <>
+            <PanelSectionHeader
+              tab={tab}
+              label={labels[tab]}
+              icon={PANEL_TAB_ICONS[tab]}
+              onClose={() => usePanelStore.getState().setBottomPanelDock(placement, null)}
+            />
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <Suspense>
+                <DeferredBottomDockPanelContent tab={tab} />
+              </Suspense>
+            </div>
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  function divider(split: typeof leftSplit, key: string) {
+    return (
+      <div
+        key={key}
+        className="poracode-pane-divider"
+        onPointerDown={split.handleResizeStart}
+        onKeyDown={split.handleResizeKeyDown}
+        role="separator"
+        tabIndex={0}
+        aria-orientation="vertical"
+        aria-label={t`Resize split`}
+        aria-valuenow={Math.round(split.percent)}
+        aria-valuemin={split.minPercent}
+        aria-valuemax={split.maxPercent}
+      />
+    );
+  }
+
+  // A divider always sits between two live segments and drives whichever of the
+  // pair is the sized one.
+  const showLeftDivider =
+    !terminalReplacesLeft && hasLeftDockSlot && (props.terminalVisible || hasRightSlot);
+  const showRightDivider = hasRightSlot && props.terminalVisible;
+
+  return (
+    <PanelDockDropZone zone="bottom-panel" className="relative h-full min-h-0 overflow-hidden">
+      <div ref={containerRef} className="flex h-full min-h-0">
+        {!terminalReplacesLeft && hasLeftDockSlot ? slot("left") : null}
+        {showLeftDivider ? divider(leftSized ? leftSplit : rightSplit, "left-divider") : null}
+        <div
+          key="terminal"
+          className={props.terminalVisible ? "min-h-0 min-w-0 flex-1 overflow-hidden" : "hidden"}
+          style={props.terminalVisible ? { minWidth: MIN_FLEX_SEGMENT } : undefined}
+        >
+          {props.children}
+        </div>
+        {showRightDivider ? divider(rightSplit, "right-divider") : null}
+        {hasRightSlot ? slot("right") : null}
+      </div>
+    </PanelDockDropZone>
+  );
+}

--- a/src/renderer/views/MainView/parts/RightPanel/parts/resolveFilesRootContext.ts
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/resolveFilesRootContext.ts
@@ -1,0 +1,18 @@
+import type { Project } from "@/shared/contracts";
+import type { FileEditorRootContext } from "@/renderer/state/fileEditorStore";
+import type { FilesPanelContext } from "@/renderer/state/panelStore";
+import { buildFileEditorContext } from "@/renderer/utils/gitHelpers";
+
+/** Resolve the files-panel store context into a live file editor root context. */
+export function resolveFilesRootContext(
+  context: FilesPanelContext | null,
+  projects: Project[],
+): FileEditorRootContext | null {
+  if (!context) return null;
+  const project = projects.find((p) => p.id === context.projectId);
+  if (!project) return null;
+  return {
+    ...buildFileEditorContext(project, context.worktreePath),
+    rootLabel: context.rootLabel,
+  };
+}


### PR DESCRIPTION
- Add a bottom dock panel that accepts dragged right-panel tabs into left/right slots, letting multiple panels stay visible at once.
- Support split panel docking in the right panel with a resizable, keyboard-accessible divider.
- Introduce dock-aware store state and selectors along with shared DnD drop-zone and dock drop handling; undocking a panel restores its previous placement.
- Localize the new dock/split UI strings across all locale catalogs.
- Add unit tests covering dock actions and panel store lifecycle.