### PR TITLE
Track running action tabs and add Stop action menus

### DIFF
--- a/src/renderer/actions/terminalActions.test.ts
+++ b/src/renderer/actions/terminalActions.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SupervisorEvent } from "@/shared/ipc";
+import type { Project } from "@/shared/contracts";
+
+const bridge = vi.hoisted(() => ({
+  onSupervisorEvent: vi.fn<(handler: (event: SupervisorEvent) => void) => () => void>(),
+  startShell: vi.fn<(payload: unknown) => Promise<void>>(),
+  writeTerminal: vi.fn<(payload: { threadId: string; data: string }) => Promise<void>>(),
+  closeThread: vi.fn<(payload: { threadId: string }) => Promise<void>>(),
+}));
+
+const supervisorHandlers: Array<(event: SupervisorEvent) => void> = [];
+
+vi.mock("@heroui/react", () => ({
+  toast: { danger: vi.fn<(message: string) => void>() },
+}));
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridge,
+}));
+
+import { runProjectAction, stopProjectAction } from "./terminalActions";
+import { useAppStore } from "@/renderer/state/appStore";
+import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadOutputStore } from "@/renderer/state/threadOutputStore";
+
+const project = {
+  id: "p1",
+  name: "Poracode",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-08-08T00:00:00.000Z",
+  scripts: {
+    actions: [{ id: "dev", name: "Dev", command: "pnpm dev" }],
+  },
+} satisfies Project;
+
+describe("runProjectAction", () => {
+  beforeEach(() => {
+    resetDevTerminalStore();
+    useThreadOutputStore.setState({ buffers: {} });
+    useAppStore.setState({ projects: [project] });
+    useSharedSettings.setState({ autoShowTerminalPanel: false });
+    bridge.startShell.mockReset().mockResolvedValue(undefined);
+    bridge.writeTerminal.mockReset().mockResolvedValue(undefined);
+    bridge.closeThread.mockReset().mockResolvedValue(undefined);
+    supervisorHandlers.length = 0;
+    bridge.onSupervisorEvent.mockReset().mockImplementation((handler) => {
+      supervisorHandlers.push(handler);
+      return () => {
+        const index = supervisorHandlers.indexOf(handler);
+        if (index >= 0) supervisorHandlers.splice(index, 1);
+      };
+    });
+  });
+
+  it("restarts an action in its existing tracked terminal", () => {
+    runProjectAction(project.id, "dev");
+    const firstTab = useDevTerminalStore.getState().tabs[0]!;
+
+    runProjectAction(project.id, "dev");
+
+    expect(useDevTerminalStore.getState().tabs).toHaveLength(1);
+    expect(useDevTerminalStore.getState().tabs[0]).toMatchObject({
+      id: firstTab.id,
+      runActionId: "dev",
+    });
+    expect(bridge.startShell).toHaveBeenCalledTimes(2);
+    expect(bridge.startShell).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ shellId: firstTab.id }),
+    );
+    expect(useDevTerminalStore.getState().runningTabs[firstTab.id]).toBe(true);
+  });
+
+  it("tracks the same action separately in each worktree", () => {
+    runProjectAction(project.id, "dev", "C:\\repo\\wt-a");
+    runProjectAction(project.id, "dev", "C:\\repo\\wt-b");
+
+    expect(useDevTerminalStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("clears the running marker when shell startup fails", async () => {
+    bridge.startShell.mockRejectedValueOnce(new Error("spawn failed"));
+    runProjectAction(project.id, "dev");
+    const tab = useDevTerminalStore.getState().tabs[0]!;
+
+    await vi.waitFor(() => {
+      expect(useDevTerminalStore.getState().runningTabs[tab.id]).toBeUndefined();
+    });
+  });
+
+  it("closes the PTY and clears the running marker when a command fails", async () => {
+    runProjectAction(project.id, "dev");
+    const tab = useDevTerminalStore.getState().tabs[0]!;
+
+    supervisorHandlers.forEach((handler) =>
+      handler({ type: "thread-output", threadId: tab.id, data: "PS> ", outputLength: 4 }),
+    );
+    const command = bridge.writeTerminal.mock.calls[0]?.[0].data ?? "";
+    const token = /poracode-shell-complete=([^:]+):/u.exec(command)?.[1];
+    expect(token).toBeTruthy();
+    supervisorHandlers.forEach((handler) =>
+      handler({
+        type: "thread-output",
+        threadId: tab.id,
+        data: command,
+        outputLength: command.length,
+      }),
+    );
+    supervisorHandlers.forEach((handler) =>
+      handler({
+        type: "thread-output",
+        threadId: tab.id,
+        data: "command failed\r\n",
+        outputLength: command.length + 16,
+      }),
+    );
+    const marker = `\u001B]777;poracode-shell-complete=${token}:1\u0007`;
+    supervisorHandlers.forEach((handler) =>
+      handler({
+        type: "thread-output",
+        threadId: tab.id,
+        data: marker,
+        outputLength: marker.length,
+      }),
+    );
+
+    expect(useDevTerminalStore.getState().runningTabs[tab.id]).toBeUndefined();
+    expect(useDevTerminalStore.getState().tabs).toContainEqual(tab);
+    expect(useThreadOutputStore.getState().readTail(tab.id, 100_000)).toContain("command failed");
+    expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: tab.id });
+  });
+
+  it("clears retained output when rerunning the action", () => {
+    runProjectAction(project.id, "dev");
+    const tab = useDevTerminalStore.getState().tabs[0]!;
+    useThreadOutputStore.getState().appendOutput(tab.id, "old run");
+
+    runProjectAction(project.id, "dev");
+
+    expect(useThreadOutputStore.getState().readTail(tab.id, 100_000)).toBe("");
+  });
+
+  it("stops an action without removing its terminal tab", async () => {
+    runProjectAction(project.id, "dev");
+    const tab = useDevTerminalStore.getState().tabs[0]!;
+
+    stopProjectAction(project.id, "dev");
+
+    expect(useDevTerminalStore.getState().runningTabs[tab.id]).toBeUndefined();
+    expect(useDevTerminalStore.getState().tabs).toContainEqual(tab);
+    await vi.waitFor(() => {
+      expect(bridge.closeThread).toHaveBeenCalledWith({ threadId: tab.id });
+    });
+  });
+
+  it("does not let an older failed restart clear a newer run", async () => {
+    let rejectFirst!: (error: Error) => void;
+    let resolveSecond!: () => void;
+    bridge.startShell
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    runProjectAction(project.id, "dev");
+    const tab = useDevTerminalStore.getState().tabs[0]!;
+    runProjectAction(project.id, "dev");
+    resolveSecond();
+    rejectFirst(new Error("old start failed"));
+
+    await vi.waitFor(() => {
+      expect(useDevTerminalStore.getState().runningTabs[tab.id]).toBe(true);
+    });
+  });
+});

--- a/src/renderer/actions/terminalActions.ts
+++ b/src/renderer/actions/terminalActions.ts
@@ -6,8 +6,15 @@ import {
   useSharedSettings,
   whenSharedSettingsHydrated,
 } from "@/renderer/state/sharedSettingsStore";
-import { startShellWithToast, writeScriptToShell } from "@/renderer/utils/shellUtils";
+import { useThreadOutputStore } from "@/renderer/state/threadOutputStore";
+import {
+  closeThreads,
+  startShellWithToast,
+  writeScriptToShellThenExitOnSuccess,
+} from "@/renderer/utils/shellUtils";
 import { closeAllPanels } from "./panelActions";
+
+const actionRunTokens = new Map<string, symbol>();
 
 function applyTerminalPanel(
   projectId: string,
@@ -77,8 +84,18 @@ export function runProjectAction(projectId: string, actionId: string, worktreePa
 
   const store = useDevTerminalStore.getState();
   const tabLabel = action.name;
-  const tab = store.addTab(projectId, tabLabel, worktreePath);
+  const tab =
+    store.tabs.find(
+      (candidate) =>
+        candidate.projectId === projectId &&
+        (candidate.worktreePath ?? undefined) === worktreePath &&
+        candidate.runActionId === actionId,
+    ) ?? store.addTab(projectId, tabLabel, worktreePath, actionId);
   store.setActiveTab(tab.id);
+  store.markShellRunning(tab.id);
+  useThreadOutputStore.getState().clearOutput(tab.id);
+  const runToken = Symbol(tab.id);
+  actionRunTokens.set(tab.id, runToken);
 
   // Decide panel visibility only once the authoritative settings are loaded —
   // right after launch the store still holds defaults (autoShowTerminalPanel:
@@ -92,13 +109,53 @@ export function runProjectAction(projectId: string, actionId: string, worktreePa
     }
   });
 
