### PR TITLE
fix(settings-sidebar): use default-density buttons in sidebar footer

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx
@@ -687,13 +687,15 @@ export function SettingsSidebar(props: {
           )}
         </div>
 
+        {/* Footer rows keep the default density (not the compact one the section
+            list uses) so they line up with the main sidebar's own 32px footer rows. */}
         <div className={sidebarFooterNavClass}>
-          <SettingsNavButton
+          <SidebarButton
             icon={<ArrowLeft className="size-4" />}
             label={t`Return to app`}
             onPress={onClose}
           />
-          <SettingsNavButton
+          <SidebarButton
             icon={<PanelLeftClose className="size-4" />}
             label={t`Hide sidebar`}
             onPress={collapse}


### PR DESCRIPTION
- Footer rows in the settings sidebar (`Return to app`, `Hide sidebar`) now use the default-density `SidebarButton` instead of the compact `SettingsNavButton`.
- The compact section-list styling made footer rows misalign with the main sidebar's 32px footer rows; using the shared default-density button keeps them visually consistent.