### PR TITLE
Add get_current_thread MCP tool and Terminal composer mention

### DIFF
--- a/src/main/app-controls/mcp/toolRegistry.test.ts
+++ b/src/main/app-controls/mcp/toolRegistry.test.ts
@@ -37,6 +37,8 @@ import type {
 } from "../../threads/appThreadLauncher";
 import { ThreadStateBroker } from "../../threads/threadStateBroker";
 import {
+  APP_CONTROLS_MCP_INSTRUCTIONS,
+  TOOLS,
   dispatchTool,
   type AppControlsSupervisorCaller,
   type AppControlsToolContext,
@@ -426,6 +428,39 @@ describe("Poracode app control tools — schedules", () => {
 });
 
 describe("Poracode app control tools — threads", () => {
+  it("returns the calling thread with its project and worktree", async () => {
+    const current = makeThread({
+      id: thread.id,
+      projectId: "project-1",
+      worktreePath: "/work/alpha/.poracode/worktrees/current",
+      worktreeBranch: "feature/current",
+    });
+    const projects = [{ id: "project-1", name: "Alpha" } as Project];
+    const { ctx } = context({ threads: [current], projects });
+
+    const result = (await dispatchTool("get_current_thread", {}, ctx)) as {
+      threadId: string;
+      projectName: string;
+      worktreePath: string;
+    };
+
+    expect(result).toMatchObject({
+      threadId: thread.id,
+      projectName: "Alpha",
+      worktreePath: "/work/alpha/.poracode/worktrees/current",
+    });
+  });
+
+  it("notes when an MCP request has no calling thread", async () => {
+    const { ctx } = context();
+    ctx.identity = {};
+
+    await expect(dispatchTool("get_current_thread", {}, ctx)).resolves.toMatchObject({
+      threadId: null,
+      note: expect.stringMatching(/not associated/),
+    });
+  });
+
   it("lists all threads merged with live runtime snapshots and applies filters", async () => {
     const threads = [
       makeThread({ id: "a", projectId: "project-1", status: "idle" }),
@@ -453,6 +488,78 @@ describe("Poracode app control tools — threads", () => {
       count: number;
     };
     expect(filtered.count).toBe(1);
+  });
+
+  it("filters threads to the calling thread's exact worktree", async () => {
+    const worktreePath = "/work/alpha/.poracode/worktrees/current";
+    const threads = [
+      makeThread({ id: thread.id, projectId: "project-1", worktreePath }),
+      makeThread({ id: "same", projectId: "project-1", worktreePath }),
+      makeThread({ id: "main", projectId: "project-1" }),
+      makeThread({ id: "other", projectId: "project-2", worktreePath }),
+    ];
+    const { ctx } = context({ threads });
+
+    const result = (await dispatchTool("list_threads", { currentWorktree: true }, ctx)) as {
+      threads: Array<{ threadId: string }>;
+    };
+
+    expect(result.threads.map((entry) => entry.threadId)).toEqual([thread.id, "same"]);
+  });
+
+  it("normalizes Windows worktree paths when filtering the calling worktree", async () => {
+    const threads = [
+      makeThread({
+        id: thread.id,
+        projectId: "project-1",
+        worktreePath: "C:\\Work\\Alpha\\Feature\\",
+      }),
+      makeThread({
+        id: "same",
+        projectId: "project-1",
+        worktreePath: "c:/work/alpha/feature",
+      }),
+      makeThread({
+        id: "other",
+        projectId: "project-1",
+        worktreePath: "C:\\Work\\Alpha\\Other",
+      }),
+    ];
+    const projects = [
+      {
+        id: "project-1",
+        name: "Alpha",
+        location: { kind: "windows", path: "C:\\Work\\Alpha" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      } satisfies Project,
+    ];
+    const { ctx } = context({ threads, projects });
+
+    const result = (await dispatchTool("list_threads", { currentWorktree: true }, ctx)) as {
+      threads: Array<{ threadId: string }>;
+    };
+
+    expect(result.threads.map((entry) => entry.threadId)).toEqual([thread.id, "same"]);
+  });
+
+  it("treats an absent worktreePath as the project's main checkout", async () => {
+    const threads = [
+      makeThread({ id: thread.id, projectId: "project-1" }),
+      makeThread({ id: "same-main", projectId: "project-1" }),
+      makeThread({
+        id: "separate-worktree",
+        projectId: "project-1",
+        worktreePath: "/work/alpha/.poracode/worktrees/feature",
+      }),
+      makeThread({ id: "other-project", projectId: "project-2" }),
+    ];
+    const { ctx } = context({ threads });
+
+    const result = (await dispatchTool("list_threads", { currentWorktree: true }, ctx)) as {
+      threads: Array<{ threadId: string }>;
+    };
+
+    expect(result.threads.map((entry) => entry.threadId)).toEqual([thread.id, "same-main"]);
   });
 
   it("create_thread inherits the calling thread's agent, model, effort, and fast", async () => {
@@ -1028,6 +1135,35 @@ describe("Poracode app control tools — app", () => {
 });
 
 describe("Poracode app control tools — terminal / steer / rollback", () => {
+  it("explains the optimized @Terminal workflow to agents", () => {
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("Treat @Terminal, or its localized equivalent");
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("get_current_thread");
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("currentWorktree=true");
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("structured/GUI thread");
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("absent worktreePath");
+    expect(APP_CONTROLS_MCP_INSTRUCTIONS).toContain("do not echo secrets");
+
+    expect(TOOLS.find((tool) => tool.name === "get_current_thread")?.description).toContain(
+      "do not ask the user",
+    );
+    expect(TOOLS.find((tool) => tool.name === "read_terminal")?.description).toContain(
+      "extract the relevant evidence",
+    );
+  });
+
+  it("read_terminal defaults to the calling thread", async () => {
+    const threads = [makeThread({ id: thread.id })];
+    const { ctx, supervisor } = context({ threads, scrollback: "current output" });
+
+    const result = (await dispatchTool("read_terminal", {}, ctx)) as {
+      threadId: string;
+      text: string;
+    };
+
+    expect(result).toMatchObject({ threadId: thread.id, text: "current output" });
+    expect(supervisor.readTerminalScrollback).toHaveBeenCalledWith({ threadId: thread.id });
+  });
+
   it("read_terminal returns the tail and flags truncation", async () => {
     const scrollback = "x".repeat(60_000);
     const threads = [makeThread({ id: "a" })];

--- a/src/main/app-controls/mcp/toolRegistry.ts
+++ b/src/main/app-controls/mcp/toolRegistry.ts
@@ -29,7 +29,7 @@ export type {
 
 export const APP_CONTROLS_MCP_INSTRUCTIONS =
   "Poracode app controls. Read and control the running app: device schedules " +
-  "(list/create/update/run/delete), app threads (list/get/read/create/send/interrupt/stop/wait/" +
+  "(list/create/update/run/delete), app threads (current/list/get/read/create/send/interrupt/stop/wait/" +
   "update/open), projects (list/get/create/update), app settings (get/update), provider usage " +
   "(get_usage), cross-app search (search), and app info (get_app_info). You can also read a " +
   "terminal thread's scrollback, queue steer guidance, stage composer input, or roll back turns; " +
@@ -45,7 +45,21 @@ export const APP_CONTROLS_MCP_INSTRUCTIONS =
   "never delete their work without asking. update_settings changes apply immediately app-wide. " +
   "Secrets are never exposed: get_settings redacts profile credentials and update_settings " +
   "refuses to touch them. Schedules run only while the device is awake and Poracode is open. " +
-  "You cannot stop, interrupt, or wait on your own thread.";
+  "You cannot stop, interrupt, or wait on your own thread. Treat @Terminal, or its localized " +
+  "equivalent inserted by the composer, as a request to inspect terminal scrollback for the " +
+  "caller's current worktree, not as a file mention or literal name. " +
+  "For @Terminal: (1) call get_current_thread to learn the caller's threadId, project, worktree, " +
+  "and presentation mode; an absent worktreePath means the project's main checkout, and you " +
+  "should never ask the user for these ids. (2) Call list_threads with " +
+  "currentWorktree=true. (3) From that result, consider only terminal-presentation threads; start " +
+  "with the caller when it is terminal-backed, then inspect the most relevant active or recently " +
+  "updated sibling terminals instead of reading every old or archived thread. If the caller is a " +
+  "structured/GUI thread, inspect relevant terminal siblings in the same worktree. (4) Call " +
+  "read_terminal with no threadId for the caller, or with a sibling's threadId. Read additional " +
+  "terminals only when needed. (5) Report the useful evidence with the source thread title/id, " +
+  "distinguish observed output from inference, and do not echo secrets or dump the entire raw " +
+  "scrollback. A missing terminal means that thread is GUI-backed, stopped, or has no live PTY; " +
+  "continue with another relevant terminal when available.";
 
 const DOMAINS: readonly ToolDomain[] = [
   scheduleTools,

--- a/src/main/app-controls/mcp/tools/threads.ts
+++ b/src/main/app-controls/mcp/tools/threads.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_TERMINAL_SIZE,
   resolveMcpLaunchSnapshot,
 } from "@/shared/contracts";
-import { buildWorktreeLocation } from "@/shared/worktree";
+import { buildWorktreeLocation, normalizeWorktreePathForComparison } from "@/shared/worktree";
 import { dbGetThreadRuntimeItemsPage } from "../../../db";
 import {
   assertNotSelf,
@@ -51,8 +51,10 @@ const ROLLBACK_MAX_TURNS = 20;
 const listArgsSchema = z.object({
   projectId: z.string().min(1).optional(),
   status: z.string().min(1).optional(),
+  currentWorktree: z.boolean().optional(),
 });
 const threadIdArgsSchema = z.object({ threadId: z.string().min(1) });
+const optionalThreadIdArgsSchema = z.object({ threadId: z.string().min(1).optional() });
 const readArgsSchema = z.object({
   threadId: z.string().min(1),
   limit: z.number().int().min(1).max(READ_MAX_LIMIT).optional(),
@@ -104,15 +106,26 @@ const updateArgsSchema = z.object({
 export const threadTools: ToolDomain = {
   specs: [
     {
+      name: "get_current_thread",
+      description:
+        "Identify the Poracode thread making this MCP call. Returns its threadId, project, presentation mode, status, and worktreePath/branch when it uses a separate worktree; an absent worktreePath means the project's main checkout. Call this before work that depends on 'this thread' or 'this worktree'; do not ask the user to provide an id. Takes no arguments.",
+      inputSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+    },
+    {
       name: "list_threads",
       description:
-        "List all app threads (across projects) with their live status, attention, project, agent, model, and worktree. Optionally filter by projectId or status.",
+        "List app threads with their live status, attention, project, agent, model, presentation mode, and worktree. Set currentWorktree=true to return only threads in the calling agent's exact project and worktree; this also matches main-checkout threads whose worktreePath is absent. Optionally filter by projectId or status.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
         properties: {
           projectId: projectIdProp,
           status: { type: "string" },
+          currentWorktree: { type: "boolean" },
         },
       },
     },
@@ -232,8 +245,8 @@ export const threadTools: ToolDomain = {
     {
       name: "read_terminal",
       description:
-        "Read the PTY scrollback of a terminal-presentation thread (the raw terminal output the user sees). Returns a note when the thread has no live terminal session (e.g. a structured/GUI thread, or its session isn't running). Only the last 50000 characters are returned; the response flags truncation.",
-      inputSchema: threadIdJsonSchema(),
+        "Read a terminal-presentation thread's raw, user-visible PTY scrollback. Omit threadId for the calling agent's own thread, or pass a sibling thread id returned by list_threads. Structured/GUI threads and stopped sessions may have no terminal scrollback. Returns at most the trailing 50000 characters and flags truncation; output may contain ANSI control sequences, so extract the relevant evidence instead of repeating the full transcript.",
+      inputSchema: optionalThreadIdJsonSchema(),
     },
     {
       name: "steer_thread",
@@ -280,13 +293,34 @@ export const threadTools: ToolDomain = {
     },
   ],
   handlers: {
+    get_current_thread: async (_args, ctx) => {
+      const threadId = ctx.identity.threadId;
+      if (!threadId) {
+        return {
+          threadId: null,
+          note: "This MCP request is not associated with a Poracode thread.",
+        };
+      }
+      const thread = requireThread(ctx, threadId);
+      const project = ctx.getProject(thread.projectId) ?? undefined;
+      const snapshots = await snapshotMap(ctx);
+      return threadView(thread, project, snapshots.get(threadId));
+    },
     list_threads: async (args, ctx) => {
-      const { projectId, status } = listArgsSchema.parse(args);
+      const { projectId, status, currentWorktree } = listArgsSchema.parse(args);
+      const caller = currentWorktree ? currentThread(ctx) : undefined;
       const projectsById = new Map(ctx.getProjects().map((project) => [project.id, project]));
+      const callerProject = caller ? projectsById.get(caller.projectId) : undefined;
       const snapshots = await snapshotMap(ctx);
       const threads = ctx
         .getThreads()
         .filter((thread) => (projectId ? thread.projectId === projectId : true))
+        .filter((thread) =>
+          caller
+            ? thread.projectId === caller.projectId &&
+              sameWorktreePath(thread.worktreePath, caller.worktreePath, callerProject)
+            : true,
+        )
         .map((thread) =>
           threadView(thread, projectsById.get(thread.projectId), snapshots.get(thread.id)),
         )
@@ -494,7 +528,8 @@ export const threadTools: ToolDomain = {
       };
     },
     read_terminal: async (args, ctx) => {
-      const { threadId } = threadIdArgsSchema.parse(args);
+      const parsed = optionalThreadIdArgsSchema.parse(args);
+      const threadId = parsed.threadId ?? currentThread(ctx).id;
       requireThread(ctx, threadId);
       const scrollback = await ctx.supervisor.readTerminalScrollback({ threadId });
       if (!scrollback) {
@@ -680,4 +715,33 @@ function threadIdJsonSchema(): Record<string, unknown> {
     required: ["threadId"],
     properties: { threadId: threadIdProp },
   };
+}
+
+function optionalThreadIdJsonSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    properties: { threadId: threadIdProp },
+  };
+}
+
+function sameWorktreePath(
+  left: string | undefined,
+  right: string | undefined,
+  project: Project | undefined,
+): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  const caseInsensitive = project?.location.kind === "windows";
+  return (
+    normalizeWorktreePathForComparison(left, caseInsensitive) ===
+    normalizeWorktreePathForComparison(right, caseInsensitive)
+  );
+}
+
+function currentThread(ctx: AppControlsToolContext): Thread {
+  const threadId = ctx.identity.threadId;
+  if (!threadId) {
+    throw new Error("This MCP request is not associated with a Poracode thread.");
+  }
+  return requireThread(ctx, threadId);
 }

--- a/src/renderer/components/composer/MentionInput.test.ts
+++ b/src/renderer/components/composer/MentionInput.test.ts
@@ -129,6 +129,28 @@ describe("buildMentionResults", () => {
     ]);
   });
 
+  it("matches a stable alias while preserving the localized display name", () => {
+    const localizedTerminal: McpMentionItem = {
+      id: "app-controls",
+      name: "Терминал",
+      searchAliases: ["Terminal"],
+      icon: Monitor,
+      detail: "Терминал",
+      enabled: true,
+    };
+
+    expect(buildMentionResults([], "ter", [localizedTerminal])).toEqual([
+      {
+        type: "mcp",
+        path: "app-controls",
+        name: "Терминал",
+        icon: Monitor,
+        detail: "Терминал",
+        enabled: true,
+      },
+    ]);
+  });
+
   it("preserves the caller's order for an empty @ mention", () => {
     expect(buildMentionResults(fileResults, "", [browser, crossagents, computerUse])).toEqual([
       {

--- a/src/renderer/components/composer/MentionInput.tsx
+++ b/src/renderer/components/composer/MentionInput.tsx
@@ -25,6 +25,8 @@ import { serializeToSegments, flattenSegments } from "./serializeMentions";
 export interface McpMentionItem {
   id: string;
   name: string;
+  /** Stable non-visible names that should also match the typed query. */
+  searchAliases?: readonly string[];
   icon: LucideIcon;
   detail: string;
   enabled: boolean;
@@ -39,10 +41,11 @@ export function buildMentionResults(
   mcpMentions: readonly McpMentionItem[] = EMPTY_MCP_MENTIONS,
 ): MentionEntry[] {
   const q = query.trim().toLowerCase();
-  // Case-insensitive prefix match on the display name, matching the legacy
-  // "browser".startsWith(q) / "computer use".startsWith(q) behavior.
+  // Case-insensitive prefix match on the display name or a stable alias.
   const mcpResults: MentionEntry[] = mcpMentions
-    .filter((item) => item.name.toLowerCase().startsWith(q))
+    .filter((item) =>
+      [item.name, ...(item.searchAliases ?? [])].some((name) => name.toLowerCase().startsWith(q)),
+    )
     .map((item) => ({
       type: "mcp",
       path: item.id,

--- a/src/renderer/components/mcp/McpServersManager.test.tsx
+++ b/src/renderer/components/mcp/McpServersManager.test.tsx
@@ -1,14 +1,15 @@
 import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  BuiltInMcpServerId,
-  DiscoverExternalMcpServersPayload,
-  DiscoverExternalMcpServersResult,
-  McpProbePayload,
-  McpProbeResult,
-  McpServer,
-  McpOauthBeginPayload,
-  McpOauthBeginResult,
+import {
+  BUILT_IN_MCP_SERVER_TOOL_COUNTS,
+  type BuiltInMcpServerId,
+  type DiscoverExternalMcpServersPayload,
+  type DiscoverExternalMcpServersResult,
+  type McpProbePayload,
+  type McpProbeResult,
+  type McpServer,
+  type McpOauthBeginPayload,
+  type McpOauthBeginResult,
 } from "@/shared/contracts";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { PoracodeBridge } from "@/shared/ipc";
@@ -171,7 +172,11 @@ describe("McpServersManager", () => {
 
     const row = document.querySelector('[data-built-in-mcp-server="app-controls"]');
     expect(row).not.toBeNull();
-    fireEvent.click(within(row as HTMLElement).getByRole("button", { name: "57 tools" }));
+    fireEvent.click(
+      within(row as HTMLElement).getByRole("button", {
+        name: `${BUILT_IN_MCP_SERVER_TOOL_COUNTS["app-controls"]} tools`,
+      }),
+    );
 
     const dialog = screen.getByRole("dialog", { name: "App Controls" });
     expect(within(dialog).getByText("list_schedules")).toBeInTheDocument();

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -208,7 +208,10 @@ function typeComposerText(editor: HTMLElement, text: string) {
 
 describe("ThreadComposerSection", () => {
   beforeEach(() => {
-    useSharedSettings.setState({ collapseTerminalComposer: false });
+    useSharedSettings.setState({
+      collapseTerminalComposer: false,
+      disabledBuiltInMcpServers: {},
+    });
     useThreadTodoDockStore.setState({
       defaultPlacement: "composer",
       defaultCollapsed: false,
@@ -316,6 +319,69 @@ describe("ThreadComposerSection", () => {
     });
 
     expect(screen.getByTestId("control-kinds")).toBeEmptyDOMElement();
+  });
+
+  it("inserts @Terminal as a Poracode MCP directive", async () => {
+    const rangeRectDescriptor = Object.getOwnPropertyDescriptor(
+      Range.prototype,
+      "getBoundingClientRect",
+    );
+    const scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollIntoView",
+    );
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ left: 0, top: 0 }),
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: () => undefined,
+    });
+    try {
+      const { onSubmitInput } = renderComposer();
+      const input = screen.getByRole("textbox");
+      typeComposerText(input, "@ter");
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.querySelector('[data-mcp-id="app-controls"]')).not.toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "send" }));
+
+      await waitFor(() =>
+        expect(onSubmitInput).toHaveBeenCalledWith("@Terminal", [
+          { kind: "mcp", id: "app-controls", name: "Terminal" },
+          { kind: "text", content: " " },
+        ]),
+      );
+    } finally {
+      if (rangeRectDescriptor) {
+        Object.defineProperty(Range.prototype, "getBoundingClientRect", rangeRectDescriptor);
+      } else {
+        Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+      }
+      if (scrollIntoViewDescriptor) {
+        Object.defineProperty(HTMLElement.prototype, "scrollIntoView", scrollIntoViewDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+      }
+    }
+  });
+
+  it("hides @Terminal when the provider owns MCP configuration", () => {
+    renderComposer({
+      agentStatus: {
+        ...codexGuiStatus,
+        capabilities: {
+          ...codexGuiStatus.capabilities,
+          mcpConfigSource: "agentSettings",
+        },
+      },
+    });
+    const input = screen.getByRole("textbox");
+    typeComposerText(input, "@ter");
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
   });
 
   it("uses GUI presentation capabilities for slash commands and /fast submission", () => {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject,
 } from "react";
 import { toast } from "@heroui/react";
-import { ChevronDown, Monitor } from "lucide-react";
+import { ChevronDown, Monitor, TerminalSquare } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentStatus, ProjectLocation, PromptSegment, Thread } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
@@ -237,6 +237,8 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     ? agentStatusForPresentation(agentStatus, presentationMode, thread.sessionRef)
     : undefined;
   const usesTerminalPresentation = presentationMode === "terminal";
+  const appControlsEnabled =
+    useSharedSettings((s) => s.disabledBuiltInMcpServers["app-controls"]) !== true;
   // Composer MCP servers are bound at session-create time for the active
   // thread, so the "+" menu shows this run's bindings read-only: the enabled
   // built-ins (from thread config), the custom servers recorded at launch,
@@ -267,6 +269,18 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         enabled: true,
       }));
   const mcpMentions: McpMentionItem[] = [
+    ...(appControlsEnabled && !providerOwnsMcp
+      ? [
+          {
+            id: "app-controls",
+            name: t`Terminal`,
+            searchAliases: ["Terminal"],
+            icon: TerminalSquare,
+            detail: t`Terminal`,
+            enabled: true,
+          },
+        ]
+      : []),
     ...composerMcpServers
       .filter((descriptor) => thread.config?.[descriptor.configKey] === true)
       .map((descriptor) => ({

--- a/src/renderer/components/thread/ThreadDraftComposerArea.tsx
+++ b/src/renderer/components/thread/ThreadDraftComposerArea.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useLayoutEffect, useRef, useState, type RefObject } from "react";
 import { toast } from "@heroui/react";
-import { Download, Monitor, Webhook, X } from "lucide-react";
+import { Download, Monitor, TerminalSquare, Webhook, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type {
   AgentHookPluginStatus,
@@ -420,10 +420,10 @@ export function ThreadDraftComposerArea(props: {
   // which workspace entries override global ones, so the menu can't drift from
   // what actually launches. Providers whose MCP set lives on their settings
   // page show no rows here at all.
-  const hideCustomMcpRows = providerOwnsMcpConfig(props.selectedAgent.capabilities);
+  const providerOwnsMcp = providerOwnsMcpConfig(props.selectedAgent.capabilities);
   const projectCustomMcpServers = props.project.mcpServers ?? [];
   const projectCustomMcpIds = new Set(projectCustomMcpServers.map((server) => server.id));
-  const mergedCustomMcpServers = hideCustomMcpRows
+  const mergedCustomMcpServers = providerOwnsMcp
     ? []
     : mergeMcpServers(userCustomMcpServers, projectCustomMcpServers);
   const customMcpServers: ComposerCustomMcpItem[] = mergedCustomMcpServers.map((server) => {
@@ -511,6 +511,18 @@ export function ThreadDraftComposerArea(props: {
   // draft; already-effective servers remain available and insert a textual
   // mention that directs the agent to use them for this turn.
   const mcpMentions: McpMentionItem[] = [
+    ...(disabledBuiltInMcpServers["app-controls"] !== true && !providerOwnsMcp
+      ? [
+          {
+            id: "app-controls",
+            name: t`Terminal`,
+            searchAliases: ["Terminal"],
+            icon: TerminalSquare,
+            detail: t`Terminal`,
+            enabled: true,
+          },
+        ]
+      : []),
     ...availableComposerMcpServers
       .filter(
         (descriptor) =>

--- a/src/renderer/components/thread/ThreadSlashCommands.test.tsx
+++ b/src/renderer/components/thread/ThreadSlashCommands.test.tsx
@@ -201,7 +201,10 @@ describe("ThreadSlashCommands", () => {
     useAppStore.getState().clearDraftContent(draftProject.id);
     useAppStore.setState({ draftContentDiscardRequests: {} });
     useComposerInputInbox.setState({ itemsByComposer: {} });
-    useSharedSettings.setState({ collapseTerminalComposer: false });
+    useSharedSettings.setState({
+      collapseTerminalComposer: false,
+      disabledBuiltInMcpServers: {},
+    });
     Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
       configurable: true,
       value: scrollIntoView,
@@ -950,6 +953,25 @@ describe("ThreadSlashCommands", () => {
     expect(onStart).not.toHaveBeenCalled();
     expect(screen.queryByText("Commands")).not.toBeInTheDocument();
     expect(editor.textContent).toBe("/review ");
+  });
+
+  it("hides @Terminal in drafts when the provider owns MCP configuration", async () => {
+    const baseCapabilities = makeAgentStatus().capabilities;
+    await renderDraftComposer(
+      makeAgentStatus({
+        capabilities: {
+          ...baseCapabilities,
+          mcpConfigSource: "agentSettings",
+        },
+      }),
+      vi.fn(),
+      "gui",
+    );
+
+    const editor = screen.getByRole("textbox");
+    typeSlashQuery(editor, "@ter");
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
   });
 
   it("saves draft composer content on ordinary unmount", () => {

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Sagen Sie dem Zielanbieter, was als nächstes zu tun ist ..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -11047,6 +11047,8 @@ msgstr "Tell the target provider what to do next..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Indica al proveedor de destino qué hacer a continuación..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -11041,6 +11041,8 @@ msgstr "Dites au fournisseur cible quoi faire ensuite..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -11040,6 +11040,8 @@ msgstr "ターゲットプロバイダーに次に何をすべきかを伝えま
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -11042,6 +11042,8 @@ msgstr "대상 공급자에게 다음에 무엇을 해야 할지 알려주세요
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Powiedz dostawcy docelowemu, co ma dalej robić..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Diga ao provedor alvo o que fazer a seguir..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Укажите целевому провайдеру, что делат�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Hedef sağlayıcıya bundan sonra ne yapacağını söyleyin..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Укажіть цільовому провайдеру, що робит�
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -11042,6 +11042,8 @@ msgstr "Cho nhà cung cấp mục tiêu biết phải làm gì tiếp theo..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -11041,6 +11041,8 @@ msgstr "告诉目标提供商下一步该做什么..."
 #: src/renderer/commands/registry.ts
 #: src/renderer/commands/shortcutCatalog.ts
 #: src/renderer/components/layout/PanelDock/panelTabMeta.ts
+#: src/renderer/components/thread/ThreadComposerSection.tsx
+#: src/renderer/components/thread/ThreadDraftComposerArea.tsx
 #: src/renderer/components/thread/ThreadToolRail.tsx
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/parts/BrowserToolbar.tsx
 #: src/renderer/views/SettingsOverlay/parts/SettingsSidebar.tsx

--- a/src/shared/contracts/mcpServer.ts
+++ b/src/shared/contracts/mcpServer.ts
@@ -130,6 +130,7 @@ export const BUILT_IN_MCP_SERVER_TOOL_NAMES = {
     "update_schedule",
     "run_schedule",
     "delete_schedule",
+    "get_current_thread",
     "list_threads",
     "get_thread",
     "read_thread",


### PR DESCRIPTION
- Add `get_current_thread` tool to the app-controls MCP server so agents can resolve the thread behind a request.
- Refine app-controls tool instructions and `read_terminal` behavior, including worktree path normalization and clearer scrollback truncation reporting.
- Surface a `Terminal` `@`-mention in thread and draft composers, matching stable English aliases even when display names are localized, and hide it when the provider owns MCP config.
- Register the new tool name in the shared MCP server contract and update tool counts in the servers manager.
- Localize the new "Terminal" mention across all 13 catalogs (`en` + 12 non-English).