### PR TITLE
Add bottom dock and split panel docking

### DIFF
--- a/src/renderer/hooks/uiSelectors.test.ts
+++ b/src/renderer/hooks/uiSelectors.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { dockPanelTab } from "@/renderer/actions/panelActions";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { EMPTY_BOTTOM_PANEL_DOCKS, usePanelStore } from "@/renderer/state/panelStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import {
+  useIsProjectGitPanelActive,
+  useIsWorktreeFilesPanelActive,
+  useIsWorktreeGitPanelActive,
+  useIsWorktreeTerminalActive,
+} from "./uiSelectors";
+
+const worktreePath = "/repo/.poracode/worktrees/feature";
+
+beforeEach(() => {
+  useSharedSettings.setState({ terminalPosition: "bottom" });
+  usePanelStore.setState({
+    rightPanelTab: "usage",
+    rightPanelSplit: null,
+    bottomPanelDocks: EMPTY_BOTTOM_PANEL_DOCKS,
+    gitReviewContext: null,
+    gitReviewAsPanel: false,
+    filesPanelContext: null,
+    usagePanelOpen: true,
+  });
+  useDevTerminalStore.setState({ isOpen: false, activeProjectId: null, activeWorktreePath: null });
+});
+
+function openGitPanel(scope: { projectId: string; worktreePath?: string }) {
+  usePanelStore.setState({
+    gitReviewContext: scope,
+    gitReviewAsPanel: true,
+  });
+}
+
+function openFilesPanel() {
+  usePanelStore.setState({
+    filesPanelContext: {
+      projectId: "project-a",
+      projectName: "Project A",
+      worktreePath,
+      rootLabel: "feature",
+    },
+  });
+}
+
+describe("sidebar panel-active selectors", () => {
+  it("marks a git panel docked into the right-panel split as active", () => {
+    openGitPanel({ projectId: "project-a", worktreePath });
+
+    const eclipsed = renderHook(() => useIsWorktreeGitPanelActive(worktreePath));
+    expect(eclipsed.result.current).toBe(false);
+
+    usePanelStore.setState({ rightPanelSplit: { tab: "git", placement: "top" } });
+    const split = renderHook(() => useIsWorktreeGitPanelActive(worktreePath));
+    expect(split.result.current).toBe(true);
+  });
+
+  it("marks a bottom-docked git panel as active", () => {
+    openGitPanel({ projectId: "project-a" });
+    usePanelStore.setState({ bottomPanelDocks: { left: "git", right: null } });
+
+    const { result } = renderHook(() => useIsProjectGitPanelActive("project-a"));
+    expect(result.current).toBe(true);
+  });
+
+  it("ignores bottom docks while the terminal owns the right edge", () => {
+    useSharedSettings.setState({ terminalPosition: "right" });
+    openGitPanel({ projectId: "project-a" });
+    usePanelStore.setState({ bottomPanelDocks: { left: "git", right: null } });
+
+    const { result } = renderHook(() => useIsProjectGitPanelActive("project-a"));
+    expect(result.current).toBe(false);
+  });
+
+  it("marks a split files panel as active without owning the active tab", () => {
+    openFilesPanel();
+
+    const eclipsed = renderHook(() => useIsWorktreeFilesPanelActive(worktreePath));
+    expect(eclipsed.result.current).toBe(false);
+
+    usePanelStore.setState({ rightPanelSplit: { tab: "files", placement: "bottom" } });
+    const split = renderHook(() => useIsWorktreeFilesPanelActive(worktreePath));
+    expect(split.result.current).toBe(true);
+  });
+
+  it("marks a bottom-docked files panel as active", () => {
+    openFilesPanel();
+    usePanelStore.setState({ bottomPanelDocks: { left: null, right: "files" } });
+
+    const { result } = renderHook(() => useIsWorktreeFilesPanelActive(worktreePath));
+    expect(result.current).toBe(true);
+  });
+
+  it("marks a split terminal as active with the terminal on the right edge", () => {
+    useSharedSettings.setState({ terminalPosition: "right" });
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: "project-a",
+      activeWorktreePath: worktreePath,
+    });
+
+    const eclipsed = renderHook(() => useIsWorktreeTerminalActive(worktreePath));
+    expect(eclipsed.result.current).toBe(false);
+
+    usePanelStore.setState({ rightPanelSplit: { tab: "terminal", placement: "top" } });
+    const split = renderHook(() => useIsWorktreeTerminalActive(worktreePath));
+    expect(split.result.current).toBe(true);
+  });
+
+  it("refuses to dock the terminal into the bottom row it already owns", () => {
+    useDevTerminalStore.setState({
+      isOpen: true,
+      activeProjectId: "project-a",
+      activeWorktreePath: worktreePath,
+    });
+
+    dockPanelTab("terminal", { zone: "bottom-panel", placement: "left" });
+    expect(usePanelStore.getState().bottomPanelDocks).toEqual(EMPTY_BOTTOM_PANEL_DOCKS);
+  });
+});

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -18,7 +18,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { createArrayKeyedMap } from "@/renderer/state/derivations";
 import { isDraftContentNonEmpty } from "@/renderer/state/slices/types";
 import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