-  startShellWithToast(
+  void startShellWithToast(
     {
       shellId: tab.id,
       projectLocation: location,
       ...(worktreePath ? { worktreePath } : {}),
     },
     tabLabel,
+  ).then((started) => {
+    if (actionRunTokens.get(tab.id) !== runToken || started) return;
+    actionRunTokens.delete(tab.id);
+    useDevTerminalStore.getState().markShellExited(tab.id);
+  });
+  const markActionComplete = () => {
+    if (actionRunTokens.get(tab.id) !== runToken) return;
+    actionRunTokens.delete(tab.id);
+    useDevTerminalStore.getState().markShellExited(tab.id);
+    void closeThreads([tab.id]);
+  };
+  writeScriptToShellThenExitOnSuccess(
+    tab.id,
+    action.command,
+    location.kind,
+    markActionComplete,
+    markActionComplete,
+    project.remoteServerId,
+    {
+      onOutput: (output) => useThreadOutputStore.getState().appendOutput(tab.id, output),
+      onReset: () => useThreadOutputStore.getState().clearOutput(tab.id),
+    },
   );
-  writeScriptToShell(tab.id, action.command, project.remoteServerId);
+}
+
+export function stopProjectAction(
+  projectId: string,
+  actionId: string,
+  worktreePath?: string,
+): void {
+  const store = useDevTerminalStore.getState();
+  const tab = store.tabs.find(
+    (candidate) =>
+      candidate.projectId === projectId &&
+      (candidate.worktreePath ?? undefined) === worktreePath &&
+      candidate.runActionId === actionId,
+  );
+  if (!tab) return;
+
+  actionRunTokens.delete(tab.id);
+  store.markShellExited(tab.id);
+  void closeThreads([tab.id]);
 }

