### PR TITLE
Add project location icons and GitHub Actions context menu item

### DIFF
--- a/src/renderer/components/common/ProjectRemoteServer.tsx
+++ b/src/renderer/components/common/ProjectRemoteServer.tsx
@@ -1,12 +1,14 @@
-import { Server } from "lucide-react";
+import { FolderOpen, House, Monitor, Server } from "lucide-react";
 import { useShallow } from "zustand/shallow";
 import type { Project } from "@/shared/contracts";
+import { isHomeProject } from "@/shared/homeScope";
 import { desktopTitle } from "@/shared/remote/desktopLabel";
 import { createArrayKeyedMap } from "@/renderer/state/derivations";
 import { remoteOwner } from "@/renderer/state/remoteProjection";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import type { RemoteServerRecord, RemoteServerStatus } from "@/renderer/state/remoteServers/types";
 import { RemoteServerStatusDot } from "./RemoteServerStatusDot";
+import { TuxIcon } from "./TuxIcon";
 
 /** What a surface needs to show that a project lives on another machine. */
 export interface ProjectRemoteServerInfo {
@@ -16,6 +18,12 @@ export interface ProjectRemoteServerInfo {
   readonly serverName: string | undefined;
   /** Live connection status of that machine, when known. */
   readonly status: RemoteServerStatus | undefined;
+}
+
+interface ProjectRemoteServerSource {
+  readonly remoteServerId?: string | undefined;
+  readonly remoteId?: string | undefined;
+  readonly location?: { readonly remoteServerId?: string | undefined } | undefined;
 }
 
 const LOCAL: ProjectRemoteServerInfo = {
@@ -37,7 +45,7 @@ const serverByDesktopId = createArrayKeyedMap<RemoteServerRecord, string, Remote
  * many projects from one subscription — calling a hook per row is not allowed.
  */
 export function useProjectRemoteServerLookup(): (
-  project: Project | undefined,
+  project: ProjectRemoteServerSource | undefined,
 ) => ProjectRemoteServerInfo {
   const servers = useRemoteServersStore((state) => state.servers);
   // Only the status is displayed, and the runtime map is rebuilt wholesale on
@@ -53,13 +61,16 @@ export function useProjectRemoteServerLookup(): (
     }),
   );
   return (project) => {
-    const desktopId = project?.remoteServerId;
+    const desktopId = project?.remoteServerId ?? project?.location?.remoteServerId;
     if (!desktopId || !project) return LOCAL;
     const server = serverByDesktopId(servers, desktopId);
     return {
       // An unpaired-but-mirrored project still reads as non-local, so the
       // glyph shows even once the machine record is gone.
-      isRemote: remoteOwner(project) !== undefined || server !== undefined,
+      isRemote:
+        remoteOwner(project) !== undefined ||
+        project.location?.remoteServerId !== undefined ||
+        server !== undefined,
       serverName: server ? desktopTitle(server.label) : undefined,
       status: statuses[desktopId],
     };
@@ -100,6 +111,49 @@ export function ProjectRemoteServerIcon(props: {
       ) : null}
     </span>
   );
+}
+
+export function ProjectLocationIcon(props: {
+  location: Project["location"];
+  className?: string | undefined;
+}) {
+  if (props.location.kind === "wsl") {
+    return (
+      <span
+        className={`${props.className ?? "size-3.5"} relative shrink-0 text-muted`}
+        aria-hidden="true"
+      >
+        <TuxIcon className="absolute left-1/2 top-1/2 h-3.5 w-6 -translate-x-1/2 -translate-y-1/2" />
+      </span>
+    );
+  }
+  const className = `${props.className ?? "size-4"} shrink-0 text-muted`;
+  return props.location.kind === "windows" ? (
+    <Monitor className={className} />
+  ) : (
+    <FolderOpen className={className} />
+  );
+}
+
+/** Leading glyph shared by project selectors: Home, host machine, or local path kind. */
+export function ProjectSelectorIcon(props: {
+  project: Project;
+  remote: ProjectRemoteServerInfo;
+  className?: string | undefined;
+}) {
+  if (isHomeProject(props.project)) {
+    return <House className={`${props.className ?? "size-4"} shrink-0 text-muted`} />;
+  }
+  if (props.remote.isRemote) {
+    return (
+      <ProjectRemoteServerIcon
+        info={props.remote}
+        className={`${props.className ?? "size-3.5"} text-muted`}
+        dotClassName="size-1"
+      />
+    );
+  }
+  return <ProjectLocationIcon location={props.project.location} className={props.className} />;
 }
 
 const CHIP_SIZE = {

--- a/src/renderer/components/common/Select.test.tsx
+++ b/src/renderer/components/common/Select.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { LARGE_DROPDOWN_VIRTUALIZATION_THRESHOLD } from "./dropdownVirtualization";
+import { Select, type SelectOption } from "./Select";
+
+const responsiveMenuState = vi.hoisted(() => ({ mobile: false }));
+
+vi.mock("@/renderer/bridge", () => ({
+  isRemoteSession: () => responsiveMenuState.mobile,
+}));
+
+vi.mock("./ResponsiveMenuSurface", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./ResponsiveMenuSurface")>()),
+  useResponsiveMenu: () => ({ mobile: responsiveMenuState.mobile }),
+}));
+
+const options: SelectOption[] = [
+  {
+    id: "alpha",
+    label: "Alpha",
+    icon: <span data-testid="alpha-icon" />,
+    detail: "C:\\Alpha",
+  },
+  {
+    id: "beta",
+    label: "Beta",
+    icon: <span data-testid="beta-icon" />,
+    detail: "C:\\Beta",
+  },
+];
+
+describe("Select rich options", () => {
+  beforeEach(() => {
+    responsiveMenuState.mobile = false;
+  });
+
+  it("renders icon and detail in the desktop trigger and selects a rich option", async () => {
+    const onChange = vi.fn<(value: string) => void>();
+    render(<Select aria-label="Project" options={options} value="alpha" onChange={onChange} />);
+
+    const trigger = screen.getByLabelText("Project");
+    expect(trigger).toHaveTextContent("AlphaC:\\Alpha");
+    expect(trigger.querySelector('[data-testid="alpha-icon"]')).not.toBeNull();
+
+    fireEvent.click(trigger);
+    const beta = await screen.findByRole("option", { name: /Beta/u });
+    expect(beta).toHaveTextContent("C:\\Beta");
+    expect(beta.querySelector('[data-testid="beta-icon"]')).not.toBeNull();
+    fireEvent.click(beta);
+
+    expect(onChange).toHaveBeenCalledWith("beta");
+  });
+
+  it("renders and selects rich options in the mobile drawer", async () => {
+    responsiveMenuState.mobile = true;
+    const onChange = vi.fn<(value: string) => void>();
+    render(<Select aria-label="Project" options={options} value="alpha" onChange={onChange} />);
+
+    const trigger = screen.getByRole("button", { name: "Project" });
+    expect(trigger).toHaveTextContent("AlphaC:\\Alpha");
+    fireEvent.click(trigger);
+
+    const beta = await screen.findByRole("button", { name: /Beta/u });
+    expect(beta).toHaveTextContent("C:\\Beta");
+    fireEvent.click(beta);
+
+    expect(onChange).toHaveBeenCalledWith("beta");
+  });
+
+  it("renders rich rows when the desktop list is virtualized", async () => {
+    const virtualizedOptions = Array.from(
+      { length: LARGE_DROPDOWN_VIRTUALIZATION_THRESHOLD + 1 },
+      (_, index): SelectOption => ({
+        id: `project-${index}`,
+        label: `Project ${index}`,
+        icon: <span data-testid={`project-${index}-icon`} />,
+        detail: `C:\\Project ${index}`,
+      }),
+    );
+    render(
+      <Select
+        aria-label="Project"
+        options={virtualizedOptions}
+        value="project-0"
+        onChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Project"));
+
+    const first = await screen.findByRole("option", { name: /Project 0/u });
+    expect(first).toHaveTextContent("C:\\Project 0");
+    expect(first.querySelector('[data-testid="project-0-icon"]')).not.toBeNull();
+  });
+});

--- a/src/renderer/components/common/Select.tsx
+++ b/src/renderer/components/common/Select.tsx
@@ -1,5 +1,6 @@
-import { useState, type ComponentProps } from "react";
+import { useState, type ComponentProps, type ReactNode } from "react";
 import {
+  Description,
   Label,
   ListBox,
   ListLayout,
@@ -18,6 +19,8 @@ import { ResponsiveMenuSurface, useResponsiveMenu } from "./ResponsiveMenuSurfac
 export interface SelectOption {
   id: string;
   label: string;
+  icon?: ReactNode;
+  detail?: string;
 }
 
 export interface SelectProps extends Omit<
@@ -37,6 +40,7 @@ export function Select(props: SelectProps) {
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
   const selectedValue = value && options.some((option) => option.id === value) ? value : null;
+  const selectedOption = options.find((option) => option.id === selectedValue);
   const isVirtualized = options.length > LARGE_DROPDOWN_VIRTUALIZATION_THRESHOLD;
 
   // Mobile PWA: a HeroUI select-listbox popover anchored to a small trigger is
@@ -44,7 +48,6 @@ export function Select(props: SelectProps) {
   // drawer of finger-sized rows instead. `mobile === isRemoteSession()`, so the
   // desktop HeroSelect below never runs on the phone and is left untouched.
   if (mobile) {
-    const selectedOption = options.find((option) => option.id === selectedValue);
     const placeholder = typeof rest.placeholder === "string" ? rest.placeholder : t`Select…`;
     // Settings pass the field name via `aria-label` (the visible label lives on
     // the surrounding SettingRow), so fall back to it for the trigger + heading.
@@ -65,9 +68,15 @@ export function Select(props: SelectProps) {
               if (!rest.isDisabled) setIsOpen(true);
             }}
           >
-            <span className={`flex-1 truncate ${selectedOption ? "" : "text-muted"}`}>
+            {selectedOption?.icon}
+            <span className={`min-w-0 flex-1 truncate ${selectedOption ? "" : "text-muted"}`}>
               {selectedOption?.label ?? placeholder}
             </span>
+            {selectedOption?.detail ? (
+              <span className="min-w-0 shrink truncate text-xs text-muted/60">
+                {selectedOption.detail}
+              </span>
+            ) : null}
             <ChevronDown className="size-4 shrink-0 text-muted" />
           </button>
         }
@@ -86,7 +95,13 @@ export function Select(props: SelectProps) {
                   onChange(option.id);
                 }}
               >
-                <span className="flex-1 truncate">{option.label}</span>
+                {option.icon}
+                <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                {option.detail ? (
+                  <span className="max-w-28 shrink-0 truncate text-xs text-muted/60">
+                    {option.detail}
+                  </span>
+                ) : null}
                 {selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
               </button>
             );
@@ -104,7 +119,19 @@ export function Select(props: SelectProps) {
         // reserves room for the checkmark so it overlaps long labels. The
         // `pe-7` utility (utilities layer) restores it.
         <ListBox.Item key={option.id} id={option.id} textValue={option.label} className="pe-7">
-          {option.label}
+          {option.icon || option.detail ? (
+            <>
+              {option.icon}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <Label className="truncate">{option.label}</Label>
+                {option.detail ? (
+                  <Description className="truncate">{option.detail}</Description>
+                ) : null}
+              </div>
+            </>
+          ) : (
+            option.label
+          )}
           <ListBox.ItemIndicator />
         </ListBox.Item>
       ))}
