### PR TITLE
Add configurable Codex context windows

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -218,6 +218,11 @@ msgstr "{0}-Hooks für {envName} entfernt."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} Installationsziele"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} ist bereits in der Liste."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Aktivitätsmetrik"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Kandidaten hinzufügen"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Claude-Profil hinzufügen"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Kontextfenster hinzufügen"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Kontext an {targetLabel} übertragen"
 msgid "Context usage"
 msgstr "Kontextverwendung"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Kontextfenster"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Weiter"
@@ -3601,6 +3615,10 @@ msgstr "Benutzerdefiniert"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Benutzerdefinierte Befehle, die im Projektkontextmenü verfügbar sind (Rechtsklick)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Benutzerdefiniertes Kontextfenster"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Lässt eingehende Hook-Umschläge auf dem Supervisor fallen, sodass Agen
 msgid "Duplicate server name in scan"
 msgstr "Doppelter Servername im Scan"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "z. B. 512k oder 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "z. B. Codex GPT-5.5 fast für schnelle Recherchen, OpenCode GLM für umfangreiche Refactorings, Claude Opus für alles Kniffelige."
@@ -4381,6 +4403,10 @@ msgstr "Geben Sie eine Repository-URL ein."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Geben Sie eine sichere Repository-URL mit HTTPS, HTTP, SSH, Git, FTP, FTPS oder scp-Syntax ein."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Gib eine Größe wie 512k oder 1m ein."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Entfernen"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "{0} entfernen"
 
@@ -9490,6 +9518,14 @@ msgstr "Erforderliche Bewertungen, Gespräche oder Statusprüfungen wurden nicht
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "zurückgesetzt"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Kontextfenster zurücksetzen"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "{env} wird abgemeldet. Erkannte Agenten werden aktualisiert, wenn der Vo
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Wird abgemeldet. Erkannte Agenten werden aktualisiert, wenn der Vorgang abgeschlossen ist."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Größen, die im Codex-Composer angezeigt werden. Die Verdichtung startet automatisch bei 90 % des gewählten Fensters. Neue Chats verwenden standardmäßig 400k, wenn diese Größe in der Liste ist."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -218,6 +218,11 @@ msgstr "{0} hooks removed for {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} install targets"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} is already in the list."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Activity metric"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Add candidate"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Add Claude profile"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Add context window"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Context transferred to {targetLabel}"
 msgid "Context usage"
 msgstr "Context usage"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Context windows"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Continue"
@@ -3601,6 +3615,10 @@ msgstr "Custom"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Custom commands available from the project context menu (right-click)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Custom context window"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Drops incoming hook envelopes on the supervisor so agents fall back to L
 msgid "Duplicate server name in scan"
 msgstr "Duplicate server name in scan"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "e.g. 512k or 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
@@ -4381,6 +4403,10 @@ msgstr "Enter a repository URL."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Enter a size like 512k or 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Remove"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Remove {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Required reviews, conversations, or status checks not met."
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "reset"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Reset"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Reset context windows"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Signing out {env}. Detected agents will refresh when it finishes."
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Signing out. Detected agents will refresh when it finishes."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -218,6 +218,11 @@ msgstr "Hooks de {0} eliminados para {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} objetivos de instalación"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} ya está en la lista."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Métrica de actividad"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Añadir candidato"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Agregar perfil de Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Añadir ventana de contexto"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Contexto transferido a {targetLabel}"
 msgid "Context usage"
 msgstr "Uso del contexto"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Ventanas de contexto"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Continuar"
@@ -3601,6 +3615,10 @@ msgstr "Personalizado"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Comandos personalizados disponibles desde el menú contextual del proyecto (clic derecho)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Ventana de contexto personalizada"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Descarta los envoltorios de hook entrantes en el supervisor para que los
 msgid "Duplicate server name in scan"
 msgstr "Nombre de servidor duplicado en el análisis"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "p. ej. 512k o 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "p. ej. Codex GPT-5.5 fast para búsquedas rápidas, OpenCode GLM para refactorizaciones masivas, Claude Opus para cualquier cosa delicada."
@@ -4381,6 +4403,10 @@ msgstr "Introduce una URL de repositorio."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Introduce una URL de repositorio segura con HTTPS, HTTP, SSH, Git, FTP, FTPS o sintaxis scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Introduce un tamaño como 512k o 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Eliminar"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Eliminar {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "No se cumplen las revisiones, conversaciones o comprobaciones de estado 
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "restablecer"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Restablecer"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Restablecer ventanas de contexto"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Cerrando sesión en {env}. Los agentes detectados se actualizarán al fi
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Cerrando sesión. Los agentes detectados se actualizarán al finalizar."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Tamaños que se muestran en el redactor de Codex. La compactación empieza automáticamente al 90% de la ventana seleccionada. Los chats nuevos usan 400k de forma predeterminada cuando ese tamaño está en la lista."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -218,6 +218,11 @@ msgstr "Hooks {0} retirés pour {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} cibles d'installation"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} est déjà dans la liste."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Métrique d'activité"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Ajouter un candidat"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Ajouter un profil Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Ajouter une fenêtre de contexte"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Contexte transféré à {targetLabel}"
 msgid "Context usage"
 msgstr "Utilisation du contexte"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Fenêtres de contexte"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Continuer"
@@ -3601,6 +3615,10 @@ msgstr "Personnalisé"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Commandes personnalisées disponibles dans le menu contextuel du projet (clic droit)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Fenêtre de contexte personnalisée"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Supprime les enveloppes de hook entrantes sur le superviseur afin que le
 msgid "Duplicate server name in scan"
 msgstr "Nom de serveur en double dans l’analyse"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "p. ex. 512k ou 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "par ex. Codex GPT-5.5 fast pour les recherches rapides, OpenCode GLM pour les refactorisations en masse, Claude Opus pour tout ce qui est subtil."
@@ -4381,6 +4403,10 @@ msgstr "Entrez une URL de dépôt."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Saisissez une URL de dépôt sûre utilisant HTTPS, HTTP, SSH, Git, FTP, FTPS ou la syntaxe scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Saisissez une taille comme 512k ou 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9256,8 +9282,10 @@ msgstr "Supprimer"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Supprimer {0}"
 
@@ -9489,6 +9517,14 @@ msgstr "Les avis, conversations ou vérifications de statut requis ne sont pas s
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "réinitialiser"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Réinitialiser"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Réinitialiser les fenêtres de contexte"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10645,6 +10681,10 @@ msgstr "Déconnexion {env}. Les agents détectés seront actualisés une fois l'
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Déconnexion. Les agents détectés seront actualisés une fois l'opération terminée."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Tailles affichées dans le Composer Codex. La compaction démarre automatiquement à 90 % de la fenêtre sélectionnée. Les nouveaux fils de discussion utilisent 400k par défaut lorsque cette taille figure dans la liste."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -218,6 +218,11 @@ msgstr "{envName}の{0}フックが削除されました。"
 #~ msgid "{0} install targets"
 #~ msgstr "{0}インストールターゲット"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} はすでにリストにあります。"
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -847,6 +852,7 @@ msgstr "アクティビティ指標"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -923,6 +929,10 @@ msgstr "候補を追加"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Claude プロファイルを追加"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "コンテキストウィンドウを追加"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3044,6 +3054,10 @@ msgstr "{targetLabel}に転送されたコンテキスト"
 msgid "Context usage"
 msgstr "コンテキストの使用量"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "コンテキストウィンドウ"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "続ける"
@@ -3600,6 +3614,10 @@ msgstr "カスタム"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "プロジェクトのコンテキスト メニュー (右クリック) から使用できるカスタム コマンド。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "カスタムコンテキストウィンドウ"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4182,6 +4200,10 @@ msgstr "受信したフック エンベロープをスーパーバイザー側�
 msgid "Duplicate server name in scan"
 msgstr "スキャン内でサーバー名が重複しています"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "例: 512k または 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "例：クイックな調査には Codex GPT-5.5 fast、大量のリファクタリングには OpenCode GLM、繊細な作業には Claude Opus。"
@@ -4380,6 +4402,10 @@ msgstr "リポジトリの URL を入力します。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "HTTPS、HTTP、SSH、Git、FTP、FTPS、または scp 構文を使用した安全なリポジトリ URL を入力してください。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "512k や 1m のようなサイズを入力してください。"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9255,8 +9281,10 @@ msgstr "削除する"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "{0}を削除"
 
