### PR TITLE
Include sub-provider in sub-agent names

### DIFF
--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -78,7 +78,10 @@ interface Harness {
 }
 
 function makeHarness(options?: {
+  providerLabel?: string;
   models?: Array<{ id: string; label: string }>;
+  subProviders?: Array<{ id: string; label: string }>;
+  modelSubProvider?: Record<string, string>;
   statusCapabilities?: AgentCapability | null;
   createFailures?: number;
   deferCreate?: boolean;
@@ -95,9 +98,11 @@ function makeHarness(options?: {
 
   const adapter = {
     kind: "codex",
-    label: "Codex",
+    label: options?.providerLabel ?? "Codex",
     capabilities: {
       models: options?.models ?? [{ id: "gpt-5.5", label: "GPT-5.5" }],
+      ...(options?.subProviders ? { subProviders: options.subProviders } : {}),
+      ...(options?.modelSubProvider ? { modelSubProvider: options.modelSubProvider } : {}),
       efforts: ["low", "high"],
       fastModels: ["gpt-5.5"],
       approvalPolicies: [
@@ -240,6 +245,25 @@ describe("SubagentRunManager", () => {
     const event = started?.event as Extract<RuntimeEvent, { type: "item.started" }> | undefined;
     expect(event?.payload).toMatchObject({
       name: "builder — Codex · GPT-5.5 · High · Fast",
+    });
+  });
+
+  it("includes the selected model's sub-provider in the sub-agent name", () => {
+    const h = makeHarness({
+      providerLabel: "OpenCode",
+      models: [{ id: "opencode-go/qwen3.8-max", label: "Qwen3.8 Max" }],
+      subProviders: [{ id: "opencode-go", label: "OpenCode Go" }],
+    });
+    h.manager.spawn(PARENT, {
+      agent: "codex",
+      prompt: "do work",
+      model: "opencode-go/qwen3.8-max",
+      effort: "high",
+    });
+    const started = h.appended.find((a) => a.event.type === "item.started");
+    const event = started?.event as Extract<RuntimeEvent, { type: "item.started" }> | undefined;
+    expect(event?.payload).toMatchObject({
+      name: "OpenCode · OpenCode Go · Qwen3.8 Max · High",
     });
   });
 

--- a/src/supervisor/crossagentMcp/spawnPlan.ts
+++ b/src/supervisor/crossagentMcp/spawnPlan.ts
@@ -92,8 +92,19 @@ function resolveAttempt(
 
   const modelLabel =
     capabilities.models.find((candidate) => candidate.id === model)?.label ?? model;
+  const subProviderLabel = capabilities.subProviders?.find((candidate) => {
+    const mappedId = capabilities.modelSubProvider?.[model];
+    return (
+      candidate.id === mappedId ||
+      model.startsWith(`${candidate.id}/`) ||
+      model.startsWith(`${candidate.id}:`)
+    );
+  })?.label;
   const selectionLabel = [
     adapter.label,
+    ...(subProviderLabel && subProviderLabel.toLowerCase() !== adapter.label.toLowerCase()
+      ? [subProviderLabel]
+      : []),
     modelLabel,
     ...(selection.effort ? [formatReasoningLabel(selection.effort)] : []),
     ...(selection.fast === true ? ["Fast"] : []),


### PR DESCRIPTION
- Bugfix: Add sub-provider labels to sub-agent names when applicable.
- Avoid duplicate provider labels in generated names.
- Add coverage for mapped sub-provider naming.