@@ -119,7 +146,23 @@ export function Select(props: SelectProps) {
     >
       {label ? <Label>{label}</Label> : null}
       <HeroSelect.Trigger>
-        <HeroSelect.Value />
+        <HeroSelect.Value>
+          {({ defaultChildren, isPlaceholder }) =>
+            !isPlaceholder && selectedOption?.icon ? (
+              <span className="flex min-w-0 items-center gap-2">
+                {selectedOption.icon}
+                <span className="min-w-0 truncate">{selectedOption.label}</span>
+                {selectedOption.detail ? (
+                  <span className="min-w-0 shrink truncate text-xs text-muted/60">
+                    {selectedOption.detail}
+                  </span>
+                ) : null}
+              </span>
+            ) : (
+              defaultChildren
+            )
+          }
+        </HeroSelect.Value>
         <HeroSelect.Indicator />
       </HeroSelect.Trigger>
       <HeroSelect.Popover {...popoverProps}>

--- a/src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+++ b/src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
@@ -2,7 +2,11 @@ import type { ReactNode } from "react";
 import { Description, Dropdown, Header, Label } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { ProjectLocation } from "@/shared/contracts";
-import { TuxIcon } from "@/renderer/components/common";
+import {
+  ProjectLocationIcon,
+  ProjectRemoteServerIcon,
+  useProjectRemoteServerLookup,
+} from "@/renderer/components/common/ProjectRemoteServer";
 
 export const GLOBAL_MCP_DESTINATION_ID = "user";
 export const MCP_WSL_DESTINATION_PREFIX = "wsl:";
@@ -27,20 +31,36 @@ export function mcpProjectLocationLabel(location: ProjectLocation): string {
 }
 
 export function McpProjectDropdownItemContent(props: { project: McpProjectDestination }) {
+  const remote = useProjectRemoteServerLookup()(props.project);
   return (
     <>
-      <Label>
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate">{props.project.name}</span>
-          {props.project.location.kind === "wsl" ? (
-            <span className="relative size-4 shrink-0 text-muted" aria-hidden="true">
-              <TuxIcon className="absolute left-1/2 top-1/2 h-3.5 w-6 -translate-x-1/2 -translate-y-1/2" />
-            </span>
-          ) : null}
-        </span>
-      </Label>
-      <Description>{mcpProjectLocationLabel(props.project.location)}</Description>
+      {remote.isRemote ? (
+        <ProjectRemoteServerIcon info={remote} className="size-3.5 text-muted" />
+      ) : (
+        <ProjectLocationIcon location={props.project.location} />
+      )}
+      <Label>{props.project.name}</Label>
+      <Description>
+        {remote.serverName ?? mcpProjectLocationLabel(props.project.location)}
+      </Description>
     </>
+  );
+}
+
+export function McpProjectDropdownTriggerContent(props: { project: McpProjectDestination }) {
+  const remote = useProjectRemoteServerLookup()(props.project);
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      {remote.isRemote ? (
+        <ProjectRemoteServerIcon info={remote} className="size-3.5 text-muted" />
+      ) : (
+        <ProjectLocationIcon location={props.project.location} className="size-3.5" />
+      )}
+      <span className="min-w-0 truncate">{props.project.name}</span>
+      {remote.serverName ? (
+        <span className="min-w-0 shrink truncate text-xs text-muted/60">{remote.serverName}</span>
+      ) : null}
+    </span>
   );
 }
 

