### PR TITLE
Sync merged PR bases and add optimistic worktree launch messaging

### DIFF
--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -2787,6 +2787,7 @@ describe("RemoteAccessServer", () => {
         config: { model: "gpt-5" },
         prompt: "",
         presentationMode: "terminal",
+        userMessageItemId: "user-optimistic",
       }),
     });
 
@@ -2809,6 +2810,7 @@ describe("RemoteAccessServer", () => {
         prompt: "",
         initialSize: { cols: 120, rows: 30 },
         presentationMode: "terminal",
+        userMessageItemId: "user-optimistic",
         ...mcpSnapshot,
       }),
     );
@@ -2818,6 +2820,7 @@ describe("RemoteAccessServer", () => {
         threadId: "thread-remote",
         projectId: "project-1",
         launchRuntime: false,
+        userMessageItemId: "user-optimistic",
       }),
     ]);
   });

--- a/src/main/remote/server/threadCommands.ts
+++ b/src/main/remote/server/threadCommands.ts
@@ -263,6 +263,7 @@ async function startRemoteThread(
       ...(command.segments ? { segments: command.segments } : {}),
       initialSize: DEFAULT_TERMINAL_SIZE,
       ...(command.presentationMode ? { presentationMode: command.presentationMode } : {}),
+      ...(command.userMessageItemId ? { userMessageItemId: command.userMessageItemId } : {}),
       ...mcpSnapshot,
     });
   } catch (error) {

--- a/src/main/ssh/SshConnectionManager.test.ts
+++ b/src/main/ssh/SshConnectionManager.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { PORACODE_REMOTE_PROTOCOL_VERSION } from "@/shared/remote";
 import { sshConnectionConfigSchema, type SshConnectionConfig } from "@/shared/ssh";
 import * as sshBootstrap from "@/shared/sshBootstrap";
 import { waitForRemoteEndpoint } from "@/shared/sshBootstrap";
@@ -88,7 +89,7 @@ function createRuntimeFixture(): {
 
 function helperDescriptor(appVersion: string) {
   return {
-    protocolVersion: 1,
+    protocolVersion: PORACODE_REMOTE_PROTOCOL_VERSION,
     hostMode: "helper",
     desktopId: "remote-test",
     label: "Remote test",
@@ -367,7 +368,7 @@ describe("SSH tunnel lifecycle", () => {
 describe("SSH helper readiness", () => {
   function descriptor(hostMode: "desktop" | "helper") {
     return {
-      protocolVersion: 1,
+      protocolVersion: PORACODE_REMOTE_PROTOCOL_VERSION,
       hostMode,
       desktopId: "remote-test",
       label: "Remote test",

--- a/src/mobile/mobileSsh.test.ts
+++ b/src/mobile/mobileSsh.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SshBridgePlugin } from "@poracode/ssh-bridge";
+import { PORACODE_REMOTE_PROTOCOL_VERSION } from "@/shared/remote";
 import type { SshConnectionConfig } from "@/shared/ssh";
 
 const bridge = vi.hoisted(() => ({
@@ -44,7 +45,7 @@ function response(input: { json?: unknown; bytes?: Uint8Array; ok?: boolean; sta
 function helperEnvironmentResponse() {
   return response({
     json: {
-      protocolVersion: 1,
+      protocolVersion: PORACODE_REMOTE_PROTOCOL_VERSION,
       hostMode: "helper",
       desktopId: "remote-test",
       label: "Remote test",

--- a/src/renderer/actions/threadActions.test.ts
+++ b/src/renderer/actions/threadActions.test.ts
@@ -78,6 +78,7 @@ describe("threadActions", () => {
       pendingActiveThreadId: null,
       pendingComposerFocusThreadId: null,
       pendingThreadLaunches: {},
+      provisioningWorktreeThreadIds: {},
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
       runtimeCompletedTurnsByThread: {},
@@ -605,6 +606,23 @@ describe("threadActions", () => {
     await waitFor(() => expect(toast.danger).toHaveBeenCalledTimes(2));
     expect(toast.danger).toHaveBeenCalledWith("remote server offline");
     expect(useAppStore.getState().threads).toEqual([thread]);
+  });
+
+  it("deletes a provisional remote thread locally before the host row exists", () => {
+    const thread = makeThread({
+      remoteServerId: "remote-server",
+      remoteId: "remote-thread-pending",
+    });
+    useAppStore.setState({
+      threads: [thread],
+      provisioningWorktreeThreadIds: { [thread.id]: true },
+    });
+
+    deleteThread(thread.id);
+
+    expect(useAppStore.getState().threads).toEqual([]);
+    expect(sendThreadCommand).not.toHaveBeenCalled();
+    expect(bridge.closeThread).not.toHaveBeenCalled();
   });
 
   it("deletes a shared-worktree thread without prompting to remove the worktree", () => {

--- a/src/renderer/actions/threadActions.ts
+++ b/src/renderer/actions/threadActions.ts
@@ -607,6 +607,10 @@ export function acknowledgeThread(threadId: string): void {
 function deleteThreadOnly(threadId: string): void {
   const store = useAppStore.getState();
   const thread = store.threads.find((candidate) => candidate.id === threadId);
+  if (store.provisioningWorktreeThreadIds[threadId] === true) {
+    store.deleteThread(threadId);
+    return;
+  }
   if (
     thread &&
     dispatchRemoteThreadMutation(

--- a/src/renderer/actions/threadLaunchActions.test.ts
+++ b/src/renderer/actions/threadLaunchActions.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Project, Thread } from "@/shared/contracts";
+import type { RemoteThreadLaunchResult } from "@/renderer/state/remoteServers/types";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 const mocks = vi.hoisted(() => {
   const appState = {
@@ -7,8 +16,23 @@ const mocks = vi.hoisted(() => {
     view: { kind: "home" as const },
     projects: [] as Project[],
     threads: [] as Thread[],
+    provisioningWorktreeThreadIds: {} as Record<string, true>,
     createThread: vi.fn<(input: unknown) => Thread>(),
-    queueThreadLaunch: vi.fn<(threadId: string, prompt: string, segments?: unknown[]) => void>(),
+    queueThreadLaunch:
+      vi.fn<
+        (threadId: string, prompt: string, segments?: unknown[], userMessageItemId?: string) => void
+      >(),
+    setThreadWorktree:
+      vi.fn<
+        (
+          threadId: string,
+          worktreePath: string,
+          worktreeBranch?: string,
+          options?: { preserveProvisioning?: boolean },
+        ) => void
+      >(),
+    applyRuntimeEvent: vi.fn<(threadId: string, event: unknown) => void>(),
+    updateThreadRuntime: vi.fn<(threadId: string, input: unknown) => void>(),
     setThreadMcpLaunchCustomServerNames:
       vi.fn<(threadId: string, names: readonly string[]) => void>(),
   };
@@ -22,7 +46,13 @@ const mocks = vi.hoisted(() => {
       transport?: { kind: "direct" } | { kind: "ssh" };
     }>,
     runtime: {} as Record<string, { status: string }>,
-    launchRemoteThread: vi.fn<(input: unknown) => Promise<void>>(),
+    launchRemoteThread:
+      vi.fn<
+        (
+          input: unknown,
+          options?: { isPendingLaunchOwned?: () => boolean },
+        ) => Promise<RemoteThreadLaunchResult>
+      >(),
     withClient:
       vi.fn<
         (
@@ -49,6 +79,8 @@ const mocks = vi.hoisted(() => {
     primeWorktreeGitState: vi.fn<(project: Project, path: string) => Promise<void>>(),
     runWorktreeSetupScript:
       vi.fn<(project: Project, path: string, script: string) => Promise<void>>(),
+    performWorktreeRemoval:
+      vi.fn<(project: Project, path: string, branch?: string) => Promise<boolean>>(),
     refreshGitProject: vi.fn<(project: unknown, reason: string, scope: string) => Promise<void>>(),
     generateTitleAsync: vi.fn<(...args: unknown[]) => void>(),
   };
@@ -114,6 +146,10 @@ vi.mock("./worktreeLaunchActions", () => ({
   runWorktreeSetupScript: mocks.runWorktreeSetupScript,
 }));
 
+vi.mock("./worktreeActions", () => ({
+  performWorktreeRemoval: mocks.performWorktreeRemoval,
+}));
+
 import { performInitialThreadLaunch, startThreadFromDraft } from "./threadLaunchActions";
 
 const localProject: Project = {
@@ -143,17 +179,33 @@ describe("startThreadFromDraft host transport", () => {
     mocks.appState.view = { kind: "home" };
     mocks.appState.projects = [];
     mocks.appState.threads = [];
-    mocks.appState.createThread.mockReturnValue({
-      id: "local-thread",
-      projectId: localProject.id,
-    } as Thread);
+    mocks.appState.provisioningWorktreeThreadIds = {};
+    mocks.appState.createThread.mockImplementation((input) => {
+      const values = input as Partial<Thread> & {
+        threadId?: string;
+        worktreeProvisioning?: boolean;
+      };
+      const thread = {
+        id: values.threadId ?? "local-thread",
+        projectId: values.projectId ?? localProject.id,
+        archived: false,
+        ...(values.presentationMode ? { presentationMode: values.presentationMode } : {}),
+        ...(values.remoteServerId ? { remoteServerId: values.remoteServerId } : {}),
+        ...(values.remoteId ? { remoteId: values.remoteId } : {}),
+      } as Thread;
+      mocks.appState.threads = [thread];
+      if (values.worktreeProvisioning) {
+        mocks.appState.provisioningWorktreeThreadIds[thread.id] = true;
+      }
+      return thread;
+    });
     mocks.createWorktree.mockResolvedValue({
       path: "C:\\shared-worktrees\\feature",
       changesTransferred: true,
     });
     mocks.remoteState.servers = [];
     mocks.remoteState.runtime = { d1: { status: "online" } };
-    mocks.remoteState.launchRemoteThread.mockResolvedValue(undefined);
+    mocks.remoteState.launchRemoteThread.mockResolvedValue("started");
     mocks.remoteState.withClient.mockImplementation((desktopId, invoke) =>
       invoke(mocks.remoteClient),
     );
@@ -161,16 +213,63 @@ describe("startThreadFromDraft host transport", () => {
     mocks.bridge.startThread.mockResolvedValue({ threadId: "local-thread" });
     mocks.primeWorktreeGitState.mockResolvedValue(undefined);
     mocks.runWorktreeSetupScript.mockResolvedValue(undefined);
+    mocks.performWorktreeRemoval.mockResolvedValue(true);
   });
 
-  it("uses the shared transport flow for a local worktree launch", async () => {
-    await startThreadFromDraft(localProject, {
-      agentKind: "codex",
-      config: { model: "gpt-5.6" },
-      prompt: "build it",
-      worktreeBranch: "feature",
-      worktreeIsNewBranch: true,
+  it("opens a local thread before its new worktree finishes provisioning", async () => {
+    let resolveWorktree!: (result: { path: string; changesTransferred?: boolean }) => void;
+    mocks.createWorktree.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorktree = resolve;
+      }),
+    );
+
+    const launch = startThreadFromDraft(
+      localProject,
+      {
+        agentKind: "codex",
+        config: { model: "gpt-5.6" },
+        prompt: "build it",
+        presentationMode: "gui",
+        worktreeBranch: "feature",
+        worktreeIsNewBranch: true,
+      },
+      { replacePaneId: "draft:local-project" },
+    );
+
+    expect(mocks.appState.createThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: localProject.id,
+        worktreeBranch: "feature",
+        worktreeProvisioning: true,
+        replacePaneId: "draft:local-project",
+      }),
+    );
+    expect(mocks.appState.createThread.mock.calls[0]?.[0]).not.toHaveProperty("worktreePath");
+    expect(mocks.appState.setThreadWorktree).not.toHaveBeenCalled();
+    expect(mocks.appState.queueThreadLaunch).not.toHaveBeenCalled();
+    expect(mocks.appState.applyRuntimeEvent).toHaveBeenCalledTimes(2);
+    const optimisticStartCall = mocks.appState.applyRuntimeEvent.mock.calls[0];
+    if (!optimisticStartCall) throw new Error("Expected an optimistic user message event");
+    const optimisticItemId = (optimisticStartCall[1] as { itemId?: string }).itemId;
+    expect(optimisticItemId).toEqual(expect.stringMatching(/^user-/));
+    expect(mocks.appState.applyRuntimeEvent).toHaveBeenNthCalledWith(
+      1,
+      "local-thread",
+      expect.objectContaining({
+        type: "item.started",
+        itemId: optimisticItemId,
+        itemType: "user_message",
+        payload: { content: [{ kind: "text", text: "build it" }] },
+      }),
+    );
+    expect(mocks.appState.updateThreadRuntime).not.toHaveBeenCalled();
+
+    resolveWorktree({
+      path: "C:\\shared-worktrees\\feature",
+      changesTransferred: true,
     });
+    await launch;
 
     expect(mocks.createWorktree).toHaveBeenCalledWith(localProject, {
       branch: "feature",
@@ -178,11 +277,16 @@ describe("startThreadFromDraft host transport", () => {
       keepChangesInSource: false,
       transferUncommitted: false,
     });
-    expect(mocks.appState.createThread).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId: localProject.id,
-        worktreePath: "C:\\shared-worktrees\\feature",
-      }),
+    expect(mocks.appState.setThreadWorktree).toHaveBeenCalledWith(
+      "local-thread",
+      "C:\\shared-worktrees\\feature",
+      "feature",
+    );
+    expect(mocks.appState.queueThreadLaunch).toHaveBeenCalledWith(
+      "local-thread",
+      "build it",
+      undefined,
+      optimisticItemId,
     );
     expect(mocks.primeWorktreeGitState).toHaveBeenCalledWith(
       localProject,
@@ -193,6 +297,95 @@ describe("startThreadFromDraft host transport", () => {
       "C:\\shared-worktrees\\feature",
       "pnpm install",
     );
+  });
+
+  it("shows a provisioning failure on the thread opened for a new local worktree", async () => {
+    mocks.createWorktree.mockRejectedValue(new Error("Branch already exists"));
+
+    await expect(
+      startThreadFromDraft(localProject, {
+        agentKind: "codex",
+        config: { model: "gpt-5.6" },
+        prompt: "build it",
+        worktreeBranch: "feature",
+        worktreeIsNewBranch: true,
+      }),
+    ).rejects.toThrow("Branch already exists");
+
+    expect(mocks.appState.applyRuntimeEvent).toHaveBeenCalledWith("local-thread", {
+      type: "error",
+      threadId: "local-thread",
+      message: "Branch already exists",
+    });
+    expect(mocks.appState.updateThreadRuntime).toHaveBeenCalledWith("local-thread", {
+      status: "error",
+      attention: "error",
+      errorMessage: "Branch already exists",
+      canResumeWithConfig: false,
+    });
+    expect(mocks.appState.queueThreadLaunch).not.toHaveBeenCalled();
+  });
+
+  it("removes a new worktree if its optimistic thread was deleted while provisioning", async () => {
+    let resolveWorktree!: (result: { path: string; changesTransferred?: boolean }) => void;
+    mocks.createWorktree.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorktree = resolve;
+      }),
+    );
+
+    const launch = startThreadFromDraft(localProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build it",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+    mocks.appState.threads = [];
+
+    resolveWorktree({ path: "C:\\shared-worktrees\\feature" });
+    await launch;
+
+    expect(mocks.performWorktreeRemoval).toHaveBeenCalledWith(
+      localProject,
+      "C:\\shared-worktrees\\feature",
+      "feature",
+    );
+    expect(mocks.appState.setThreadWorktree).not.toHaveBeenCalled();
+    expect(mocks.appState.queueThreadLaunch).not.toHaveBeenCalled();
+    expect(mocks.runWorktreeSetupScript).not.toHaveBeenCalled();
+  });
+
+  it("keeps an archived optimistic thread stopped after worktree provisioning", async () => {
+    mocks.appState.createThread.mockImplementation(() => {
+      const thread = {
+        id: "local-thread",
+        projectId: localProject.id,
+        archived: true,
+      } as Thread;
+      mocks.appState.threads = [thread];
+      return thread;
+    });
+
+    await startThreadFromDraft(localProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build it",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+
+    expect(mocks.appState.setThreadWorktree).toHaveBeenCalledWith(
+      "local-thread",
+      "C:\\shared-worktrees\\feature",
+      "feature",
+    );
+    expect(mocks.appState.updateThreadRuntime).toHaveBeenCalledWith("local-thread", {
+      status: "inactive",
+      attention: "none",
+      canResumeWithConfig: false,
+    });
+    expect(mocks.appState.queueThreadLaunch).not.toHaveBeenCalled();
   });
 
   it("launches a helper thread through the same flow and runs setup from the client", async () => {
@@ -216,22 +409,178 @@ describe("startThreadFromDraft host transport", () => {
       keepChangesInSource: false,
       transferUncommitted: false,
     });
-    expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledWith({
-      desktopId: "d1",
-      projectId: "p1",
-      agentKind: "codex",
-      config: { model: "gpt-5.6" },
-      prompt: "build it",
-      presentationMode: "terminal",
-      worktreePath: "/srv/worktrees/feature",
-      worktreeBranch: "feature",
-      isNewWorktree: true,
-    });
+    expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledWith(
+      {
+        threadId: expect.any(String),
+        desktopId: "d1",
+        projectId: "p1",
+        agentKind: "codex",
+        config: { model: "gpt-5.6" },
+        prompt: "build it",
+        presentationMode: "terminal",
+        worktreePath: "/srv/worktrees/feature",
+        worktreeBranch: "feature",
+        isNewWorktree: true,
+      },
+      { isPendingLaunchOwned: expect.any(Function) },
+    );
     expect(mocks.runWorktreeSetupScript).toHaveBeenCalledWith(
       remoteProject,
       "/srv/worktrees/feature",
       "pnpm install",
     );
+  });
+
+  it("shows the same optimistic GUI launch while a remote worktree is provisioning", async () => {
+    mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
+    let resolveWorktree!: (result: { path: string; changesTransferred?: boolean }) => void;
+    mocks.createWorktree.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorktree = resolve;
+      }),
+    );
+
+    const launch = startThreadFromDraft(remoteProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build remotely",
+      presentationMode: "gui",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+
+    const createInput = mocks.appState.createThread.mock.calls[0]?.[0] as
+      | (Partial<Thread> & { threadId?: string; worktreeProvisioning?: boolean })
+      | undefined;
+    expect(createInput).toMatchObject({
+      projectId: remoteProject.id,
+      remoteServerId: "d1",
+      worktreeBranch: "feature",
+      worktreeProvisioning: true,
+      presentationMode: "gui",
+    });
+    expect(createInput?.remoteId).toEqual(expect.any(String));
+    expect(createInput?.threadId).toBe(`remote:d1:thread:${createInput?.remoteId}`);
+    expect(mocks.appState.applyRuntimeEvent).toHaveBeenCalledWith(
+      createInput?.threadId,
+      expect.objectContaining({
+        type: "item.started",
+        itemType: "user_message",
+        payload: { content: [{ kind: "text", text: "build remotely" }] },
+      }),
+    );
+    expect(mocks.remoteState.launchRemoteThread).not.toHaveBeenCalled();
+
+    const optimisticItemId = (
+      mocks.appState.applyRuntimeEvent.mock.calls[0]?.[1] as { itemId?: string } | undefined
+    )?.itemId;
+    resolveWorktree({ path: "/srv/worktrees/feature", changesTransferred: true });
+    await launch;
+
+    expect(mocks.appState.updateThreadRuntime).toHaveBeenCalledWith(createInput?.threadId, {
+      status: "working",
+      attention: "working",
+      canResumeWithConfig: false,
+    });
+    expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledWith(
+      {
+        threadId: createInput?.remoteId,
+        desktopId: "d1",
+        projectId: "p1",
+        agentKind: "codex",
+        config: { model: "gpt-5.6" },
+        prompt: "build remotely",
+        presentationMode: "gui",
+        worktreePath: "/srv/worktrees/feature",
+        worktreeBranch: "feature",
+        isNewWorktree: true,
+        userMessageItemId: optimisticItemId,
+      },
+      { isPendingLaunchOwned: expect.any(Function) },
+    );
+    expect(mocks.appState.setThreadWorktree).toHaveBeenNthCalledWith(
+      1,
+      createInput?.threadId,
+      "/srv/worktrees/feature",
+      "feature",
+      { preserveProvisioning: true },
+    );
+    expect(mocks.appState.setThreadWorktree).toHaveBeenLastCalledWith(
+      createInput?.threadId,
+      "/srv/worktrees/feature",
+      "feature",
+    );
+  });
+
+  it("removes the host thread and worktree when the provisional remote row is deleted mid-start", async () => {
+    mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
+    const remoteStart = deferred<RemoteThreadLaunchResult>();
+    mocks.remoteState.launchRemoteThread.mockReturnValue(remoteStart.promise);
+    mocks.createWorktree.mockResolvedValue({ path: "/srv/worktrees/feature" });
+
+    const launch = startThreadFromDraft(remoteProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build remotely",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+    await vi.waitFor(() => expect(mocks.remoteState.launchRemoteThread).toHaveBeenCalledOnce());
+    mocks.appState.threads = [];
+    remoteStart.resolve("cancelled");
+    await launch;
+
+    expect(mocks.performWorktreeRemoval).toHaveBeenCalledWith(
+      remoteProject,
+      "/srv/worktrees/feature",
+      "feature",
+    );
+  });
+
+  it("retains the worktree when cancellation cannot remove the host thread", async () => {
+    mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
+    mocks.createWorktree.mockResolvedValue({ path: "/srv/worktrees/feature" });
+    mocks.remoteState.launchRemoteThread.mockResolvedValue("cancellation-failed");
+
+    await startThreadFromDraft(remoteProject, {
+      agentKind: "codex",
+      config: { model: "gpt-5.6" },
+      prompt: "build remotely",
+      worktreeBranch: "feature",
+      worktreeIsNewBranch: true,
+    });
+
+    expect(mocks.performWorktreeRemoval).not.toHaveBeenCalled();
+    expect(mocks.primeWorktreeGitState).not.toHaveBeenCalled();
+  });
+
+  it("retains remote worktree context when host startup fails", async () => {
+    mocks.remoteState.servers = [{ desktopId: "d1", hostMode: "helper" }];
+    mocks.createWorktree.mockResolvedValue({ path: "/srv/worktrees/feature" });
+    mocks.remoteState.launchRemoteThread.mockRejectedValue(new Error("Host refused launch"));
+
+    await expect(
+      startThreadFromDraft(remoteProject, {
+        agentKind: "codex",
+        config: { model: "gpt-5.6" },
+        prompt: "build remotely",
+        worktreeBranch: "feature",
+        worktreeIsNewBranch: true,
+      }),
+    ).rejects.toThrow("Host refused launch");
+
+    expect(mocks.appState.setThreadWorktree).toHaveBeenCalledWith(
+      expect.any(String),
+      "/srv/worktrees/feature",
+      "feature",
+      { preserveProvisioning: true },
+    );
+    expect(mocks.appState.updateThreadRuntime).toHaveBeenLastCalledWith(expect.any(String), {
+      status: "error",
+      attention: "error",
+      errorMessage: "Host refused launch",
+      canResumeWithConfig: false,
+    });
   });
 
   it("refuses to launch on a remote project whose server is offline", async () => {
@@ -343,5 +692,34 @@ describe("performInitialThreadLaunch host transport", () => {
       }),
     );
     expect(mocks.remoteState.withClient).not.toHaveBeenCalled();
+  });
+
+  it("reuses an optimistic user message created before provider launch", async () => {
+    const thread = {
+      ...localThread,
+      presentationMode: "gui",
+    } as Thread;
+
+    await performInitialThreadLaunch({
+      thread,
+      projectLocation: localProject.location,
+      prompt: "build it",
+      userMessageItemId: "user-provisioning",
+      initialSize,
+    });
+
+    expect(mocks.appState.applyRuntimeEvent).not.toHaveBeenCalled();
+    expect(mocks.appState.updateThreadRuntime).toHaveBeenCalledWith("local-thread", {
+      status: "working",
+      attention: "working",
+      canResumeWithConfig: undefined,
+    });
+    expect(mocks.bridge.startThread).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "local-thread",
+        prompt: "build it",
+        userMessageItemId: "user-provisioning",
+      }),
+    );
   });
 });

--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -25,9 +25,10 @@ import { findExperimentByGroupId } from "@/renderer/state/experimentStore";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { refreshGitProject } from "@/renderer/state/gitRefresh";
 import { unprojectProjectLocation } from "@/renderer/remoteProcedureRouter";
-import { remoteOwner } from "@/renderer/state/remoteProjection";
+import { remoteOwner, remoteThreadId } from "@/renderer/state/remoteProjection";
 import { isRemoteProjectUnreachable } from "@/renderer/state/remoteServers/reachability";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
+import type { RemoteThreadLaunchResult } from "@/renderer/state/remoteServers/types";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { generateTitleAsync } from "@/renderer/utils/titleGen";
 import { buildProjectDraftConfig } from "@/renderer/views/MainView/parts/AppContent/draftConfig";
@@ -36,15 +37,17 @@ import {
   primeWorktreeGitState,
   runWorktreeSetupScript,
 } from "./worktreeLaunchActions";
+import { performWorktreeRemoval } from "./worktreeActions";
 
 export async function performInitialThreadLaunch(input: {
   thread: Thread;
   projectLocation: ProjectLocation;
   prompt: string;
   segments?: PromptSegment[];
+  userMessageItemId?: string;
   initialSize: TerminalSize;
 }): Promise<void> {
-  const { thread, projectLocation, prompt, segments, initialSize } = input;
+  const { thread, projectLocation, prompt, segments, userMessageItemId, initialSize } = input;
   const presentation = thread.presentationMode ?? "terminal";
   if (thread.config.model) {
     useSharedSettings
@@ -58,21 +61,9 @@ export async function performInitialThreadLaunch(input: {
       );
   }
 
-  let optimisticUserMessageItemId: string | undefined;
-  if (presentation === "gui" && prompt.length > 0 && thread.sessionRef === undefined) {
-    optimisticUserMessageItemId = `user-${crypto.randomUUID()}`;
-    useAppStore.getState().applyRuntimeEvent(thread.id, {
-      type: "item.started",
-      threadId: thread.id,
-      itemId: optimisticUserMessageItemId,
-      itemType: "user_message",
-      payload: { content: buildPromptContentBlocks(prompt, segments) },
-    });
-    useAppStore.getState().applyRuntimeEvent(thread.id, {
-      type: "item.completed",
-      threadId: thread.id,
-      itemId: optimisticUserMessageItemId,
-    });
+  const optimisticUserMessageItemId =
+    userMessageItemId ?? appendOptimisticInitialUserMessage(thread, prompt, segments);
+  if (optimisticUserMessageItemId) {
     useAppStore.getState().updateThreadRuntime(thread.id, {
       status: "working",
       attention: "working",
@@ -140,20 +131,27 @@ export async function performInitialThreadLaunch(input: {
   }
 }
 
+interface ThreadLaunchRequest {
+  readonly threadId?: string;
+  readonly remoteServerId?: string;
+  readonly remoteId?: string;
+  readonly project: Project;
+  readonly agentKind: string;
+  readonly config: ThreadConfig;
+  readonly prompt: string;
+  readonly segments?: PromptSegment[];
+  readonly presentationMode?: ThreadPresentationMode;
+  readonly worktreePath?: string;
+  readonly worktreeBranch?: string;
+  readonly worktreeProvisioning?: boolean;
+  readonly userMessageItemId?: string;
+  readonly isNewWorktree: boolean;
+  readonly options: { replacePaneId?: string; preserveActiveGroup?: boolean };
+}
+
 interface ThreadLaunchHostTransport {
   readonly setupRunsOnHost: boolean;
-  startThread(input: {
-    readonly project: Project;
-    readonly agentKind: string;
-    readonly config: ThreadConfig;
-    readonly prompt: string;
-    readonly segments?: PromptSegment[];
-    readonly presentationMode?: ThreadPresentationMode;
-    readonly worktreePath?: string;
-    readonly worktreeBranch?: string;
-    readonly isNewWorktree: boolean;
-    readonly options: { replacePaneId?: string; preserveActiveGroup?: boolean };
-  }): Promise<void>;
+  startThread(input: ThreadLaunchRequest): Promise<RemoteThreadLaunchResult>;
 }
 
 export async function startThreadFromDraft(
@@ -184,6 +182,7 @@ export async function startThreadFromDraft(
   }
 
   const isHomeScope = isHomeProject(project);
+  const owner = remoteOwner(project);
   const host = threadLaunchHost(project);
 
   useAppStore.getState().updateProjectDraftConfig(
@@ -197,6 +196,32 @@ export async function startThreadFromDraft(
 
   let worktreePath = isHomeScope ? undefined : existingWorktreePath;
   let isNewWorktree = false;
+  const createsWorktree = !isHomeScope && !worktreePath && !!worktreeBranch;
+  const remoteHostThreadId = createsWorktree && owner ? crypto.randomUUID() : undefined;
+  const pendingThread = createsWorktree
+    ? createThreadRow({
+        ...(owner && remoteHostThreadId
+          ? {
+              threadId: remoteThreadId(owner.desktopId, remoteHostThreadId),
+              remoteServerId: owner.desktopId,
+              remoteId: remoteHostThreadId,
+            }
+          : {}),
+        project,
+        agentKind,
+        config,
+        prompt,
+        ...(segments ? { segments } : {}),
+        ...(presentationMode ? { presentationMode } : {}),
+        worktreeBranch,
+        worktreeProvisioning: true,
+        isNewWorktree: true,
+        options,
+      })
+    : undefined;
+  const pendingUserMessageItemId = pendingThread
+    ? appendOptimisticInitialUserMessage(pendingThread, prompt, segments)
+    : undefined;
   if (!isHomeScope && !worktreePath && worktreeBranch) {
     try {
       const transferUncommitted = worktreeTransferUncommitted ?? false;
@@ -218,23 +243,109 @@ export async function startThreadFromDraft(
       }
     } catch (error) {
       console.error("[renderer] failed to create worktree:", error);
-      toast.danger(friendlyError(error));
+      const message = friendlyError(error);
+      if (pendingThread) {
+        const store = useAppStore.getState();
+        store.applyRuntimeEvent(pendingThread.id, {
+          type: "error",
+          threadId: pendingThread.id,
+          message,
+        });
+        store.updateThreadRuntime(pendingThread.id, {
+          status: "error",
+          attention: "error",
+          errorMessage: message,
+          canResumeWithConfig: false,
+        });
+      }
+      toast.danger(message);
       throw error;
     }
   }
 
-  await host.startThread({
-    project,
-    agentKind,
-    config,
-    prompt,
-    ...(segments ? { segments } : {}),
-    ...(presentationMode ? { presentationMode } : {}),
-    ...(worktreePath ? { worktreePath } : {}),
-    ...(worktreeBranch ? { worktreeBranch } : {}),
-    isNewWorktree,
-    options,
-  });
+  if (pendingThread && worktreePath) {
+    const store = useAppStore.getState();
+    const currentThread = store.threads.find((thread) => thread.id === pendingThread.id);
+    if (!currentThread) {
+      await performWorktreeRemoval(project, worktreePath, worktreeBranch);
+      return;
+    }
+    if (currentThread.archived) {
+      store.setThreadWorktree(pendingThread.id, worktreePath, worktreeBranch);
+      store.updateThreadRuntime(pendingThread.id, {
+        status: "inactive",
+        attention: "none",
+        canResumeWithConfig: false,
+      });
+    } else if (owner && remoteHostThreadId) {
+      store.setThreadWorktree(pendingThread.id, worktreePath, worktreeBranch, {
+        preserveProvisioning: true,
+      });
+      store.updateThreadRuntime(pendingThread.id, {
+        status: "working",
+        attention: "working",
+        canResumeWithConfig: false,
+      });
+      try {
+        const started = await host.startThread({
+          threadId: remoteHostThreadId,
+          project,
+          agentKind,
+          config,
+          prompt,
+          ...(segments ? { segments } : {}),
+          ...(presentationMode ? { presentationMode } : {}),
+          worktreePath,
+          ...(worktreeBranch ? { worktreeBranch } : {}),
+          ...(pendingUserMessageItemId ? { userMessageItemId: pendingUserMessageItemId } : {}),
+          isNewWorktree: true,
+          options,
+        });
+        if (started === "cancelled") {
+          await performWorktreeRemoval(project, worktreePath, worktreeBranch);
+          return;
+        }
+        if (started === "cancellation-failed") return;
+      } catch (error) {
+        if (!useAppStore.getState().threads.some((thread) => thread.id === pendingThread.id)) {
+          await performWorktreeRemoval(project, worktreePath, worktreeBranch);
+          return;
+        }
+        const message = friendlyError(error);
+        store.applyRuntimeEvent(pendingThread.id, {
+          type: "error",
+          threadId: pendingThread.id,
+          message,
+        });
+        store.updateThreadRuntime(pendingThread.id, {
+          status: "error",
+          attention: "error",
+          errorMessage: message,
+          canResumeWithConfig: false,
+        });
+        throw error;
+      }
+      if (useAppStore.getState().threads.some((thread) => thread.id === pendingThread.id)) {
+        useAppStore.getState().setThreadWorktree(pendingThread.id, worktreePath, worktreeBranch);
+      }
+    } else {
+      store.setThreadWorktree(pendingThread.id, worktreePath, worktreeBranch);
+      store.queueThreadLaunch(pendingThread.id, prompt, segments, pendingUserMessageItemId);
+    }
+  } else {
+    await host.startThread({
+      project,
+      agentKind,
+      config,
+      prompt,
+      ...(segments ? { segments } : {}),
+      ...(presentationMode ? { presentationMode } : {}),
+      ...(worktreePath ? { worktreePath } : {}),
+      ...(worktreeBranch ? { worktreeBranch } : {}),
+      isNewWorktree,
+      options,
+    });
+  }
 
   if (worktreePath) {
     void primeWorktreeGitState(project, worktreePath);
@@ -260,18 +371,31 @@ function threadLaunchHost(project: Project): ThreadLaunchHostTransport {
     return {
       setupRunsOnHost: !helperHost,
       startThread: async (launch) => {
-        await useRemoteServersStore.getState().launchRemoteThread({
-          desktopId: owner.desktopId,
-          projectId: owner.remoteId,
-          agentKind: launch.agentKind,
-          config: launch.config,
-          prompt: launch.prompt,
-          ...(launch.segments ? { segments: launch.segments } : {}),
-          presentationMode: launch.presentationMode ?? "terminal",
-          ...(launch.worktreePath ? { worktreePath: launch.worktreePath } : {}),
-          ...(launch.worktreeBranch ? { worktreeBranch: launch.worktreeBranch } : {}),
-          ...(launch.isNewWorktree ? { isNewWorktree: true } : {}),
-        });
+        const remoteId = launch.threadId;
+        return useRemoteServersStore.getState().launchRemoteThread(
+          {
+            ...(remoteId ? { threadId: remoteId } : {}),
+            desktopId: owner.desktopId,
+            projectId: owner.remoteId,
+            agentKind: launch.agentKind,
+            config: launch.config,
+            prompt: launch.prompt,
+            ...(launch.segments ? { segments: launch.segments } : {}),
+            presentationMode: launch.presentationMode ?? "terminal",
+            ...(launch.worktreePath ? { worktreePath: launch.worktreePath } : {}),
+            ...(launch.worktreeBranch ? { worktreeBranch: launch.worktreeBranch } : {}),
+            ...(launch.isNewWorktree ? { isNewWorktree: true } : {}),
+            ...(launch.userMessageItemId ? { userMessageItemId: launch.userMessageItemId } : {}),
+          },
+          remoteId
+            ? {
+                isPendingLaunchOwned: () =>
+                  useAppStore.getState().provisioningWorktreeThreadIds[
+                    remoteThreadId(owner.desktopId, remoteId)
+                  ] === true,
+              }
+            : undefined,
+        );
       },
     };
   }
@@ -279,47 +403,80 @@ function threadLaunchHost(project: Project): ThreadLaunchHostTransport {
   return {
     setupRunsOnHost: false,
     startThread: (launch) => {
+      const thread = createThreadRow(launch);
       const store = useAppStore.getState();
-      const { agentStatuses, wslAgentStatuses } = useAgentStatusesStore.getState();
-      const projectAgentStatuses = getProjectAgentStatuses(
-        launch.project.location,
-        agentStatuses,
-        wslAgentStatuses,
-      );
-      const titlePrompt = titlePromptFromSegments(launch.prompt, launch.segments);
-      const currentView = store.view;
-      const activeGroup =
-        launch.options.preserveActiveGroup !== false &&
-        currentView.kind === "thread" &&
-        currentView.activeGroupId &&
-        !findExperimentByGroupId(currentView.activeGroupId)
-          ? {
-              groupId: currentView.activeGroupId,
-              groupName: store.threads.find(
-                (thread) => thread.groupId === currentView.activeGroupId,
-              )?.groupName,
-            }
-          : undefined;
-
-      const thread = store.createThread({
-        projectId: launch.project.id,
-        agentKind: launch.agentKind,
-        config: launch.config,
-        prompt: titlePrompt,
-        ...(launch.presentationMode ? { presentationMode: launch.presentationMode } : {}),
-        ...(launch.worktreePath
-          ? {
-              worktreePath: launch.worktreePath,
-              ...(launch.worktreeBranch ? { worktreeBranch: launch.worktreeBranch } : {}),
-            }
-          : {}),
-        ...(launch.options.replacePaneId ? { replacePaneId: launch.options.replacePaneId } : {}),
-        ...(activeGroup?.groupId ? { groupId: activeGroup.groupId } : {}),
-        ...(activeGroup?.groupName ? { groupName: activeGroup.groupName } : {}),
-      });
       store.queueThreadLaunch(thread.id, launch.prompt, launch.segments);
-      generateTitleAsync(thread.id, launch.project.location, projectAgentStatuses, titlePrompt);
-      return Promise.resolve();
+      return Promise.resolve("started");
     },
   };
+}
+
+function createThreadRow(launch: ThreadLaunchRequest): Thread {
+  const store = useAppStore.getState();
+  const { agentStatuses, wslAgentStatuses } = useAgentStatusesStore.getState();
+  const projectAgentStatuses = getProjectAgentStatuses(
+    launch.project.location,
+    agentStatuses,
+    wslAgentStatuses,
+  );
+  const titlePrompt = titlePromptFromSegments(launch.prompt, launch.segments);
+  const currentView = store.view;
+  const activeGroup =
+    launch.options.preserveActiveGroup !== false &&
+    currentView.kind === "thread" &&
+    currentView.activeGroupId &&
+    !findExperimentByGroupId(currentView.activeGroupId)
+      ? {
+          groupId: currentView.activeGroupId,
+          groupName: store.threads.find((thread) => thread.groupId === currentView.activeGroupId)
+            ?.groupName,
+        }
+      : undefined;
+
+  const thread = store.createThread({
+    ...(launch.threadId ? { threadId: launch.threadId } : {}),
+    projectId: launch.project.id,
+    agentKind: launch.agentKind,
+    config: launch.config,
+    prompt: titlePrompt,
+    ...(launch.presentationMode ? { presentationMode: launch.presentationMode } : {}),
+    ...(launch.worktreePath ? { worktreePath: launch.worktreePath } : {}),
+    ...(launch.worktreeBranch ? { worktreeBranch: launch.worktreeBranch } : {}),
+    ...(launch.worktreeProvisioning ? { worktreeProvisioning: true } : {}),
+    ...(launch.remoteServerId ? { remoteServerId: launch.remoteServerId } : {}),
+    ...(launch.remoteId ? { remoteId: launch.remoteId } : {}),
+    ...(launch.options.replacePaneId ? { replacePaneId: launch.options.replacePaneId } : {}),
+    ...(activeGroup?.groupId ? { groupId: activeGroup.groupId } : {}),
+    ...(activeGroup?.groupName ? { groupName: activeGroup.groupName } : {}),
+  });
+  if (!launch.remoteServerId) {
+    generateTitleAsync(thread.id, launch.project.location, projectAgentStatuses, titlePrompt);
+  }
+  return thread;
+}
+
+function appendOptimisticInitialUserMessage(
+  thread: Thread,
+  prompt: string,
+  segments?: PromptSegment[],
+): string | undefined {
+  const presentation = thread.presentationMode ?? "terminal";
+  if (presentation !== "gui" || prompt.length === 0 || thread.sessionRef !== undefined) {
+    return undefined;
+  }
+
+  const itemId = `user-${crypto.randomUUID()}`;
+  useAppStore.getState().applyRuntimeEvent(thread.id, {
+    type: "item.started",
+    threadId: thread.id,
+    itemId,
+    itemType: "user_message",
+    payload: { content: buildPromptContentBlocks(prompt, segments) },
+  });
+  useAppStore.getState().applyRuntimeEvent(thread.id, {
+    type: "item.completed",
+    threadId: thread.id,
+    itemId,
+  });
+  return itemId;
 }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -363,7 +363,16 @@ const mainWindowCleanups: Array<() => void> = isMainWindow
             ...(command.groupName ? { groupName: command.groupName } : {}),
           });
           if (command.launchRuntime !== false) {
-            store.queueThreadLaunch(thread.id, command.prompt, command.segments);
+            if (command.userMessageItemId) {
+              store.queueThreadLaunch(
+                thread.id,
+                command.prompt,
+                command.segments,
+                command.userMessageItemId,
+              );
+            } else {
+              store.queueThreadLaunch(thread.id, command.prompt, command.segments);
+            }
           }
           const { agentStatuses, wslAgentStatuses } = useAgentStatusesStore.getState();
           const projectAgentStatuses = getProjectAgentStatuses(

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -252,7 +252,35 @@ describe("ChatPane", () => {
       runtimeCompletedTurnsByThread: {},
       fileCheckpointsByThread: {},
       fileCheckpointTurnsByThread: {},
+      provisioningWorktreeThreadIds: {},
     }));
+  });
+
+  it("shows the submitted prompt while its worktree is being created", async () => {
+    const thread = {
+      ...makeThread(),
+      status: "launching",
+      worktreeBranch: "poracode/feature",
+    } as Thread;
+    useAppStore.setState({
+      threads: [thread],
+      provisioningWorktreeThreadIds: { [thread.id]: true },
+    });
+    seedUserMessage(thread.id, "Build the feature");
+
+    const { rerender } = renderChatPane(thread);
+
+    expect(await screen.findByText("Build the feature")).toBeInTheDocument();
+    expect(screen.getByText("Creating worktree…")).toBeInTheDocument();
+
+    useAppStore.setState({ provisioningWorktreeThreadIds: {} });
+    rerender(
+      <AppProvider>
+        <ChatPane {...chatPaneProps({ ...thread, status: "working" })} />
+      </AppProvider>,
+    );
+
+    expect(screen.queryByText("Creating worktree…")).not.toBeInTheDocument();
   });
 
   it("loads the next persisted page when LegendList reaches the start", async () => {

--- a/src/renderer/components/thread/ChatPane/ChatPane.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.tsx
@@ -32,7 +32,11 @@ import { showSubAgentPanel } from "@/renderer/actions/panelActions";
 import { ChatFindBar, type ScrollToIndex } from "@/renderer/components/find/ChatFindBar";
 import { ChatPaneActionsContext, type ChatPaneActions } from "./chatPaneActionsContext";
 import { ChatScrollControls, type ChatScrollControlsHandle } from "./ChatScrollControls";
-import { ChatTurnElapsedFooter, type TurnTiming } from "./ChatTurnElapsed";
+import {
+  ChatTurnElapsedFooter,
+  ChatWorktreeProvisioningFooter,
+  type TurnTiming,
+} from "./ChatTurnElapsed";
 import {
   selectMostRecentDisplayableCompletedTurn,
   selectVisibleThreadTimelineEntries,
@@ -286,6 +290,9 @@ export function ChatPane(props: ChatPaneProps) {
 
   const isEmpty = timelineEntries.length === 0 && !hasSupplementaryContent;
   const isLive = isThreadTurnActive(status);
+  const isWorktreeProvisioning = useAppStore(
+    (s) => s.provisioningWorktreeThreadIds[threadId] === true && status === "launching",
+  );
   // Detached background work keeps the thread doing real work after the
   // foreground turn settles. Treat that as "still working" for the tail-loader
   // timer (so it keeps ticking "Working for ...") without touching `status` -
@@ -390,7 +397,9 @@ export function ChatPane(props: ChatPaneProps) {
               ) : null
             }
             footer={
-              showTailLoader && tailTurn ? (
+              isWorktreeProvisioning ? (
+                <ChatWorktreeProvisioningFooter />
+              ) : showTailLoader && tailTurn ? (
                 <ChatTurnElapsedFooter turn={tailTurn} isPaused={isTurnPaused} />
               ) : null
             }
@@ -447,7 +456,7 @@ export function ChatPane(props: ChatPaneProps) {
             layoutChangeToken={layoutChangeToken}
             tailEntryId={timelineEntries.at(-1)?.id ?? null}
             threadId={threadId}
-            tailLoaderVisible={showTailLoader}
+            tailLoaderVisible={isWorktreeProvisioning || showTailLoader}
             initialScrollSettled={isInitialScrollSettled}
             initialScrollRevealDelayMs={props.initialScrollRevealDelayMs ?? 0}
             virtualScrollToBottomRef={virtualScrollToBottomRef}

--- a/src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
@@ -28,6 +28,30 @@ export function ChatTurnElapsedFooter({
   );
 }
 
+export function ChatWorktreeProvisioningFooter() {
+  const { t } = useLingui();
+  const textRef = useRef<HTMLSpanElement>(null);
+  const text = t`Creating worktree…`;
+  useShimmerRef(textRef, true);
+
+  return (
+    <div className="mx-auto w-full max-w-[920px]">
+      <Surface variant="transparent" className={chatMessageSurfaceClass}>
+        <div className="inline-flex items-center gap-1.5 text-[length:var(--lc-chat-font-size-meta)] text-foreground-muted">
+          <span
+            ref={textRef}
+            className="poracode-thinking-text"
+            data-poracode-shimmer-text={text}
+            aria-live="polite"
+          >
+            {text}
+          </span>
+        </div>
+      </Surface>
+    </div>
+  );
+}
+
 /**
  * Self-ticking elapsed-time label. While `turn.endedAt` is null, ticks every
  * second as "Working for N"; once set, freezes as "Worked for N". When

--- a/src/renderer/components/thread/TerminalThreadContent.tsx
+++ b/src/renderer/components/thread/TerminalThreadContent.tsx
@@ -1,4 +1,6 @@
+import { useLingui } from "@lingui/react/macro";
 import { PixelLoader } from "../common/PixelLoader";
+import { useAppStore } from "@/renderer/state/appStore";
 import { useThread } from "@/renderer/state/useThread";
 import { TerminalPane } from "./TerminalPane";
 import { ThreadComposerSection } from "./ThreadComposerSection";
@@ -24,6 +26,11 @@ export function TerminalThreadContent(
   },
 ) {
   const thread = useThread(props.threadId) ?? props.fallbackThread;
+  const { t } = useLingui();
+  const awaitingWorktree = useAppStore(
+    (state) =>
+      state.provisioningWorktreeThreadIds[thread.id] === true && thread.status === "launching",
+  );
 
   return (
     <>
@@ -43,8 +50,12 @@ export function TerminalThreadContent(
         )}
         {thread.status === "launching" ||
         (thread.remoteServerId && !props.remoteTerminalTransport) ? (
-          <div className="absolute inset-0 flex items-center justify-center">
+          <div
+            className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-sm text-foreground-muted"
+            aria-live="polite"
+          >
             <PixelLoader size="md" />
+            {awaitingWorktree ? <span>{t`Creating worktree…`}</span> : null}
           </div>
         ) : null}
       </div>

--- a/src/renderer/components/thread/ThreadComposerSection.test.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.test.tsx
@@ -3,9 +3,10 @@ import { toast } from "@heroui/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
-import type { AgentStatus, Thread } from "@/shared/contracts";
+import type { AgentStatus, GitStatusResult, Thread } from "@/shared/contracts";
 import "@/renderer/components/providers/bootstrap";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useGitStore } from "@/renderer/state/gitStore";
 import {
   useComposerInputInbox,
   worktreeComposerInboxKey,
@@ -221,7 +222,9 @@ describe("ThreadComposerSection", () => {
       pendingSteerByThreadId: {},
       pendingComposerFocusThreadId: null,
       threadDraftContents: {},
+      provisioningWorktreeThreadIds: {},
     });
+    useGitStore.setState({ statuses: {} });
     useComposerInputInbox.setState({ itemsByComposer: {} });
     bridgeMock.isRemoteSession.mockReturnValue(false);
     bridgeMock.clearPendingSteer.mockClear();
@@ -240,6 +243,42 @@ describe("ThreadComposerSection", () => {
     runtimeActions.submitThreadInput.mockClear();
     runtimeActions.submitThreadInput.mockResolvedValue(undefined);
     toastDangerSpy.mockClear();
+  });
+
+  it("hides base-checkout changes while a new worktree is provisioning", () => {
+    useAppStore.setState({
+      provisioningWorktreeThreadIds: { [guiThread.id]: true },
+    });
+    useGitStore.setState({
+      statuses: {
+        "project-1": {
+          isRepo: true,
+          branch: "main",
+          tracking: "origin/main",
+          hasRemote: true,
+          remoteInfo: null,
+          ahead: 0,
+          behind: 0,
+          staged: [],
+          unstaged: [],
+          totalInsertions: 12,
+          totalDeletions: 3,
+        } as GitStatusResult,
+      },
+    });
+
+    render(
+      composerElement({
+        thread: {
+          ...guiThread,
+          status: "launching",
+          sessionRef: undefined,
+          worktreeBranch: "poracode/feature",
+        },
+      }),
+    );
+
+    expect(screen.queryByRole("button", { name: "Review changes" })).toBeNull();
   });
 
   function composerElement(opts?: {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -162,6 +162,10 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     goalDockState,
     errorDockStates,
   } = props;
+  const awaitingWorktree = useAppStore(
+    (state) =>
+      state.provisioningWorktreeThreadIds[thread.id] === true && thread.status === "launching",
+  );
   const { t } = useLingui();
   const [prompt, setPrompt] = useState("");
   const [hasContent, setHasContent] = useState(false);
@@ -651,11 +655,13 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
     <>
       {thread.status !== "launching" || !usesTerminalPresentation ? (
         <div className="relative">
-          <ThreadChangesBubble
-            projectId={thread.projectId}
-            {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
-            {...(thread.worktreePath && branchName ? { worktreeName: branchName } : {})}
-          />
+          {awaitingWorktree ? null : (
+            <ThreadChangesBubble
+              projectId={thread.projectId}
+              {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+              {...(thread.worktreePath && branchName ? { worktreeName: branchName } : {})}
+            />
+          )}
           <div
             className={`grid transition-[grid-template-rows] ease-[cubic-bezier(0.16,1,0.3,1)] ${isComposerCollapsed ? "duration-300" : "duration-200"}`}
             style={{ gridTemplateRows: isComposerCollapsed ? "0fr" : "1fr" }}

--- a/src/renderer/components/thread/ThreadView.test.tsx
+++ b/src/renderer/components/thread/ThreadView.test.tsx
@@ -95,6 +95,7 @@ describe("ThreadView", () => {
       runtimeItemIdsByThread: {},
       runtimeItemsByIdByThread: {},
       runtimeRequestsByThread: {},
+      provisioningWorktreeThreadIds: {},
     });
   });
 
@@ -1823,6 +1824,56 @@ describe("ThreadView", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("hides base-checkout thread tools while a new worktree is provisioning", async () => {
+    const thread: Thread = {
+      id: "thread-worktree-provisioning",
+      projectId: "project-1",
+      title: "Provisioning worktree",
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      status: "launching",
+      attention: "none",
+      canResumeWithConfig: false,
+      worktreeBranch: "poracode/feature",
+      archived: false,
+      done: false,
+      starred: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const props: Parameters<typeof ThreadView>[0] = {
+      thread,
+      agentStatus: undefined,
+      projectLocation: { kind: "windows", path: "C:\\repo" },
+      paneCount: 2,
+    };
+    useAppStore.setState({
+      provisioningWorktreeThreadIds: { [thread.id]: true },
+    });
+    const { rerender } = renderThreadView(props);
+
+    expect(screen.queryByRole("button", { name: "Show thread tools" })).toBeNull();
+    expect(screen.getByText("Creating worktree…")).toBeInTheDocument();
+
+    rerender(
+      <AppProvider>
+        <ThreadView
+          {...props}
+          thread={{
+            ...thread,
+            status: "error",
+            attention: "error",
+            errorMessage: "Host refused launch",
+            worktreePath: "C:\\worktrees\\feature",
+          }}
+        />
+      </AppProvider>,
+    );
+
+    expect(screen.getByRole("button", { name: "Show thread tools" })).toBeInTheDocument();
+    expect(screen.queryByText("Creating worktree…")).toBeNull();
   });
 
   it("allows queued follow-ups and stop while a GUI ACP thread is running", async () => {

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -73,6 +73,7 @@ function areThreadViewPropsEqual(prev: ThreadViewProps, next: ThreadViewProps): 
     prev.projectName === next.projectName &&
     prev.pendingLaunchPrompt === next.pendingLaunchPrompt &&
     prev.pendingLaunchSegments === next.pendingLaunchSegments &&
+    prev.pendingLaunchUserMessageItemId === next.pendingLaunchUserMessageItemId &&
     prev.isWsl === next.isWsl &&
     prev.showCloseButton === next.showCloseButton &&
     prev.paneAlign === next.paneAlign &&
@@ -101,6 +102,7 @@ export type ThreadViewProps = {
   projectName?: string;
   pendingLaunchPrompt?: string;
   pendingLaunchSegments?: PromptSegment[];
+  pendingLaunchUserMessageItemId?: string;
   isWsl?: boolean;
   showCloseButton?: boolean;
   paneAlign?: "left" | "center" | "right";
@@ -157,6 +159,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     projectName,
     pendingLaunchPrompt,
     pendingLaunchSegments,
+    pendingLaunchUserMessageItemId,
     isWsl,
     showCloseButton,
     paneAlign = "center",
@@ -196,6 +199,10 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
   const usesTerminalPresentation =
     (thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal") ===
     "terminal";
+  const awaitingWorktree = useAppStore(
+    (state) =>
+      state.provisioningWorktreeThreadIds[thread.id] === true && thread.status === "launching",
+  );
   const launchTerminalSize = usesTerminalPresentation ? terminalSize : DEFAULT_HIDDEN_TERMINAL_SIZE;
 
   useLayoutEffect(() => {
@@ -235,6 +242,9 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         projectLocation,
         prompt: pendingLaunchPrompt,
         ...(pendingLaunchSegments ? { segments: pendingLaunchSegments } : {}),
+        ...(pendingLaunchUserMessageItemId
+          ? { userMessageItemId: pendingLaunchUserMessageItemId }
+          : {}),
         initialSize: launchTerminalSize,
       });
     })().catch((error) => {
@@ -247,6 +257,7 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
     onLaunchFailed,
     pendingLaunchPrompt,
     pendingLaunchSegments,
+    pendingLaunchUserMessageItemId,
     projectLocation,
     launchTerminalSize,
     thread,
@@ -379,11 +390,13 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
                     <CircleCheck className="size-3.5" />
                   </button>
                 ) : null}
-                <ThreadToolRail
-                  projectId={thread.projectId}
-                  paneCount={paneCount}
-                  {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
-                />
+                {awaitingWorktree ? null : (
+                  <ThreadToolRail
+                    projectId={thread.projectId}
+                    paneCount={paneCount}
+                    {...(thread.worktreePath ? { worktreePath: thread.worktreePath } : {})}
+                  />
+                )}
                 {showCloseButton ? (
                   <button
                     type="button"

--- a/src/renderer/hooks/uiSelectors.ts
+++ b/src/renderer/hooks/uiSelectors.ts
@@ -395,11 +395,13 @@ export function useActiveGroupName(): string | undefined {
 export function useThreadPendingLaunch(threadId: string): {
   prompt: string | undefined;
   segments: PromptSegment[] | undefined;
+  userMessageItemId: string | undefined;
 } {
   return useAppStore(
     useShallow((s) => ({
       prompt: s.pendingThreadLaunches[threadId],
       segments: s.pendingLaunchSegments[threadId],
+      userMessageItemId: s.pendingLaunchUserMessageItemIds[threadId],
     })),
   );
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Mit Agent erstellen"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Es wurde ein Arbeitsbaum für „{newBranch}“ erstellt, aber die Änderungen widersprachen und verbleiben in einem Git-Stash – lösen Sie sie im Arbeitsbaum auf."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Worktree wird erstellt…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Anmeldeinformationen sind konfiguriert."

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3292,6 +3292,11 @@ msgstr "Create with Agent"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Creating worktree…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Credentials are configured."

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Crear con un agente"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Se creó un worktree en \"{newBranch}\", pero los cambios entraron en conflicto y permanecen en un stash de git: resuélvelos en el worktree."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Creando worktree…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Las credenciales están configuradas."

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Créer avec un agent"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Arbre de travail créé sur \"{newBranch}\", mais les modifications sont entrées en conflit et restent dans un stash git — résolvez-les dans l'arbre de travail."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Création de l’arbre de travail…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Les informations d'identification sont configurées."

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3286,6 +3286,11 @@ msgstr "エージェントで作成"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "「{newBranch}」にワークツリーを作成しましたが、変更が競合し、git stash に残っています。ワークツリー内で解決してください。"
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "ワークツリーを作成しています…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "資格情報が設定されています。"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3287,6 +3287,11 @@ msgstr "에이전트로 만들기"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "\"{newBranch}\"에 작업 트리를 만들었지만 변경 사항이 충돌하여 git stash에 남아 있습니다. 작업 트리에서 해결하세요."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "작업 트리 생성 중…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "자격 증명이 구성되었습니다."

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Utwórz z agentem"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Utworzono drzewo pracy na „{newBranch}”, ale zmiany kolidują ze sobą i pozostają w skrytce git — rozwiąż je w drzewie pracy."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Tworzenie drzewa roboczego…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Poświadczenia są skonfigurowane."

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Criar com agente"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Criou uma árvore de trabalho em \"{newBranch}\", mas as alterações entraram em conflito e permanecem em um git stash — resolva-as na árvore de trabalho."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Criando árvore de trabalho…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "As credenciais estão configuradas."

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Создать с агентом"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Worktree создан на \"{newBranch}\", но изменения вызвали конфликт и остаются в git stash — разрешите их в worktree."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Создание worktree…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Учётные данные настроены."

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Ajanla oluştur"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "\"{newBranch}\" üzerinde bir çalışma ağacı oluşturuldu, ancak değişiklikler çakıştı ve bir git stash'inde kaldı; bunları çalışma ağacında çözün."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Çalışma ağacı oluşturuluyor…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Kimlik bilgileri yapılandırıldı."

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Створити з агентом"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Worktree створено на \"{newBranch}\", але зміни спричинили конфлікт і залишаються в git stash — вирішіть їх у worktree."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Створення worktree…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Облікові дані налаштовано."

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3287,6 +3287,11 @@ msgstr "Tạo bằng tác nhân"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "Đã tạo một cây làm việc trên \"{newBranch}\", nhưng những thay đổi này xung đột và vẫn nằm trong kho lưu trữ git — hãy giải quyết chúng trong cây làm việc."
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "Đang tạo cây làm việc…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "Thông tin xác thực được cấu hình."

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3287,6 +3287,11 @@ msgstr "使用代理创建"
 msgid "Created a worktree on \"{newBranch}\", but the changes conflicted and remain in a git stash — resolve them in the worktree."
 msgstr "在“{newBranch}”上创建了一个工作树，但更改发生冲突并保留在 git 存储中 - 在工作树中解决它们。"
 
+#: src/renderer/components/thread/ChatPane/ChatTurnElapsed.tsx
+#: src/renderer/components/thread/TerminalThreadContent.tsx
+msgid "Creating worktree…"
+msgstr "正在创建工作树…"
+
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Credentials are configured."
 msgstr "凭证已配置。"

--- a/src/renderer/state/appStore.test.ts
+++ b/src/renderer/state/appStore.test.ts
@@ -6,7 +6,7 @@ import {
   splitStorageKey,
   writeStoredSizes,
 } from "@/renderer/components/layout/paneSizeStorage";
-import { useAppStore } from "./appStore";
+import { useAppStore, type AppStoreState } from "./appStore";
 import { usePanelStore } from "./panelStore";
 
 describe("appStore runtime config sync", () => {
@@ -17,6 +17,8 @@ describe("appStore runtime config sync", () => {
       ...state,
       projects: [],
       threads: [],
+      pendingLaunchUserMessageItemIds: {},
+      provisioningWorktreeThreadIds: {},
       view: { kind: "home" },
     }));
     usePanelStore.getState().setGitHubActionsContext(null);
@@ -66,6 +68,101 @@ describe("appStore runtime config sync", () => {
     const updated = useAppStore.getState().threads.find((t) => t.id === thread.id);
     expect(updated?.worktreePath).toBe("/repo/wt");
     expect(updated?.worktreeBranch).toBe("feature/x");
+  });
+
+  it("keeps an unresolved optimistic worktree thread out of persisted state", () => {
+    const project = useAppStore.getState().addProject({ kind: "windows", path: "C:\\repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "hello",
+      worktreeBranch: "poracode/feature",
+      worktreeProvisioning: true,
+    });
+    const experimentThread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "compare it",
+      worktreeBranch: "poracode/experiment-feature",
+      groupId: "experiment-1",
+      focus: false,
+    });
+    const partialize = useAppStore.persist.getOptions().partialize!;
+
+    const unresolved = partialize(useAppStore.getState()) as Pick<
+      AppStoreState,
+      "threads" | "view"
+    >;
+    expect(unresolved.threads).not.toContainEqual(expect.objectContaining({ id: thread.id }));
+    expect(unresolved.threads).toContainEqual(expect.objectContaining({ id: experimentThread.id }));
+    expect(unresolved.view).toEqual({ kind: "home" });
+
+    useAppStore.getState().updateThreadRuntime(thread.id, {
+      status: "error",
+      attention: "error",
+      canResumeWithConfig: false,
+    });
+    const failed = partialize(useAppStore.getState()) as Pick<AppStoreState, "threads">;
+    expect(failed.threads).not.toContainEqual(expect.objectContaining({ id: thread.id }));
+
+    useAppStore
+      .getState()
+      .setThreadWorktree(thread.id, "C:\\worktrees\\feature", "poracode/feature");
+    const resolved = partialize(useAppStore.getState()) as Pick<AppStoreState, "threads" | "view">;
+    expect(resolved.threads).toContainEqual(
+      expect.objectContaining({ id: thread.id, worktreePath: "C:\\worktrees\\feature" }),
+    );
+    expect(useAppStore.getState().provisioningWorktreeThreadIds[thread.id]).toBeUndefined();
+    expect(resolved.view).toMatchObject({ kind: "thread", panes: [thread.id] });
+    expect(useAppStore.persist.getOptions().version).toBe(4);
+  });
+
+  it("clears provisional worktree launch state when deleting its project", () => {
+    const project = useAppStore.getState().addProject({ kind: "windows", path: "C:\\repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "hello",
+      worktreeProvisioning: true,
+    });
+    useAppStore.setState({
+      pendingLaunchUserMessageItemIds: { [thread.id]: "user-message" },
+    });
+
+    useAppStore.getState().deleteProject(project.id);
+
+    expect(useAppStore.getState().provisioningWorktreeThreadIds[thread.id]).toBeUndefined();
+    expect(useAppStore.getState().pendingLaunchUserMessageItemIds[thread.id]).toBeUndefined();
+  });
+
+  it("rehydrates the previous v4 shape without provisional launch maps", () => {
+    const project = useAppStore.getState().addProject({ kind: "windows", path: "C:\\repo" });
+    const thread = useAppStore.getState().createThread({
+      projectId: project.id,
+      agentKind: "codex",
+      config: { model: "gpt-5.4" },
+      prompt: "hello",
+    });
+    const merge = useAppStore.persist.getOptions().merge!;
+    const previousV4State = {
+      projects: [project],
+      threads: [thread],
+      view: { kind: "thread", panes: [thread.id] },
+      groupLayouts: {},
+    };
+
+    const hydrated = merge(previousV4State, useAppStore.getState()) as AppStoreState;
+
+    expect(hydrated.projects).toEqual([project]);
+    expect(hydrated.threads).toEqual([
+      expect.objectContaining({ ...thread, status: "inactive", doneAt: undefined }),
+    ]);
+    expect(hydrated.view).toEqual({ kind: "thread", panes: [thread.id] });
+    expect(hydrated.pendingLaunchUserMessageItemIds).toEqual({});
+    expect(hydrated.provisioningWorktreeThreadIds).toEqual({});
   });
 
   it("ensures the hidden Home project without replacing its draft config", () => {

--- a/src/renderer/state/appStore.ts
+++ b/src/renderer/state/appStore.ts
@@ -66,10 +66,22 @@ export const useAppStore = create<AppStoreState>()(
               view.panes.some((paneId) =>
                 state.threads.some((thread) => thread.id === paneId && thread.remoteServerId),
               ));
+          const hasPendingWorktreeView =
+            view.kind === "thread" &&
+            view.panes.some((paneId) =>
+              state.threads.some(
+                (thread) => thread.id === paneId && state.provisioningWorktreeThreadIds[thread.id],
+              ),
+            );
           return {
             projects: state.projects.filter((project) => !project.remoteServerId),
-            threads: state.threads.filter((thread) => !thread.remoteServerId),
-            view: hasRemoteView ? { kind: "home" as const } : view,
+            // Worktree-provisioning rows are renderer-only placeholders. If one
+            // survived a restart, `launching` would hydrate as `inactive` and
+            // reopening it would launch the agent in the base checkout.
+            threads: state.threads.filter(
+              (thread) => !thread.remoteServerId && !state.provisioningWorktreeThreadIds[thread.id],
+            ),
+            view: hasRemoteView || hasPendingWorktreeView ? { kind: "home" as const } : view,
             groupLayouts: state.groupLayouts,
           };
         },

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -67,6 +67,8 @@ export interface RemoteSocketLike {
 
 export type RemoteSocketFactory = (url: string) => RemoteSocketLike;
 
+export type RemoteThreadLaunchResult = "started" | "cancelled" | "cancellation-failed";
+
 export interface RemoteServersState {
   servers: RemoteServerRecord[];
   runtime: Record<string, RemoteServerRuntime>;
@@ -92,7 +94,8 @@ export interface RemoteServersState {
   openThread: OpenRemoteThread | null;
   launchRemoteThread(
     input: StartRemoteNewThreadInput & { readonly desktopId: string },
-  ): Promise<void>;
+    options?: { readonly isPendingLaunchOwned?: () => boolean },
+  ): Promise<RemoteThreadLaunchResult>;
   /**
    * Hydrate a remote thread's history and focus it. Never rejects. Resolves
    * `true` only when the snapshot was actually applied — `false` when the

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -3,7 +3,7 @@ import type { GitStatusResult, Project, Thread } from "@/shared/contracts";
 import type { IpcProcedureName, IpcProcedurePayload, IpcProcedureResult } from "@/shared/ipc";
 import type { GitStatePatch, GitStateSnapshot } from "@/shared/gitState";
 import { HOME_PROJECT_ID } from "@/shared/homeScope";
-import type { RemoteGitSummaries } from "@/shared/remote";
+import { PORACODE_REMOTE_PROTOCOL_VERSION, type RemoteGitSummaries } from "@/shared/remote";
 import { RemoteClientError, RemoteDesktopClient } from "@/shared/remote/client";
 import {
   __resetRemoteServersStoreForTest,
@@ -189,6 +189,7 @@ function makeClient(opts?: {
   snapshotThrows?: boolean;
   snapshot?: RemoteDesktopClient["snapshot"];
   agentStatuses?: RemoteDesktopClient["agentStatuses"];
+  environment?: RemoteDesktopClient["environment"];
   environmentHttpBaseUrl?: string;
   hostMode?: "desktop" | "helper";
   projectCommand?: RemoteDesktopClient["projectCommand"];
@@ -199,6 +200,7 @@ function makeClient(opts?: {
   threadRuntimeItemsPage?: RemoteDesktopClient["threadRuntimeItemsPage"];
   websocketTicket?: RemoteDesktopClient["websocketTicket"];
   websocketUrl?: RemoteDesktopClient["websocketUrl"];
+  sendThreadCommand?: RemoteDesktopClient["sendThreadCommand"];
   sendThreadInput?: RemoteDesktopClient["sendThreadInput"];
   uploadAttachment?: RemoteDesktopClient["uploadAttachment"];
   startThread?: RemoteDesktopClient["startThread"];
@@ -217,17 +219,19 @@ function makeClient(opts?: {
       expiresAt: "2099-01-01T00:00:00.000Z",
       scopes: ["session:read", "projects:manage"],
     }),
-    environment: async () => ({
-      protocolVersion: 1,
-      ...(opts?.hostMode ? { hostMode: opts.hostMode } : {}),
-      desktopId: "d1",
-      label: "Server One",
-      appVersion: "1.0",
-      endpoints: {
-        httpBaseUrl: opts?.environmentHttpBaseUrl ?? "http://192.168.1.9:38987/",
-        wsBaseUrl: "ws://192.168.1.9:38987/",
-      },
-    }),
+    environment:
+      opts?.environment ??
+      (async () => ({
+        protocolVersion: PORACODE_REMOTE_PROTOCOL_VERSION,
+        ...(opts?.hostMode ? { hostMode: opts.hostMode } : {}),
+        desktopId: "d1",
+        label: "Server One",
+        appVersion: "1.0",
+        endpoints: {
+          httpBaseUrl: opts?.environmentHttpBaseUrl ?? "http://192.168.1.9:38987/",
+          wsBaseUrl: "ws://192.168.1.9:38987/",
+        },
+      })),
     agentStatuses:
       opts?.agentStatuses ?? (async () => ({ windows: [], wsl: [], updatedAt: "now" })),
     snapshot:
@@ -253,6 +257,7 @@ function makeClient(opts?: {
     websocketTicket: opts?.websocketTicket ?? (async () => "ticket-1"),
     websocketUrl: opts?.websocketUrl ?? (() => "ws://192.168.1.9:38987/ws?ticket=ticket-1"),
     parseSocketMessage: (value: string) => JSON.parse(value),
+    sendThreadCommand: opts?.sendThreadCommand ?? (async () => {}),
     sendThreadInput: opts?.sendThreadInput ?? (async () => {}),
     uploadAttachment: opts?.uploadAttachment ?? (async () => "/remote/attachment.png"),
     startThread: opts?.startThread ?? (async () => ({ threadId: remoteThread.id })),
@@ -302,6 +307,10 @@ describe("useRemoteServersStore", () => {
       lastKnownProjects: {},
       openThread: null,
     });
+    useAppStore.setState((state) => ({
+      threads: state.threads.filter((thread) => !thread.remoteServerId),
+      provisioningWorktreeThreadIds: {},
+    }));
     useGitStore.setState({ statuses: {}, worktreeStatuses: {} });
     sync.applyThreadSnapshot.mockClear();
     sync.dispatchRemoteSupervisorEvent.mockClear();
@@ -835,6 +844,42 @@ describe("useRemoteServersStore", () => {
     expect(useRemoteServersStore.getState().runtime.d1).toMatchObject({
       status: "offline",
       message: "SSH connection failed",
+    });
+  });
+
+  it("stops reconnecting when a persisted server reports the previous protocol", async () => {
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>();
+    const environment = vi.fn<RemoteDesktopClient["environment"]>(async () => {
+      throw new RemoteClientError(
+        "This app version is incompatible with that server.",
+        409,
+        "protocol_version_mismatch",
+      );
+    });
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(factoryFor(makeClient({ environment, snapshot })));
+    useRemoteServersStore.setState({
+      servers: [
+        {
+          desktopId: "d1",
+          label: "Old host",
+          endpoint: "http://127.0.0.1:38987/",
+          accessToken: "token",
+          scopes: [],
+        },
+      ],
+      runtime: {
+        d1: { status: "offline", projects: [], threads: [] },
+      },
+    });
+
+    await useRemoteServersStore.getState().connectAll();
+
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(useRemoteServersStore.getState().runtime.d1).toMatchObject({
+      status: "error",
+      message: "This app version is incompatible with that server.",
     });
   });
 
@@ -1979,22 +2024,355 @@ describe("useRemoteServersStore", () => {
     useRemoteServersStore.getState().setClientFactory(factoryFor(client));
     await pairIsolated(() => makeSocket());
     await useRemoteServersStore.getState().launchRemoteThread({
+      threadId: "rt-new",
       desktopId: "d1",
       projectId: "p1",
       agentKind: "claude",
       config: { model: "claude-sonnet" },
       prompt: "work remotely",
       presentationMode: "gui",
+      userMessageItemId: "user-optimistic",
     });
 
     expect(startNewThread).toHaveBeenCalledWith({
+      threadId: "rt-new",
       projectId: "p1",
       agentKind: "claude",
       config: { model: "claude-sonnet" },
       prompt: "work remotely",
       presentationMode: "gui",
+      userMessageItemId: "user-optimistic",
     });
     expect(useRemoteServersStore.getState().openThread?.threadId).toBe("rt-new");
+  });
+
+  it("preserves an optimistic remote thread while its worktree is provisioning", async () => {
+    const socket = makeSocket();
+    useRemoteServersStore.getState().setClientFactory(factoryFor(makeClient()));
+    useRemoteServersStore.getState().setSocketFactory(() => socket);
+    await useRemoteServersStore
+      .getState()
+      .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+    const pendingId = remoteThreadId("d1", "rt-pending");
+    useAppStore.getState().createThread({
+      threadId: pendingId,
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-pending",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "work remotely",
+      presentationMode: "gui",
+      worktreeBranch: "feature",
+      worktreeProvisioning: true,
+    });
+    useAppStore.getState().createThread({
+      threadId: remoteThreadId("d1", "rt-stale"),
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-stale",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "stale remote row",
+      presentationMode: "gui",
+    });
+    sync.dispatchRemoteSupervisorEvent.mockClear();
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 1,
+        event: {
+          type: "thread-state",
+          threadId: "rt-stale",
+          status: "working",
+          attention: "working",
+          canResumeWithConfig: false,
+        },
+      }),
+    });
+    expect(sync.dispatchRemoteSupervisorEvent).not.toHaveBeenCalled();
+
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: "event",
+        seq: 2,
+        event: {
+          type: "thread-state",
+          threadId: "rt-pending",
+          status: "working",
+          attention: "working",
+          canResumeWithConfig: false,
+        },
+      }),
+    });
+
+    expect(sync.dispatchRemoteSupervisorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: pendingId }),
+    );
+
+    await useRemoteServersStore.getState().refreshServer("d1");
+
+    expect(useAppStore.getState().threads).toContainEqual(
+      expect.objectContaining({
+        id: pendingId,
+        remoteServerId: "d1",
+        remoteId: "rt-pending",
+      }),
+    );
+
+    useRemoteServersStore.getState().setClientFactory(
+      factoryFor(
+        makeClient({
+          snapshot: async () => ({
+            snapshotSeq: 3,
+            projects: [proj],
+            threads: [
+              {
+                ...remoteThread,
+                id: "rt-pending",
+                projectId: "p1",
+                worktreePath: "/srv/worktrees/feature",
+              },
+            ],
+            runtimeSummariesByThread: {},
+            updatedAt: "confirmed",
+          }),
+        }),
+      ),
+    );
+    await useRemoteServersStore.getState().refreshServer("d1");
+
+    expect(useAppStore.getState().provisioningWorktreeThreadIds[pendingId]).toBe(true);
+  });
+
+  it("compensates when an authoritative snapshot precedes deletion and the start response", async () => {
+    const start = deferred<{ threadId: string }>();
+    const startNewThread = vi.fn<RemoteDesktopClient["startNewThread"]>(() => start.promise);
+    const sendThreadCommand = vi.fn<RemoteDesktopClient["sendThreadCommand"]>(async () => {});
+    let authoritative = false;
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => ({
+      snapshotSeq: authoritative ? 2 : 1,
+      projects: [proj],
+      threads: authoritative
+        ? [{ ...remoteThread, id: "rt-cancelled", worktreePath: "/srv/worktrees/feature" }]
+        : [],
+      runtimeSummariesByThread: {},
+      updatedAt: authoritative ? "authoritative" : "initial",
+    }));
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(factoryFor(makeClient({ snapshot, startNewThread, sendThreadCommand })));
+    await pairIsolated(() => makeSocket());
+    const projectedId = remoteThreadId("d1", "rt-cancelled");
+    useAppStore.getState().createThread({
+      threadId: projectedId,
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-cancelled",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "work remotely",
+      presentationMode: "gui",
+      worktreeBranch: "feature",
+      worktreeProvisioning: true,
+    });
+
+    const launch = useRemoteServersStore.getState().launchRemoteThread(
+      {
+        threadId: "rt-cancelled",
+        desktopId: "d1",
+        projectId: "p1",
+        agentKind: "claude",
+        config: { model: "claude-sonnet" },
+        prompt: "work remotely",
+        presentationMode: "gui",
+        worktreePath: "/srv/worktrees/feature",
+      },
+      {
+        isPendingLaunchOwned: () =>
+          useAppStore.getState().provisioningWorktreeThreadIds[projectedId] === true,
+      },
+    );
+    await vi.waitFor(() => expect(startNewThread).toHaveBeenCalledOnce());
+    authoritative = true;
+    await useRemoteServersStore.getState().refreshServer("d1");
+    expect(useAppStore.getState().provisioningWorktreeThreadIds[projectedId]).toBe(true);
+    useAppStore.getState().deleteThread(projectedId);
+    start.resolve({ threadId: "rt-cancelled" });
+
+    await expect(launch).resolves.toBe("cancelled");
+    expect(sendThreadCommand).toHaveBeenCalledWith({
+      kind: "delete",
+      threadId: "rt-cancelled",
+    });
+    expect(useAppStore.getState().threads.map((thread) => thread.id)).not.toContain(projectedId);
+    expect(useRemoteServersStore.getState().openThread).toBeNull();
+  });
+
+  it("compensates when the provisional row is deleted while waiting for host appearance", async () => {
+    const appearance = deferred<Awaited<ReturnType<RemoteDesktopClient["snapshot"]>>>();
+    let snapshotCalls = 0;
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => {
+      snapshotCalls += 1;
+      if (snapshotCalls === 1) {
+        return {
+          snapshotSeq: 1,
+          projects: [proj],
+          threads: [],
+          runtimeSummariesByThread: {},
+          updatedAt: "initial",
+        };
+      }
+      return appearance.promise;
+    });
+    const startNewThread = vi.fn<RemoteDesktopClient["startNewThread"]>(async () => ({
+      threadId: "rt-waiting",
+    }));
+    const sendThreadCommand = vi.fn<RemoteDesktopClient["sendThreadCommand"]>(async () => {});
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(factoryFor(makeClient({ snapshot, startNewThread, sendThreadCommand })));
+    await pairIsolated(() => makeSocket());
+    const projectedId = remoteThreadId("d1", "rt-waiting");
+    useAppStore.getState().createThread({
+      threadId: projectedId,
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-waiting",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "work remotely",
+      presentationMode: "gui",
+      worktreeProvisioning: true,
+    });
+
+    const launch = useRemoteServersStore.getState().launchRemoteThread(
+      {
+        threadId: "rt-waiting",
+        desktopId: "d1",
+        projectId: "p1",
+        agentKind: "claude",
+        config: { model: "claude-sonnet" },
+        prompt: "work remotely",
+        presentationMode: "gui",
+      },
+      {
+        isPendingLaunchOwned: () =>
+          useAppStore.getState().provisioningWorktreeThreadIds[projectedId] === true,
+      },
+    );
+    await vi.waitFor(() => expect(snapshot).toHaveBeenCalledTimes(2));
+    useAppStore.getState().deleteThread(projectedId);
+    appearance.resolve({
+      snapshotSeq: 2,
+      projects: [proj],
+      threads: [{ ...remoteThread, id: "rt-waiting" }],
+      runtimeSummariesByThread: {},
+      updatedAt: "appeared",
+    });
+
+    await expect(launch).resolves.toBe("cancelled");
+    expect(sendThreadCommand).toHaveBeenCalledWith({
+      kind: "delete",
+      threadId: "rt-waiting",
+    });
+    expect(useRemoteServersStore.getState().openThread).toBeNull();
+  });
+
+  it("retains a cancelled remote launch when compensating deletion fails", async () => {
+    const sendThreadCommand = vi.fn<RemoteDesktopClient["sendThreadCommand"]>(async () => {
+      throw new Error("remote delete failed");
+    });
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(factoryFor(makeClient({ sendThreadCommand })));
+    await pairIsolated(() => makeSocket());
+
+    await expect(
+      useRemoteServersStore.getState().launchRemoteThread(
+        {
+          threadId: "rt-orphaned",
+          desktopId: "d1",
+          projectId: "p1",
+          agentKind: "claude",
+          config: { model: "claude-sonnet" },
+          prompt: "work remotely",
+          presentationMode: "gui",
+          worktreePath: "/srv/worktrees/feature",
+        },
+        { isPendingLaunchOwned: () => false },
+      ),
+    ).resolves.toBe("cancellation-failed");
+    expect(toastDanger).toHaveBeenCalledWith("remote delete failed");
+    expect(useRemoteServersStore.getState().openThread).toBeNull();
+  });
+
+  it("closes a deleted launch opened during history hydration when compensation fails", async () => {
+    const history = deferred<RemoteThreadHistorySnapshot>();
+    let snapshotCalls = 0;
+    const snapshot = vi.fn<RemoteDesktopClient["snapshot"]>(async () => {
+      snapshotCalls += 1;
+      return {
+        snapshotSeq: snapshotCalls,
+        projects: [proj],
+        threads: snapshotCalls === 1 ? [] : [{ ...remoteThread, id: "rt-hydrating" }],
+        runtimeSummariesByThread: {},
+        updatedAt: `snapshot-${snapshotCalls}`,
+      };
+    });
+    const startNewThread = vi.fn<RemoteDesktopClient["startNewThread"]>(async () => ({
+      threadId: "rt-hydrating",
+    }));
+    const threadHistory = vi.fn<RemoteDesktopClient["threadHistory"]>(() => history.promise);
+    const sendThreadCommand = vi.fn<RemoteDesktopClient["sendThreadCommand"]>(async () => {
+      throw new Error("remote delete failed");
+    });
+    useRemoteServersStore
+      .getState()
+      .setClientFactory(
+        factoryFor(makeClient({ snapshot, startNewThread, threadHistory, sendThreadCommand })),
+      );
+    await pairIsolated(() => makeSocket());
+    const projectedId = remoteThreadId("d1", "rt-hydrating");
+    useAppStore.getState().createThread({
+      threadId: projectedId,
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-hydrating",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "work remotely",
+      presentationMode: "gui",
+      worktreeProvisioning: true,
+    });
+
+    const launch = useRemoteServersStore.getState().launchRemoteThread(
+      {
+        threadId: "rt-hydrating",
+        desktopId: "d1",
+        projectId: "p1",
+        agentKind: "claude",
+        config: { model: "claude-sonnet" },
+        prompt: "work remotely",
+        presentationMode: "gui",
+      },
+      {
+        isPendingLaunchOwned: () =>
+          useAppStore.getState().provisioningWorktreeThreadIds[projectedId] === true,
+      },
+    );
+    await vi.waitFor(() => expect(threadHistory).toHaveBeenCalledWith("rt-hydrating"));
+    useAppStore.getState().deleteThread(projectedId);
+    history.resolve(remoteThreadSnapshot("rt-hydrating"));
+
+    await expect(launch).resolves.toBe("cancellation-failed");
+    expect(sendThreadCommand).toHaveBeenCalledWith({
+      kind: "delete",
+      threadId: "rt-hydrating",
+    });
+    expect(useRemoteServersStore.getState().openThread).toBeNull();
+    expect(useAppStore.getState().threads.map((thread) => thread.id)).not.toContain(projectedId);
   });
 
   it("keeps the latest open remote thread when an earlier history request resolves last", async () => {
@@ -2437,6 +2815,17 @@ describe("useRemoteServersStore", () => {
       .getState()
       .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
     const callsAfterPairing = snapshot.mock.calls.length;
+    const provisionalId = remoteThreadId("d1", "rt-provisional");
+    useAppStore.getState().createThread({
+      threadId: provisionalId,
+      projectId: remoteProjectId("d1", "p1"),
+      remoteServerId: "d1",
+      remoteId: "rt-provisional",
+      agentKind: "claude",
+      config: { model: "claude-sonnet" },
+      prompt: "work remotely",
+      worktreeProvisioning: true,
+    });
 
     useRemoteServersStore.getState().setRemoteProjectSynced("d1", "p1", false);
 
@@ -2448,6 +2837,8 @@ describe("useRemoteServersStore", () => {
     expect(remoteIds()).toEqual(["p2"]);
     // Threads of an unsynced project would be orphans in the sidebar.
     expect(useAppStore.getState().threads.map((thread) => thread.remoteId)).not.toContain("rt-1");
+    expect(useAppStore.getState().threads.map((thread) => thread.id)).not.toContain(provisionalId);
+    expect(useAppStore.getState().provisioningWorktreeThreadIds[provisionalId]).toBeUndefined();
     // Purely local state — nothing was asked of the server.
     expect(snapshot).toHaveBeenCalledTimes(callsAfterPairing);
     expect(useRemoteServersStore.getState().excludedProjectIds.d1).toEqual(["p1"]);

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -36,6 +36,7 @@ import {
   projectRemoteThreadSnapshot,
   remoteOwner,
   remoteProjectId,
+  remoteThreadId,
 } from "@/renderer/state/remoteProjection";
 import {
   emitRemoteTerminalExited,
@@ -76,6 +77,7 @@ import type {
   RemoteServersState,
   RemoteSocketFactory,
   RemoteSocketLike,
+  RemoteThreadLaunchResult,
 } from "@/renderer/state/remoteServers/types";
 
 /**
@@ -191,6 +193,8 @@ function syncRemoteAppRows(
     };
   });
   const projectedThreads = threads?.map((thread) => projectRemoteThread(desktopId, thread));
+  const appState = useAppStore.getState();
+  const projectedThreadIds = new Set(projectedThreads?.map((thread) => thread.id) ?? []);
   if (projectedProjects) {
     const projectedProjectIds = new Set(projectedProjects.map((project) => project.id));
     for (const project of useAppStore.getState().projects) {
@@ -200,31 +204,46 @@ function syncRemoteAppRows(
     }
   }
   if (projectedThreads) {
-    const projectedThreadIds = new Set(projectedThreads.map((thread) => thread.id));
-    for (const thread of useAppStore.getState().threads) {
-      if (thread.remoteServerId === desktopId && !projectedThreadIds.has(thread.id)) {
+    for (const thread of appState.threads) {
+      if (
+        thread.remoteServerId === desktopId &&
+        !projectedThreadIds.has(thread.id) &&
+        appState.provisioningWorktreeThreadIds[thread.id] !== true
+      ) {
         useAppStore.getState().deleteThread(thread.id);
       }
     }
   }
-  useAppStore.setState((state) => ({
-    ...(projectedProjects
-      ? {
-          projects: [
-            ...state.projects.filter((project) => project.remoteServerId !== desktopId),
-            ...projectedProjects,
-          ],
-        }
-      : {}),
-    ...(projectedThreads
-      ? {
-          threads: [
-            ...state.threads.filter((thread) => thread.remoteServerId !== desktopId),
-            ...projectedThreads,
-          ],
-        }
-      : {}),
-  }));
+  useAppStore.setState((state) => {
+    const provisioningThreads = projectedThreads
+      ? state.threads.filter(
+          (thread) =>
+            thread.remoteServerId === desktopId &&
+            state.provisioningWorktreeThreadIds[thread.id] === true &&
+            !projectedThreadIds.has(thread.id) &&
+            state.projects.some((project) => project.id === thread.projectId),
+        )
+      : [];
+    return {
+      ...(projectedProjects
+        ? {
+            projects: [
+              ...state.projects.filter((project) => project.remoteServerId !== desktopId),
+              ...projectedProjects,
+            ],
+          }
+        : {}),
+      ...(projectedThreads
+        ? {
+            threads: [
+              ...state.threads.filter((thread) => thread.remoteServerId !== desktopId),
+              ...provisioningThreads,
+              ...projectedThreads,
+            ],
+          }
+        : {}),
+    };
+  });
   if (!projectedProjects) return;
   if (useRemoteServersStore.getState().runtime[desktopId]?.status !== "online") return;
   const gitStatuses = useGitStore.getState().statuses;
@@ -598,6 +617,18 @@ export const useRemoteServersStore = create<RemoteServersState>()(
                   const remoteThreadIds = new Set(
                     get().runtime[server.desktopId]?.threads.map((thread) => thread.id) ?? [],
                   );
+                  const appState = useAppStore.getState();
+                  if (Object.keys(appState.provisioningWorktreeThreadIds).length > 0) {
+                    for (const thread of appState.threads) {
+                      if (
+                        appState.provisioningWorktreeThreadIds[thread.id] === true &&
+                        thread.remoteServerId === server.desktopId &&
+                        thread.remoteId
+                      ) {
+                        remoteThreadIds.add(thread.remoteId);
+                      }
+                    }
+                  }
                   if (open?.desktopId === server.desktopId) {
                     remoteThreadIds.add(open.threadId);
                   }
@@ -762,8 +793,12 @@ export const useRemoteServersStore = create<RemoteServersState>()(
               candidate.desktopId === updated.desktopId ? updated : candidate,
             ),
           }));
-        } catch {
-          // refreshServer below owns the visible connection error.
+        } catch (error) {
+          if (error instanceof RemoteClientError && error.code === "protocol_version_mismatch") {
+            setRemoteServerFailure(server.desktopId, "error", friendlyError(error));
+            return;
+          }
+          // refreshServer below owns other visible connection errors.
         }
         await get().refreshServer(server.desktopId);
         startRemoteServerEventStream(server);
@@ -847,23 +882,50 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           set({ socketFactory: factory });
         },
 
-        launchRemoteThread: async (input) => {
+        launchRemoteThread: async (input, options) => {
           const runtime = get().runtime[input.desktopId];
           const project = runtime?.projects.find((entry) => entry.id === input.projectId);
           if (!project) throw new Error(i18n._(msg`Remote project not found.`));
           const result = await withClient(input.desktopId, (client) =>
             client.startNewThread({
+              ...(input.threadId ? { threadId: input.threadId } : {}),
               projectId: input.projectId,
               agentKind: input.agentKind,
               config: input.config,
               prompt: input.prompt,
               ...(input.segments ? { segments: input.segments } : {}),
               presentationMode: input.presentationMode,
+              ...(input.userMessageItemId ? { userMessageItemId: input.userMessageItemId } : {}),
               ...(input.worktreePath ? { worktreePath: input.worktreePath } : {}),
               ...(input.worktreeBranch ? { worktreeBranch: input.worktreeBranch } : {}),
               ...(input.isNewWorktree ? { isNewWorktree: true } : {}),
             }),
           );
+          const compensateIfAbandoned = async (): Promise<
+            Exclude<RemoteThreadLaunchResult, "started"> | undefined
+          > => {
+            if (options?.isPendingLaunchOwned?.() !== false) return undefined;
+            const clearProjectedLaunch = () => {
+              const open = get().openThread;
+              if (open?.desktopId === input.desktopId && open.threadId === result.threadId) {
+                get().closeRemoteThread();
+              }
+              useAppStore.getState().deleteThread(remoteThreadId(input.desktopId, result.threadId));
+            };
+            try {
+              await withClient(input.desktopId, (client) =>
+                client.sendThreadCommand({ kind: "delete", threadId: result.threadId }),
+              );
+            } catch (error) {
+              toast.danger(friendlyError(error));
+              clearProjectedLaunch();
+              return "cancellation-failed";
+            }
+            clearProjectedLaunch();
+            return "cancelled";
+          };
+          let cancellation = await compensateIfAbandoned();
+          if (cancellation) return cancellation;
           const appeared = await waitForRemoteThreadAppearance({
             refresh: () => get().refreshServer(input.desktopId),
             hasThread: () =>
@@ -872,7 +934,12 @@ export const useRemoteServersStore = create<RemoteServersState>()(
               ) ?? false,
           });
           if (!appeared) throw new Error(i18n._(msg`Unable to start the remote thread.`));
+          cancellation = await compensateIfAbandoned();
+          if (cancellation) return cancellation;
           await get().openRemoteThread(input.desktopId, result.threadId);
+          cancellation = await compensateIfAbandoned();
+          if (cancellation) return cancellation;
+          return "started";
         },
 
         openRemoteThread: async (desktopId, threadId) => {

--- a/src/renderer/state/slices/launchSlice.ts
+++ b/src/renderer/state/slices/launchSlice.ts
@@ -4,14 +4,21 @@ import type { SliceCreator } from "./shared";
 export interface LaunchSlice {
   pendingThreadLaunches: Record<string, string>;
   pendingLaunchSegments: Record<string, PromptSegment[]>;
-  queueThreadLaunch: (threadId: string, prompt: string, segments?: PromptSegment[]) => void;
+  pendingLaunchUserMessageItemIds: Record<string, string>;
+  queueThreadLaunch: (
+    threadId: string,
+    prompt: string,
+    segments?: PromptSegment[],
+    userMessageItemId?: string,
+  ) => void;
   consumeThreadLaunch: (threadId: string) => void;
 }
 
 export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
   pendingThreadLaunches: {},
   pendingLaunchSegments: {},
-  queueThreadLaunch: (threadId, prompt, segments) =>
+  pendingLaunchUserMessageItemIds: {},
+  queueThreadLaunch: (threadId, prompt, segments, userMessageItemId) =>
     set((state) => ({
       pendingThreadLaunches: {
         ...state.pendingThreadLaunches,
@@ -25,6 +32,14 @@ export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
             },
           }
         : {}),
+      ...(userMessageItemId
+        ? {
+            pendingLaunchUserMessageItemIds: {
+              ...state.pendingLaunchUserMessageItemIds,
+              [threadId]: userMessageItemId,
+            },
+          }
+        : {}),
     })),
   consumeThreadLaunch: (threadId) =>
     set((state) => {
@@ -34,6 +49,8 @@ export const createLaunchSlice: SliceCreator<LaunchSlice> = (set) => ({
 
       const { [threadId]: _removed, ...pendingThreadLaunches } = state.pendingThreadLaunches;
       const { [threadId]: _removedSeg, ...pendingLaunchSegments } = state.pendingLaunchSegments;
-      return { pendingThreadLaunches, pendingLaunchSegments };
+      const { [threadId]: _removedUserMessage, ...pendingLaunchUserMessageItemIds } =
+        state.pendingLaunchUserMessageItemIds;
+      return { pendingThreadLaunches, pendingLaunchSegments, pendingLaunchUserMessageItemIds };
     }),
 });

--- a/src/renderer/state/slices/projectSlice.ts
+++ b/src/renderer/state/slices/projectSlice.ts
@@ -150,6 +150,16 @@ export const createProjectSlice: SliceCreator<ProjectSlice> = (set) => ({
           ([threadId]) => !projectThreadIds.has(threadId),
         ),
       );
+      const nextPendingLaunchUserMessageItemIds = Object.fromEntries(
+        Object.entries(state.pendingLaunchUserMessageItemIds).filter(
+          ([threadId]) => !projectThreadIds.has(threadId),
+        ),
+      );
+      const nextProvisioningWorktreeThreadIds = Object.fromEntries(
+        Object.entries(state.provisioningWorktreeThreadIds).filter(
+          ([threadId]) => !projectThreadIds.has(threadId),
+        ),
+      ) as Record<string, true>;
 
       const { [projectId]: _draft, ...nextDraftContents } = state.draftContents;
       const nextThreadDraftContents = Object.fromEntries(
@@ -179,6 +189,8 @@ export const createProjectSlice: SliceCreator<ProjectSlice> = (set) => ({
         threads: nextThreads,
         pendingThreadLaunches: nextPendingThreadLaunches,
         pendingLaunchSegments: nextPendingLaunchSegments,
+        pendingLaunchUserMessageItemIds: nextPendingLaunchUserMessageItemIds,
+        provisioningWorktreeThreadIds: nextProvisioningWorktreeThreadIds,
         draftContents: nextDraftContents,
         threadDraftContents: nextThreadDraftContents,
         view: nextView,

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -30,6 +30,8 @@ import type { SliceCreator } from "./shared";
 
 export interface ThreadSlice {
   threads: Thread[];
+  /** Optimistic local and projected-remote rows whose host launches are not authoritative yet. */
+  provisioningWorktreeThreadIds: Record<string, true>;
   /**
    * Per-thread snapshot of the supervisor's last-reported `session.config`.
    * Used to distinguish "supervisor truly changed the config" from "supervisor
@@ -60,6 +62,8 @@ export interface ThreadSlice {
   createThread: (input: {
     threadId?: string;
     projectId: string;
+    remoteServerId?: string;
+    remoteId?: string;
     agentKind: Thread["agentKind"];
     agentInstanceId?: AgentInstanceId;
     config: ThreadConfig;
@@ -68,6 +72,7 @@ export interface ThreadSlice {
     title?: string;
     worktreePath?: string;
     worktreeBranch?: string;
+    worktreeProvisioning?: boolean;
     groupId?: string;
     groupName?: string;
     replacePaneId?: string;
@@ -79,7 +84,12 @@ export interface ThreadSlice {
   }) => Thread;
   deleteThread: (threadId: string) => void;
   renameThread: (threadId: string, title: string) => void;
-  setThreadWorktree: (threadId: string, worktreePath: string, worktreeBranch?: string) => void;
+  setThreadWorktree: (
+    threadId: string,
+    worktreePath: string,
+    worktreeBranch?: string,
+    options?: { preserveProvisioning?: boolean },
+  ) => void;
   updateThreadConfig: (threadId: string, config: ThreadConfig) => void;
   updateThreadRuntime: (
     threadId: string,
@@ -92,6 +102,7 @@ export interface ThreadSlice {
       canResumeWithConfig: boolean;
       threadStatusSource?: ThreadStatusSource;
       forceCloseActiveTurn?: boolean;
+      errorMessage?: string;
     },
   ) => void;
   archiveThread: (threadId: string) => void;
@@ -113,6 +124,7 @@ export interface ThreadSlice {
 
 export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
   threads: [],
+  provisioningWorktreeThreadIds: {},
   lastRuntimeConfigByThreadId: {},
   lastViewedAtByThreadId: {},
   mcpLaunchCustomServerNamesByThreadId: {},
@@ -145,6 +157,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
   createThread: ({
     threadId,
     projectId,
+    remoteServerId,
+    remoteId,
     agentKind,
     agentInstanceId,
     config,
@@ -152,6 +166,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
     title,
     worktreePath,
     worktreeBranch,
+    worktreeProvisioning,
     groupId,
     groupName,
     replacePaneId: replacePaneIdParam,
@@ -163,6 +178,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
     const thread: Thread = {
       id: threadId ?? crypto.randomUUID(),
       projectId,
+      ...(remoteServerId ? { remoteServerId } : {}),
+      ...(remoteId ? { remoteId } : {}),
       title: title ?? makeThreadTitle(prompt),
       agentKind,
       ...(agentInstanceId ? { agentInstanceId } : {}),
@@ -203,6 +220,9 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
       }
       return {
         threads: [thread, ...state.threads],
+        provisioningWorktreeThreadIds: worktreeProvisioning
+          ? { ...state.provisioningWorktreeThreadIds, [thread.id]: true }
+          : state.provisioningWorktreeThreadIds,
         view: nextView,
         lastRuntimeConfigByThreadId: {
           ...state.lastRuntimeConfigByThreadId,
@@ -246,6 +266,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         state.lastViewedAtByThreadId;
       const { [threadId]: _droppedMcpLaunch, ...mcpLaunchCustomServerNamesByThreadId } =
         state.mcpLaunchCustomServerNamesByThreadId;
+      const { [threadId]: _droppedProvisioning, ...provisioningWorktreeThreadIds } =
+        state.provisioningWorktreeThreadIds;
       const { [threadId]: _droppedThreadDraft, ...threadDraftContents } = state.threadDraftContents;
       // The thread is gone — drop it from the keep-alive cache so its terminal
       // disposes and doesn't leak.
@@ -254,11 +276,15 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         threads: nextThreads,
         threadDraftContents,
         mcpLaunchCustomServerNamesByThreadId,
+        provisioningWorktreeThreadIds,
         pendingThreadLaunches: Object.fromEntries(
           Object.entries(state.pendingThreadLaunches).filter(([id]) => id !== threadId),
         ),
         pendingLaunchSegments: Object.fromEntries(
           Object.entries(state.pendingLaunchSegments).filter(([id]) => id !== threadId),
+        ),
+        pendingLaunchUserMessageItemIds: Object.fromEntries(
+          Object.entries(state.pendingLaunchUserMessageItemIds).filter(([id]) => id !== threadId),
         ),
         runtimeItemIdsByThread,
         runtimeItemsByIdByThread,
@@ -278,19 +304,26 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
         thread.id === threadId ? { ...thread, title, updatedAt: new Date().toISOString() } : thread,
       ),
     })),
-  setThreadWorktree: (threadId, worktreePath, worktreeBranch) =>
-    set((state) => ({
-      threads: state.threads.map((thread) =>
-        thread.id === threadId
-          ? {
-              ...thread,
-              worktreePath,
-              ...(worktreeBranch ? { worktreeBranch } : {}),
-              updatedAt: new Date().toISOString(),
-            }
-          : thread,
-      ),
-    })),
+  setThreadWorktree: (threadId, worktreePath, worktreeBranch, options) =>
+    set((state) => {
+      const { [threadId]: _droppedProvisioning, ...provisioningWorktreeThreadIds } =
+        state.provisioningWorktreeThreadIds;
+      return {
+        threads: state.threads.map((thread) =>
+          thread.id === threadId
+            ? {
+                ...thread,
+                worktreePath,
+                ...(worktreeBranch ? { worktreeBranch } : {}),
+                updatedAt: new Date().toISOString(),
+              }
+            : thread,
+        ),
+        provisioningWorktreeThreadIds: options?.preserveProvisioning
+          ? state.provisioningWorktreeThreadIds
+          : provisioningWorktreeThreadIds,
+      };
+    }),
   updateThreadConfig: (threadId, config) =>
     set((state) => {
       let changed = false;
@@ -378,7 +411,8 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
           !sessionRefChanged &&
           thread.activeTurnStartedAt === nextTurnTiming.activeTurnStartedAt &&
           thread.lastTurnStartedAt === nextTurnTiming.lastTurnStartedAt &&
-          thread.lastTurnEndedAt === nextTurnTiming.lastTurnEndedAt
+          thread.lastTurnEndedAt === nextTurnTiming.lastTurnEndedAt &&
+          (input.errorMessage === undefined || thread.errorMessage === input.errorMessage)
         ) {
           return thread;
         }
@@ -402,6 +436,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
             : {}),
           ...(nextSessionRef ? { sessionRef: nextSessionRef } : {}),
           ...(input.slashCommands !== undefined ? { slashCommands: input.slashCommands } : {}),
+          ...(input.errorMessage !== undefined ? { errorMessage: input.errorMessage } : {}),
           ...(turnStarted ? { updatedAt: nowIso } : {}),
           ...(activityClearsDone ? { done: false, doneAt: undefined } : {}),
           ...nextTurnTiming,

--- a/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
+++ b/src/renderer/views/MainView/parts/AppContent/parts/ThreadPane.tsx
@@ -65,9 +65,11 @@ export function ThreadPane(props: {
     ? (remoteAgentStatuses ?? [])
     : projectAgentStatuses;
   const agentStatus = effectiveAgentStatuses.find((status) => status.kind === thread?.agentKind);
-  const { prompt: pendingLaunchPrompt, segments: pendingLaunchSegments } = useThreadPendingLaunch(
-    props.threadId,
-  );
+  const {
+    prompt: pendingLaunchPrompt,
+    segments: pendingLaunchSegments,
+    userMessageItemId: pendingLaunchUserMessageItemId,
+  } = useThreadPendingLaunch(props.threadId);
   const { applyRuntimeEvent, updateThreadRuntime, consumeThreadLaunch } = useAppStore.getState();
 
   const paneElementRef = useRef<HTMLDivElement>(null);
@@ -174,6 +176,7 @@ export function ThreadPane(props: {
       }}
       {...(pendingLaunchPrompt !== undefined ? { pendingLaunchPrompt } : {})}
       {...(pendingLaunchSegments ? { pendingLaunchSegments } : {})}
+      {...(pendingLaunchUserMessageItemId ? { pendingLaunchUserMessageItemId } : {})}
       installedAgents={thread.remoteServerId ? effectiveAgentStatuses : installedAgents}
       {...(thread.remoteServerId
         ? {

--- a/src/server/createHeadlessRemoteHost.test.ts
+++ b/src/server/createHeadlessRemoteHost.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PORACODE_REMOTE_PROTOCOL_VERSION } from "@/shared/remote";
 import { createHeadlessRemoteHost, resolveLocalProxyBase } from "./createHeadlessRemoteHost";
 
 // Mutable state shared with the hoisted vi.mock factories.
@@ -143,7 +144,7 @@ describe("createHeadlessRemoteHost", () => {
       new URL("/.well-known/poracode/environment", info.httpBaseUrl),
     ).then((response) => response.json());
     expect(descriptor).toMatchObject({
-      protocolVersion: 1,
+      protocolVersion: PORACODE_REMOTE_PROTOCOL_VERSION,
       hostMode: "helper",
       appVersion: "9.9.9-test",
     });

--- a/src/shared/contracts/thread.ts
+++ b/src/shared/contracts/thread.ts
@@ -247,6 +247,7 @@ export const remoteThreadCommandSchema = z.discriminatedUnion("kind", [
     title: z.string().min(1).optional(),
     segments: z.array(promptSegmentSchema).optional(),
     presentationMode: threadPresentationModeSchema.optional(),
+    userMessageItemId: z.string().min(1).optional(),
     worktreePath: z.string().min(1).optional(),
     worktreeBranch: z.string().optional(),
     prNumber: z.number().int().min(1).optional(),

--- a/src/shared/remote/client.test.ts
+++ b/src/shared/remote/client.test.ts
@@ -5,6 +5,7 @@ import {
   RemoteClientError,
   RemoteDesktopClient,
 } from "./client";
+import { PORACODE_REMOTE_PROTOCOL_VERSION } from "./protocol";
 
 describe("remote error classification", () => {
   it("separates transport failures from reachable application errors", () => {
@@ -406,6 +407,46 @@ describe("RemoteDesktopClient", () => {
     expect(commandId).toBe("user-message-1");
   });
 
+  it("forwards a preallocated thread and optimistic message id when starting remotely", async () => {
+    let requestUrl = "";
+    let requestBody: unknown;
+    const client = new RemoteDesktopClient(
+      "http://127.0.0.1:38987/",
+      "lc_access_test",
+      async (url, init) => {
+        requestUrl = String(url);
+        requestBody = JSON.parse(typeof init?.body === "string" ? init.body : "{}") as unknown;
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+
+    await expect(
+      client.startNewThread({
+        threadId: "thread-preallocated",
+        projectId: "project-1",
+        agentKind: "codex",
+        config: { model: "gpt-5" },
+        prompt: "build remotely",
+        presentationMode: "gui",
+        userMessageItemId: "user-optimistic",
+      }),
+    ).resolves.toEqual({ threadId: "thread-preallocated" });
+
+    expect(requestBody).toEqual({
+      kind: "start",
+      projectId: "project-1",
+      agentKind: "codex",
+      config: { model: "gpt-5" },
+      prompt: "build remotely",
+      presentationMode: "gui",
+      userMessageItemId: "user-optimistic",
+    });
+    expect(requestUrl).toBe("http://127.0.0.1:38987/api/threads/thread-preallocated/command");
+  });
+
   it("forwards goal controls to the paired desktop", async () => {
     let requestUrl = "";
     let requestBody: unknown;
@@ -544,9 +585,9 @@ describe("RemoteDesktopClient", () => {
       { status: 200, headers: { "content-type": "application/json" } },
     );
 
-  it("surfaces a protocol-version mismatch as a readable, branchable error", async () => {
+  it("rejects a released v1 host that cannot preserve optimistic user-message ids", async () => {
     const client = new RemoteDesktopClient("http://127.0.0.1:38987/", undefined, async () =>
-      descriptorResponse(999, ["session:read"]),
+      descriptorResponse(1, ["session:read"]),
     );
 
     await expect(client.environment()).rejects.toMatchObject({
@@ -570,7 +611,7 @@ describe("RemoteDesktopClient", () => {
           },
         );
       }
-      return descriptorResponse(1, ["session:read"]);
+      return descriptorResponse(PORACODE_REMOTE_PROTOCOL_VERSION, ["session:read"]);
     });
 
     await expect(client.environment()).resolves.toMatchObject({ desktopId: "desktop-1" });
@@ -582,7 +623,11 @@ describe("RemoteDesktopClient", () => {
 
   it("drops server-advertised scopes this build does not know instead of failing to parse", async () => {
     const client = new RemoteDesktopClient("http://127.0.0.1:38987/", undefined, async () =>
-      descriptorResponse(1, ["session:read", "session:operate", "future:capability"]),
+      descriptorResponse(PORACODE_REMOTE_PROTOCOL_VERSION, [
+        "session:read",
+        "session:operate",
+        "future:capability",
+      ]),
     );
 
     const descriptor = await client.environment();

--- a/src/shared/remote/client.ts
+++ b/src/shared/remote/client.ts
@@ -186,13 +186,13 @@ interface StartRemoteThreadCommon {
   readonly prompt: string;
   readonly segments?: readonly PromptSegment[] | undefined;
   readonly presentationMode?: ThreadPresentationMode | undefined;
+  readonly userMessageItemId?: StartThreadPayload["userMessageItemId"] | undefined;
 }
 
 export interface StartRemoteThreadInput extends StartRemoteThreadCommon {
   readonly projectLocation: ProjectLocation;
   readonly initialSize?: TerminalSize | undefined;
   readonly sessionRef?: StartThreadPayload["sessionRef"] | undefined;
-  readonly userMessageItemId?: StartThreadPayload["userMessageItemId"] | undefined;
 }
 
 export interface StartRemoteNewThreadInput extends StartRemoteThreadCommon {
@@ -637,6 +637,7 @@ export class RemoteDesktopClient {
       prompt: input.prompt,
       ...(input.segments && input.segments.length > 0 ? { segments: [...input.segments] } : {}),
       ...(input.presentationMode ? { presentationMode: input.presentationMode } : {}),
+      ...(input.userMessageItemId ? { userMessageItemId: input.userMessageItemId } : {}),
       ...(input.worktreePath ? { worktreePath: input.worktreePath } : {}),
       ...(input.worktreeBranch ? { worktreeBranch: input.worktreeBranch } : {}),
       ...(input.isNewWorktree ? { isNewWorktree: true } : {}),

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -15,7 +15,9 @@ import { persistedCompletedTurnSchema, persistedRuntimeItemSchema } from "../ipc
 import { gitStateInterestSchema, gitStatePatchSchema, gitStateSnapshotSchema } from "../gitState";
 import { sharedSettingsSchema } from "../settings";
 
-export const PORACODE_REMOTE_PROTOCOL_VERSION = 1;
+// v2 requires remote start commands to preserve caller-supplied user-message
+// ids so optimistic GUI prompts reconcile without duplication across hosts.
+export const PORACODE_REMOTE_PROTOCOL_VERSION = 2;
 export const REMOTE_COMMAND_ID_HEADER = "x-poracode-command-id";
 
 export const remoteAccessScopeSchema = z.enum([


### PR DESCRIPTION
- Feature PR (with a chat fix): optimistic worktree launch messaging, PR merge-base sync + sidebar sync badges, and project location icons in selectors
- Show optimistic user messages and "Creating worktree…" state while a thread's worktree provisions, and clean up the placeholder if launch is canceled
- Sync merged PR bases into worktree projects and surface sync badges across sidebar thread and worktree groups
- Show project location icons (local vs remote) in project selectors across MCP, skills, GitHub Actions, schedules, and other pickers
- Fix chat so trailing goal updates don't reopen completed turns; bump the remote protocol to v2 for the new launch message contract