### PR TITLE
Track sub-agent resume rows; fix draft/sidebar/worktree regressions

### DIFF
--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -1175,7 +1175,9 @@ export function ThreadDraftComposerArea(props: {
               : {})}
           />
         </div>
-      ) : null}
+      ) : props.compact ? null : (
+        <div aria-hidden data-draft-worktree-row="" className="mt-1.5 min-h-[1.625rem] px-1" />
+      )}
     </>
   );
 }

--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -524,6 +524,17 @@ describe("ThreadDraftView", () => {
     expect(container.querySelector("[data-draft-worktree-row]")).toBeInTheDocument();
   });
 
+  it("reserves the worktree control row for Home drafts", () => {
+    const { container } = render(
+      <ThreadDraftView project={homeProject} agentStatuses={[codexStatus]} onStart={() => {}} />,
+    );
+
+    const worktreeRow = container.querySelector("[data-draft-worktree-row]");
+    expect(worktreeRow).toBeEmptyDOMElement();
+    expect(worktreeRow).toHaveClass("min-h-[1.625rem]");
+    expect(screen.queryByRole("button", { name: "Worktree mode" })).not.toBeInTheDocument();
+  });
+
   it("restores the selection replaced by a targeted worktree when the inline composer collapses", async () => {
     useGitStore.setState({
       statuses: {


### PR DESCRIPTION
- **Sub-agent resume rows (feature):** the Claude canonical mapping now detects resumed sub-agent launches, emits them as `Agent Resume` rows (with a provider-supplied `subAgentType` when the tool args don't carry one), and redirects nested rows to the live resume row instead of a dead launch row; the renderer displays them distinctly rather than as plain agent rows. Fully translated across all 13 locales.
- **Draft config fix:** carry an explicit Fast off selection forward into the next draft instead of persisting only Fast on.
- **Sidebar fix:** enforce a fixed height on the project filter trigger to stop layout shifts.
- **Thread fix:** reserve worktree row space on Home drafts so the composer doesn't jump when the worktree row renders or collapses.
- Tests added/updated for each of the above areas.