### PR TITLE
Add terminal action to sidebar project menus

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Tailscale öffnen"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Terminal öffnen"
 

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Open Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Open terminal"
 

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Abrir Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Abrir terminal"
 

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8025,6 +8025,7 @@ msgstr "Ouvrir Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Ouvrir le terminal"
 

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8024,6 +8024,7 @@ msgstr "Tailscaleを開く"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "ターミナルを開く"
 

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Tailscale 열기"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "터미널 열기"
 

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Otwórz Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Otwórz terminal"
 

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Abrir o Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Abrir terminal"
 

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Открыть Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Открыть терминал"
 

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Tailscale'i aç"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Terminali aç"
 

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Відкрити Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Открыть терминал"
 

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8026,6 +8026,7 @@ msgstr "Mở Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "Mở terminal"
 

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8025,6 +8025,7 @@ msgstr "打开 Tailscale"
 #: src/mobile/views/TerminalView.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
+#: src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
 msgid "Open terminal"
 msgstr "打开终端"
 

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
@@ -4,6 +4,7 @@ import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import type { Project } from "@/shared/contracts";
 import { HOME_PROJECT_ID } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
+import { useDevTerminalStore } from "@/renderer/state/devTerminalStore";
 import { usePanelStore } from "@/renderer/state/panelStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { SidebarProjectFilter } from "./SidebarProjectFilter";
@@ -186,11 +187,31 @@ describe("SidebarProjectFilter", () => {
 
       // The overflow menu opens while the filter menu stays open beneath it.
       expect(await screen.findByRole("menuitem", { name: "Project Settings" })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: "Open terminal" })).toBeInTheDocument();
       expect(screen.getByRole("menuitem", { name: "Disable Project" })).toBeInTheDocument();
       expect(screen.getByRole("menuitem", { name: "Remove Project" })).toBeInTheDocument();
       expect(screen.getByRole("menuitemcheckbox", { name: "All projects" })).toBeInTheDocument();
       expect(screen.getByRole("menuitemcheckbox", { name: /Beta/ })).toBeInTheDocument();
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("opens the project terminal from the overflow menu", async () => {
+      useDevTerminalStore.setState({
+        isOpen: false,
+        explicitlyOpened: false,
+        activeProjectId: null,
+        activeWorktreePath: null,
+        tabs: [],
+        activeTabId: null,
+      });
+      renderFilter(null);
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+      fireEvent.click(await screen.findByRole("menuitem", { name: "Open terminal" }));
+
+      expect(useDevTerminalStore.getState().isOpen).toBe(true);
+      expect(useDevTerminalStore.getState().activeProjectId).toBe("b");
     });
 
     it("keeps a disabled project available for re-enabling", async () => {
@@ -214,6 +235,26 @@ describe("SidebarProjectFilter", () => {
       expect(
         useAppStore.getState().projects.find((candidate) => candidate.id === "b")?.disabled,
       ).toBe(undefined);
+    });
+
+    it("hides host actions while a project is disabled", async () => {
+      const disabledProject = { ...projects[1]!, disabled: true };
+      useAppStore.setState({ projects: [projects[0]!, disabledProject], threads: [] });
+      render(
+        <SidebarProjectFilter
+          projects={[projects[0]!, disabledProject]}
+          filterableProjectIds={new Set(["a"])}
+          threadCounts={threadCounts}
+          value={null}
+          onChange={vi.fn<(next: string[] | null) => void>()}
+        />,
+      );
+      await openMenu();
+
+      fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
+
+      expect(await screen.findByRole("menuitem", { name: "Enable Project" })).toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: "Open terminal" })).not.toBeInTheDocument();
     });
 
     it("keeps a disabled project available for re-enabling on mobile", async () => {
@@ -264,6 +305,10 @@ describe("SidebarProjectFilter", () => {
       fireEvent.click(screen.getByRole("button", { name: "Project actions for Beta" }));
 
       expect(await screen.findByRole("menuitem", { name: "Remove Project" })).toHaveAttribute(
+        "aria-disabled",
+        "true",
+      );
+      expect(screen.getByRole("menuitem", { name: "Open terminal" })).toHaveAttribute(
         "aria-disabled",
         "true",
       );

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -154,7 +154,7 @@ function ProjectRowMenuButton(props: {
  * The full project context menu (the same entries the grouped sidebar's
  * project header offers on right-click) anchored at a filter row's overflow
  * button. The flat list has no project headers, so this is the only route to
- * project settings/git/run/workspace actions.
+ * project settings/terminal/git/run/workspace actions.
  *
  * Rendered *inside* the filter's popover so React Aria treats it as a nested
  * overlay: its focus scope registers as a child of the filter menu's, which is

--- a/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/useProjectMenu.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   Settings2,
   Square,
+  SquareTerminal,
   Trash2,
   Workflow,
 } from "lucide-react";
@@ -19,7 +20,11 @@ import type { ContextMenuEntry, ContextMenuItem } from "@/renderer/components/co
 import { setProjectDisabled, deleteProject } from "@/renderer/actions/projectActions";
 import { openGitReview, openProjectSettings } from "@/renderer/actions/panelActions";
 import { gitSync } from "@/renderer/actions/gitActions";
-import { runProjectAction, stopProjectAction } from "@/renderer/actions/terminalActions";
+import {
+  runProjectAction,
+  showTerminalPanel,
+  stopProjectAction,
+} from "@/renderer/actions/terminalActions";
 import {
   WORKSPACE_UNFILED_KEY,
   parseWorkspaceMenuKey,
@@ -37,7 +42,7 @@ import { useRunningProjectActionIds } from "@/renderer/hooks/uiSelectors";
  * every surface that offers project actions — the grouped sidebar's project
  * header (right-click) and the flat list's project filter rows (overflow
  * button). `isUnreachable` greys out entries that execute on the project's
- * host (git, run-scripts, removal) while a mirrored project's server is down.
+ * host (terminal, git, run-scripts, removal) while a mirrored project's server is down.
  */
 export function useProjectMenu(
   project: Project,
@@ -84,6 +89,12 @@ export function useProjectMenu(
     ...(isDisabled
       ? []
       : [
+          {
+            id: "open-terminal",
+            label: t`Open terminal`,
+            icon: <SquareTerminal className="size-3.5" />,
+            isDisabled: isUnreachable,
+          },
           {
             type: "submenu" as const,
             id: "git",
@@ -174,6 +185,7 @@ export function useProjectMenu(
 
   const onAction = (key: string) => {
     if (key === "project-settings") openProjectSettings(project.id);
+    if (key === "open-terminal") showTerminalPanel(project.id);
     if (key === "stop-syncing" && project.remoteServerId && project.remoteId) {
       setRemoteProjectSynced(project.remoteServerId, project.remoteId, false);
     }


### PR DESCRIPTION
- Feature: add an Open terminal action to project menus.
- Disable terminal access for unreachable projects.
- Cover the new behavior with sidebar menu tests.
- Register the terminal label across all supported locales.