### PR TITLE
Add sub-agent resume rows to Claude transcripts

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.test.ts
@@ -214,6 +214,34 @@ describe("deriveToolDisplay", () => {
     expect(deriveToolDisplay(payload).title).toBe("Agent (rubber-duck): Critiquing path fixes");
   });
 
+  it("labels a resumed sub-agent distinctly from a fresh launch", () => {
+    // Claude Code's SendMessage resuming an agent: the args name the agent, not
+    // the run, so the provider supplies the send's summary plus the type.
+    const payload = makePayload({
+      name: "SendMessage",
+      title: "list repo files",
+      subAgentType: "general-purpose",
+      isSubAgent: true,
+      isSubAgentResume: true,
+      args: { to: "af31fc7876375a53a", message: "…", summary: "list repo files" },
+    });
+
+    expect(isSubAgentTool(payload)).toBe(true);
+    expect(deriveToolDisplay(payload).title).toBe(
+      "Agent Resume (general-purpose): list repo files",
+    );
+  });
+
+  it("does not label a fresh Agent launch as a resume", () => {
+    const payload = makePayload({
+      name: "Agent",
+      isSubAgent: true,
+      args: { description: "probe worker alpha", subagent_type: "general-purpose" },
+    });
+
+    expect(deriveToolDisplay(payload).title).toBe("Agent (general-purpose): probe worker alpha");
+  });
+
   it("keeps Crossagents distinct from native subagents", () => {
     const payload = makePayload({
       name: "Critiquing path fixes",

--- a/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+++ b/src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
@@ -126,6 +126,8 @@ export function deriveToolDisplay(payload: ToolCallPayload): ToolDisplay {
       title: formatAgentTitle(args, payload.title?.trim() || payload.name.trim(), {
         preferFallback: payload.title !== undefined,
         isCrossagent: payload.isCrossagent === true,
+        isResume: payload.isSubAgentResume === true,
+        ...(payload.subAgentType ? { subAgentType: payload.subAgentType } : {}),
       }),
       Icon: Bot,
     };
@@ -333,13 +335,28 @@ function formatGrepDisplay(args: Record<string, unknown> | undefined): ToolDispl
 function formatAgentTitle(
   args: Record<string, unknown> | undefined,
   fallbackDescription?: string,
-  options?: { preferFallback?: boolean; isCrossagent?: boolean },
+  options?: {
+    preferFallback?: boolean;
+    isCrossagent?: boolean;
+    isResume?: boolean;
+    subAgentType?: string;
+  },
 ): string {
   const argsDescription = readStr(args, "description");
   const description = options?.preferFallback
     ? (fallbackDescription ?? argsDescription)
     : (argsDescription ?? fallbackDescription);
-  const subagent = readSubAgentType(args);
+  const subagent = readSubAgentType(args) ?? options?.subAgentType;
+  // A resume continues an agent that already has a row above it. Labelling it
+  // "Agent" too would read as a second, unrelated agent.
+  if (options?.isResume) {
+    if (description) {
+      return subagent
+        ? i18n._(msg`Agent Resume (${subagent}): ${description}`)
+        : i18n._(msg`Agent Resume: ${description}`);
+    }
+    return subagent ? i18n._(msg`Agent Resume: ${subagent}`) : i18n._(msg`Agent Resume`);
+  }
   if (options?.isCrossagent) {
     if (description) {
       return subagent

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Agent nicht gefunden"
 msgid "Agent Registry"
 msgstr "Agentenregister"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Agent-Fortsetzung"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Agent-Fortsetzung ({subagent}):{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Agent-Fortsetzung:{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Agent-Fortsetzung:{subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1038,6 +1038,22 @@ msgstr "Agent not found"
 msgid "Agent Registry"
 msgstr "Agent Registry"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Agent Resume"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Agent Resume ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Agent Resume: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Agent Resume: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Agente no encontrado"
 msgid "Agent Registry"
 msgstr "Registro de agentes"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Agente reanudado"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Agente reanudado ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Agente reanudado: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Agente reanudado: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Agent introuvable"
 msgid "Agent Registry"
 msgstr "Registre des agents"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Agent repris"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Agent repris ({subagent}) : {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Agent repris : {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Agent repris : {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1032,6 +1032,22 @@ msgstr "エージェントが見つかりません"
 msgid "Agent Registry"
 msgstr "エージェントレジストリ"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "エージェント再開"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "エージェント再開 ({subagent}):{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "エージェント再開:{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "エージェント再開:{subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1033,6 +1033,22 @@ msgstr "에이전트를 찾을 수 없습니다."
 msgid "Agent Registry"
 msgstr "에이전트 레지스트리"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "에이전트 재개"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "에이전트 재개 ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "에이전트 재개: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "에이전트 재개: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Nie znaleziono agenta"
 msgid "Agent Registry"
 msgstr "Rejestr agentów"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Wznowienie agenta"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Wznowienie agenta ({subagent}):{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Wznowienie agenta:{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Wznowienie agenta:{subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Agente não encontrado"
 msgid "Agent Registry"
 msgstr "Registro de Agente"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Agente retomado"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Agente retomado ({subagent}):{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Agente retomado:{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Agente retomado:{subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Агент не найден"
 msgid "Agent Registry"
 msgstr "Реестр агентов"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Агент возобновлён"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Агент возобновлён ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Агент возобновлён: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Агент возобновлён: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Temsilci bulunamadı"
 msgid "Agent Registry"
 msgstr "Temsilci Kaydı"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Temsilci sürdürme"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Temsilci sürdürme ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Temsilci sürdürme: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Temsilci sürdürme: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Агента не знайдено"
 msgid "Agent Registry"
 msgstr "Реєстр агентів"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Агент продовжено"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Агент продовжено ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Агент продовжено: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Агент продовжено: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1033,6 +1033,22 @@ msgstr "Không tìm thấy tác nhân"
 msgid "Agent Registry"
 msgstr "Sổ đăng ký tác nhân"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "Tiếp tục tác nhân"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "Tiếp tục tác nhân ({subagent}): {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "Tiếp tục tác nhân: {description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "Tiếp tục tác nhân: {subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1033,6 +1033,22 @@ msgstr "未找到代理"
 msgid "Agent Registry"
 msgstr "代理注册表"
 
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume"
+msgstr "继续代理"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume ({subagent}): {description}"
+msgstr "继续代理 ({subagent})：{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {description}"
+msgstr "继续代理：{description}"
+
+#: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
+msgid "Agent Resume: {subagent}"
+msgstr "继续代理：{subagent}"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Agent terminal font size"

--- a/src/shared/contracts/runtimeEvent.ts
+++ b/src/shared/contracts/runtimeEvent.ts
@@ -262,6 +262,19 @@ export const toolCallPayloadSchema = z.object({
   status: toolCallStatusSchema,
   progress: toolCallProgressSchema.optional(),
   isSubAgent: z.boolean().optional(),
+  /**
+   * This agent row CONTINUES an earlier run instead of launching a new agent —
+   * e.g. Claude Code's `SendMessage` resuming a completed sub-agent from its
+   * transcript. Without it a resume is indistinguishable from a fresh launch in
+   * the transcript. Absent on rows persisted before resumes were recognized;
+   * those keep rendering as plain agent rows, which is what they were.
+   */
+  isSubAgentResume: z.boolean().optional(),
+  /**
+   * Provider-reported sub-agent type for rows whose own tool args don't carry
+   * one (a resume names the agent, not its type).
+   */
+  subAgentType: z.string().min(1).optional(),
   isCrossagent: z.boolean().optional(),
   workflow: toolCallWorkflowSchema.optional(),
 });

--- a/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/dispatch.ts
@@ -31,9 +31,14 @@ import {
   applyTaskUpdated,
   mapPermissionDenied,
   registerSubAgentTaskIfNeeded,
+  resolveSubAgentParentToolUseId,
 } from "./taskLifecycle";
 import { completeTextItem, ensureTextItem, closeClaudeOpenItems } from "./textItems";
-import { createToolItemState, hasToolCallPayload, isSubAgentToolName } from "./toolClassification";
+import {
+  createToolItemState,
+  hasToolCallPayload,
+  isSubAgentParentTool,
+} from "./toolClassification";
 import { startToolItem, syncSubAgentModelProgress } from "./toolItems";
 import { toolPayload } from "./toolPayload";
 import { createClaudeUsageSpentEvent, readClaudeAssistantSpendTokens } from "./usageSpent";
@@ -90,7 +95,19 @@ export function mapClaudeSdkMessage(
   options?: ClaudeSdkMessageMappingOptions,
 ): RuntimeEvent[] {
   const events = mapClaudeSdkMessageInner(message, state, options);
-  return tagParent(events, readParentToolUseId(message), state);
+  return tagParent(events, readSubAgentParentItemId(message, state), state);
+}
+
+/**
+ * The parent row a forwarded sub-agent message belongs to. A resumed agent's
+ * children still name the tool that originally launched it, so route through
+ * the alias to whichever row currently owns the run.
+ */
+function readSubAgentParentItemId(
+  message: SDKMessage,
+  state: ClaudeMapperState,
+): string | undefined {
+  return resolveSubAgentParentToolUseId(state, readParentToolUseId(message));
 }
 
 /**
@@ -189,10 +206,10 @@ function syncSubAgentModelFromChildAssistant(
   message: SDKMessage,
   state: ClaudeMapperState,
 ): RuntimeEvent[] {
-  const parentToolUseId = readParentToolUseId(message);
+  const parentToolUseId = readSubAgentParentItemId(message, state);
   if (!parentToolUseId) return [];
   const tool = state.toolItemsById.get(parentToolUseId);
-  if (!tool || !isSubAgentToolName(tool.toolName)) return [];
+  if (!tool || !isSubAgentParentTool(tool)) return [];
   if (tool.progress?.model) return [];
   const inner = (message as { message?: unknown }).message;
   if (!inner || typeof inner !== "object") return [];

--- a/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/taskLifecycle.ts
@@ -1,7 +1,11 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { RuntimeEvent, ToolCallProgress } from "@/shared/contracts";
 import type { ClaudeMapperState, ToolItemState } from "../sdkCanonicalMappingState";
-import { classifyToolItemType, isSubAgentToolName } from "./toolClassification";
+import {
+  classifyToolItemType,
+  isAgentAddressableToolName,
+  isSubAgentToolName,
+} from "./toolClassification";
 import { syncSubAgentModelProgress } from "./toolItems";
 import { toolPayload } from "./toolPayload";
 
@@ -98,6 +102,7 @@ export function applyTaskLifecycle(message: SDKMessage, state: ClaudeMapperState
 function unregisterSubAgentTask(state: ClaudeMapperState, taskId: string, toolUseId: string): void {
   state.activeSubAgentTaskToTool?.delete(taskId);
   state.activeSubAgentToolToTask?.delete(toolUseId);
+  forgetSubAgentParentAlias(state, taskId);
 }
 
 /**
@@ -106,9 +111,20 @@ function unregisterSubAgentTask(state: ClaudeMapperState, taskId: string, toolUs
  * genuine subagent launches register: a `task_started` WITHOUT `subagent_type`
  * (a plain background Bash task) whose tool is not a subagent-like tool is
  * ignored so it still completes normally when its tool_result arrives.
+ *
+ * A `SendMessage` that resumes a completed sub-agent reports the resumed run
+ * against its OWN tool_use id, so the binding also promotes that row to a
+ * sub-agent parent (see {@link isAgentAddressableToolName}) and titles it from
+ * the run's description. A send that resumes nothing emits no `task_started`,
+ * never registers, and completes as an ordinary tool row.
  */
 export function registerSubAgentTaskIfNeeded(message: SDKMessage, state: ClaudeMapperState): void {
-  const obj = message as { task_id?: unknown; tool_use_id?: unknown; subagent_type?: unknown };
+  const obj = message as {
+    task_id?: unknown;
+    tool_use_id?: unknown;
+    subagent_type?: unknown;
+    description?: unknown;
+  };
   const taskId =
     typeof obj.task_id === "string" && obj.task_id.length > 0 ? obj.task_id : undefined;
   const toolUseId =
@@ -120,6 +136,77 @@ export function registerSubAgentTaskIfNeeded(message: SDKMessage, state: ClaudeM
   if (!hasSubagentType && !toolIsSubAgent) return;
   (state.activeSubAgentTaskToTool ??= new Map<string, string>()).set(taskId, toolUseId);
   (state.activeSubAgentToolToTask ??= new Map<string, string>()).set(toolUseId, taskId);
+  rememberSubAgentParent(state, taskId, toolUseId);
+  if (!tool || toolIsSubAgent || !isAgentAddressableToolName(tool.toolName)) return;
+  tool.subAgentParent = true;
+  const subagentType = readNonEmptyString(obj.subagent_type);
+  if (subagentType) tool.subAgentType = subagentType;
+  // The send's own `summary` describes THIS message; `task_started.description`
+  // is frozen at the agent's original spawn, so leading with it would label
+  // every resume of one agent identically.
+  const title =
+    readNonEmptyString(tool.input.summary) ?? readNonEmptyString(obj.description) ?? subagentType;
+  if (title) tool.subAgentTitle = title;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+const MAX_TRACKED_SUBAGENT_LAUNCHES = 500;
+
+/**
+ * Track which tool call currently owns a sub-agent task. The first
+ * `task_started` records the launch tool; a later one for the same task means
+ * the agent was resumed by a different tool (`SendMessage`), so the launch id
+ * is aliased forward. The resumed run's forwarded children keep naming the
+ * ORIGINAL launch id in `parent_tool_use_id`, and that row was completed and
+ * dropped when the first run ended — the alias is what re-points them at the
+ * live row. Verified against the SDK: a resumed agent's `Glob`/`Read` children
+ * carry the launch `Agent` tool_use id while its `task_progress` carries the
+ * `SendMessage` id.
+ */
+function rememberSubAgentParent(state: ClaudeMapperState, taskId: string, toolUseId: string): void {
+  const launches = (state.subAgentTaskLaunchTools ??= new Map<string, string>());
+  const launchToolUseId = launches.get(taskId);
+  if (!launchToolUseId) {
+    // Bounded: one entry per sub-agent ever launched in this session.
+    if (launches.size >= MAX_TRACKED_SUBAGENT_LAUNCHES) launches.clear();
+    launches.set(taskId, toolUseId);
+    return;
+  }
+  if (launchToolUseId === toolUseId) return;
+  (state.subAgentParentAliases ??= new Map<string, string>()).set(launchToolUseId, toolUseId);
+}
+
+/**
+ * Follow {@link ClaudeMapperState.subAgentParentAliases} to the tool call that
+ * currently owns a sub-agent run. Returns the input unchanged when it is still
+ * live (or has no alias), so ordinary nesting is untouched. The hop limit
+ * guards against a cycle if a tool id were ever reused.
+ */
+export function resolveSubAgentParentToolUseId(
+  state: ClaudeMapperState,
+  parentToolUseId: string | undefined,
+): string | undefined {
+  if (!parentToolUseId) return parentToolUseId;
+  if (state.toolItemsById.has(parentToolUseId)) return parentToolUseId;
+  const aliases = state.subAgentParentAliases;
+  if (!aliases || aliases.size === 0) return parentToolUseId;
+  let current = parentToolUseId;
+  for (let hop = 0; hop < 8; hop += 1) {
+    const next = aliases.get(current);
+    if (!next || next === current) return current;
+    current = next;
+    if (state.toolItemsById.has(current)) return current;
+  }
+  return current;
+}
+
+/** Drop a superseded-parent alias once its run is closed for good. */
+export function forgetSubAgentParentAlias(state: ClaudeMapperState, taskId: string): void {
+  const launchToolUseId = state.subAgentTaskLaunchTools?.get(taskId);
+  if (launchToolUseId) state.subAgentParentAliases?.delete(launchToolUseId);
 }
 
 /**

--- a/src/supervisor/agents/claude/canonicalMapping/toolClassification.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/toolClassification.ts
@@ -23,6 +23,35 @@ export function isSubAgentToolName(toolName: string): boolean {
   );
 }
 
+/**
+ * Tools that address an existing agent rather than launching one. `SendMessage`
+ * resumes a completed sub-agent from its transcript, and the resumed run
+ * reports its `task_started` / `task_notification` against the SendMessage
+ * tool_use id — so such a row can become an agent row mid-flight.
+ *
+ * A canonical item type is fixed at `item.started`, before we know whether the
+ * send actually resumed anything, so these open as `tool_call` (the item type
+ * the renderer draws agent rows from). The payload's `isSubAgent` flag — set
+ * only once a task binds — decides which row is actually drawn.
+ */
+export function isAgentAddressableToolName(toolName: string): boolean {
+  const name = toolName.toLowerCase();
+  if (parseMcpToolName(name)) return false;
+  return name === "sendmessage" || name === "send_message";
+}
+
+/**
+ * Whether a tool item is the sub-agent row itself: a launch tool, or a tool a
+ * `task_started` promoted (see {@link isAgentAddressableToolName}). MCP calls
+ * are never promoted — a Crossagents spawn owns its own row treatment.
+ */
+export function isSubAgentParentTool(
+  tool: Pick<ToolItemState, "toolName" | "subAgentParent">,
+): boolean {
+  if (isSubAgentToolName(tool.toolName)) return true;
+  return tool.subAgentParent === true && !parseMcpToolName(tool.toolName.toLowerCase());
+}
+
 function parseMcpToolName(name: string): { server: string; tool: string } | undefined {
   const canonical = /^mcp__(.+?)__(.+)$/.exec(name);
   if (canonical) return { server: canonical[1]!, tool: canonical[2]! };
@@ -34,7 +63,7 @@ function parseMcpToolName(name: string): { server: string; tool: string } | unde
 export function classifyToolItemType(toolName: string): CanonicalItemType {
   const name = toolName.toLowerCase();
   if (name === "todowrite" || name.includes("todo")) return "plan";
-  if (isSubAgentToolName(name)) {
+  if (isSubAgentToolName(name) || isAgentAddressableToolName(name)) {
     return "tool_call";
   }
   if (

--- a/src/supervisor/agents/claude/canonicalMapping/toolItems.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/toolItems.ts
@@ -2,7 +2,7 @@ import type { RuntimeEvent } from "@/shared/contracts";
 import { readStringField } from "../../fileChangeSummary";
 import type { ClaudeMapperState, ToolItemState } from "../sdkCanonicalMappingState";
 import { applyPlanAggregatorInput } from "./planMapping";
-import { isSubAgentToolName } from "./toolClassification";
+import { isSubAgentParentTool } from "./toolClassification";
 import { toolPayload } from "./toolPayload";
 
 /**
@@ -50,7 +50,7 @@ export function startToolItem(
 }
 
 export function syncSubAgentModelProgress(tool: ToolItemState): void {
-  if (!isSubAgentToolName(tool.toolName)) return;
+  if (!isSubAgentParentTool(tool)) return;
   const model = readStringField(tool.input, "model");
   if (!model) return;
   tool.progress = { ...tool.progress, model };

--- a/src/supervisor/agents/claude/canonicalMapping/toolPayload.ts
+++ b/src/supervisor/agents/claude/canonicalMapping/toolPayload.ts
@@ -1,7 +1,7 @@
 import { readDiffSummary, readFileChangePath } from "../../fileChangeSummary";
 import type { ToolItemState } from "../sdkCanonicalMappingState";
 import { extractPlanSteps, summarizeToolRequest } from "./helpers";
-import { inferFileChangeKind, inferToolKind, isSubAgentToolName } from "./toolClassification";
+import { inferFileChangeKind, inferToolKind, isSubAgentParentTool } from "./toolClassification";
 
 export function toolPayload(
   tool: ToolItemState,
@@ -57,13 +57,17 @@ export function toolPayload(
   const kind = inferToolKind(tool.toolName);
   return {
     name: tool.toolName,
+    ...(tool.subAgentTitle ? { title: tool.subAgentTitle } : {}),
     ...(kind ? { kind } : {}),
     args: tool.input,
     result,
     ...(images && images.length > 0 ? { images } : {}),
     status,
     ...(tool.progress ? { progress: tool.progress } : {}),
-    ...(isSubAgentToolName(tool.toolName) ? { isSubAgent: true } : {}),
+    ...(isSubAgentParentTool(tool) ? { isSubAgent: true } : {}),
+    // Only a promoted row is a resume; a native Agent/Task/Workflow launch is not.
+    ...(tool.subAgentParent === true ? { isSubAgentResume: true } : {}),
+    ...(tool.subAgentType ? { subAgentType: tool.subAgentType } : {}),
     ...(tool.workflow ? { workflow: tool.workflow } : {}),
   };
 }

--- a/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMapping.test.ts
@@ -2672,6 +2672,226 @@ describe("sdkCanonicalMapping — background sub-agents", () => {
     expect(state.activeSubAgentToolToTask?.has("toolu_parent") ?? false).toBe(false);
   });
 
+  /**
+   * `SendMessage` resumes a completed sub-agent from its transcript. The
+   * resumed run reports `task_started` / `task_notification` against the
+   * SendMessage tool_use id, so that row must become an agent row — otherwise
+   * the resumed agent shows as a raw tool call and never reaches the composer's
+   * active-sub-agent dock (which keys off `isSubAgent`).
+   */
+  function startSendMessageTool(
+    state: ReturnType<typeof createClaudeMapperState>,
+    toolUseId: string,
+  ): RuntimeEvent[] {
+    return mapClaudeSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: toolUseId,
+          name: "SendMessage",
+          input: { to: "af31fc7876375a53a", message: "keep going", summary: "ask for more" },
+        },
+      }),
+      state,
+    );
+  }
+
+  it("promotes a SendMessage that resumes a sub-agent to an agent row", () => {
+    const state = createClaudeMapperState("thread-1");
+    const started = startSendMessageTool(state, "toolu_send");
+    // Opens as tool_call (the item type agent rows are drawn from) but is not
+    // yet an agent row — the send may not resume anything.
+    expect(started).toMatchObject([
+      {
+        type: "item.started",
+        itemId: "toolu_send",
+        itemType: "tool_call",
+        payload: { name: "SendMessage", status: "running" },
+      },
+    ]);
+    expect(
+      (started[0] as { payload: { isSubAgent?: boolean } }).payload.isSubAgent,
+    ).toBeUndefined();
+
+    const bound = mapClaudeSdkMessage(taskStarted("toolu_send", "general-purpose"), state);
+    expect(bound).toMatchObject([
+      {
+        type: "item.updated",
+        itemId: "toolu_send",
+        payload: {
+          name: "SendMessage",
+          // The send's own summary, not the agent's frozen spawn description.
+          title: "ask for more",
+          subAgentType: "general-purpose",
+          status: "running",
+          isSubAgent: true,
+          isSubAgentResume: true,
+          progress: { description: "Investigate" },
+        },
+      },
+    ]);
+
+    // The send's own tool_result must not close the row — the resumed run is
+    // still going, and its task_notification owns the close.
+    const resultEvents = mapClaudeSdkMessage(launchToolResult("toolu_send"), state);
+    expect(resultEvents.some((e) => e.type === "item.completed")).toBe(false);
+    expect(state.toolItemsById.has("toolu_send")).toBe(true);
+
+    const closed = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_send",
+        status: "completed",
+        summary: "Recomputed per model",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(closed).toMatchObject([
+      { type: "item.updated", itemId: "toolu_send", payload: { status: "success" } },
+      {
+        type: "item.completed",
+        itemId: "toolu_send",
+        payload: {
+          status: "success",
+          isSubAgent: true,
+          isSubAgentResume: true,
+          title: "ask for more",
+        },
+      },
+    ]);
+    expect(state.toolItemsById.has("toolu_send")).toBe(false);
+  });
+
+  it("re-parents a resumed agent's children from the dead launch row to the resume row", () => {
+    const state = createClaudeMapperState("thread-1");
+    // Run 1: a normal Agent launch that completes and is dropped from state.
+    startAgentTool(state, "toolu_launch");
+    mapClaudeSdkMessage(taskStarted("toolu_launch", "general-purpose"), state);
+    mapClaudeSdkMessage(launchToolResult("toolu_launch"), state);
+    mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_notification",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_launch",
+        status: "completed",
+        summary: "ALPHA",
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(state.toolItemsById.has("toolu_launch")).toBe(false);
+
+    // Run 2: SendMessage resumes the SAME task under a new tool_use id.
+    startSendMessageTool(state, "toolu_send");
+    mapClaudeSdkMessage(taskStarted("toolu_send", "general-purpose"), state);
+
+    // The resumed run's forwarded children still name the ORIGINAL launch id.
+    const childEvents = mapClaudeSdkMessage(
+      {
+        type: "assistant",
+        session_id: "claude-session",
+        parent_tool_use_id: "toolu_launch",
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-6",
+          content: [
+            { type: "tool_use", id: "toolu_child", name: "Glob", input: { pattern: "*.json" } },
+          ],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+    const childStart = childEvents.find(
+      (e) => e.type === "item.started" && e.itemId === "toolu_child",
+    );
+    // Without the alias this would be "toolu_launch" — a row the renderer has
+    // already closed, so the child would nest under the finished agent.
+    expect(childStart).toMatchObject({ parentItemId: "toolu_send" });
+    // …and the live row is the one whose step counter ticks.
+    expect(
+      childEvents.some(
+        (e) =>
+          e.type === "item.updated" &&
+          e.itemId === "toolu_send" &&
+          (e.payload as { progress?: { stepCount?: number } }).progress?.stepCount === 1,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps live task_progress on the resume row (steps, last tool, description)", () => {
+    const state = createClaudeMapperState("thread-1");
+    startSendMessageTool(state, "toolu_send");
+    mapClaudeSdkMessage(taskStarted("toolu_send", "general-purpose"), state);
+
+    const events = mapClaudeSdkMessage(
+      {
+        type: "system",
+        subtype: "task_progress",
+        session_id: "claude-session",
+        task_id: "task-A",
+        tool_use_id: "toolu_send",
+        description: "Finding *.json",
+        last_tool_name: "Glob",
+        usage: { total_tokens: 30_521, tool_uses: 2, duration_ms: 27_341 },
+      } as unknown as SDKMessage,
+      state,
+    );
+    expect(events).toMatchObject([
+      {
+        type: "item.updated",
+        itemId: "toolu_send",
+        payload: {
+          isSubAgent: true,
+          status: "running",
+          progress: {
+            description: "Finding *.json",
+            lastToolName: "Glob",
+            stepCount: 2,
+            toolUses: 2,
+            tokens: 30_521,
+          },
+        },
+      },
+    ]);
+  });
+
+  it("leaves a SendMessage that resumed nothing as a plain tool row", () => {
+    const state = createClaudeMapperState("thread-1");
+    startSendMessageTool(state, "toolu_send");
+    // No task_started: an unreachable name, or a message to a teammate that is
+    // already running, starts no new run.
+    const events = mapClaudeSdkMessage(
+      {
+        type: "user",
+        session_id: "claude-session",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_send",
+              content: '{"success":false,"message":"No agent named \'probe\' is reachable."}',
+            },
+          ],
+        },
+      } as unknown as SDKMessage,
+      state,
+    );
+    const updated = events.find((e) => e.type === "item.updated");
+    expect(updated).toMatchObject({ payload: { name: "SendMessage", status: "success" } });
+    expect(
+      (updated as { payload: { isSubAgent?: boolean; title?: string } }).payload.isSubAgent,
+    ).toBeUndefined();
+    expect(events.some((e) => e.type === "item.completed" && e.itemId === "toolu_send")).toBe(true);
+    expect(state.toolItemsById.has("toolu_send")).toBe(false);
+  });
+
   it("preserves structured Workflow launch metadata through the task lifecycle", () => {
     const state = createClaudeMapperState("thread-1");
     startAgentTool(state, "toolu_wf", "Workflow");

--- a/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
+++ b/src/supervisor/agents/claude/sdkCanonicalMappingState.ts
@@ -48,6 +48,29 @@ export interface ToolItemState {
    */
   fileChangeMetadata?: FileChangeMetadata;
   /**
+   * Set when a `task_started` bound this tool call to a live sub-agent run even
+   * though the tool is not itself a launch tool. `SendMessage` resumes a
+   * completed sub-agent from its transcript, and the resumed run reports
+   * `task_started` / `task_notification` against the *SendMessage* tool_use id
+   * — so that row is an agent row, not a plain tool row. A send that resumes
+   * nothing (unreachable name, message to a live teammate) gets no
+   * `task_started` and stays unflagged.
+   */
+  subAgentParent?: boolean;
+  /**
+   * Display title for a promoted sub-agent parent. Prefers the send's own
+   * `summary` — the recap of what THIS message asked for — because the resumed
+   * run's `task_started` description is frozen at the agent's original spawn,
+   * so every resume of one agent would otherwise carry an identical, stale
+   * label.
+   */
+  subAgentTitle?: string;
+  /**
+   * Sub-agent type reported by `task_started`, kept because a promoted row's
+   * own tool args name the agent, not its type.
+   */
+  subAgentType?: string;
+  /**
    * Structured launch metadata from a `Workflow` tool's `tool_use_result`
    * (SDK `WorkflowOutput`). Kept on the tool state so every later payload —
    * task_progress updates and the closing task_notification — still carries
@@ -59,6 +82,21 @@ export interface ToolItemState {
 
 export interface ClaudeMapperState {
   threadId: string;
+  /**
+   * First tool_use id that launched each sub-agent task, kept for the life of
+   * the session. A resumed run reports a NEW `tool_use_id` (the `SendMessage`
+   * call), but its forwarded children still carry the ORIGINAL launch id in
+   * `parent_tool_use_id` — so this is what lets a resume recognize that it
+   * supersedes an earlier row. See {@link subAgentParentAliases}.
+   */
+  subAgentTaskLaunchTools?: Map<string, string>;
+  /**
+   * Superseded sub-agent parent tool id → the tool id that currently owns the
+   * run. Children of a resumed agent name the original launch tool, which was
+   * completed and dropped when the first run finished; without this redirect
+   * they would nest under that dead row instead of the live resume row.
+   */
+  subAgentParentAliases?: Map<string, string>;
   /**
    * Per-call usage scope (SDK session id + epoch) for `usage.spent` emission.
    * Owned by the session layer (sdkSession.ts); undefined in tests/terminal


### PR DESCRIPTION
- Recognize resumed sub-agent runs in the Claude adapter: `task_started` events that continue an earlier agent are promoted to a live resume row via a parent tool-use alias redirect, so follow-up events nest under the live row instead of the dead launch.
- Distinguish resume rows from fresh launches in the shared contract (`isSubAgentResume`, `subAgentType`) so payloads carry resume metadata and a provider-reported agent type.
- Render new "Agent Resume" labels in the chat transcript while keeping fresh Agent launches labeled as plain agents; classify agent-addressing tools (e.g. SendMessage) as tool calls.
- Localize the new strings across all 12 non-English catalogs.
- Add tests covering resume promotion, alias lifecycle, and fresh-launch vs. resume labeling.