### PR TITLE
Update DeepSeek Pro preset model to deepseek-v4-pro-0813

### DIFF
--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
@@ -329,7 +329,7 @@ describe("ClaudeProfileProviderSettings", () => {
     expect(screen.getByDisplayValue("CLAUDE_CODE_SUBAGENT_MODEL")).toBeInTheDocument();
     expect(
       screen.getAllByLabelText("Model id").map((input) => input.getAttribute("value")),
-    ).toEqual(["deepseek-v4-pro[1m]", "deepseek-v4-flash"]);
+    ).toEqual(["deepseek-v4-pro-0813[1m]", "deepseek-v4-flash"]);
     expect(settingsState.setAgentInstance).toHaveBeenCalledWith({
       id: "glm",
       driver: "claude",
@@ -337,13 +337,13 @@ describe("ClaudeProfileProviderSettings", () => {
       config: {
         configDir: "~/.poracode/claude-profiles/glm",
         models: [
-          { id: "deepseek-v4-pro[1m]", label: "DeepSeek V4 Pro" },
+          { id: "deepseek-v4-pro-0813[1m]", label: "DeepSeek V4 Pro 0813" },
           { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
         ],
         efforts: ["max"],
         defaultEffort: "max",
         modelEfforts: {
-          "deepseek-v4-pro[1m]": ["max"],
+          "deepseek-v4-pro-0813[1m]": ["max"],
           "deepseek-v4-flash": ["max"],
         },
       },
@@ -422,7 +422,7 @@ describe("ClaudeProfileProviderSettings", () => {
       "qwen3.7-plus",
       "qwen3.6-flash",
       "glm-5.2",
-      "deepseek-v4-pro",
+      "deepseek-v4-pro-0813",
       "deepseek-v4-flash-0731",
     ]);
     expect(config).toMatchObject({

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
@@ -105,9 +105,9 @@ describe("ClaudeProfileSettingsModel", () => {
         applyPresetEnvRows(DEEPSEEK_PRESET_ROWS, [], nextRowId).map((row) => [row.key, row.value]),
       );
       expect(byKey.ANTHROPIC_BASE_URL).toBe("https://api.deepseek.com/anthropic");
-      expect(byKey.ANTHROPIC_MODEL).toBe("deepseek-v4-pro[1m]");
-      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("deepseek-v4-pro[1m]");
-      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("deepseek-v4-pro[1m]");
+      expect(byKey.ANTHROPIC_MODEL).toBe("deepseek-v4-pro-0813[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("deepseek-v4-pro-0813[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("deepseek-v4-pro-0813[1m]");
       expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("deepseek-v4-flash");
       expect(byKey.CLAUDE_CODE_SUBAGENT_MODEL).toBe("deepseek-v4-flash");
       expect(byKey.CLAUDE_CODE_EFFORT_LEVEL).toBe("max");

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
@@ -35,9 +35,9 @@ export const ZAI_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
 export const DEEPSEEK_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
   { key: "ANTHROPIC_BASE_URL", value: "https://api.deepseek.com/anthropic", sensitive: false },
   { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
-  { key: "ANTHROPIC_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "deepseek-v4-pro[1m]", sensitive: false },
+  { key: "ANTHROPIC_MODEL", value: "deepseek-v4-pro-0813[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "deepseek-v4-pro-0813[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "deepseek-v4-pro-0813[1m]", sensitive: false },
   { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "deepseek-v4-flash", sensitive: false },
   { key: "CLAUDE_CODE_SUBAGENT_MODEL", value: "deepseek-v4-flash", sensitive: false },
   { key: "CLAUDE_CODE_EFFORT_LEVEL", value: "max", sensitive: false },
@@ -91,7 +91,7 @@ const QWEN_TOKEN_PLAN_MODELS = [
   { id: "qwen3.7-plus", label: "Qwen3.7 Plus" },
   { id: "qwen3.6-flash", label: "Qwen3.6 Flash" },
   { id: "glm-5.2", label: "GLM-5.2" },
-  { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+  { id: "deepseek-v4-pro-0813", label: "DeepSeek V4 Pro 0813" },
   { id: "deepseek-v4-flash-0731", label: "DeepSeek V4 Flash 0731" },
 ] as const;
 
@@ -150,13 +150,13 @@ export const PROFILE_PRESETS: readonly ProfilePreset[] = [
     label: msg`DeepSeek`,
     envRows: DEEPSEEK_PRESET_ROWS,
     models: [
-      { id: "deepseek-v4-pro[1m]", label: "DeepSeek V4 Pro" },
+      { id: "deepseek-v4-pro-0813[1m]", label: "DeepSeek V4 Pro 0813" },
       { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash" },
     ],
     efforts: ["max"],
     defaultEffort: "max",
     modelEfforts: {
-      "deepseek-v4-pro[1m]": ["max"],
+      "deepseek-v4-pro-0813[1m]": ["max"],
       "deepseek-v4-flash": ["max"],
     },
   },


### PR DESCRIPTION
- Update DeepSeek preset environment variables and model configurations to use the newer `deepseek-v4-pro-0813` model identifier.
- Refresh model definitions and labels across Claude profile presets and token plan model options.
- Update related renderer unit and component tests to match the new model identifier and label.