### PR TITLE
feat(supervisor): single-declaration baseSpawnEnv for every agent CLI spawn

### DIFF
--- a/.agents/docs/agent-adapters.md
+++ b/.agents/docs/agent-adapters.md
@@ -8,8 +8,9 @@ Every supported agent implements the `AgentAdapter` interface (`src/supervisor/a
 
 - `kind` / `label` — Provider identifier and display name.
 - `capabilities` — Declares models, efforts, modes, approval policies, sandbox modes, resume/direct-input support, live input mode (terminal | server), presentation mode (terminal | gui).
-- `spawnEnv?` — Optional `{ native?, wsl? }` env records the runtime merges into the PTY spawn (e.g. `BROWSER=/bin/true` under WSL for OAuth-flow providers). Runtime owns no provider-specific env.
-- `detectInstall(ctx?)` — Typically one line: `return detectAgentInstall(ctx, spec)`. Declare a `DetectionSpec` (binary, capabilities, versionArgs?, authProbes?, capabilitiesProbe?) and let the engine own the WSL vs native probe + binary resolution + version + auth/capability merge.
+- `spawnEnv?` — Optional `{ native?, wsl? }` env records the runtime merges into the PTY spawn (e.g. `BROWSER=/bin/true` under WSL for OAuth-flow providers). Location-specific only — env that must ride EVERY spawn of the CLI belongs in `baseSpawnEnv` instead.
+- `baseSpawnEnv?` — Env applied to every Poracode-made spawn of this CLI in every lane (detection probes, terminal login, PTY launch, ACP session/auth/logout, one-shots, context extraction, subagent children), merged UNDER lane-specific env. Declare it once on the `DetectionSpec`; the adapter re-exposes it via `...inheritBaseSpawnEnv(spec)` so the two can never drift. Shared runtime fans it out — never repeat it per command builder. Deliberately NOT applied to `update` commands so the user-driven "update agent" action still reaches the CLI's own updater. WSL caveat: the shared merge sets spawn-level env; env that must reach the distro still has to be baked into the wsl.exe login-shell script by the command builder (`buildAgentCommand` does this) — keep the same map reference there, as factory does.
+- `detectInstall(ctx?)` — Typically one line: `return detectAgentInstall(ctx, spec)`. Declare a `DetectionSpec` (binary, capabilities, versionArgs?, authProbes?, capabilitiesProbe?, baseSpawnEnv?) and let the engine own the WSL vs native probe + binary resolution + version + auth/capability merge.
 - `buildLaunchArgv()` / `buildResumeArgv()` — Return an `AgentArgvSpec` (`{ binary, args, env?, sessionRef? }`). The runtime wraps it through `resolveLaunchSpec` which owns WSL login-shell, Windows PowerShell encoding, and env injection. **Adapters must never call `buildAgentCommand` on the main launch path** — the contract is structurally argv-only.
 - `createInitialSessionRef()` — Generate a session ID on first launch (or `undefined` if the CLI generates its own).
 
@@ -97,6 +98,11 @@ most often forgotten.
         "Re-login" for a never-signed-in user (and the inverse if you then drop
         the probe). Return `authenticated` when the credential exists, else
         `missing`. (Providers that only auth on first TUI launch may skip this.)
+  - [ ] ⚠️ `baseSpawnEnv` — if the CLI runs a background self-updater (or other
+        opt-out-able side effect) on spawn, declare the opt-out env ONCE here.
+        Shared runtime applies it to every spawn lane except the explicit
+        `update` command; never repeat it per command builder. Re-expose it on
+        the adapter via `...inheritBaseSpawnEnv(spec)` (see the `index.ts` item).
 - [ ] `argv.ts` — `build<Kind>Args(config, prompt, …)`. Map `config.mode`/`approvalPolicy`/
       `sandboxMode` to flags. Pass a trust/skip-prompt flag so the PTY never blocks.
 - [ ] `terminal.ts` — `detect<Kind>TerminalStatus` hint table (working/needs_approval/idle).
@@ -106,7 +112,9 @@ most often forgotten.
 - [ ] `index.ts` — `create<Kind>Adapter()`: `buildLaunchArgv`/`buildResumeArgv`,
       `buildDirectInput`, `formatPromptSegments`, `detectTerminalStatus`,
       `detectInvalidSessionRef`, `defaultOneShotModel` + `buildOneShotCommand`,
-      `spawnEnv` (`BROWSER=/bin/true` under WSL for OAuth providers).
+      `spawnEnv` (`BROWSER=/bin/true` under WSL for OAuth providers), and
+      `...inheritBaseSpawnEnv(spec)` when the spec declares `baseSpawnEnv`
+      (derive it — never re-declare the literal on the adapter).
   - [ ] ⚠️ Re-expose `update` on the returned adapter object:
         `...(spec.update ? { update: spec.update } : {})`. The shared updater reads
         `status.update ?? adapter.update`, but the registry card's latest-version

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,9 +45,39 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    expect(options.version).toBe(11);
+    // Mirrors supervisor STATUS_CACHE_VERSION=14: a persisted antigravity
+    // status from before the derivation would build the `agy` login command
+    // without `AGY_CLI_DISABLE_AUTO_UPDATE`.
+    const staleLogin = makeStatus({
+      kind: "antigravity",
+      label: "Antigravity",
+      authState: "missing",
+      authMethods: [{ id: "antigravity-login", name: "Antigravity login", type: "terminal" }],
+      capabilities: { ...makeStatus().capabilities },
+    });
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [staleLogin],
+        wslAgentStatuses: [],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      10,
+    );
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
+
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(10);
+    expect(options.version).toBe(11);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -74,7 +104,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(10);
+    expect(options.version).toBe(11);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -255,11 +255,14 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 10,
-      // v10 adds ACP session readiness separately from authentication and
-      // normalized ACP approval-policy labels. This mirrors the supervisor
-      // STATUS_CACHE_VERSION=13 bump, which only invalidates the supervisor's
-      // on-disk cache, not this localStorage copy.
+      version: 11,
+      // v11 mirrors the supervisor STATUS_CACHE_VERSION=14 bump: terminal auth
+      // methods now carry baseSpawnEnv-derived `env`, and a persisted status
+      // from before that derivation would build a login command without the
+      // provider's base env. This mirrors the supervisor cache invalidation,
+      // which only covers the supervisor's on-disk cache, not this localStorage
+      // copy. (v10 added ACP session readiness separately from authentication
+      // and normalized ACP approval-policy labels.)
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/supervisor/agents/acp/dispatch.test.ts
+++ b/src/supervisor/agents/acp/dispatch.test.ts
@@ -249,3 +249,71 @@ describe("dispatchAcpLogout", () => {
     ).rejects.toThrow("did not return an ACP logout command");
   });
 });
+
+describe("baseSpawnEnv — every ACP auth/logout spawn carries the adapter's base env", () => {
+  const baseSpawnEnv = { DROID_DISABLE_AUTO_UPDATE: "true" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateAcpAgentMock.mockResolvedValue(undefined);
+    logoutAcpAgentMock.mockResolvedValue(undefined);
+    readCommandOutputAsyncMock.mockResolvedValue({ ok: true, stdout: "", stderr: "" });
+  });
+
+  it("applies it to ACP auth commands", async () => {
+    await dispatchAcpAuthenticate({
+      adapter: makeAdapter({ command: "droid", args: ["exec"] }, { baseSpawnEnv }),
+      methodId: "login",
+      envKind: "posix",
+    });
+
+    const [, , , options] = authenticateAcpAgentMock.mock.calls[0]!;
+    expect(options?.env).toMatchObject(baseSpawnEnv);
+  });
+
+  it("lets command-declared env win over the base env", async () => {
+    await dispatchAcpAuthenticate({
+      adapter: makeAdapter(
+        { command: "droid", args: ["exec"], env: { DROID_DISABLE_AUTO_UPDATE: "false" } },
+        { baseSpawnEnv },
+      ),
+      methodId: "login",
+      envKind: "posix",
+    });
+
+    const [, , , options] = authenticateAcpAgentMock.mock.calls[0]!;
+    expect(options?.env).toMatchObject({ DROID_DISABLE_AUTO_UPDATE: "false" });
+  });
+
+  it("applies it to direct logout commands", async () => {
+    await dispatchAcpLogout({
+      adapter: makeAdapter(
+        { command: "droid", args: ["exec"] },
+        {
+          baseSpawnEnv,
+          async buildAcpLogoutCommand() {
+            return { command: "droid", args: ["logout"] };
+          },
+        },
+      ),
+      envKind: "posix",
+    });
+
+    const [, , options] = readCommandOutputAsyncMock.mock.calls[0]!;
+    expect(options).toEqual(
+      expect.objectContaining({ env: expect.objectContaining(baseSpawnEnv) }),
+    );
+  });
+
+  it("applies it to the logout RPC fallback", async () => {
+    await dispatchAcpLogout({
+      adapter: makeAdapter({ command: "droid", args: ["exec"] }, { baseSpawnEnv }),
+      envKind: "posix",
+    });
+
+    const options = logoutAcpAgentMock.mock.calls[0]?.[2] as
+      | { env?: Record<string, string> }
+      | undefined;
+    expect(options?.env).toMatchObject(baseSpawnEnv);
+  });
+});

--- a/src/supervisor/agents/acp/dispatch.ts
+++ b/src/supervisor/agents/acp/dispatch.ts
@@ -13,7 +13,13 @@
 
 import type { ProjectLocation } from "@/shared/contracts";
 import type { AgentAdapter, AgentEnvContext } from "../base";
-import { detectProbeLocation, injectWslEnv, readCommandOutputAsync } from "../base";
+import {
+  detectProbeLocation,
+  injectWslEnv,
+  mergeSpawnEnv,
+  readCommandOutputAsync,
+  withCommandBaseSpawnEnv,
+} from "../base";
 import { resolveProbeSpawnCwd } from "../probeCwd";
 import { authenticateAcpAgent, logoutAcpAgent } from "./probe";
 
@@ -51,19 +57,20 @@ export async function dispatchAcpAuthenticate(input: {
     throw new Error(`Agent does not support ACP authentication: ${input.adapter.kind}`);
   }
   const ctx = envContextFromPayload(input.envKind, input.wslDistro);
-  const command = await input.adapter.buildAcpAuthCommand(ctx);
-  if (!command) {
+  const rawCommand = await input.adapter.buildAcpAuthCommand(ctx);
+  if (!rawCommand) {
     throw new Error(`Agent did not return an ACP auth command: ${input.adapter.kind}`);
   }
+  const command = withCommandBaseSpawnEnv(rawCommand, input.adapter.baseSpawnEnv);
   const location = detectProbeLocation(ctx);
   const processCwd = resolveProbeSpawnCwd(location, command.cwd);
   const browserEnv = authBrowserEnv(input.envKind);
-  const env = { ...(command.env ?? {}), ...(browserEnv ?? {}) };
+  const env = mergeSpawnEnv(command.env, browserEnv);
   const authCommand =
     location.kind === "wsl" && browserEnv ? injectWslEnv(command, location, browserEnv) : command;
   await authenticateAcpAgent(authCommand.command, authCommand.args, input.methodId, {
     ...(processCwd ? { processCwd } : {}),
-    ...(location.kind !== "wsl" && Object.keys(env).length > 0 ? { env } : {}),
+    ...(location.kind !== "wsl" && env ? { env } : {}),
     label: input.adapter.label,
   });
 }
@@ -79,10 +86,13 @@ export async function dispatchAcpLogout(input: {
     if (input.adapter.preferAcpLogoutRpc) {
       await tryAcpLogoutRpc(input.adapter, ctx, location);
     }
-    const command = await input.adapter.buildAcpLogoutCommand(ctx);
-    if (!command) {
+    const rawCommand = await input.adapter.buildAcpLogoutCommand(ctx);
+    if (!rawCommand) {
       throw new Error(`Agent did not return an ACP logout command: ${input.adapter.kind}`);
     }
+    // Same lane as auth: the logout command spawns the CLI, so it carries the
+    // adapter's base env; command-declared values win.
+    const command = withCommandBaseSpawnEnv(rawCommand, input.adapter.baseSpawnEnv);
     const processCwd = resolveProbeSpawnCwd(location, command.cwd);
     const result = await readCommandOutputAsync(
       command.command,
@@ -122,8 +132,9 @@ async function runAcpLogoutRpc(
   ctx: AgentEnvContext | undefined,
   location: ProjectLocation,
 ): Promise<boolean> {
-  const command = await adapter.buildAcpAuthCommand?.(ctx);
-  if (!command) return false;
+  const rawCommand = await adapter.buildAcpAuthCommand?.(ctx);
+  if (!rawCommand) return false;
+  const command = withCommandBaseSpawnEnv(rawCommand, adapter.baseSpawnEnv);
   const processCwd = resolveProbeSpawnCwd(location, command.cwd);
   await logoutAcpAgent(command.command, command.args, {
     ...(processCwd ? { processCwd } : {}),

--- a/src/supervisor/agents/acp/sessionFactory.test.ts
+++ b/src/supervisor/agents/acp/sessionFactory.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CreateStructuredSessionInput } from "../base";
+import { AcpStructuredSession } from "./session";
+import { createAcpStructuredSession } from "./sessionFactory";
+
+function makeInput(
+  overrides: Partial<CreateStructuredSessionInput> = {},
+): CreateStructuredSessionInput {
+  return {
+    threadId: "thread-1",
+    projectLocation: { kind: "windows", path: "C:\\repo" },
+    config: { model: "test-model" },
+    ...overrides,
+  };
+}
+
+// The ACP child is spawned from `command.env` (session.ts spreads it into the
+// child env), so the command `AcpStructuredSession.create` receives IS the
+// proof that the provider's baseSpawnEnv reaches the spawn.
+describe("createAcpStructuredSession baseSpawnEnv merge", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function spyOnCreate() {
+    return vi
+      .spyOn(AcpStructuredSession, "create")
+      .mockReturnValue({ sessionId: "session-1" } as unknown as AcpStructuredSession);
+  }
+
+  it("applies input.baseSpawnEnv to the spawned ACP command", () => {
+    const createSpy = spyOnCreate();
+
+    createAcpStructuredSession(
+      { command: "droid", args: ["exec", "--output-format", "acp"] },
+      makeInput({ baseSpawnEnv: { DROID_DISABLE_AUTO_UPDATE: "true" } }),
+    );
+
+    expect(createSpy.mock.calls[0]?.[0]).toEqual({
+      command: "droid",
+      args: ["exec", "--output-format", "acp"],
+      env: { DROID_DISABLE_AUTO_UPDATE: "true" },
+    });
+  });
+
+  it("lets command-declared env win over the base env", () => {
+    const createSpy = spyOnCreate();
+
+    createAcpStructuredSession(
+      {
+        command: "droid",
+        args: ["exec"],
+        env: { DROID_DISABLE_AUTO_UPDATE: "false", EXTRA: "kept" },
+      },
+      makeInput({ baseSpawnEnv: { DROID_DISABLE_AUTO_UPDATE: "true" } }),
+    );
+
+    expect(createSpy.mock.calls[0]?.[0]).toMatchObject({
+      env: { DROID_DISABLE_AUTO_UPDATE: "false", EXTRA: "kept" },
+    });
+  });
+
+  it("passes the command through unchanged when nothing contributes env", () => {
+    const createSpy = spyOnCreate();
+    const command = { command: "droid", args: ["exec"] };
+
+    createAcpStructuredSession(command, makeInput());
+
+    expect(createSpy.mock.calls[0]?.[0]).toBe(command);
+  });
+});

--- a/src/supervisor/agents/acp/sessionFactory.ts
+++ b/src/supervisor/agents/acp/sessionFactory.ts
@@ -1,4 +1,8 @@
-import type { CommandSpec, CreateStructuredSessionInput } from "../base";
+import {
+  withCommandBaseSpawnEnv,
+  type CommandSpec,
+  type CreateStructuredSessionInput,
+} from "../base";
 import { AcpStructuredSession, type AcpStructuredSessionOptions } from "./session";
 
 /**
@@ -47,7 +51,11 @@ export function createAcpStructuredSession(
   if (!shouldSpawnAcpSession(input)) {
     return undefined;
   }
-  return AcpStructuredSession.create(acpCommand, input.projectLocation, input.threadId, {
+  // The ACP child is spawned from `command.env`, so this is where the
+  // provider's `baseSpawnEnv` has to land — an ACP adapter must not have to
+  // remember to repeat it on its own launch argv. Command-declared env wins.
+  const command = withCommandBaseSpawnEnv(acpCommand, input.baseSpawnEnv);
+  return AcpStructuredSession.create(command, input.projectLocation, input.threadId, {
     ...(input.loadSessionErrorRewriter
       ? { loadSessionErrorRewriter: input.loadSessionErrorRewriter }
       : {}),

--- a/src/supervisor/agents/antigravity/antigravityAccountProbe.ts
+++ b/src/supervisor/agents/antigravity/antigravityAccountProbe.ts
@@ -11,6 +11,7 @@ import {
   queryLs,
 } from "./antigravityLanguageServer";
 import { resolveAntigravityLsEndpoints } from "./antigravityProcessScan";
+import { ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV } from "./detection";
 
 /**
  * Resolve the signed-in Antigravity account (email + plan) from its local
@@ -84,6 +85,11 @@ async function spawnAndReadAccount(
     cwd,
     stdio: "ignore",
     windowsHide: true,
+    // The account probe runs on a 5-minute TTL, which is exactly the cadence
+    // that keeps re-arming the CLI's background self-updater — and the updater
+    // detaches into its own console window (see
+    // ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV in detection.ts).
+    env: { ...process.env, ...ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV },
   });
   try {
     const deadline = Date.now() + SPAWN_LS_TIMEOUT_MS;

--- a/src/supervisor/agents/antigravity/detection.ts
+++ b/src/supervisor/agents/antigravity/detection.ts
@@ -10,6 +10,20 @@ import { ANTIGRAVITY_CONFIG_SUBPATH, antigravityConfigDirExists } from "./sessio
 
 export const ANTIGRAVITY_DEFAULT_MODEL_ID = "Gemini 3.5 Flash";
 
+// `agy` runs a detached background self-updater (`agy --bg-updater`, which then
+// shells out to `agy --version`) on its own rate-limited schedule — so it fires
+// on the first spawn after a quiet period, not on every spawn. The updater
+// escapes the pseudoconsole its parent runs in and allocates a fresh Windows
+// console; when the user's default terminal application is Windows Terminal the
+// OS hands that console off, popping a stray terminal window mid-session.
+// Poracode owns agent updates (Settings update button -> `agy update`), so we
+// set `AGY_CLI_DISABLE_AUTO_UPDATE` on every `agy` spawn we make (detection
+// probes, account probe, PTY launches, one-shots). `agy update` runs without
+// this env (separate path), so explicit updates still work.
+export const ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV: Record<string, string> = {
+  AGY_CLI_DISABLE_AUTO_UPDATE: "1",
+};
+
 const defaultModelCapabilities = buildAntigravityModelCapabilities(
   ANTIGRAVITY_KNOWN_MODEL_VARIANTS,
 );
@@ -72,6 +86,8 @@ const ANTIGRAVITY_TERMINAL_AUTH_METHOD: AgentAuthMethod = {
   id: "antigravity-login",
   name: "Antigravity login",
   args: [],
+  // No `env` needed: `detectAgentInstall` merges `baseSpawnEnv` into every
+  // terminal auth method as it assembles the status.
 };
 
 export function createAntigravityDetectionSpec(
@@ -90,6 +106,10 @@ export function createAntigravityDetectionSpec(
     // never shows a Logout button that would have nothing to invoke.
     loginCommand: "agy",
     capabilities: defaultAntigravityCapabilities,
+    // Single declaration point: shared runtime fans this out to the launch-time
+    // `agy --version` / `agy models` / `agy --help` probes, terminal login, PTY
+    // launches, one-shots, context extraction, and subagent children.
+    baseSpawnEnv: ANTIGRAVITY_DISABLE_AUTO_UPDATE_ENV,
     authProbes: [configDirAuthProbe],
     async capabilitiesProbe(ctx) {
       // Advertise the terminal login method regardless of the model-probe

--- a/src/supervisor/agents/antigravity/index.ts
+++ b/src/supervisor/agents/antigravity/index.ts
@@ -8,6 +8,7 @@ import {
   detectAgentInstall,
   watchSessionPaths,
   type AgentAdapter,
+  inheritBaseSpawnEnv,
 } from "../base";
 import { probeAntigravityAccount } from "./antigravityAccountProbe";
 import { buildAntigravityArgs, buildAntigravityModelArgs } from "./argv";
@@ -93,6 +94,9 @@ export function createAntigravityAdapter(): AgentAdapter {
     spawnEnv: {
       wsl: { BROWSER: "/bin/true" },
     },
+    // Stops `agy`'s background self-updater from detaching out of the thread's
+    // pseudoconsole and popping a stray terminal window.
+    ...inheritBaseSpawnEnv(detectionSpec),
 
     async detectInstall(ctx) {
       const status = await detectAgentInstall(ctx, detectionSpec);

--- a/src/supervisor/agents/base.detect-version.test.ts
+++ b/src/supervisor/agents/base.detect-version.test.ts
@@ -133,6 +133,91 @@ describe("detectAgentInstall version probe", () => {
   });
 });
 
+describe("detectAgentInstall baseSpawnEnv fan-out", () => {
+  const originalPlatform = process.platform;
+  const baseSpawnEnv = { AGY_CLI_DISABLE_AUTO_UPDATE: "1" };
+  let probeCtxSeen: import("./base").DetectProbeCtx | undefined;
+
+  const baseEnvSpec: DetectionSpec = {
+    ...spec,
+    baseSpawnEnv,
+    probeEnv: { PROBE_ONLY: "1" },
+    async capabilitiesProbe(ctx) {
+      probeCtxSeen = ctx;
+      return { authMethods: [{ id: "login", name: "Login", type: "terminal", args: [] }] };
+    },
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    clearExecutablePathCache();
+    probeCtxSeen = undefined;
+    execFileAsyncMock.mockReset();
+    spawnMock.mockReset();
+    spawnMock.mockImplementation((command, args, options) => {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const child = Object.assign(new EventEmitter(), {
+        stdout,
+        stderr,
+        pid: 12_345,
+        killed: false,
+      }) as unknown as import("node:child_process").ChildProcess;
+      queueMicrotask(() => {
+        void execFileAsyncMock(command, args, options).then(
+          (result) => {
+            stdout.end(result.stdout);
+            stderr.end(result.stderr ?? "");
+            child.emit("close", 0);
+          },
+          (error: unknown) => child.emit("error", error),
+        );
+      });
+      return child;
+    });
+    execFileAsyncMock.mockImplementation(async (_cmd: unknown, args: unknown) => {
+      const joined = (Array.isArray(args) ? args : []).join(" ");
+      if (joined.includes("command -v")) return { stdout: "/opt/tools/grok\n", stderr: "" };
+      return { stdout: "grok version 1.2.3\n", stderr: "" };
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  it("merges baseSpawnEnv under probeEnv for the probes and the version spawn", async () => {
+    await detectAgentInstall(undefined, baseEnvSpec);
+
+    // The capabilities probe sees the shared merge (base first, probeEnv wins).
+    expect(probeCtxSeen?.probeEnv).toEqual({
+      AGY_CLI_DISABLE_AUTO_UPDATE: "1",
+      PROBE_ONLY: "1",
+    });
+
+    // The `--version` spawn carries the same merged env.
+    const versionCall = execFileAsyncMock.mock.calls.find(([, args]) =>
+      (Array.isArray(args) ? args : []).includes("--version"),
+    );
+    expect(versionCall).toBeDefined();
+    expect(versionCall?.[2]).toEqual(
+      expect.objectContaining({
+        env: expect.objectContaining({ AGY_CLI_DISABLE_AUTO_UPDATE: "1", PROBE_ONLY: "1" }),
+      }),
+    );
+  });
+
+  it("applies baseSpawnEnv to terminal auth methods when assembling the status", async () => {
+    const status = await detectAgentInstall(undefined, baseEnvSpec);
+
+    // probeEnv is detection-only: the login method gets the base env, not it.
+    expect(status.authMethods).toEqual([
+      { id: "login", name: "Login", type: "terminal", args: [], env: baseSpawnEnv },
+    ]);
+  });
+});
+
 describe("detectAgentInstall WSL interop guard", () => {
   const originalPlatform = process.platform;
   // WSL `command -v` output the fake bridge returns for the binary probe; set

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -32,6 +32,7 @@ import {
   quotePowerShellLiteral,
 } from "./shellBasics";
 import { detectPowerShell, type DetectedPowerShell } from "../../shellPreference";
+import { mergeSpawnEnv, withBaseSpawnEnv } from "./spawnEnv";
 import type {
   AgentArgvSpec,
   AgentEnvContext,
@@ -93,6 +94,7 @@ export * from "./expectedRuntimeError";
 export * from "./promptSession";
 export * from "./processRuntime";
 export * from "./shellBasics";
+export * from "./spawnEnv";
 export type { DetectedPowerShell } from "../../shellPreference";
 export * from "./sessionFs";
 export function buildWindowsCmdCommand(cwd: string, command: string, args: string[]): CommandSpec {
@@ -717,16 +719,21 @@ export async function detectAgentInstall(
   const executablePath = await resolveDetectedBinary(ctx, spec);
   ctx?.signal?.throwIfAborted();
 
+  // `baseSpawnEnv` applies to every lane; `probeEnv` narrows further to
+  // detection only. Merge once here so each probe below gets both without
+  // having to know the difference.
+  const probeEnv = mergeSpawnEnv(spec.baseSpawnEnv, spec.probeEnv);
+
   const versionArgs = spec.versionArgs ?? ["--version"];
   const version = spec.versionProbe
     ? await spec.versionProbe({
         location,
         executablePath,
         ...(ctx?.agentSettings ? { agentSettings: ctx.agentSettings } : {}),
-        ...(spec.probeEnv ? { probeEnv: spec.probeEnv } : {}),
+        ...(probeEnv ? { probeEnv } : {}),
         ...(ctx?.signal ? { signal: ctx.signal } : {}),
       })
-    : await readDetectedVersion(location, executablePath, versionArgs, spec.probeEnv, ctx?.signal);
+    : await readDetectedVersion(location, executablePath, versionArgs, probeEnv, ctx?.signal);
 
   let capabilities = spec.capabilities;
   let statusProbeResult: StatusProbeResult | undefined;
@@ -741,7 +748,7 @@ export async function detectAgentInstall(
       executablePath,
       version,
       ...(ctx?.agentSettings ? { agentSettings: ctx.agentSettings } : {}),
-      probeEnv: spec.probeEnv,
+      probeEnv,
       ...(ctx?.signal ? { signal: ctx.signal } : {}),
     };
     const [capabilityPartial, nextStatusProbeResult] = await Promise.all([
@@ -829,7 +836,9 @@ export async function detectAgentInstall(
     ...(spec.update ? { update: spec.update } : {}),
     authState,
     ...(providerMetadata ? { providerMetadata } : {}),
-    ...(probedAuthMethods ? { authMethods: probedAuthMethods } : {}),
+    ...(probedAuthMethods
+      ? { authMethods: withBaseSpawnEnv(probedAuthMethods, spec.baseSpawnEnv) }
+      : {}),
     ...(probedAuthLogoutSupported ? { authLogoutSupported: true } : {}),
     capabilities,
   };

--- a/src/supervisor/agents/base/spawnEnv.ts
+++ b/src/supervisor/agents/base/spawnEnv.ts
@@ -1,0 +1,78 @@
+import type { AgentAuthMethod } from "@/shared/contracts";
+import type { AgentMetadata, CommandSpec, DetectionSpec } from "./types";
+
+/**
+ * Merge env layers for an agent spawn, most-general first. Later layers win.
+ *
+ * Returns `undefined` rather than `{}` when nothing is contributed, so callers
+ * can conditionally spread into option objects under
+ * `exactOptionalPropertyTypes` without inventing an empty env.
+ */
+export function mergeSpawnEnv(
+  ...layers: ReadonlyArray<Record<string, string> | undefined>
+): Record<string, string> | undefined {
+  let merged: Record<string, string> | undefined;
+  for (const layer of layers) {
+    if (!layer) continue;
+    for (const [key, value] of Object.entries(layer)) {
+      merged ??= {};
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Apply `baseSpawnEnv` to a command-level spawn (one-shots, context
+ * extraction, subagent children, ACP session/auth/logout commands). The
+ * command's own `env` wins on conflict — a lane-specific override stays
+ * authoritative. Returns the original object unchanged when nothing is
+ * contributed, so callers never invent an empty env.
+ *
+ * Generic over the command shape so lane-specific extras survive the wrap:
+ * several callers pass a superset of `CommandSpec` (a one-shot's `stdin`, an
+ * `isolateCwd` flag) and go on to read those fields off the result.
+ */
+export function withCommandBaseSpawnEnv<T extends CommandSpec>(
+  command: T,
+  baseSpawnEnv: Record<string, string> | undefined,
+): T {
+  const env = mergeSpawnEnv(baseSpawnEnv, command.env);
+  return env ? { ...command, env } : command;
+}
+
+/**
+ * Apply `baseSpawnEnv` to every terminal auth method in a detected status.
+ *
+ * Terminal login is built in the renderer from `AgentStatus.authMethods` (it
+ * prefixes `env` onto the login command), so status assembly is the only place
+ * shared code can reach that lane. Method-declared env wins on conflict — a
+ * provider that deliberately overrides a value for login keeps it.
+ */
+export function withBaseSpawnEnv(
+  methods: readonly AgentAuthMethod[],
+  baseSpawnEnv: Record<string, string> | undefined,
+): AgentAuthMethod[] {
+  if (!baseSpawnEnv) return [...methods];
+  return methods.map((method) => {
+    if (method.type !== "terminal") return method;
+    const env = mergeSpawnEnv(baseSpawnEnv, method.env);
+    return env ? { ...method, env } : method;
+  });
+}
+
+/**
+ * Spread helper for adapters deriving `baseSpawnEnv` from their detection spec:
+ * `...inheritBaseSpawnEnv(fooDetectionSpec)`.
+ *
+ * Providers must never re-declare the literal on the adapter — deriving it is
+ * what keeps the two from drifting. `exactOptionalPropertyTypes` rejects a plain
+ * `baseSpawnEnv: spec.baseSpawnEnv` assignment because the spec's value is
+ * optional, and a conditional spread at every call site is noise, so it lives
+ * here once.
+ */
+export function inheritBaseSpawnEnv(
+  spec: Pick<DetectionSpec, "baseSpawnEnv">,
+): Pick<AgentMetadata, "baseSpawnEnv"> {
+  return spec.baseSpawnEnv ? { baseSpawnEnv: spec.baseSpawnEnv } : {};
+}

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -168,6 +168,12 @@ export interface CreateStructuredSessionInput {
   config: ThreadConfig;
   agentSettings?: Record<string, boolean | string>;
   env?: Record<string, string>;
+  /**
+   * {@link AgentMetadata.baseSpawnEnv}, supplied by the shared runtime so the
+   * ACP session factory can apply it without every ACP provider remembering to
+   * put it on its own launch argv.
+   */
+  baseSpawnEnv?: Record<string, string>;
   mcpIdentity?: McpThreadIdentity;
   mcpServers?: readonly ResolvedMcpServer[];
   sessionRef?: SessionRef;
@@ -262,7 +268,10 @@ export interface DetectProbeCtx {
   version?: string | undefined;
   signal?: AbortSignal;
   agentSettings?: Record<string, boolean | string>;
-  /** {@link DetectionSpec.probeEnv}, so `capabilitiesProbe`/`statusProbe` can forward it. */
+  /**
+   * The merged {@link DetectionSpec.baseSpawnEnv} + {@link DetectionSpec.probeEnv},
+   * so `capabilitiesProbe`/`statusProbe` can forward it to their own spawns.
+   */
   probeEnv?: Record<string, string> | undefined;
 }
 
@@ -314,14 +323,29 @@ export interface DetectionSpec {
   update?: AgentUpdateInfo;
   versionArgs?: string[];
   /**
-   * Env merged onto the `--version` probe spawn. Used to neutralize a CLI's own
-   * background self-updater during detection — e.g. `command-code` spawns a
-   * detached npm install on every invocation unless `COMMANDCODE_SKIP_UPDATES`
-   * is set, which otherwise surfaces as a stray terminal window on app launch.
-   * Also exposed to `capabilitiesProbe`/`statusProbe` via `DetectProbeCtx.probeEnv`
-   * so they can forward it to their own `readAgentCommandOutput` calls.
+   * Detection-only env layered ON TOP of {@link DetectionSpec.baseSpawnEnv} for
+   * the `--version` probe spawn. Use this for overlays that must not leak into
+   * interactive sessions (a unique probe cache dir, a probe-only flag).
+   * Updater/telemetry opt-outs belong on `baseSpawnEnv` — they have to ride
+   * every spawn, not just detection. Exposed to `capabilitiesProbe`/`statusProbe`
+   * via {@link DetectProbeCtx.probeEnv} as the already-merged map so they can
+   * forward it to their own `readAgentCommandOutput` calls.
    */
   probeEnv?: Record<string, string>;
+  /**
+   * Env applied to EVERY spawn of this CLI that Poracode makes, in every lane:
+   * detection probes, terminal login, PTY thread launches, launch/resume argv,
+   * one-shot generation, context extraction, and subagent children. Shared
+   * runtime merges it at each launch point, so a provider declares its
+   * updater/telemetry opt-outs once here and a NEW launch point picks them up
+   * for free — instead of every command builder having to remember its own
+   * `env`. Deliberately NOT applied to `update` commands, so an explicit
+   * "update agent" action can still reach the CLI's own updater.
+   *
+   * The adapter re-exposes the same map as {@link AgentMetadata.baseSpawnEnv}
+   * for the lanes that run off the adapter rather than the detection spec.
+   */
+  baseSpawnEnv?: Record<string, string>;
   /** Provider-specific version probe for CLIs whose Windows shim cannot be spawned safely. */
   versionProbe?: (ctx: DetectProbeCtx) => Promise<string | undefined>;
   statusProbe?: StatusProbe;
@@ -339,6 +363,14 @@ export interface AgentMetadata {
     native?: Record<string, string>;
     wsl?: Record<string, string>;
   };
+  /**
+   * {@link DetectionSpec.baseSpawnEnv}, re-exposed so the adapter-driven lanes
+   * (PTY launch, one-shots, context extraction, subagent children) can apply it
+   * without reaching for the detection spec. Providers must derive it with
+   * `...inheritBaseSpawnEnv(spec)` rather than repeating the literal, so the
+   * two can never drift.
+   */
+  baseSpawnEnv?: Record<string, string>;
 }
 
 export interface AgentLauncher {

--- a/src/supervisor/agents/baseSpawnEnv.test.ts
+++ b/src/supervisor/agents/baseSpawnEnv.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import type { AgentAuthMethod } from "@/shared/contracts";
+import {
+  inheritBaseSpawnEnv,
+  mergeSpawnEnv,
+  withBaseSpawnEnv,
+  withCommandBaseSpawnEnv,
+} from "./base";
+import { antigravityDetectionSpec } from "./antigravity/detection";
+import { commandCodeDetectionSpec } from "./commandcode/detection";
+import { factoryDetectionSpec } from "./factory/detection";
+import { museDetectionSpec } from "./muse/detection";
+import { createAgentRegistry } from "./registry";
+
+/**
+ * `baseSpawnEnv` is the single declaration point for env that must ride EVERY
+ * Poracode-made spawn of a CLI — in practice, opt-outs for CLIs that otherwise
+ * fire a detached background self-updater. On Windows such an updater escapes
+ * its parent's pseudoconsole, allocates a fresh console, and (with Windows
+ * Terminal as the default terminal app) pops a stray window mid-session.
+ *
+ * The value of the design is that a NEW launch point can't silently miss it, so
+ * these tests pin both halves of that guarantee:
+ *   1. every provider that declares it on its detection spec also exposes it on
+ *      its adapter (the lanes split across the two), and
+ *   2. the shared merge helpers behave as the launch points assume.
+ */
+
+const SPECS_WITH_BASE_ENV = [
+  ["antigravity", antigravityDetectionSpec],
+  ["commandcode", commandCodeDetectionSpec],
+  ["factory", factoryDetectionSpec],
+  ["muse", museDetectionSpec],
+] as const;
+
+describe("baseSpawnEnv declaration", () => {
+  it.each(SPECS_WITH_BASE_ENV)("%s declares a non-empty baseSpawnEnv", (_kind, spec) => {
+    expect(spec.baseSpawnEnv).toBeDefined();
+    expect(Object.keys(spec.baseSpawnEnv ?? {}).length).toBeGreaterThan(0);
+  });
+
+  it.each(SPECS_WITH_BASE_ENV)(
+    "%s's adapter exposes the same map as its detection spec",
+    (kind, spec) => {
+      const adapter = createAgentRegistry().find((candidate) => candidate.kind === kind);
+      expect(adapter).toBeDefined();
+      // Derived via `inheritBaseSpawnEnv`, so the two can never drift. A
+      // provider that re-declares the literal on the adapter would pass this
+      // today and silently diverge on the next edit.
+      expect(adapter?.baseSpawnEnv).toBe(spec.baseSpawnEnv);
+    },
+  );
+
+  it("never leaks into the explicit update command", () => {
+    // Suppressing the CLI's updater must not disable the user-driven
+    // "update agent" action, which is the sanctioned way to update.
+    const builtIns = SPECS_WITH_BASE_ENV.map(
+      ([kind, spec]) => [kind, spec.update?.builtIn] as const,
+    ).filter(([, builtIn]) => builtIn !== undefined);
+    expect(builtIns.length).toBeGreaterThan(0);
+    for (const [, builtIn] of builtIns) {
+      expect(builtIn).not.toHaveProperty("env");
+    }
+  });
+});
+
+describe("inheritBaseSpawnEnv", () => {
+  it("omits the key entirely when the spec declares nothing", () => {
+    // Must be an absent key, not `undefined` — `exactOptionalPropertyTypes`.
+    expect(inheritBaseSpawnEnv({})).not.toHaveProperty("baseSpawnEnv");
+  });
+
+  it("passes the spec's map through by reference", () => {
+    const baseSpawnEnv = { A: "1" };
+    expect(inheritBaseSpawnEnv({ baseSpawnEnv }).baseSpawnEnv).toBe(baseSpawnEnv);
+  });
+});
+
+describe("mergeSpawnEnv", () => {
+  it("returns undefined when nothing is contributed", () => {
+    expect(mergeSpawnEnv(undefined, undefined)).toBeUndefined();
+    expect(mergeSpawnEnv()).toBeUndefined();
+  });
+
+  it("lets later (more specific) layers win", () => {
+    expect(mergeSpawnEnv({ A: "base", B: "base" }, { A: "lane" })).toEqual({
+      A: "lane",
+      B: "base",
+    });
+  });
+
+  it("does not mutate its inputs", () => {
+    const base = { A: "base" };
+    mergeSpawnEnv(base, { A: "lane" });
+    expect(base).toEqual({ A: "base" });
+  });
+});
+
+describe("withBaseSpawnEnv", () => {
+  const terminal = { type: "terminal", id: "login", name: "Login" } as const;
+
+  it("applies the base env to terminal auth methods", () => {
+    const [method] = withBaseSpawnEnv([terminal], { A: "1" });
+    expect(method).toMatchObject({ id: "login", env: { A: "1" } });
+  });
+
+  it("keeps a method's own env winning on conflict", () => {
+    const [method] = withBaseSpawnEnv([{ ...terminal, env: { A: "method" } }], { A: "base" });
+    expect(method).toMatchObject({ env: { A: "method" } });
+  });
+
+  it("leaves non-terminal auth methods untouched", () => {
+    const envVar: AgentAuthMethod = { type: "env_var", id: "key", name: "API key", vars: [] };
+    expect(withBaseSpawnEnv([envVar], { A: "1" })).toEqual([envVar]);
+  });
+
+  it("is a no-op without a base env", () => {
+    expect(withBaseSpawnEnv([terminal], undefined)).toEqual([terminal]);
+  });
+});
+
+describe("withCommandBaseSpawnEnv", () => {
+  const command: import("./base").CommandSpec = { command: "agy", args: ["--version"] };
+
+  it("applies the base env to a command without its own env", () => {
+    expect(withCommandBaseSpawnEnv(command, { A: "1" })).toEqual({
+      command: "agy",
+      args: ["--version"],
+      env: { A: "1" },
+    });
+  });
+
+  it("lets the command's own env win on conflict", () => {
+    expect(
+      withCommandBaseSpawnEnv({ ...command, env: { A: "command" } }, { A: "base", B: "base" }),
+    ).toMatchObject({ env: { A: "command", B: "base" } });
+  });
+
+  it("returns the same object when nothing is contributed", () => {
+    expect(withCommandBaseSpawnEnv(command, undefined)).toBe(command);
+  });
+
+  it("preserves lane-specific extras on the command", () => {
+    // Callers pass supersets of CommandSpec (a one-shot's `stdin`, an
+    // `isolateCwd` flag) and read those fields back off the result.
+    const oneShot = { ...command, stdin: "prompt", isolateCwd: true };
+    expect(withCommandBaseSpawnEnv(oneShot, { A: "1" })).toEqual({
+      ...oneShot,
+      env: { A: "1" },
+    });
+  });
+});

--- a/src/supervisor/agents/commandcode/commandcode.test.ts
+++ b/src/supervisor/agents/commandcode/commandcode.test.ts
@@ -247,8 +247,6 @@ describe("createCommandCodeAdapter", () => {
         "summarize",
       ],
       stdin: "",
-      // Suppress the CLI's background self-updater on one-shot utility runs.
-      env: { COMMANDCODE_SKIP_UPDATES: "1" },
     });
   });
 });
@@ -304,17 +302,16 @@ describe("commandCodeDetectionSpec auth", () => {
   // Suppresses the CLI's background self-updater. The one-shot and terminal-login
   // surfaces are asserted by their own tests above; this covers the detection
   // probe + PTY-launch surfaces.
-  it("sets COMMANDCODE_SKIP_UPDATES on the version probe and PTY launch env", () => {
-    // `--version` probe (also flows to capabilitiesProbe via DetectProbeCtx.probeEnv).
-    expect(commandCodeDetectionSpec.probeEnv).toEqual({ COMMANDCODE_SKIP_UPDATES: "1" });
+  it("declares COMMANDCODE_SKIP_UPDATES once, for every launch lane", () => {
+    // Single declaration point; shared runtime fans it out to the version
+    // probe, login, PTY launch, one-shots, extraction, and subagents.
+    expect(commandCodeDetectionSpec.baseSpawnEnv).toEqual({ COMMANDCODE_SKIP_UPDATES: "1" });
 
-    // Interactive / login PTY launch (spawnEnv); wsl keeps the OAuth BROWSER shim.
     const adapter = createCommandCodeAdapter();
-    expect(adapter.spawnEnv?.native).toEqual({ COMMANDCODE_SKIP_UPDATES: "1" });
-    expect(adapter.spawnEnv?.wsl).toEqual({
-      BROWSER: "/bin/true",
-      COMMANDCODE_SKIP_UPDATES: "1",
-    });
+    expect(adapter.baseSpawnEnv).toBe(commandCodeDetectionSpec.baseSpawnEnv);
+    // `spawnEnv` is now only the genuinely location-specific OAuth shim.
+    expect(adapter.spawnEnv?.native).toBeUndefined();
+    expect(adapter.spawnEnv?.wsl).toEqual({ BROWSER: "/bin/true" });
   });
 
   it("advertises a terminal login method when installed (drives the Login button)", async () => {
@@ -324,12 +321,9 @@ describe("commandCodeDetectionSpec auth", () => {
       executablePath: "C:\\bin\\command-code.cmd",
     });
     expect(result?.authMethods).toEqual([
-      {
-        id: "commandcode-terminal-login",
-        name: "Login",
-        type: "terminal",
-        env: { COMMANDCODE_SKIP_UPDATES: "1" },
-      },
+      // No `env` here: the raw probe result is pre-merge. `detectAgentInstall`
+      // applies `baseSpawnEnv` when it assembles the status (baseSpawnEnv.test.ts).
+      { id: "commandcode-terminal-login", name: "Login", type: "terminal" },
     ]);
   });
 

--- a/src/supervisor/agents/commandcode/detection.ts
+++ b/src/supervisor/agents/commandcode/detection.ts
@@ -19,7 +19,7 @@ import { commandCodeHasStoredCredentials } from "./session";
 // also honors `CI`, but that flips broader non-interactive behavior, so we use
 // the dedicated switch. `command-code update` runs without this env (separate
 // path), so explicit updates still work.
-export const COMMANDCODE_SKIP_UPDATES_ENV: Record<string, string> = {
+const COMMANDCODE_SKIP_UPDATES_ENV: Record<string, string> = {
   COMMANDCODE_SKIP_UPDATES: "1",
 };
 
@@ -402,10 +402,8 @@ const COMMANDCODE_TERMINAL_AUTH: AgentTerminalAuthMethod = {
   id: "commandcode-terminal-login",
   name: "Login",
   type: "terminal",
-  // `runTerminalLogin` forwards `env` into the login command; suppress the
-  // CLI's background self-updater so `command-code login` doesn't spawn a
-  // detached `npm i` terminal alongside the login overlay.
-  env: COMMANDCODE_SKIP_UPDATES_ENV,
+  // No `env` needed: `detectAgentInstall` merges `baseSpawnEnv` into every
+  // terminal auth method as it assembles the status.
 };
 
 export const commandCodeDetectionSpec: DetectionSpec = {
@@ -432,7 +430,8 @@ export const commandCodeDetectionSpec: DetectionSpec = {
         timeoutMs: 8_000,
         wslLinuxCwd: "/tmp",
         posixCwd: getAgentProbeCwd(ctx.location),
-        // Suppress the CLI's background self-updater (sourced from spec.probeEnv).
+        // Suppress the CLI's background self-updater (ctx.probeEnv is the
+        // shared `baseSpawnEnv` + `probeEnv` merge from detectAgentInstall).
         ...(ctx.probeEnv ? { env: ctx.probeEnv } : {}),
         ...(ctx.signal ? { signal: ctx.signal } : {}),
       },
@@ -450,6 +449,7 @@ export const commandCodeDetectionSpec: DetectionSpec = {
   // and is the automatic fallback if the built-in updater fails, since the CLI
   // is distributed as the `command-code` npm package on every platform.
   update: { builtIn: { binary: "command-code", args: ["update"] }, npm: "command-code" },
-  // Suppress the CLI's own background self-updater on the `--version` probe.
-  probeEnv: COMMANDCODE_SKIP_UPDATES_ENV,
+  // Suppress the CLI's background self-updater on every spawn lane (shared
+  // runtime fans this out; the explicit `update` command stays exempt).
+  baseSpawnEnv: COMMANDCODE_SKIP_UPDATES_ENV,
 };

--- a/src/supervisor/agents/commandcode/index.ts
+++ b/src/supervisor/agents/commandcode/index.ts
@@ -1,11 +1,15 @@
 import type { AgentCapability, PromptSegment } from "@/shared/contracts";
 import { inlinePromptSegmentText } from "@/shared/promptContent";
-import { detectAgentInstall, type AgentAdapter, type TerminalStatusHint } from "../base";
+import {
+  detectAgentInstall,
+  type AgentAdapter,
+  type TerminalStatusHint,
+  inheritBaseSpawnEnv,
+} from "../base";
 import { resolveInstallNodePath, warnIfPluginManifestMissing } from "../plugin/installerBase";
 import { buildCommandCodeArgs } from "./argv";
 import {
   COMMANDCODE_DEFAULT_MODEL_ID,
-  COMMANDCODE_SKIP_UPDATES_ENV,
   commandCodeDetectionSpec,
   defaultCommandCodeCapabilities,
 } from "./detection";
@@ -83,13 +87,12 @@ export function createCommandCodeAdapter(): AgentAdapter {
     // `command-code login` opens a browser for OAuth; BROWSER=/bin/true keeps
     // the WSL flow from trying to `xdg-open` inside the distro and hanging the
     // PTY (the user completes auth via the printed URL instead).
-    // COMMANDCODE_SKIP_UPDATES disables the CLI's background self-updater so an
-    // interactive/login launch doesn't spawn a detached `npm i` terminal window
-    // (see COMMANDCODE_SKIP_UPDATES_ENV in detection.ts).
     spawnEnv: {
-      native: COMMANDCODE_SKIP_UPDATES_ENV,
-      wsl: { BROWSER: "/bin/true", ...COMMANDCODE_SKIP_UPDATES_ENV },
+      wsl: { BROWSER: "/bin/true" },
     },
+    // Disables the CLI's background self-updater so no lane can spawn a
+    // detached `npm i` terminal window.
+    ...inheritBaseSpawnEnv(commandCodeDetectionSpec),
 
     // ── CLI hook plugin support ──────────────────────────────────────────
     // Command Code emits no OSC; its Claude-compatible hook system is the only
@@ -198,8 +201,6 @@ export function createCommandCodeAdapter(): AgentAdapter {
           prompt,
         ],
         stdin: "",
-        // Don't let a one-shot utility run trigger the CLI's background updater.
-        env: COMMANDCODE_SKIP_UPDATES_ENV,
       };
     },
 
@@ -222,7 +223,6 @@ export function createCommandCodeAdapter(): AgentAdapter {
           prompt,
         ],
         stdin: "",
-        env: COMMANDCODE_SKIP_UPDATES_ENV,
       };
     },
   };

--- a/src/supervisor/agents/factory/detection.ts
+++ b/src/supervisor/agents/factory/detection.ts
@@ -3,6 +3,7 @@ import { dedupeAcpAuthMethods, probeAcpCapabilities, type AcpProbeResult } from 
 import {
   buildAgentCommand,
   envVarAuthProbe,
+  mergeSpawnEnv,
   type CapabilitiesProbeResult,
   type DetectionSpec,
 } from "../base";
@@ -39,13 +40,27 @@ export const factoryDefaultCapabilities: AgentCapability = {
   settingDefs: [],
 };
 
-export function buildFactoryCommand(location: ProjectLocation, executablePath?: string) {
+// The session/auth command builder keeps the env baked in even though the same
+// map rides `baseSpawnEnv`: these commands are also the WSL lane, where env
+// must be exported inside the wsl.exe login-shell script (spawn-level env does
+// not reliably cross into the distro). `buildAgentCommand` does that baking —
+// and it is the SAME constant as `factoryDetectionSpec.baseSpawnEnv`, so the
+// shared merge at the ACP session/auth lanes is idempotent, never a drift.
+//
+// `extraEnv` layers ON TOP of that constant rather than replacing it, so a
+// caller forwarding a narrower env (e.g. a probe-only overlay) can never drop
+// the updater opt-out out of the WSL script.
+export function buildFactoryCommand(
+  location: ProjectLocation,
+  executablePath?: string,
+  extraEnv?: Record<string, string>,
+) {
   return buildAgentCommand(
     location,
     "droid",
     [...FACTORY_ACP_ARGS],
     executablePath,
-    FACTORY_DISABLE_AUTO_UPDATE_ENV,
+    mergeSpawnEnv(FACTORY_DISABLE_AUTO_UPDATE_ENV, extraEnv),
   );
 }
 
@@ -86,9 +101,13 @@ export function buildFactoryProbeCapabilities(probe: AcpProbeResult): Capabiliti
 async function probeCapabilities(
   location: ProjectLocation,
   executablePath: string,
+  probeEnv: Record<string, string> | undefined,
   signal?: AbortSignal,
 ): Promise<CapabilitiesProbeResult | undefined> {
-  const command = buildFactoryCommand(location, executablePath);
+  // Env comes from the shared merge (`detectAgentInstall` passes
+  // `baseSpawnEnv`+`probeEnv` as ctx.probeEnv) — the probe lane honors the
+  // single declaration point; `buildFactoryCommand` bakes it into the WSL script.
+  const command = buildFactoryCommand(location, executablePath, probeEnv);
   const processCwd = resolveProbeSpawnCwd(location, command.cwd);
   const probe = await probeAcpCapabilities(
     command.command,
@@ -115,10 +134,10 @@ export const factoryDetectionSpec: DetectionSpec = {
     builtIn: { binary: "droid", args: ["update"] },
     npm: "droid",
   },
-  probeEnv: FACTORY_DISABLE_AUTO_UPDATE_ENV,
+  baseSpawnEnv: FACTORY_DISABLE_AUTO_UPDATE_ENV,
   authProbes: [envVarAuthProbe(["FACTORY_API_KEY"])],
   async capabilitiesProbe(ctx) {
     if (!ctx.executablePath) return undefined;
-    return probeCapabilities(ctx.location, ctx.executablePath, ctx.signal);
+    return probeCapabilities(ctx.location, ctx.executablePath, ctx.probeEnv, ctx.signal);
   },
 };

--- a/src/supervisor/agents/factory/factory.test.ts
+++ b/src/supervisor/agents/factory/factory.test.ts
@@ -12,9 +12,14 @@ import {
 } from "./detection";
 import { createFactoryAdapter } from "./index";
 
+const probeAcpCapabilitiesMock = vi.hoisted(() =>
+  vi.fn<(...args: unknown[]) => Promise<undefined>>(),
+);
+
 vi.mock("../acp", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../acp")>()),
   createAcpStructuredSession: vi.fn<() => undefined>(() => undefined),
+  probeAcpCapabilities: probeAcpCapabilitiesMock,
 }));
 
 describe("Factory Droid detection", () => {
@@ -27,7 +32,7 @@ describe("Factory Droid detection", () => {
         builtIn: { binary: "droid", args: ["update"] },
         npm: "droid",
       },
-      probeEnv: FACTORY_DISABLE_AUTO_UPDATE_ENV,
+      baseSpawnEnv: FACTORY_DISABLE_AUTO_UPDATE_ENV,
     });
     expect(factoryDetectionSpec.capabilities).toMatchObject({
       liveInputMode: "server",
@@ -48,6 +53,30 @@ describe("Factory Droid detection", () => {
       cwd: "C:\\repo",
       env: expect.objectContaining(FACTORY_DISABLE_AUTO_UPDATE_ENV),
     });
+  });
+
+  it("forwards the shared probe-env merge into the ACP capabilities probe spawn", async () => {
+    probeAcpCapabilitiesMock.mockReset();
+    probeAcpCapabilitiesMock.mockResolvedValue(undefined);
+
+    const probeEnv = { ...FACTORY_DISABLE_AUTO_UPDATE_ENV, PROBE_ONLY: "1" };
+    await factoryDetectionSpec.capabilitiesProbe?.({
+      location: { kind: "windows", path: "C:\\repo" },
+      executablePath: "C:\\bin\\droid.exe",
+      // What detectAgentInstall passes: mergeSpawnEnv(baseSpawnEnv, probeEnv).
+      probeEnv,
+    });
+
+    // The probe lane honors the single declaration point via ctx.probeEnv
+    // instead of hardcoding the constant.
+    expect(probeAcpCapabilitiesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        env: expect.objectContaining(probeEnv),
+      }),
+    );
   });
 
   it("keeps the Factory token rate compact while retaining the full tooltip", () => {
@@ -137,7 +166,6 @@ describe("Factory Droid adapter", () => {
     ).toEqual({
       command: "droid",
       args: ["exec", "--output-format", "text", "--model", "model-a", "--reasoning-effort", "high"],
-      env: FACTORY_DISABLE_AUTO_UPDATE_ENV,
     });
   });
 
@@ -148,10 +176,11 @@ describe("Factory Droid adapter", () => {
     ).toEqual({
       binary: "droid",
       args: [...FACTORY_ACP_ARGS],
-      env: FACTORY_DISABLE_AUTO_UPDATE_ENV,
     });
-    const authCommand = await adapter.buildAcpAuthCommand?.();
-    expect(authCommand?.env).toEqual(expect.objectContaining(FACTORY_DISABLE_AUTO_UPDATE_ENV));
+    // The updater opt-out is no longer repeated on the argv: shared runtime
+    // applies `baseSpawnEnv` at the ACP session/auth lanes (see
+    // baseSpawnEnv.test.ts), so the adapter declares it exactly once.
+    expect(adapter.baseSpawnEnv).toEqual(FACTORY_DISABLE_AUTO_UPDATE_ENV);
   });
 
   it("declares HTTP MCP support Droid never advertises so built-in servers reach it", async () => {

--- a/src/supervisor/agents/factory/index.ts
+++ b/src/supervisor/agents/factory/index.ts
@@ -5,12 +5,12 @@ import {
   type AgentAdapter,
   type AgentEnvContext,
   type CreateStructuredSessionInput,
+  inheritBaseSpawnEnv,
 } from "../base";
 import { resolveAgentBinaryPath } from "../binaryResolver";
 import {
   buildFactoryCommand,
   FACTORY_ACP_ARGS,
-  FACTORY_DISABLE_AUTO_UPDATE_ENV,
   factoryDefaultCapabilities,
   factoryDetectionSpec,
 } from "./detection";
@@ -53,6 +53,7 @@ export function createFactoryAdapter(): AgentAdapter {
       },
     },
     ...(factoryDetectionSpec.update ? { update: factoryDetectionSpec.update } : {}),
+    ...inheritBaseSpawnEnv(factoryDetectionSpec),
     get capabilities() {
       return capabilities;
     },
@@ -65,14 +66,12 @@ export function createFactoryAdapter(): AgentAdapter {
       return {
         binary: "droid",
         args: [...FACTORY_ACP_ARGS],
-        env: FACTORY_DISABLE_AUTO_UPDATE_ENV,
       };
     },
     buildResumeArgv() {
       return {
         binary: "droid",
         args: [...FACTORY_ACP_ARGS],
-        env: FACTORY_DISABLE_AUTO_UPDATE_ENV,
       };
     },
     createInitialSessionRef() {
@@ -107,7 +106,6 @@ export function createFactoryAdapter(): AgentAdapter {
       return {
         command: "droid",
         args,
-        env: FACTORY_DISABLE_AUTO_UPDATE_ENV,
       };
     },
   };

--- a/src/supervisor/agents/muse/detection.test.ts
+++ b/src/supervisor/agents/muse/detection.test.ts
@@ -100,7 +100,7 @@ describe("museDetectionSpec", () => {
     expect(museDetectionSpec.binary).toBe("muse");
     expect(museDetectionSpec.loginCommand).toBe("muse login");
     expect(museDetectionSpec.versionArgs).toEqual(["--version"]);
-    expect(museDetectionSpec.probeEnv).toEqual({ MUSE_NO_AUTO_UPDATE: "1" });
+    expect(museDetectionSpec.baseSpawnEnv).toEqual({ MUSE_NO_AUTO_UPDATE: "1" });
   });
 
   it("ships installer-only update (no npm, no builtIn)", () => {

--- a/src/supervisor/agents/muse/detection.ts
+++ b/src/supervisor/agents/muse/detection.ts
@@ -12,6 +12,10 @@ import { nativeMuseAuthPath, WSL_MUSE_AUTH_PATH } from "./paths";
 
 // Models are static — Muse has no `list-models` command. All three ship with a
 // 1M context window (verified against Muse Code 0.1.0 docs/binary).
+const MUSE_DISABLE_AUTO_UPDATE_ENV: Record<string, string> = {
+  MUSE_NO_AUTO_UPDATE: "1",
+};
+
 export const MUSE_DEFAULT_MODEL_ID = "muse-spark-1.2";
 
 const MUSE_MODEL_IDS = [
@@ -128,7 +132,7 @@ export const museDetectionSpec: DetectionSpec = {
   // The installed `muse` command is a launcher that otherwise checks for and
   // starts a background update. Detection must stay read-only and predictable;
   // explicit updates still use the installer spec below.
-  probeEnv: { MUSE_NO_AUTO_UPDATE: "1" },
+  baseSpawnEnv: MUSE_DISABLE_AUTO_UPDATE_ENV,
   // META_API_KEY takes priority over stored credentials at the CLI; treat either
   // as signed-in. The file probe keys off a non-empty `providers` object, not
   // mere config-dir existence (the dir appears on first run regardless).

--- a/src/supervisor/agents/muse/index.ts
+++ b/src/supervisor/agents/muse/index.ts
@@ -1,5 +1,5 @@
 import type { AgentCapability } from "@/shared/contracts";
-import { detectAgentInstall, type AgentAdapter } from "../base";
+import { detectAgentInstall, type AgentAdapter, inheritBaseSpawnEnv } from "../base";
 import { buildMuseArgs, buildMuseResumeArgs } from "./argv";
 import { MUSE_DEFAULT_MODEL_ID, museDefaultCapabilities, museDetectionSpec } from "./detection";
 import { formatMusePromptSegments } from "./prompt";
@@ -34,6 +34,7 @@ export function createMuseAdapter(): AgentAdapter {
     // `muse login` opens a browser for Meta OAuth; BROWSER=/bin/true keeps the
     // WSL flow from trying to `xdg-open` inside the distro and hanging the PTY.
     spawnEnv: { wsl: { BROWSER: "/bin/true" } },
+    ...inheritBaseSpawnEnv(museDetectionSpec),
 
     async detectInstall(ctx) {
       const status = await detectAgentInstall(ctx, museDetectionSpec);

--- a/src/supervisor/agents/updateAgent.test.ts
+++ b/src/supervisor/agents/updateAgent.test.ts
@@ -333,6 +333,26 @@ describe("runUpdateCommandWithFallback", () => {
       { timeoutMs: 5 * 60 * 1000 },
     );
   });
+
+  it("does not apply adapter baseSpawnEnv to the explicit update spawn", async () => {
+    readAgentCommandOutputMock.mockResolvedValue({ ok: true, stdout: "updated", stderr: "" });
+    const adapter = {
+      ...makeAdapter("antigravity"),
+      baseSpawnEnv: { AGY_CLI_DISABLE_AUTO_UPDATE: "1" },
+    };
+    const status = makeStatus({
+      kind: "antigravity",
+      executablePath: "C:\\agy.exe",
+    });
+
+    const result = await runUpdateCommandWithFallback(adapter, status, NATIVE_WIN);
+
+    expect(result).toEqual({ ok: true, strategy: "built-in", output: "updated" });
+    expect(readAgentCommandOutputMock).toHaveBeenCalledWith(expect.anything(), "agy", ["update"], {
+      timeoutMs: 5 * 60 * 1000,
+    });
+    expect(readAgentCommandOutputMock.mock.calls[0]?.[3]).not.toHaveProperty("env");
+  });
 });
 
 describe("getLatestVersionForAdapter", () => {

--- a/src/supervisor/commitMessageGenerator.test.ts
+++ b/src/supervisor/commitMessageGenerator.test.ts
@@ -32,11 +32,13 @@ const getDiffMock = vi.hoisted(() =>
   >(),
 );
 
-vi.mock("node:child_process", () => ({
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
   spawn: spawnMock,
 }));
 
-vi.mock("./agents/base", () => ({
+vi.mock("./agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents/base")>()),
   buildAgentCommand: buildAgentCommandMock,
 }));
 

--- a/src/supervisor/contextExtractor.ts
+++ b/src/supervisor/contextExtractor.ts
@@ -1,5 +1,5 @@
 import type { ExtractContextResult, ProjectLocation, SessionRef } from "@/shared/contracts";
-import type { AgentAdapter } from "./agents/base";
+import { withCommandBaseSpawnEnv, type AgentAdapter } from "./agents/base";
 import { runOneShotPromptWithFallback } from "./oneShotPromptRunner";
 import { buildOneShotSpec, spawnAgent } from "./oneShotSpawn";
 
@@ -60,9 +60,15 @@ export async function extractContext(
   if (adapter.buildContextExtractionCommand) {
     const cmd = adapter.buildContextExtractionCommand(sessionRef, location, model);
     if (cmd) {
-      const spawnSpec = buildOneShotSpec(location, cmd.command, cmd.args, {
-        ...(cmd.env ? { env: cmd.env } : {}),
-      });
+      const extractionCommand = withCommandBaseSpawnEnv(cmd, adapter.baseSpawnEnv);
+      const spawnSpec = buildOneShotSpec(
+        location,
+        extractionCommand.command,
+        extractionCommand.args,
+        {
+          ...(extractionCommand.env ? { env: extractionCommand.env } : {}),
+        },
+      );
       console.log(`[context-extract] spawning: ${spawnSpec.command} ${spawnSpec.args.join(" ")}`);
 
       const raw = await spawnAgent(

--- a/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
+++ b/src/supervisor/crossagentMcp/SubagentAttemptRunner.ts
@@ -70,6 +70,10 @@ export class SubagentAttemptRunner {
         projectLocation: state.plan.projectLocation,
         config,
         presentationMode: "gui",
+        // Same contract as SpawnPipeline.createStructuredSession: the shared
+        // runtime — not the provider — supplies `baseSpawnEnv`, so a structured
+        // subagent child spawns with the provider's updater/telemetry opt-outs.
+        ...(adapter.baseSpawnEnv ? { baseSpawnEnv: adapter.baseSpawnEnv } : {}),
         ...(mcpAccess ?? {}),
       });
       if (!handle) {

--- a/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
+++ b/src/supervisor/crossagentMcp/SubagentRunManager.test.ts
@@ -89,6 +89,7 @@ function makeHarness(options?: {
   createFailures?: number;
   deferCreate?: boolean;
   interruptError?: string;
+  baseSpawnEnv?: Record<string, string>;
 }): Harness {
   const handles: FakeHandle[] = [];
   const inputs: CreateStructuredSessionInput[] = [];
@@ -103,6 +104,7 @@ function makeHarness(options?: {
   const adapter = {
     kind: "codex",
     label: options?.providerLabel ?? "Codex",
+    ...(options?.baseSpawnEnv ? { baseSpawnEnv: options.baseSpawnEnv } : {}),
     capabilities: {
       models: options?.models ?? [{ id: "gpt-5.5", label: "GPT-5.5" }],
       ...(options?.subProviders ? { subProviders: options.subProviders } : {}),
@@ -741,6 +743,28 @@ describe("SubagentRunManager", () => {
       status: "failed",
       error: { message: "Subagent session closed before the turn completed" },
     });
+  });
+
+  it("forwards the provider's baseSpawnEnv to the structured child session", async () => {
+    // The shared runtime — not the provider — supplies `baseSpawnEnv`, so every
+    // launch point that builds a `CreateStructuredSessionInput` has to pass it.
+    // Miss it here and a structured subagent spawns without the provider's
+    // updater opt-out, which on Windows pops a stray terminal window.
+    const baseSpawnEnv = { DROID_DISABLE_AUTO_UPDATE: "true" };
+    const h = makeHarness({ baseSpawnEnv });
+    h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+
+    expect(h.inputs[0]!.baseSpawnEnv).toEqual(baseSpawnEnv);
+  });
+
+  it("omits baseSpawnEnv entirely for a provider that declares none", async () => {
+    // Absent key, not `undefined` — `exactOptionalPropertyTypes`.
+    const h = makeHarness();
+    h.manager.spawn(PARENT, { agent: "codex", prompt: "go" });
+    await flush();
+
+    expect(h.inputs[0]!).not.toHaveProperty("baseSpawnEnv");
   });
 
   it("uses unrestricted permissions and inherits non-recursive MCPs", async () => {

--- a/src/supervisor/crossagentMcp/oneShotChild.ts
+++ b/src/supervisor/crossagentMcp/oneShotChild.ts
@@ -2,7 +2,7 @@ import { spawn as spawnChild } from "node:child_process";
 import { spawn as spawnPty, type IDisposable } from "node-pty";
 import { stripAnsi } from "@/shared/ansi";
 import type { ProjectLocation } from "@/shared/contracts";
-import type { AgentAdapter } from "@/supervisor/agents/base";
+import { withCommandBaseSpawnEnv, type AgentAdapter } from "@/supervisor/agents/base";
 import { buildOneShotSpec } from "@/supervisor/oneShotSpawn";
 import { ensureNodePtySpawnHelperExecutable } from "@/supervisor/nodePty";
 import { processEnvRecord } from "@/supervisor/processEnv";
@@ -109,10 +109,11 @@ export function runOneShotChild(params: OneShotChildParams): OneShotChildHandle 
     return NOOP_HANDLE;
   }
 
-  const spec = buildOneShotSpec(params.projectLocation, cmd.command, cmd.args, {
-    ...(cmd.env ? { env: cmd.env } : {}),
+  const childCommand = withCommandBaseSpawnEnv(cmd, params.adapter.baseSpawnEnv);
+  const spec = buildOneShotSpec(params.projectLocation, childCommand.command, childCommand.args, {
+    ...(childCommand.env ? { env: childCommand.env } : {}),
   });
-  const input = cmd.stdin ?? params.prompt;
+  const input = childCommand.stdin ?? params.prompt;
   const maxLifetimeMs = params.maxLifetimeMs ?? ONE_SHOT_CHILD_MAX_LIFETIME_MS;
 
   let transport: ChildTransport;

--- a/src/supervisor/oneShotPromptRunner.test.ts
+++ b/src/supervisor/oneShotPromptRunner.test.ts
@@ -14,8 +14,14 @@ const buildAgentCommandMock = vi.hoisted(() =>
   >(),
 );
 
-vi.mock("node:child_process", () => ({ spawn: spawnMock }));
-vi.mock("./agents/base", () => ({ buildAgentCommand: buildAgentCommandMock }));
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
+}));
+vi.mock("./agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents/base")>()),
+  buildAgentCommand: buildAgentCommandMock,
+}));
 
 import {
   isArgvLikelyTooLong,
@@ -196,6 +202,42 @@ describe("runOneShotPromptWithFallback", () => {
       ["-p", "read solution-1.patch"],
       undefined,
       undefined,
+    );
+  });
+
+  it("applies adapter baseSpawnEnv under the one-shot command env", async () => {
+    const child = createMockChildProcess();
+    spawnMock.mockReturnValueOnce(child);
+    const adapter = {
+      label: "FactoryLike",
+      baseSpawnEnv: { DROID_DISABLE_AUTO_UPDATE: "true" },
+      buildOneShotCommand: (_model: string, _effort?: string, prompt?: string) => ({
+        command: "droid",
+        args: ["exec", prompt ?? ""],
+        env: { DROID_DISABLE_AUTO_UPDATE: "false", LANE: "1" },
+      }),
+    } as unknown as AgentAdapter;
+
+    const pending = runOneShotPromptWithFallback({
+      location: windowsProject,
+      adapter,
+      model: "model-a",
+      effort: undefined,
+      timeoutMs: 10_000,
+      logTag: "test",
+      attempts: [{ level: "full", buildPrompt: () => "summarize" }],
+    });
+    await flushPromises();
+    child.stdout.emit("data", Buffer.from("ok"));
+    child.emit("close", 0);
+
+    await expect(pending).resolves.toBe("ok");
+    expect(buildAgentCommandMock).toHaveBeenCalledWith(
+      windowsProject,
+      "droid",
+      ["exec", "summarize"],
+      undefined,
+      { DROID_DISABLE_AUTO_UPDATE: "false", LANE: "1" },
     );
   });
 

--- a/src/supervisor/oneShotPromptRunner.ts
+++ b/src/supervisor/oneShotPromptRunner.ts
@@ -1,5 +1,5 @@
 import type { ProjectLocation } from "@/shared/contracts";
-import type { AgentAdapter, CommandSpec } from "./agents/base";
+import { withCommandBaseSpawnEnv, type AgentAdapter, type CommandSpec } from "./agents/base";
 import { prepareOneShot } from "./oneShotSpawn";
 
 // Spawn returns these errno codes when the OS rejects the argv length:
@@ -179,8 +179,11 @@ async function runOneShotPromptWithFallbackImpl(
     // The judge workspace is already throwaway and contains the only files the
     // model may inspect. Preserve it even for adapters that normally move
     // utility one-shots to the OS temp root for session-cache isolation.
-    const effectiveCommand =
+    const baseCommand =
       options.readOnlyWorkspace && cmd.isolateCwd ? { ...cmd, isolateCwd: false } : cmd;
+    // Every Poracode-made spawn of this CLI carries the provider's base env
+    // (updater/telemetry opt-outs); a command-specific `env` wins on conflict.
+    const effectiveCommand = withCommandBaseSpawnEnv(baseCommand, options.adapter.baseSpawnEnv);
     const { spec: spawnSpec, spawn } = prepareOneShot(options.location, effectiveCommand);
 
     if (hasNextAttempt && isArgvLikelyTooLong(spawnSpec)) {

--- a/src/supervisor/prSummaryGenerator.test.ts
+++ b/src/supervisor/prSummaryGenerator.test.ts
@@ -20,11 +20,13 @@ const buildAgentCommandMock = vi.hoisted(() =>
 const getLogRangeMock = vi.hoisted(() => vi.fn<() => Promise<string>>());
 const getDiffRangeMock = vi.hoisted(() => vi.fn<() => Promise<string>>());
 
-vi.mock("node:child_process", () => ({
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
   spawn: spawnMock,
 }));
 
-vi.mock("./agents/base", () => ({
+vi.mock("./agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents/base")>()),
   buildAgentCommand: buildAgentCommandMock,
 }));
 

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -113,6 +113,48 @@ describe("agent status cache", () => {
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 
+  it("invalidates v13 caches whose terminal auth methods lack baseSpawnEnv-derived env", () => {
+    // Pre-v14 statuses assembled terminal auth methods WITHOUT the provider's
+    // baseSpawnEnv (antigravity's `AGY_CLI_DISABLE_AUTO_UPDATE` did not exist
+    // on the method). Serving that stale status would build the `agy` login
+    // command without the opt-out — the stray-updater window the v14
+    // derivation exists to prevent.
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 13,
+        windows: [
+          {
+            kind: "antigravity",
+            label: "Antigravity",
+            installed: true,
+            authState: "missing",
+            authMethods: [{ id: "antigravity-login", name: "Antigravity login", type: "terminal" }],
+            capabilities: { models: [] },
+          },
+        ],
+      }),
+    );
+
+    const runtime = makeRuntime(() => {});
+    const cached = (
+      runtime.agentStatusService as unknown as {
+        readCachedStatuses: (wslDistros: readonly string[]) => {
+          windows: AgentStatus[];
+          wsl: AgentStatus[];
+          fromCache: boolean;
+        };
+      }
+    ).readCachedStatuses([]);
+
+    expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
+
   it("migrates stale cached settingDefs to current schema", () => {
     const dataDir = makeTempDir();
     process.env.PORACODE_DATA_DIR = dataDir;

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -55,8 +55,12 @@ const execFileAsync = promisify(execFile);
  * advertised auth methods do not create a false Login requirement. v13
  * normalizes ACP mode labels for display, so statuses cached with raw ids
  * (`smart_approve`) as approval-policy labels must be re-probed.
+ * v14 derives terminal auth-method `env` from `DetectionSpec.baseSpawnEnv`
+ * during status assembly, so statuses cached before that derivation (e.g.
+ * antigravity login without `AGY_CLI_DISABLE_AUTO_UPDATE`) must be re-probed
+ * or the login command runs without the provider's base env.
  */
-export const STATUS_CACHE_VERSION = 13;
+export const STATUS_CACHE_VERSION = 14;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 

--- a/src/supervisor/runtime/threadSession/spawnPipeline.ts
+++ b/src/supervisor/runtime/threadSession/spawnPipeline.ts
@@ -57,6 +57,7 @@ import {
   injectWslEnv,
   primeProjectShellEnv,
   resolveLaunchSpec,
+  mergeSpawnEnv,
 } from "../../agents/base";
 import { captureSupervisorException } from "../../diagnostics/sentry";
 import { ensureNodePtySpawnHelperExecutable } from "../../nodePty";
@@ -910,10 +911,14 @@ export class SpawnPipeline {
 
     const agentEnv = this.resolveAgentProcessEnv(input.adapter);
     const cliHookEnvInjected = Boolean(input.extraEnv?.PORACODE_HOOK_URL);
-    const providerEnv =
+    // `baseSpawnEnv` underlies every lane; the location-specific `spawnEnv`
+    // layers on top so a provider can still override per platform.
+    const providerEnv = mergeSpawnEnv(
+      input.adapter.baseSpawnEnv,
       input.projectLocation.kind === "wsl"
         ? input.adapter.spawnEnv?.wsl
-        : input.adapter.spawnEnv?.native;
+        : input.adapter.spawnEnv?.native,
+    );
     if (providerEnv) {
       Object.assign(agentEnv, providerEnv);
     }
@@ -1269,6 +1274,7 @@ export class SpawnPipeline {
         projectLocation,
         config,
         agentSettings: this.ctx.resolveAgentSettings(adapter),
+        ...(adapter.baseSpawnEnv ? { baseSpawnEnv: adapter.baseSpawnEnv } : {}),
         ...(mcpIdentity ? { mcpIdentity } : {}),
         ...(mcpServers.length > 0 || adapter.capabilities.mcpConfigSource === "agentSettings"
           ? { mcpServers }

--- a/src/supervisor/titleGenerator.test.ts
+++ b/src/supervisor/titleGenerator.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectLocation } from "@/shared/contracts";
+import type { AgentAdapter } from "./agents/base";
+
+const prepareOneShotMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      location: ProjectLocation,
+      cmd: { command: string; args: string[]; env?: Record<string, string> },
+    ) => {
+      spec: unknown;
+      spawn: (spec: unknown, input: string, timeoutMs: number) => Promise<string>;
+    }
+  >(),
+);
+
+vi.mock("./oneShotSpawn", () => ({
+  prepareOneShot: prepareOneShotMock,
+}));
+
+import { generateTitle } from "./titleGenerator";
+
+const windowsProject: ProjectLocation = { kind: "windows", path: "C:\\Users\\demo\\project" };
+const baseSpawnEnv = { DROID_DISABLE_AUTO_UPDATE: "true" };
+
+function cliAdapter(overrides: Partial<AgentAdapter> = {}): AgentAdapter {
+  return {
+    label: "Factory Droid",
+    defaultOneShotModel: "model-a",
+    baseSpawnEnv,
+    buildOneShotCommand: () => ({
+      command: "droid",
+      args: ["exec"],
+    }),
+    ...overrides,
+  } as AgentAdapter;
+}
+
+describe("generateTitle CLI spawn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prepareOneShotMock.mockReturnValue({
+      spec: { command: "droid", args: ["exec"] },
+      spawn: async () => "Fix login timeout",
+    });
+  });
+
+  it("applies adapter baseSpawnEnv to the one-shot command", async () => {
+    await generateTitle(windowsProject, cliAdapter(), "the login times out");
+
+    expect(prepareOneShotMock).toHaveBeenCalledWith(
+      windowsProject,
+      expect.objectContaining({
+        command: "droid",
+        args: ["exec"],
+        env: baseSpawnEnv,
+      }),
+    );
+  });
+
+  it("lets command-declared env win on conflict", async () => {
+    await generateTitle(
+      windowsProject,
+      cliAdapter({
+        buildOneShotCommand: () => ({
+          command: "droid",
+          args: ["exec"],
+          env: { DROID_DISABLE_AUTO_UPDATE: "false", OTHER: "1" },
+        }),
+      }),
+      "the login times out",
+    );
+
+    expect(prepareOneShotMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        env: { DROID_DISABLE_AUTO_UPDATE: "false", OTHER: "1" },
+      }),
+    );
+  });
+});

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -1,5 +1,5 @@
 import type { ProjectLocation } from "@/shared/contracts";
-import type { AgentAdapter } from "./agents/base";
+import { withCommandBaseSpawnEnv, type AgentAdapter } from "./agents/base";
 import { prepareOneShot } from "./oneShotSpawn";
 
 /**
@@ -123,7 +123,12 @@ async function runViaCli(
   if (!cmd) {
     throw new Error(`${adapter.label} does not support one-shot generation`);
   }
-  const { spec, spawn } = prepareOneShot(location, cmd);
+  // Same wrap as commit/PR/judge one-shots: title gen is a Poracode-made CLI
+  // spawn, so updater opt-outs have to ride it. Command-declared env wins.
+  const { spec, spawn } = prepareOneShot(
+    location,
+    withCommandBaseSpawnEnv(cmd, adapter.baseSpawnEnv),
+  );
   return spawn(spec, cmd.stdin ?? prompt, TITLE_GEN_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
## Summary

Introduces `baseSpawnEnv` as the single declaration point for env that must ride **every** Poracode-made spawn of an agent CLI, replacing per-command-builder `env` duplication. In practice this is for CLIs that fire a detached background self-updater — on Windows that updater escapes its parent's pseudoconsole, allocates a fresh console, and (with Windows Terminal as the default terminal app) pops a stray terminal window mid-session.

A provider now declares its opt-out once on the `DetectionSpec`; shared runtime fans it out to every lane, so a **new** launch point picks it up for free instead of every command builder having to remember its own `env`.

## Changes

- **`base/spawnEnv.ts`** (new) — `mergeSpawnEnv`, `withCommandBaseSpawnEnv`, `withBaseSpawnEnv`, `inheritBaseSpawnEnv`. Adapters derive the map from their spec via `...inheritBaseSpawnEnv(spec)` so the two can never drift.
- **Lane fan-out** — detection probes (merged under `probeEnv`), terminal login (via `authMethods[].env`), PTY launch, ACP session/auth/logout, one-shots, context extraction, and subagent children.
- **`update` stays exempt** — the user-driven "update agent" action must still reach the CLI's own updater.
- **New: antigravity `AGY_CLI_DISABLE_AUTO_UPDATE`** — including the account probe, whose 5-minute TTL was exactly the cadence that kept re-arming the updater.
- **Migrated to `baseSpawnEnv`** — commandcode, factory, and muse drop their repeated per-builder `env`.
- **Cache invalidation** — `STATUS_CACHE_VERSION` 13→14 and the renderer store 10→11, since terminal auth methods now carry `baseSpawnEnv`-derived `env`; a status persisted before that derivation would build a login command without it.

## Review fixes folded in

- `SubagentAttemptRunner` built a `CreateStructuredSessionInput` by hand and never passed `baseSpawnEnv`, unlike `SpawnPipeline` — the one launch point where the "can't silently miss it" guarantee wasn't holding. Pinned with two regression tests.
- `buildFactoryCommand`'s env parameter *replaced* the base constant instead of layering on top, so a caller forwarding a narrower env would have silently dropped the opt-out out of the WSL login-shell script — the one lane where spawn-level env can't rescue it. Now merges.
- `withCommandBaseSpawnEnv` is generic over the command shape, so lane extras (`stdin`, `isolateCwd`) survive the wrap.

## Testing

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run fmt:check` — all pass.
- `pnpm exec vitest run src/supervisor src/renderer/state` — 4098 passed, 1 failed. The single failure is the pre-existing `gemini/plugin/install.test.ts` pwsh-absolute-path assertion, in a file this branch does not touch.
- Verified `AGY_CLI_DISABLE_AUTO_UPDATE` is a real string in the shipped `agy.exe` (adjacent to `failed to check for updates`), so the new opt-out is not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
