### PR TITLE
Improve pane insert DnD and new-thread project drag

### DIFF
--- a/src/renderer/components/common/ContextMenu.test.tsx
+++ b/src/renderer/components/common/ContextMenu.test.tsx
@@ -3,6 +3,16 @@ import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ContextMenu, ContextMenuSurface } from "./ContextMenu";
 
+const dragState = { isDragging: false };
+const draggableInputs: unknown[] = [];
+
+vi.mock("@dnd-kit/react", () => ({
+  useDraggable: (input: unknown) => {
+    draggableInputs.push(input);
+    return { isDragging: dragState.isDragging, ref: () => {} };
+  },
+}));
+
 vi.hoisted(() => {
   class TestPointerEvent extends MouseEvent {
     pointerId: number;
@@ -61,6 +71,60 @@ describe("ContextMenu", () => {
     expect(onAction).not.toHaveBeenCalledWith("run");
     await vi.waitFor(() => {
       expect(screen.queryByRole("menuitem", { name: "Run" })).not.toBeInTheDocument();
+    });
+  });
+
+  describe("draggable rows", () => {
+    const dragSource = {
+      id: "new-thread-menu:p2",
+      type: "new-thread",
+      data: { type: "new-thread", projectId: "p2" },
+    };
+
+    function renderSurface(onClose: () => void, position: { x: number; y: number }) {
+      return (
+        <ContextMenuSurface
+          position={position}
+          items={[{ id: "p2", label: "Beta", dragSource }]}
+          onAction={vi.fn<(key: string) => void>()}
+          onClose={onClose}
+        />
+      );
+    }
+
+    it("registers the row as a drag source and marks it grabbable", async () => {
+      dragState.isDragging = false;
+      draggableInputs.length = 0;
+      render(renderSurface(vi.fn<() => void>(), { x: 0, y: 0 }));
+
+      const row = await screen.findByRole("menuitem", { name: "Beta" });
+      expect(row).toHaveClass("cursor-grab");
+      expect(draggableInputs).toContainEqual(dragSource);
+    });
+
+    it("hides the menu while a row is dragged and closes it on drop", async () => {
+      dragState.isDragging = false;
+      const onClose = vi.fn<() => void>();
+      const { rerender } = render(renderSurface(onClose, { x: 0, y: 0 }));
+      await screen.findByRole("menuitem", { name: "Beta" });
+
+      // The dragged row keeps following the pointer (dnd-kit puts its feedback
+      // in the top layer); the surface around it must not stay in the way.
+      dragState.isDragging = true;
+      rerender(renderSurface(onClose, { x: 0, y: 1 }));
+      const menu = screen.getByRole("menu");
+      await vi.waitFor(() => {
+        expect(menu.closest(".opacity-0")).not.toBeNull();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+      // Still mounted: unmounting the dragged row would cancel the drag.
+      expect(screen.getByRole("menuitem", { name: "Beta" })).toBeInTheDocument();
+
+      dragState.isDragging = false;
+      rerender(renderSurface(onClose, { x: 0, y: 2 }));
+      await vi.waitFor(() => {
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/src/renderer/components/common/ContextMenu.tsx
+++ b/src/renderer/components/common/ContextMenu.tsx
@@ -1,6 +1,7 @@
-import React, { type MouseEventHandler, type ReactNode, useEffect, useState } from "react";
+import React, { type MouseEventHandler, type ReactNode, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Button, Dropdown, Label, Separator } from "@heroui/react";
+import { Button, Description, Dropdown, Label, Separator } from "@heroui/react";
+import { useDraggable } from "@dnd-kit/react";
 
 // Context menus can stack (e.g. the flat-list filter stacks a project menu
 // over its own), so dismissal tracks a stack of closers: a new surface pushes
@@ -25,10 +26,29 @@ function closeAllMenus(): void {
  */
 export const MENU_BACKDROP_ATTR = "data-poracode-menu-backdrop";
 
+/**
+ * Registers a menu row as a drag source in the app's drag-and-drop provider, so
+ * an entry can be dragged out of the menu onto a target elsewhere (e.g. a
+ * thread pane). `type` is matched against each drop zone's `accept` list and
+ * `data` is the payload the drop handler receives.
+ */
+export interface ContextMenuDragSource {
+  id: string;
+  type: string;
+  data: Record<string, unknown>;
+}
+
 export interface ContextMenuItem {
   id: string;
   label: string;
   icon?: ReactNode;
+  description?: string;
+  /**
+   * Makes the row draggable. The menu hides itself while the drag is in flight
+   * instead of closing: unmounting the dragged row would cancel the operation.
+   * It closes once the drag ends.
+   */
+  dragSource?: ContextMenuDragSource;
   endAction?: {
     id: string;
     label: string;
@@ -85,10 +105,65 @@ function splitSections(entries: ContextMenuEntry[]): (ContextMenuItem | ContextM
   return sections.filter((s) => s.length > 0);
 }
 
+/** Reports a row's drag state up to the surface, keyed by item id. */
+type ItemDragChangeHandler = (itemId: string, isDragging: boolean) => void;
+
 function renderDropdownItem(
   item: ContextMenuItem,
   close: () => void,
   onAction: (key: string) => void,
+  onItemDragChange?: ItemDragChangeHandler,
+) {
+  if (item.dragSource) {
+    return (
+      <DraggableDropdownItem
+        key={item.id}
+        item={item}
+        dragSource={item.dragSource}
+        close={close}
+        onAction={onAction}
+        {...(onItemDragChange ? { onItemDragChange } : {})}
+      />
+    );
+  }
+  return renderDropdownItemRow(item, close, onAction);
+}
+
+/**
+ * A draggable row. The draggable is registered on the menu item's own element,
+ * so dnd-kit's drag feedback moves the row the user grabbed — the item keeps its
+ * normal layout, unlike wrapping its content in an extra element.
+ */
+function DraggableDropdownItem(props: {
+  item: ContextMenuItem;
+  dragSource: ContextMenuDragSource;
+  close: () => void;
+  onAction: (key: string) => void;
+  onItemDragChange?: ItemDragChangeHandler;
+}) {
+  const { item, dragSource, onItemDragChange } = props;
+  const { isDragging, ref } = useDraggable({
+    id: dragSource.id,
+    type: dragSource.type,
+    data: dragSource.data,
+  });
+  const wasDraggingRef = useRef(false);
+  useEffect(() => {
+    // Report only real transitions: menus re-render on hover, and the surface
+    // closes itself on the dragging → idle edge.
+    if (wasDraggingRef.current === isDragging) return;
+    wasDraggingRef.current = isDragging;
+    onItemDragChange?.(item.id, isDragging);
+  }, [isDragging, item.id, onItemDragChange]);
+
+  return renderDropdownItemRow(props.item, props.close, props.onAction, ref);
+}
+
+function renderDropdownItemRow(
+  item: ContextMenuItem,
+  close: () => void,
+  onAction: (key: string) => void,
+  dragRef?: (element: Element | null) => void,
 ) {
   return (
     <Dropdown.Item
@@ -97,6 +172,7 @@ function renderDropdownItem(
       aria-label={item.label}
       textValue={item.label}
       variant={item.variant === "danger" ? "danger" : undefined}
+      {...(dragRef ? { ref: dragRef, className: "cursor-grab active:cursor-grabbing" } : {})}
     >
       {item.icon && (
         <span
@@ -105,9 +181,18 @@ function renderDropdownItem(
           {item.icon}
         </span>
       )}
-      <Label className={`flex-1 ${item.variant === "warning" ? "text-warning" : ""}`}>
-        {item.label}
-      </Label>
+      {item.description ? (
+        <>
+          <Label className={item.variant === "warning" ? "text-warning" : undefined}>
+            {item.label}
+          </Label>
+          <Description>{item.description}</Description>
+        </>
+      ) : (
+        <Label className={`flex-1 ${item.variant === "warning" ? "text-warning" : ""}`}>
+          {item.label}
+        </Label>
+      )}
       {item.endAction ? (
         <Button
           isIconOnly
@@ -133,6 +218,7 @@ function renderEntry(
   entry: ContextMenuItem | ContextMenuSubmenu,
   close: () => void,
   onAction: (key: string) => void,
+  onItemDragChange?: ItemDragChangeHandler,
 ) {
   if (isSubmenu(entry)) {
     return (
@@ -155,7 +241,7 @@ function renderEntry(
       </Dropdown.SubmenuTrigger>
     );
   }
-  return renderDropdownItem(entry, close, onAction);
+  return renderDropdownItem(entry, close, onAction, onItemDragChange);
 }
 
 /**
@@ -185,6 +271,27 @@ export function ContextMenuSurface(props: {
   withBackdrop?: boolean;
 }) {
   const { position, items, onAction, onClose } = props;
+  // A row being dragged out of the menu: the menu hides but stays mounted —
+  // unmounting the dragged element cancels the dnd-kit operation — and closes
+  // once the drag ends. dnd-kit promotes its drag feedback into the top layer,
+  // so the row the user grabbed keeps following the pointer while the surface
+  // around it is transparent.
+  const [isRowDragging, setIsRowDragging] = useState(false);
+  const draggingRowIdRef = useRef<string | null>(null);
+
+  function handleItemDragChange(itemId: string, isDragging: boolean) {
+    if (isDragging) {
+      draggingRowIdRef.current = itemId;
+      setIsRowDragging(true);
+      return;
+    }
+    if (draggingRowIdRef.current !== itemId) return;
+    draggingRowIdRef.current = null;
+    setIsRowDragging(false);
+    onClose();
+  }
+
+  const hiddenWhileDraggingClass = isRowDragging ? "pointer-events-none opacity-0" : "";
 
   useEffect(() => {
     if (!position) return;
@@ -229,7 +336,7 @@ export function ContextMenuSurface(props: {
             // can tell this apart from a press outside every menu.
             <div
               {...{ [MENU_BACKDROP_ATTR]: true }}
-              className="poracode-menu-backdrop fixed inset-0"
+              className={`poracode-menu-backdrop fixed inset-0 ${hiddenWhileDraggingClass}`}
               onPointerDown={(event) => {
                 event.preventDefault();
                 event.stopPropagation();
@@ -254,6 +361,7 @@ export function ContextMenuSurface(props: {
             <Dropdown.Popover
               placement="bottom start"
               isNonModal
+              className={hiddenWhileDraggingClass}
               {...(props.shouldCloseOnInteractOutside
                 ? { shouldCloseOnInteractOutside: props.shouldCloseOnInteractOutside }
                 : {})}
@@ -272,13 +380,15 @@ export function ContextMenuSurface(props: {
                   const sections = splitSections(items);
                   if (sections.length <= 1) {
                     return (sections[0] ?? []).map((entry) =>
-                      renderEntry(entry, onClose, onAction),
+                      renderEntry(entry, onClose, onAction, handleItemDragChange),
                     );
                   }
                   return sections.flatMap((section, sIdx) => {
                     const sectionEl = (
                       <Dropdown.Section key={`section-${sIdx}`}>
-                        {section.map((entry) => renderEntry(entry, onClose, onAction))}
+                        {section.map((entry) =>
+                          renderEntry(entry, onClose, onAction, handleItemDragChange),
+                        )}
                       </Dropdown.Section>
                     );
                     return sIdx > 0 ? [<Separator key={`sep-${sIdx}`} />, sectionEl] : [sectionEl];

--- a/src/renderer/components/common/ProjectRemoteServer.tsx
+++ b/src/renderer/components/common/ProjectRemoteServer.tsx
@@ -120,10 +120,10 @@ export function ProjectLocationIcon(props: {
   if (props.location.kind === "wsl") {
     return (
       <span
-        className={`${props.className ?? "size-3.5"} relative shrink-0 text-muted`}
+        className={`${props.className ?? "size-4"} relative inline-flex shrink-0 items-center justify-center text-muted`}
         aria-hidden="true"
       >
-        <TuxIcon className="absolute left-1/2 top-1/2 h-3.5 w-6 -translate-x-1/2 -translate-y-1/2" />
+        <TuxIcon className="size-full" />
       </span>
     );
   }

--- a/src/renderer/components/layout/SplitPaneContainer.tsx
+++ b/src/renderer/components/layout/SplitPaneContainer.tsx
@@ -6,6 +6,7 @@ import { type PaneLayout, type PaneLayoutAxis } from "@/shared/paneLayout";
 import { useIsInsertSplitHighlighted, useIsRootInsertHighlighted } from "@/renderer/dnd";
 import { i18n } from "@/renderer/i18n/i18n";
 import { beginPanelResize, endPanelResize } from "@/renderer/state/panelResizeSignal";
+import { paneInsertZoneId } from "./paneInsertZone";
 import {
   MIN_PANE_PERCENT,
   readStoredSizes,
@@ -106,7 +107,7 @@ export function computeLayout(
               height: DIVIDER_SIZE,
             };
         dividers.push({
-          zoneId: `pane-insert:${node.axis}:${path.join("-")}:${i + 1}`,
+          zoneId: paneInsertZoneId({ axis: node.axis, path, index: i + 1 }),
           path,
           parentAxis: node.axis,
           insertIndex: i + 1,

--- a/src/renderer/components/layout/paneInsertZone.test.ts
+++ b/src/renderer/components/layout/paneInsertZone.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { PaneLayout } from "@/shared/paneLayout";
+import { resolveSiblingInsertTarget } from "@/renderer/dnd";
+import { computeLayout } from "./SplitPaneContainer";
+
+const layout: PaneLayout = {
+  kind: "split",
+  axis: "vertical",
+  children: [
+    { kind: "leaf", paneId: "a" },
+    { kind: "leaf", paneId: "b" },
+    { kind: "leaf", paneId: "c" },
+  ],
+};
+
+const equalSizes = (_key: string, count: number) =>
+  Array.from({ length: count }, () => 100 / count);
+
+function dividerZoneIds() {
+  return computeLayout(
+    layout,
+    { left: 0, top: 0, width: 900, height: 600 },
+    equalSizes,
+  ).dividers.map((divider) => divider.zoneId);
+}
+
+describe("pane insert zone ids", () => {
+  // A drag over a pane's inner edge and a drag over the divider itself resolve
+  // to the same insert position, so they must produce the same zone id —
+  // otherwise the edge drag highlights nothing.
+  it("matches the divider zone id when hovering the pane edge before it", () => {
+    const target = resolveSiblingInsertTarget(layout, "b", "left");
+    expect(target?.zoneId).toBe(dividerZoneIds()[0]);
+    expect(target?.target).toEqual({ path: [], axis: "vertical", index: 1 });
+  });
+
+  it("matches the divider zone id when hovering the pane edge after it", () => {
+    const target = resolveSiblingInsertTarget(layout, "b", "right");
+    expect(target?.zoneId).toBe(dividerZoneIds()[1]);
+    expect(target?.target).toEqual({ path: [], axis: "vertical", index: 2 });
+  });
+
+  it("has no sibling divider on the outer edges or across axes", () => {
+    expect(resolveSiblingInsertTarget(layout, "a", "left")).toBeNull();
+    expect(resolveSiblingInsertTarget(layout, "c", "right")).toBeNull();
+    expect(resolveSiblingInsertTarget(layout, "b", "top")).toBeNull();
+    expect(resolveSiblingInsertTarget(layout, "b", "bottom")).toBeNull();
+  });
+});

--- a/src/renderer/components/layout/paneInsertZone.ts
+++ b/src/renderer/components/layout/paneInsertZone.ts
@@ -1,0 +1,18 @@
+import type { PaneLayoutAxis } from "@/shared/paneLayout";
+
+/**
+ * Id of the drop zone that inserts a pane at a split's divider.
+ *
+ * Built in one place because two paths produce it and they must agree: the
+ * divider's own droppable (`SplitPaneContainer`) and the sibling-edge target
+ * derived while a drag hovers the inner edge of a pane (`dnd.tsx`). When the two
+ * formats drift, the drag indicator silently stops highlighting — the id no
+ * longer matches any rendered divider.
+ */
+export function paneInsertZoneId(input: {
+  axis: PaneLayoutAxis;
+  path: readonly number[];
+  index: number;
+}): string {
+  return `pane-insert:${input.axis}:${input.path.join("-")}:${input.index}`;
+}

--- a/src/renderer/components/layout/paneSizeStorage.test.ts
+++ b/src/renderer/components/layout/paneSizeStorage.test.ts
@@ -106,6 +106,62 @@ describe("paneSizeStorage", () => {
       expect(readStoredSizes(key("vertical", ["left", "right", "new"]), 2)).toEqual([38, 62]);
     });
 
+    it("gives an inserted sibling an equal share and shrinks the others proportionally", () => {
+      const previous: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "a" },
+          { kind: "leaf", paneId: "b" },
+        ],
+      };
+      const next: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "a" },
+          { kind: "leaf", paneId: "new" },
+          { kind: "leaf", paneId: "b" },
+        ],
+      };
+
+      writeStoredSizes(key("vertical", ["a", "b"]), [50, 50]);
+      preservePaneSizeStorageForLayoutChange(previous, next);
+
+      const sizes = readStoredSizes(key("vertical", ["a", "new", "b"]), 3);
+      expect(sizes[0]).toBeCloseTo(100 / 3);
+      expect(sizes[1]).toBeCloseTo(100 / 3);
+      expect(sizes[2]).toBeCloseTo(100 / 3);
+    });
+
+    it("keeps the existing panes' relative proportions when a sibling is inserted", () => {
+      const previous: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "a" },
+          { kind: "leaf", paneId: "b" },
+        ],
+      };
+      const next: PaneLayout = {
+        kind: "split",
+        axis: "vertical",
+        children: [
+          { kind: "leaf", paneId: "a" },
+          { kind: "leaf", paneId: "b" },
+          { kind: "leaf", paneId: "new" },
+        ],
+      };
+
+      writeStoredSizes(key("vertical", ["a", "b"]), [70, 30]);
+      preservePaneSizeStorageForLayoutChange(previous, next);
+
+      const sizes = readStoredSizes(key("vertical", ["a", "b", "new"]), 3);
+      expect(sizes[2]).toBeCloseTo(100 / 3);
+      // 70 : 30 preserved across the remaining two thirds.
+      expect(sizes[0]! / sizes[1]!).toBeCloseTo(70 / 30);
+    });
+
     it("keeps ancestor split sizes when a pane is removed inside one child", () => {
       const previous: PaneLayout = {
         kind: "split",

--- a/src/renderer/components/layout/paneSizeStorage.ts
+++ b/src/renderer/components/layout/paneSizeStorage.ts
@@ -178,8 +178,10 @@ function projectSizes(previous: SplitStorageEntry, next: SplitStorageEntry): num
   }
 
   const usedPreviousIndexes = new Set<number>();
-  const equalNewSize = 100 / next.layout.children.length;
-  const nextSizes = next.childPaneIds.map((nextChildIds) => {
+  const nextCount = next.layout.children.length;
+  const equalNewSize = 100 / nextCount;
+  // `null` marks a child with no previous counterpart (a newly inserted pane).
+  const matchedSizes = next.childPaneIds.map((nextChildIds) => {
     let bestIndex = -1;
     let bestOverlap = 0;
     for (let i = 0; i < previous.childPaneIds.length; i++) {
@@ -190,13 +192,23 @@ function projectSizes(previous: SplitStorageEntry, next: SplitStorageEntry): num
         bestOverlap = overlap;
       }
     }
-    if (bestIndex === -1) return equalNewSize;
+    if (bestIndex === -1) return null;
     usedPreviousIndexes.add(bestIndex);
-    return previousSizes[bestIndex] ?? equalNewSize;
+    return previousSizes[bestIndex] ?? null;
   });
 
-  const total = nextSizes.reduce((sum, value) => sum + value, 0);
-  return total > 0 ? nextSizes.map((value) => (value / total) * 100) : equalSizes(nextSizes.length);
+  const insertedCount = matchedSizes.filter((value) => value === null).length;
+  const survivingTotal = matchedSizes.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+  if (survivingTotal <= 0) return equalSizes(nextCount);
+
+  // Newly inserted children take an equal share of the split; the surviving
+  // children shrink proportionally into what's left. Normalizing a mixed list
+  // instead would shrink the new pane along with the others, so it would always
+  // end up smaller than its siblings (2 panes at 50/50 + 1 new → 37.5/37.5/25).
+  const remainingTotal = 100 - insertedCount * equalNewSize;
+  if (remainingTotal <= 0) return equalSizes(nextCount);
+  const scale = remainingTotal / survivingTotal;
+  return matchedSizes.map((value) => (value === null ? equalNewSize : value * scale));
 }
 
 export function preservePaneSizeStorageForLayoutChange(

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -1013,6 +1013,7 @@ export function ThreadDraftView(props: {
       ref={props.droppableRef}
       className={`relative flex ${rootSizeClass} flex-col ${props.isDragging ? "opacity-50" : ""}`}
     >
+      <ThreadDraftDropIndicators dropIndicator={props.dropIndicator} />
       {props.compact && !props.quickComposer && (
         <ThreadDraftCompactHeader
           alignClass={alignClass}
@@ -1030,7 +1031,6 @@ export function ThreadDraftView(props: {
         data-draft-body=""
         className={`${compactComposer ? alignClass : "mx-auto"} relative flex ${bodySizeClass} flex-col ${bodyPaddingClass}`}
       >
-        <ThreadDraftDropIndicators dropIndicator={props.dropIndicator} />
         {props.quickComposer ? null : props.compact ? (
           <ThreadDraftHero compact={props.compact} />
         ) : (

--- a/src/renderer/components/thread/ThreadView.tsx
+++ b/src/renderer/components/thread/ThreadView.tsx
@@ -276,6 +276,37 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         data-poracode-thread-pane=""
         className={`group/pane relative flex h-full min-h-0 flex-col ${isDragging ? "opacity-50" : ""}`}
       >
+        {dropIndicator === "replace" && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 z-20 rounded-2xl bg-accent/10 ring-1 ring-inset ring-accent/30"
+          />
+        )}
+        {dropIndicator === "insert-left" && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-0.5 rounded-full bg-accent"
+          />
+        )}
+        {dropIndicator === "insert-right" && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute top-0 right-0 bottom-0 z-20 w-0.5 rounded-full bg-accent"
+          />
+        )}
+        {dropIndicator === "insert-top" && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute top-0 right-0 left-0 z-20 h-0.5 rounded-full bg-accent"
+          />
+        )}
+        {dropIndicator === "insert-bottom" && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute right-0 bottom-0 left-0 z-20 h-0.5 rounded-full bg-accent"
+          />
+        )}
+
         {/* Header bar — provider icon outside pane drag handle; status tooltip uses HeroUI tooltip (anchored bottom start). */}
         <div className={`px-2 ${headerNeedsTrafficLightPad ? macosTrafficLightPadClass : ""}`}>
           <div
@@ -416,37 +447,6 @@ export const ThreadView = memo(function ThreadView(props: ThreadViewProps) {
         </div>
 
         <div className={contentShellClass}>
-          {dropIndicator === "replace" && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-0 z-20 rounded-2xl bg-accent/10 ring-1 ring-inset ring-accent/30"
-            />
-          )}
-          {dropIndicator === "insert-left" && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-0.5 rounded-full bg-accent"
-            />
-          )}
-          {dropIndicator === "insert-right" && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute top-0 right-0 bottom-0 z-20 w-0.5 rounded-full bg-accent"
-            />
-          )}
-          {dropIndicator === "insert-top" && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute top-0 right-0 left-0 z-20 h-0.5 rounded-full bg-accent"
-            />
-          )}
-          {dropIndicator === "insert-bottom" && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute right-0 bottom-0 left-0 z-20 h-0.5 rounded-full bg-accent"
-            />
-          )}
-
           <div className={contentBodyClass}>
             {usesTerminalPresentation ? (
               <TerminalThreadContent

--- a/src/renderer/dnd.tsx
+++ b/src/renderer/dnd.tsx
@@ -16,6 +16,7 @@ import {
 import { isSortable } from "@dnd-kit/react/sortable";
 import type { PaneLayout, PaneLayoutAxis, PaneLayoutInsertTarget } from "@/shared/paneLayout";
 import { findPanePath } from "@/shared/paneLayout";
+import { paneInsertZoneId } from "./components/layout/paneInsertZone";
 import type { PanelDockTarget, PanelDockZone, RightPanelTab } from "./state/panelStore";
 import { useFileEditorStore } from "./state/fileEditorStore";
 import { useThread } from "./state/useThread";
@@ -327,7 +328,13 @@ function getNodeAtPath(layout: PaneLayout, path: number[]): PaneLayout | null {
   return current;
 }
 
-function resolveSiblingInsertTarget(
+/**
+ * The divider between a pane and its sibling, when a drag hovers the pane's
+ * inner edge. Dropping there inserts between the two panes instead of splitting
+ * the hovered one, so the indicator must be the divider's own zone — the ids are
+ * built through the shared helper for exactly that reason.
+ */
+export function resolveSiblingInsertTarget(
   layout: PaneLayout,
   paneId: string,
   zone: "left" | "right" | "top" | "bottom",
@@ -340,44 +347,19 @@ function resolveSiblingInsertTarget(
   if (parent?.kind !== "split") return null;
 
   const childIndex = panePath[panePath.length - 1]!;
-  if (zone === "left" && parent.axis === "vertical" && childIndex > 0) {
-    const index = childIndex;
-    return {
-      kind: "insert-split",
-      target: { path: parentPath, axis: "vertical", index },
-      zoneId: `split-divider:vertical:${parentPath.join("-")}:${index}`,
-    };
-  }
-  if (zone === "right" && parent.axis === "vertical" && childIndex < parent.children.length - 1) {
-    const index = childIndex + 1;
-    return {
-      kind: "insert-split",
-      target: { path: parentPath, axis: "vertical", index },
-      zoneId: `split-divider:vertical:${parentPath.join("-")}:${index}`,
-    };
-  }
-  if (zone === "top" && parent.axis === "horizontal" && childIndex > 0) {
-    const index = childIndex;
-    return {
-      kind: "insert-split",
-      target: { path: parentPath, axis: "horizontal", index },
-      zoneId: `split-divider:horizontal:${parentPath.join("-")}:${index}`,
-    };
-  }
-  if (
-    zone === "bottom" &&
-    parent.axis === "horizontal" &&
-    childIndex < parent.children.length - 1
-  ) {
-    const index = childIndex + 1;
-    return {
-      kind: "insert-split",
-      target: { path: parentPath, axis: "horizontal", index },
-      zoneId: `split-divider:horizontal:${parentPath.join("-")}:${index}`,
-    };
-  }
+  const axis: PaneLayoutAxis = zone === "left" || zone === "right" ? "vertical" : "horizontal";
+  if (parent.axis !== axis) return null;
 
-  return null;
+  const isBefore = zone === "left" || zone === "top";
+  if (isBefore && childIndex === 0) return null;
+  if (!isBefore && childIndex === parent.children.length - 1) return null;
+
+  const index = isBefore ? childIndex : childIndex + 1;
+  return {
+    kind: "insert-split",
+    target: { path: parentPath, axis, index },
+    zoneId: paneInsertZoneId({ axis, path: parentPath, index }),
+  };
 }
 
 /**

--- a/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.test.tsx
@@ -1,10 +1,15 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { NewThreadButton } from "./NewThreadButton";
 
+const draggableInputs: { id?: string; type?: string; data?: unknown }[] = [];
+
 vi.mock("@dnd-kit/react", () => ({
-  useDraggable: () => ({}),
+  useDraggable: (input: { id?: string; type?: string; data?: unknown }) => {
+    draggableInputs.push(input);
+    return { isDragging: false, ref: () => {} };
+  },
 }));
 
 function renderButton(overrides: Partial<Parameters<typeof NewThreadButton>[0]> = {}) {
@@ -57,5 +62,58 @@ describe("NewThreadButton", () => {
     fireEvent.click(await screen.findByRole("menuitem", { name: "Open as Panel" }));
 
     expect(onOpenAsPanel).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers active projects as flat context-menu items", async () => {
+    const onSelectProject = vi.fn<(projectId: string) => void>();
+    renderButton({
+      inline: true,
+      projectOptions: [
+        { id: "p1", name: "Alpha", icon: <span data-testid="alpha-project-icon" /> },
+        {
+          id: "p2",
+          name: "Beta",
+          icon: <span data-testid="beta-project-icon" />,
+          description: "MacBook 16",
+        },
+      ],
+      onSelectProject,
+    });
+
+    fireEvent.contextMenu(screen.getAllByRole("button", { name: "New thread" })[0]!);
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu).queryByRole("menuitem", { name: "Select project" }),
+    ).not.toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Alpha" })).toBeInTheDocument();
+    expect(within(menu).getByTestId("beta-project-icon")).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "Beta" })).toHaveTextContent("MacBook 16");
+
+    fireEvent.click(within(menu).getByRole("menuitem", { name: "Beta" }));
+
+    expect(onSelectProject).toHaveBeenCalledWith("p2");
+  });
+
+  it("makes each project row draggable onto a pane target", async () => {
+    draggableInputs.length = 0;
+    renderButton({
+      inline: true,
+      projectOptions: [
+        { id: "p1", name: "Alpha" },
+        { id: "p2", name: "Beta" },
+      ],
+      onSelectProject: vi.fn<(projectId: string) => void>(),
+    });
+
+    fireEvent.contextMenu(screen.getAllByRole("button", { name: "New thread" })[0]!);
+    await screen.findByRole("menu");
+
+    for (const projectId of ["p1", "p2"]) {
+      expect(draggableInputs).toContainEqual({
+        id: `new-thread-menu:${projectId}`,
+        type: "new-thread",
+        data: { type: "new-thread", projectId },
+      });
+    }
   });
 });

--- a/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/NewThreadButton.tsx
@@ -1,8 +1,8 @@
-import { useRef } from "react";
+import { useRef, type ReactNode } from "react";
 import { Columns2, Plus } from "lucide-react";
 import { useDraggable } from "@dnd-kit/react";
 import { useLingui } from "@lingui/react/macro";
-import { ContextMenu } from "@/renderer/components/common/ContextMenu";
+import { ContextMenu, type ContextMenuEntry } from "@/renderer/components/common/ContextMenu";
 import { SidebarButton } from "@/renderer/components/common/SidebarButton";
 import type { DragSourceData } from "@/renderer/dnd";
 import { DraftIndicator } from "./DraftIndicator";
@@ -15,6 +15,13 @@ export function NewThreadButton(props: {
   canOpenAsPanel: boolean;
   onPress: () => void;
   onOpenAsPanel: () => void;
+  projectOptions?: readonly {
+    id: string;
+    name: string;
+    icon?: ReactNode;
+    description?: string;
+  }[];
+  onSelectProject?: (projectId: string) => void;
   /**
    * Docked into the flat list's head row next to the project filter instead
    * of taking a full-width row. Renders both a labelled button and an
@@ -30,10 +37,29 @@ export function NewThreadButton(props: {
     id: `new-thread:${props.projectId}`,
     type: "new-thread",
     data: { type: "new-thread", projectId: props.projectId } satisfies DragSourceData,
+    handle: newThreadRef,
     element: newThreadRef,
   });
 
-  const contextMenuItems = [
+  const projectMenuItems: ContextMenuEntry[] =
+    props.projectOptions && props.onSelectProject
+      ? props.projectOptions.map((project) => ({
+          id: `new-thread-project:${project.id}`,
+          label: project.name,
+          ...(project.icon ? { icon: project.icon } : {}),
+          ...(project.description ? { description: project.description } : {}),
+          // Same payload as dragging the button itself, so a row can be dropped
+          // straight onto a pane target to open that project's draft there.
+          dragSource: {
+            id: `new-thread-menu:${project.id}`,
+            type: "new-thread",
+            data: { type: "new-thread", projectId: project.id } satisfies DragSourceData,
+          },
+        }))
+      : [];
+  const contextMenuItems: ContextMenuEntry[] = [
+    ...projectMenuItems,
+    ...(projectMenuItems.length > 0 ? [{ type: "separator" as const }] : []),
     {
       id: "open-as-panel",
       label: t({
@@ -45,6 +71,10 @@ export function NewThreadButton(props: {
     },
   ];
   const handleContextMenuAction = (key: string) => {
+    if (key.startsWith("new-thread-project:")) {
+      props.onSelectProject?.(key.slice("new-thread-project:".length));
+      return;
+    }
     if (key === "open-as-panel") props.onOpenAsPanel();
   };
 
@@ -58,7 +88,7 @@ export function NewThreadButton(props: {
         <div ref={newThreadRef} className="flex shrink-0 items-center">
           <button
             type="button"
-            className={`poracode-flat-new-thread-full flex h-8 shrink-0 cursor-default items-center gap-1.5 rounded-3xl px-2 text-xs outline-none transition-colors focus-visible:focus-ring ${stateClass}`}
+            className={`poracode-flat-new-thread-full flex h-8 shrink-0 cursor-grab items-center gap-1.5 rounded-3xl px-2 text-xs outline-none transition-colors active:cursor-grabbing focus-visible:focus-ring ${stateClass}`}
             onClick={props.onPress}
           >
             <Plus className="size-3.5" />
@@ -67,7 +97,7 @@ export function NewThreadButton(props: {
           </button>
           <SidebarButton
             iconOnly
-            className="poracode-flat-new-thread-icon"
+            className="poracode-flat-new-thread-icon cursor-grab active:cursor-grabbing"
             icon={<Plus className="size-4" />}
             label={t`New thread`}
             isActive={props.isActive}

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -3,6 +3,7 @@ import type { Project } from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
 import {
   ProjectRemoteServerChip,
+  ProjectSelectorIcon,
   useProjectRemoteServerLookup,
 } from "@/renderer/components/common/ProjectRemoteServer";
 import { openNewThread, openNewThreadSideBySide } from "@/renderer/actions/threadActions";
@@ -94,6 +95,11 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
     if (!project.remoteServerId) return true;
     return remoteServerFor(project).status === "online";
   });
+  const newThreadProjects = [...visibleProjects].sort((a, b) => {
+    const rank = (project: Project) =>
+      isHomeProject(project) ? 0 : project.remoteServerId ? 2 : 1;
+    return rank(a) - rank(b);
+  });
   const projectsById = new Map(visibleProjects.map((project) => [project.id, project]));
   const filterableProjectIds = new Set(projectsById.keys());
 
@@ -157,7 +163,17 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
         isActive={isDraftActive}
         isDraggingAnything={!!source}
         canOpenAsPanel={currentThreadCount > 0 && currentThreadCount < 3}
+        projectOptions={newThreadProjects.map((project) => {
+          const remote = remoteServerFor(project);
+          return {
+            id: project.id,
+            name: project.name,
+            icon: <ProjectSelectorIcon project={project} remote={remote} />,
+            ...(remote.serverName ? { description: remote.serverName } : {}),
+          };
+        })}
         onPress={() => openNewThread(latestProjectId)}
+        onSelectProject={openNewThread}
         onOpenAsPanel={() => openNewThreadSideBySide(latestProjectId)}
       />
     ) : null;

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.test.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 import { fireEvent, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
@@ -15,6 +15,7 @@ type MockContextMenuItem = {
 
 const {
   sortableRefMock,
+  sortableHandleRefMock,
   sortableOptionsMock,
   contextMenuItemsMock,
   getStatusToneMock,
@@ -24,6 +25,7 @@ const {
   openTerminalMock,
 } = vi.hoisted(() => ({
   sortableRefMock: vi.fn<(element: HTMLElement | null) => void>(),
+  sortableHandleRefMock: vi.fn<(element: HTMLElement | null) => void>(),
   sortableOptionsMock: vi.fn<(options: unknown) => void>(),
   contextMenuItemsMock: vi.fn<(items: MockContextMenuItem[]) => void>(),
   getStatusToneMock:
@@ -41,7 +43,7 @@ vi.mock("@dnd-kit/react", () => ({
 vi.mock("@dnd-kit/react/sortable", () => ({
   useSortable: (options: unknown) => {
     sortableOptionsMock(options);
-    return { ref: sortableRefMock };
+    return { ref: sortableRefMock, handleRef: sortableHandleRefMock };
   },
 }));
 
@@ -57,11 +59,13 @@ vi.mock("@/renderer/components/common/ContextMenu", () => ({
 }));
 
 vi.mock("@/renderer/components/common/SidebarButton", () => ({
-  SidebarButton: (props: { label: ReactNode; suffix?: ReactNode }) => (
-    <button type="button">
-      {props.label}
-      {props.suffix}
-    </button>
+  SidebarButton: forwardRef<HTMLDivElement, { label: ReactNode; suffix?: ReactNode }>(
+    (props, ref) => (
+      <div ref={ref} role="button">
+        {props.label}
+        {props.suffix}
+      </div>
+    ),
   ),
 }));
 
@@ -183,6 +187,7 @@ const project: Project = {
 describe("SortableThreadItem", () => {
   beforeEach(() => {
     sortableRefMock.mockClear();
+    sortableHandleRefMock.mockClear();
     sortableOptionsMock.mockClear();
     contextMenuItemsMock.mockClear();
     openFilesPanelMock.mockClear();
@@ -265,6 +270,25 @@ describe("SortableThreadItem", () => {
 
     expect(row).toBeInstanceOf(HTMLElement);
     expect(sortableRefMock).toHaveBeenCalledWith(row);
+  });
+
+  it("registers the nested sidebar row as the drag handle", () => {
+    render(
+      <SortableThreadItem
+        thread={makeThread()}
+        threadIndex={1}
+        project={project}
+        showWorktreeBadge={false}
+        editingThreadId={null}
+        setEditingThreadId={vi.fn<(id: string | null) => void>()}
+        group="project-entries:project-1"
+      />,
+    );
+
+    const handle = sortableHandleRefMock.mock.calls.at(-1)?.[0];
+
+    expect(handle).toBeInstanceOf(HTMLDivElement);
+    expect(handle).toHaveTextContent("Thread 1");
   });
 
   it("keeps automatic-sort rows draggable into panes while disabling sidebar reordering", () => {

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SortableThreadItem/SortableThreadItem.tsx
@@ -48,7 +48,7 @@ export function SortableThreadItem(props: {
   const isCurrentThread = useIsCurrentThread(thread.id);
   const hasDraft = useThreadHasDraft(thread.id);
 
-  const { ref } = useSortable({
+  const { ref, handleRef } = useSortable({
     id: `thread:${thread.id}`,
     index: props.threadIndex,
     type: "thread",
@@ -111,6 +111,7 @@ export function SortableThreadItem(props: {
         showProjectActions={stacked}
       >
         <SidebarButton
+          ref={handleRef}
           size="xs"
           density={stacked ? "compact" : "default"}
           statusTone={statusTone}

--- a/website/public/changelog.json
+++ b/website/public/changelog.json
@@ -36,6 +36,11 @@
           "text": "Usage now shows Command Code's rolling 5-hour and weekly dollar limits alongside monthly credits, with reset countdowns, matching Studio and the CLI."
         },
         {
+          "kind": "added",
+          "label": "Panes",
+          "text": "The New thread menu lists your projects, and you can drag any of them straight onto a pane or the gap between two panes to start that project's draft exactly where you want it."
+        },
+        {
           "kind": "improved",
           "label": "Crossagents",
           "text": "Subagent runs are named with the model's sub-provider so similar selections are easy to tell apart, the learned selections list scrolls when it grows long, and the provider filter explains that unchecked providers only opt out of automatic routing."
@@ -59,6 +64,11 @@
           "kind": "improved",
           "label": "Composer",
           "text": "The add menu is tidier: Computer Use and Experiment keep single-line rows with their descriptions moved into info tooltips."
+        },
+        {
+          "kind": "fixed",
+          "label": "Panes",
+          "text": "Opening a pane now splits the space evenly instead of squeezing the newest one, existing panes keep their relative widths, and the insert line lights up as soon as you drag near the edge between two panes."
         },
         {
           "kind": "fixed",


### PR DESCRIPTION
**Type:** Feature + Bugfix

- Add project rows to the New thread menu so users can drag a project onto a pane or between panes to open its draft in place
- Fix pane insert sizing so new panes get an equal share while existing panes keep their relative widths
- Align insert-zone targeting so the insert indicator lights up when dragging near sibling pane edges
- Keep context menus open during item drags and tidy long menu rows with description tooltips
- Update the public changelog for the new-thread drag and pane insert fixes