-import { usePanelStore } from "@/renderer/state/panelStore";
+import { usePanelStore, type RightPanelTab } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -143,12 +143,41 @@ export function isGitPanelEclipsed(
   );
 }
 
-export function useIsProjectTerminalActive(projectId: string): boolean {
+/**
+ * Whether a panel tab is painted right now — as the right panel's active
+ * layer, as the split section stacked with it, or in a bottom dock slot.
+ * Docking never touches `rightPanelTab`, so the active-layer rules below are
+ * not enough on their own (mirrors `UnifiedRightPanel`'s `isTabOnScreen`).
+ * Bottom docks only render while the terminal owns the bottom edge.
+ */
+function isPanelTabOnScreen(
+  panel: ReturnType<typeof usePanelStore.getState>,
+  terminalPosition: "right" | "bottom",
+  tab: RightPanelTab,
+): boolean {
+  if (panel.rightPanelSplit?.tab === tab) return true;
+  if (
+    terminalPosition === "bottom" &&
+    (panel.bottomPanelDocks.left === tab || panel.bottomPanelDocks.right === tab)
+  ) {
+    return true;
+  }
+  if (tab === "terminal") return !isTerminalEclipsedOnRight(terminalPosition, panel.rightPanelTab);
+  if (tab === "git") return !isGitPanelEclipsed(terminalPosition, panel.rightPanelTab);
+  return panel.rightPanelTab === tab;
+}
+
+/** Primitive subscription so a sidebar row re-renders only when its own tab's visibility flips. */
+function usePanelTabOnScreen(tab: RightPanelTab): boolean {
   const terminalPosition = useSharedSettings((s) => s.terminalPosition);
-  const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
+  return usePanelStore((s) => isPanelTabOnScreen(s, terminalPosition, tab));
+}
+
+export function useIsProjectTerminalActive(projectId: string): boolean {
+  const onScreen = usePanelTabOnScreen("terminal");
   return useDevTerminalStore((s) => {
     if (!s.isOpen || s.activeProjectId !== projectId || s.activeWorktreePath) return false;
-    return !isTerminalEclipsedOnRight(terminalPosition, rightPanelTab);
+    return onScreen;
   });
 }
 
@@ -159,11 +188,10 @@ export function useIsProjectTerminalOpen(projectId: string): boolean {
 }
 
 export function useIsWorktreeTerminalActive(worktreePath: string | null | undefined): boolean {
-  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
-  const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
+  const onScreen = usePanelTabOnScreen("terminal");
   return useDevTerminalStore((s) => {
     if (!worktreePath || !s.isOpen || s.activeWorktreePath !== worktreePath) return false;
-    return !isTerminalEclipsedOnRight(terminalPosition, rightPanelTab);
+    return onScreen;
   });
 }
 
@@ -197,37 +225,37 @@ export function useIsWorktreeTerminalBusy(worktreePath: string | null | undefine
 }
 
 export function useIsProjectGitPanelActive(projectId: string): boolean {
-  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
+  const onScreen = usePanelTabOnScreen("git");
   return usePanelStore((s) => {
     const ctx = s.gitReviewContext;
-    if (!ctx || !s.gitReviewAsPanel) return false;
-    if (isGitPanelEclipsed(terminalPosition, s.rightPanelTab)) return false;
+    if (!ctx || !s.gitReviewAsPanel || !onScreen) return false;
     return ctx.projectId === projectId && !ctx.worktreePath;
   });
 }
 
 export function useIsWorktreeGitPanelActive(worktreePath: string | null | undefined): boolean {
-  const terminalPosition = useSharedSettings((s) => s.terminalPosition);
+  const onScreen = usePanelTabOnScreen("git");
   return usePanelStore((s) => {
     if (!worktreePath) return false;
     const ctx = s.gitReviewContext;
-    if (!ctx || !s.gitReviewAsPanel) return false;
-    if (isGitPanelEclipsed(terminalPosition, s.rightPanelTab)) return false;
+    if (!ctx || !s.gitReviewAsPanel || !onScreen) return false;
     return ctx.worktreePath === worktreePath;
   });
 }
 
 export function useIsProjectFilesPanelActive(projectId: string): boolean {
+  const onScreen = usePanelTabOnScreen("files");
   return usePanelStore((s) => {
-    if (s.rightPanelTab !== "files") return false;
+    if (!onScreen) return false;
     const ctx = s.filesPanelContext;
     return ctx?.projectId === projectId && !ctx.worktreePath;
   });
 }
 
 export function useIsWorktreeFilesPanelActive(worktreePath: string | null | undefined): boolean {
+  const onScreen = usePanelTabOnScreen("files");
   return usePanelStore((s) => {
-    if (!worktreePath || s.rightPanelTab !== "files") return false;
+    if (!worktreePath || !onScreen) return false;
     return s.filesPanelContext?.worktreePath === worktreePath;
   });
 }

--- a/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/Sidebar.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/renderer/hooks/uiSelectors";
 import { useScrollFade } from "@/renderer/hooks/useScrollFade";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useIsPanelTabVisible } from "@/renderer/state/panelDockSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
