### PR TITLE
Surface hidden projects in flat-list filter and guard remote actions

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
@@ -50,9 +50,15 @@ vi.mock("./SidebarThreadRow", () => ({
 // Filter interaction is covered by SidebarProjectFilter.test.tsx; here a stub
 // exposes the effective (normalized) filter the list passes down.
 vi.mock("./SidebarProjectFilter", () => ({
-  SidebarProjectFilter: (props: { value: ReadonlySet<string> | null }) => (
+  SidebarProjectFilter: (props: {
+    projects: readonly Project[];
+    filterableProjectIds: ReadonlySet<string>;
+    value: ReadonlySet<string> | null;
+  }) => (
     <div data-testid="project-filter">
       {props.value === null ? "all" : [...props.value].join(",")}
+      {` projects:${props.projects.map((project) => project.id).join(",")}`}
+      {` filterable:${[...props.filterableProjectIds].join(",")}`}
     </div>
   ),
 }));
@@ -298,6 +304,21 @@ describe("SidebarFlatThreadList", () => {
 
     expect(screen.queryByTestId("project-filter")).not.toBeInTheDocument();
     expect(screen.getByText(/thread:p1 in Poracode/)).toBeInTheDocument();
+  });
+
+  it("keeps the only disabled project in the filter so it can be re-enabled", () => {
+    useSharedSettings.setState({ homeScopeEnabled: false } as never);
+    useAppStore.setState({
+      projects: [{ ...localProject, disabled: true }],
+      threads: [makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z")],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("projects:local-1");
+    expect(screen.getByTestId("project-filter")).toHaveTextContent("filterable:");
+    expect(screen.queryByText(/thread:p1/)).not.toBeInTheDocument();
+    expect(screen.queryByText("new-thread:local-1")).not.toBeInTheDocument();
   });
 
   it("docks the new-thread control into the filter head row when several projects are visible", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -81,16 +81,21 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
   // machine reports `error`, not `offline`), so only online servers' threads
   // mix into the list.
   const includedIds = new Set(workspaceProjectIds);
-  const visibleProjects = projects.filter((project) => {
+  const workspaceProjects = projects.filter((project) => {
     // Home is a synthetic row persisted with `disabled: true` by design — the
     // home-scope setting alone decides whether it shows (mirrors the grouped
     // sidebar's dedicated Home section).
     if (isHomeProject(project)) return homeScopeEnabled;
-    if (!includedIds.has(project.id) || project.disabled) return false;
+    return includedIds.has(project.id);
+  });
+  const visibleProjects = workspaceProjects.filter((project) => {
+    if (isHomeProject(project)) return true;
+    if (project.disabled) return false;
     if (!project.remoteServerId) return true;
     return remoteServerFor(project).status === "online";
   });
   const projectsById = new Map(visibleProjects.map((project) => [project.id, project]));
+  const filterableProjectIds = new Set(projectsById.keys());
 
   // The persisted filter can name projects that are gone or currently hidden
   // (workspace switch, home scope off, dead remote server); only ids
@@ -159,13 +164,14 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-      {visibleProjects.length > 1 ? (
+      {visibleProjects.length > 1 || workspaceProjects.length > visibleProjects.length ? (
         // Filter and new-thread share one head row; the new-thread control
         // collapses to an icon button (tooltip) when the row is narrow.
         <div className="poracode-flat-list-head flex shrink-0 items-center gap-1 pb-0.5">
           <div className="min-w-0 flex-1">
             <SidebarProjectFilter
-              projects={visibleProjects}
+              projects={workspaceProjects}
+              filterableProjectIds={filterableProjectIds}
               threadCounts={threadCounts}
               value={activeProjectFilter}
               onChange={setFlatListProjectFilter}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
@@ -8,9 +8,16 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { SidebarProjectFilter } from "./SidebarProjectFilter";
 
+const responsiveMenuState = vi.hoisted(() => ({ mobile: false }));
+
 vi.mock("@/renderer/bridge", () => ({
   readBridge: () => ({}),
-  isRemoteSession: () => false,
+  isRemoteSession: () => responsiveMenuState.mobile,
+}));
+
+vi.mock("@/renderer/components/common/ResponsiveMenuSurface", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/renderer/components/common/ResponsiveMenuSurface")>()),
+  useResponsiveMenu: () => ({ mobile: responsiveMenuState.mobile }),
 }));
 
 function project(id: string, name: string): Project {
@@ -38,6 +45,7 @@ function renderFilter(
   render(
     <SidebarProjectFilter
       projects={list}
+      filterableProjectIds={new Set(list.map((candidate) => candidate.id))}
       threadCounts={threadCounts}
       value={value}
       onChange={onChange}
@@ -52,6 +60,10 @@ function openMenu() {
 }
 
 describe("SidebarProjectFilter", () => {
+  beforeEach(() => {
+    responsiveMenuState.mobile = false;
+  });
+
   it("names the hosting machine on mirrored rows and on a lone selection", async () => {
     const mirrored = {
       ...project("r", "Alpha"),
@@ -163,6 +175,7 @@ describe("SidebarProjectFilter", () => {
     beforeEach(() => {
       usePanelStore.setState({ settingsOpen: false, projectSettingsId: null });
       useAppStore.setState({ projects: [...projects], threads: [] });
+      useRemoteServersStore.setState({ servers: [], runtime: {} });
     });
 
     it("stacks the project context menu on top of the open filter menu", async () => {
@@ -178,6 +191,86 @@ describe("SidebarProjectFilter", () => {
       expect(screen.getByRole("menuitemcheckbox", { name: "All projects" })).toBeInTheDocument();
       expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("keeps a disabled project available for re-enabling", async () => {
+      const disabledProject = { ...projects[1]!, disabled: true };
+      useAppStore.setState({ projects: [projects[0]!, disabledProject], threads: [] });
+      render(
+        <SidebarProjectFilter
+          projects={[projects[0]!, disabledProject]}
+          filterableProjectIds={new Set(["a"])}
+          threadCounts={threadCounts}
+          value={null}
+          onChange={vi.fn<(next: string[] | null) => void>()}
+        />,
+      );
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Enable Project" }));
+
+      expect(
+        useAppStore.getState().projects.find((candidate) => candidate.id === "b")?.disabled,
+      ).toBe(undefined);
+    });
+
+    it("keeps a disabled project available for re-enabling on mobile", async () => {
+      responsiveMenuState.mobile = true;
+      const disabledProject = { ...projects[1]!, disabled: true };
+      useAppStore.setState({ projects: [projects[0]!, disabledProject], threads: [] });
+      render(
+        <SidebarProjectFilter
+          projects={[projects[0]!, disabledProject]}
+          filterableProjectIds={new Set(["a"])}
+          threadCounts={threadCounts}
+          value={null}
+          onChange={vi.fn<(next: string[] | null) => void>()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Filter by project" }));
+      fireEvent.click(await screen.findByRole("button", { name: "Project actions for Beta" }));
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Enable Project" }));
+
+      expect(
+        useAppStore.getState().projects.find((candidate) => candidate.id === "b")?.disabled,
+      ).toBe(undefined);
+    });
+
+    it("keeps host actions disabled for an unreachable remote project", async () => {
+      const mirrored = {
+        ...projects[1]!,
+        remoteServerId: "desktop-1",
+        remoteId: "remote-b",
+      } as Project;
+      useRemoteServersStore.setState({
+        servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+        runtime: { "desktop-1": { status: "offline", projects: [], threads: [] } },
+      } as never);
+      useAppStore.setState({ projects: [mirrored], threads: [] });
+      render(
+        <SidebarProjectFilter
+          projects={[mirrored]}
+          filterableProjectIds={new Set()}
+          threadCounts={threadCounts}
+          value={null}
+          onChange={vi.fn<(next: string[] | null) => void>()}
+        />,
+      );
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+
+      expect(await screen.findByRole("menuitem", { name: "Remove Project" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+      expect(screen.getByRole("menuitem", { name: "Disable Project" })).not.toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
     });
 
     it("closes both menus once an action is picked", async () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -11,6 +11,7 @@ import {
   ProjectRemoteServerChip,
   useProjectRemoteServerLookup,
 } from "@/renderer/components/common/ProjectRemoteServer";
+import { isRemoteProjectStatusUnreachable } from "@/renderer/state/remoteServers/reachability";
 import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
@@ -168,9 +169,13 @@ function ProjectOverflowMenu(props: {
   /** Fired before dispatching a picked action, so the filter menu can close. */
   onAction: () => void;
 }) {
-  // Flat-list projects are visible by construction: enabled, local or backed
-  // by an online server — nothing here is host-unreachable.
-  const projectMenu = useProjectMenu(props.project, { isUnreachable: false });
+  const remoteServerFor = useProjectRemoteServerLookup();
+  const projectMenu = useProjectMenu(props.project, {
+    isUnreachable: isRemoteProjectStatusUnreachable(
+      props.project,
+      remoteServerFor(props.project).status,
+    ),
+  });
   return (
     <ContextMenuSurface
       position={props.anchor}
@@ -200,12 +205,14 @@ function ProjectOverflowMenu(props: {
  * {@link SidebarWorkspaceSwitcher}.
  */
 export function SidebarProjectFilter(props: {
-  /** Projects offered in the menu (already visibility-filtered by the caller). */
+  /** Projects offered in the menu, including unavailable projects with actions. */
   projects: readonly Project[];
+  /** Projects whose threads can currently participate in the filter. */
+  filterableProjectIds: ReadonlySet<string>;
   /** Unarchived thread counts per project id, shown as row hints. */
   threadCounts: ReadonlyMap<string, number>;
   /**
-   * Selected project ids, pre-intersected with `projects` by the caller;
+   * Selected project ids, pre-intersected with `filterableProjectIds` by the caller;
    * null = all projects.
    */
   value: ReadonlySet<string> | null;
@@ -251,15 +258,21 @@ export function SidebarProjectFilter(props: {
     event.stopPropagation();
   };
 
-  const visibleIds = props.projects.map((project) => project.id);
+  const filterableProjects = props.projects.filter((project) =>
+    props.filterableProjectIds.has(project.id),
+  );
+  const unavailableProjects = props.projects.filter(
+    (project) => !props.filterableProjectIds.has(project.id),
+  );
+  const filterableIds = filterableProjects.map((project) => project.id);
   const isAll = props.value === null;
   // In the all state every project reads as selected — unchecking one then
   // filters it out, matching checkbox expectations.
-  const selectedProjects: ReadonlySet<string> = props.value ?? new Set(visibleIds);
+  const selectedProjects: ReadonlySet<string> = props.value ?? new Set(filterableIds);
 
   const soleSelected =
     !isAll && selectedProjects.size === 1
-      ? props.projects.find((project) => selectedProjects.has(project.id))
+      ? filterableProjects.find((project) => selectedProjects.has(project.id))
       : undefined;
   const soleMachine = soleSelected ? remoteServerFor(soleSelected).serverName : undefined;
   const baseLabel = isAll
@@ -286,7 +299,7 @@ export function SidebarProjectFilter(props: {
     if (next.has(projectId)) next.delete(projectId);
     else next.add(projectId);
     // Empty and complete selections are both just "all projects".
-    props.onChange(next.size === 0 || next.size >= visibleIds.length ? null : [...next]);
+    props.onChange(next.size === 0 || next.size >= filterableIds.length ? null : [...next]);
   };
 
   const triggerContent = (
@@ -333,7 +346,7 @@ export function SidebarProjectFilter(props: {
             </span>
             {isAll ? <Check className="size-4 shrink-0 text-accent" /> : null}
           </button>
-          {props.projects.map((project) => {
+          {filterableProjects.map((project) => {
             const selected = selectedProjects.has(project.id);
             const remote = remoteServerFor(project);
             return (
@@ -353,7 +366,30 @@ export function SidebarProjectFilter(props: {
               </button>
             );
           })}
+          {unavailableProjects.map((project) => {
+            const remote = remoteServerFor(project);
+            return (
+              <div key={project.id} className="m-sheet-action opacity-50" data-static="true">
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                <ProjectRemoteServerChip info={remote} size="md" />
+                {isHomeProject(project) ? null : (
+                  <ProjectRowMenuButton
+                    project={project}
+                    onOpenMenu={(anchor) => setOverflowTarget({ project, anchor })}
+                  />
+                )}
+              </div>
+            );
+          })}
         </div>
+        {overflowTarget ? (
+          <ProjectOverflowMenu
+            project={overflowTarget.project}
+            anchor={overflowTarget.anchor}
+            onClose={() => setOverflowTarget(null)}
+            onAction={close}
+          />
+        ) : null}
       </ResponsiveMenuSurface>
     );
   }
@@ -447,7 +483,7 @@ export function SidebarProjectFilter(props: {
             <Dropdown.ItemIndicator />
           </Dropdown.Item>
           <Separator />
-          {props.projects.map((project) => {
+          {filterableProjects.map((project) => {
             const remote = remoteServerFor(project);
             return (
               <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
@@ -471,6 +507,24 @@ export function SidebarProjectFilter(props: {
               </Dropdown.Item>
             );
           })}
+          {unavailableProjects.length > 0 ? <Separator /> : null}
+          <Dropdown.Section selectionMode="none">
+            {unavailableProjects.map((project) => {
+              const remote = remoteServerFor(project);
+              return (
+                <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+                  <Label className="min-w-0 truncate opacity-50">{project.name}</Label>
+                  <ProjectRemoteServerChip info={remote} size="md" />
+                  {isHomeProject(project) ? null : (
+                    <ProjectRowMenuButton
+                      project={project}
+                      onOpenMenu={(anchor) => setOverflowTarget({ project, anchor })}
+                    />
+                  )}
+                </Dropdown.Item>
+              );
+            })}
+          </Dropdown.Section>
         </Dropdown.Menu>
         {overflowTarget ? (
           <ProjectOverflowMenu


### PR DESCRIPTION
- Flat thread list now passes workspace projects into the project filter so a sole hidden project stays selectable and can be re-enabled instead of disappearing.
- Filter menu surfaces unavailable projects (disabled, home-scope off, or unreachable remote) in a muted separate section with per-project actions kept available.
- Project overflow menu now treats unreachable remote projects as unreachable, keeping destructive host actions like Remove Project disabled.
- Adds tests covering filterability of the only hidden project and gating of remote project actions.