--- a/src/renderer/components/mcp/McpServerEditor.tsx
+++ b/src/renderer/components/mcp/McpServerEditor.tsx
@@ -3,10 +3,10 @@ import { Description, FieldError, Input, Label, Modal, TextArea, TextField } fro
 import { ChevronDown } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { DEFAULT_MCP_SERVER_TIMEOUT_MS, type McpServer } from "@/shared/contracts";
-import { Button, LightballTabs, Select, TuxIcon } from "@/renderer/components/common";
+import { Button, LightballTabs, Select } from "@/renderer/components/common";
 import {
-  GLOBAL_MCP_DESTINATION_ID,
   McpProjectDestinationDropdown,
+  McpProjectDropdownTriggerContent,
   mcpProjectDestinationId,
   type McpProjectDestination,
 } from "./McpProjectDestinationDropdown";
@@ -200,16 +200,11 @@ export function McpServerEditor(props: {
                       aria-label={t`Scope`}
                       className="w-44 justify-between text-foreground"
                     >
-                      <span className="flex min-w-0 items-center gap-2">
-                        <span className="truncate">
-                          {props.scopeId === GLOBAL_MCP_DESTINATION_ID
-                            ? t`Global`
-                            : selectedProject?.name}
-                        </span>
-                        {selectedProject?.location.kind === "wsl" ? (
-                          <TuxIcon aria-hidden="true" className="h-3.5 w-6 shrink-0 text-muted" />
-                        ) : null}
-                      </span>
+                      {selectedProject ? (
+                        <McpProjectDropdownTriggerContent project={selectedProject} />
+                      ) : (
+                        <span className="truncate">{t`Global`}</span>
+                      )}
                       <ChevronDown className="size-3.5 shrink-0 text-muted" />
                     </Button>
                   }

--- a/src/renderer/components/mcp/McpServersManager.test.tsx
+++ b/src/renderer/components/mcp/McpServersManager.test.tsx
@@ -12,6 +12,7 @@ import {
   type McpOauthBeginResult,
 } from "@/shared/contracts";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import type { PoracodeBridge } from "@/shared/ipc";
 import { McpServersManager, type McpImportProjectTarget } from "./McpServersManager";
 
@@ -140,6 +141,7 @@ describe("McpServersManager", () => {
     bridge.openExternalNative.mockClear();
     bridge.waitMcpServerOauth.mockClear();
     bridge.clearMcpServerOauth.mockClear();
+    useRemoteServersStore.setState({ servers: [], runtime: {} });
   });
 
   it("renders immutable built-ins separately from editable configured servers", () => {
@@ -458,6 +460,34 @@ describe("McpServersManager", () => {
     expect(
       screen.getByRole<HTMLTextAreaElement>("textbox", { name: "Full configuration" }).value,
     ).toContain('"cwd": "C:\\\\repo"');
+  });
+
+  it("identifies a remote project by its host in the scope trigger and menu", async () => {
+    useRemoteServersStore.setState({
+      servers: [{ desktopId: "d1", label: "Poracode on MacBook 16" }],
+      runtime: { d1: { status: "online", projects: [], threads: [] } },
+    } as never);
+    render(
+      managerElement({
+        workspaceServers: [],
+        defaultScope: "workspace",
+        projectLocation: {
+          kind: "posix",
+          path: "/remote/project",
+          remoteServerId: "d1",
+        },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add MCP server" }));
+    const scope = screen.getByLabelText("Scope");
+    expect(scope).toHaveTextContent("Demo projectMacBook 16");
+    expect(scope.querySelector(".lucide-server")).not.toBeNull();
+
+    fireEvent.click(scope);
+    const option = await screen.findByRole("menuitemradio", { name: /Demo project.*MacBook 16/u });
+    expect(option.querySelector(".lucide-server")).not.toBeNull();
+    expect(option).not.toHaveTextContent("/remote/project");
   });
 
   it("dismisses the modal with Escape", () => {

--- a/src/renderer/components/skills/SkillsManager.tsx
+++ b/src/renderer/components/skills/SkillsManager.tsx
@@ -14,6 +14,7 @@ import {
 import {
   GLOBAL_MCP_DESTINATION_ID,
   McpProjectDestinationDropdown,
+  McpProjectDropdownTriggerContent,
   type McpProjectDestination,
 } from "@/renderer/components/mcp/McpProjectDestinationDropdown";
 import { newThreadFromText } from "@/renderer/actions/notesActions";
@@ -267,7 +268,11 @@ export function SkillsManager(props: {
               aria-label={t`Skills location`}
               className="min-w-48 justify-between"
             >
-              <span className="truncate">{targetLabel}</span>
+              {target.project ? (
+                <McpProjectDropdownTriggerContent project={target.project} />
+              ) : (
+                <span className="truncate">{targetLabel}</span>
+              )}
               <ChevronDown className="size-3.5 shrink-0 text-muted" />
             </Button>
           }

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -1,8 +1,7 @@
 import { startTransition, useState } from "react";
-import { Check, ChevronDown, FolderOpen, House, Monitor } from "lucide-react";
+import { Check, ChevronDown, House } from "lucide-react";
 import { Description, Dropdown, Header, Label } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { Project } from "@/shared/contracts";
 import { HOME_PROJECT_NAME, isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { makeDraftPaneId } from "@/shared/paneId";
 import { switchWorkspaceForProject } from "@/renderer/actions/workspaceActions";
@@ -12,58 +11,11 @@ import {
   ResponsiveMenuSurface,
   useResponsiveMenu,
 } from "@/renderer/components/common/ResponsiveMenuSurface";
-import { TuxIcon } from "@/renderer/components/common/TuxIcon";
 import {
-  ProjectRemoteServerIcon,
+  ProjectSelectorIcon,
   useProjectRemoteServerLookup,
-  type ProjectRemoteServerInfo,
 } from "@/renderer/components/common/ProjectRemoteServer";
 import { useProjectSwitchGroups, type ProjectSwitchEntry } from "./projectSwitchGroups";
-
-function LocationIcon(props: {
-  kind: Project["location"]["kind"];
-  className?: string | undefined;
-}) {
-  if (props.kind === "wsl") {
-    return (
-      <span className={`${props.className ?? "size-3.5"} relative shrink-0 text-muted`}>
-        <TuxIcon className="absolute left-1/2 top-1/2 h-3.5 w-6 -translate-x-1/2 -translate-y-1/2" />
-      </span>
-    );
-  }
-  const className = `${props.className ?? "size-4"} shrink-0 text-muted`;
-  if (props.kind === "windows") {
-    return <Monitor className={className} />;
-  }
-  return <FolderOpen className={className} />;
-}
-
-/**
- * Leading glyph for a project row. A mirrored project is marked by the machine
- * hosting it rather than by its path kind — which machine it lives on is what
- * distinguishes it from the same-named project on this one.
- */
-function ProjectIcon(props: {
-  project: Project;
-  remote: ProjectRemoteServerInfo;
-  className?: string | undefined;
-}) {
-  if (isHomeProject(props.project)) {
-    return <House className={`${props.className ?? "size-4"} shrink-0 text-muted`} />;
-  }
-  if (props.remote.isRemote) {
-    // The compact glyph with the small status light — same treatment as the
-    // flat list's row tags, a step below the location/Home glyphs beside it.
-    return (
-      <ProjectRemoteServerIcon
-        info={props.remote}
-        className={`${props.className ?? "size-3.5"} text-muted`}
-        dotClassName="size-1"
-      />
-    );
-  }
-  return <LocationIcon kind={props.project.location.kind} className={props.className} />;
-}
 
 export function ProjectSwitchMenu(props: {
   currentProjectId: string;
@@ -97,7 +49,7 @@ export function ProjectSwitchMenu(props: {
   const triggerIcon = isHomeCurrent ? (
     <House className="size-3.5 shrink-0 text-muted" />
   ) : current ? (
-    <ProjectIcon project={current} remote={currentRemote} className="size-3.5" />
+    <ProjectSelectorIcon project={current} remote={currentRemote} className="size-3.5" />
   ) : null;
   // The machine trails the name, so the project stays the thing you read first.
   const triggerMachine = currentRemote.serverName ? (
@@ -146,7 +98,7 @@ export function ProjectSwitchMenu(props: {
             handleSelect(project.id);
           }}
         >
-          <ProjectIcon project={project} remote={remote} />
+          <ProjectSelectorIcon project={project} remote={remote} />
           <span className="min-w-0 flex-1 truncate">{itemLabel}</span>
           {remote.serverName ? (
             <span className="max-w-28 shrink-0 truncate text-xs text-muted/60">
@@ -171,7 +123,7 @@ export function ProjectSwitchMenu(props: {
       const description = [remote.serverName, otherWorkspaceName].filter(Boolean).join(" · ");
       return (
         <Dropdown.Item key={project.id} id={project.id} textValue={itemLabel}>
-          <ProjectIcon project={project} remote={remote} />
+          <ProjectSelectorIcon project={project} remote={remote} />
           <Label>{itemLabel}</Label>
           {description ? <Description>{description}</Description> : null}
         </Dropdown.Item>

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Git-Status für {0}: kein Git-Repository"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -5094,6 +5094,7 @@ msgstr "Git status for {0}: not a Git repository"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Estado de Git para {0}: no es un repositorio Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Statut Git pour {0} : pas un dépôt Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -5088,6 +5088,7 @@ msgstr "{0}の Git ステータス: Git リポジトリではありません"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -5089,6 +5089,7 @@ msgstr "{0}에 대한 Git 상태: Git 저장소가 아닙니다."
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Status Git dla {0}: to nie jest repozytorium Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Status do Git para {0}: não é um repositório Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Состояние Git для {0}: не репозиторий Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -5089,6 +5089,7 @@ msgstr "{0} için Git durumu: Git deposu değil"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Стан Git для {0}: не репозиторій Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -5089,6 +5089,7 @@ msgstr "Trạng thái Git cho {0}: không phải kho lưu trữ Git"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -5089,6 +5089,7 @@ msgstr "{0}的 Git 状态：不是 Git 存储库"
 #: src/renderer/views/MainView/parts/Sidebar/parts/sidebarShortcuts.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
 #: src/renderer/views/SettingsOverlay/parts/SidebarShortcutsSelector.tsx
 msgid "GitHub Actions"
 msgstr "GitHub Actions"

--- a/src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
@@ -1,16 +1,20 @@
-import { Button, Dropdown, Label } from "@heroui/react";
+import { Button, Description, Dropdown, Label } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import {
   ArrowLeft,
-  ChevronDown,
+  ChevronsUpDown,
   PanelLeft,
   PanelLeftClose,
   Pin,
   Play,
   Workflow,
 } from "lucide-react";
-import type { GitHubActionsWorkflow } from "@/shared/contracts";
+import type { GitHubActionsWorkflow, Project } from "@/shared/contracts";
 import { SidebarButton } from "@/renderer/components/common";
+import {
+  ProjectSelectorIcon,
+  useProjectRemoteServerLookup,
+} from "@/renderer/components/common/ProjectRemoteServer";
 import {
   overlaySidebarColumnClass,
   overlaySidebarSurfaceClass,
@@ -27,7 +31,7 @@ const workflowIconButtonHoverClass =
   "hover:bg-[color:color-mix(in_oklab,var(--foreground)_12%,transparent)]";
 
 export function GitHubActionsSidebar(props: {
-  projects: { id: string; label: string }[];
+  projects: Project[];
   selectedProjectId: string | null;
   workflows: GitHubActionsWorkflow[];
   selectedWorkflowId: number | null;
@@ -41,8 +45,10 @@ export function GitHubActionsSidebar(props: {
 }) {
   const { t } = useLingui();
   const { isCollapsed, collapse, expand } = useSidebar();
+  const remoteServerFor = useProjectRemoteServerLookup();
   const pinned = new Set(props.pinnedWorkflowIds);
   const selectedProject = props.projects.find((project) => project.id === props.selectedProjectId);
+  const selectedRemote = remoteServerFor(selectedProject);
   const workflows = [...props.workflows].sort((a, b) => {
     const aPinned = pinned.has(a.id);
     const bPinned = pinned.has(b.id);
@@ -86,30 +92,44 @@ export function GitHubActionsSidebar(props: {
       >
         <div className={sidebarBodyScrollClass()}>
           {selectedProject ? (
-            <div className="px-2 py-1">
+            <div className="py-1">
               <Dropdown>
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-8 w-full min-w-0 justify-between rounded-3xl px-2 font-mono text-xs text-muted"
+                  className="h-8 w-full min-w-0 justify-start gap-2 rounded-3xl px-2 text-sm text-muted"
                   aria-label={t`Project`}
                 >
-                  <span className="min-w-0 truncate">{selectedProject.label}</span>
-                  <ChevronDown className="size-3 shrink-0" />
+                  <ProjectSelectorIcon project={selectedProject} remote={selectedRemote} />
+                  <span className="min-w-0 truncate">{selectedProject.name}</span>
+                  {selectedRemote.serverName ? (
+                    <span className="min-w-0 shrink truncate text-xs text-muted/60">
+                      {selectedRemote.serverName}
+                    </span>
+                  ) : null}
+                  <ChevronsUpDown className="ms-auto size-3.5 shrink-0" />
                 </Button>
-                <Dropdown.Popover placement="bottom start">
+                <Dropdown.Popover placement="bottom start" className="min-w-[--trigger-width]">
                   <Dropdown.Menu
                     aria-label={t`Project`}
+                    className="poracode-menu"
                     selectionMode="single"
                     selectedKeys={[selectedProject.id]}
                     onAction={(key) => props.onSelectProject(String(key))}
                   >
-                    {props.projects.map((project) => (
-                      <Dropdown.Item key={project.id} id={project.id} textValue={project.label}>
-                        <Dropdown.ItemIndicator />
-                        <Label>{project.label}</Label>
-                      </Dropdown.Item>
-                    ))}
+                    {props.projects.map((project) => {
+                      const remote = remoteServerFor(project);
+                      return (
+                        <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+                          <ProjectSelectorIcon project={project} remote={remote} />
+                          <Label>{project.name}</Label>
+                          {remote.serverName ? (
+                            <Description>{remote.serverName}</Description>
+                          ) : null}
+                          <Dropdown.ItemIndicator />
+                        </Dropdown.Item>
+                      );
+                    })}
                   </Dropdown.Menu>
                 </Dropdown.Popover>
               </Dropdown>

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
@@ -20,6 +20,7 @@ import type {
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 
 const bridge = vi.hoisted(() => ({
@@ -153,6 +154,7 @@ describe("GitHubActionsView", () => {
     bridge.ghCancelWorkflowRun.mockReset().mockResolvedValue(undefined);
     bridge.ghDeleteWorkflowRun.mockReset().mockResolvedValue(undefined);
     bridge.openExternal.mockReset().mockResolvedValue(undefined);
+    useRemoteServersStore.setState({ servers: [], runtime: {} });
     useAppStore.setState({ projects: [project] });
     useSidebarUiStore.setState({ pinnedGitHubWorkflows: {} });
     useGitStore.setState({
@@ -200,10 +202,42 @@ describe("GitHubActionsView", () => {
   it("selects the first active project by default", async () => {
     render(<GitHubActionsView onClose={() => {}} />);
 
-    expect(await screen.findByRole("button", { name: "Project" })).toHaveTextContent(project.name);
+    const trigger = await screen.findByRole("button", { name: "Project" });
+    expect(trigger).toHaveTextContent(project.name);
+    expect(trigger).toHaveClass("text-sm");
+    expect(trigger).not.toHaveClass("font-mono");
+    expect(trigger.querySelector(".lucide-monitor")).not.toBeNull();
     expect(bridge.ghListWorkflows).toHaveBeenCalledWith({
       projectLocation: project.location,
     });
+  });
+
+  it("shows project icons and the hosting machine in the trigger and menu", async () => {
+    const mirrored: Project = {
+      ...project,
+      id: "remote:desktop-1:project:project-1",
+      remoteServerId: "desktop-1",
+      remoteId: project.id,
+      location: { ...project.location, remoteServerId: "desktop-1" },
+    };
+    useRemoteServersStore.setState({
+      servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+      runtime: { "desktop-1": { status: "online", projects: [], threads: [] } },
+    } as never);
+    useAppStore.setState({ projects: [project, mirrored] });
+
+    render(<GitHubActionsView projectId={mirrored.id} onClose={() => {}} />);
+
+    const trigger = await screen.findByRole("button", { name: "Project" });
+    expect(trigger).toHaveTextContent("PoracodeMacBook 16");
+    expect(trigger.querySelector(".lucide-server")).not.toBeNull();
+    expect(trigger.parentElement).not.toHaveClass("px-2");
+
+    fireEvent.click(trigger);
+    const remoteRow = await screen.findByRole("menuitemradio", { name: /MacBook 16/ });
+    expect(remoteRow).toHaveTextContent("MacBook 16");
+    expect(remoteRow.querySelector(".lucide-server")).not.toBeNull();
+    expect(document.querySelector('[class~="min-w-[--trigger-width]"]')).toBeInTheDocument();
   });
 
   it("selects the first pinned workflow by default", async () => {

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.tsx
@@ -32,7 +32,6 @@ export function GitHubActionsView(props: {
     loadingWorkflows,
     openGitHubActions,
     pendingRunId,
-    projectOptions,
     runs,
     selectedProject,
     selectedRun,
@@ -102,7 +101,7 @@ export function GitHubActionsView(props: {
 
   const sidebar = (
     <GitHubActionsSidebar
-      projects={projectOptions}
+      projects={activeProjects}
       selectedProjectId={selectedProject?.id ?? null}
       workflows={workflows}
       selectedWorkflowId={selectedWorkflowId}

--- a/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
+++ b/src/renderer/views/GitHubActionsView/useGitHubActionsViewModel.ts
@@ -369,11 +369,6 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
     selectedRunDetails?.id === selectedRunId
       ? selectedRunDetails
       : (runs.find((run) => run.id === selectedRunId) ?? null);
-  const projectOptions = activeProjects.map((project) => ({
-    id: project.id,
-    label: project.name,
-  }));
-
   function selectWorkflow(workflowId: number) {
     userPickedWorkflowRef.current = true;
     if (workflowId === selectedWorkflowId) {
@@ -517,7 +512,6 @@ export function useGitHubActionsViewModel(props: { projectId?: string; runId?: n
     loadingWorkflows,
     openGitHubActions,
     pendingRunId,
-    projectOptions,
     runs,
     selectedProject,
     selectedRun,

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import type { Selection } from "@heroui/react";
-import { Dropdown, Label, Separator } from "@heroui/react";
+import { Description, Dropdown, Label, Separator } from "@heroui/react";
 import { Check, ChevronsUpDown, ListFilter, MoreHorizontal } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { plural } from "@lingui/core/macro";
@@ -8,7 +8,7 @@ import type { Project } from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
 import { ContextMenuSurface, MENU_BACKDROP_ATTR } from "@/renderer/components/common/ContextMenu";
 import {
-  ProjectRemoteServerChip,
+  ProjectSelectorIcon,
   useProjectRemoteServerLookup,
 } from "@/renderer/components/common/ProjectRemoteServer";
 import { isRemoteProjectStatusUnreachable } from "@/renderer/state/remoteServers/reachability";
@@ -357,8 +357,13 @@ export function SidebarProjectFilter(props: {
                 aria-pressed={selected || undefined}
                 onClick={() => toggleProject(project.id)}
               >
+                <ProjectSelectorIcon project={project} remote={remote} />
                 <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                <ProjectRemoteServerChip info={remote} size="md" />
+                {remote.serverName ? (
+                  <span className="max-w-24 shrink-0 truncate text-xs text-muted/60">
+                    {remote.serverName}
+                  </span>
+                ) : null}
                 <span className="shrink-0 text-xs text-muted">
                   {props.threadCounts.get(project.id) ?? 0}
                 </span>
@@ -370,8 +375,13 @@ export function SidebarProjectFilter(props: {
             const remote = remoteServerFor(project);
             return (
               <div key={project.id} className="m-sheet-action opacity-50" data-static="true">
+                <ProjectSelectorIcon project={project} remote={remote} />
                 <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                <ProjectRemoteServerChip info={remote} size="md" />
+                {remote.serverName ? (
+                  <span className="max-w-24 shrink-0 truncate text-xs text-muted/60">
+                    {remote.serverName}
+                  </span>
+                ) : null}
                 {isHomeProject(project) ? null : (
                   <ProjectRowMenuButton
                     project={project}
@@ -487,8 +497,9 @@ export function SidebarProjectFilter(props: {
             const remote = remoteServerFor(project);
             return (
               <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+                <ProjectSelectorIcon project={project} remote={remote} />
                 <Label className="min-w-0 truncate">{project.name}</Label>
-                <ProjectRemoteServerChip info={remote} size="md" />
+                {remote.serverName ? <Description>{remote.serverName}</Description> : null}
                 <span className="ms-auto shrink-0 text-xs text-muted">
                   {props.threadCounts.get(project.id) ?? 0}
                 </span>
@@ -513,8 +524,9 @@ export function SidebarProjectFilter(props: {
               const remote = remoteServerFor(project);
               return (
                 <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+                  <ProjectSelectorIcon project={project} remote={remote} />
                   <Label className="min-w-0 truncate opacity-50">{project.name}</Label>
-                  <ProjectRemoteServerChip info={remote} size="md" />
+                  {remote.serverName ? <Description>{remote.serverName}</Description> : null}
                   {isHomeProject(project) ? null : (
                     <ProjectRowMenuButton
                       project={project}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project, Thread } from "@/shared/contracts";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import type { WorktreeThreadGroup } from "./groupThreads";
 import { SidebarWorktreeGroup } from "./SidebarWorktreeGroup";
 
@@ -24,7 +25,7 @@ vi.mock("@/renderer/dnd", () => ({
 vi.mock("@/renderer/actions/terminalActions", () => terminalActions);
 
 vi.mock("./useWorktreeActions", () => ({
-  useWorktreeGitItems: () => [],
+  useWorktreeGitItems: () => [{ id: "github-actions", label: "GitHub Actions", icon: null }],
 }));
 
 vi.mock("./WorktreeGroupHeader", async (importOriginal) => {
@@ -130,5 +131,18 @@ describe("SidebarWorktreeGroup Run menu", () => {
       "build",
       worktreePath,
     );
+  });
+});
+
+describe("SidebarWorktreeGroup Git menu", () => {
+  it("opens GitHub Actions for the project", async () => {
+    usePanelStore.setState({ githubActionsContext: null });
+    renderGroup([makeThread("t1", "inactive")], new Set());
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "worktree" }));
+    fireEvent.pointerEnter(screen.getByRole("menuitem", { name: "Git" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "GitHub Actions" }));
+
+    expect(usePanelStore.getState().githubActionsContext).toEqual({ projectId: project.id });
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarWorktreeGroup.tsx
@@ -31,6 +31,7 @@ import { deleteWorktreeGroup } from "@/renderer/actions/worktreeActions";
 import { markThreadDone, openNewThreadInWorktree } from "@/renderer/actions/threadActions";
 import { readBridge } from "@/renderer/bridge";
 import { useGitStore } from "@/renderer/state/gitStore";
+import { useAppStore } from "@/renderer/state/appStore";
 import { useIsWorktreeCollapsed, useSidebarUiStore } from "@/renderer/state/sidebarUiStore";
 import { resolveActionIcon } from "@/renderer/utils/actionIcons";
 import { resolveWorktreeBranch } from "@/renderer/utils/gitHelpers";
@@ -164,6 +165,7 @@ export function SidebarWorktreeGroup(props: {
                 group.worktreeBranch,
             });
           if (key === "git-review") openGitReview(project.id, group.worktreePath);
+          if (key === "github-actions") useAppStore.getState().openGitHubActions(project.id);
           if (key === "delete-worktree")
             deleteWorktreeGroup(project.id, group.worktreePath, groupThreadIds);
           if (key === "mark-all-done") {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/ThreadContextMenu.test.tsx
@@ -4,6 +4,7 @@ import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project, Thread } from "@/shared/contracts";
 import { HOME_PROJECT_ID } from "@/shared/homeScope";
 import { resetDevTerminalStore, useDevTerminalStore } from "@/renderer/state/devTerminalStore";
+import { usePanelStore } from "@/renderer/state/panelStore";
 import { ThreadContextMenu } from "./ThreadContextMenu";
 
 vi.mock("@/renderer/bridge", () => ({
@@ -58,6 +59,7 @@ function renderMenu(
 describe("ThreadContextMenu project actions", () => {
   beforeEach(() => {
     resetDevTerminalStore();
+    usePanelStore.setState({ githubActionsContext: null });
   });
 
   it("offers project Git and Run submenus on flat main-branch rows", async () => {
@@ -92,6 +94,15 @@ describe("ThreadContextMenu project actions", () => {
 
     expect(screen.getAllByRole("menuitem", { name: "Git" })).toHaveLength(1);
     expect(screen.getByRole("menuitem", { name: "Run" })).toBeInTheDocument();
+  });
+
+  it("opens GitHub Actions from a worktree Git submenu", async () => {
+    await renderMenu(thread({ worktreePath: "C:\\repo\\wt" }), project);
+
+    fireEvent.pointerEnter(screen.getByRole("menuitem", { name: "Git" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "GitHub Actions" }));
+
+    expect(usePanelStore.getState().githubActionsContext).toEqual({ projectId: project.id });
   });
 
   it("omits the Run submenu when the project defines no scripts", async () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/gitMenuIcons.tsx
@@ -6,11 +6,13 @@ import {
   GitMerge,
   GitPullRequest,
   RefreshCw,
+  Workflow,
 } from "lucide-react";
 import type { GitMenuIcons } from "./useWorktreeActions";
 
 export const gitMenuIcons: GitMenuIcons = {
   review: <FileDiff className="size-3.5" />,
+  githubActions: <Workflow className="size-3.5" />,
   sync: <RefreshCw className="size-3.5" />,
   push: <ArrowUpFromLine className="size-3.5" />,
   pull: <ArrowDownToLine className="size-3.5" />,

--- a/src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/useWorktreeActions.ts
@@ -7,6 +7,7 @@ import { isPrActive } from "@/renderer/utils/prStatus";
 
 export type GitMenuIcons = {
   review: React.ReactNode;
+  githubActions: React.ReactNode;
   sync: React.ReactNode;
   push: React.ReactNode;
   pull: React.ReactNode;
@@ -97,6 +98,11 @@ export function buildWorktreeGitItems(
 
   return [
     { id: "git-review", label: i18n._(msg`Review Changes`), icon: icons.review },
+    {
+      id: "github-actions",
+      label: i18n._(msg`GitHub Actions`),
+      icon: icons.githubActions,
+    },
     syncMap[vis.syncAction],
     ...(vis.showPullFromSource
       ? [

--- a/src/renderer/views/SchedulesView/ScheduleEditor.tsx
+++ b/src/renderer/views/SchedulesView/ScheduleEditor.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from "react";
 import { Button, Input, Label, Modal, TextArea, TextField } from "@heroui/react";
+import { House } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { AgentStatus, ThreadPresentationMode } from "@/shared/contracts";
+import type { AgentStatus, ProjectLocation, ThreadPresentationMode } from "@/shared/contracts";
 import { Select, ToggleSwitch } from "@/renderer/components/common";
+import { ProjectLocationIcon } from "@/renderer/components/common/ProjectRemoteServer";
 import { useAppStore } from "@/renderer/state/appStore";
 import { HOME_PROJECT_ID, isHomeProject } from "@/shared/homeScope";
 import { capabilitiesForPresentation } from "@/shared/agentSelection";
@@ -34,6 +36,10 @@ interface ScheduleEditorProps {
 
 const CONTROL_WIDTH = "w-[280px] max-w-[60%] shrink-0";
 
+function projectLocationLabel(location: ProjectLocation): string {
+  return location.kind === "wsl" ? `${location.distro}: ${location.linuxPath}` : location.path;
+}
+
 /** A titled group of rows, matching the settings section header treatment. */
 function EditorSection(props: { title: ReactNode; children: ReactNode }) {
   return (
@@ -62,10 +68,19 @@ export function ScheduleEditor(props: ScheduleEditorProps) {
   const projects = useAppStore((state) => state.projects);
   const draft = props.draft;
   const projectOptions = [
-    { id: HOME_PROJECT_ID, label: t`Home` },
+    {
+      id: HOME_PROJECT_ID,
+      label: t`Home`,
+      icon: <House className="size-4 shrink-0 text-muted" />,
+    },
     ...projects
       .filter((project) => !isHomeProject(project) && !project.remoteServerId)
-      .map((project) => ({ id: project.id, label: project.name })),
+      .map((project) => ({
+        id: project.id,
+        label: project.name,
+        icon: <ProjectLocationIcon location={project.location} />,
+        detail: projectLocationLabel(project.location),
+      })),
   ];
   // A schedule can reference a project that was deleted since it was created.
   // Surface it as a fallback option (rather than silently snapping to Home) so

--- a/src/renderer/views/SchedulesView/SchedulesView.test.tsx
+++ b/src/renderer/views/SchedulesView/SchedulesView.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentStatus, ScheduledTask, ScheduledTaskRun } from "@/shared/contracts";
+import type { AgentStatus, Project, ScheduledTask, ScheduledTaskRun } from "@/shared/contracts";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 
 const task: ScheduledTask = {
@@ -60,7 +60,7 @@ const appState = vi.hoisted(() => ({
     projectId: string;
     config: { model: string; effort?: string };
   }[],
-  projects: [] as { id: string; name: string; remoteServerId?: string }[],
+  projects: [] as Project[],
 }));
 
 const agentState = vi.hoisted(() => ({
@@ -288,8 +288,20 @@ describe("SchedulesView", () => {
 
   it("does not offer remote projects to device-owned schedules", async () => {
     appState.projects = [
-      { id: "local-project", name: "Local project" },
-      { id: "remote-project", name: "Remote project", remoteServerId: "d1" },
+      {
+        id: "local-project",
+        name: "Local project",
+        location: { kind: "windows", path: "C:\\local-project" },
+        createdAt: "2026-07-01T00:00:00.000Z",
+      },
+      {
+        id: "remote-project",
+        name: "Remote project",
+        location: { kind: "windows", path: "C:\\remote-project", remoteServerId: "d1" },
+        remoteServerId: "d1",
+        remoteId: "remote-project",
+        createdAt: "2026-07-01T00:00:00.000Z",
+      },
     ];
     bridge.getSchedules.mockResolvedValueOnce([]);
     render(<SchedulesView />);
@@ -299,6 +311,8 @@ describe("SchedulesView", () => {
     fireEvent.click(screen.getByLabelText("Project"));
 
     expect((await screen.findAllByText("Local project")).length).toBeGreaterThan(0);
+    const location = screen.getByText("C:\\local-project");
+    expect(location.closest('[role="option"]')?.querySelector(".lucide-monitor")).not.toBeNull();
     expect(screen.queryByText("Remote project")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
- Show project location icons, paths, and remote server info in project selectors across schedules, MCP/skills destinations, and thread switching via shared `ProjectLocationIcon`/`ProjectSelectorIcon` components
- Extend the common `Select` with icon/detail rendering so project options present consistent location context
- Surface remote server names in the GitHub Actions sidebar, MCP project dropdowns, and sidebar project filter for clearer remote-vs-local disambiguation
- Add a "GitHub Actions" item to worktree and thread context menus that opens the actions view for the active project
- Refresh all 12 non-English locale catalogs for the new UI strings