### PR TITLE
Fix end action press propagation in context menu

### DIFF
--- a/src/renderer/components/common/ContextMenu.test.tsx
+++ b/src/renderer/components/common/ContextMenu.test.tsx
@@ -3,6 +3,24 @@ import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ContextMenu, ContextMenuSurface } from "./ContextMenu";
 
+vi.hoisted(() => {
+  class TestPointerEvent extends MouseEvent {
+    pointerId: number;
+    pointerType: string;
+
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 1;
+      this.pointerType = init.pointerType ?? "mouse";
+    }
+  }
+
+  Object.defineProperty(globalThis, "PointerEvent", {
+    configurable: true,
+    value: TestPointerEvent,
+  });
+});
+
 describe("ContextMenu", () => {
   it("does not wrap its child in an extra DOM element", () => {
     const { container } = render(
@@ -35,6 +53,8 @@ describe("ContextMenu", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: "Row" }));
     const stopButton = await screen.findByRole("button", { name: "Stop Run" });
     expect(stopButton).toHaveClass("[--button-bg-hover:var(--row-hover)]");
+    fireEvent.pointerDown(stopButton, { pointerId: 1, pointerType: "mouse", button: 0 });
+    fireEvent.pointerUp(stopButton, { pointerId: 1, pointerType: "mouse", button: 0 });
     fireEvent.click(stopButton);
 
     expect(onAction).toHaveBeenCalledWith("stop");

--- a/src/renderer/components/common/ContextMenu.tsx
+++ b/src/renderer/components/common/ContextMenu.tsx
@@ -116,6 +116,7 @@ function renderDropdownItem(
           aria-label={item.endAction.label}
           className="ml-auto size-5 min-w-0 text-muted hover:text-foreground [--button-bg-hover:var(--row-hover)]"
           {...(item.endAction.isDisabled ? { isDisabled: true } : {})}
+          onPressStart={(event) => event.continuePropagation()}
           onPress={() => {
             close();
             onAction(item.endAction!.id);


### PR DESCRIPTION
- **Bugfix**: The end action button in context-menu rows (e.g. Stop Run, the `ml-auto` trailing button) now continues the press event to the underlying row, so clicking it reliably fires the action.
- Previously the press was captured by the context-menu handling, leaving the end action unresponsive.
- Added test coverage in `ContextMenu.test.tsx` that simulates the full pointer down/up/click sequence, with a `PointerEvent` shim for the test environment.