### PR TITLE
Normalize Grok web search calls and share display logic

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -68,6 +68,7 @@ import {
   type ToolGroupRowSegment,
 } from "./toolCallCategorization";
 import { deriveToolDisplay } from "./toolDisplay";
+import { deriveWebSearchDisplay } from "./webSearchDisplay";
 import { FileContentPlaceholder, useReadAbsoluteFile } from "./useReadAbsoluteFile";
 
 interface ToolCallGroupProps {
@@ -754,31 +755,30 @@ function getWebSearchRow(
 ): InlineRow | null {
   const payload = getRuntimeItemPayload<WebSearchPayload>(item, "web_search");
   if (!payload) return null;
-  const title = payload.query || formatWebSearchName(readPayloadString(payload, "name"), t);
+  const display = deriveWebSearchDisplay(payload, t);
   const sections: ToolCallSection[] =
-    isExpanded && hasAuxFields(payload)
+    isExpanded && display.hasDetails
       ? [
           { label: "query", part: extractAcpArgsPart(payload) },
           { label: "results", part: extractAcpResultPart(payload) },
         ]
       : [];
   const isRunning = item.state !== "completed";
-  const resultCount = payload.resultCount ?? deriveResultCount(payload);
+  // Keep the `resultCount` binding: it is the Lingui placeholder name baked
+  // into the `{resultCount, plural, …}` msgid across all catalogs.
+  const resultCount = display.resultCount;
   const rightLabel: ReactNode = isRunning ? undefined : resultCount != null ? (
     <Plural value={resultCount} one="# result" other="# results" />
   ) : undefined;
   return {
     Icon: Globe,
-    title,
+    title: display.title,
+    ...(display.parts ? { titleParts: display.parts } : {}),
     rightLabel,
     rightLabelClassName: "text-[color:var(--muted)]",
-    hasDetails: hasAuxFields(payload),
+    hasDetails: display.hasDetails,
     sections,
   };
-}
-
-function formatWebSearchName(name: string | undefined, t: TranslateFn): string {
-  return name === "WebSearch" || !name ? t(msg`Web search`) : name;
 }
 
 function hasAuxFields(payload: unknown): boolean {
@@ -804,13 +804,4 @@ function readPayloadString(payload: unknown, key: string): string | undefined {
   if (!payload || typeof payload !== "object") return undefined;
   const v = (payload as Record<string, unknown>)[key];
   return typeof v === "string" && v.length > 0 ? v : undefined;
-}
-
-function deriveResultCount(payload: unknown): number | undefined {
-  if (!payload || typeof payload !== "object") return undefined;
-  const result = (payload as Record<string, unknown>).result;
-  if (!result || typeof result !== "object") return undefined;
-  const contents = (result as Record<string, unknown>).contents;
-  if (Array.isArray(contents)) return contents.length;
-  return undefined;
 }

--- a/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
@@ -1,7 +1,5 @@
 import { memo, useMemo, useState } from "react";
-import { msg } from "@lingui/core/macro";
 import { Plural, useLingui } from "@lingui/react/macro";
-import type { TranslateFn } from "@/renderer/i18n/i18n";
 import { Globe } from "lucide-react";
 import type { WebSearchPayload } from "@/shared/contracts";
 import {
@@ -11,6 +9,7 @@ import {
 import { ChatItemAccordion } from "./ChatItemAccordion";
 import { ToolCallSections, type ToolCallSection } from "./ToolCallSections";
 import { extractAcpArgsPart, extractAcpResultPart } from "./acpToolPayload";
+import { deriveWebSearchDisplay } from "./webSearchDisplay";
 
 interface WebSearchItemProps {
   item: RuntimeChatItem;
@@ -28,9 +27,10 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
     ];
   }, [isExpanded, payload]);
   if (!payload) return null;
-  const title = payload.query || formatWebSearchName(readPayloadString(payload, "name"), t);
-  const hasDetails = hasAuxFields(payload);
-  const resultCount = payload.resultCount ?? deriveResultCount(payload);
+  const display = deriveWebSearchDisplay(payload, t);
+  // Keep the `resultCount` binding: it is the Lingui placeholder name baked
+  // into the `{resultCount, plural, …}` msgid across all catalogs.
+  const resultCount = display.resultCount;
   const right =
     resultCount != null ? (
       <Plural value={resultCount} one="# result" other="# results" />
@@ -39,10 +39,11 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
   return (
     <ChatItemAccordion
       icon={<Globe className="size-3" />}
-      title={title}
+      title={display.title}
+      {...(display.parts ? { titleParts: display.parts } : {})}
       isRunning={item.state !== "completed"}
       rightLabel={right}
-      hasBody={hasDetails}
+      hasBody={display.hasDetails}
       isExpanded={isExpanded}
       onExpandedChange={setIsExpanded}
     >
@@ -50,33 +51,3 @@ export const WebSearchItem = memo(function WebSearchItem({ item }: WebSearchItem
     </ChatItemAccordion>
   );
 });
-
-function hasAuxFields(payload: unknown): boolean {
-  if (!payload || typeof payload !== "object") return false;
-  const p = payload as Record<string, unknown>;
-  return p.args !== undefined || p.result !== undefined;
-}
-
-function readPayloadString(payload: unknown, key: string): string | undefined {
-  if (!payload || typeof payload !== "object") return undefined;
-  const v = (payload as Record<string, unknown>)[key];
-  return typeof v === "string" && v.length > 0 ? v : undefined;
-}
-
-function formatWebSearchName(name: string | undefined, t: TranslateFn): string {
-  return name === "WebSearch" || !name ? t(msg`Web search`) : name;
-}
-
-/**
- * When a structured `resultCount` isn't present (codex doesn't surface it,
- * older ACP servers may not), derive it from the tool's `result.contents`
- * array — both ACP and codex put per-result blocks there.
- */
-function deriveResultCount(payload: unknown): number | undefined {
-  if (!payload || typeof payload !== "object") return undefined;
-  const result = (payload as Record<string, unknown>).result;
-  if (!result || typeof result !== "object") return undefined;
-  const contents = (result as Record<string, unknown>).contents;
-  if (Array.isArray(contents)) return contents.length;
-  return undefined;
-}

--- a/src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { MessageDescriptor } from "@lingui/core";
+import type { WebSearchPayload } from "@/shared/contracts";
+import { i18n, type TranslateFn } from "@/renderer/i18n/i18n";
+import { deriveWebSearchDisplay } from "./webSearchDisplay";
+
+const t = ((descriptor: MessageDescriptor) => i18n._(descriptor)) as TranslateFn;
+
+function makePayload(payload: Record<string, unknown>): WebSearchPayload {
+  return payload as unknown as WebSearchPayload;
+}
+
+describe("deriveWebSearchDisplay", () => {
+  it("labels the query with the tool name when the provider names the tool", () => {
+    // Grok: name from the ACP title, query lifted off the backend result.
+    const grok = deriveWebSearchDisplay(
+      makePayload({
+        name: "Web search",
+        query: "best electric toothbrush 2026",
+        result: { contents: [{ type: "text", text: "https://example.com/a" }] },
+      }),
+      t,
+    );
+    expect(grok.title).toBe("Web search: best electric toothbrush 2026");
+    expect(grok.parts).toEqual({ prefix: "Web search: ", path: "best electric toothbrush 2026" });
+    expect(grok.resultCount).toBe(1);
+
+    // Codex spells the same tool `webSearch` and surfaces no result blocks.
+    const codex = deriveWebSearchDisplay(
+      makePayload({ name: "webSearch", query: "cron-parser 5.6.2 strict mode" }),
+      t,
+    );
+    expect(codex.title).toBe("Web search: cron-parser 5.6.2 strict mode");
+    expect(codex.resultCount).toBeUndefined();
+  });
+
+  it("leaves self-describing rows alone", () => {
+    // Claude folds the whole call into the query and carries no tool name.
+    const claude = deriveWebSearchDisplay(
+      makePayload({ query: 'WebFetch: {"url":"https://agent-plugins.org/"}' }),
+      t,
+    );
+    expect(claude.title).toBe('WebFetch: {"url":"https://agent-plugins.org/"}');
+    expect(claude.parts).toBeUndefined();
+
+    // OpenCode reuses the type for page fetches; its name is the fetched URL.
+    const opencode = deriveWebSearchDisplay(
+      makePayload({
+        name: "https://cursor.com/docs (text/plain)",
+        query: "https://cursor.com/docs",
+        result: "# Cursor",
+      }),
+      t,
+    );
+    expect(opencode.title).toBe("https://cursor.com/docs");
+    expect(opencode.parts).toBeUndefined();
+  });
+
+  it("falls back to the generic label while the query is still unknown", () => {
+    const pending = deriveWebSearchDisplay(makePayload({ name: "WebSearch", query: "" }), t);
+    expect(pending.title).toBe("Web search");
+    expect(pending.parts).toBeUndefined();
+    expect(pending.hasDetails).toBe(false);
+  });
+
+  it("does not repeat the tool name when the query is still the placeholder", () => {
+    // Grok's opening tool_call has no query yet, so the canonical query falls
+    // back to the title — the row must not read `Web search: Web search`.
+    for (const query of ["Web search", "Web search:", "web_search"]) {
+      const running = deriveWebSearchDisplay(makePayload({ name: "Web search", query }), t);
+      expect(running.title).toBe("Web search");
+      expect(running.parts).toBeUndefined();
+    }
+  });
+});

--- a/src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared title/count derivation for canonical `web_search` rows, used by both
+ * the standalone accordion and the grouped inline row so the two can't drift.
+ *
+ * Providers disagree on what the payload carries: Grok and Codex name the tool
+ * (`Web search` / `webSearch`) and keep the query separate, Claude folds the
+ * whole call into `query`, and OpenCode reuses the type for page fetches whose
+ * `name` is the fetched URL. Only the first shape gets the `Web search: <query>`
+ * prefix treatment — the others already read as a complete label on their own.
+ */
+
+import { msg } from "@lingui/core/macro";
+import type { TranslateFn } from "@/renderer/i18n/i18n";
+import type { WebSearchPayload } from "@/shared/contracts";
+
+export interface WebSearchDisplay {
+  title: string;
+  /** Set when the row shows `<tool name>: <query>`; mirrors `ToolDisplay["parts"]`. */
+  parts?: { prefix: string; path: string };
+  resultCount?: number;
+  hasDetails: boolean;
+}
+
+export function deriveWebSearchDisplay(
+  payload: WebSearchPayload,
+  t: TranslateFn,
+): WebSearchDisplay {
+  const label = t(msg`Web search`);
+  const name = readPayloadString(payload, "name");
+  // A query that is just the tool's name is a placeholder, not a search: the
+  // canonical `query` falls back to the ACP title, and servers that search
+  // remotely (Grok) only learn the real query once the results come back.
+  // Treating it as unknown keeps the running row from reading `Web search ·
+  // Web search`.
+  const rawQuery = payload.query?.trim();
+  const query = rawQuery && !isGenericWebSearchName(rawQuery) ? rawQuery : undefined;
+  const resultCount = payload.resultCount ?? deriveResultCount(payload);
+  const base = {
+    hasDetails: hasAuxFields(payload),
+    ...(resultCount != null ? { resultCount } : {}),
+  };
+  if (query && isGenericWebSearchName(name)) {
+    const prefix = `${label}: `;
+    return { ...base, title: `${prefix}${query}`, parts: { prefix, path: query } };
+  }
+  return { ...base, title: query || (name && !isGenericWebSearchName(name) ? name : label) };
+}
+
+/**
+ * Whether `name` is the tool's own name rather than a per-call label. Providers
+ * spell it `WebSearch`, `webSearch`, `web_search` or `Web search:` — all of
+ * those are redundant with the localized label and leave the query free to be
+ * shown next to it.
+ */
+function isGenericWebSearchName(name: string | undefined): boolean {
+  return name !== undefined && /^web[\s_-]?search:?$/i.test(name.trim());
+}
+
+function hasAuxFields(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+  const p = payload as Record<string, unknown>;
+  return p.args !== undefined || p.result !== undefined;
+}
+
+function readPayloadString(payload: unknown, key: string): string | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * When a structured `resultCount` isn't present (codex doesn't surface it,
+ * older ACP servers may not), derive it from the tool's `result.contents`
+ * array — ACP, codex and the Grok web-search normalizer all put per-result
+ * blocks there.
+ */
+function deriveResultCount(payload: unknown): number | undefined {
+  if (!payload || typeof payload !== "object") return undefined;
+  const result = (payload as Record<string, unknown>).result;
+  if (!result || typeof result !== "object") return undefined;
+  const contents = (result as Record<string, unknown>).contents;
+  if (Array.isArray(contents)) return contents.length;
+  return undefined;
+}

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Aufwärmen der WSL-Shell-Umgebung…"
 msgid "We have a winner!"
 msgstr "Wir haben einen Gewinner!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Websuche"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -12542,9 +12542,8 @@ msgstr "Warming up WSL shell environment…"
 msgid "We have a winner!"
 msgstr "We have a winner!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Web search"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Preparando el entorno de shell de WSL…"
 msgid "We have a winner!"
 msgstr "¡Tenemos un ganador!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Búsqueda web"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -12536,9 +12536,8 @@ msgstr "Préparation de l'environnement shell WSL…"
 msgid "We have a winner!"
 msgstr "Nous avons un gagnant !"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Recherche sur le Web"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -12535,9 +12535,8 @@ msgstr "WSL シェル環境をウォームアップしています…"
 msgid "We have a winner!"
 msgstr "勝者が決まりました！"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "ウェブ検索"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -12537,9 +12537,8 @@ msgstr "WSL 셸 환경 준비 중…"
 msgid "We have a winner!"
 msgstr "우승자가 결정되었습니다!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "웹 검색"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Rozgrzewanie środowiska powłoki WSL…"
 msgid "We have a winner!"
 msgstr "Mamy zwycięzcę!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Wyszukiwanie w Internecie"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Aquecendo o ambiente shell WSL…"
 msgid "We have a winner!"
 msgstr "Temos um vencedor!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Pesquisa na web"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Подготовка окружения оболочки WSL…"
 msgid "We have a winner!"
 msgstr "У нас есть победитель!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Веб-поиск"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -12537,9 +12537,8 @@ msgstr "WSL kabuk ortamı ısınıyor…"
 msgid "We have a winner!"
 msgstr "Bir kazananımız var!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Web araması"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Підготовка середовища оболонки WSL…"
 msgid "We have a winner!"
 msgstr "У нас є переможець!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Веб-пошук"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -12537,9 +12537,8 @@ msgstr "Đang khởi động môi trường shell WSL…"
 msgid "We have a winner!"
 msgstr "Chúng ta đã có ứng viên thắng!"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "Tìm kiếm trên web"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -12536,9 +12536,8 @@ msgstr "正在预热 WSL shell 环境..."
 msgid "We have a winner!"
 msgstr "优胜者诞生了！"
 
-#: src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
-#: src/renderer/components/thread/ChatPane/parts/items/WebSearchItem.tsx
+#: src/renderer/components/thread/ChatPane/parts/items/webSearchDisplay.ts
 msgid "Web search"
 msgstr "网页搜索"
 

--- a/src/supervisor/agents/acp/canonicalMapping.test.ts
+++ b/src/supervisor/agents/acp/canonicalMapping.test.ts
@@ -1375,6 +1375,33 @@ describe("mapAcpSessionUpdate", () => {
     expect(started.payload.query).toBe("repo:foo bar");
   });
 
+  it("replaces a placeholder web_search query when a later update reveals it", () => {
+    const state = createAcpMapperState("t-ws-late");
+    mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-ws-late",
+        title: "Web search",
+        kind: "search",
+        status: "in_progress",
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const events = mapAcpSessionUpdate(
+      note({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-ws-late",
+        status: "completed",
+        rawInput: { query: "acp tool call update" },
+      } as Parameters<typeof mapAcpSessionUpdate>[0]["update"]),
+      state,
+    );
+    const completed = events.find((event) => event.type === "item.completed");
+    expect((completed?.payload as Record<string, unknown> | undefined)?.query).toBe(
+      "acp tool call update",
+    );
+  });
+
   it("keeps local ACP search tools as generic tool_call rows", () => {
     const state = createAcpMapperState("t-search-local");
     const events = mapAcpSessionUpdate(

--- a/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
+++ b/src/supervisor/agents/acp/canonicalMapping/toolCallPayloads.ts
@@ -125,6 +125,7 @@ export function buildAcpToolCallUpdatePayload(
   toolCall: {
     title?: string | null;
     kind?: string | null;
+    rawInput?: unknown;
     rawOutput?: unknown;
     content?: unknown;
     locations?: Array<{ path?: string | null; line?: number | null }> | null;
@@ -196,6 +197,13 @@ export function buildAcpToolCallUpdatePayload(
       payload.editOldText = primary.oldText;
       payload.editNewText = primary.newText;
     }
+  }
+  if (item.itemType === "web_search") {
+    // Servers that run the search remotely (Grok) only learn the query once the
+    // results come back, so a later `rawInput.query` / `title` has to replace
+    // the placeholder query captured when the call opened.
+    const query = readStringField(toolCall.rawInput, "query") ?? title;
+    if (query) payload.query = query;
   }
   return payload;
 }

--- a/src/supervisor/agents/grok/acpRecord.ts
+++ b/src/supervisor/agents/grok/acpRecord.ts
@@ -1,0 +1,27 @@
+/**
+ * Tolerant readers for Grok's ACP session notifications.
+ *
+ * Grok carries its extensions (goals, subagents, backend web search) as loose
+ * JSON on `SessionNotification.update`, so the transforms treat every field as
+ * unknown and narrow it here rather than trusting the SDK types.
+ */
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+
+export function plainRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function withUpdate(
+  notification: SessionNotification,
+  update: Record<string, unknown>,
+): SessionNotification {
+  return { ...notification, update: update as SessionNotification["update"] };
+}

--- a/src/supervisor/agents/grok/acpTransform.ts
+++ b/src/supervisor/agents/grok/acpTransform.ts
@@ -9,11 +9,14 @@ import {
   withAcpTopLevelToolCall,
 } from "../acp/subagentCoordinator";
 import type { AcpSessionUpdateTransform } from "../base";
+import { plainRecord, readString, withUpdate } from "./acpRecord";
+import { createGrokWebSearchNormalizer } from "./webSearchTransform";
 
 const GROK_SPAWN_SUBAGENT_TOOL = "spawn_subagent";
 
 export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform {
   const subagents = createAcpSubagentCoordinator();
+  const normalizeWebSearch = createGrokWebSearchNormalizer();
   const pendingToolCallIds: string[] = [];
   const childSessionByToolCallId = new Map<string, string>();
   const toolCallIdByChildSession = new Map<string, string>();
@@ -128,6 +131,8 @@ export function createGrokAcpSessionUpdateTransform(): AcpSessionUpdateTransform
     const toolCallId = readString(update, "toolCallId");
     if (!toolCallId) return notification;
     if (isMappedTaskOutput(update, subagents)) return asNoop(notification);
+    const webSearch = normalizeWebSearch(notification, update, toolCallId);
+    if (webSearch) return webSearch;
     const metaTool = plainRecord(plainRecord(update._meta)["x.ai/tool"]);
     const isSpawn =
       readString(metaTool, "name") === GROK_SPAWN_SUBAGENT_TOOL ||
@@ -298,24 +303,6 @@ function withGoalMeta(
 
 function asNoop(notification: SessionNotification): SessionNotification {
   return withUpdate(notification, { sessionUpdate: "session_info_update" });
-}
-
-function withUpdate(
-  notification: SessionNotification,
-  update: Record<string, unknown>,
-): SessionNotification {
-  return { ...notification, update: update as SessionNotification["update"] };
-}
-
-function plainRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function readString(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function readStringArray(record: Record<string, unknown>, key: string): string[] {

--- a/src/supervisor/agents/grok/webSearchTransform.test.ts
+++ b/src/supervisor/agents/grok/webSearchTransform.test.ts
@@ -1,0 +1,138 @@
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { describe, expect, it } from "vitest";
+import { createAcpMapperState, mapAcpSessionUpdate } from "../acp/canonicalMapping";
+import { createGrokAcpSessionUpdateTransform } from "./acpTransform";
+
+const SESSION_ID = "grok-session";
+const TOOL_CALL_ID = "call-web-search";
+
+function notification(update: Record<string, unknown>): SessionNotification {
+  return { sessionId: SESSION_ID, update } as unknown as SessionNotification;
+}
+
+/** Verbatim shape captured from a Grok 0.x ACP backend web search. */
+function searchResult(query: string, urls: string[]): Record<string, unknown> {
+  return {
+    action: {
+      type: "search",
+      query,
+      sources: urls.map((url) => ({ type: "url", url })),
+    },
+    id: "ws_83d64a1d",
+    status: "completed",
+  };
+}
+
+function payloadOf(event: { payload?: unknown } | undefined): Record<string, unknown> {
+  return event?.payload && typeof event.payload === "object" && !Array.isArray(event.payload)
+    ? (event.payload as Record<string, unknown>)
+    : {};
+}
+
+describe("Grok backend web search", () => {
+  it("surfaces the query and visited URLs once the backend returns results", () => {
+    const transform = createGrokAcpSessionUpdateTransform();
+    const state = createAcpMapperState("thread-ws");
+
+    const started = mapAcpSessionUpdate(
+      transform(
+        notification({
+          sessionUpdate: "tool_call",
+          toolCallId: TOOL_CALL_ID,
+          title: "Web search:",
+          kind: "search",
+          status: "in_progress",
+          rawInput: { variant: "WebSearch", backend: true },
+        }),
+      ),
+      state,
+    );
+    const startEvent = started.find((event) => event.type === "item.started");
+    expect(startEvent).toMatchObject({ itemType: "web_search" });
+    // The dangling placeholder separator never reaches the row.
+    expect(payloadOf(startEvent).name).toBe("Web search");
+    expect(payloadOf(startEvent).query).toBe("Web search");
+
+    const completed = mapAcpSessionUpdate(
+      transform(
+        notification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: TOOL_CALL_ID,
+          status: "completed",
+          rawOutput: searchResult("best electric toothbrush 2026", [
+            "https://www.nytimes.com/wirecutter/reviews/best-electric-toothbrush/",
+            "https://www.consumerreports.org/health/toothbrushes/",
+          ]),
+        }),
+      ),
+      state,
+    );
+    const completedPayload = payloadOf(completed.find((event) => event.type === "item.completed"));
+    expect(completedPayload.query).toBe("best electric toothbrush 2026");
+    // The completion carries no new name: the tool keeps the one it opened with,
+    // so the row can render `Web search: <query>`.
+    expect(completedPayload).not.toHaveProperty("name");
+    expect(completedPayload.args).toEqual({
+      variant: "WebSearch",
+      backend: true,
+      query: "best electric toothbrush 2026",
+    });
+    // One content block per source: the renderer counts these and lists them.
+    expect(completedPayload.result).toMatchObject({
+      contents: [
+        {
+          type: "text",
+          text: "https://www.nytimes.com/wirecutter/reviews/best-electric-toothbrush/",
+        },
+        { type: "text", text: "https://www.consumerreports.org/health/toothbrushes/" },
+      ],
+    });
+  });
+
+  it("leaves non-web-search tool calls untouched", () => {
+    const transform = createGrokAcpSessionUpdateTransform();
+    const update = {
+      sessionUpdate: "tool_call",
+      toolCallId: "call-read",
+      title: "Read file:",
+      kind: "read",
+      status: "in_progress",
+      rawInput: { path: "README.md" },
+    };
+    expect(transform(notification(update)).update).toEqual(update);
+  });
+
+  it("normalizes a resumed search whose opening tool_call was never seen", () => {
+    const transform = createGrokAcpSessionUpdateTransform();
+    const state = createAcpMapperState("thread-ws-resume");
+
+    mapAcpSessionUpdate(
+      transform(
+        notification({
+          sessionUpdate: "tool_call",
+          toolCallId: TOOL_CALL_ID,
+          title: "Web search:",
+          kind: "search",
+          status: "in_progress",
+        }),
+      ),
+      state,
+    );
+    const completed = mapAcpSessionUpdate(
+      transform(
+        notification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: TOOL_CALL_ID,
+          status: "completed",
+          rawOutput: searchResult("acp spec tool_call_update", [
+            "https://agentclientprotocol.com/",
+          ]),
+        }),
+      ),
+      state,
+    );
+    const completedPayload = payloadOf(completed.find((event) => event.type === "item.completed"));
+    expect(completedPayload.query).toBe("acp spec tool_call_update");
+    expect(completedPayload.args).toEqual({ query: "acp spec tool_call_update" });
+  });
+});

--- a/src/supervisor/agents/grok/webSearchTransform.ts
+++ b/src/supervisor/agents/grok/webSearchTransform.ts
@@ -1,0 +1,95 @@
+/**
+ * Normalize Grok's backend web-search tool calls into the provider-agnostic
+ * shape the shared ACP mapper already understands.
+ *
+ * Grok runs web search server-side, so the opening `tool_call` knows nothing
+ * about the search yet: it carries `rawInput: { variant: "WebSearch", backend:
+ * true }` plus the placeholder title `"Web search:"` (the CLI formats
+ * `Web search: <query>` before the query exists). The mapper therefore records
+ * `query: "Web search:"` and the row stays that way — the actual query and the
+ * pages that were consulted only arrive later under `rawOutput.action`, where
+ * they end up as an opaque JSON blob.
+ *
+ * This transform bridges the two ends: it drops the dangling placeholder on the
+ * way in, and on the way out lifts `action.query` onto `rawInput.query` (the
+ * mapper's canonical query source) and the visited URLs onto `rawOutput.contents`
+ * text blocks — the one-block-per-result shape the renderer already counts and
+ * lists for other providers. The tool's own title stays the tool name so the row
+ * can still label itself `Web search: <query>`.
+ */
+
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { plainRecord, readString, withUpdate } from "./acpRecord";
+
+/** `rawInput.variant` Grok stamps on every backend web-search tool call. */
+const GROK_WEB_SEARCH_VARIANT = "WebSearch";
+
+interface GrokSearchAction {
+  query: string | undefined;
+  /** Pages the backend consulted, in the order Grok reported them. */
+  urls: string[];
+}
+
+export type GrokWebSearchNormalizer = (
+  notification: SessionNotification,
+  update: Record<string, unknown>,
+  toolCallId: string,
+) => SessionNotification | undefined;
+
+/**
+ * Returns the rewritten notification for Grok web-search tool calls, or
+ * `undefined` when the notification belongs to any other tool.
+ */
+export function createGrokWebSearchNormalizer(): GrokWebSearchNormalizer {
+  // `tool_call_update` omits the launch `rawInput`, so keep it around to merge
+  // the query into rather than replacing the tool's own arguments.
+  const rawInputByToolCallId = new Map<string, Record<string, unknown>>();
+
+  return (notification, update, toolCallId) => {
+    const rawInput = plainRecord(update.rawInput);
+    const action = readGrokSearchAction(update.rawOutput);
+    const known = rawInputByToolCallId.has(toolCallId);
+    if (!known && rawInput.variant !== GROK_WEB_SEARCH_VARIANT && !action) return undefined;
+    if (!known || Object.keys(rawInput).length > 0) {
+      rawInputByToolCallId.set(toolCallId, rawInput);
+    }
+
+    const next: Record<string, unknown> = { ...update };
+    const title = readString(update, "title");
+    const stripped = title ? stripPlaceholderSuffix(title) : undefined;
+    if (stripped) next.title = stripped;
+    if (action?.query) {
+      next.rawInput = { ...rawInputByToolCallId.get(toolCallId), query: action.query };
+    }
+    if (action && action.urls.length > 0) {
+      next.rawOutput = {
+        ...plainRecord(update.rawOutput),
+        contents: action.urls.map((url) => ({ type: "text", text: url })),
+      };
+    }
+    if (update.status === "completed" || update.status === "failed") {
+      rawInputByToolCallId.delete(toolCallId);
+    }
+    return withUpdate(notification, next);
+  };
+}
+
+function readGrokSearchAction(rawOutput: unknown): GrokSearchAction | undefined {
+  const action = plainRecord(plainRecord(rawOutput).action);
+  if (readString(action, "type") !== "search") return undefined;
+  const sources = Array.isArray(action.sources) ? action.sources : [];
+  const urls = sources
+    .map((source) => readString(plainRecord(source), "url"))
+    .filter((url): url is string => url !== undefined);
+  return { query: readString(action, "query"), urls };
+}
+
+/**
+ * Trim the trailing separator left behind when Grok formats a title around a
+ * value it doesn't have yet (`"Web search:"`). Returns `undefined` when there is
+ * nothing to trim, so the caller keeps the agent's own title untouched.
+ */
+function stripPlaceholderSuffix(title: string): string | undefined {
+  const trimmed = title.replace(/[\s:]+$/, "");
+  return trimmed.length > 0 && trimmed !== title ? trimmed : undefined;
+}


### PR DESCRIPTION
- Normalize Grok's server-side web search tool calls into the provider-agnostic canonical `web_search` shape the shared ACP mapper understands.
- Replace the placeholder query captured when a web search tool call opens once a later update reveals the real query (Grok learns it only when results return).
- Extract shared web-search title/result-count derivation into `webSearchDisplay.ts` so the standalone accordion and grouped inline row can't drift, and stop rendering "Web search: Web search" placeholder rows.
- Update all 12 non-English i18n catalogs and add unit tests for the Grok transforms and display logic.