### PR TITLE
Tighten word spacing in tool call group summaries

### DIFF
--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.test.tsx
@@ -80,7 +80,7 @@ describe("ToolCallGroup", () => {
     );
 
     // Header still derives from the summary while collapsed.
-    expect(screen.getByText(byTextContent("2 views"))).toBeInTheDocument();
+    expect(screen.getByText(byTextContent("2 views"))).toHaveClass("[word-spacing:-0.25em]");
     // No child row content and no viewport container are mounted.
     expect(view.container.querySelector(".poracode-tool-call-group-viewport")).toBeNull();
     expect(screen.queryByText("Read file one")).not.toBeInTheDocument();

--- a/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/ToolCallGroup.tsx
@@ -183,7 +183,7 @@ export const ToolCallGroup = memo(function ToolCallGroup({
                       ) : null}
                       <span className="flex shrink-0 items-center gap-1">
                         <section.Icon className="size-3" />
-                        <code className="font-mono tabular-nums !text-[color:var(--muted)]">
+                        <code className="font-mono tabular-nums [word-spacing:-0.25em] !text-[color:var(--muted)]">
                           <AnimatedNumber value={section.count} />{" "}
                           {section.category === "mcp" ? (
                             <Plural value={section.count} one="MCP" other="MCPs" />
@@ -305,7 +305,7 @@ function SameFileEditGroupTitle({ summary }: { summary: SameFileEditGroupSummary
     <>
       <span className="flex shrink-0 items-center gap-1">
         <Pencil className="size-3" />
-        <code className="font-mono tabular-nums !text-[color:var(--muted)]">
+        <code className="font-mono tabular-nums [word-spacing:-0.25em] !text-[color:var(--muted)]">
           <AnimatedNumber value={summary.count} />{" "}
           <Plural value={summary.count} one="edit" other="edits" />:
         </code>


### PR DESCRIPTION
- Tightens word spacing in collapsed tool call group summary headers so category counts and labels read more compactly.
- Applies the condensed spacing to both section group summaries and same-file edit group titles.
- Updates the ToolCallGroup test to assert the new styling on the collapsed summary header.