### PR TITLE
Scroll learned selections and clarify crossagent auto-selection filter

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Automatisches Aktualisierungsintervall in Minuten, 0 zum Ausschalten"
 msgid "Auto-review"
 msgstr "Automatische Überprüfung"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Auto-Auswahl"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent nicht gefunden."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagent-Anbieter und -Modelle"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagent-Anbieter und -Modelle"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Automatische Crossagents-Auswahl"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Anbieter"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Anbieter & Modelle"
+#~ msgid "Providers & models"
+#~ msgstr "Anbieter & Modelle"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Deaktiviert"
 #~ msgstr "Nicht markierte Modelle werden nur von Crossagents übersprungen."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Nicht markierte Anbieter und Modelle werden nur von Crossagents übersprungen."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Nicht ausgewählte Anbieter und Modelle werden vom automatischen Crossagents-Routing ausgeschlossen, bleiben aber für manuell gestartete Agenten-Threads verfügbar."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Nicht markierte Anbieter und Modelle werden nur von Crossagents übersprungen."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -1518,6 +1518,10 @@ msgstr "Auto-refresh interval in minutes, 0 to turn off"
 msgid "Auto-review"
 msgstr "Auto-review"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Auto-selection"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3320,8 +3324,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent not found."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagent providers and models"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagent providers and models"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3355,6 +3359,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Crossagents auto-selection"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8537,8 +8545,8 @@ msgid "Providers"
 msgstr "Providers"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Providers & models"
+#~ msgid "Providers & models"
+#~ msgstr "Providers & models"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12026,8 +12034,12 @@ msgstr "Unchecked"
 #~ msgstr "Unchecked models are skipped by Crossagents only."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Unchecked providers and models are skipped by Crossagents only."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Unchecked providers and models are skipped by Crossagents only."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Intervalo de actualización automática en minutos, 0 para desactivar"
 msgid "Auto-review"
 msgstr "Revisión automática"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Selección automática"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "No se encontró Crossagent."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Proveedores y modelos de Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Proveedores y modelos de Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Selección automática de Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Proveedores"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Proveedores y modelos"
+#~ msgid "Providers & models"
+#~ msgstr "Proveedores y modelos"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "No seleccionado"
 #~ msgstr "Crossagents solo omite los modelos no seleccionados."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Crossagents solo omite los proveedores y modelos no seleccionados."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Los proveedores y modelos no seleccionados se excluyen del enrutamiento automático de Crossagents, pero siguen disponibles para los hilos de agentes iniciados manualmente."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Crossagents solo omite los proveedores y modelos no seleccionados."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Intervalle de rafraîchissement automatique en minutes, 0 pour désactiv
 msgid "Auto-review"
 msgstr "Révision automatique"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Sélection automatique"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}) : {description}"
 #~ msgstr "Crossagent introuvable."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Fournisseurs et modèles Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Fournisseurs et modèles Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent : {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Sélection automatique de Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8531,8 +8539,8 @@ msgid "Providers"
 msgstr "Fournisseurs"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Fournisseurs et modèles"
+#~ msgid "Providers & models"
+#~ msgstr "Fournisseurs et modèles"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12020,8 +12028,12 @@ msgstr "Décoché"
 #~ msgstr "Les modèles décochés sont ignorés uniquement par Crossagents."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Les fournisseurs et modèles décochés sont ignorés uniquement par Crossagents."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Les fournisseurs et modèles non sélectionnés sont exclus du routage automatique de Crossagents, mais restent disponibles pour les fils d’agents lancés manuellement."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Les fournisseurs et modèles décochés sont ignorés uniquement par Crossagents."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -1512,6 +1512,10 @@ msgstr "自動更新間隔 (分単位)、オフにする場合は 0"
 msgid "Auto-review"
 msgstr "自動レビュー"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "自動選択"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3314,8 +3318,8 @@ msgstr "Crossagent（{subagent}）：{description}"
 #~ msgstr "Crossagentが見つかりません。"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagentのプロバイダーとモデル"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagentのプロバイダーとモデル"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3349,6 +3353,10 @@ msgstr "Crossagent：{subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Crossagents の自動選択"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8530,8 +8538,8 @@ msgid "Providers"
 msgstr "プロバイダー"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "プロバイダーとモデル"
