### PR TITLE
Unify context menu end action hover with row hover style

### DIFF
--- a/src/renderer/components/common/ContextMenu.test.tsx
+++ b/src/renderer/components/common/ContextMenu.test.tsx
@@ -33,7 +33,9 @@ describe("ContextMenu", () => {
     );
 
     fireEvent.contextMenu(screen.getByRole("button", { name: "Row" }));
-    fireEvent.click(await screen.findByRole("button", { name: "Stop Run" }));
+    const stopButton = await screen.findByRole("button", { name: "Stop Run" });
+    expect(stopButton).toHaveClass("[--button-bg-hover:var(--row-hover)]");
+    fireEvent.click(stopButton);
 
     expect(onAction).toHaveBeenCalledWith("stop");
     expect(onAction).not.toHaveBeenCalledWith("run");

--- a/src/renderer/components/common/ContextMenu.tsx
+++ b/src/renderer/components/common/ContextMenu.tsx
@@ -114,7 +114,7 @@ function renderDropdownItem(
           size="sm"
           variant="ghost"
           aria-label={item.endAction.label}
-          className="ml-auto size-5 min-w-0 text-muted hover:text-foreground"
+          className="ml-auto size-5 min-w-0 text-muted hover:text-foreground [--button-bg-hover:var(--row-hover)]"
           {...(item.endAction.isDisabled ? { isDisabled: true } : {})}
           onPress={() => {
             close();


### PR DESCRIPTION
- Fix inconsistent hover styling between the context menu end action button and its surrounding row.
- Apply the row hover background variable to the end action button so hover states match.
- Add a regression test asserting the end action uses the row hover style.