### PR TITLE
Reject leaked tool-call markers in one-shot output

### DIFF
--- a/src/supervisor/agents/opencode/sdkOneShot.test.ts
+++ b/src/supervisor/agents/opencode/sdkOneShot.test.ts
@@ -67,4 +67,22 @@ describe("runOpenCodeOneShot", () => {
       permission: [{ permission: "*", pattern: "*", action: "deny" }],
     });
   });
+
+  it.each(["<｜DSML｜tool_calls>", "< | | DSML | | tool_calls>"])(
+    "rejects a leaked DeepSeek tool-call marker: %s",
+    async (marker) => {
+      prompt.mockResolvedValue({
+        data: { info: {}, parts: [{ type: "text", text: marker }] },
+      });
+
+      await expect(
+        runOpenCodeOneShot({
+          location,
+          model: "opencode-go/deepseek-v4-flash",
+          prompt: "Generate a title",
+        }),
+      ).rejects.toThrow("OpenCode returned a provider tool-call marker instead of text.");
+      expect(dispose).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/src/supervisor/agents/opencode/sdkOneShot.ts
+++ b/src/supervisor/agents/opencode/sdkOneShot.ts
@@ -57,6 +57,10 @@ function extractAssistantText(parts: ReadonlyArray<unknown> | undefined): string
   return out.trim();
 }
 
+function containsDsmlToolCallMarker(text: string): boolean {
+  return /<[\s|｜]*DSML[\s|｜]*tool_calls\b/i.test(text);
+}
+
 function extractInfoErrorMessage(info: unknown): string | undefined {
   if (!info || typeof info !== "object") return undefined;
   const err = (info as { error?: unknown }).error;
@@ -153,6 +157,9 @@ export async function runOpenCodeOneShot(input: RunOneShotInput): Promise<string
       );
     }
     const text = extractAssistantText(result.data?.parts);
+    if (containsDsmlToolCallMarker(text)) {
+      throw new Error("OpenCode returned a provider tool-call marker instead of text.");
+    }
     if (text.length === 0) {
       throw new Error("OpenCode returned empty output for one-shot prompt.");
     }

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -20,6 +20,7 @@ function buildPrompt(language?: string): string {
     languageRule +
     "- Preserve technical terms, function names, file names, and libraries exactly\n" +
     "- No quotes, no prefix label, no markdown — just the title text\n" +
+    "- Answer from the message alone; do not call tools or output tool-call syntax\n" +
     "- Use sentence case (capitalize only the first word)\n" +
     "- Reply with only the title, nothing else\n\n"
   );


### PR DESCRIPTION
- Treat leaked DeepSeek tool-call markers (e.g. `<｜DSML｜tool_calls>`) as an error in `runOpenCodeOneShot` instead of surfacing raw markers as title text.
- Hardened the title-generator prompt to answer from the message alone and forbid tool calls or tool-call syntax.
- Added table-driven tests covering both marker formats and verifying the session is disposed on rejection.

Tickets: none