+#~ msgid "Providers & models"
+#~ msgstr "プロバイダーとモデル"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12019,8 +12027,12 @@ msgstr "チェック解除"
 #~ msgstr "チェックを外したモデルはCrossagentsでのみスキップされます。"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "チェックを外したプロバイダーとモデルはCrossagentsでのみスキップされます。"
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "選択を解除したプロバイダーとモデルは Crossagents の自動ルーティングから除外されますが、手動で開始するエージェントスレッドでは引き続き利用できます。"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "チェックを外したプロバイダーとモデルはCrossagentsでのみスキップされます。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -1513,6 +1513,10 @@ msgstr "자동 새로고침 간격(분), 0이면 끄기"
 msgid "Auto-review"
 msgstr "자동 검토"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "자동 선택"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent를 찾을 수 없습니다."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagent 제공자 및 모델"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagent 제공자 및 모델"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Crossagents 자동 선택"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "공급자"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "제공자 및 모델"
+#~ msgid "Providers & models"
+#~ msgstr "제공자 및 모델"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "선택 해제됨"
 #~ msgstr "선택 해제된 모델은 Crossagents에서만 건너뜁니다."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "선택 해제된 제공자와 모델은 Crossagents에서만 건너뜁니다."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "선택 해제한 공급자와 모델은 Crossagents 자동 라우팅에서 제외되지만 수동으로 시작하는 에이전트 스레드에서는 계속 사용할 수 있습니다."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "선택 해제된 제공자와 모델은 Crossagents에서만 건너뜁니다."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Interwał automatycznego odświeżania w minutach, 0, aby wyłączyć"
 msgid "Auto-review"
 msgstr "Automatyczny przegląd"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Wybór automatyczny"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Nie znaleziono Crossagenta."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Dostawcy i modele Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Dostawcy i modele Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Automatyczny wybór Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Dostawcy"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Dostawcy i modele"
+#~ msgid "Providers & models"
+#~ msgstr "Dostawcy i modele"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Niezaznaczone"
 #~ msgstr "Niezaznaczone modele są pomijane tylko przez Crossagents."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Niezaznaczeni dostawcy i modele są pomijani tylko przez Crossagents."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Odznaczeni dostawcy i modele są wykluczani z automatycznego routingu Crossagents, ale nadal są dostępni dla ręcznie uruchamianych wątków agentów."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Niezaznaczeni dostawcy i modele są pomijani tylko przez Crossagents."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Intervalo de atualização automática em minutos, 0 para desligar"
 msgid "Auto-review"
 msgstr "Revisão automática"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Seleção automática"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent não encontrado."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Provedores e modelos do Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Provedores e modelos do Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Seleção automática do Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Provedores"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Provedores e modelos"
+#~ msgid "Providers & models"
+#~ msgstr "Provedores e modelos"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Desmarcado"
 #~ msgstr "Os modelos desmarcados são ignorados apenas pelo Crossagents."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Provedores e modelos desmarcados são ignorados apenas pelo Crossagents."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Provedores e modelos desmarcados são excluídos do roteamento automático do Crossagents, mas continuam disponíveis para threads de agentes iniciadas manualmente."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Provedores e modelos desmarcados são ignorados apenas pelo Crossagents."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Интервал автообновления в минутах, 0 — �
 msgid "Auto-review"
 msgstr "Автопроверка"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Автовыбор"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent не найден."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Провайдеры и модели Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Провайдеры и модели Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Автовыбор Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Провайдеры"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Провайдеры и модели"
+#~ msgid "Providers & models"
+#~ msgstr "Провайдеры и модели"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Не отмечено"
 #~ msgstr "Неотмеченные модели пропускаются только Crossagents."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Неотмеченные провайдеры и модели пропускаются только Crossagents."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Провайдеры и модели без отметки исключаются из автоматической маршрутизации Crossagents, но остаются доступными для потоков агентов, запускаемых вручную."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Неотмеченные провайдеры и модели пропускаются только Crossagents."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Dakika cinsinden otomatik yenileme aralığı, kapatmak için 0"
 msgid "Auto-review"
 msgstr "Otomatik inceleme"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Otomatik seçim"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent bulunamadı."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagent sağlayıcıları ve modelleri"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagent sağlayıcıları ve modelleri"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Crossagents otomatik seçimi"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Sağlayıcılar"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Sağlayıcılar ve modeller"
+#~ msgid "Providers & models"
+#~ msgstr "Sağlayıcılar ve modeller"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "İşaretlenmemiş"
 #~ msgstr "İşaretlenmemiş modeller yalnızca Crossagents tarafından atlanır."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "İşaretlenmemiş sağlayıcılar ve modeller yalnızca Crossagents tarafından atlanır."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "İşareti kaldırılan sağlayıcılar ve modeller, otomatik Crossagents yönlendirmesinin dışında tutulur ancak elle başlatılan aracı iş parçacıkları için kullanılabilir olmaya devam eder."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "İşaretlenmemiş sağlayıcılar ve modeller yalnızca Crossagents tarafından atlanır."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Інтервал автооновлення у хвилинах, 0 — �
 msgid "Auto-review"
 msgstr "Автоперевірка"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Автовибір"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Crossagent не знайдено."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Провайдери та моделі Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Провайдери та моделі Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Автовибір Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Постачальники"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Провайдери та моделі"