@@ -9488,6 +9516,14 @@ msgstr "必要なレビュー、会話、ステータスチェックが満たさ
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "リセット"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "リセット"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "コンテキストウィンドウをリセット"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10644,6 +10680,10 @@ msgstr "{env}からサインアウトします。検出されたエージェン�
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "サインアウトしています。検出されたエージェントは終了時に更新されます。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Codex のコンポーザーに表示するサイズです。選択したウィンドウの 90% で自動圧縮が始まります。リストに 400k がある場合、新しいチャットのデフォルトは 400k です。"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -218,6 +218,11 @@ msgstr "{envName}에 대한 {0} 후크가 제거되었습니다."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} 설치 대상"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0}은(는) 이미 목록에 있습니다."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "활동 지표"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "후보 추가"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Claude 프로필 추가"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "컨텍스트 창 추가"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "컨텍스트가 {targetLabel}(으)로 전송되었습니다."
 msgid "Context usage"
 msgstr "컨텍스트 사용량"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "컨텍스트 창"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "계속"
@@ -3601,6 +3615,10 @@ msgstr "맞춤"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "프로젝트 상황에 맞는 메뉴(오른쪽 클릭)에서 사용할 수 있는 사용자 정의 명령."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "사용자 지정 컨텍스트 창"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "에이전트가 설치 또는 iTerm2 알림을 건드리지 않고 L2(OS
 msgid "Duplicate server name in scan"
 msgstr "스캔에 중복된 서버 이름이 있습니다"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "예: 512k 또는 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "예: 빠른 조회에는 Codex GPT-5.5 fast, 대규모 리팩터링에는 OpenCode GLM, 미묘한 작업에는 Claude Opus."
@@ -4381,6 +4403,10 @@ msgstr "저장소 URL을 입력하세요."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "HTTPS, HTTP, SSH, Git, FTP, FTPS 또는 scp 구문을 사용하는 안전한 저장소 URL을 입력하세요."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "512k 또는 1m과 같은 크기를 입력하세요."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "제거"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "{0} 제거"
 
@@ -9490,6 +9518,14 @@ msgstr "필수 검토, 대화 또는 상태 확인이 충족되지 않았습니�
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "재설정"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "재설정"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "컨텍스트 창 재설정"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "{env} 로그아웃 중입니다. 감지된 에이전트는 완료되면 
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "로그아웃합니다. 감지된 에이전트는 완료되면 새로 고쳐집니다."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Codex 작성기에 표시되는 크기입니다. 선택한 창의 90%에서 자동으로 압축이 시작됩니다. 목록에 400k가 있으면 새 채팅의 기본값은 400k입니다."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -218,6 +218,11 @@ msgstr "{0} – haki usunięte dla {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} cele instalacji"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} jest już na liście."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Metryka aktywności"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Dodaj kandydata"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Dodaj profil Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Dodaj okno kontekstu"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Kontekst przeniesiony do {targetLabel}"
 msgid "Context usage"
 msgstr "Użycie kontekstu"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Okna kontekstu"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Kontynuuj"
@@ -3601,6 +3615,10 @@ msgstr "Niestandardowe"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Polecenia niestandardowe dostępne z menu kontekstowego projektu (kliknij prawym przyciskiem myszy)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Niestandardowe okno kontekstu"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Upuszcza przychodzące koperty haków na nadzorcę, dzięki czemu agenci
 msgid "Duplicate server name in scan"
 msgstr "Powtórzona nazwa serwera w wynikach skanowania"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "np. 512k lub 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "np. Codex GPT-5.5 fast do szybkich wyszukiwań, OpenCode GLM do masowych refaktoryzacji, Claude Opus do wszystkiego, co subtelne."
@@ -4381,6 +4403,10 @@ msgstr "Wprowadź adres URL repozytorium."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Wprowadź bezpieczny adres URL repozytorium używający HTTPS, HTTP, SSH, Git, FTP, FTPS lub składni scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Wpisz rozmiar, np. 512k lub 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Usuń"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Usuń {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Nie spełniono wymaganych recenzji, rozmów lub kontroli stanu."
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "reset"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Resetuj"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Resetuj okna kontekstu"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Wylogowywanie z {env}. Wykryci agenci zostaną odświeżeni po zakończe
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Wylogowanie. Wykryci agenci zostaną odświeżeni po zakończeniu."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Rozmiary wyświetlane w kompozytorze Codex. Kompaktowanie zaczyna się automatycznie przy 90% wybranego okna. Nowe wątki domyślnie używają 400k, jeśli ten rozmiar jest na liście."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -218,6 +218,11 @@ msgstr "{0} hooks removidos para {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} destinos de instalação"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} já está na lista."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Métrica de atividade"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Adicionar candidato"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Adicionar perfil do Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Adicionar janela de contexto"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Contexto transferido para {targetLabel}"
 msgid "Context usage"
 msgstr "Uso de contexto"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Janelas de contexto"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Continuar"
@@ -3601,6 +3615,10 @@ msgstr "Personalizado"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Comandos personalizados disponíveis no menu de contexto do projeto (clique com o botão direito)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Janela de contexto personalizada"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Descarta envelopes de gancho recebidos no supervisor para que os agentes
 msgid "Duplicate server name in scan"
 msgstr "Nome de servidor duplicado na verificação"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "ex.: 512k ou 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "ex.: Codex GPT-5.5 fast para consultas rápidas, OpenCode GLM para refatorações em massa, Claude Opus para qualquer coisa sutil."
@@ -4381,6 +4403,10 @@ msgstr "Insira um URL do repositório."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Insira uma URL de repositório segura usando HTTPS, HTTP, SSH, Git, FTP, FTPS ou a sintaxe scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Digite um tamanho como 512k ou 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Remover"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Remover {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Avaliações, conversas ou verificações de status necessárias não at
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "redefinir"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Redefinir"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Redefinir janelas de contexto"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Saindo de {env}. Os agentes detectados serão atualizados quando termina
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Saindo. Os agentes detectados serão atualizados quando terminar."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Tamanhos mostrados no Composer do Codex. A compactação começa automaticamente em 90% da janela selecionada. Novos tópicos usam 400k por padrão quando esse tamanho está na lista."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -218,6 +218,11 @@ msgstr "Хуки {0} удалены для {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} целей установки"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} уже есть в списке."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Метрика активности"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Добавить кандидата"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Добавить профиль Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Добавить контекстное окно"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Контекст передан в {targetLabel}"
 msgid "Context usage"
 msgstr "Использование контекста"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Контекстные окна"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Продолжить"
@@ -3601,6 +3615,10 @@ msgstr "Пользовательский"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Пользовательские команды доступны из контекстного меню проекта (правый клик)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Пользовательское контекстное окно"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Отбрасывает входящие конверты хуков на
 msgid "Duplicate server name in scan"
 msgstr "Повторяющееся имя сервера в результатах сканирования"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "напр. 512k или 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "напр., Codex GPT-5.5 fast для быстрых запросов, OpenCode GLM для массовых рефакторингов, Claude Opus для всего тонкого."
@@ -4381,6 +4403,10 @@ msgstr "Введите URL репозитория."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Введите безопасный URL репозитория с использованием HTTPS, HTTP, SSH, Git, FTP, FTPS или синтаксиса scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Введите размер, например 512k или 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Удалить"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Удалить {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Не выполнены обязательные проверки, об�
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "сброс"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Сбросить"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Сбросить контекстные окна"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Выход из {env}. Обнаруженные агенты обнов�
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Выход. Обнаруженные агенты обновятся по завершении."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Размеры, отображаемые в поле ввода Codex. Сжатие автоматически начинается на 90% выбранного окна. Новые треды по умолчанию используют 400k, если этот размер есть в списке."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -218,6 +218,11 @@ msgstr "{0} kancaları {envName} için kaldırıldı."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} yükleme hedefi"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} zaten listede."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Etkinlik metriği"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Aday ekle"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Claude profili ekle"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Bağlam penceresi ekle"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Bağlam {targetLabel} hedefine aktarıldı"
 msgid "Context usage"
 msgstr "Bağlam kullanımı"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Bağlam pencereleri"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Devam et"