--- a/src/renderer/actions/worktreeLaunchActions.ts
+++ b/src/renderer/actions/worktreeLaunchActions.ts
@@ -97,7 +97,7 @@ function startWorktreeSetupScript(
   // Visible tabs mount an XTerm surface that starts the PTY. Start it eagerly
   // only when no surface will mount, avoiding a second setup process.
   if (!openTerminalPanel || (!autoShow && !panelAlreadyOpen)) {
-    startShellWithToast(
+    void startShellWithToast(
       { shellId: tab.id, projectLocation: wtLocation, worktreePath },
       "setup shell",
     );

--- a/src/renderer/app.test.tsx
+++ b/src/renderer/app.test.tsx
@@ -14,6 +14,8 @@ import { usePanelStore } from "./state/panelStore";
 import { useSidebarUiStore } from "./state/sidebarUiStore";
 import { useExperimentStore } from "./state/experimentStore";
 import { useWorkspaceStore } from "./state/workspaceStore";
+import { resetDevTerminalStore, useDevTerminalStore } from "./state/devTerminalStore";
+import { useThreadOutputStore } from "./state/threadOutputStore";
 import { gitMergeAndRemove } from "@/renderer/actions/gitActions";
 import { openThread, unloadThread } from "@/renderer/actions/threadActions";
 
@@ -429,6 +431,8 @@ describe("App", () => {
       lastViewedAtByThreadId: {},
       view: { kind: "home" },
     }));
+    resetDevTerminalStore();
+    useThreadOutputStore.setState({ buffers: {} });
     useExperimentStore.setState({ experiments: {} });
     useGitStore.setState({
       statuses: {},
@@ -629,6 +633,30 @@ describe("App", () => {
     expect(applyRuntimeEventBatches.mock.calls[1]?.[0].map((batch) => batch.threadId)).toEqual([
       "hidden",
     ]);
+  });
+
+  it("clears the running marker when an action shell exits", () => {
+    const tab = useDevTerminalStore.getState().addTab("project-1", "Dev", undefined, "dev");
+    useDevTerminalStore.getState().markShellRunning(tab.id);
+
+    supervisorEventListeners.at(-1)?.({
+      type: "thread-exited",
+      threadId: tab.id,
+      exitCode: 1,
+    });
+
+    expect(useDevTerminalStore.getState().runningTabs[tab.id]).toBeUndefined();
+  });
+
+  it("retains action output until its terminal tab is removed", () => {
+    const tab = useDevTerminalStore.getState().addTab("project-1", "Dev", undefined, "dev");
+    useThreadOutputStore.getState().appendOutput(tab.id, "finished output");
+
+    useAppStore.setState({ threads: [] });
+    expect(useThreadOutputStore.getState().readTail(tab.id, 100_000)).toBe("finished output");
+
+    useDevTerminalStore.getState().removeTab(tab.id);
+    expect(useThreadOutputStore.getState().readTail(tab.id, 100_000)).toBe("");
   });
 
   it("batches ten background threads with five subagents each into one store update", () => {

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -181,6 +181,8 @@ function handleSupervisorEvent(event: SupervisorEvent): void {
   if ("threadId" in event && event.threadId.startsWith("shell:")) {
     if (event.type === "thread-output") {
       useDevTerminalStore.getState().noteShellOutput(event.threadId);
+    } else if (event.type === "thread-exited") {
+      useDevTerminalStore.getState().markShellExited(event.threadId);
     }
     return;
   }
@@ -268,12 +270,23 @@ function handleSupervisorEvent(event: SupervisorEvent): void {
 }
 
 function installThreadOutputPruning(): () => void {
-  return useAppStore.subscribe((state, previousState) => {
-    if (state.threads === previousState.threads) return;
-    useThreadOutputStore
-      .getState()
-      .retainOutputs(new Set(state.threads.map((thread) => thread.id)));
+  const retainActiveOutputs = () => {
+    const threadIds = new Set(useAppStore.getState().threads.map((thread) => thread.id));
+    for (const tab of useDevTerminalStore.getState().tabs) {
+      if (tab.runActionId) threadIds.add(tab.id);
+    }
+    useThreadOutputStore.getState().retainOutputs(threadIds);
+  };
+  const unsubscribeThreads = useAppStore.subscribe((state, previousState) => {
+    if (state.threads !== previousState.threads) retainActiveOutputs();
   });
+  const unsubscribeTerminals = useDevTerminalStore.subscribe((state, previousState) => {
+    if (state.tabs !== previousState.tabs) retainActiveOutputs();
+  });
+  return () => {
+    unsubscribeThreads();
+    unsubscribeTerminals();
+  };
 }
 
 function handleUpdateStatus(status: UpdateStatus): void {

--- a/src/renderer/commands/registry.ts
+++ b/src/renderer/commands/registry.ts
@@ -627,7 +627,7 @@ function runTerminalCommand(args: unknown): void {
   }
   terminal.setActiveTab(tab.id);
 
-  startShellWithToast(
+  void startShellWithToast(
     {
       shellId: tab.id,
       projectLocation: location,

--- a/src/renderer/components/common/ContextMenu.test.tsx
+++ b/src/renderer/components/common/ContextMenu.test.tsx
@@ -15,6 +15,33 @@ describe("ContextMenu", () => {
     expect(screen.getByRole("button", { name: "Row" })).toBe(container.firstElementChild);
   });
 
+  it("dispatches an item's trailing action without dispatching the row", async () => {
+    const onAction = vi.fn<(key: string) => void>();
+    render(
+      <ContextMenu
+        items={[
+          {
+            id: "run",
+            label: "Run",
+            endAction: { id: "stop", label: "Stop Run", icon: <span /> },
+          },
+        ]}
+        onAction={onAction}
+      >
+        <button type="button">Row</button>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Row" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Stop Run" }));
+
+    expect(onAction).toHaveBeenCalledWith("stop");
+    expect(onAction).not.toHaveBeenCalledWith("run");
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+    });
+  });
+
   describe("stacked ContextMenuSurface", () => {
     // Mirrors the real structure: the thread-row ContextMenu and the filter
     // subtree (overflow state + stacked surface) are siblings, so toggling

--- a/src/renderer/components/common/ContextMenu.tsx
+++ b/src/renderer/components/common/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import React, { type MouseEventHandler, type ReactNode, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Dropdown, Label, Separator } from "@heroui/react";
+import { Button, Dropdown, Label, Separator } from "@heroui/react";
 
 // Context menus can stack (e.g. the flat-list filter stacks a project menu
 // over its own), so dismissal tracks a stack of closers: a new surface pushes
@@ -29,6 +29,12 @@ export interface ContextMenuItem {
   id: string;
   label: string;
   icon?: ReactNode;
+  endAction?: {
+    id: string;
+    label: string;
+    icon: ReactNode;
+    isDisabled?: boolean;
+  };
   variant?: "default" | "danger" | "warning";
   isDisabled?: boolean;
   disabledReason?: string;
@@ -79,11 +85,16 @@ function splitSections(entries: ContextMenuEntry[]): (ContextMenuItem | ContextM
   return sections.filter((s) => s.length > 0);
 }
 
-function renderDropdownItem(item: ContextMenuItem) {
+function renderDropdownItem(
+  item: ContextMenuItem,
+  close: () => void,
+  onAction: (key: string) => void,
+) {
   return (
     <Dropdown.Item
       key={item.id}
       id={item.id}
+      aria-label={item.label}
       textValue={item.label}
       variant={item.variant === "danger" ? "danger" : undefined}
     >
@@ -94,9 +105,25 @@ function renderDropdownItem(item: ContextMenuItem) {
           {item.icon}
         </span>
       )}
-      <Label className={item.variant === "warning" ? "text-warning" : undefined}>
+      <Label className={`flex-1 ${item.variant === "warning" ? "text-warning" : ""}`}>
         {item.label}
       </Label>
+      {item.endAction ? (
+        <Button
+          isIconOnly
+          size="sm"
+          variant="ghost"
+          aria-label={item.endAction.label}
+          className="ml-auto size-5 min-w-0 text-muted hover:text-foreground"
+          {...(item.endAction.isDisabled ? { isDisabled: true } : {})}
+          onPress={() => {
+            close();
+            onAction(item.endAction!.id);
+          }}
+        >
+          {item.endAction.icon}
+        </Button>
+      ) : null}
     </Dropdown.Item>
   );
 }
@@ -121,13 +148,13 @@ function renderEntry(
               onAction(String(key));
             }}
           >
-            {entry.items.map((item) => renderDropdownItem(item))}
+            {entry.items.map((item) => renderDropdownItem(item, close, onAction))}
           </Dropdown.Menu>
         </Dropdown.Popover>
       </Dropdown.SubmenuTrigger>
     );
   }
-  return renderDropdownItem(entry);
+  return renderDropdownItem(entry, close, onAction);
 }
 
 /**

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -224,6 +224,25 @@ export function useIsWorktreeTerminalBusy(worktreePath: string | null | undefine
   });
 }
 
+export function useRunningProjectActionIds(
+  projectId: string,
+  worktreePath?: string,
+): readonly string[] {
+  return useDevTerminalStore(
+    useShallow((state) =>
+      state.tabs
+        .filter(
+          (tab) =>
+            tab.projectId === projectId &&
+            (tab.worktreePath ?? undefined) === worktreePath &&
+            tab.runActionId &&
+            state.runningTabs[tab.id],
+        )
+        .map((tab) => tab.runActionId!),
+    ),
+  );
+}
+
 export function useIsProjectGitPanelActive(projectId: string): boolean {
   const onScreen = usePanelTabOnScreen("git");
   return usePanelStore((s) => {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} verwendet"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} Workflows"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Leerlauf"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Wird ausgeführt"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (lokaler Befehl)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Stopp"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "{0} stoppen"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} used"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} workflows"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Idle"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Running"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10724,6 +10736,13 @@ msgstr "stdio (local command)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Stop"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Stop {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} usados"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} flujos de trabajo"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Inactivo"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Ejecutándose"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (comando local)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Detener"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Detener {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} utilisé"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} workflows"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Inactif"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, En cours d'exécution"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10718,6 +10730,13 @@ msgstr "stdio (commande locale)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Arrêter"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Arrêter {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -345,6 +345,18 @@ msgstr "{0}が使用されました"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} 個のワークフロー"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}、アイドル状態"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}、実行中"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10717,6 +10729,13 @@ msgstr "stdio（ローカルコマンド）"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "停止"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "{0}を停止"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} 사용됨"
 #~ msgid "{0} workflows"
 #~ msgstr "{0}개 워크플로"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, 유휴"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, 실행 중"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio(로컬 명령)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "중지"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "{0} 중지"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -345,6 +345,18 @@ msgstr "Wykorzystano {0}"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} przepływów pracy"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Bezczynny"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, W trakcie"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (polecenie lokalne)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Zatrzymaj"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Zatrzymaj {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} usado"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} fluxos de trabalho"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Inativo"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Em execução"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (comando local)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Parar"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Parar {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} использовано"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} рабочих процессов"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Ожидание"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Выполняется"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (локальная команда)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Остановить"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Остановить {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} kullanıldı"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} iş akışı"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Boşta"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Çalışıyor"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (yerel komut)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Durdur"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "{0} öğesini durdur"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -345,6 +345,18 @@ msgstr "{0} використано"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} робочих процесів"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Очікування"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Виконується"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (локальна команда)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Зупинити"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Зупинити {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -345,6 +345,18 @@ msgstr "Đã dùng {0}"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} quy trình"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}, Nhàn rỗi"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}, Đang chạy"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10719,6 +10731,13 @@ msgstr "stdio (lệnh cục bộ)"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "Dừng lại"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "Dừng {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -345,6 +345,18 @@ msgstr "已使用 {0}"
 #~ msgid "{0} workflows"
 #~ msgstr "{0} 个工作流"
 
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Idle"
+msgstr "{0}，空闲"
+
+#. placeholder {0}: tab.title
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+#: src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+msgid "{0}, Running"
+msgstr "{0}，正在运行"
+
 #. placeholder {0}: skill.name
 #: src/renderer/components/skills/SkillImportModal.tsx
 msgid "{0}: {stateLabel}"
@@ -10718,6 +10730,13 @@ msgstr "stdio（本地命令）"
 #: src/renderer/views/SettingsOverlay/parts/AudioSettings.tsx
 msgid "Stop"
 msgstr "停止"
+
+#. placeholder {0}: action.name
+#: src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+msgid "Stop {0}"
+msgstr "停止 {0}"
 
 #: src/mobile/views/PortsView.tsx
 msgid "Stop forwarding"

--- a/src/renderer/state/devTerminalStore.test.ts
+++ b/src/renderer/state/devTerminalStore.test.ts
@@ -23,6 +23,7 @@ describe("devTerminalStore cycleTab", () => {
       focusRequestId: 0,
       tabActivity: {},
       streamingTabs: {},
+      runningTabs: {},
     });
   });
 
@@ -124,6 +125,7 @@ describe("devTerminalStore explicit open marker", () => {
       focusRequestId: 0,
       tabActivity: {},
       streamingTabs: {},
+      runningTabs: {},
     });
   });
 
@@ -168,6 +170,40 @@ describe("devTerminalStore explicit open marker", () => {
       activeProjectId: "p1",
       activeTabId: "b",
     });
+  });
+});
+
+describe("devTerminalStore run-action tabs", () => {
+  beforeEach(() => {
+    useDevTerminalStore.setState({
+      tabs: [],
+      activeTabId: null,
+      runningTabs: {},
+    });
+  });
+
+  it("tags action-owned tabs and clears their running marker when removed", () => {
+    const store = useDevTerminalStore.getState();
+    const actionTab = store.addTab("p1", "Dev", "/wt/x", "dev");
+
+    store.markShellRunning(actionTab.id);
+    expect(useDevTerminalStore.getState()).toMatchObject({
+      tabs: [{ id: actionTab.id, runActionId: "dev" }],
+      runningTabs: { [actionTab.id]: true },
+    });
+
+    store.removeTab(actionTab.id);
+    expect(useDevTerminalStore.getState().runningTabs).toEqual({});
+  });
+
+  it("clears a running marker when its shell exits", () => {
+    const store = useDevTerminalStore.getState();
+    const actionTab = store.addTab("p1", "Dev", undefined, "dev");
+    store.markShellRunning(actionTab.id);
+
+    store.markShellExited(actionTab.id);
+
+    expect(useDevTerminalStore.getState().runningTabs).toEqual({});
   });
 });
 // @vitest-environment node

--- a/src/renderer/state/devTerminalStore.ts
+++ b/src/renderer/state/devTerminalStore.ts
@@ -4,6 +4,8 @@ export interface DevTerminalTab {
   id: string;
   projectId: string;
   worktreePath?: string;
+  /** Project action whose process owns this tab, when launched from the Run menu. */
+  runActionId?: string;
   title: string;
   createdAt: string;
   /** When set, a second shell is shown side-by-side within this tab. */
@@ -35,6 +37,8 @@ interface DevTerminalState {
    * output, cleared after a short idle debounce. Ephemeral — not persisted.
    */
   streamingTabs: Record<string, true>;
+  /** Run-action commands currently executing. Ephemeral — not persisted. */
+  runningTabs: Record<string, true>;
 }
 
 interface DevTerminalActions {
@@ -44,7 +48,12 @@ interface DevTerminalActions {
   setActiveProject: (projectId: string) => void;
   /** Re-scope an open panel without opening it or spawning a shell. */
   setPanelScope: (projectId: string, worktreePath?: string) => void;
-  addTab: (projectId: string, projectName: string, worktreePath?: string) => DevTerminalTab;
+  addTab: (
+    projectId: string,
+    projectName: string,
+    worktreePath?: string,
+    runActionId?: string,
+  ) => DevTerminalTab;
   removeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
   /**
@@ -64,6 +73,8 @@ interface DevTerminalActions {
   clearTabActivity: (tabId: string) => void;
   /** Note PTY output for a shell, flagging it as streaming until output idles. */
   noteShellOutput: (shellId: string) => void;
+  markShellRunning: (shellId: string) => void;
+  markShellExited: (shellId: string) => void;
   updateTabTitle: (tabId: string, title: string) => void;
 }
 
@@ -92,6 +103,7 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
   focusRequestId: 0,
   tabActivity: {},
   streamingTabs: {},
+  runningTabs: {},
 
   openPanel: (projectId) =>
     set((state) => ({
@@ -146,11 +158,12 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       };
     }),
 
-  addTab: (projectId, projectName, worktreePath?) => {
+  addTab: (projectId, projectName, worktreePath?, runActionId?) => {
     const tab: DevTerminalTab = {
       id: `shell:${crypto.randomUUID()}`,
       projectId,
       ...(worktreePath ? { worktreePath } : {}),
+      ...(runActionId ? { runActionId } : {}),
       title: projectName,
       createdAt: new Date().toISOString(),
     };
@@ -173,8 +186,11 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       const streamingTabs = { ...state.streamingTabs };
       delete streamingTabs[tabId];
       if (removed?.splitId) delete streamingTabs[removed.splitId];
+      const runningTabs = { ...state.runningTabs };
+      delete runningTabs[tabId];
+      if (removed?.splitId) delete runningTabs[removed.splitId];
       clearStreaming(removed?.splitId ? [tabId, removed.splitId] : [tabId]);
-      return { tabs, activeTabId, tabActivity, streamingTabs };
+      return { tabs, activeTabId, tabActivity, streamingTabs, runningTabs };
     }),
 
   setActiveTab: (tabId) => {
@@ -221,16 +237,19 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       }
       const tabActivity = { ...state.tabActivity };
       const streamingTabs = { ...state.streamingTabs };
+      const runningTabs = { ...state.runningTabs };
       for (const id of removed) {
         delete tabActivity[id];
         delete streamingTabs[id];
+        delete runningTabs[id];
       }
       for (const id of splitIds) {
         delete tabActivity[id];
         delete streamingTabs[id];
+        delete runningTabs[id];
       }
       clearStreaming([...removed, ...splitIds]);
-      return { tabs, activeTabId, tabActivity, streamingTabs };
+      return { tabs, activeTabId, tabActivity, streamingTabs, runningTabs };
     });
     return [...removed, ...splitIds];
   },
@@ -250,16 +269,19 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       }
       const tabActivity = { ...state.tabActivity };
       const streamingTabs = { ...state.streamingTabs };
+      const runningTabs = { ...state.runningTabs };
       for (const id of removed) {
         delete tabActivity[id];
         delete streamingTabs[id];
+        delete runningTabs[id];
       }
       for (const id of splitIds) {
         delete tabActivity[id];
         delete streamingTabs[id];
+        delete runningTabs[id];
       }
       clearStreaming([...removed, ...splitIds]);
-      return { tabs, activeTabId, tabActivity, streamingTabs };
+      return { tabs, activeTabId, tabActivity, streamingTabs, runningTabs };
     });
     return [...removed, ...splitIds];
   },
@@ -286,8 +308,10 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
       delete tabActivity[splitId];
       const streamingTabs = { ...state.streamingTabs };
       delete streamingTabs[splitId];
+      const runningTabs = { ...state.runningTabs };
+      delete runningTabs[splitId];
       clearStreaming([splitId]);
-      return { tabs, tabActivity, streamingTabs };
+      return { tabs, tabActivity, streamingTabs, runningTabs };
     });
     return splitId;
   },
