### PR TITLE
Enforce fixed height on sidebar project filter trigger

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
@@ -78,9 +78,9 @@ describe("SidebarProjectFilter", () => {
 
   it("labels the trigger with the current selection", () => {
     renderFilter(null);
-    expect(screen.getByRole("button", { name: "Filter by project" })).toHaveTextContent(
-      "All projects",
-    );
+    const trigger = screen.getByRole("button", { name: "Filter by project" });
+    expect(trigger).toHaveTextContent("All projects");
+    expect(trigger).toHaveClass("h-8");
   });
 
   it("labels the trigger with the project name when one project is selected", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -417,7 +417,7 @@ export function SidebarProjectFilter(props: {
         <Dropdown.Trigger
           {...{ [TRIGGER_ATTR]: true }}
           aria-label={t`Filter by project`}
-          className={sidebarRowClass({ size: "xs" })}
+          className={`${sidebarRowClass({ size: "xs" })} h-8`}
         >
           {triggerContent}
         </Dropdown.Trigger>


### PR DESCRIPTION
- Fixes the project filter dropdown trigger in the sidebar to use a fixed `h-8` height, keeping it consistent with sibling sidebar rows and preventing layout shifts.
- Updates the trigger test to assert the fixed height class alongside the current selection label.