### PR TITLE
Support grok-4.6 and resolve reasoning effort defaults

### DIFF
--- a/src/supervisor/agents/grok/detection.test.ts
+++ b/src/supervisor/agents/grok/detection.test.ts
@@ -57,6 +57,22 @@ const GROK_45_META = {
   ],
 };
 
+// grok-4.6 as returned live by `grok agent stdio` 1.0.5. Note that it flags
+// BOTH xhigh and high `default: true`; only `reasoningEffort` names the tier a
+// session actually starts on.
+const GROK_46_META = {
+  totalContextTokens: 500_000,
+  agentType: "grok-build-plan",
+  supportsReasoningEffort: true,
+  reasoningEffort: "high",
+  reasoningEfforts: [
+    { id: "xhigh", value: "xhigh", label: "Extra High Effort", default: true },
+    { id: "high", value: "high", label: "High Effort", default: true },
+    { id: "medium", value: "medium", label: "Medium Effort", default: false },
+    { id: "low", value: "low", label: "Low Effort", default: false },
+  ],
+};
+
 const MODEL_WITHOUT_EFFORT_META = {
   totalContextTokens: 200_000,
   agentType: "cursor",
@@ -130,6 +146,46 @@ describe("mapGrokEffortCapabilities", () => {
     });
     expect(caps.modelEfforts["m"]).toEqual(["low", "turbo", "hyper"]);
     expect(caps.defaultEffort).toBe("low");
+  });
+
+  it("prefers the advertised reasoningEffort when several tiers claim default", () => {
+    const caps = mapGrokEffortCapabilities({
+      "grok-4.6": GROK_46_META,
+      "grok-4.5": GROK_45_META,
+    });
+    // grok-4.6 flags xhigh and high both `default: true`; `reasoningEffort`
+    // breaks the tie the way the CLI itself does.
+    expect(caps.defaultEffort).toBe("high");
+    expect(caps.efforts).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(caps.modelEfforts).toEqual({
+      "grok-4.6": ["low", "medium", "high", "xhigh"],
+      "grok-4.5": ["low", "medium", "high"],
+    });
+  });
+
+  it("falls back to the flagged tier when the model omits reasoningEffort", () => {
+    const caps = mapGrokEffortCapabilities({
+      m: {
+        reasoningEfforts: [
+          { id: "high", default: true },
+          { id: "low", default: false },
+        ],
+      },
+    });
+    expect(caps.defaultEffort).toBe("high");
+  });
+
+  it("ignores a reasoningEffort that names no advertised tier", () => {
+    const caps = mapGrokEffortCapabilities({
+      m: {
+        reasoningEffort: "ludicrous",
+        reasoningEfforts: [
+          { id: "high", default: true },
+          { id: "low", default: false },
+        ],
+      },
+    });
+    expect(caps.defaultEffort).toBe("high");
   });
 
   it("returns empty capabilities when metadata is missing or malformed", () => {

--- a/src/supervisor/agents/grok/detection.ts
+++ b/src/supervisor/agents/grok/detection.ts
@@ -153,9 +153,10 @@ type GrokReasoningEffortMeta = { id?: unknown; default?: unknown };
 
 /**
  * Derive effort capabilities from the per-model `_meta.reasoningEfforts` the
- * grok 0.2.x ACP handshake advertises (verified live on 0.2.118: grok-4.5
- * exposes high/medium/low with high as default). Models without tiers get an
- * explicit empty list so the shared model picker hides the effort dropdown.
+ * grok ACP handshake advertises (verified live on 1.0.5: grok-4.6 exposes
+ * xhigh/high/medium/low, grok-4.5 high/medium/low, both defaulting to high).
+ * Models without tiers get an explicit empty list so the shared model picker
+ * hides the effort dropdown.
  */
 export function mapGrokEffortCapabilities(
   modelMetadata: Record<string, Record<string, unknown>> | undefined,
@@ -177,13 +178,30 @@ export function mapGrokEffortCapabilities(
       .map((entry) => entry.id);
     modelEfforts[modelId] = sorted;
     if (sorted.length > efforts.length) efforts = sorted;
-    if (!defaultEffort) {
-      const def = entries.find((entry) => entry?.default === true);
-      if (def && typeof def.id === "string") defaultEffort = def.id;
-    }
+    defaultEffort ??= readGrokModelDefaultEffort(meta, entries, sorted);
   }
 
   return { efforts, modelEfforts, ...(defaultEffort ? { defaultEffort } : {}) };
+}
+
+/**
+ * Pick the tier a session actually starts on. Grok flags more than one tier
+ * `default: true` since 1.0.5 (grok-4.6 marks both xhigh and high), so the
+ * flag alone cannot identify the real default. The model's
+ * `_meta.reasoningEffort` names it unambiguously — "high" for grok-4.6,
+ * matching the session's `model_changed` update and the `x.ai/sessionConfig`
+ * selection — so prefer it and fall back to the first flagged tier for models
+ * that omit it.
+ */
+function readGrokModelDefaultEffort(
+  meta: Record<string, unknown>,
+  entries: GrokReasoningEffortMeta[],
+  tierIds: string[],
+): string | undefined {
+  const advertised = meta["reasoningEffort"];
+  if (typeof advertised === "string" && tierIds.includes(advertised)) return advertised;
+  const flagged = entries.find((entry) => entry?.default === true);
+  return flagged && typeof flagged.id === "string" ? flagged.id : undefined;
 }
 
 /**

--- a/src/supervisor/agents/grok/grok.test.ts
+++ b/src/supervisor/agents/grok/grok.test.ts
@@ -309,3 +309,31 @@ describe("createGrokAdapter L1 hook plugin support", () => {
     expect(extras?.env).toBeUndefined();
   });
 });
+
+describe("createGrokAdapter one-shot", () => {
+  const adapter = createGrokAdapter();
+
+  it("defaults to the model grok advertises as current and builds the headless -p command", () => {
+    // `grok models` and the ACP handshake both report grok-4.6 as the default
+    // on 1.0.5 (grok-4.5 stays selectable). Utility runs follow that default.
+    expect(adapter.defaultOneShotModel).toBe("grok-4.6");
+    expect(adapter.buildOneShotCommand?.("grok-4.6", "low", "hello")).toEqual({
+      command: "grok",
+      args: [
+        "--no-auto-update",
+        "-p",
+        "hello",
+        "-m",
+        "grok-4.6",
+        "--reasoning-effort",
+        "low",
+        "--always-approve",
+      ],
+      stdin: "",
+    });
+  });
+
+  it("returns undefined without a prompt", () => {
+    expect(adapter.buildOneShotCommand?.("grok-4.6", undefined, "")).toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/grok/index.ts
+++ b/src/supervisor/agents/grok/index.ts
@@ -252,9 +252,10 @@ export function createGrokAdapter(): AgentAdapter {
     // One-shot (title / commit) generation reuses Grok's documented headless
     // path: `grok -p <prompt>`. `--always-approve` keeps the non-interactive run
     // from blocking on a tool-approval prompt it cannot answer (mirrors the
-    // launch/ACP bypass in argv.ts). Grok 0.2.118 advertises grok-4.5 as its
-    // supported model, so utility runs use the same live catalog entry.
-    defaultOneShotModel: "grok-4.5",
+    // launch/ACP bypass in argv.ts). Grok 1.0.5 advertises grok-4.6 as its
+    // default model (grok-4.5 remains selectable), so utility runs use the same
+    // live catalog default.
+    defaultOneShotModel: "grok-4.6",
     buildOneShotCommand(model, effort, prompt) {
       if (!prompt) return undefined;
       const args = ["--no-auto-update", "-p", prompt];


### PR DESCRIPTION
- **Feature**: Update the default one-shot model to `grok-4.6` to align with Grok CLI 1.0.5.
- Prioritize advertised `reasoningEffort` metadata over ambiguous `default: true` flags when resolving default effort tiers.
- Add unit tests for effort capability mapping and one-shot command generation.