+#~ msgid "Providers & models"
+#~ msgstr "Провайдери та моделі"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Не позначено"
 #~ msgstr "Непозначені моделі пропускаються лише Crossagents."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Непозначені провайдери та моделі пропускаються лише Crossagents."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Постачальники й моделі без позначки виключаються з автоматичної маршрутизації Crossagents, але залишаються доступними для потоків агентів, запущених вручну."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Непозначені провайдери та моделі пропускаються лише Crossagents."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -1513,6 +1513,10 @@ msgstr "Khoảng thời gian tự động làm mới tính bằng phút, 0 để
 msgid "Auto-review"
 msgstr "Tự động xem xét"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "Tự động chọn"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent ({subagent}): {description}"
 #~ msgstr "Không tìm thấy Crossagent."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Nhà cung cấp và mô hình Crossagent"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Nhà cung cấp và mô hình Crossagent"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent: {subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Tự động chọn Crossagents"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8532,8 +8540,8 @@ msgid "Providers"
 msgstr "Nhà cung cấp"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "Nhà cung cấp & mô hình"
+#~ msgid "Providers & models"
+#~ msgstr "Nhà cung cấp & mô hình"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12021,8 +12029,12 @@ msgstr "Bỏ chọn"
 #~ msgstr "Các mô hình không được chọn chỉ bị Crossagents bỏ qua."
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "Nhà cung cấp và mô hình không được chọn chỉ bị Crossagents bỏ qua."
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "Nhà cung cấp và mô hình bị bỏ chọn sẽ không được dùng trong định tuyến Crossagents tự động, nhưng vẫn khả dụng cho các luồng tác nhân được khởi chạy thủ công."
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "Nhà cung cấp và mô hình không được chọn chỉ bị Crossagents bỏ qua."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -1513,6 +1513,10 @@ msgstr "自动刷新间隔以分钟为单位，0为关闭"
 msgid "Auto-review"
 msgstr "自动审核"
 
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Auto-selection"
+msgstr "自动选择"
+
 #: src/renderer/views/SettingsOverlay/parts/settingsSearchIndex.ts
 #: src/renderer/views/SettingsOverlay/parts/TerminalSettings.tsx
 msgid "Auto-show terminal panel"
@@ -3315,8 +3319,8 @@ msgstr "Crossagent（{subagent}）：{description}"
 #~ msgstr "未找到 Crossagent。"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Crossagent providers and models"
-msgstr "Crossagent 提供商和模型"
+#~ msgid "Crossagent providers and models"
+#~ msgstr "Crossagent 提供商和模型"
 
 #: src/renderer/components/thread/ChatPane/parts/items/SubAgentToolCall.tsx
 msgid "Crossagent Result"
@@ -3350,6 +3354,10 @@ msgstr "Crossagent：{subagent}"
 #: src/renderer/views/SettingsOverlay/parts/OpenCodeProviderSettings.tsx
 msgid "Crossagents"
 msgstr "Crossagents"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+msgid "Crossagents auto-selection"
+msgstr "Crossagents 自动选择"
 
 #: src/renderer/components/composer/composerMcpServers.ts
 msgid "Crossagents enabled for this thread"
@@ -8531,8 +8539,8 @@ msgid "Providers"
 msgstr "提供商"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Providers & models"
-msgstr "提供商和模型"
+#~ msgid "Providers & models"
+#~ msgstr "提供商和模型"
 
 #: src/renderer/components/skills/SkillMarketplaceModal.tsx
 msgid "Public registry with verified sources and GitHub metrics."
@@ -12020,8 +12028,12 @@ msgstr "未选中"
 #~ msgstr "未选中的模型仅由 Crossagents 跳过。"
 
 #: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
-msgid "Unchecked providers and models are skipped by Crossagents only."
-msgstr "未选中的提供商和模型仅由 Crossagents 跳过。"
+msgid "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads."
+msgstr "未选中的提供商和模型不会参与 Crossagents 自动路由，但仍可用于手动启动的智能体线程。"
+
+#: src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+#~ msgid "Unchecked providers and models are skipped by Crossagents only."
+#~ msgstr "未选中的提供商和模型仅由 Crossagents 跳过。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserTabGroupMenu.tsx
 msgid "Ungroup"

