### PR TITLE
fix(git): prune stat-only phantom rows from status

### DIFF
--- a/src/supervisor/git.test.ts
+++ b/src/supervisor/git.test.ts
@@ -1610,7 +1610,14 @@ describe("GitService.getStatus Windows path normalization", () => {
         };
       }
       if (args[0] === "remote") return { stdout: "" };
-      if (args[0] === "diff") return { stdout: "" };
+      // numstat backs each porcelain row — a row absent here is pruned as a
+      // stat-only phantom, so both sides must echo the backslash paths.
+      if (args[0] === "diff" && args[1] === "--cached") {
+        return { stdout: "3\t1\tsrc\\staged.ts" };
+      }
+      if (args[0] === "diff") {
+        return { stdout: "2\t1\tdocs\\{renamed-old.md => renamed-new.md}" };
+      }
       return { stdout: "" };
     });
 

--- a/src/supervisor/git.ts
+++ b/src/supervisor/git.ts
@@ -45,7 +45,11 @@ import {
   type WorktreePathOptions,
 } from "./git/exec";
 import { GitMergeService } from "./git/mergeService";
-import { buildGitStatusResultFromOutputs, parseStatusPorcelainV2 } from "./git/statusParsing";
+import {
+  buildGitStatusResultFromOutputs,
+  numstatFromBatchResult,
+  parseStatusPorcelainV2,
+} from "./git/statusParsing";
 import { GitExperimentService } from "./git/experimentService";
 import { GitStatusService } from "./git/statusService";
 import {
@@ -148,8 +152,8 @@ export class GitService {
       isRepo,
       statusOutput: results[1]!.stdout,
       remoteOutput: results[2]!.stdout,
-      stagedNumstat: results[3]!.stdout,
-      unstagedNumstat: results[4]!.stdout,
+      stagedNumstat: numstatFromBatchResult(results[3]),
+      unstagedNumstat: numstatFromBatchResult(results[4]),
     });
     const status = isRepo
       ? await this.statusService.applyMergeState(

--- a/src/supervisor/git/statusParsing.ts
+++ b/src/supervisor/git/statusParsing.ts
@@ -41,26 +41,69 @@ export function parseRemoteInfo(remoteOutput: string): {
   return { hasRemote, remoteInfo };
 }
 
-/** Merge staged/unstaged `--numstat` counts into the parsed porcelain entries. */
+/**
+ * Read a batched-bridge command result as a numstat output for
+ * {@link applyNumstatCounts}: `null` when the command failed, so an errored
+ * numstat is never mistaken for "no tracked file has a diff".
+ */
+export function numstatFromBatchResult(
+  result: { ok: boolean; stdout: string } | undefined,
+): string | null {
+  return result?.ok ? result.stdout : null;
+}
+
+/**
+ * Merge one side's `--numstat` counts into its porcelain entries and drop the
+ * tracked rows numstat has nothing to say about. `null` means the numstat
+ * command failed — the rows are returned untouched rather than wiped.
+ */
+function applyNumstatToSide(
+  files: readonly GitFileChange[],
+  numstat: string | null,
+): GitFileChange[] {
+  if (numstat === null) return [...files];
+  const stats = new Map(parseDiffNumstat(numstat).map((entry) => [entry.path, entry]));
+  const result: GitFileChange[] = [];
+  for (const file of files) {
+    // Untracked files never appear in `git diff`; their counts are filled
+    // separately by reading the file (see `replaceUntrackedEntries`).
+    if (file.status === "?") {
+      result.push(file);
+      continue;
+    }
+    const entry = stats.get(file.path);
+    if (!entry) continue;
+    result.push({ ...file, insertions: entry.insertions, deletions: entry.deletions });
+  }
+  return result;
+}
+
+/**
+ * Merge staged/unstaged `--numstat` counts into the parsed porcelain entries,
+ * dropping tracked entries that carry no diff at all.
+ *
+ * `git status` can call a tracked file modified from cached stat data alone:
+ * git's `ie_modified()` short-circuits on a size mismatch and never re-reads the
+ * blob. On Windows with `core.autocrlf=true` that fires en masse — a tool
+ * rewrites files with LF endings, so each file's on-disk size drops below the
+ * CRLF size the index cached at checkout while the content git actually tracks
+ * is unchanged. `git status` then reports hundreds of modified files that
+ * `git diff` has nothing to say about, and the Changes panel fills with rows
+ * that show no +/- and open an empty diff.
+ *
+ * `git diff --numstat` is the ground truth for "this file has a diff": every
+ * real change surfaces there — binaries as `- -`, mode-only changes as `0 0`,
+ * dirty submodules through the `-dirty` commit marker — so a tracked row missing
+ * from it has nothing to show and is dropped. Pass `null` for a side whose
+ * numstat command failed so neither counts nor pruning are applied to it.
+ */
 export function applyNumstatCounts(
   parsed: ParsedPorcelainStatus,
-  stagedNumstat: string,
-  unstagedNumstat: string,
+  stagedNumstat: string | null,
+  unstagedNumstat: string | null,
 ): void {
-  for (const entry of parseDiffNumstat(stagedNumstat)) {
-    const match = parsed.staged.find((file) => file.path === entry.path);
-    if (match) {
-      match.insertions = entry.insertions;
-      match.deletions = entry.deletions;
-    }
-  }
-  for (const entry of parseDiffNumstat(unstagedNumstat)) {
-    const match = parsed.unstaged.find((file) => file.path === entry.path);
-    if (match) {
-      match.insertions = entry.insertions;
-      match.deletions = entry.deletions;
-    }
-  }
+  parsed.staged = applyNumstatToSide(parsed.staged, stagedNumstat);
+  parsed.unstaged = applyNumstatToSide(parsed.unstaged, unstagedNumstat);
 }
 
 /** Sum insertions/deletions across staged + unstaged entries. */
@@ -331,8 +374,10 @@ export function buildGitStatusResultFromOutputs(args: {
   isRepo: boolean;
   statusOutput: string;
   remoteOutput: string;
-  stagedNumstat: string;
-  unstagedNumstat: string;
+  /** `null` when the numstat command failed — see {@link applyNumstatCounts}. */
+  stagedNumstat: string | null;
+  /** `null` when the numstat command failed — see {@link applyNumstatCounts}. */
+  unstagedNumstat: string | null;
 }): GitStatusResult {
   if (!args.isRepo) {
     return {

--- a/src/supervisor/git/statusService.parser.test.ts
+++ b/src/supervisor/git/statusService.parser.test.ts
@@ -394,6 +394,64 @@ describe("buildGitStatusResultFromOutputs", () => {
     expect(result.totalDeletions).toBe(2);
   });
 
+  it("drops tracked rows that `git diff --numstat` has no entry for", () => {
+    // Windows + core.autocrlf=true: a tool rewrote src/phantom.ts with LF
+    // endings, so its on-disk size no longer matches the CRLF size the index
+    // cached at checkout. `git status` reports it modified from that stale stat
+    // alone while `git diff` shows nothing — the row must not reach the panel.
+    const result = buildGitStatusResultFromOutputs({
+      isRepo: true,
+      statusOutput: [
+        "# branch.head main",
+        "1 M. N... 100644 100644 100644 aaa aaa src/staged-phantom.ts",
+        "1 M. N... 100644 100644 100644 bbb bbb src/staged-real.ts",
+        "1 .M N... 100644 100644 100644 ccc ccc src/phantom.ts",
+        "1 .M N... 100644 100644 100644 ddd ddd src/real.ts",
+        "? src/new.ts",
+      ].join("\n"),
+      remoteOutput: "",
+      stagedNumstat: "5\t1\tsrc/staged-real.ts",
+      unstagedNumstat: "2\t3\tsrc/real.ts",
+    });
+    expect(result.staged.map((f) => f.path)).toEqual(["src/staged-real.ts"]);
+    // The untracked row survives: it never appears in `git diff --numstat`.
+    expect(result.unstaged.map((f) => f.path)).toEqual(["src/real.ts", "src/new.ts"]);
+    expect(result.totalInsertions).toBe(7);
+    expect(result.totalDeletions).toBe(4);
+  });
+
+  it("keeps rows numstat reports with zero counts (binary and mode-only changes)", () => {
+    const result = buildGitStatusResultFromOutputs({
+      isRepo: true,
+      statusOutput: [
+        "# branch.head main",
+        "1 .M N... 100644 100755 100755 aaa aaa src/mode-only.sh",
+        "1 .M N... 100644 100644 100644 bbb bbb assets/logo.png",
+      ].join("\n"),
+      remoteOutput: "",
+      stagedNumstat: "",
+      unstagedNumstat: ["0\t0\tsrc/mode-only.sh", "-\t-\tassets/logo.png"].join("\n"),
+    });
+    expect(result.unstaged.map((f) => f.path)).toEqual(["src/mode-only.sh", "assets/logo.png"]);
+  });
+
+  it("keeps every row when a numstat command failed (null), rather than wiping the list", () => {
+    const result = buildGitStatusResultFromOutputs({
+      isRepo: true,
+      statusOutput: [
+        "# branch.head main",
+        "1 M. N... 100644 100644 100644 aaa aaa src/a.ts",
+        "1 .M N... 100644 100644 100644 bbb bbb src/b.ts",
+      ].join("\n"),
+      remoteOutput: "",
+      stagedNumstat: null,
+      unstagedNumstat: null,
+    });
+    expect(result.staged.map((f) => f.path)).toEqual(["src/a.ts"]);
+    expect(result.unstaged.map((f) => f.path)).toEqual(["src/b.ts"]);
+    expect(result.totalInsertions).toBe(0);
+  });
+
   it("returns hasRemote=false when remoteOutput is empty", () => {
     const result = buildGitStatusResultFromOutputs({
       isRepo: true,

--- a/src/supervisor/git/statusService.ts
+++ b/src/supervisor/git/statusService.ts
@@ -25,6 +25,7 @@ import {
   expandUntrackedEntries,
   LS_FILES_UNTRACKED_ARGS,
   nonRepoSummaryStatus,
+  numstatFromBatchResult,
   parseDiffNumstat,
   parseRemoteInfo,
   parseStatusPorcelainV2,
@@ -112,15 +113,17 @@ export class GitStatusService {
         console.warn("[git] 'remote -v' failed:", error);
         return "";
       }),
+      // `null` on failure, NOT "" — an empty numstat is a real answer ("no file
+      // has a diff") that `applyNumstatCounts` prunes against.
       execGit(location, ["diff", "--cached", "--numstat"], { timeout: GIT_STATUS_TIMEOUT }).catch(
         (error) => {
           console.warn("[git] 'diff --cached --numstat' failed:", error);
-          return "";
+          return null;
         },
       ),
       execGit(location, ["diff", "--numstat"], { timeout: GIT_STATUS_TIMEOUT }).catch((error) => {
         console.warn("[git] 'diff --numstat' failed:", error);
-        return "";
+        return null;
       }),
     ]);
 
@@ -277,8 +280,8 @@ export class GitStatusService {
       isRepo,
       statusOutput: results[1]!.stdout,
       remoteOutput: results[2]!.stdout,
-      stagedNumstat: results[3]!.stdout,
-      unstagedNumstat: results[4]!.stdout,
+      stagedNumstat: numstatFromBatchResult(results[3]),
+      unstagedNumstat: numstatFromBatchResult(results[4]),
     });
     if (!isRepo) return base;
     const enriched = await this.enrichStatusInternal(location, base);
@@ -318,8 +321,8 @@ export class GitStatusService {
           isRepo,
           statusOutput,
           remoteOutput: results[off + 2]!.stdout,
-          stagedNumstat: results[off + 3]!.stdout,
-          unstagedNumstat: results[off + 4]!.stdout,
+          stagedNumstat: numstatFromBatchResult(results[off + 3]),
+          unstagedNumstat: numstatFromBatchResult(results[off + 4]),
         });
         if (!isRepo) {
           out[path] = base;


### PR DESCRIPTION
Tickets: none
- Bugfix: drop tracked status rows that `git diff --numstat` has no entry for, removing stale-stat phantom rows (e.g. LF/CRLF stat-cache mismatches with `core.autocrlf`) before they reach the changes panel.
- Distinguish failed numstat commands from legitimately empty ones, so a transient diff failure preserves the full row list instead of wiping it.
- Keep rows numstat reports with zero counts, so binary and mode-only changes still surface.
- Handle missing/partial numstat and update parser and service tests, including Windows path normalization coverage.