### PR TITLE
Render ACP skills as accessible skill badges

### DIFF
--- a/src/renderer/components/composer/SlashCommandChip.ts
+++ b/src/renderer/components/composer/SlashCommandChip.ts
@@ -1,3 +1,6 @@
+import { msg } from "@lingui/core/macro";
+import { i18n } from "@/renderer/i18n/i18n";
+
 /**
  * Inline, non-editable badge representing a slash command inside the composer's
  * contentEditable. Plain commands serialize to `/<id>`; skill commands retain
@@ -22,10 +25,12 @@ export function createSlashCommandChipElement(
   chip.contentEditable = "false";
   chip.dataset.slashCommand = command.id;
   // `skillPath` is optional: provider-native skills carry no SKILL.md path.
-  const isSkill = Boolean(
+  // Full metadata is required to serialize as a skill segment; `skillName`
+  // alone is enough to show the skill glyph (ACP catalogs often omit the rest).
+  const isSkillSegment = Boolean(
     command.skillName && command.skillInvocation && command.skillProvider && command.skillScope,
   );
-  if (isSkill) {
+  if (isSkillSegment) {
     chip.dataset.skillName = command.skillName;
     if (command.skillPath) chip.dataset.skillPath = command.skillPath;
     chip.dataset.skillInvocation = command.skillInvocation;
@@ -33,12 +38,18 @@ export function createSlashCommandChipElement(
     chip.dataset.skillScope = command.skillScope;
     if (command.pluginId) chip.dataset.pluginId = command.pluginId;
     if (command.pluginName) chip.dataset.pluginName = command.pluginName;
+  } else if (command.skillName) {
+    chip.dataset.skillName = command.skillName;
+  }
+  if (command.skillName) {
+    const skill = command.pluginName ?? command.skillName;
+    chip.setAttribute("aria-label", i18n._(msg`Skill: ${skill}`));
   }
   chip.className = "poracode-slash-chip";
 
   const slash = document.createElement("span");
   slash.className = "poracode-slash-chip__slash";
-  if (isSkill) {
+  if (command.skillName) {
     slash.innerHTML =
       '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5a2 2 0 0 0 1.437 1.437l6.135 1.582a.5.5 0 0 1 0 .962L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/></svg>';
   } else {

--- a/src/renderer/components/composer/serializeMentions.test.ts
+++ b/src/renderer/components/composer/serializeMentions.test.ts
@@ -216,7 +216,10 @@ describe("serializeComposerContent", () => {
     });
     container.appendChild(chip);
 
-    expect(chip.textContent).toBe("/simplify");
+    expect(chip.textContent).toBe("simplify");
+    expect(chip.querySelector("svg")).not.toBeNull();
+    expect(chip.dataset.skillName).toBe("simplify");
+    expect(chip.getAttribute("aria-label")).toBe("Skill: simplify");
     expect(serializeComposerContent(container)).toBe("/skill:simplify");
   });
 

--- a/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatPane.test.tsx
@@ -1350,6 +1350,41 @@ describe("ChatPane", () => {
     expect(screen.queryByText("$simplify")).not.toBeInTheDocument();
   });
 
+  it("renders slash-invoked skills as skill badges instead of command chips", async () => {
+    const thread = makeThread();
+    seedUserMessageContent(thread.id, [
+      { kind: "skill", name: "code-review", invocation: "/code-review" },
+      { kind: "text", text: " check the diff" },
+    ]);
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const badge = container.querySelector('[data-skill-name="code-review"]');
+    expect(badge).toHaveTextContent("code-review");
+    expect(badge).toHaveAttribute("aria-label", "Skill: code-review");
+    expect(badge?.querySelector("svg")).toBeInTheDocument();
+    expect(badge?.querySelector(".poracode-slash-chip__slash")?.textContent).not.toBe("/");
+    expect(screen.getByText(/check the diff/)).toBeInTheDocument();
+  });
+
+  it("keeps a leading slash command when a later skill chip is present", async () => {
+    const thread = makeThread();
+    seedUserMessageContent(thread.id, [
+      { kind: "text", text: "/goal plan this " },
+      { kind: "skill", name: "code-review", invocation: "/code-review" },
+    ]);
+
+    const { container } = renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    expect(screen.getByText("goal").parentElement).toHaveClass("poracode-slash-chip");
+    expect(screen.getByText("goal").previousElementSibling).toHaveTextContent("/");
+    const skill = container.querySelector('[data-skill-name="code-review"]');
+    expect(skill).toHaveTextContent("code-review");
+    expect(skill?.querySelector("svg")).toBeInTheDocument();
+  });
+
   it("renders MCP mentions in user messages as badges", async () => {
     const thread = makeThread();
     seedUserMessageContent(thread.id, [{ kind: "mcp", name: "Browser" }]);
@@ -1446,8 +1481,25 @@ describe("ChatPane", () => {
     renderChatPane(thread);
     await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
 
-    expect(screen.getByText("simplify").parentElement).toHaveClass("poracode-slash-chip");
+    const badge = screen.getByText("simplify").parentElement;
+    expect(badge).toHaveClass("poracode-slash-chip");
+    expect(badge).toHaveAttribute("data-skill-name", "simplify");
+    expect(badge).toHaveAttribute("aria-label", "Skill: simplify");
+    expect(badge?.querySelector("svg")).toBeInTheDocument();
     expect(screen.queryByText("skill:simplify")).not.toBeInTheDocument();
+  });
+
+  it("renders mixed-case ACP skill commands with the skill icon", async () => {
+    const thread = makeThread();
+    seedUserMessage(thread.id, "/Skill:simplify review these changes");
+
+    renderChatPane(thread);
+    await waitFor(() => expect(hydrateThreadRuntimeItems).toHaveBeenCalledWith(thread.id));
+
+    const badge = screen.getByText("simplify").parentElement;
+    expect(badge).toHaveAttribute("data-skill-name", "simplify");
+    expect(badge?.querySelector("svg")).toBeInTheDocument();
+    expect(screen.queryByText("Skill:simplify")).not.toBeInTheDocument();
   });
 
   it("reports failed user message link opens", async () => {

--- a/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
+++ b/src/renderer/components/thread/ChatPane/parts/items/UserMessage.tsx
@@ -84,11 +84,11 @@ export const UserMessage = memo(function UserMessage({
   const content = payload?.content ?? [];
   const rawText = buildUserPromptText(content);
   const { slashCommand, body } = extractLeadingSlashCommand(rawText);
-  const displaySlashCommand = slashCommand?.startsWith("skill:")
-    ? slashCommand.slice("skill:".length)
-    : slashCommand;
+  const acpSkillName = parseAcpSkillCommand(slashCommand);
+  const displaySlashCommand = acpSkillName ?? slashCommand;
   const text = body;
   const commandPrefixLength = slashCommand ? rawText.length - body.length : 0;
+  const leadingSlashFromSkill = firstInlineContentBlock(content)?.kind === "skill";
   const hasInlineContent = content.some(
     (block) =>
       block.kind === "skill" ||
@@ -228,11 +228,20 @@ export const UserMessage = memo(function UserMessage({
 
   let bodyContent: ReactNode = null;
   let bodyClass = baseBodyClass;
-  if (slashCommand) {
+  // Slash-invocation skills (`/code-review`) flatten to the same leading
+  // token as a real slash command. Prefer the structured skill chip only
+  // when that leading token came from the skill block itself, so a later
+  // skill cannot swallow `/goal`.
+  if (slashCommand && !leadingSlashFromSkill) {
+    const skill = acpSkillName;
     bodyClass = inlineBodyClass;
     bodyContent = (
       <>
-        <UserMessageSlashChip icon="/" label={displaySlashCommand ?? slashCommand} />
+        <UserMessageSlashChip
+          icon={skill ? <Sparkles aria-hidden="true" /> : "/"}
+          label={displaySlashCommand ?? slashCommand}
+          {...(skill ? { skillName: skill } : {})}
+        />
         {renderUserMessageInlineContent(content, commandPrefixLength, actions)}
       </>
     );
@@ -312,11 +321,32 @@ export const UserMessage = memo(function UserMessage({
 });
 
 const LEADING_SLASH_COMMAND_RE = /^\/([A-Za-z][A-Za-z0-9_.:-]*)(\s+|$)/;
+const ACP_SKILL_PREFIX_RE = /^skill:/iu;
 
 function extractLeadingSlashCommand(text: string): { slashCommand: string | null; body: string } {
   const match = text.match(LEADING_SLASH_COMMAND_RE);
   if (!match) return { slashCommand: null, body: text };
   return { slashCommand: match[1]!, body: text.slice(match[0].length) };
+}
+
+function parseAcpSkillCommand(slashCommand: string | null): string | undefined {
+  if (!slashCommand || !ACP_SKILL_PREFIX_RE.test(slashCommand)) return undefined;
+  const name = slashCommand.slice(slashCommand.indexOf(":") + 1);
+  return name.length > 0 ? name : undefined;
+}
+
+function firstInlineContentBlock(
+  content: CanonicalContentBlock[],
+): CanonicalContentBlock | undefined {
+  return content.find((block) => {
+    if (block.kind === "text") return block.text.length > 0;
+    return (
+      block.kind === "skill" ||
+      block.kind === "diff_comment" ||
+      block.kind === "mcp" ||
+      (block.kind === "file" && block.source !== "attachment")
+    );
+  });
 }
 
 function buildUserPromptText(content: CanonicalContentBlock[]): string {
@@ -448,10 +478,14 @@ function UserMessageSlashChip({
   mcpName?: string;
   pluginId?: string;
 }) {
+  const { t } = useLingui();
+  const skill = label;
+  const resolvedAriaLabel = skillName ? t`Skill: ${skill}` : undefined;
   return (
     <span
       className="poracode-slash-chip mr-1.5"
       title={title}
+      {...(resolvedAriaLabel ? { "aria-label": resolvedAriaLabel } : {})}
       {...(skillName ? { "data-skill-name": skillName } : {})}
       {...(mcpName ? { "data-mcp-name": mcpName } : {})}
       {...(pluginId ? { "data-plugin-id": pluginId } : {})}

--- a/src/renderer/components/thread/ThreadCommandPanel.tsx
+++ b/src/renderer/components/thread/ThreadCommandPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Terminal } from "lucide-react";
+import { Sparkles, Terminal } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { AgentSlashCommand } from "@/shared/contracts";
 import { slashCommandDisplayId } from "./threadSlashCommands";
@@ -65,6 +65,8 @@ export function ThreadCommandPanel(props: ThreadCommandPanelProps) {
                 </div>
                 {group.items.map(({ command: cmd, index }) => {
                   const isActive = index === activeIndex;
+                  const displayId = slashCommandDisplayId(cmd);
+                  const skill = displayId;
                   const key =
                     cmd.section === "skills" ? `skill:${cmd.skillPath ?? cmd.id}` : cmd.id;
                   return (
@@ -79,11 +81,17 @@ export function ThreadCommandPanel(props: ThreadCommandPanelProps) {
                         role="option"
                         tabIndex={-1}
                         type="button"
+                        {...(cmd.section === "skills" ? { "aria-label": t`Skill: ${skill}` } : {})}
                         onMouseDown={(event) => event.preventDefault()}
                         onClick={() => onSelect(cmd)}
                       >
-                        <span className="shrink-0 font-bold text-foreground">
-                          /{slashCommandDisplayId(cmd)}
+                        <span className="flex shrink-0 items-center gap-1 font-bold text-foreground">
+                          {cmd.section === "skills" ? (
+                            <Sparkles aria-hidden="true" className="size-3" />
+                          ) : (
+                            "/"
+                          )}
+                          {displayId}
                         </span>
                         {cmd.description && (
                           <span className="min-w-0 flex-1 truncate font-normal text-[color:var(--muted)]">

--- a/src/renderer/components/thread/ThreadSlashCommands.test.tsx
+++ b/src/renderer/components/thread/ThreadSlashCommands.test.tsx
@@ -262,7 +262,7 @@ describe("ThreadSlashCommands", () => {
     const editor = screen.getByRole("textbox");
     typeSlashQuery(editor, "/browser");
 
-    expect(screen.getByText("/browser-control")).toBeInTheDocument();
+    expect(screen.getByText("browser-control")).toBeInTheDocument();
     expect(
       screen.getByText("Navega, inspecciona y prueba páginas con el MCP del navegador integrado."),
     ).toBeInTheDocument();
@@ -465,8 +465,8 @@ describe("ThreadSlashCommands", () => {
     typeSlashQuery(editor, "/");
 
     expect(await screen.findByText("Skills")).toBeInTheDocument();
-    expect(screen.getByText("/review-code")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("/review-code"));
+    expect(screen.getByText("review-code")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("review-code"));
     fireEvent.keyDown(editor, { key: "Enter" });
 
     expect(onStart).toHaveBeenCalledWith(
@@ -762,11 +762,15 @@ describe("ThreadSlashCommands", () => {
     const editor = screen.getByRole("textbox");
     typeSlashQuery(editor, "/sim");
 
-    expect(screen.getByText("/simplify")).toBeInTheDocument();
+    const option = screen.getByRole("option", { name: "Skill: simplify" });
+    expect(option).toBeInTheDocument();
+    expect(option.querySelector("svg.lucide-sparkles")).not.toBeNull();
+    expect(screen.getByText("simplify")).toBeInTheDocument();
     expect(screen.queryByText("/skill:simplify")).not.toBeInTheDocument();
 
     fireEvent.keyDown(editor, { key: "Enter" });
-    expect(editor.textContent).toBe("/simplify ");
+    expect(editor.textContent).toBe("simplify ");
+    expect(editor.querySelector("svg")).not.toBeNull();
 
     fireEvent.keyDown(editor, { key: "Enter" });
     expect(onStart).toHaveBeenCalledWith(


### PR DESCRIPTION
- Bugfix: distinguish ACP skills from regular slash commands in composer and chat.
- Add skill icons, accessible labels, and metadata for partial skill information.
- Preserve slash-command and skill serialization across mixed content.
- Expand coverage for composer, chat rendering, and command selection behavior.

Branch: poracode/fresh-beacon-74b8752b → master