### PR TITLE
Update Kimi subscription credit multipliers

### DIFF
--- a/packages/agents-usage/src/collectors/kimi.test.ts
+++ b/packages/agents-usage/src/collectors/kimi.test.ts
@@ -39,9 +39,13 @@ describe("parseKimiUsage", () => {
     expect(session.resetsAt).toBe(Date.parse(SESSION_RESET));
   });
 
-  it("maps the membership level to the subscription plan name with its credit multiplier", () => {
-    const snap = parseKimiUsage(JSON.parse(USAGES_BODY), FAKE_NOW_MS);
-    expect(snap.plan).toBe("Allegretto 5x");
+  it("maps paid membership levels to the current subscription credit multipliers", () => {
+    const body = JSON.parse(USAGES_BODY);
+    expect(parseKimiUsage(body, FAKE_NOW_MS).plan).toBe("Allegretto 2x");
+    body.user.membership.level = "LEVEL_ADVANCED";
+    expect(parseKimiUsage(body, FAKE_NOW_MS).plan).toBe("Allegro 5x");
+    body.user.membership.level = "LEVEL_STANDARD";
+    expect(parseKimiUsage(body, FAKE_NOW_MS).plan).toBe("Vivace 10x");
   });
 
   it("humanizes unknown membership levels and omits plan when absent", () => {

--- a/packages/agents-usage/src/collectors/kimi.ts
+++ b/packages/agents-usage/src/collectors/kimi.ts
@@ -56,7 +56,7 @@ export interface KimiUsagesResponse {
  * Subscription tier names shown on kimi.com/membership, keyed by the
  * `user.membership.level` enum the usages endpoint returns. Paid tiers above
  * the base carry the Kimi Code credit multiplier from the pricing page
- * (Allegretto 5x / Allegro 15x / Vivace 30x), mirroring the Codex plan labels
+ * (Allegretto 2x / Allegro 5x / Vivace 10x), mirroring the Codex plan labels
  * ("ChatGPT Pro 20x"). Unknown levels fall back to a humanized form of the
  * enum ("LEVEL_SOMETHING" → "Something") so a new tier still shows a readable
  * name instead of nothing.
@@ -65,9 +65,9 @@ const KIMI_PLAN_BY_LEVEL: Record<string, string> = {
   LEVEL_FREE: "Adagio",
   LEVEL_TRIAL: "Andante",
   LEVEL_BASIC: "Moderato",
-  LEVEL_INTERMEDIATE: "Allegretto 5x",
-  LEVEL_ADVANCED: "Allegro 15x",
-  LEVEL_STANDARD: "Vivace 30x",
+  LEVEL_INTERMEDIATE: "Allegretto 2x",
+  LEVEL_ADVANCED: "Allegro 5x",
+  LEVEL_STANDARD: "Vivace 10x",
 };
 
 function formatKimiPlan(level: unknown): string | undefined {


### PR DESCRIPTION
Tickets: None

- Correct Kimi paid-tier credit multipliers to match current subscriptions.
- Expand collector tests to cover all paid membership levels.