### PR TITLE
fix(acp): drop whitespace-only stream boundary chunks

### DIFF
--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -194,7 +194,15 @@ describe("chatPaneSelectors", () => {
   it("hides completed assistant messages with no renderable content", () => {
     const state = {
       runtimeItemIdsByThread: {
-        t1: ["empty", "streaming", "stream-text", "payload-text", "payload-image"],
+        t1: [
+          "empty",
+          "whitespace",
+          "payload-whitespace",
+          "streaming",
+          "stream-text",
+          "payload-text",
+          "payload-image",
+        ],
       },
       runtimeItemsByIdByThread: {
         t1: {
@@ -203,6 +211,20 @@ describe("chatPaneSelectors", () => {
             type: "assistant_message",
             state: "completed",
             streams: { assistant_text: "" },
+          },
+          // Factory Droid persists "\n\n" stream-boundary chunks as assistant rows.
+          whitespace: {
+            id: "whitespace",
+            type: "assistant_message",
+            state: "completed",
+            streams: { assistant_text: "\n\n" },
+          },
+          "payload-whitespace": {
+            id: "payload-whitespace",
+            type: "assistant_message",
+            state: "completed",
+            payload: { content: [{ kind: "text", text: "\n" }] },
+            streams: {},
           },
           streaming: {
             id: "streaming",

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -250,6 +250,16 @@ export function growingStreamLength(item: RuntimeChatItem): number {
   );
 }
 
+/**
+ * Whether text has at least one non-whitespace character. Used instead of
+ * `trim()` because the visibility filter re-runs over every item on each
+ * structural bump — trimming would copy each message's full text per pass.
+ */
+const NON_WHITESPACE = /\S/;
+function hasVisibleText(text: string): boolean {
+  return NON_WHITESPACE.test(text);
+}
+
 function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {
   // Plans and goals are rendered exclusively in composer docks — never inline
   // in chat. Empty completed reasoning items are already dropped at the data
@@ -263,16 +273,17 @@ function isVisibleRuntimeItem(item: RuntimeChatItem): boolean {
   // null for `error`); excluding them here keeps the virtualized list from
   // allocating an empty slot that shows up as a gap.
   if (item.type === "error") return false;
-  // Old ACP sessions may contain completed assistant items created from an
-  // empty provider stream-boundary chunk. They have no renderable content, so
+  // Old ACP sessions may contain completed assistant items created from a blank
+  // provider stream-boundary chunk — empty, or whitespace-only (Factory Droid
+  // emits "\n\n" after tool calls). They have no renderable content, so
   // allocating a virtualized row for them only produces a blank gap. Keep an
   // empty in-flight item visible for its loader and preserve text/image payloads.
   if (item.type === "assistant_message" && item.state === "completed") {
     const payload = getRuntimeItemPayload<MessageItemPayload>(item, "assistant_message");
     const hasPayloadContent = payload?.content.some(
-      (block) => (block.kind === "text" && block.text.length > 0) || block.kind === "image",
+      (block) => (block.kind === "text" && hasVisibleText(block.text)) || block.kind === "image",
     );
-    if (!(item.streams.assistant_text?.length || hasPayloadContent)) return false;
+    if (!(hasVisibleText(item.streams.assistant_text ?? "") || hasPayloadContent)) return false;
   }
   if (isToolLikeItem(item)) {
     const payload = getToolLikePayload(item);

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -200,6 +200,43 @@ describe("mapAcpSessionUpdate", () => {
     expect(state.openAssistantItemId).toBe(itemId);
   });
 
+  it("drops whitespace-only agent text chunks but keeps whitespace inside a streaming message", () => {
+    const state = createAcpMapperState("t-blank-agent-chunk");
+
+    // Factory Droid (DeepSeek models) emits "\n\n" as a post-tool-call stream
+    // boundary; it must not open a blank assistant row.
+    expect(
+      mapAcpSessionUpdate(
+        note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "\n\n" } }),
+        state,
+      ),
+    ).toEqual([]);
+    expect(state.openAssistantItemId).toBeUndefined();
+
+    mapAcpSessionUpdate(
+      note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Line" } }),
+      state,
+    );
+    const itemId = state.openAssistantItemId;
+
+    // Once a message is streaming, whitespace is real spacing.
+    expect(
+      mapAcpSessionUpdate(
+        note({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "\n\n" } }),
+        state,
+      ),
+    ).toEqual([
+      {
+        type: "content.delta",
+        threadId: "t-blank-agent-chunk",
+        itemId,
+        stream: "assistant_text",
+        delta: "\n\n",
+      },
+    ]);
+    expect(state.openAssistantItemId).toBe(itemId);
+  });
+
   it("maps Factory Droid API failures in agent_message_chunk to runtime errors", () => {
     const state = createAcpMapperState("t-droid-limit");
     const text =

--- a/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/dispatch.ts
@@ -100,11 +100,14 @@ export function mapAcpSessionUpdate(
         events.push(...closeAllOpenContentItems(state));
       }
       const content = (update as { content?: ContentBlock }).content;
-      // Some ACP agents emit an empty text chunk after every tool call. It is
-      // only a stream boundary, not an assistant message; opening an item for
-      // it leaves a completed blank row between the tool and the next thought.
-      if (content?.type === "text" && content.text.length === 0) {
-        break;
+      // Some ACP agents emit a blank text chunk after every tool call — empty
+      // for most, newline-only for Factory Droid on DeepSeek models. It is only
+      // a stream boundary, not an assistant message; opening an item for it
+      // leaves a completed blank row between the tool and the next thought.
+      if (content?.type === "text" && content.text.trim().length === 0) {
+        // A zero-length chunk is always a no-op. Whitespace is real spacing
+        // only once an assistant message is already streaming.
+        if (content.text.length === 0 || !contentState.openAssistantItemId) break;
       }
       // Gemini echoes `[MODE_UPDATE] <mode>` as an agent text chunk whenever the
       // session is launched (or switched) into a specific approval mode. The


### PR DESCRIPTION
- ACP agents emit a blank text chunk after tool calls as a stream boundary; Factory Droid also emits "\n\n", which previously opened blank assistant rows and gaps in chat.
- Supervisor ACP mapper now drops whitespace-only text chunks when no message is streaming, while preserving whitespace as real spacing once a message is in flight.
- Renderer chat visibility filter hides completed assistant items whose stream or payload text is whitespace-only, using a non-whitespace check that avoids per-pass `trim()` copies.
- Tests added for both the mapper boundary handling and the renderer visibility filter.