### PR TITLE
Show live status tone for collapsed worktree groups

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarThreadRow.tsx
@@ -72,6 +72,7 @@ export function SidebarThreadRow(props: {
           project={project}
           sortableGroup={row.sortableGroup}
           sortDisabled={row.sortDisabled}
+          liveBackgroundThreadIds={row.liveBackgroundThreadIds}
           {...(projectTag !== undefined ? { projectTag } : {})}
         />
       ) : row.kind === "thread-group" ? (

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
@@ -1,0 +1,116 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Project, Thread } from "@/shared/contracts";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
+import type { WorktreeThreadGroup } from "./groupThreads";
+
+vi.mock("@dnd-kit/react/sortable", () => ({
+  useSortable: () => ({ ref: vi.fn<(node: HTMLElement | null) => void>() }),
+}));
+
+vi.mock("@/renderer/dnd", () => ({
+  useDragSource: () => null,
+  useIsDraggingWorktreeGroup: () => false,
+}));
+
+vi.mock("@/renderer/components/common/ContextMenu", () => ({
+  ContextMenu: (props: { children: React.ReactNode }) => props.children,
+}));
+
+vi.mock("@/renderer/hooks/uiSelectors", () => ({
+  useIsWorktreeFilesPanelActive: () => false,
+  useIsWorktreeGitPanelActive: () => false,
+  useIsWorktreeTerminalActive: () => false,
+  useIsWorktreeTerminalBusy: () => false,
+  useIsWorktreeTerminalOpen: () => false,
+}));
+
+vi.mock("@/renderer/state/sidebarUiStore", () => ({
+  useIsWorktreeCollapsed: () => true,
+  useSidebarUiStore: (selector: (state: { toggleWorktreeCollapsed: () => void }) => unknown) =>
+    selector({ toggleWorktreeCollapsed: vi.fn<() => void>() }),
+}));
+
+vi.mock("./useWorktreeActions", () => ({
+  useWorktreeGitItems: () => [],
+}));
+
+vi.mock("./WorktreeGroupHeader", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./WorktreeGroupHeader")>();
+  return {
+    ...actual,
+    WorktreeGroupHeader: (props: { collapsedStatusTone?: string }) => (
+      <div data-testid="group-status">{props.collapsedStatusTone ?? "none"}</div>
+    ),
+  };
+});
+
+const project = {
+  id: "project-1",
+  name: "Poracode",
+  location: { kind: "windows", path: "C:\\repo" },
+  createdAt: "2026-08-08T00:00:00.000Z",
+} as Project;
+
+function makeThread(id: string, status: Thread["status"]): Thread {
+  return {
+    id,
+    projectId: project.id,
+    title: id,
+    agentKind: "codex",
+    config: { model: "gpt-5.4" },
+    status,
+    attention: "none",
+    canResumeWithConfig: false,
+    archived: false,
+    done: false,
+    starred: false,
+    createdAt: "2026-08-08T00:00:00.000Z",
+    updatedAt: "2026-08-08T00:00:00.000Z",
+    worktreePath: "C:\\repo\\worktree",
+    worktreeBranch: "feature/status",
+  };
+}
+
+function renderGroup(threads: Thread[], liveBackgroundThreadIds: ReadonlySet<string>) {
+  const group: WorktreeThreadGroup = {
+    kind: "worktree",
+    threads,
+    worktreePath: "C:\\repo\\worktree",
+    worktreeBranch: "feature/status",
+  };
+  render(
+    <SidebarWorktreeGroup
+      group={group}
+      entryIndex={0}
+      project={project}
+      sortableGroup="project-entries:project-1"
+      liveBackgroundThreadIds={liveBackgroundThreadIds}
+    />,
+  );
+}
+
+describe("SidebarWorktreeGroup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows working when a settled child has live background activity", () => {
+    renderGroup(
+      [makeThread("live", "idle"), makeThread("inactive", "inactive")],
+      new Set(["live"]),
+    );
+
+    expect(screen.getByTestId("group-status")).toHaveTextContent("working");
+  });
+
+  it("keeps finished priority over a child with live background activity", () => {
+    renderGroup(
+      [makeThread("live", "idle"), makeThread("finished", "finished")],
+      new Set(["live"]),
+    );
+
+    expect(screen.getByTestId("group-status")).toHaveTextContent("finished");
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -11,6 +11,7 @@ import {
   useIsWorktreeTerminalBusy,
   useIsWorktreeTerminalOpen,
 } from "@/renderer/hooks/uiSelectors";
+import { getStatusTone } from "@/renderer/components/providers/statusTone";
 import {
   gitMergeAndRemove,
   gitMergeToSource,
@@ -31,7 +32,7 @@ import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
 import { gitMenuIcons } from "./gitMenuIcons";
 import type { WorktreeThreadGroup } from "./groupThreads";
 import { useWorktreeGitItems } from "./useWorktreeActions";
-import { WorktreeGroupHeader } from "./WorktreeGroupHeader";
+import { getWorktreeGroupStatusTone, WorktreeGroupHeader } from "./WorktreeGroupHeader";
 
 export function SidebarWorktreeGroup(props: {
   group: WorktreeThreadGroup;
@@ -39,6 +40,7 @@ export function SidebarWorktreeGroup(props: {
   project: Project;
   sortableGroup: string;
   sortDisabled?: boolean;
+  liveBackgroundThreadIds: ReadonlySet<string>;
   /** Trailing project label for cross-project (flat) lists. */
   projectTag?: React.ReactNode;
 }) {
@@ -52,6 +54,13 @@ export function SidebarWorktreeGroup(props: {
   const isBusyTerminal = useIsWorktreeTerminalBusy(group.worktreePath);
   const isActiveFiles = useIsWorktreeFilesPanelActive(group.worktreePath);
   const isActiveGit = useIsWorktreeGitPanelActive(group.worktreePath);
+  const collapsedStatusTone = getWorktreeGroupStatusTone(
+    group.threads.map((thread) =>
+      getStatusTone(thread, {
+        hasBackgroundActivity: props.liveBackgroundThreadIds.has(thread.id),
+      }),
+    ),
+  );
   const groupThreadIds = group.threads.map((thread) => thread.id);
   const activeThreads = group.threads.filter((thread) => !thread.done);
   const isDone = group.threads.every((thread) => thread.done);
@@ -175,6 +184,7 @@ export function SidebarWorktreeGroup(props: {
           isDraggingAnything={!!source}
           isDone={isDone}
           updatedAt={latestThreadUpdatedAt}
+          {...(collapsedStatusTone !== undefined ? { collapsedStatusTone } : {})}
           {...(props.projectTag !== undefined ? { projectTag: props.projectTag } : {})}
         />
       </ContextMenu>

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { getWorktreeGroupStatusTone, WorktreeGroupHeader } from "./WorktreeGroupHeader";
+
+vi.mock("@/renderer/components/common/SidebarButton", () => ({
+  SidebarButton: (props: { icon: React.ReactNode }) => <div>{props.icon}</div>,
+}));
+
+function renderHeader(props: {
+  isCollapsed: boolean;
+  isDone?: boolean;
+  childTones: Parameters<typeof getWorktreeGroupStatusTone>[0];
+}) {
+  const collapsedStatusTone = getWorktreeGroupStatusTone(props.childTones);
+  return render(
+    <WorktreeGroupHeader
+      worktreePath="C:\\repo\\worktree"
+      worktreeBranch="feature/status"
+      projectId="project-1"
+      isCollapsed={props.isCollapsed}
+      {...(props.isDone !== undefined ? { isDone: props.isDone } : {})}
+      hasTerminal={false}
+      isActiveTerminal={false}
+      isActiveGit={false}
+      onToggleCollapse={vi.fn<() => void>()}
+      onOpenFiles={vi.fn<() => void>()}
+      onOpenGitReview={vi.fn<() => void>()}
+      onOpenTerminal={vi.fn<() => void>()}
+      onDeleteWorktree={vi.fn<() => void>()}
+      updatedAt="2026-08-08T00:00:00.000Z"
+      {...(collapsedStatusTone !== undefined ? { collapsedStatusTone } : {})}
+    />,
+  );
+}
+
+describe("WorktreeGroupHeader", () => {
+  it("prioritizes moonlight over green when collapsed", () => {
+    const { container } = renderHeader({
+      isCollapsed: true,
+      childTones: ["working", "finished"],
+    });
+
+    expect(container.querySelector(".lucide-git-fork")).toHaveClass("text-[oklch(0.82_0.12_260)]");
+  });
+
+  it("shows green for a working child when no child is finished", () => {
+    const { container } = renderHeader({
+      isCollapsed: true,
+      childTones: ["inactive", "working"],
+    });
+
+    expect(container.querySelector(".lucide-git-fork")).toHaveClass("text-success");
+  });
+
+  it("stays white while expanded", () => {
+    const { container } = renderHeader({
+      isCollapsed: false,
+      childTones: ["finished", "working"],
+    });
+
+    expect(container.querySelector(".lucide-git-fork")).toHaveClass("text-foreground");
+  });
+
+  it("stays white while expanded when every child is done", () => {
+    const { container } = renderHeader({
+      isCollapsed: false,
+      isDone: true,
+      childTones: ["done", "done"],
+    });
+
+    expect(container.querySelector(".lucide-git-fork")).toHaveClass("text-foreground");
+    expect(container.querySelector(".lucide-check")).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/WorktreeGroupHeader.tsx
@@ -3,9 +3,20 @@ import { useLingui } from "@lingui/react/macro";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import { AnimatedTerminalIcon } from "@/renderer/components/common/AnimatedTerminalIcon";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
+import type { StatusTone } from "@/renderer/components/providers/statusTone";
 import { GitBadge } from "./GitBadge";
 import { SidebarPanelDragButton } from "./SidebarPanelDragButton";
 import { SyncBadge } from "./SyncBadge";
+
+type WorktreeGroupStatusTone = Extract<StatusTone, "finished" | "working">;
+
+export function getWorktreeGroupStatusTone(
+  childTones: readonly StatusTone[],
+): WorktreeGroupStatusTone | undefined {
+  if (childTones.includes("finished")) return "finished";
+  if (childTones.includes("working")) return "working";
+  return undefined;
+}
 
 export function WorktreeGroupHeader(props: {
   ref?: React.Ref<HTMLDivElement>;
@@ -26,6 +37,7 @@ export function WorktreeGroupHeader(props: {
   isDragging?: boolean;
   isDraggingAnything?: boolean;
   isDone?: boolean;
+  collapsedStatusTone?: WorktreeGroupStatusTone;
   updatedAt: string;
   onContextMenu?: React.MouseEventHandler | undefined;
   /** Trailing project label for cross-project (flat) lists. */
@@ -140,7 +152,9 @@ export function WorktreeGroupHeader(props: {
       {...(props.ref != null ? { ref: props.ref } : {})}
       onContextMenu={props.onContextMenu}
       icon={
-        props.isDone ? (
+        !props.isCollapsed ? (
+          <GitFork className="size-3 shrink-0 text-foreground transition-colors" />
+        ) : props.isDone ? (
           <span className="relative size-3.5 shrink-0 text-muted">
             <GitFork className="size-3.5 opacity-40" />
             <Check
@@ -151,7 +165,11 @@ export function WorktreeGroupHeader(props: {
         ) : (
           <GitFork
             className={`size-3 shrink-0 transition-colors ${
-              props.isCollapsed ? "text-muted/60" : "text-foreground"
+              props.collapsedStatusTone === "finished"
+                ? "text-[oklch(0.82_0.12_260)]"
+                : props.collapsedStatusTone === "working"
+                  ? "text-success"
+                  : "text-muted/60"
             }`}
           />
         )

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.test.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.test.ts
@@ -170,6 +170,32 @@ describe("buildSidebarProjectRows — See more cap (date sort)", () => {
     expect(allDone[1]).toMatchObject({ kind: "worktree-group" });
   });
 
+  it("carries live background thread ids to worktree group rows", () => {
+    const liveBackgroundThreadIds = new Set(["wt-live"]);
+    const rows = buildSidebarProjectRows({
+      projectId: "project-1",
+      projectThreads: [
+        makeThread({
+          id: "wt-live",
+          worktreePath: "/repo/wt",
+          worktreeBranch: "feature",
+        }),
+        makeThread({
+          id: "wt-idle",
+          worktreePath: "/repo/wt",
+          worktreeBranch: "feature",
+        }),
+      ],
+      sortMode: "updated",
+      collapsedWorktrees: {},
+      visibleLimit: 10,
+      liveBackgroundThreadIds,
+    });
+
+    const group = rows.find((row) => row.kind === "worktree-group");
+    expect(group?.liveBackgroundThreadIds).toBe(liveBackgroundThreadIds);
+  });
+
   it("hides done threads behind See more before live ones", () => {
     const threads = [
       ...Array.from({ length: 8 }, (_, i) => makeThread({ id: `live-${i}` })),

--- a/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/sidebarProjectRows.ts
@@ -31,6 +31,7 @@ export type SidebarRow =
       entryIndex: number;
       sortableGroup: string;
       sortDisabled: boolean;
+      liveBackgroundThreadIds: ReadonlySet<string>;
     }
   | {
       kind: "thread-group";
@@ -121,6 +122,7 @@ function pushEntryRows(
     dndDisabled: boolean;
     isCollapsed: (key: string) => boolean;
     nextUngroupedIndex: () => number;
+    liveBackgroundThreadIds: ReadonlySet<string>;
     experimentCandidateOrder?: ReadonlyMap<string, number>;
   },
 ) {
@@ -147,6 +149,7 @@ function pushEntryRows(
       entryIndex,
       sortableGroup: input.dndGroup,
       sortDisabled: input.dndDisabled,
+      liveBackgroundThreadIds: input.liveBackgroundThreadIds,
     });
     if (!input.isCollapsed(entry.group.worktreePath)) {
       entry.group.threads.forEach((thread, threadIndex) => {
@@ -311,6 +314,7 @@ export function buildSidebarProjectRows(input: {
         dndDisabled: true,
         isCollapsed,
         nextUngroupedIndex,
+        liveBackgroundThreadIds,
         ...(input.experimentCandidateOrder
           ? { experimentCandidateOrder: input.experimentCandidateOrder }
           : {}),


### PR DESCRIPTION
- Collapsed worktree groups in the sidebar now surface a live status tone on the group header instead of showing only a muted icon.
- Thread tones (including live background activity) are aggregated via a new `getWorktreeGroupStatusTone` helper, with finished taking priority over working.
- The `liveBackgroundThreadIds` set is threaded through the sidebar row builder so settled thread groups still reflect live background work.
- Added unit tests for the new tone logic, the group header icon coloring, and row-builder propagation.