### PR TITLE
fix: preserve explicit Fast off in next draft config

### DIFF
--- a/src/renderer/views/MainView/parts/AppContent/draftConfig.test.ts
+++ b/src/renderer/views/MainView/parts/AppContent/draftConfig.test.ts
@@ -51,4 +51,14 @@ describe("buildProjectDraftConfig", () => {
       worktreeMode: true,
     });
   });
+
+  it("preserves an explicit Fast off selection for the next draft", () => {
+    expect(
+      buildProjectDraftConfig({
+        agentKind: "codex",
+        config: { model: "gpt-5.6-sol", fast: false },
+        worktreeMode: false,
+      }).fast,
+    ).toBe(false);
+  });
 });

--- a/src/renderer/views/MainView/parts/AppContent/draftConfig.ts
+++ b/src/renderer/views/MainView/parts/AppContent/draftConfig.ts
@@ -12,7 +12,7 @@ export function buildProjectDraftConfig(input: {
     model: config.model,
     ...(config.effort !== undefined ? { effort: config.effort } : {}),
     ...(config.contextSize ? { contextSize: config.contextSize } : {}),
-    ...(config.fast === true ? { fast: true } : {}),
+    ...(config.fast !== undefined ? { fast: config.fast } : {}),
     ...(config.thinking === true ? { thinking: true } : {}),
     ...(config.mode ? { mode: config.mode } : {}),
     // Preserve explicit empty strings — "" means "use provider defaults"


### PR DESCRIPTION
- Bugfix: building the next project draft config only forwarded `fast: true`, so an explicitly disabled Fast toggle was dropped and the following draft silently reverted to Fast on.
- Now forwards `fast` whenever it is set, honoring the user's explicit off selection.
- Adds a regression test covering an explicit `fast: false` config with no worktree mode.