@@ -190,7 +191,9 @@ export function Sidebar() {
   const remoteAccessSettingsActive = settingsOpen && settingsSection === "remoteAccess";
   const otherSettingsActive = settingsOpen && !remoteAccessSettingsActive;
   const threadSearchOpen = usePanelStore((s) => s.threadSearchOpen);
-  const browserVisible = usePanelStore((s) => s.browserPanelOpen && s.rightPanelTab === "browser");
+  const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
+  const browserOnScreen = useIsPanelTabVisible("browser");
+  const browserVisible = browserPanelOpen && browserOnScreen;
   const openThreadSearch = usePanelStore((s) => s.openThreadSearch);
   const isHomeProjectCollapsed = useSidebarUiStore((s) =>
     homeProject ? (s.collapsedProjects[homeProject.id] ?? false) : false,

--- a/src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
+++ b/src/renderer/views/MainView/parts/SidebarHeaderControls.tsx
@@ -1,6 +1,7 @@
 import { FolderPlus, Globe, Search } from "lucide-react";
 import { Button, Dropdown, Label, Separator, Tooltip } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { useIsPanelTabVisible } from "@/renderer/state/panelDockSelectors";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { toggleBrowserPanel } from "@/renderer/actions/panelActions";
 import {
@@ -19,8 +20,8 @@ export function SidebarHeaderControls() {
   const threadSortMode = usePanelStore((s) => s.threadSortMode);
   const threadListLayout = usePanelStore((s) => s.threadListLayout);
   const browserPanelOpen = usePanelStore((s) => s.browserPanelOpen);
-  const rightPanelTab = usePanelStore((s) => s.rightPanelTab);
-  const browserVisible = browserPanelOpen && rightPanelTab === "browser";
+  const browserOnScreen = useIsPanelTabVisible("browser");
+  const browserVisible = browserPanelOpen && browserOnScreen;
 
   return (
     <div className="poracode-overlay-header__controls flex items-center gap-1.5">


### PR DESCRIPTION
- Add a bottom dock with left/right slots and split right-panel docking, including drag-and-drop, split resize, and per-tab drop zones.
- Read Cursor context-window usage from the SDK checkpoint store.
- Support Factory droid's bare AskUser tool in ACP question handling and classification.
- Fix chat turn anchoring to renderable timeline rows, prune stat-only phantom rows from git status, and drop whitespace-only ACP stream-boundary chunks.
- Refactor the sidebar footer into reusable nav components and sort the project switcher Home, local, then remote.