### PR TITLE
fix(chat): anchor completed turns to renderable timeline rows only

### DIFF
--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -1669,6 +1669,36 @@ describe("ChatPane", () => {
     expect(label.closest(".surface")).not.toBeNull();
   });
 
+  it("renders a completed turn whose stored anchor is an unrendered goal item", () => {
+    const thread = {
+      ...makeThread(),
+      status: "idle" as const,
+      activeTurnStartedAt: undefined,
+      lastTurnStartedAt: "2026-05-01T12:00:00.000Z",
+      lastTurnEndedAt: "2026-05-01T12:01:15.000Z",
+    };
+    seedAssistantMessage(thread.id, "Inspect output");
+    completeAssistantMessage(thread.id);
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "goal-1",
+      itemType: "goal",
+      payload: { entries: [{ id: "1", title: "Ship it", status: "completed" }] },
+    });
+    useAppStore.getState().hydrateThreadCompletedTurns(thread.id, [
+      {
+        startedAt: new Date("2026-05-01T12:00:00.000Z").getTime(),
+        endedAt: new Date("2026-05-01T12:01:15.000Z").getTime(),
+        anchorItemId: "goal-1",
+      },
+    ]);
+
+    renderChatPane(thread);
+
+    expect(screen.getAllByText("Worked for 1m 15s")).toHaveLength(1);
+  });
+
   it("keeps a completed turn anchored before an optimistic follow-up prompt", async () => {
     const thread = {
       ...makeThread(),

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -33,7 +33,11 @@ import { ChatFindBar, type ScrollToIndex } from "@/renderer/components/find/Chat
 import { ChatPaneActionsContext, type ChatPaneActions } from "./chatPaneActionsContext";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
 import { ChatTurnElapsedFooter, type TurnTiming } from "./ChatTurnElapsed";
-import { selectVisibleThreadTimelineEntries, type ChatTimelineEntry } from "./chatPaneSelectors";
+import {
+  selectMostRecentDisplayableCompletedTurn,
+  selectVisibleThreadTimelineEntries,
+  type ChatTimelineEntry,
+} from "./chatPaneSelectors";
 import { shouldMarkUserScrollIntentFromPointerTarget } from "./chatScrollGeometry";
 import { normalizeChatProjectPath } from "./chatPathUtils";
 import { MessageList, type CheckpointRevertActions } from "./parts/MessageList";
@@ -297,7 +301,7 @@ export function ChatPane(props: ChatPaneProps) {
   // turn.
   const turn = resolveTurnTiming(thread, showWorkingTimer);
   const mostRecentDisplayableCompletedTurn = useAppStore((s) =>
-    selectMostRecentDisplayableCompletedTurn(s.runtimeCompletedTurnsByThread[threadId]),
+    selectMostRecentDisplayableCompletedTurn(s, threadId),
   );
   const mostRecentCompletedTurnAnchor = mostRecentDisplayableCompletedTurn?.anchorItemId ?? null;
   const completedTurnAnchorAtTail = isCompletedTurnAnchorAtTimelineTail(
@@ -475,11 +479,6 @@ export function ChatPane(props: ChatPaneProps) {
   );
 }
 
-interface CompletedTurnTiming extends TurnTiming {
-  anchorItemId: string | null;
-  endedAt: number;
-}
-
 function parseTurnTimestamp(iso: string | undefined): number | null {
   if (!iso) return null;
   const ms = new Date(iso).getTime();
@@ -514,17 +513,6 @@ function resolveTurnTiming(thread: Thread, forceLive = false): TurnTiming | null
     startedAt,
     endedAt: Math.max(startedAt, endedAt),
   };
-}
-
-function selectMostRecentDisplayableCompletedTurn(
-  records: readonly CompletedTurnTiming[] | undefined,
-): CompletedTurnTiming | null {
-  if (!records) return null;
-  for (let index = records.length - 1; index >= 0; index -= 1) {
-    const record = records[index]!;
-    if (record.endedAt - record.startedAt >= 1000) return record;
-  }
-  return null;
 }
 
 function isScrollNavigationKey(key: string): boolean {

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -9,6 +9,8 @@ import {
 import {
   selectChatScrollAnchor,
   selectChildTimelineEntries,
+  selectCompletedTurnsByAnchorItem,
+  selectMostRecentDisplayableCompletedTurn,
   selectVisibleThreadRuntimeItemIds,
   selectVisibleThreadTimelineEntries,
 } from "./chatPaneSelectors";
@@ -1115,6 +1117,90 @@ describe("chatPaneSelectors", () => {
         itemIds: ["tool-edit-1", "tool-edit-2", "tool-read-1", "tool-edit-3"],
       },
     ]);
+  });
+
+  describe("completed turn anchors", () => {
+    function stateWithGoalTail(
+      records: ReadonlyArray<{ startedAt: number; endedAt: number; anchorItemId: string | null }>,
+    ): AppStoreState {
+      return {
+        runtimeItemIdsByThread: { t1: ["user-1", "assistant-1", "goal-1"] },
+        runtimeItemsByIdByThread: {
+          t1: {
+            "user-1": { id: "user-1", type: "user_message", state: "completed", streams: {} },
+            "assistant-1": {
+              id: "assistant-1",
+              type: "assistant_message",
+              state: "completed",
+              streams: { assistant_text: "Done." },
+            },
+            "goal-1": { id: "goal-1", type: "goal", state: "completed", streams: {} },
+          },
+        },
+        runtimeStructuralVersionByThread: { t1: 1 },
+        runtimeCompletedTurnsByThread: { t1: records },
+      } as unknown as AppStoreState;
+    }
+
+    it("resolves an anchor on an unrendered goal item back to the last rendered row", () => {
+      const state = stateWithGoalTail([
+        { startedAt: 1_000, endedAt: 76_000, anchorItemId: "goal-1" },
+      ]);
+
+      expect([...selectCompletedTurnsByAnchorItem(state, "t1").keys()]).toEqual(["assistant-1"]);
+      expect(selectMostRecentDisplayableCompletedTurn(state, "t1")).toMatchObject({
+        anchorItemId: "assistant-1",
+        endedAt: 76_000,
+      });
+    });
+
+    it("does not let a later turn steal the row an earlier turn ends on", () => {
+      const state = stateWithGoalTail([
+        { startedAt: 1_000, endedAt: 76_000, anchorItemId: "assistant-1" },
+        { startedAt: 90_000, endedAt: 100_000, anchorItemId: "goal-1" },
+      ]);
+
+      expect(selectCompletedTurnsByAnchorItem(state, "t1").get("assistant-1")).toMatchObject({
+        endedAt: 76_000,
+      });
+      // The goal-only turn has no row of its own; the tail footer shows it.
+      expect(selectMostRecentDisplayableCompletedTurn(state, "t1")).toMatchObject({
+        anchorItemId: null,
+        endedAt: 100_000,
+      });
+    });
+
+    it("lets a real turn keep a row a sub-second turn was recorded against", () => {
+      const state = stateWithGoalTail([
+        { startedAt: 1_000, endedAt: 1_400, anchorItemId: "assistant-1" },
+        { startedAt: 2_000, endedAt: 62_000, anchorItemId: "goal-1" },
+      ]);
+
+      expect(selectCompletedTurnsByAnchorItem(state, "t1").get("assistant-1")).toMatchObject({
+        endedAt: 62_000,
+      });
+    });
+
+    it("never anchors a turn onto a user message row", () => {
+      const state = {
+        runtimeItemIdsByThread: { t1: ["user-1", "goal-1"] },
+        runtimeItemsByIdByThread: {
+          t1: {
+            "user-1": { id: "user-1", type: "user_message", state: "completed", streams: {} },
+            "goal-1": { id: "goal-1", type: "goal", state: "completed", streams: {} },
+          },
+        },
+        runtimeStructuralVersionByThread: { t1: 1 },
+        runtimeCompletedTurnsByThread: {
+          t1: [{ startedAt: 1_000, endedAt: 76_000, anchorItemId: "goal-1" }],
+        },
+      } as unknown as AppStoreState;
+
+      expect(selectCompletedTurnsByAnchorItem(state, "t1").size).toBe(0);
+      expect(selectMostRecentDisplayableCompletedTurn(state, "t1")).toMatchObject({
+        anchorItemId: null,
+      });
+    });
   });
 });
 // @vitest-environment node

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -250,7 +250,12 @@ export function growingStreamLength(item: RuntimeChatItem): number {
   );
 }
 