@@ -3601,6 +3615,10 @@ msgstr "Özel"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Proje içerik menüsünden erişilebilen özel komutlar (sağ tıklama)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Özel bağlam penceresi"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Aracıların kurulum veya iTerm2 bildirimlerine dokunmadan L2'ye (OSC 9;
 msgid "Duplicate server name in scan"
 msgstr "Taramada yinelenen sunucu adı"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "örn. 512k veya 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "örn. hızlı aramalar için Codex GPT-5.5 fast, toplu yeniden düzenlemeler için OpenCode GLM, ince işler için Claude Opus."
@@ -4381,6 +4403,10 @@ msgstr "Bir depo URL'si girin."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "HTTPS, HTTP, SSH, Git, FTP, FTPS veya scp söz dizimini kullanan güvenli bir depo URL'si girin."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "512k veya 1m gibi bir boyut girin."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Kaldır"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "{0} öğesini kaldır"
 
@@ -9490,6 +9518,14 @@ msgstr "Gerekli incelemeler, görüşmeler veya durum kontrolleri karşılanmad�
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "sıfırlama"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Sıfırla"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Bağlam pencerelerini sıfırla"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "{env} oturumu kapatılıyor. Algılanan aracılar tamamlandığında yen
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Çıkış yapılıyor. Algılanan aracılar tamamlandığında yenilenecektir."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Codex Composer’da gösterilen boyutlar. Sıkıştırma, seçilen pencerenin %90’ında otomatik başlar. Bu boyut listede olduğunda yeni Konular varsayılan olarak 400k kullanır."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -218,6 +218,11 @@ msgstr "Хуки {0} видалено для {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} цілей встановлення"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} уже є в списку."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Метрика активності"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Додати кандидата"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Додати профіль Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Додати контекстне вікно"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Контекст передано до {targetLabel}"
 msgid "Context usage"
 msgstr "Використання контексту"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Контекстні вікна"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Продовжити"
@@ -3601,6 +3615,10 @@ msgstr "Користувацький"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Користувацькі команди доступні з контекстного меню проекту (правий клік)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Власне контекстне вікно"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Відкидає вхідні конверти хуків на супе�
 msgid "Duplicate server name in scan"
 msgstr "Повторювана назва сервера в результатах сканування"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "напр. 512k або 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "напр., Codex GPT-5.5 fast для швидких запитів, OpenCode GLM для масових рефакторингів, Claude Opus для всього тонкого."
@@ -4381,6 +4403,10 @@ msgstr "Введіть URL репозиторію."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Введіть безпечну URL-адресу репозиторію з використанням HTTPS, HTTP, SSH, Git, FTP, FTPS або синтаксису scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Введіть розмір, наприклад 512k або 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Видалити"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Видалити {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Не виконано обов'язкові рецензії, обгов
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "скидання"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Скинути"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Скинути контекстні вікна"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Вихід із {env}. Виявлені агенти оновлятьс�
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Вихід. Виявлені агенти оновляться після завершення."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Розміри, що показуються в полі вводу Codex. Стискання автоматично починається на 90% вибраного вікна. Нові треди за замовчуванням використовують 400k, якщо цей розмір є в списку."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -218,6 +218,11 @@ msgstr "Đã xóa hook {0} cho {envName}."
 #~ msgid "{0} install targets"
 #~ msgstr "{0} mục tiêu cài đặt"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} đã có trong danh sách."
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "Chỉ số hoạt động"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "Thêm ứng viên"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "Thêm hồ sơ Claude"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "Thêm cửa sổ ngữ cảnh"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "Ngữ cảnh được chuyển sang {targetLabel}"
 msgid "Context usage"
 msgstr "Sử dụng ngữ cảnh"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "Cửa sổ ngữ cảnh"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "Tiếp tục"
@@ -3601,6 +3615,10 @@ msgstr "Tùy chỉnh"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "Các lệnh tùy chỉnh có sẵn từ menu ngữ cảnh của dự án (nhấp chuột phải)."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "Cửa sổ ngữ cảnh tùy chỉnh"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "Loại bỏ các gói hook đến tại trình giám sát để các tá
 msgid "Duplicate server name in scan"
 msgstr "Tên máy chủ bị trùng trong kết quả quét"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "vd. 512k hoặc 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "ví dụ: Codex GPT-5.5 fast cho các tra cứu nhanh, OpenCode GLM cho tái cấu trúc hàng loạt, Claude Opus cho những việc tinh tế."
@@ -4381,6 +4403,10 @@ msgstr "Nhập URL kho lưu trữ."
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "Nhập URL kho lưu trữ an toàn sử dụng HTTPS, HTTP, SSH, Git, FTP, FTPS hoặc cú pháp scp."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "Nhập kích thước như 512k hoặc 1m."
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9257,8 +9283,10 @@ msgstr "Xóa"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "Xóa {0}"
 
@@ -9490,6 +9518,14 @@ msgstr "Các đánh giá, cuộc trò chuyện hoặc kiểm tra trạng thái b
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "đặt lại"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "Đặt lại"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "Đặt lại cửa sổ ngữ cảnh"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10646,6 +10682,10 @@ msgstr "Đang đăng xuất {env}. Các tác nhân được phát hiện sẽ l�
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "Đang đăng xuất. Các tác nhân được phát hiện sẽ làm mới khi nó kết thúc."
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "Các kích thước hiện trong Composer của Codex. Việc nén tự động bắt đầu ở 90% cửa sổ đã chọn. Các cuộc trò chuyện mới mặc định dùng 400k khi kích thước đó có trong danh sách."
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -218,6 +218,11 @@ msgstr "删除了{envName}的{0}挂钩。"
 #~ msgid "{0} install targets"
 #~ msgstr "{0}安装目标"
 
+#. placeholder {0}: parsed.label
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "{0} is already in the list."
+msgstr "{0} 已在列表中。"
+
 #. placeholder {0}: agent.label
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "{0} is already up to date."
@@ -848,6 +853,7 @@ msgstr "活动指标"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/mcp/McpServerEditor.tsx
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/RemoteServersSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/SearchExcludeBody.tsx
 msgid "Add"
@@ -924,6 +930,10 @@ msgstr "添加候选项"
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
 msgid "Add Claude profile"
 msgstr "添加 Claude 配置文件"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Add context window"
+msgstr "添加上下文窗口"
 
 #: src/renderer/components/thread/ThreadAuthRequiredDock.tsx
 msgid "Add credentials before this thread can run."
@@ -3045,6 +3055,10 @@ msgstr "上下文转移到{targetLabel}"
 msgid "Context usage"
 msgstr "上下文使用"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Context windows"
+msgstr "上下文窗口"
+
 #: src/renderer/components/thread/ThreadRuntimeRequestPanel/structuredElicitation.tsx
 msgid "Continue"
 msgstr "继续"
@@ -3601,6 +3615,10 @@ msgstr "定制"
 #: src/renderer/views/ProjectSettingsOverlay/parts/ActionsSection.tsx
 msgid "Custom commands available from the project context menu (right-click)."
 msgstr "可从项目上下文菜单（右键单击）使用自定义命令。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Custom context window"
+msgstr "自定义上下文窗口"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "custom path"
@@ -4183,6 +4201,10 @@ msgstr "在监管进程上丢弃传入的挂钩信封，以便代理回退到 L2
 msgid "Duplicate server name in scan"
 msgstr "扫描结果中存在重复的服务器名称"
 
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "e.g. 512k or 1m"
+msgstr "例如 512k 或 1m"
+
 #: src/renderer/views/SettingsOverlay/parts/CrossagentRoutingSection.tsx
 msgid "e.g. Codex GPT-5.5 fast for quick lookups, OpenCode GLM for bulk refactors, Claude Opus for anything subtle."
 msgstr "例如：Codex GPT-5.5 fast 用于快速查询，OpenCode GLM 用于批量重构，Claude Opus 用于任何微妙的任务。"
@@ -4381,6 +4403,10 @@ msgstr "输入存储库 URL。"
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a safe repository URL using HTTPS, HTTP, SSH, Git, FTP, FTPS, or scp syntax."
 msgstr "请输入使用 HTTPS、HTTP、SSH、Git、FTP、FTPS 或 scp 语法的安全仓库 URL。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Enter a size like 512k or 1m."
+msgstr "请输入类似 512k 或 1m 的大小。"
 
 #: src/renderer/i18n/sharedMessages.ts
 msgid "Enter a valid absolute project path."
