### PR TITLE
Allow unrestricted agent sessions in Home scope

### DIFF
--- a/src/renderer/actions/threadLaunchActions.ts
+++ b/src/renderer/actions/threadLaunchActions.ts
@@ -1,6 +1,7 @@
 import { msg } from "@lingui/core/macro";
 import { toast } from "@heroui/react";
 import { getProjectAgentStatuses } from "@/shared/agentStatus";
+import { applyHomeScopePermissions } from "@/shared/agents/unrestrictedPermissions";
 import type {
   Project,
   ProjectLocation,
@@ -461,11 +462,17 @@ function createThreadRow(launch: ThreadLaunchRequest): Thread {
         }
       : undefined;
 
+  const agentStatus = projectAgentStatuses.find((status) => status.kind === launch.agentKind);
+  const config =
+    isHomeProject(launch.project) && agentStatus
+      ? applyHomeScopePermissions(launch.project.location, launch.config, agentStatus.capabilities)
+      : launch.config;
+
   const thread = store.createThread({
     ...(launch.threadId ? { threadId: launch.threadId } : {}),
     projectId: launch.project.id,
     agentKind: launch.agentKind,
-    config: launch.config,
+    config,
     prompt: titlePrompt,
     ...(launch.presentationMode ? { presentationMode: launch.presentationMode } : {}),
     ...(launch.worktreePath ? { worktreePath: launch.worktreePath } : {}),

--- a/src/shared/agents/unrestrictedPermissions.ts
+++ b/src/shared/agents/unrestrictedPermissions.ts
@@ -1,4 +1,5 @@
-import type { AgentCapability } from "@/shared/contracts";
+import type { AgentCapability, ProjectLocation, ThreadConfig } from "@/shared/contracts";
+import { isHomeScopeLocation } from "@/shared/homeScope";
 
 /** The capability slice needed to resolve a provider's full-bypass posture. */
 export type UnrestrictedPermissionCapabilities = Pick<
@@ -36,6 +37,22 @@ export function resolveUnrestrictedPermissionConfig(
     ...(approvalPolicy ? { approvalPolicy } : {}),
     ...(sandboxMode ? { sandboxMode } : {}),
   };
+}
+
+/**
+ * Home is OS-level: every agent launches with that provider's strongest
+ * advertised approval/sandbox posture so the native CLI is not confined to
+ * the home folder. Repo workspaces are left unchanged.
+ */
+export function applyHomeScopePermissions(
+  location: ProjectLocation,
+  config: ThreadConfig,
+  capabilities: UnrestrictedPermissionCapabilities,
+): ThreadConfig {
+  if (!isHomeScopeLocation(location)) return config;
+  const unrestricted = resolveUnrestrictedPermissionConfig(capabilities);
+  if (!unrestricted.approvalPolicy && !unrestricted.sandboxMode) return config;
+  return { ...config, ...unrestricted };
 }
 
 function resolveUnrestrictedOption(

--- a/src/shared/homeScope.test.ts
+++ b/src/shared/homeScope.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { HOME_PROJECT_ID, HOME_PROJECT_NAME, isHomeProjectId, isHomeProject } from "./homeScope";
+import {
+  HOME_PROJECT_ID,
+  HOME_PROJECT_NAME,
+  isHomeProjectId,
+  isHomeProject,
+  isHomeScopeLocation,
+} from "./homeScope";
 
 describe("homeScope constants", () => {
   it("HOME_PROJECT_ID has expected value", () => {
@@ -36,5 +42,26 @@ describe("isHomeProject", () => {
 
   it("returns false for undefined", () => {
     expect(isHomeProject(undefined)).toBe(false);
+  });
+});
+
+describe("isHomeScopeLocation", () => {
+  it("treats the user home directory as Home scope", () => {
+    expect(isHomeScopeLocation({ kind: "windows", path: "C:\\Users\\me" })).toBe(true);
+    expect(isHomeScopeLocation({ kind: "posix", path: "/home/me" })).toBe(true);
+    expect(
+      isHomeScopeLocation({
+        kind: "wsl",
+        distro: "Ubuntu",
+        linuxPath: "/home/me",
+        uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat a repo under home as Home scope", () => {
+    expect(isHomeScopeLocation({ kind: "windows", path: "C:\\Users\\me\\Documents" })).toBe(false);
+    expect(isHomeScopeLocation({ kind: "windows", path: "C:\\repo" })).toBe(false);
+    expect(isHomeScopeLocation({ kind: "posix", path: "/home/me/src/app" })).toBe(false);
   });
 });

--- a/src/shared/homeScope.ts
+++ b/src/shared/homeScope.ts
@@ -1,4 +1,4 @@
-import type { Project } from "./contracts";
+import type { Project, ProjectLocation } from "./contracts";
 
 // Persisted in project/thread rows; keep the legacy ID so upgraded databases
 // do not create a second Home project or orphan existing Home threads.
@@ -11,4 +11,18 @@ export function isHomeProjectId(projectId: string | undefined): boolean {
 
 export function isHomeProject(project: Pick<Project, "id"> | undefined): boolean {
   return isHomeProjectId(project?.id);
+}
+
+/**
+ * True when the workspace *is* the user home directory (Poracode's Home
+ * scope). Home is a projectless OS-level session, so agents must not be
+ * confined to that folder — every provider, not just ACP.
+ */
+export function isHomeScopeLocation(location: ProjectLocation): boolean {
+  const raw = location.kind === "wsl" ? location.linuxPath : location.path;
+  const normalized = raw.replace(/\\/gu, "/").replace(/\/+$/u, "");
+  if (location.kind === "windows" || /^[A-Za-z]:\//.test(normalized)) {
+    return /^[A-Za-z]:\/Users\/[^/]+$/i.test(normalized);
+  }
+  return /^\/(?:home\/[^/]+|Users\/[^/]+|root)$/.test(normalized);
 }

--- a/src/supervisor/agents/acp/session.test.ts
+++ b/src/supervisor/agents/acp/session.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -11,6 +11,8 @@ import type { CreateStructuredSessionInput } from "../base";
 import type { ThreadConfig } from "@/shared/contracts";
 import {
   AcpStructuredSession,
+  isAcpHomeScopeLocation,
+  resolveAcpGlobalSkillFallbackHostFsPath,
   resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
   resolveAcpWritableHostFsPath,
@@ -616,6 +618,50 @@ describe("ACP resource path helpers", () => {
     ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\me\\.agents\\skills\\agent-browser\\SKILL.md");
   });
 
+  it("allows read-only access to Grok bundled and vendor skill files outside the project", () => {
+    const grokBundled = "C:\\Users\\me\\.grok\\bundled\\skills\\review\\SKILL.md";
+    const grokUser = "C:\\Users\\me\\.grok\\skills\\commit\\SKILL.md";
+    const claude = "C:\\Users\\me\\.claude\\skills\\review\\SKILL.md";
+    const cursor = "C:\\Users\\me\\.cursor\\skills\\review\\SKILL.md";
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, grokBundled)).toBe(grokBundled);
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, grokUser)).toBe(grokUser);
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, claude)).toBe(claude);
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, cursor)).toBe(cursor);
+    expect(
+      resolveAcpReadableHostFsPath(WSL_LOCATION, "/home/me/.grok/bundled/skills/review/SKILL.md"),
+    ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\me\\.grok\\bundled\\skills\\review\\SKILL.md");
+    expect(() => resolveAcpWritableHostFsPath(WINDOWS_LOCATION, grokBundled)).toThrow(
+      "Invalid params",
+    );
+    expect(() =>
+      resolveAcpReadableHostFsPath(WINDOWS_LOCATION, "C:\\Users\\me\\.grok\\auth.json"),
+    ).toThrow("Invalid params");
+  });
+
+  it("maps a missing project skill path to the matching user-global skill file", () => {
+    expect(
+      resolveAcpGlobalSkillFallbackHostFsPath(
+        WSL_LOCATION,
+        "/home/me/repo/.agents/skills/code-review/SKILL.md",
+      ),
+    ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\me\\.agents\\skills\\code-review\\SKILL.md");
+    expect(
+      resolveAcpGlobalSkillFallbackHostFsPath(
+        WSL_LOCATION,
+        "/home/me/repo/.grok/skills/commit/SKILL.md",
+      ),
+    ).toBe("\\\\wsl.localhost\\Ubuntu\\home\\me\\.grok\\skills\\commit\\SKILL.md");
+    expect(resolveAcpGlobalSkillFallbackHostFsPath(WSL_LOCATION, "/home/me/repo/src/main.ts")).toBe(
+      undefined,
+    );
+    expect(
+      resolveAcpGlobalSkillFallbackHostFsPath(
+        WSL_LOCATION,
+        "/home/me/.agents/skills/code-review/SKILL.md",
+      ),
+    ).toBe(undefined);
+  });
+
   it("rejects user agent skill paths that escape through parent segments", () => {
     expect(() =>
       resolveAcpReadableHostFsPath(
@@ -646,6 +692,13 @@ describe("ACP resource path helpers", () => {
     );
     expect(resolveAcpWritableHostFsPath(WINDOWS_LOCATION, KIMI_PLAN_WINDOWS, [".kimi-code"])).toBe(
       KIMI_PLAN_WINDOWS,
+    );
+    const grokBundled = "C:\\Users\\me\\.grok\\bundled\\skills\\review\\SKILL.md";
+    expect(resolveAcpReadableHostFsPath(WINDOWS_LOCATION, grokBundled, [".grok"])).toBe(
+      grokBundled,
+    );
+    expect(resolveAcpWritableHostFsPath(WINDOWS_LOCATION, grokBundled, [".grok"])).toBe(
+      grokBundled,
     );
   });
 
@@ -690,6 +743,40 @@ describe("ACP resource path helpers", () => {
     expect(() =>
       resolveAcpWritableHostFsPath(WSL_LOCATION, "/home/me/.kimi-code", [".kimi-code"]),
     ).toThrow("Invalid params");
+  });
+
+  const HOME_WINDOWS = { kind: "windows", path: "C:\\Users\\me" } as const;
+  const HOME_WSL = {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/home/me",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me",
+  } as const;
+
+  it("treats a workspace that is the user home as the Home scope", () => {
+    expect(isAcpHomeScopeLocation(HOME_WINDOWS)).toBe(true);
+    expect(isAcpHomeScopeLocation(HOME_WSL)).toBe(true);
+    expect(isAcpHomeScopeLocation({ kind: "posix", path: "/home/me" })).toBe(true);
+    expect(isAcpHomeScopeLocation(WINDOWS_LOCATION)).toBe(false);
+    expect(isAcpHomeScopeLocation(WSL_LOCATION)).toBe(false);
+    expect(isAcpHomeScopeLocation({ kind: "windows", path: "C:\\Users\\me\\Documents" })).toBe(
+      false,
+    );
+  });
+
+  it("does not confine Home-scope reads or writes to the home folder", () => {
+    expect(resolveAcpReadableHostFsPath(HOME_WINDOWS, "E:\\work\\repo\\file.ts")).toBe(
+      "E:\\work\\repo\\file.ts",
+    );
+    expect(resolveAcpWritableHostFsPath(HOME_WINDOWS, "E:\\work\\repo\\file.ts")).toBe(
+      "E:\\work\\repo\\file.ts",
+    );
+    expect(resolveAcpReadableHostFsPath(HOME_WSL, "/tmp/notes.md")).toBe(
+      "\\\\wsl.localhost\\Ubuntu\\tmp\\notes.md",
+    );
+    expect(resolveAcpWritableHostFsPath(HOME_WSL, "/tmp/notes.md")).toBe(
+      "\\\\wsl.localhost\\Ubuntu\\tmp\\notes.md",
+    );
   });
 });
 
@@ -740,6 +827,59 @@ describe("ACP client protocol helpers", () => {
     );
 
     await expect(read({ sessionId: "session-1", path: outside })).rejects.toThrow("Invalid params");
+  });
+
+  it("serves ACP fs reads and writes anywhere when the workspace is Home", async () => {
+    const outsideRoot = makePosixProject();
+    writeFileSync(join(outsideRoot, "notes.txt"), "from-outside", "utf8");
+    const { session } = makeConfigSyncSession();
+    (session as unknown as Record<string, unknown>)["projectLocation"] =
+      HOST_KIND === "windows"
+        ? { kind: "windows", path: "C:\\Users\\me" }
+        : { kind: "posix", path: "/home/me" };
+
+    const read = (session as unknown as { handleReadTextFile: Function }).handleReadTextFile.bind(
+      session,
+    );
+    const write = (
+      session as unknown as { handleWriteTextFile: Function }
+    ).handleWriteTextFile.bind(session);
+
+    await expect(
+      read({ sessionId: "session-1", path: join(outsideRoot, "notes.txt") }),
+    ).resolves.toEqual({ content: "from-outside" });
+    await write({
+      sessionId: "session-1",
+      path: join(outsideRoot, "out.txt"),
+      content: "ok",
+    });
+    expect(readFileSync(join(outsideRoot, "out.txt"), "utf8")).toBe("ok");
+  });
+
+  it("falls back to the user-global skill when the project copy is missing", async () => {
+    const projectRoot = makePosixProject();
+    const folder = `poracode-acp-skill-fallback-${Date.now()}`;
+    const globalDir = join(homedir(), ".agents", "skills", folder);
+    mkdirSync(globalDir, { recursive: true });
+    writeFileSync(join(globalDir, "SKILL.md"), "global-body", "utf8");
+    try {
+      const { session } = makeConfigSyncSession();
+      (session as unknown as Record<string, unknown>)["projectLocation"] = {
+        kind: HOST_KIND,
+        path: projectRoot,
+      };
+      const read = (session as unknown as { handleReadTextFile: Function }).handleReadTextFile.bind(
+        session,
+      );
+      await expect(
+        read({
+          sessionId: "session-1",
+          path: join(projectRoot, ".agents", "skills", folder, "SKILL.md"),
+        }),
+      ).resolves.toEqual({ content: "global-body" });
+    } finally {
+      rmSync(globalDir, { recursive: true, force: true });
+    }
   });
 
   it("advertises the fs text capabilities by default", async () => {

--- a/src/supervisor/agents/acp/session.ts
+++ b/src/supervisor/agents/acp/session.ts
@@ -81,9 +81,11 @@ import { AcpSessionConfigSync } from "./sessionConfigSync";
 
 // ── Helpers ──────────────────────────────────────────────────────
 
-import { toAcpFsRequestError } from "./sessionFsErrors";
+import { isMissingPathError, toAcpFsRequestError } from "./sessionFsErrors";
 import { AcpPlanModeToolTracker } from "./sessionPlanMode";
 import {
+  isAcpHomeScopeLocation,
+  resolveAcpGlobalSkillFallbackHostFsPath,
   resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
   resolveAcpWritableHostFsPath,
@@ -94,6 +96,8 @@ import {
 } from "./sessionPaths";
 
 export {
+  isAcpHomeScopeLocation,
+  resolveAcpGlobalSkillFallbackHostFsPath,
   resolveAcpReadableHostFsPath,
   resolveAcpResourcePath,
   resolveAcpWritableHostFsPath,
@@ -1202,11 +1206,25 @@ export class AcpStructuredSession implements StructuredSessionHandle {
       params.path,
       this.fsAgentHomeDirs,
     );
-    const fullContent = await readFile(path, "utf8").catch((error: unknown) => {
+    try {
+      const fullContent = await readFile(path, "utf8");
+      return { content: sliceTextFileContent(fullContent, params.line, params.limit) };
+    } catch (error: unknown) {
+      const fallbackPath = resolveAcpGlobalSkillFallbackHostFsPath(
+        this.projectLocation,
+        params.path,
+      );
+      if (fallbackPath && fallbackPath !== path && isMissingPathError(error)) {
+        try {
+          const fullContent = await readFile(fallbackPath, "utf8");
+          return { content: sliceTextFileContent(fullContent, params.line, params.limit) };
+        } catch {
+          // Keep the original project-path error so a missing skill stays
+          // resource-not-found for the path the agent asked about.
+        }
+      }
       throw toAcpFsRequestError(error, params.path);
-    });
-    const content = sliceTextFileContent(fullContent, params.line, params.limit);
-    return { content };
+    }
   }
 
   private async handleWriteTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {

--- a/src/supervisor/agents/acp/sessionFsErrors.ts
+++ b/src/supervisor/agents/acp/sessionFsErrors.ts
@@ -14,6 +14,11 @@ import { RequestError } from "@agentclientprotocol/sdk";
 /** Node errnos that mean "this path does not resolve to a file". */
 const NOT_FOUND_CODES = new Set(["ENOENT", "ENOTDIR"]);
 
+export function isMissingPathError(error: unknown): boolean {
+  const code = errnoOf(error);
+  return code !== undefined && NOT_FOUND_CODES.has(code);
+}
+
 function errnoOf(error: unknown): string | undefined {
   if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
   const code = (error as { code?: unknown }).code;

--- a/src/supervisor/agents/acp/sessionPaths.ts
+++ b/src/supervisor/agents/acp/sessionPaths.ts
@@ -1,8 +1,31 @@
+import { homedir } from "node:os";
 import { posix, win32 } from "node:path";
 import { pathToFileURL } from "node:url";
 import { RequestError } from "@agentclientprotocol/sdk";
 import type { ProjectLocation } from "@/shared/contracts";
+import { isHomeScopeLocation } from "@/shared/homeScope";
 import { toWslUncPath } from "@/shared/wsl";
+
+/**
+ * Home-relative directories ACP agents may *read* even though they sit
+ * outside the project. Grok (and other CLIs that speak ACP) discover
+ * skills from these roots, then load `SKILL.md` through the client fs
+ * bridge — without the carve-out the read is rejected as
+ * "Path is outside the project" and the skill cannot run.
+ *
+ * Write stays denied: skill bodies are instructions, not session state.
+ */
+const ACP_SKILL_READ_DIRS = [
+  ".agents/skills",
+  ".agents/commands",
+  ".grok/skills",
+  ".grok/commands",
+  ".grok/bundled/skills",
+  ".claude/skills",
+  ".claude/commands",
+  ".cursor/skills",
+  ".cursor/commands",
+] as const;
 
 /** CWD to pass into the ACP session (the agent's working directory). */
 export function resolveSessionCwd(location: ProjectLocation): string {
@@ -88,6 +111,10 @@ export function resolveAcpHostFsPath(location: ProjectLocation, rawPath: string)
     : win32.join(location.uncPath, ...relative.split("/").filter(Boolean));
 }
 
+export function isAcpHomeScopeLocation(location: ProjectLocation): boolean {
+  return isHomeScopeLocation(location);
+}
+
 export function resolveAcpReadableHostFsPath(
   location: ProjectLocation,
   rawPath: string,
@@ -99,6 +126,7 @@ export function resolveAcpReadableHostFsPath(
   }
   const normalizedPath = normalizeAcpPath(location, absolutePath);
   if (
+    !isAcpHomeScopeLocation(location) &&
     !isAgentSkillReadPath(location, normalizedPath) &&
     !isAgentHomeDirPath(location, normalizedPath, agentHomeDirs)
   ) {
@@ -108,10 +136,45 @@ export function resolveAcpReadableHostFsPath(
 }
 
 /**
+ * When an ACP agent asks for a project-relative skill path that is not
+ * on disk (Grok stores `~/.agents/skills/foo` as `{cwd}/.agents/skills/foo`
+ * after joining the catalog's relative root against the session cwd), map
+ * it to the matching user-global skill file. Only well-known skill roots
+ * are rewritten; regular project files are left alone.
+ */
+export function resolveAcpGlobalSkillFallbackHostFsPath(
+  location: ProjectLocation,
+  rawPath: string,
+): string | undefined {
+  const absolutePath = normalizeAcpPath(location, resolveAcpResourcePath(location, rawPath));
+  if (!isProjectRelativePath(location, absolutePath)) return undefined;
+
+  const projectRoot = location.kind === "wsl" ? location.linuxPath : location.path;
+  const relative =
+    location.kind === "windows"
+      ? win32.relative(projectRoot, absolutePath)
+      : posix.relative(projectRoot, absolutePath);
+  const posixRelative = relative.replace(/\\/gu, "/");
+  const matched = ACP_SKILL_READ_DIRS.find(
+    (dir) => posixRelative === dir || posixRelative.startsWith(`${dir}/`),
+  );
+  if (!matched || posixRelative === matched) return undefined;
+
+  const home = userHomePrefix(location);
+  if (!home) return undefined;
+
+  const fallback =
+    location.kind === "windows"
+      ? win32.join(home, ...posixRelative.split("/"))
+      : posix.join(home, posixRelative);
+  return toHostFsPathOutsideProject(location, fallback);
+}
+
+/**
  * Like {@link resolveAcpHostFsPath}, but with the provider's declared
  * home-relative carve-outs (`agentHomeDirs`) writable in addition to the
- * project root. `~/.agents/skills` stays read-only — it is deliberately NOT
- * honored here.
+ * project root. Global skill directories stay read-only — they are
+ * deliberately NOT honored here.
  */
 export function resolveAcpWritableHostFsPath(
   location: ProjectLocation,
@@ -123,7 +186,10 @@ export function resolveAcpWritableHostFsPath(
     return resolveAcpHostFsPath(location, rawPath);
   }
   const normalizedPath = normalizeAcpPath(location, absolutePath);
-  if (!isAgentHomeDirPath(location, normalizedPath, agentHomeDirs)) {
+  if (
+    !isAcpHomeScopeLocation(location) &&
+    !isAgentHomeDirPath(location, normalizedPath, agentHomeDirs)
+  ) {
     throw RequestError.invalidParams({ message: `Path is outside the project: ${rawPath}` });
   }
   return toHostFsPathOutsideProject(location, normalizedPath);
@@ -193,7 +259,24 @@ export function sliceTextFileContent(
 }
 
 function isAgentSkillReadPath(location: ProjectLocation, absolutePath: string): boolean {
-  return isUserHomeRelativePath(location, absolutePath, ".agents/skills");
+  return ACP_SKILL_READ_DIRS.some((dir) => isUserHomeRelativePath(location, absolutePath, dir));
+}
+
+function userHomePrefix(location: ProjectLocation): string | undefined {
+  switch (location.kind) {
+    case "windows": {
+      const match = /^([A-Za-z]:[\\/]Users[\\/][^\\/]+)/i.exec(homedir());
+      return match?.[1];
+    }
+    case "posix": {
+      const home = homedir();
+      return /^\/(?:home\/[^/]+|Users\/[^/]+|root)$/.test(home) ? home : undefined;
+    }
+    case "wsl": {
+      const match = /^(\/(?:home\/[^/]+|Users\/[^/]+|root))(?:\/|$)/.exec(location.linuxPath);
+      return match?.[1];
+    }
+  }
 }
 
 function isAgentHomeDirPath(

--- a/src/supervisor/agents/acp/sessionTerminalLaunch.test.ts
+++ b/src/supervisor/agents/acp/sessionTerminalLaunch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ProjectLocation } from "@/shared/contracts";
 import { getWslCommand } from "../base";
-import { buildAcpTerminalLaunch } from "./sessionTerminalLaunch";
+import { buildAcpTerminalLaunch, resolveAcpTerminalCwd } from "./sessionTerminalLaunch";
 
 const wslProject: ProjectLocation = {
   kind: "wsl",
@@ -33,5 +33,28 @@ describe.skipIf(process.platform !== "win32")("buildAcpTerminalLaunch", () => {
       "-c",
       "export TERM='xterm-256color'; exec 'node' '-p' 'line1\nline2 `$(ignored)` '\\''single'\\'' \"double\"'",
     ]);
+  });
+});
+
+describe("resolveAcpTerminalCwd", () => {
+  it("rejects a cwd outside a regular project", () => {
+    expect(() => resolveAcpTerminalCwd(wslProject, "/tmp/elsewhere")).toThrow("Invalid params");
+  });
+
+  it("allows any cwd when the workspace is Home", () => {
+    expect(
+      resolveAcpTerminalCwd(
+        {
+          kind: "wsl",
+          distro: "Ubuntu",
+          linuxPath: "/home/demo",
+          uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo",
+        },
+        "/tmp/elsewhere",
+      ),
+    ).toBe("/tmp/elsewhere");
+    expect(
+      resolveAcpTerminalCwd({ kind: "windows", path: "C:\\Users\\me" }, "E:\\work\\repo"),
+    ).toBe("E:\\work\\repo");
   });
 });

--- a/src/supervisor/agents/acp/sessionTerminalLaunch.ts
+++ b/src/supervisor/agents/acp/sessionTerminalLaunch.ts
@@ -19,7 +19,12 @@ import {
   getWindowsPathOverrideEnv,
   quotePosixShellArg,
 } from "../base";
-import { resolveAcpHostFsPath, resolveAcpProjectPath } from "./sessionPaths";
+import {
+  isAcpHomeScopeLocation,
+  resolveAcpHostFsPath,
+  resolveAcpProjectPath,
+  resolveAcpResourcePath,
+} from "./sessionPaths";
 import type { AcpTerminalRecord } from "./sessionTerminal";
 
 export function buildTerminalCommandLine(command: string, args: string[]): string {
@@ -94,6 +99,9 @@ export function acpTerminalEnvEntries(
 }
 
 export function resolveAcpTerminalCwd(location: ProjectLocation, cwd: string): string {
+  if (isAcpHomeScopeLocation(location)) {
+    return resolveAcpResourcePath(location, cwd);
+  }
   return location.kind === "wsl"
     ? resolveAcpProjectPath(location, cwd)
     : resolveAcpHostFsPath(location, cwd);

--- a/src/supervisor/agents/grok/acpFsHome.test.ts
+++ b/src/supervisor/agents/grok/acpFsHome.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+// `createStructuredSession` would spawn a real `grok agent stdio` process;
+// stub the session factory so the test only inspects the options the adapter
+// hands the shared ACP session.
+vi.mock("../acp", () => ({
+  createAcpStructuredSession: vi.fn<() => undefined>(() => undefined),
+}));
+
+import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
+import { createAcpStructuredSession } from "../acp";
+import { createGrokAdapter } from "./index";
+
+async function createSessionOptions() {
+  const adapter = createGrokAdapter();
+  await adapter.createStructuredSession?.({
+    threadId: "thread-1",
+    projectLocation: { kind: "windows", path: "C:\\repo" } as ProjectLocation,
+    config: { mode: "agent" } as ThreadConfig,
+  });
+  return vi.mocked(createAcpStructuredSession).mock.calls[0]?.[1];
+}
+
+describe("Grok ACP fs home carve-out", () => {
+  it("lets Grok read ~/.grok through the client fs bridge", async () => {
+    // Grok ACP loads bundled and user skills (and session files) from
+    // ~/.grok via fs/read_text_file. Without the carve-out the shared
+    // bridge rejects those paths as outside the project.
+    expect(await createSessionOptions()).toMatchObject({ acpFsAgentHomeDirs: [".grok"] });
+  });
+});

--- a/src/supervisor/agents/grok/index.ts
+++ b/src/supervisor/agents/grok/index.ts
@@ -181,6 +181,11 @@ export function createGrokAdapter(): AgentAdapter {
       );
       return createAcpStructuredSession(command, {
         ...input,
+        // Grok ACP proxies ReadFile through the client, including SKILL.md
+        // loads from ~/.grok/bundled/skills and ~/.grok/skills. Without a
+        // home-dir carve-out the shared fs bridge rejects those paths as
+        // outside the project and every global/bundled skill fails.
+        acpFsAgentHomeDirs: [".grok"],
         acpSessionUpdateTransform: createGrokAcpSessionUpdateTransform(),
       });
     },

--- a/src/supervisor/runtime/threadSession/invalidSessionRecovery.ts
+++ b/src/supervisor/runtime/threadSession/invalidSessionRecovery.ts
@@ -5,7 +5,7 @@ import { applyLaunchArgsConfigRewrite, mergeCliHookExtraArgs } from "./cliHookAr
 import type { CliHookSessionCoordinator } from "./cliHookPlugin";
 import { shouldPrimeNativeProjectShellEnv } from "./helpers";
 import type { PtyLifecycle } from "./ptyLifecycle";
-import { effectiveLaunchConfig, type SpawnPipeline } from "./spawnPipeline";
+import { workspaceLaunchConfig, type SpawnPipeline } from "./spawnPipeline";
 import type { ThreadOutputPipeline } from "../threadOutputPipeline";
 
 type RecoverySpawnPipeline = Pick<
@@ -73,8 +73,10 @@ export class InvalidSessionRecoveryCoordinator {
       return;
     }
 
-    const launchConfig = effectiveLaunchConfig(
+    const launchConfig = workspaceLaunchConfig(
+      session.projectLocation,
       session.config,
+      session.adapter,
       mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
       mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );

--- a/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.test.ts
@@ -5,6 +5,7 @@ import {
   composeResolvedMcpServers,
   effectiveLaunchConfig,
   usesProviderSessionCrossagentRouting,
+  workspaceLaunchConfig,
 } from "./spawnPipeline";
 
 const baseConfig: ThreadConfig = {
@@ -72,6 +73,40 @@ describe("effectiveLaunchConfig — single gate for built-in MCP disables", () =
       crossagentMcp: true,
       computerUse: true,
       chromeMcp: false,
+    });
+  });
+});
+
+describe("workspaceLaunchConfig — Home scope unrestricted for every agent", () => {
+  const adapter = {
+    capabilities: {
+      approvalPolicies: [
+        { id: "default", label: "Default" },
+        { id: "bypassPermissions", label: "Bypass" },
+      ],
+      sandboxModes: [
+        { id: "workspace-write", label: "Workspace" },
+        { id: "danger-full-access", label: "Full" },
+      ],
+      bypassPermissions: { approvalPolicy: "bypassPermissions", sandboxMode: "danger-full-access" },
+    },
+  };
+
+  it("leaves a repo workspace config unchanged", () => {
+    const config = { ...baseConfig, approvalPolicy: "default", sandboxMode: "workspace-write" };
+    expect(
+      workspaceLaunchConfig({ kind: "windows", path: "C:\\repo" }, config, adapter, []),
+    ).toEqual(config);
+  });
+
+  it("forces each provider's unrestricted posture in Home", () => {
+    const config = { ...baseConfig, approvalPolicy: "default", sandboxMode: "workspace-write" };
+    expect(
+      workspaceLaunchConfig({ kind: "windows", path: "C:\\Users\\me" }, config, adapter, []),
+    ).toEqual({
+      ...config,
+      approvalPolicy: "bypassPermissions",
+      sandboxMode: "danger-full-access",
     });
   });
 });

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { spawn } from "node-pty";
-import { applyHomeScopePermissions } from "@/shared/agents/unrestrictedPermissions";
+import {
+  applyHomeScopePermissions,
+  type UnrestrictedPermissionCapabilities,
+} from "@/shared/agents/unrestrictedPermissions";
 import {
   type AgentKind,
   type CloseThreadPayload,
@@ -139,7 +142,7 @@ export function effectiveLaunchConfig(
 export function workspaceLaunchConfig(
   location: ProjectLocation,
   config: ThreadConfig,
-  adapter: Pick<AgentAdapter, "capabilities">,
+  adapter: { capabilities: UnrestrictedPermissionCapabilities },
   disabledBuiltInMcpServerIds: readonly BuiltInMcpServerId[],
   pluginBuiltInMcpServerIds: readonly BuiltInMcpServerId[] = [],
 ): ThreadConfig {

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
 import { spawn } from "node-pty";
+import { applyHomeScopePermissions } from "@/shared/agents/unrestrictedPermissions";
 import {
   type AgentKind,
   type CloseThreadPayload,
@@ -128,6 +129,25 @@ export function effectiveLaunchConfig(
   if (disabledBuiltInMcpServerIds.includes("computer-use")) next.computerUse = false;
   if (disabledBuiltInMcpServerIds.includes("chrome")) next.chromeMcp = false;
   return next;
+}
+
+/**
+ * Launch config for a workspace: MCP flag gating plus Home-scope unrestricted
+ * approval/sandbox so every agent (not just ACP) can read and write anywhere
+ * when the session is the projectless Home folder.
+ */
+export function workspaceLaunchConfig(
+  location: ProjectLocation,
+  config: ThreadConfig,
+  adapter: Pick<AgentAdapter, "capabilities">,
+  disabledBuiltInMcpServerIds: readonly BuiltInMcpServerId[],
+  pluginBuiltInMcpServerIds: readonly BuiltInMcpServerId[] = [],
+): ThreadConfig {
+  return applyHomeScopePermissions(
+    location,
+    effectiveLaunchConfig(config, disabledBuiltInMcpServerIds, pluginBuiltInMcpServerIds),
+    adapter.capabilities,
+  );
 }
 
 /**
@@ -343,8 +363,10 @@ export class SpawnPipeline {
             payload.userMessageItemId,
           )
         : undefined;
-    const optimisticLaunchConfig = effectiveLaunchConfig(
+    const optimisticLaunchConfig = workspaceLaunchConfig(
+      payload.projectLocation,
       payload.config,
+      adapter,
       payload.disabledBuiltInMcpServerIds ?? [],
       pluginContributions.builtInMcpServerIds,
     );
@@ -392,8 +414,10 @@ export class SpawnPipeline {
       disabledBuiltInMcpTools: payload.disabledBuiltInMcpTools ?? {},
       pluginBuiltInMcpServerIds: pluginContributions.builtInMcpServerIds,
     };
-    const launchConfig = effectiveLaunchConfig(
+    const launchConfig = workspaceLaunchConfig(
+      payload.projectLocation,
       payload.config,
+      adapter,
       mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
       mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );
@@ -686,8 +710,10 @@ export class SpawnPipeline {
     }
 
     const mcpIdentity = { threadId: session.threadId };
-    const launchConfig = effectiveLaunchConfig(
+    const launchConfig = workspaceLaunchConfig(
+      session.projectLocation,
       config,
+      session.adapter,
       mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
       mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );
@@ -955,8 +981,10 @@ export class SpawnPipeline {
       ...(input.nativePlugins ? { nativePlugins: input.nativePlugins } : {}),
       launchConfig:
         input.launchConfig ??
-        effectiveLaunchConfig(
+        workspaceLaunchConfig(
+          input.projectLocation,
           input.config,
+          input.adapter,
           mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
           mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
         ),

--- a/src/supervisor/runtime/threadSessionManager.ts
+++ b/src/supervisor/runtime/threadSessionManager.ts
@@ -30,6 +30,7 @@ import {
   type McpLaunchSnapshot,
   type ResolvedMcpServer,
 } from "@/shared/contracts";
+import { applyHomeScopePermissions } from "@/shared/agents/unrestrictedPermissions";
 import { TranscriptBuffer } from "@/shared/transcriptBuffer";
 import {
   type AgentAdapter,
@@ -65,7 +66,7 @@ import { SteerCoordinator, clearPendingSteerSlot } from "./threadSession/steerCo
 import { buildShellCommand } from "./threadSession/shellCommand";
 import {
   SpawnPipeline,
-  effectiveLaunchConfig,
+  workspaceLaunchConfig,
   type SpawnThreadInput,
 } from "./threadSession/spawnPipeline";
 import { StructuredTurnQueue } from "./threadSession/structuredTurnQueue";
@@ -310,8 +311,10 @@ export class ThreadSessionManager {
     if (!session) return undefined;
     // Children inherit the effective launch config with built-in disables applied.
     const disabledIds = session.mcpLaunchSnapshot.disabledBuiltInMcpServerIds;
-    const effectiveConfig = effectiveLaunchConfig(
+    const effectiveConfig = workspaceLaunchConfig(
+      session.projectLocation,
       session.config,
+      session.adapter,
       disabledIds,
       session.mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );
@@ -333,8 +336,10 @@ export class ThreadSessionManager {
     const targetAdapter = this.options.adapters.get(targetAgentKind);
     if (!targetAdapter) return {};
     const mcpLaunchSnapshot = session.mcpLaunchSnapshot;
-    const launchConfig = effectiveLaunchConfig(
+    const launchConfig = workspaceLaunchConfig(
+      session.projectLocation,
       session.config,
+      targetAdapter,
       mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
       mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
     );
@@ -370,8 +375,10 @@ export class ThreadSessionManager {
       reloads.push(
         (async () => {
           try {
-            const launchConfig = effectiveLaunchConfig(
+            const launchConfig = workspaceLaunchConfig(
+              session.projectLocation,
               session.config,
+              session.adapter,
               session.mcpLaunchSnapshot.disabledBuiltInMcpServerIds,
               session.mcpLaunchSnapshot.pluginBuiltInMcpServerIds,
             );
@@ -525,12 +532,17 @@ export class ThreadSessionManager {
     const effectiveSegments = await this.filterPluginSkillSegments(session, wslSegments);
     const prompt = this.formatSegmentsForPrompt(session, effectiveSegments, payload.prompt);
 
-    const effectiveConfig =
+    const turnConfig =
       session.presentationMode !== "gui" &&
       payload.config.mode === "plan" &&
       session.config.mode === undefined
         ? { ...payload.config, mode: undefined }
         : payload.config;
+    const effectiveConfig = applyHomeScopePermissions(
+      session.projectLocation,
+      turnConfig,
+      session.adapter.capabilities,
+    );
 
     session.config = effectiveConfig;
     const inlineInstructions = usesStructuredFlow


### PR DESCRIPTION
- Bugfix: let Home-scope sessions use each provider’s unrestricted permissions.
- Allow ACP agents to access global skills and launch from arbitrary Home paths.
- Preserve project workspace restrictions while improving session recovery and launch consistency.
- Add coverage for Home detection, ACP paths, Grok skills, and spawn behavior.