-function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {
+/**
+ * Whether an item gets its own row in the chat timeline. Anything that answers
+ * `false` here can never host an inline indicator, so callers that pick an
+ * anchor row (see `appendCompletedTurnIfClosed`) must consult this too.
+ */
+export function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {
   // Plans and goals are rendered exclusively in composer docks — never inline
   // in chat. Empty completed reasoning items are already dropped at the data
   // layer.
@@ -426,34 +431,152 @@ export function getChildTimelineEntriesStoreSelector(
 }
 
 /**
- * Per-thread Map<anchorItemId, CompletedTurnRecord>. Cached against the source
- * array reference so per-row lookups stay O(1) without rebuilding the map on
- * every render. The most-recent record is intentionally included — callers can
- * skip it (e.g. when the live tail loader is already showing it).
+ * Frozen turn records with `anchorItemId` remapped onto the row that actually
+ * renders. A turn's raw anchor is the last item present when it closed, which
+ * is often filtered out of the timeline (goals/plans emitted at the end of an
+ * ACP turn, empty assistant boundaries, unnamed tool calls). An anchor that
+ * matches no rendered row drops the turn's "Worked for X" line entirely — both
+ * the inline indicator and the tail footer key off it — so each anchor is
+ * resolved back to the nearest preceding row that does render.
+ *
+ * `null` after resolution means "no row to hang it on"; the tail footer then
+ * renders it for the most recent turn. Anchoring onto a `user_message` is
+ * avoided so a synthetic window never shows a stale "Worked for" under a prompt.
  */
-const completedTurnsByAnchorCache = new WeakMap<
+interface ResolvedCompletedTurns {
+  byAnchor: ReadonlyMap<string, CompletedTurnRecord>;
+  mostRecentDisplayable: CompletedTurnRecord | null;
+}
+
+/**
+ * Keyed on the two source array identities (records, then the visible-id list),
+ * so entries are released automatically when the store replaces either — the
+ * same store-array-identity derivation pattern used elsewhere in the renderer.
+ */
+const resolvedCompletedTurnsCache = new WeakMap<
   ReadonlyArray<CompletedTurnRecord>,
-  ReadonlyMap<string, CompletedTurnRecord>
+  WeakMap<ReadonlyArray<string>, ResolvedCompletedTurns>
 >();
 
 const EMPTY_TURN_ANCHOR_MAP: ReadonlyMap<string, CompletedTurnRecord> = new Map();
+const EMPTY_RESOLVED_TURNS: ResolvedCompletedTurns = Object.freeze({
+  byAnchor: EMPTY_TURN_ANCHOR_MAP,
+  mostRecentDisplayable: null,
+});
 
+/** A turn shorter than a second has nothing worth showing. */
+function isDisplayableCompletedTurn(record: CompletedTurnRecord): boolean {
+  return record.endedAt - record.startedAt >= 1000;
+}
+
+function selectResolvedCompletedTurns(
+  state: AppStoreState,
+  threadId: string,
+): ResolvedCompletedTurns {
+  const sourceRecords = state.runtimeCompletedTurnsByThread[threadId];
+  if (!sourceRecords || sourceRecords.length === 0) return EMPTY_RESOLVED_TURNS;
+  // Reference-stable per (itemIds, structuralVersion); visibility only changes
+  // through structural events, so this doubles as the resolution's cache key.
+  const visibleItemIds = selectVisibleThreadRuntimeItemIds(state, threadId);
+  let byVisibleItemIds = resolvedCompletedTurnsCache.get(sourceRecords);
+  const cached = byVisibleItemIds?.get(visibleItemIds);
+  if (cached) return cached;
+
+  const resolved = buildResolvedCompletedTurns(state, threadId, sourceRecords, visibleItemIds);
+  if (!byVisibleItemIds) {
+    byVisibleItemIds = new WeakMap();
+    resolvedCompletedTurnsCache.set(sourceRecords, byVisibleItemIds);
+  }
+  byVisibleItemIds.set(visibleItemIds, resolved);
+  return resolved;
+}
+
+function buildResolvedCompletedTurns(
+  state: AppStoreState,
+  threadId: string,
+  sourceRecords: readonly CompletedTurnRecord[],
+  visibleItemIds: readonly string[],
+): ResolvedCompletedTurns {
+  const itemIds = state.runtimeItemIdsByThread[threadId] ?? EMPTY_THREAD_ITEM_IDS;
+  const items = state.runtimeItemsByIdByThread[threadId];
+  const visible = new Set(visibleItemIds);
+  const rawAnchors = new Set<string>();
+  for (const record of sourceRecords) {
+    if (record.anchorItemId) rawAnchors.add(record.anchorItemId);
+  }
+
+  // One pass: every raw anchor maps to the last anchorable row at or before it.
+  const anchorResolution = new Map<string, string | null>();
+  let lastAnchorable: string | null = null;
+  for (const itemId of itemIds) {
+    if (visible.has(itemId) && items?.[itemId]?.type !== "user_message") {
+      lastAnchorable = itemId;
+    }
+    if (rawAnchors.has(itemId)) anchorResolution.set(itemId, lastAnchorable);
+  }
+
+  // Records are chronological, so the first turn to claim a row is the one that
+  // actually ends there. A later turn that produced no row of its own (only a
+  // goal update, only an error) must not steal it — that would both hide the
+  // earlier duration and misattribute the later one. It falls back to `null`
+  // and still reaches the tail footer when it is the most recent turn.
+  const claimedAnchors = new Set<string>();
+  const records = sourceRecords.map((record) => {
+    // A sub-second turn renders nothing, so it neither needs nor claims a row.
+    if (!record.anchorItemId || !isDisplayableCompletedTurn(record)) return record;
+    // Anchors older than the hydrated window are left untouched — their row is
+    // simply not loaded yet, not filtered out.
+    if (!anchorResolution.has(record.anchorItemId)) {
+      claimedAnchors.add(record.anchorItemId);
+      return record;
+    }
+    const resolvedAnchor = anchorResolution.get(record.anchorItemId) ?? null;
+    const anchorItemId =
+      resolvedAnchor !== null && !claimedAnchors.has(resolvedAnchor) ? resolvedAnchor : null;
+    if (anchorItemId !== null) claimedAnchors.add(anchorItemId);
+    return anchorItemId === record.anchorItemId ? record : { ...record, anchorItemId };
+  });
+
+  const byAnchor = new Map<string, CompletedTurnRecord>();
+  for (const record of records) {
+    if (record.anchorItemId && isDisplayableCompletedTurn(record)) {
+      byAnchor.set(record.anchorItemId, record);
+    }
+  }
+
+  let mostRecentDisplayable: CompletedTurnRecord | null = null;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    if (isDisplayableCompletedTurn(record)) {
+      mostRecentDisplayable = record;
+      break;
+    }
+  }
+
+  return { byAnchor, mostRecentDisplayable };
+}
+
+/**
+ * Per-thread Map<anchorItemId, CompletedTurnRecord> over resolved anchors, so
+ * per-row lookups stay O(1). The most-recent record is intentionally included —
+ * callers can skip it (e.g. when the live tail loader is already showing it).
+ */
 export function selectCompletedTurnsByAnchorItem(
   state: AppStoreState,
   threadId: string,
 ): ReadonlyMap<string, CompletedTurnRecord> {
-  const records = state.runtimeCompletedTurnsByThread[threadId];
-  if (!records || records.length === 0) return EMPTY_TURN_ANCHOR_MAP;
-  const cached = completedTurnsByAnchorCache.get(records);
-  if (cached) return cached;
-  const map = new Map<string, CompletedTurnRecord>();
-  for (const record of records) {
-    if (record.anchorItemId && record.endedAt - record.startedAt >= 1000) {
-      map.set(record.anchorItemId, record);
-    }
-  }
-  completedTurnsByAnchorCache.set(records, map);
-  return map;
+  return selectResolvedCompletedTurns(state, threadId).byAnchor;
+}
+
+/**
+ * The newest turn worth showing a "Worked for X" line for, with its anchor
+ * already resolved onto a rendered row (or `null` when no row can host it).
+ */
+export function selectMostRecentDisplayableCompletedTurn(
+  state: AppStoreState,
+  threadId: string,
+): CompletedTurnRecord | null {
+  return selectResolvedCompletedTurns(state, threadId).mostRecentDisplayable;
 }
 
 /**

--- a/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/MessageList.test.tsx
@@ -995,6 +995,18 @@ function seedCompletedItem(
   itemType: "assistant_message" | "user_message",
 ) {
   seedStartedItem(threadId, itemId, itemType);
+  if (itemType === "assistant_message") {
+    // A completed assistant message with no content is filtered out of the
+    // timeline, so give it text — otherwise the fixture models a row chat
+    // would never render.
+    useAppStore.getState().applyRuntimeEvent(threadId, {
+      type: "content.delta",
+      threadId,
+      itemId,
+      stream: "assistant_text",
+      delta: "answer",
+    });
+  }
   useAppStore.getState().applyRuntimeEvent(threadId, {
     type: "item.completed",
     threadId,

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -970,6 +970,66 @@ describe("appStore runtime config sync", () => {
     });
   });
 
+  it("skips trailing goal items chat never renders when anchoring a completed turn", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+    const project = useAppStore.getState().addProject({
+      kind: "windows",
+      path: "C:\\repo",
+    });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "grok",
+      config: { model: "m" },
+      prompt: "a",
+      presentationMode: "gui",
+    });
+
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "assistant-1",
+      itemType: "assistant_message",
+    });
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "content.delta",
+      threadId: thread.id,
+      itemId: "assistant-1",
+      stream: "assistant_text",
+      delta: "Done.",
+    });
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.completed",
+      threadId: thread.id,
+      itemId: "assistant-1",
+    });
+    // ACP providers close a turn with a final plan/goal update; goals render in
+    // the composer dock, never as a chat row.
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.started",
+      threadId: thread.id,
+      itemId: "goal-1",
+      itemType: "goal",
+      payload: { entries: [{ id: "1", title: "Ship it", status: "completed" }] },
+    });
+    useAppStore.getState().applyRuntimeEvent(thread.id, {
+      type: "item.completed",
+      threadId: thread.id,
+      itemId: "goal-1",
+    });
+
+    vi.setSystemTime(new Date("2026-05-01T12:00:30.000Z"));
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+    });
+
+    expect(useAppStore.getState().runtimeCompletedTurnsByThread[thread.id]?.[0]).toMatchObject({
+      anchorItemId: "assistant-1",
+    });
+  });
+
   it("reopens a GUI turn when structured runtime activity arrives after a premature idle", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));

--- a/src/renderer/state/slices/threadTurnHelpers.ts
+++ b/src/renderer/state/slices/threadTurnHelpers.ts
@@ -1,4 +1,5 @@
 import { type Thread, type ThreadStatus, isThreadTurnActive } from "@/shared/contracts";
+import { isVisibleRuntimeItem } from "@/renderer/components/thread/ChatPane/chatPaneSelectors";
 import type { CompletedTurnRecord } from "./runtimeEventSlice";
 import type { AppStoreState } from "./shared";
 
@@ -72,7 +73,12 @@ function resolveCompletedTurnAnchorItemId(state: AppStoreState, threadId: string
     // A short startup status blip can close before the provider emits any
     // assistant/tool output. Anchoring that synthetic window to the optimistic
     // user_message makes chat show a stale "Worked for 1s" under the prompt.
-    if (item.type === "user_message" || item.type === "plan" || item.type === "error") continue;
+    if (item.type === "user_message") continue;
+    // Items that chat filters out (goals/plans, errors, empty assistant
+    // boundaries, unnamed tool calls, sub-agent children) have no row to hang
+    // the indicator on. ACP turns routinely end on a goal update, so anchoring
+    // there would drop the turn's "Worked for X" line entirely.
+    if (item.parentItemId !== undefined || !isVisibleRuntimeItem(item)) continue;
     return itemId;
   }
 


### PR DESCRIPTION
- Completed turns were anchored to items chat never renders (goal/plan updates, errors, empty assistant boundaries, unnamed tool calls, sub-agent children), which could drop or misplace the "Worked for X" line — ACP turns routinely end on a goal update.
- Turn anchoring in `threadTurnHelpers` now skips items with no renderable chat row and falls back to the last row chat actually displays.
- `chatPaneSelectors` resolves each turn's anchor onto the row that renders (with `selectMostRecentDisplayableCompletedTurn` / `selectCompletedTurnsByAnchorItem`), and `ChatPane` consumes the store-based selector.
- Added/updated tests in `ChatPane`, `chatPaneSelectors`, `MessageList`, and `appStore` covering goal-tail anchoring, sub-second turns, and never anchoring onto user-message rows.