@@ -9256,8 +9282,10 @@ msgstr "删除"
 
 #. placeholder {0}: att.name
 #. placeholder {0}: removeConfirm.target.name
+#. placeholder {0}: window.label
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/renderer/components/composer/AttachmentBar.tsx
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
 msgid "Remove {0}"
 msgstr "删除{0}"
 
@@ -9489,6 +9517,14 @@ msgstr "未满足所需的审查、对话或状态检查。"
 #: src/renderer/views/ProjectSettingsOverlay/parts/SearchSection.tsx
 msgid "reset"
 msgstr "重置"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset"
+msgstr "重置"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Reset context windows"
+msgstr "重置上下文窗口"
 
 #: src/renderer/views/SettingsOverlay/parts/ModelOrderSection.tsx
 msgid "Reset model order"
@@ -10645,6 +10681,10 @@ msgstr "注销{env}。检测到的代理将在完成后刷新。"
 #: src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
 msgid "Signing out. Detected agents will refresh when it finishes."
 msgstr "正在退出。检测到的代理将在完成后刷新。"
+
+#: src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+msgid "Sizes shown in the Codex composer. Compaction starts automatically at 90% of the selected window. New chats default to 400k when that size is in the list."
+msgstr "显示在 Codex Composer 中的大小。压缩会在所选窗口的 90% 时自动开始。当列表中包含 400k 时，新对话默认使用 400k。"
 
 #: src/renderer/components/plugins/PluginDetail.tsx
 msgid "Skill"

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,9 +45,34 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v7 statuses cached before Codex context-window capabilities", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    expect(options.version).toBe(8);
+    const staleCodex = makeStatus({
+      kind: "codex",
+      label: "Codex",
+      capabilities: { ...makeStatus().capabilities },
+    });
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [staleCodex],
+        wslAgentStatuses: [],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      7,
+    );
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
+
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(7);
+    expect(options.version).toBe(8);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({
@@ -96,6 +121,38 @@ describe("setAgentStatuses", () => {
     useAgentStatusesStore.getState().setAgentStatuses([fresh]);
     expect(useAgentStatusesStore.getState().agentStatuses[0]?.capabilities.slashCommands).toEqual(
       fresh.capabilities.slashCommands,
+    );
+  });
+
+  it("replaces the array when only Codex context-window capabilities change", () => {
+    const cached = makeStatus({
+      kind: "codex",
+      capabilities: {
+        ...makeStatus().capabilities,
+        contextSizes: [
+          { id: "272k", label: "272k" },
+          { id: "400k", label: "400k" },
+          { id: "1m", label: "1M" },
+        ],
+        defaultContextSize: "400k",
+      },
+    });
+    const fresh = makeStatus({
+      kind: "codex",
+      capabilities: {
+        ...cached.capabilities,
+        contextSizes: [
+          { id: "400k", label: "400k" },
+          { id: "512k", label: "512k" },
+        ],
+        defaultContextSize: "400k",
+        modelContextSizes: { "gpt-5.6-sol": ["400k", "512k"] },
+      },
+    });
+    useAgentStatusesStore.getState().hydrateFromCache({ windows: [cached], wsl: [] });
+    useAgentStatusesStore.getState().setAgentStatuses([fresh]);
+    expect(useAgentStatusesStore.getState().agentStatuses[0]?.capabilities.contextSizes).toEqual(
+      fresh.capabilities.contextSizes,
     );
   });
 

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -80,6 +80,14 @@ function capabilitiesEqual(
   // gets replaced — otherwise the one-shot AI selectors would keep hiding
   // one-shot-capable providers for the whole first post-upgrade session.
   if ((a.supportsOneShot ?? false) !== (b.supportsOneShot ?? false)) return false;
+  // Codex context-window lists are user-editable. A detection that only
+  // changes those fields must replace the cached status or the composer keeps
+  // the previous picker after settings save / next launch.
+  if (JSON.stringify(a.contextSizes ?? []) !== JSON.stringify(b.contextSizes ?? [])) return false;
+  if (JSON.stringify(a.modelContextSizes ?? {}) !== JSON.stringify(b.modelContextSizes ?? {})) {
+    return false;
+  }
+  if ((a.defaultContextSize ?? "") !== (b.defaultContextSize ?? "")) return false;
   return true;
 }
 
@@ -246,12 +254,11 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 7,
-      // v7 drops the v6 status written when the macOS Grok ACP probe lost the
-      // login-shell PATH and could not start its Node-backed executable. This
-      // prevents the UI from hydrating that stale 0/0 before detection reruns.
-      // This mirrors the supervisor STATUS_CACHE_VERSION=10 bump, which only
-      // invalidates the supervisor's on-disk cache, not this localStorage copy.
+      version: 8,
+      // v8 drops statuses cached before Codex advertised selectable context
+      // windows. This mirrors the supervisor STATUS_CACHE_VERSION=11 bump, which
+      // only invalidates the supervisor's on-disk cache, not this localStorage
+      // copy.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.test.tsx
@@ -1,0 +1,226 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import type { ChangeEvent, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
+import {
+  CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+  serializeContextWindows,
+  DEFAULT_CODEX_CONTEXT_WINDOWS,
+} from "@/shared/agents/codexContextWindows";
+
+const toastMock = vi.hoisted(() => ({
+  danger: vi.fn<(message: string) => void>(),
+  warning: vi.fn<(message: string) => void>(),
+  success: vi.fn<(message: string) => void>(),
+}));
+
+vi.mock("@heroui/react", () => ({
+  Button: (props: {
+    children?: ReactNode;
+    "aria-label"?: string;
+    isDisabled?: boolean;
+    type?: "button" | "submit";
+    onPress?: () => void;
+  }) => (
+    <button
+      type={props.type === "submit" ? "submit" : "button"}
+      aria-label={props["aria-label"]}
+      disabled={props.isDisabled}
+      onClick={props.onPress}
+    >
+      {props.children}
+    </button>
+  ),
+  toast: toastMock,
+}));
+
+vi.mock("@/renderer/components/common", () => ({
+  Input: (props: {
+    "aria-label"?: string;
+    value: string;
+    disabled?: boolean;
+    placeholder?: string;
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <input
+      aria-label={props["aria-label"]}
+      value={props.value}
+      disabled={props.disabled}
+      placeholder={props.placeholder}
+      onChange={props.onChange}
+    />
+  ),
+}));
+
+const bridgeMock = vi.hoisted(() => ({
+  refreshAgentStatuses: vi.fn<(...args: unknown[]) => Promise<void>>(),
+}));
+const flushSharedSettingsMock = vi.hoisted(() => vi.fn<() => Promise<void>>());
+
+vi.mock("@/renderer/bridge", () => ({
+  readBridge: () => bridgeMock,
+}));
+
+vi.mock("@/renderer/state/sharedSettingsStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/renderer/state/sharedSettingsStore")>();
+  return { ...actual, flushSharedSettings: flushSharedSettingsMock };
+});
+
+import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { CodexProviderSettings } from "./CodexProviderSettings";
+import { NATIVE_AGENT_REGISTRY_ENTRIES } from "./agentRegistryNative";
+
+const setAgentSettingMock = vi.hoisted(() =>
+  vi.fn<(agentKind: string, key: string, value: boolean | string) => void>(),
+);
+
+beforeEach(() => {
+  bridgeMock.refreshAgentStatuses.mockReset().mockResolvedValue(undefined);
+  flushSharedSettingsMock.mockReset().mockResolvedValue(undefined);
+  toastMock.danger.mockReset();
+  toastMock.warning.mockReset();
+  setAgentSettingMock.mockReset().mockImplementation((agentKind, key, value) => {
+    const current = useSharedSettings.getState().agentSettings;
+    useSharedSettings.setState({
+      agentSettings: {
+        ...current,
+        [agentKind]: { ...current[agentKind], [key]: value },
+      },
+    });
+  });
+  useSharedSettings.setState({
+    agentSettings: {},
+    setAgentSetting: setAgentSettingMock,
+  });
+});
+
+describe("CodexProviderSettings", () => {
+  it("registers the provider-local panel for Codex", () => {
+    expect(NATIVE_AGENT_REGISTRY_ENTRIES.find((entry) => entry.id === "codex")?.settingsPanel).toBe(
+      CodexProviderSettings,
+    );
+  });
+
+  it("shows the default 272k, 400k, and 1M sizes", () => {
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    expect(screen.getByText("272k")).toBeInTheDocument();
+    expect(screen.getByText("400k")).toBeInTheDocument();
+    expect(screen.getByText("1M")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset context windows" })).toBeDisabled();
+  });
+
+  it("adds a custom size and refreshes Codex detection", async () => {
+    render(<CodexProviderSettings agentKind="codex" wslDistros={["Ubuntu"]} />);
+
+    fireEvent.change(screen.getByLabelText("Custom context window"), {
+      target: { value: "512k" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add context window" }));
+    });
+
+    expect(setAgentSettingMock).toHaveBeenCalledWith(
+      "codex",
+      CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+      serializeContextWindows([
+        DEFAULT_CODEX_CONTEXT_WINDOWS[0]!,
+        DEFAULT_CODEX_CONTEXT_WINDOWS[1]!,
+        { id: "512k", label: "512k", tokens: 512_000 },
+        DEFAULT_CODEX_CONTEXT_WINDOWS[2]!,
+      ]),
+    );
+    expect(flushSharedSettingsMock).toHaveBeenCalled();
+    expect(bridgeMock.refreshAgentStatuses).toHaveBeenCalledWith(["Ubuntu"], {
+      agentKinds: ["codex"],
+    });
+    expect(screen.getByText("512k")).toBeInTheDocument();
+  });
+
+  it("removes a size from the list", async () => {
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Remove 272k" }));
+    });
+
+    expect(setAgentSettingMock).toHaveBeenCalledWith(
+      "codex",
+      CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+      '["400k","1m"]',
+    );
+    expect(screen.queryByText("272k")).not.toBeInTheDocument();
+  });
+
+  it("ignores Enter when the custom size field is empty", async () => {
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    await act(async () => {
+      fireEvent.submit(screen.getByLabelText("Custom context window").closest("form")!);
+    });
+
+    expect(toastMock.warning).not.toHaveBeenCalled();
+    expect(flushSharedSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid and duplicate sizes", async () => {
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    fireEvent.change(screen.getByLabelText("Custom context window"), {
+      target: { value: "nope" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add context window" }));
+    });
+    expect(toastMock.warning).toHaveBeenCalledWith("Enter a size like 512k or 1m.");
+
+    fireEvent.change(screen.getByLabelText("Custom context window"), {
+      target: { value: "400k" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Add context window" }));
+    });
+    expect(toastMock.warning).toHaveBeenCalledWith("400k is already in the list.");
+    expect(flushSharedSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("resets a customized list back to the built-in sizes", async () => {
+    useSharedSettings.setState({
+      agentSettings: { codex: { contextWindows: '["400k","512k"]' } },
+    });
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Reset context windows" }));
+    });
+
+    expect(setAgentSettingMock).toHaveBeenCalledWith(
+      "codex",
+      CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+      serializeContextWindows(DEFAULT_CODEX_CONTEXT_WINDOWS),
+    );
+    expect(screen.getByText("272k")).toBeInTheDocument();
+    expect(screen.getByText("1M")).toBeInTheDocument();
+    expect(screen.queryByText("512k")).not.toBeInTheDocument();
+  });
+
+  it("restores the previous list when refresh fails", async () => {
+    useSharedSettings.setState({
+      agentSettings: { codex: { contextWindows: '["400k","1m"]' } },
+    });
+    flushSharedSettingsMock.mockRejectedValueOnce(new Error("disk write failed"));
+    render(<CodexProviderSettings agentKind="codex" wslDistros={[]} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Remove 400k" }));
+    });
+
+    expect(setAgentSettingMock).toHaveBeenLastCalledWith(
+      "codex",
+      CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+      '["400k","1m"]',
+    );
+    expect(toastMock.danger).toHaveBeenCalled();
+    expect(screen.getByText("400k")).toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CodexProviderSettings.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { Button, toast } from "@heroui/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { Plus, RotateCcw, X } from "lucide-react";
+import {
+  CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+  contextWindowsEqual,
+  DEFAULT_CODEX_CONTEXT_WINDOWS,
+  parseContextWindowInput,
+  resolveCodexContextWindows,
+  serializeContextWindows,
+  type CodexContextWindow,
+} from "@/shared/agents/codexContextWindows";
+import { Input } from "@/renderer/components/common";
+import { readBridge } from "@/renderer/bridge";
+import { flushSharedSettings, useSharedSettings } from "@/renderer/state/sharedSettingsStore";
+import { friendlyError } from "@/shared/messages";
+
+export function CodexProviderSettings(props: { agentKind: string; wslDistros: string[] }) {
+  const { t } = useLingui();
+  const { agentKind, wslDistros } = props;
+  const stored = useSharedSettings((state) => state.agentSettings[agentKind]);
+  const setAgentSetting = useSharedSettings((state) => state.setAgentSetting);
+  const windows = resolveCodexContextWindows(stored);
+  const [draft, setDraft] = useState("");
+  const [pendingAction, setPendingAction] = useState<string | undefined>();
+  const isBusy = pendingAction !== undefined;
+  const isDefaultList = contextWindowsEqual(windows, DEFAULT_CODEX_CONTEXT_WINDOWS);
+
+  const persist = async (next: CodexContextWindow[], action: string) => {
+    setPendingAction(action);
+    const previous = stored?.[CODEX_CONTEXT_WINDOWS_SETTING_KEY];
+    setAgentSetting(agentKind, CODEX_CONTEXT_WINDOWS_SETTING_KEY, serializeContextWindows(next));
+    try {
+      await flushSharedSettings();
+      await readBridge().refreshAgentStatuses(wslDistros, { agentKinds: [agentKind] });
+    } catch (error) {
+      if (typeof previous === "string") {
+        setAgentSetting(agentKind, CODEX_CONTEXT_WINDOWS_SETTING_KEY, previous);
+      } else {
+        setAgentSetting(
+          agentKind,
+          CODEX_CONTEXT_WINDOWS_SETTING_KEY,
+          serializeContextWindows(DEFAULT_CODEX_CONTEXT_WINDOWS),
+        );
+      }
+      toast.danger(friendlyError(error));
+    } finally {
+      setPendingAction(undefined);
+    }
+  };
+
+  const addWindow = () => {
+    if (!draft.trim()) return;
+    const parsed = parseContextWindowInput(draft);
+    if (!parsed) {
+      toast.warning(t`Enter a size like 512k or 1m.`);
+      return;
+    }
+    if (windows.some((window) => window.tokens === parsed.tokens)) {
+      toast.warning(t`${parsed.label} is already in the list.`);
+      return;
+    }
+    const next = [...windows, parsed].sort((left, right) => left.tokens - right.tokens);
+    setDraft("");
+    void persist(next, "add");
+  };
+
+  const removeWindow = (id: string) => {
+    if (windows.length <= 1) return;
+    void persist(
+      windows.filter((window) => window.id !== id),
+      `remove:${id}`,
+    );
+  };
+
+  return (
+    <div className="border-t border-border/10 pt-3">
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground">
+            <Trans>Context windows</Trans>
+          </p>
+          <p className="text-xs text-muted">
+            <Trans>
+              Sizes shown in the Codex composer. Compaction starts automatically at 90% of the
+              selected window. New chats default to 400k when that size is in the list.
+            </Trans>
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-7 min-h-7 shrink-0 gap-1 px-2 text-[11px]"
+          aria-label={t`Reset context windows`}
+          isDisabled={isDefaultList || isBusy}
+          isPending={pendingAction === "reset"}
+          onPress={() => void persist([...DEFAULT_CODEX_CONTEXT_WINDOWS], "reset")}
+        >
+          <RotateCcw className="size-3" />
+          <Trans>Reset</Trans>
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {windows.map((window) => (
+          <span
+            key={window.id}
+            className="inline-flex items-center gap-1 rounded-md border border-border bg-surface-secondary px-2 py-0.5 text-xs text-foreground"
+          >
+            {window.label}
+            <Button
+              isIconOnly
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 min-h-6 min-w-6 text-muted"
+              aria-label={t`Remove ${window.label}`}
+              isDisabled={windows.length <= 1 || isBusy}
+              isPending={pendingAction === `remove:${window.id}`}
+              onPress={() => removeWindow(window.id)}
+            >
+              <X className="size-3" />
+            </Button>
+          </span>
+        ))}
+      </div>
+
+      <form
+        className="mt-2 flex items-center gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          addWindow();
+        }}
+      >
+        <Input
+          aria-label={t`Custom context window`}
+          className="h-8 min-h-8 max-w-[180px]"
+          placeholder={t`e.g. 512k or 1m`}
+          value={draft}
+          disabled={isBusy}
+          onChange={(event) => setDraft(event.currentTarget.value)}
+        />
+        <Button
+          size="sm"
+          variant="tertiary"
+          className="h-8 min-h-8 gap-1 px-2.5 text-[11px]"
+          type="submit"
+          aria-label={t`Add context window`}
+          isDisabled={isBusy || draft.trim().length === 0}
+          isPending={pendingAction === "add"}
+        >
+          <Plus className="size-3" />
+          <Trans>Add</Trans>
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
+++ b/src/renderer/views/SettingsOverlay/parts/agentRegistryNative.ts
@@ -4,6 +4,7 @@ import type { MessageDescriptor } from "@lingui/core";
 import type { AgentKind, AgentProviderMetadata, AgentStatus, Project } from "@/shared/contracts";
 import { isMac, isWindows, readBridge } from "@/renderer/bridge";
 import { ClaudeAgentSettingsPanel } from "./ClaudeProfileSettings";
+import { CodexProviderSettings } from "./CodexProviderSettings";
 import { CursorProviderSettings } from "./CursorProviderSettings";
 import { OpenCodeProviderSettings } from "./OpenCodeProviderSettings";
 import { cursorAgentInstallCommand, cursorRuntimeSlots } from "./cursorRuntimeInstall";
@@ -129,6 +130,7 @@ export const NATIVE_AGENT_REGISTRY_ENTRIES: NativeAgentRegistryEntry[] = [
         windows:
           "if (Get-Command powershell -ErrorAction SilentlyContinue) { powershell -ExecutionPolicy ByPass -c \"irm https://chatgpt.com/codex/install.ps1 | iex\" } elseif (Get-Command npm -ErrorAction SilentlyContinue) { npm install -g @openai/codex } else { Write-Host 'No supported installer found. Install Windows PowerShell or Node.js/npm first, then refresh detected agents.' }",
       }),
+    settingsPanel: CodexProviderSettings,
   },
   {
     id: "claude",

--- a/src/shared/agents/codexContextWindows.test.ts
+++ b/src/shared/agents/codexContextWindows.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  autoCompactTokenLimit,
+  buildCodexContextSizeCapabilities,
+  codexContextWindowOverrides,
+  DEFAULT_CODEX_CONTEXT_SIZE,
+  DEFAULT_CODEX_CONTEXT_WINDOWS,
+  parseContextWindowInput,
+  parseStoredContextWindows,
+  resolveCodexContextWindows,
+  resolveDefaultCodexContextSize,
+  serializeContextWindows,
+} from "./codexContextWindows";
+
+describe("parseContextWindowInput", () => {
+  it("parses k/m suffixes and raw token counts", () => {
+    expect(parseContextWindowInput("272k")).toEqual({ id: "272k", label: "272k", tokens: 272_000 });
+    expect(parseContextWindowInput("400K")).toEqual({ id: "400k", label: "400k", tokens: 400_000 });
+    expect(parseContextWindowInput("1m")).toEqual({ id: "1m", label: "1M", tokens: 1_000_000 });
+    expect(parseContextWindowInput("1.05M")).toEqual({
+      id: "1.05m",
+      label: "1.05M",
+      tokens: 1_050_000,
+    });
+    expect(parseContextWindowInput("512000")).toEqual({
+      id: "512k",
+      label: "512k",
+      tokens: 512_000,
+    });
+  });
+
+  it("rejects empty, zero, and out-of-range values", () => {
+    expect(parseContextWindowInput("")).toBeUndefined();
+    expect(parseContextWindowInput("0k")).toBeUndefined();
+    expect(parseContextWindowInput("12")).toBeUndefined();
+    expect(parseContextWindowInput("20m")).toBeUndefined();
+    expect(parseContextWindowInput("huge")).toBeUndefined();
+  });
+});
+
+describe("stored Codex context windows", () => {
+  it("falls back to 272k, 400k, and 1M", () => {
+    expect(parseStoredContextWindows(undefined).map((window) => window.id)).toEqual([
+      "272k",
+      "400k",
+      "1m",
+    ]);
+    expect(DEFAULT_CODEX_CONTEXT_WINDOWS.map((window) => window.id)).toEqual([
+      "272k",
+      "400k",
+      "1m",
+    ]);
+  });
+
+  it("dedupes, sorts, and round-trips custom values", () => {
+    const windows = parseStoredContextWindows('["1m","512k","512000","272k"]');
+    expect(windows.map((window) => window.id)).toEqual(["272k", "512k", "1m"]);
+    expect(parseStoredContextWindows(serializeContextWindows(windows))).toEqual(windows);
+  });
+
+  it("reads the agent-settings key and keeps 400k as the default when present", () => {
+    const windows = resolveCodexContextWindows({ contextWindows: '["1m","272k"]' });
+    expect(windows.map((window) => window.id)).toEqual(["272k", "1m"]);
+    expect(resolveDefaultCodexContextSize(windows)).toBe("272k");
+    expect(resolveDefaultCodexContextSize(DEFAULT_CODEX_CONTEXT_WINDOWS)).toBe(
+      DEFAULT_CODEX_CONTEXT_SIZE,
+    );
+  });
+});
+
+describe("Codex context-window launch overrides", () => {
+  it("defaults to 400k with compaction at 90%", () => {
+    expect(codexContextWindowOverrides()).toEqual({
+      model_context_window: 400_000,
+      model_auto_compact_token_limit: 360_000,
+    });
+    expect(codexContextWindowOverrides("1m")).toEqual({
+      model_context_window: 1_000_000,
+      model_auto_compact_token_limit: 900_000,
+    });
+    expect(autoCompactTokenLimit(272_000)).toBe(244_800);
+  });
+});
+
+describe("buildCodexContextSizeCapabilities", () => {
+  it("puts 400k first on every model so new drafts default to it", () => {
+    const caps = buildCodexContextSizeCapabilities(
+      ["gpt-5.6-sol", "gpt-5.6-terra"],
+      DEFAULT_CODEX_CONTEXT_WINDOWS,
+    );
+    expect(caps.defaultContextSize).toBe("400k");
+    expect(caps.contextSizes?.map((size) => size.id)).toEqual(["272k", "400k", "1m"]);
+    expect(caps.modelContextSizes).toEqual({
+      "gpt-5.6-sol": ["400k", "272k", "1m"],
+      "gpt-5.6-terra": ["400k", "272k", "1m"],
+    });
+  });
+});

--- a/src/shared/agents/codexContextWindows.ts
+++ b/src/shared/agents/codexContextWindows.ts
@@ -1,0 +1,161 @@
+import type { AgentCapability, LabeledOption } from "@/shared/contracts";
+
+/** Agent-settings key storing the user's Codex context-window list as JSON. */
+export const CODEX_CONTEXT_WINDOWS_SETTING_KEY = "contextWindows";
+
+/** Poracode's default Codex context window. Codex's own CLI default is 272k. */
+export const DEFAULT_CODEX_CONTEXT_SIZE = "400k";
+
+const MIN_CONTEXT_WINDOW_TOKENS = 1_000;
+const MAX_CONTEXT_WINDOW_TOKENS = 10_000_000;
+const AUTO_COMPACT_RATIO = 0.9;
+
+export interface CodexContextWindow {
+  id: string;
+  label: string;
+  tokens: number;
+}
+
+const CONTEXT_WINDOW_INPUT = /^(\d+(?:\.\d+)?)\s*([kKmM])?$/;
+
+export function parseContextWindowInput(raw: string): CodexContextWindow | undefined {
+  const trimmed = raw.trim().replaceAll(",", "");
+  if (!trimmed) return undefined;
+  const match = CONTEXT_WINDOW_INPUT.exec(trimmed);
+  if (!match) return undefined;
+  const amount = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(amount) || amount <= 0) return undefined;
+  const suffix = match[2]?.toLowerCase();
+  const tokens =
+    suffix === "m"
+      ? Math.round(amount * 1_000_000)
+      : suffix === "k"
+        ? Math.round(amount * 1_000)
+        : Math.round(amount);
+  if (tokens < MIN_CONTEXT_WINDOW_TOKENS || tokens > MAX_CONTEXT_WINDOW_TOKENS) {
+    return undefined;
+  }
+  const id = contextWindowIdFromTokens(tokens);
+  return { id, label: contextWindowLabelFromId(id), tokens };
+}
+
+export function contextWindowIdFromTokens(tokens: number): string {
+  if (tokens >= 1_000_000 && tokens % 10_000 === 0) {
+    const millions = tokens / 1_000_000;
+    const text = Number.isInteger(millions)
+      ? String(millions)
+      : String(Math.round(millions * 100) / 100);
+    return `${text}m`;
+  }
+  if (tokens % 1_000 === 0) return `${tokens / 1_000}k`;
+  return String(tokens);
+}
+
+export function contextWindowLabelFromId(id: string): string {
+  return id.endsWith("m") ? `${id.slice(0, -1)}M` : id;
+}
+
+export const DEFAULT_CODEX_CONTEXT_WINDOWS: readonly CodexContextWindow[] = [
+  parseContextWindowInput("272k")!,
+  parseContextWindowInput("400k")!,
+  parseContextWindowInput("1m")!,
+];
+
+export function parseStoredContextWindows(value: unknown): CodexContextWindow[] {
+  if (typeof value !== "string" || !value.trim()) {
+    return [...DEFAULT_CODEX_CONTEXT_WINDOWS];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [...DEFAULT_CODEX_CONTEXT_WINDOWS];
+    const windows = new Map<number, CodexContextWindow>();
+    for (const entry of parsed) {
+      const window =
+        typeof entry === "string"
+          ? parseContextWindowInput(entry)
+          : typeof entry === "number"
+            ? parseContextWindowInput(String(entry))
+            : undefined;
+      if (window) windows.set(window.tokens, window);
+    }
+    if (windows.size === 0) return [...DEFAULT_CODEX_CONTEXT_WINDOWS];
+    return [...windows.values()].sort((a, b) => a.tokens - b.tokens);
+  } catch {
+    return [...DEFAULT_CODEX_CONTEXT_WINDOWS];
+  }
+}
+
+export function serializeContextWindows(windows: readonly CodexContextWindow[]): string {
+  return JSON.stringify(windows.map((window) => window.id));
+}
+
+export function resolveCodexContextWindows(
+  agentSettings?: Record<string, boolean | string>,
+): CodexContextWindow[] {
+  return parseStoredContextWindows(agentSettings?.[CODEX_CONTEXT_WINDOWS_SETTING_KEY]);
+}
+
+export function resolveDefaultCodexContextSize(windows: readonly CodexContextWindow[]): string {
+  if (windows.some((window) => window.id === DEFAULT_CODEX_CONTEXT_SIZE)) {
+    return DEFAULT_CODEX_CONTEXT_SIZE;
+  }
+  return windows[0]?.id ?? DEFAULT_CODEX_CONTEXT_SIZE;
+}
+
+export function contextWindowsEqual(
+  left: readonly CodexContextWindow[],
+  right: readonly CodexContextWindow[],
+): boolean {
+  return (
+    left.length === right.length && left.every((window, index) => window.id === right[index]?.id)
+  );
+}
+
+/**
+ * Compaction starts below the window so Codex has headroom to summarize.
+ * Matches the documented 1M → 900k pairing (90%).
+ */
+export function autoCompactTokenLimit(windowTokens: number): number {
+  if (windowTokens <= 1) return 1;
+  return Math.max(1, Math.min(Math.floor(windowTokens * AUTO_COMPACT_RATIO), windowTokens - 1));
+}
+
+export function resolveCodexContextWindowTokens(contextSize?: string): number {
+  return (
+    parseContextWindowInput(contextSize ?? "")?.tokens ??
+    parseContextWindowInput(DEFAULT_CODEX_CONTEXT_SIZE)!.tokens
+  );
+}
+
+export function codexContextWindowOverrides(contextSize?: string): {
+  model_context_window: number;
+  model_auto_compact_token_limit: number;
+} {
+  const tokens = resolveCodexContextWindowTokens(contextSize);
+  return {
+    model_context_window: tokens,
+    model_auto_compact_token_limit: autoCompactTokenLimit(tokens),
+  };
+}
+
+export function buildCodexContextSizeCapabilities(
+  modelIds: readonly string[],
+  windows: readonly CodexContextWindow[],
+): Pick<AgentCapability, "contextSizes" | "modelContextSizes" | "defaultContextSize"> {
+  const defaultId = resolveDefaultCodexContextSize(windows);
+  const defaultFirst = [
+    defaultId,
+    ...windows.map((window) => window.id).filter((id) => id !== defaultId),
+  ];
+  const contextSizes: LabeledOption[] = windows.map((window) => ({
+    id: window.id,
+    label: window.label,
+  }));
+  return {
+    contextSizes,
+    defaultContextSize: defaultId,
+    ...(modelIds.length > 0
+      ? { modelContextSizes: Object.fromEntries(modelIds.map((id) => [id, defaultFirst])) }
+      : {}),
+  };
+}

--- a/src/supervisor/agents/codex/argv.ts
+++ b/src/supervisor/agents/codex/argv.ts
@@ -19,6 +19,7 @@ import {
   probeCodexCliSemver,
 } from "./plugin/install";
 import { resolveCodexWindowsLaunchBinary } from "./windowsExecutable";
+import { codexContextWindowOverrides } from "@/shared/agents/codexContextWindows";
 import { buildCodexMcp } from "../userMcp";
 import { buildCodexMcpSkillConflictArgs } from "./mcpSkillConflicts";
 
@@ -65,6 +66,13 @@ function buildCodexArgs(opts: BuildCodexArgsOptions): string[] {
       // Codex's `service_tier="fast"` selects the priority lane on supported models.
       args.push("-c", 'service_tier="fast"');
     }
+    const contextWindow = codexContextWindowOverrides(config.contextSize);
+    args.push(
+      "-c",
+      `model_context_window=${contextWindow.model_context_window}`,
+      "-c",
+      `model_auto_compact_token_limit=${contextWindow.model_auto_compact_token_limit}`,
+    );
     if (config.approvalPolicy) {
       args.push("-a", config.approvalPolicy);
     }

--- a/src/supervisor/agents/codex/codex.test.ts
+++ b/src/supervisor/agents/codex/codex.test.ts
@@ -1298,6 +1298,8 @@ describe("CodexStructuredSession", () => {
           config: {
             model_reasoning_effort: "high",
             model_reasoning_summary: "auto",
+            model_context_window: 400_000,
+            model_auto_compact_token_limit: 360_000,
           },
           threadId: "provider-thread",
           lastTurnId: "turn-2",
@@ -2837,6 +2839,15 @@ describe("mapCodexSlashCommands", () => {
     expect(codexDefaultCapabilities.slashCommands?.map((cmd) => cmd.id)).toEqual(
       expect.arrayContaining(["status", "model", "review", "compact", "permissions"]),
     );
+  });
+
+  it("advertises 272k, 400k, and 1M context windows with a 400k default", () => {
+    expect(codexDefaultCapabilities.defaultContextSize).toBe("400k");
+    expect(codexDefaultCapabilities.contextSizes?.map((size) => size.id)).toEqual([
+      "272k",
+      "400k",
+      "1m",
+    ]);
   });
 
   it("normalizes Codex app-server command metadata", () => {

--- a/src/supervisor/agents/codex/detection.contextWindows.test.ts
+++ b/src/supervisor/agents/codex/detection.contextWindows.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+
+const probeCodexCapabilities = vi.hoisted(() =>
+  vi.fn<typeof import("./probe").probeCodexCapabilities>(),
+);
+
+vi.mock("./probe", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./probe")>();
+  return {
+    ...actual,
+    probeCodexCapabilities,
+  };
+});
+
+import { codexDetectionSpec } from "./detection";
+
+const location: ProjectLocation = { kind: "windows", path: "C:\\repo" };
+
+describe("codex capabilitiesProbe context windows", () => {
+  beforeEach(() => {
+    probeCodexCapabilities.mockReset().mockResolvedValue({
+      models: [
+        { id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+        { id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+      ],
+    });
+  });
+
+  it("applies the saved custom list to every probed model", async () => {
+    const result = await codexDetectionSpec.capabilitiesProbe?.({
+      location,
+      executablePath: "codex",
+      agentSettings: { contextWindows: '["512k","1m"]' },
+    });
+
+    expect(result?.defaultContextSize).toBe("512k");
+    expect(result?.contextSizes?.map((size) => size.id)).toEqual(["512k", "1m"]);
+    expect(result?.modelContextSizes).toEqual({
+      "gpt-5.6-sol": ["512k", "1m"],
+      "gpt-5.6-terra": ["512k", "1m"],
+    });
+  });
+});

--- a/src/supervisor/agents/codex/detection.ts
+++ b/src/supervisor/agents/codex/detection.ts
@@ -10,6 +10,11 @@ import {
   type StatusProbeResult,
 } from "../base";
 import { getAgentProbeCwd } from "../probeCwd";
+import {
+  buildCodexContextSizeCapabilities,
+  DEFAULT_CODEX_CONTEXT_WINDOWS,
+  resolveCodexContextWindows,
+} from "@/shared/agents/codexContextWindows";
 import { probeCodexAccount, probeCodexCapabilities, type CodexProbeResult } from "./probe";
 import { codexAuthPath } from "./sessionFiles";
 
@@ -215,6 +220,7 @@ export const codexDefaultCapabilities: AgentCapability = {
   // Codex delivers its enabled skills through the ACP session (`skills/list`),
   // so its GUI catalog is authoritative even when it reports zero skills.
   reportsSkillCatalog: true,
+  ...buildCodexContextSizeCapabilities([], DEFAULT_CODEX_CONTEXT_WINDOWS),
 };
 
 export function probeResultToCapabilityPartial(probe: CodexProbeResult): Partial<AgentCapability> {
@@ -378,6 +384,10 @@ export const codexDetectionSpec: DetectionSpec = {
     // `buildAcpLogoutCommand` to invoke `codex logout`. Mirrors Claude.
     return {
       ...(probe ? probeResultToCapabilityPartial(probe) : {}),
+      ...buildCodexContextSizeCapabilities(
+        probe?.models?.map((model) => model.id) ?? [],
+        resolveCodexContextWindows(ctx.agentSettings),
+      ),
       authMethods: [CODEX_TERMINAL_AUTH_METHOD],
       authLogoutSupported: true,
     };

--- a/src/supervisor/agents/codex/threadOverrides.test.ts
+++ b/src/supervisor/agents/codex/threadOverrides.test.ts
@@ -27,6 +27,8 @@ describe("buildCodexThreadOverrides", () => {
     expect(overrides.cwd).toBe("C:\\repo");
     expect(overrides.config).toMatchObject({
       model_reasoning_effort: "high",
+      model_context_window: 400_000,
+      model_auto_compact_token_limit: 360_000,
       "mcp_servers.browser": {
         url: "http://127.0.0.1:9000/mcp?thread=local-thread",
         bearer_token_env_var: codexMcpTokenEnvVar(browser),
@@ -34,5 +36,14 @@ describe("buildCodexThreadOverrides", () => {
       },
     });
     expect(JSON.stringify(overrides.config)).not.toContain("secret-token");
+  });
+
+  it("maps a selected context size to the window and 90% compact limit", () => {
+    const overrides = buildCodexThreadOverrides({ model: "gpt-5.6-sol", contextSize: "1m" });
+
+    expect(overrides.config).toMatchObject({
+      model_context_window: 1_000_000,
+      model_auto_compact_token_limit: 900_000,
+    });
   });
 });

--- a/src/supervisor/agents/codex/threadOverrides.ts
+++ b/src/supervisor/agents/codex/threadOverrides.ts
@@ -1,3 +1,4 @@
+import { codexContextWindowOverrides } from "@/shared/agents/codexContextWindows";
 import type { ProjectLocation, ResolvedMcpServer, ThreadConfig } from "@/shared/contracts";
 import { getProjectPosixPath } from "@/shared/wsl";
 import { buildCodexMcp } from "../userMcp";
@@ -38,6 +39,7 @@ export function buildCodexThreadOverrides(
     config: {
       ...(config.effort ? { model_reasoning_effort: config.effort } : {}),
       model_reasoning_summary: "auto",
+      ...codexContextWindowOverrides(config.contextSize),
       ...mcpConfig,
     },
   };

--- a/src/supervisor/agents/commandBuilders.test.ts
+++ b/src/supervisor/agents/commandBuilders.test.ts
@@ -195,6 +195,20 @@ describe("agent command builders", () => {
     expect(spec.args).toContain('approvals_reviewer="auto_review"');
   });
 
+  it("passes the Codex context window and compact limit to terminal sessions", () => {
+    const spec = buildCodexArgvFor(windowsProject, { ...config, contextSize: "1m" }, "hello");
+
+    expect(spec.args).toContain("model_context_window=1000000");
+    expect(spec.args).toContain("model_auto_compact_token_limit=900000");
+  });
+
+  it("defaults Codex terminal sessions to a 400k context window", () => {
+    const spec = buildCodexArgvFor(windowsProject, config, "hello");
+
+    expect(spec.args).toContain("model_context_window=400000");
+    expect(spec.args).toContain("model_auto_compact_token_limit=360000");
+  });
+
   it("injects Codex browser MCP config when enabled, using a token env var", () => {
     const spec = buildCodexAppServerCommand(windowsProject, {
       mcpServers: [

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -40,6 +40,42 @@ afterEach(() => {
 });
 
 describe("agent status cache", () => {
+  it("invalidates v10 caches produced before Codex context-window capabilities", () => {
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 10,
+        windows: [
+          {
+            kind: "codex",
+            label: "Codex",
+            installed: true,
+            authState: "authenticated",
+            capabilities: { models: [{ id: "gpt-5.6-sol", label: "GPT-5.6 Sol" }] },
+          },
+        ],
+      }),
+    );
+
+    const runtime = makeRuntime(() => {});
+    const cached = (
+      runtime.agentStatusService as unknown as {
+        readCachedStatuses: (wslDistros: readonly string[]) => {
+          windows: AgentStatus[];
+          wsl: AgentStatus[];
+          fromCache: boolean;
+        };
+      }
+    ).readCachedStatuses([]);
+
+    expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
+
   it("invalidates v9 caches produced without the Grok login-shell environment", () => {
     const dataDir = makeTempDir();
     process.env.PORACODE_DATA_DIR = dataDir;

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -49,8 +49,10 @@ const execFileAsync = promisify(execFile);
  * lists advertised through initialize metadata (used by Grok 0.2.x). v10
  * invalidates v9 results whose macOS Grok probe could not find Node because
  * the login-shell environment was not forwarded to the ACP child process.
+ * v11 adds Codex context-window sizes (272k/400k/1m plus a user-editable list)
+ * so cached statuses without those capability fields are not reused.
  */
-export const STATUS_CACHE_VERSION = 10;
+export const STATUS_CACHE_VERSION = 11;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 


### PR DESCRIPTION
Codex sessions in Poracode can now use 272k, 400k, or 1M context, and users can add custom sizes in Settings → Codex.

## Why
Codex's built-in default is 272k. Models like GPT-5.6 Sol support a much larger window, but that requires `model_context_window` and `model_auto_compact_token_limit` on launch.

## What changed
- Composer picker offers **272k / 400k / 1M**
- Poracode default is **400k**
- Compaction is set automatically at **90%** of the window (Codex's own formula: 400k → 360k, 1M → 900k)
- TUI argv and GUI `thread/start|resume|fork` both send the overrides
- Settings → Codex lets you add, remove, or reset sizes (for example `512k` or `1.05m`)
- Status-cache versions bump so stale Codex statuses without these capabilities are not reused
- Renderer status equality now includes context-window fields so a custom list is not dropped after detection

## Test plan
- [ ] Open Settings → Codex and confirm 272k, 400k, 1M
- [ ] Add `512k`, confirm it appears in the composer picker after refresh
- [ ] Start a new Codex GUI thread and confirm it defaults to 400k
- [ ] Start/resume a terminal Codex thread and confirm `-c model_context_window` / `model_auto_compact_token_limit` are passed