@@ -324,6 +348,19 @@ export const useDevTerminalStore = create<DevTerminalState & DevTerminalActions>
     if (get().streamingTabs[shellId]) return;
     set((state) => ({ streamingTabs: { ...state.streamingTabs, [shellId]: true } }));
   },
+
+  markShellRunning: (shellId) =>
+    set((state) =>
+      state.runningTabs[shellId] ? {} : { runningTabs: { ...state.runningTabs, [shellId]: true } },
+    ),
+
+  markShellExited: (shellId) =>
+    set((state) => {
+      if (!state.runningTabs[shellId]) return {};
+      const runningTabs = { ...state.runningTabs };
+      delete runningTabs[shellId];
+      return { runningTabs };
+    }),
 
   updateTabTitle: (tabId, rawTitle) => {
     // Shell titles are often full paths (e.g. "C:\Windows\System32\cmd.exe").
@@ -365,5 +402,6 @@ export function resetDevTerminalStore(): void {
     focusRequestId: 0,
     tabActivity: {},
     streamingTabs: {},
+    runningTabs: {},
   });
 }

--- a/src/renderer/state/threadOutputStore.ts
+++ b/src/renderer/state/threadOutputStore.ts
@@ -3,7 +3,7 @@ import { TranscriptBuffer } from "@/shared/transcriptBuffer";
 
 /**
  * Renderer-side append-only PTY scrollback for agent (terminal-presentation)
- * threads.
+ * threads and action-owned terminal tabs.
  *
  * The supervisor keeps a raw byte transcript (`outputTranscript`) for every
  * live session, but agent thread panes are unmounted when the user switches
@@ -13,12 +13,12 @@ import { TranscriptBuffer } from "@/shared/transcriptBuffer";
  * (Claude no-flicker, Command Code) only ever write their current frame, so
  * replaying raw bytes gives the latest frame but no scrollback.
  *
- * This store keeps a bounded append-only copy of each thread's PTY bytes —
- * the same effect the dev-terminal panel gets by keeping its tabs mounted.
+ * This store keeps a bounded append-only copy of each thread's PTY bytes.
  * The global supervisor-event handler feeds `thread-output` here regardless of
  * which pane is visible, so hidden threads accumulate their scrollback, and
+ * action launch routing does the same for local and remote action terminals.
  * `XTermSurface` hydrates from it on (re)mount instead of relying solely on
- * the supervisor transcript.
+ * a live supervisor session.
  */
 interface ThreadOutputState {
   /** threadId -> raw PTY bytes, oldest to newest, capped at MAX_BYTES. */

--- a/src/renderer/utils/shellUtils.test.ts
+++ b/src/renderer/utils/shellUtils.test.ts
@@ -9,10 +9,11 @@ const bridge = vi.hoisted(() => ({
 }));
 
 const supervisorHandlers = vi.hoisted(() => [] as Array<(event: SupervisorEvent) => void>);
+const toastDanger = vi.hoisted(() => vi.fn<(message: string) => void>());
 
 vi.mock("@heroui/react", () => ({
   toast: {
-    danger: vi.fn<(message: string) => void>(),
+    danger: toastDanger,
     success: vi.fn<(message: string) => void>(),
     warning: vi.fn<(message: string) => void>(),
   },
@@ -93,10 +94,11 @@ describe("eager shell start registry", () => {
   beforeEach(() => {
     bridge.startShell.mockReset().mockResolvedValue(undefined);
     bridge.closeThread.mockReset().mockResolvedValue(undefined);
+    toastDanger.mockReset();
   });
 
   it("marks shells started via startShellWithToast and clears them on close", async () => {
-    startShellWithToast(
+    void startShellWithToast(
       { shellId: "shell:eager", projectLocation: { kind: "windows", path: "C:\\p" } },
       "dev",
     );
@@ -108,12 +110,46 @@ describe("eager shell start registry", () => {
   });
 
   it("clears entries via clearEagerShellStart", () => {
-    startShellWithToast(
+    void startShellWithToast(
       { shellId: "shell:eager2", projectLocation: { kind: "windows", path: "C:\\p" } },
       "dev",
     );
     clearEagerShellStart("shell:eager2");
     expect(wasShellStartedEagerly("shell:eager2")).toBe(false);
+  });
+
+  it("does not let an older failed start clear a newer same-id shell", async () => {
+    let rejectFirst!: (error: Error) => void;
+    let resolveSecond!: () => void;
+    bridge.startShell
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    const first = startShellWithToast(
+      { shellId: "shell:reused", projectLocation: { kind: "windows", path: "C:\\p" } },
+      "dev",
+    );
+    const second = startShellWithToast(
+      { shellId: "shell:reused", projectLocation: { kind: "windows", path: "C:\\p" } },
+      "dev",
+    );
+    resolveSecond();
+    await second;
+    rejectFirst(new Error("old start failed"));
+    await first;
+
+    expect(wasShellStartedEagerly("shell:reused")).toBe(true);
+    expect(toastDanger).not.toHaveBeenCalled();
   });
 });
 
@@ -298,6 +334,13 @@ describe("writeScriptToShellThenExitOnSuccess", () => {
     expect(innerScript).toContain("__poracode_setup_exit=$?");
     expect(innerScript).toContain('exit "$__poracode_setup_exit"');
 
+    const echoedCommand = lastWrite();
+    emit({
+      type: "thread-output",
+      threadId: "shell:1",
+      data: echoedCommand,
+      outputLength: echoedCommand.length,
+    });
     const marker = `\u001B]777;poracode-shell-complete=${token}:1\u0007`;
     emit({ type: "thread-output", threadId: "shell:1", data: marker, outputLength: marker.length });
 

--- a/src/renderer/utils/shellUtils.ts
+++ b/src/renderer/utils/shellUtils.ts
@@ -24,6 +24,7 @@ interface StartShellPayload {
  * command just written into it). The surface still resizes the live PTY.
  */
 const eagerlyStartedShells = new Set<string>();
+const eagerStartTokens = new Map<string, symbol>();
 
 export function wasShellStartedEagerly(shellId: string): boolean {
   return eagerlyStartedShells.has(shellId);
@@ -31,16 +32,33 @@ export function wasShellStartedEagerly(shellId: string): boolean {
 
 export function clearEagerShellStart(shellId: string): void {
   eagerlyStartedShells.delete(shellId);
+  eagerStartTokens.delete(shellId);
   disposeRoutedShellSession(shellId);
 }
 
-export function startShellWithToast(payload: StartShellPayload, label: string): void {
+export function startShellWithToast(payload: StartShellPayload, label: string): Promise<boolean> {
+  const startToken = Symbol(payload.shellId);
   eagerlyStartedShells.add(payload.shellId);
-  void readBridge()
+  eagerStartTokens.set(payload.shellId, startToken);
+  return readBridge()
     .startShell(payload)
-    .catch((error) =>
-      toast.danger(error instanceof Error ? error.message : i18n._(msg`Unable to start ${label}.`)),
-    );
+    .then(() => {
+      if (eagerStartTokens.get(payload.shellId) === startToken) {
+        eagerStartTokens.delete(payload.shellId);
+      }
+      return true;
+    })
+    .catch((error) => {
+      if (eagerStartTokens.get(payload.shellId) === startToken) {
+        eagerlyStartedShells.delete(payload.shellId);
+        eagerStartTokens.delete(payload.shellId);
+        disposeRoutedShellSession(payload.shellId);
+        toast.danger(
+          error instanceof Error ? error.message : i18n._(msg`Unable to start ${label}.`),
+        );
+      }
+      return false;
+    });
 }
 
 export function normalizeShellScript(script: string): string {
@@ -128,6 +146,7 @@ export function writeScriptToShell(
   shellId: string,
   script: string,
   remoteServerId?: string,
+  onExit?: (exitCode: number | null) => void,
 ): () => void {
   const command = normalizeShellScript(script);
   if (!command) return () => undefined;
@@ -135,6 +154,7 @@ export function writeScriptToShell(
     shellId,
     data: `${command}\r`,
     ...(remoteServerId ? { remoteServerId } : {}),
+    ...(onExit ? { onExited: onExit } : {}),
     onWriteError: (error) => {
       console.warn(
         `[shellUtils] Unable to write command to shell ${shellId}:`,
@@ -187,6 +207,7 @@ export function writeScriptToShellThenExitOnSuccess(
   onExit: (exitCode: number | null) => void,
   onCommandComplete?: (exitCode: number) => void,
   remoteServerId?: string,
+  outputHandlers?: { onOutput: (output: string) => void; onReset: () => void },
 ): () => void {
   const command = normalizeShellScript(script);
   // Nothing meaningful to run — leave the (caller-guarded) shell untouched.
@@ -214,12 +235,14 @@ export function writeScriptToShellThenExitOnSuccess(
       // A fresh PTY spawned; re-send on its first output so the command runs
       // in the survivor rather than a PTY that is about to be replaced.
       outputBuffer = "";
+      outputHandlers?.onReset();
     },
     onOutput: (output) => {
+      outputHandlers?.onOutput(output);
       if (!completionToken) return;
       outputBuffer = `${outputBuffer}${output}`.slice(-1024);
       const marker = shellCompletionMarker(completionToken);
-      const markerStart = outputBuffer.indexOf(marker);
+      const markerStart = outputBuffer.lastIndexOf(marker);
       if (markerStart < 0) return;
       const match = /^(\d+)/u.exec(outputBuffer.slice(markerStart + marker.length));
       if (match) reportCommandComplete(Number(match[1]));
@@ -282,6 +305,7 @@ export async function closeThreads(threadIds: readonly string[]): Promise<void> 
   const uniqueThreadIds = [...new Set(threadIds.filter(Boolean))];
   for (const threadId of uniqueThreadIds) {
     eagerlyStartedShells.delete(threadId);
+    eagerStartTokens.delete(threadId);
     disposeRoutedShellSession(threadId);
   }
   await Promise.allSettled(

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.test.tsx
@@ -184,6 +184,16 @@ describe("DevTerminalPanel", () => {
     await vi.waitFor(() => expect(bridge.startShell).toHaveBeenCalledTimes(2));
   });
 
+  it("does not spawn an interactive shell when an idle action tab remounts", () => {
+    useSharedSettings.setState({ terminalPosition: "bottom" });
+    useDevTerminalStore.setState({ tabs: [{ ...tab, runActionId: "dev" }] });
+    render(<DevTerminalPanel hideHeader />);
+
+    layouts.bottomOnTerminalResize?.(tab.id, { cols: 100, rows: 30 });
+
+    expect(bridge.startShell).not.toHaveBeenCalled();
+  });
+
   it("shows the project and worktree in the terminal scope label", () => {
     const worktreePath = "/repo/.poracode/worktrees/feature";
     useSharedSettings.setState({ terminalPosition: "bottom" });

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/DevTerminalPanel.tsx
@@ -107,6 +107,10 @@ export function DevTerminalPanel(props: {
     if (wasShellStartedEagerly(terminalId)) return;
     const owningTab = tabs.find((tab) => tab.id === terminalId || tab.splitId === terminalId);
     if (!owningTab) return;
+    // An idle action tab preserves its completed output. Only another Run
+    // action should replace its PTY; remounting the panel must not create an
+    // unrelated interactive shell in the action-owned tab.
+    if (owningTab.id === terminalId && owningTab.runActionId) return;
     const project = projects.find((p) => p.id === owningTab.projectId);
     if (!project) return;
     const location = owningTab.worktreePath

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.test.tsx
@@ -1,20 +1,31 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { dynamicActivate } from "@/renderer/i18n/i18n";
+import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { BottomTerminalLayout } from "./BottomTerminalLayout";
 
 vi.mock("./TerminalSurfaces", () => ({
   TerminalSurfaces: () => <div data-testid="terminal-surfaces" />,
 }));
 
-function renderLayout() {
+const actionTab = {
+  id: "shell:action",
+  projectId: "project-1",
+  runActionId: "dev",
+  title: "Dev",
+  createdAt: "2026-08-08T00:00:00.000Z",
+};
+
+function renderLayout(options: { showActionTab?: boolean } = {}) {
+  const projectTabs = options.showActionTab ? [actionTab] : [];
   return render(
     <BottomTerminalLayout
-      tabs={[]}
-      projectTabs={[]}
+      tabs={projectTabs}
+      projectTabs={projectTabs}
       activeScopeLabel="Poracode / feature"
-      selectedTabId="__add__"
-      activeTab={undefined}
+      selectedTabId={options.showActionTab ? actionTab.id : "__add__"}
+      activeTab={options.showActionTab ? actionTab : undefined}
       focusRequestId={0}
       markTabActive={vi.fn<() => void>()}
       updateTabTitle={vi.fn<() => void>()}
@@ -32,6 +43,7 @@ function renderLayout() {
 describe("BottomTerminalLayout", () => {
   beforeEach(() => {
     localStorage.clear();
+    resetDevTerminalStore();
   });
 
   it("shows the project and worktree scope in the header", () => {
@@ -63,5 +75,25 @@ describe("BottomTerminalLayout", () => {
 
     expect(sidebar).toHaveStyle({ width: "210px" });
     expect(localStorage.getItem("poracode-bottom-terminal-sidebar-width")).toBe("210");
+  });
+
+  it("announces whether an action-owned tab is idle or running", () => {
+    renderLayout({ showActionTab: true });
+
+    expect(screen.getByRole("tab", { name: "Dev, Idle" })).toBeInTheDocument();
+
+    act(() => useDevTerminalStore.getState().markShellRunning(actionTab.id));
+
+    expect(screen.getByRole("tab", { name: "Dev, Running" })).toBeInTheDocument();
+  });
+
+  it("localizes the complete accessible action-tab status", async () => {
+    await act(() => dynamicActivate("de"));
+    const view = renderLayout({ showActionTab: true });
+
+    expect(screen.getByRole("tab", { name: "Dev, Leerlauf" })).toBeInTheDocument();
+
+    view.unmount();
+    await act(() => dynamicActivate("en"));
   });
 });

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/BottomTerminalLayout.tsx
@@ -1,4 +1,4 @@
-import { Columns2, PanelBottomClose, Plus, Trash2 } from "lucide-react";
+import { Columns2, Loader2, PanelBottomClose, Play, Plus, Trash2 } from "lucide-react";
 import { Tabs } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import type { TerminalSize } from "@/shared/contracts";
@@ -60,6 +60,7 @@ export function BottomTerminalLayout(props: {
   } = props;
   const { sidebarRef, sidebarWidth, handleResizeStart, handleResizeKeyDown } =
     useBottomTerminalSidebarResize();
+  const runningTabs = useDevTerminalStore((state) => state.runningTabs);
 
   // Build flat entries: primary tabs + their split children
   type TabRow = { id: string; tab: DevTerminalTab; isSplit: boolean };
@@ -110,6 +111,13 @@ export function BottomTerminalLayout(props: {
                       key={id}
                       id={id}
                       className={`group w-full gap-0 pl-3 pr-1 text-xs ${isSplit && parentSelected ? "text-foreground" : ""}`}
+                      {...(!isSplit && tab.runActionId
+                        ? {
+                            "aria-label": runningTabs[tab.id]
+                              ? t`${tab.title}, Running`
+                              : t`${tab.title}, Idle`,
+                          }
+                        : {})}
                     >
                       <ContextMenu
                         items={getTabContextItems(tab)}
@@ -122,6 +130,18 @@ export function BottomTerminalLayout(props: {
                           >
                             {isSplit ? (tab.splitTitle ?? tab.title) : tab.title}
                           </span>
+                          {!isSplit && tab.runActionId ? (
+                            <>
+                              {runningTabs[tab.id] ? (
+                                <Loader2
+                                  className="size-3 shrink-0 animate-spin text-accent"
+                                  aria-hidden
+                                />
+                              ) : (
+                                <Play className="size-3 shrink-0 text-accent" aria-hidden />
+                              )}
+                            </>
+                          ) : null}
                           {isSplit ? <Columns2 className="size-3 shrink-0 text-accent" /> : null}
                         </span>
                       </ContextMenu>

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/RightTerminalLayout.tsx
@@ -1,4 +1,4 @@
-import { PanelRightClose, Plus, Trash2 } from "lucide-react";
+import { Loader2, PanelRightClose, Play, Plus, Trash2 } from "lucide-react";
 import { Tabs } from "@heroui/react";
 import { useLingui } from "@lingui/react/macro";
 import type { TerminalSize } from "@/shared/contracts";
@@ -46,6 +46,7 @@ export function RightTerminalLayout(props: {
     onTerminalResize,
     watchTerminal,
   } = props;
+  const runningTabs = useDevTerminalStore((state) => state.runningTabs);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[var(--content-background)]" style={fadeStyle}>
@@ -77,11 +78,30 @@ export function RightTerminalLayout(props: {
                   key={tab.id}
                   id={tab.id}
                   className="group w-[120px] gap-0 pl-3 pr-1 text-xs"
+                  {...(tab.runActionId
+                    ? {
+                        "aria-label": runningTabs[tab.id]
+                          ? t`${tab.title}, Running`
+                          : t`${tab.title}, Idle`,
+                      }
+                    : {})}
                 >
                   <span className="flex min-w-0 flex-1 items-center gap-1">
                     <span className="truncate" title={tab.title}>
                       {tab.title}
                     </span>
+                    {tab.runActionId ? (
+                      <>
+                        {runningTabs[tab.id] ? (
+                          <Loader2
+                            className="size-3 shrink-0 animate-spin text-accent"
+                            aria-hidden
+                          />
+                        ) : (
+                          <Play className="size-3 shrink-0 text-accent" aria-hidden />
+                        )}
+                      </>
+                    ) : null}
                   </span>
                   <button
                     className="ml-auto flex size-4 shrink-0 items-center justify-center rounded opacity-0 transition hover:text-danger group-hover:opacity-100"

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.test.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.test.tsx
@@ -2,6 +2,7 @@ import { act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { DevTerminalTab } from "@/renderer/state/devTerminalStore";
+import { useThreadOutputStore } from "@/renderer/state/threadOutputStore";
 import type { TerminalFeedListener } from "@/shared/remote/terminalFeed";
 import { TerminalSurfaces } from "./TerminalSurfaces";
 
@@ -96,6 +97,7 @@ function renderSurfaces(props: {
 
 describe("TerminalSurfaces", () => {
   beforeEach(() => {
+    useThreadOutputStore.setState({ buffers: {} });
     state.focusCalls = [];
     state.refitCalls = [];
     state.surfaceProps.clear();
@@ -181,5 +183,23 @@ describe("TerminalSurfaces", () => {
     expect(surface?.preferDomRenderer).toBe(true);
     expect(surface?.outputSource?.(listener)).toBe(unsubscribe);
     expect(watchTerminal).toHaveBeenCalledWith(tabA.id, listener);
+  });
+
+  it("restores retained output when an action terminal remounts", () => {
+    const actionTab = { ...tabA, runActionId: "dev" };
+    useThreadOutputStore.getState().appendOutput(actionTab.id, "finished output\r\n");
+
+    render(
+      <TerminalSurfaces
+        tabs={[actionTab]}
+        selectedTabId={actionTab.id}
+        activeTab={actionTab}
+        focusRequestId={1}
+        markTabActive={vi.fn<() => void>()}
+        updateTabTitle={vi.fn<() => void>()}
+      />,
+    );
+
+    expect(state.surfaceProps.get(actionTab.id)?.initialScrollback).toBe("finished output\r\n");
   });
 });

--- a/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
+++ b/src/renderer/views/MainView/parts/RightPanel/parts/DevTerminalPanel/parts/TerminalSurfaces.tsx
@@ -3,6 +3,7 @@ import { useLingui } from "@lingui/react/macro";
 import type { DevTerminalTab } from "@/renderer/state/devTerminalStore";
 import { XTermSurface, type XTermSurfaceHandle } from "@/renderer/components/terminal/XTermSurface";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { useThreadOutputStore } from "@/renderer/state/threadOutputStore";
 import type { TerminalSize } from "@/shared/contracts";
 import type { TerminalFeedListener } from "@/shared/remote/terminalFeed";
 
@@ -147,13 +148,18 @@ export function TerminalSurfaces(props: {
     setSplitPercent(clamped);
   }
 
-  function remoteSurfaceProps(terminalId: string) {
-    return watchTerminal
-      ? {
-          outputSource: (listener: TerminalFeedListener) => watchTerminal(terminalId, listener),
-          initialScrollback: "",
-          preferDomRenderer: true,
-        }
+  function surfaceProps(tab: DevTerminalTab) {
+    if (watchTerminal) {
+      return {
+        outputSource: (listener: TerminalFeedListener) => watchTerminal(tab.id, listener),
+        initialScrollback: tab.runActionId
+          ? useThreadOutputStore.getState().readTail(tab.id, 100_000)
+          : "",
+        preferDomRenderer: true,
+      };
+    }
+    return tab.runActionId
+      ? { initialScrollback: useThreadOutputStore.getState().readTail(tab.id, 100_000) }
       : {};
   }
 
@@ -203,7 +209,7 @@ export function TerminalSurfaces(props: {
                 onActivity={() => markTabActive(tab.id)}
                 onBell={() => markTabActive(tab.id)}
                 onTitleChange={(title) => updateTabTitle(tab.id, title)}
-                {...remoteSurfaceProps(tab.id)}
+                {...surfaceProps(tab)}
                 {...(onTerminalResize
                   ? { onTerminalResize: (size) => onTerminalResize(tab.id, size) }
                   : {})}
@@ -241,7 +247,14 @@ export function TerminalSurfaces(props: {
                   onActivity={() => markTabActive(tab.id)}
                   onBell={() => markTabActive(tab.id)}
                   onTitleChange={(title) => updateTabTitle(tab.splitId!, title)}
-                  {...remoteSurfaceProps(tab.splitId!)}
+                  {...(watchTerminal
+                    ? {
+                        outputSource: (listener: TerminalFeedListener) =>
+                          watchTerminal(tab.splitId!, listener),
+                        initialScrollback: "",
+                        preferDomRenderer: true,
+                      }
+                    : {})}
                   {...(onTerminalResize
                     ? { onTerminalResize: (size) => onTerminalResize(tab.splitId!, size) }
                     : {})}
@@ -276,7 +289,7 @@ export function TerminalSurfaces(props: {
             onActivity={() => markTabActive(tab.id)}
             onBell={() => markTabActive(tab.id)}
             onTitleChange={(title) => updateTabTitle(tab.id, title)}
-            {...remoteSurfaceProps(tab.id)}
+            {...surfaceProps(tab)}
             {...(onTerminalResize
               ? { onTerminalResize: (size) => onTerminalResize(tab.id, size) }
               : {})}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import type { Project, Thread } from "@/shared/contracts";
+import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
+
+const terminalActions = vi.hoisted(() => ({
+  openWorktreeTerminal: vi.fn<(projectId: string, worktreePath: string) => void>(),
+  runProjectAction: vi.fn<(projectId: string, actionId: string, worktreePath?: string) => void>(),
+  stopProjectAction: vi.fn<(projectId: string, actionId: string, worktreePath?: string) => void>(),
+}));
+
+vi.mock("@dnd-kit/react/sortable", () => ({
+  useSortable: () => ({ ref: vi.fn<(node: HTMLElement | null) => void>() }),
+}));
+
+vi.mock("@/renderer/dnd", () => ({
+  useDragSource: () => null,
+  useIsDraggingWorktreeGroup: () => false,
+}));
+
+vi.mock("@/renderer/actions/terminalActions", () => terminalActions);
+
+vi.mock("./useWorktreeActions", () => ({
+  useWorktreeGitItems: () => [],
+}));
+
+vi.mock("./WorktreeGroupHeader", () => ({
+  WorktreeGroupHeader: (props: { onContextMenu?: React.MouseEventHandler<HTMLButtonElement> }) => (
+    <button type="button" onContextMenu={props.onContextMenu}>
+      worktree
+    </button>
+  ),
+}));
+
+const worktreePath = "C:\\repo\\wt";
+const project = {
+  id: "p1",
+  name: "Poracode",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-08-08T00:00:00.000Z",
+  scripts: { actions: [{ id: "build", name: "Build", command: "pnpm build" }] },
+} satisfies Project;
+
+const thread = {
+  id: "t1",
+  projectId: project.id,
+  title: "Thread",
+  status: "inactive",
+  done: false,
+  starred: false,
+  archived: false,
+  createdAt: "2026-08-08T00:00:00.000Z",
+  updatedAt: "2026-08-08T00:00:00.000Z",
+  agentKind: "claude",
+  worktreePath,
+  worktreeBranch: "feature",
+} as unknown as Thread;
+
+describe("SidebarWorktreeGroup Run menu", () => {
+  beforeEach(() => {
+    resetDevTerminalStore();
+    terminalActions.stopProjectAction.mockReset();
+    const terminal = useDevTerminalStore.getState();
+    const tab = terminal.addTab(project.id, "Build", worktreePath, "build");
+    terminal.markShellRunning(tab.id);
+  });
+
+  it("offers a scoped Stop action for a running worktree command", async () => {
+    render(
+      <SidebarWorktreeGroup
+        group={{
+          kind: "worktree",
+          threads: [thread],
+          worktreePath,
+          worktreeBranch: "feature",
+        }}
+        entryIndex={0}
+        project={project}
+        sortableGroup="project:p1"
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "worktree" }));
+    fireEvent.pointerEnter(screen.getByRole("menuitem", { name: "Run" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Stop Build" }));
+
+    expect(terminalActions.stopProjectAction).toHaveBeenCalledWith(
+      project.id,
+      "build",
+      worktreePath,
+    );
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -1,8 +1,8 @@
-import { CircleCheck, GitFork, Play, Plus, Trash2 } from "lucide-react";
+import { CircleCheck, GitFork, Loader2, Play, Plus, Square, Trash2 } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { useSortable } from "@dnd-kit/react/sortable";
 import type { Project } from "@/shared/contracts";
-import { ContextMenu } from "@/renderer/components/common/ContextMenu";
+import { ContextMenu, type ContextMenuItem } from "@/renderer/components/common/ContextMenu";
 import { useDragSource, useIsDraggingWorktreeGroup, type DragSourceData } from "@/renderer/dnd";
 import {
   useIsWorktreeFilesPanelActive,
@@ -10,6 +10,7 @@ import {
   useIsWorktreeTerminalActive,
   useIsWorktreeTerminalBusy,
   useIsWorktreeTerminalOpen,
+  useRunningProjectActionIds,
 } from "@/renderer/hooks/uiSelectors";
 import {
   gitMergeAndRemove,
@@ -20,7 +21,11 @@ import {
   gitSync,
 } from "@/renderer/actions/gitActions";
 import { openFilesPanel, openGitReview } from "@/renderer/actions/panelActions";
-import { openWorktreeTerminal, runProjectAction } from "@/renderer/actions/terminalActions";
+import {
+  openWorktreeTerminal,
+  runProjectAction,
+  stopProjectAction,
+} from "@/renderer/actions/terminalActions";
 import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 import { markThreadDone, openNewThreadInWorktree } from "@/renderer/actions/threadActions";
 import { readBridge } from "@/renderer/bridge";
@@ -52,6 +57,29 @@ export function SidebarWorktreeGroup(props: {
   const isBusyTerminal = useIsWorktreeTerminalBusy(group.worktreePath);
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
   const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
+  const runningActionIds = useRunningProjectActionIds(project.id, group.worktreePath);
+  const runActionItems: ContextMenuItem[] = [];
+  for (const action of project.scripts?.actions ?? []) {
+    const isRunning = runningActionIds.includes(action.id);
+    runActionItems.push({
+      id: `action:${action.id}`,
+      label: action.name,
+      icon: isRunning ? (
+        <Loader2 className="size-3.5 animate-spin text-accent" aria-hidden />
+      ) : (
+        resolveActionIcon(action.icon)
+      ),
+      ...(isRunning
+        ? {
+            endAction: {
+              id: `stop-action:${action.id}`,
+              label: t`Stop ${action.name}`,
+              icon: <Square className="size-3 fill-current" aria-hidden />,
+            },
+          }
+        : {}),
+    });
+  }
   const groupThreadIds = group.threads.map((thread) => thread.id);
   const activeThreads = group.threads.filter((thread) => !thread.done);
   const isDone = group.threads.every((thread) => thread.done);
@@ -106,11 +134,7 @@ export function SidebarWorktreeGroup(props: {
                   id: "run-action",
                   label: t`Run`,
                   icon: <Play className="size-3.5" />,
-                  items: project.scripts.actions.map((action) => ({
-                    id: `action:${action.id}`,
-                    label: action.name,
-                    icon: resolveActionIcon(action.icon),
-                  })),
+                  items: runActionItems,
                 },
               ]
             : []),
@@ -151,6 +175,9 @@ export function SidebarWorktreeGroup(props: {
           if (key === "create-pr") openGitReview(project.id, group.worktreePath);
           if (key.startsWith("action:")) {
             runProjectAction(project.id, key.slice("action:".length), group.worktreePath);
+          }
+          if (key.startsWith("stop-action:")) {
+            stopProjectAction(project.id, key.slice("stop-action:".length), group.worktreePath);
           }
         }}
       >

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -82,6 +82,7 @@ vi.mock("@/renderer/hooks/uiSelectors", () => ({
   useIsWorktreeTerminalActive: () => false,
   useIsWorktreeTerminalBusy: () => false,
   useIsWorktreeTerminalOpen: () => false,
+  useRunningProjectActionIds: () => [],
 }));
 
 vi.mock("@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions", () => ({

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project, Thread } from "@/shared/contracts";
 import { HOME_PROJECT_ID } from "@/shared/homeScope";
+import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { ThreadContextMenu } from "./ThreadContextMenu";
 
 vi.mock("@/renderer/bridge", () => ({
@@ -55,6 +56,10 @@ function renderMenu(
 }
 
 describe("ThreadContextMenu project actions", () => {
+  beforeEach(() => {
+    resetDevTerminalStore();
+  });
+
   it("offers project Git and Run submenus on flat main-branch rows", async () => {
     await renderMenu(thread(), project, { showProjectActions: true });
 
@@ -95,5 +100,19 @@ describe("ThreadContextMenu project actions", () => {
 
     expect(screen.getByRole("menuitem", { name: "Git" })).toBeInTheDocument();
     expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+  });
+
+  it("shows a running indicator for the action-owned terminal", async () => {
+    const terminal = useDevTerminalStore.getState();
+    const tab = terminal.addTab(project.id, "Build", undefined, "build");
+    terminal.markShellRunning(tab.id);
+    await renderMenu(thread(), project, { showProjectActions: true });
+
+    fireEvent.pointerEnter(screen.getByRole("menuitem", { name: "Run" }));
+    const action = await screen.findByRole("menuitem", { name: "Build" });
+
+    expect(action.querySelector(".animate-spin")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Stop Build" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Stop Build" })).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
@@ -7,10 +7,12 @@ import {
   FileDiff,
   FlaskConical,
   GitFork,
+  Loader2,
   Pencil,
   Play,
   Plus,
   RefreshCw,
+  Square,
   Star,
   Trash2,
   Workflow,
@@ -22,7 +24,7 @@ import { isHomeProject } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useExperimentStore } from "@/renderer/state/experimentStore";
 import { useGitStore } from "@/renderer/state/gitStore";
-import { ContextMenu } from "@/renderer/components/common/ContextMenu";
+import { ContextMenu, type ContextMenuItem } from "@/renderer/components/common/ContextMenu";
 import { readBridge } from "@/renderer/bridge";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { useWorktreeGitItems } from "@/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions";
@@ -31,6 +33,7 @@ import {
   useCurrentThreadIdsCount,
   useIsCurrentThread,
   useProjectAgentStatuses,
+  useRunningProjectActionIds,
 } from "@/renderer/hooks/uiSelectors";
 import { openGitReview } from "@/renderer/actions/panelActions";
 import { moveThreadToWorktree } from "@/renderer/actions/moveThreadToWorktreeActions";
@@ -51,7 +54,7 @@ import {
   continueInProvider,
   openNewThreadInWorktree,
 } from "@/renderer/actions/threadActions";
-import { runProjectAction } from "@/renderer/actions/terminalActions";
+import { runProjectAction, stopProjectAction } from "@/renderer/actions/terminalActions";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 
 /**
@@ -94,6 +97,29 @@ export function ThreadContextMenu(props: {
   // Home has no project menu even in the grouped layout (its sidebar section
   // is a plain header), so flat Home threads don't get project actions either.
   const showProjectActions = props.showProjectActions === true && !isHomeProject(project);
+  const runningActionIds = useRunningProjectActionIds(project.id, thread.worktreePath);
+  const runActionItems: ContextMenuItem[] = [];
+  for (const action of project.scripts?.actions ?? []) {
+    const isRunning = runningActionIds.includes(action.id);
+    runActionItems.push({
+      id: `action:${action.id}`,
+      label: action.name,
+      icon: isRunning ? (
+        <Loader2 className="size-3.5 animate-spin text-accent" aria-hidden />
+      ) : (
+        resolveActionIcon(action.icon)
+      ),
+      ...(isRunning
+        ? {
+            endAction: {
+              id: `stop-action:${action.id}`,
+              label: t`Stop ${action.name}`,
+              icon: <Square className="size-3 fill-current" aria-hidden />,
+            },
+          }
+        : {}),
+    });
+  }
 
   return (
     <ContextMenu
@@ -171,11 +197,7 @@ export function ThreadContextMenu(props: {
                 id: "run-action",
                 label: t`Run`,
                 icon: <Play className="size-3.5" />,
-                items: project.scripts.actions.map((action) => ({
-                  id: `action:${action.id}`,
-                  label: action.name,
-                  icon: resolveActionIcon(action.icon),
-                })),
+                items: runActionItems,
               },
             ]
           : []),
@@ -359,6 +381,9 @@ export function ThreadContextMenu(props: {
           deleteThread(thread.id, thread.worktreePath, thread.projectId);
         if (key.startsWith("action:")) {
           runProjectAction(project.id, key.slice("action:".length), thread.worktreePath);
+        }
+        if (key.startsWith("stop-action:")) {
+          stopProjectAction(project.id, key.slice("stop-action:".length), thread.worktreePath);
         }
       }}
     >

--- a/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
@@ -3,21 +3,23 @@ import {
   FileDiff,
   GitFork,
   Layers,
+  Loader2,
   Play,
   Power,
   PowerOff,
   RefreshCw,
   Settings2,
+  Square,
   Trash2,
   Workflow,
 } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { Project } from "@/shared/contracts";
-import type { ContextMenuEntry } from "@/renderer/components/common/ContextMenu";
+import type { ContextMenuEntry, ContextMenuItem } from "@/renderer/components/common/ContextMenu";
 import { setProjectDisabled, deleteProject } from "@/renderer/actions/projectActions";
 import { openGitReview, openProjectSettings } from "@/renderer/actions/panelActions";
 import { gitSync } from "@/renderer/actions/gitActions";
-import { runProjectAction } from "@/renderer/actions/terminalActions";
+import { runProjectAction, stopProjectAction } from "@/renderer/actions/terminalActions";
 import {
   WORKSPACE_UNFILED_KEY,
   parseWorkspaceMenuKey,
@@ -28,6 +30,7 @@ import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
+import { useRunningProjectActionIds } from "@/renderer/hooks/uiSelectors";
 
 /**
  * The project context menu: entries plus their action dispatcher, shared by
@@ -46,6 +49,31 @@ export function useProjectMenu(
   const setRemoteProjectSynced = useRemoteServersStore((state) => state.setRemoteProjectSynced);
   const isDisabled = !!project.disabled;
   const isRemote = project.remoteServerId !== undefined && project.remoteId !== undefined;
+  const runningActionIds = useRunningProjectActionIds(project.id);
+  const runActionItems: ContextMenuItem[] = [];
+  for (const action of project.scripts?.actions ?? []) {
+    const isRunning = runningActionIds.includes(action.id);
+    runActionItems.push({
+      id: `action:${action.id}`,
+      label: action.name,
+      icon: isRunning ? (
+        <Loader2 className="size-3.5 animate-spin text-accent" aria-hidden />
+      ) : (
+        resolveActionIcon(action.icon)
+      ),
+      isDisabled: isUnreachable,
+      ...(isRunning
+        ? {
+            endAction: {
+              id: `stop-action:${action.id}`,
+              label: t`Stop ${action.name}`,
+              icon: <Square className="size-3 fill-current" aria-hidden />,
+              isDisabled: isUnreachable,
+            },
+          }
+        : {}),
+    });
+  }
 
   const items: ContextMenuEntry[] = [
     {
@@ -89,12 +117,7 @@ export function useProjectMenu(
                   id: "run-action",
                   label: t`Run`,
                   icon: <Play className="size-3.5" />,
-                  items: project.scripts.actions.map((action) => ({
-                    id: `action:${action.id}`,
-                    label: action.name,
-                    icon: resolveActionIcon(action.icon),
-                    isDisabled: isUnreachable,
-                  })),
+                  items: runActionItems,
                 },
               ]
             : []),
@@ -163,6 +186,9 @@ export function useProjectMenu(
     if (key === "git-sync") gitSync(project.id);
     if (key.startsWith("action:")) {
       runProjectAction(project.id, key.slice("action:".length));
+    }
+    if (key.startsWith("stop-action:")) {
+      stopProjectAction(project.id, key.slice("stop-action:".length));
     }
     const workspaceChoice = parseWorkspaceMenuKey(key);
     if (workspaceChoice?.kind === "unfiled") {


### PR DESCRIPTION
- Add running-state tracking for project action terminals and Stop action menu entries, letting users cancel running dev/build actions from sidebar worktree groups and thread context menus.
- Retain terminal output for finished action tabs so scrollback survives shell exit and survives re-mount, with corrected shell lifecycle teardown tokens.
- Localize the new Stop action labels across all 12 non-English catalogs.
- Add unit coverage for the store, actions, context menus, and terminal layouts.