--- a/src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.test.tsx
@@ -201,7 +201,7 @@ describe("CrossagentRoutingSection", () => {
   it("pauses a provider by unchecking it in the global filter and resumes it", async () => {
     render(<CrossagentRoutingSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Crossagent providers and models" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Crossagents auto-selection" }));
     fireEvent.click(await screen.findByRole("option", { name: /Kimi Code/ }));
     expect(useSharedSettings.getState().crossagentPausedProviders).toEqual(["kimi"]);
 
@@ -218,7 +218,7 @@ describe("CrossagentRoutingSection", () => {
   it("filters Crossagent models from the global filter without touching global visibility", async () => {
     render(<CrossagentRoutingSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Crossagent providers and models" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Crossagents auto-selection" }));
     fireEvent.click(await screen.findByRole("option", { name: /k3/i }));
 
     expect(useSharedSettings.getState().crossagentHiddenModels).toEqual({ kimi: ["k3"] });
@@ -228,7 +228,7 @@ describe("CrossagentRoutingSection", () => {
   it("treats Hide all and Show all as inverses across providers and models", async () => {
     render(<CrossagentRoutingSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Crossagent providers and models" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Crossagents auto-selection" }));
     fireEvent.click(await screen.findByRole("button", { name: "Hide all" }));
 
     // Nothing is usable afterwards: every model hidden and every provider unchecked.
@@ -252,12 +252,17 @@ describe("CrossagentRoutingSection", () => {
     useSharedSettings.setState({ crossagentHiddenModels: { kimi: ["k3"] } });
     render(<CrossagentRoutingSection />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Crossagent providers and models" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Crossagents auto-selection" }));
 
     const [kimiHeader] = await screen.findAllByRole("option", { name: /Kimi Code/ });
     expect(kimiHeader).toHaveAccessibleName(/Unchecked/);
     const [claudeHeader] = screen.getAllByRole("option", { name: /Claude Code/ });
     expect(claudeHeader).toHaveAccessibleName(/Checked/);
+    expect(
+      screen.getByText(
+        "Unchecked providers and models are excluded from automatic Crossagents routing, but remain available for manual agent threads.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("edits tags and removes learned memory entries", async () => {
@@ -292,6 +297,9 @@ describe("CrossagentRoutingSection", () => {
 
     expect(await screen.findByText("Learned selections")).toBeInTheDocument();
     expect(screen.getByText("#mobile · #simulator")).toBeInTheDocument();
+    expect(screen.getByText("#mobile · #simulator").closest("div.max-h-80")).toHaveClass(
+      "overflow-y-auto",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Edit tags for Kimi Code" }));
     fireEvent.click(await screen.findByRole("button", { name: "Remove tag mobile" }));

--- a/src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentMemorySection.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentMemorySection.tsx
@@ -83,7 +83,7 @@ export function CrossagentMemorySection() {
           <Trans>No learned selections yet.</Trans>
         </p>
       ) : (
-        <div className="overflow-hidden rounded-lg border border-border">
+        <div className="max-h-80 overflow-y-auto rounded-lg border border-border">
           {learned.map((entry) => {
             const key = entryRowKey(entry);
             const tags = normalizeCrossagentTags(entry.tags);

--- a/src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/crossagent/CrossagentProviderModelFilter.tsx
@@ -48,7 +48,7 @@ export function CrossagentProviderModelFilter(props: {
   });
   if (menuProviders.length === 0) return null;
 
-  const ariaLabel = t`Crossagent providers and models`;
+  const ariaLabel = t`Crossagents auto-selection`;
   return (
     <ModelVisibilityPopover
       providers={menuProviders}
@@ -58,10 +58,15 @@ export function CrossagentProviderModelFilter(props: {
         uncheckedKinds: crossagentPausedProviders,
         onCheckedChange: (kind, checked) => setCrossagentProviderPaused(kind, !checked),
       }}
-      triggerLabel={<Trans>Providers & models</Trans>}
+      triggerLabel={<Trans>Auto-selection</Trans>}
       listAriaLabel={ariaLabel}
       summaryKind="usable"
-      footer={<Trans>Unchecked providers and models are skipped by Crossagents only.</Trans>}
+      footer={
+        <Trans>
+          Unchecked providers and models are excluded from automatic Crossagents routing, but remain
+          available for manual agent threads.
+        </Trans>
+      }
       compactTriggerCount
       triggerAriaLabel={ariaLabel}
       triggerClassName="shrink-0 tabular-nums"


### PR DESCRIPTION
- Make the learned selections list scrollable instead of clipping when it grows long.
- Rename the provider/model filter trigger to "Auto-selection" to reflect its routing scope.
- Clarify that unchecked providers and models are excluded from automatic Crossagents routing but remain available for manual agent threads.
- Update tests and synchronize new/changed strings across all 12 non-English locales.