### PR TITLE
Include explicit fast=false in draft thread launch config

### DIFF
--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -960,6 +960,48 @@ describe("ThreadDraftView", () => {
     });
   });
 
+  it("submits an explicit Fast-off selection in the launch config", async () => {
+    const onStart = vi.fn<(input: unknown) => void>();
+
+    render(
+      <ThreadDraftView
+        project={project}
+        agentStatuses={[cursorStatus]}
+        lastDraftConfig={{
+          agentKind: "cursor",
+          model: "composer-2",
+          effort: "",
+          fast: false,
+          mode: "agent",
+          approvalPolicy: "default",
+          sandboxMode: "",
+          worktreeMode: false,
+        }}
+        onStart={onStart}
+      />,
+    );
+
+    await waitFor(() => {
+      const props = composerSpy.mock.lastCall?.[0] as {
+        controls: Array<{ kind?: string; currentModel?: string }>;
+      };
+      expect(
+        props.controls.some(
+          (control) => control.kind === "provider-model" && control.currentModel === "composer-2",
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByText("set-prompt"));
+    fireEvent.click(screen.getByText("submit"));
+
+    expect(onStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ fast: false }),
+      }),
+    );
+  });
+
   it("keeps a globally disabled built-in out of the composer and launch config", async () => {
     const onStart = vi.fn<(input: unknown) => void>();
     useSharedSettings.setState({

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -43,6 +43,7 @@ import {
   resolvePreferredAgentKind,
   resolveProviderDraftConfig,
   resolveSavedProviderDraftConfig,
+  supportsUsableFastMode,
   resolveThinkingValue,
 } from "./threadDraftViewHelpers";
 import { friendlyError } from "@/shared/messages";
@@ -1075,7 +1076,10 @@ export function ThreadDraftView(props: {
               model,
               ...(effort ? { effort } : {}),
               ...(contextSize ? { contextSize } : {}),
-              ...(fast ? { fast } : {}),
+              ...(selectedAgentForConfig &&
+              supportsUsableFastMode(selectedAgentForConfig.capabilities, model)
+                ? { fast }
+                : {}),
               ...(thinking ? { thinking } : {}),
               ...(mode ? { mode } : {}),
               ...(approvalPolicy ? { approvalPolicy } : {}),


### PR DESCRIPTION
**Type:** Bugfix

- Preserve an explicit Fast-off choice when starting a thread from a draft so launch config no longer drops `fast: false`.
- Only emit the `fast` flag for agents/models that support usable Fast mode, keeping launch config accurate for those providers.
- Add a regression test that submits a draft with Fast off and asserts `fast: false` is present in the start config.