### PR TITLE
Clean up created sessions before stopping probed agent

### DIFF
--- a/src/supervisor/agents/acp/fixtures/fake-acp-agent.mjs
+++ b/src/supervisor/agents/acp/fixtures/fake-acp-agent.mjs
@@ -17,8 +17,13 @@
  *   FAKE_HANG_SET_CONFIG        "1" → never answer session/set_config_option (simulates a wedged agent)
  *   FAKE_CRASH_AFTER_NEW_SESSION "1" → exit(0) immediately after answering session/new
  *   FAKE_AUTH_REQUIRED_ON_NEW     "1" → reject session/new as unauthenticated
+ *   FAKE_SESSION_CLEANUP_CAPABILITY "delete" | "close" | "null" | "null-delete-close"
+ *   FAKE_SESSION_CLEANUP_MARKER    path written with the received cleanup method
+ *   FAKE_SESSION_CLEANUP_BEHAVIOR  "error" | "hang" → fail or wedge cleanup
+ *   FAKE_SESSION_NEW_MARKER        path written after the session/new response flushes
  *   FAKE_SELF_DESTRUCT_MS       exit(0) after N ms regardless (test cleanup guard)
  */
+import { writeFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 const env = process.env;
@@ -41,6 +46,10 @@ const setConfigDelayMs = Number(env.FAKE_SET_CONFIG_DELAY_MS ?? 0);
 const hangSetConfig = env.FAKE_HANG_SET_CONFIG === "1";
 const crashAfterNewSession = env.FAKE_CRASH_AFTER_NEW_SESSION === "1";
 const authRequiredOnNewSession = env.FAKE_AUTH_REQUIRED_ON_NEW === "1";
+const sessionCleanupCapability = env.FAKE_SESSION_CLEANUP_CAPABILITY;
+const sessionCleanupMarker = env.FAKE_SESSION_CLEANUP_MARKER;
+const sessionCleanupBehavior = env.FAKE_SESSION_CLEANUP_BEHAVIOR;
+const sessionNewMarker = env.FAKE_SESSION_NEW_MARKER;
 const selfDestructMs = Number(env.FAKE_SELF_DESTRUCT_MS ?? 0);
 const includeReasoningEffort = env.FAKE_REASONING_EFFORT === "1";
 
@@ -51,12 +60,12 @@ if (selfDestructMs > 0) {
 
 let currentModel = models[0];
 
-function send(message) {
-  process.stdout.write(`${JSON.stringify(message)}\n`);
+function send(message, callback) {
+  process.stdout.write(`${JSON.stringify(message)}\n`, callback);
 }
 
-function respond(id, result) {
-  send({ jsonrpc: "2.0", id, result });
+function respond(id, result, callback) {
+  send({ jsonrpc: "2.0", id, result }, callback);
 }
 
 function notifySessionUpdate(update) {
@@ -109,7 +118,19 @@ rl.on("line", (line) => {
     case "initialize":
       respond(id, {
         protocolVersion: 1,
-        agentCapabilities: { promptCapabilities: {}, sessionCapabilities: {} },
+        agentCapabilities: {
+          promptCapabilities: {},
+          sessionCapabilities:
+            sessionCleanupCapability === "delete"
+              ? { delete: {} }
+              : sessionCleanupCapability === "close"
+                ? { close: {} }
+                : sessionCleanupCapability === "null-delete-close"
+                  ? { delete: null, close: {} }
+                  : sessionCleanupCapability === "null"
+                    ? { delete: null, close: null }
+                    : {},
+        },
         agentInfo: { name: "fake-acp-agent", version: "0.0.0" },
         ...(initializeModels.length > 0
           ? {
@@ -141,14 +162,18 @@ rl.on("line", (line) => {
         });
         return;
       }
-      respond(id, {
-        sessionId: SESSION_ID,
-        modes: {
-          currentModeId: "default",
-          availableModes: [{ id: "default", name: "Default" }],
+      respond(
+        id,
+        {
+          sessionId: SESSION_ID,
+          modes: {
+            currentModeId: "default",
+            availableModes: [{ id: "default", name: "Default" }],
+          },
+          configOptions: configOptions(),
         },
-        configOptions: configOptions(),
-      });
+        sessionNewMarker ? () => writeFileSync(sessionNewMarker, SESSION_ID) : undefined,
+      );
       for (const batch of slashBatches) {
         setTimeout(
           () => {
@@ -185,6 +210,17 @@ rl.on("line", (line) => {
 
     case "session/cancel":
       return; // notification — no response
+
+    case "session/delete":
+    case "session/close":
+      if (sessionCleanupMarker) writeFileSync(sessionCleanupMarker, method);
+      if (sessionCleanupBehavior === "hang") return;
+      if (sessionCleanupBehavior === "error") {
+        send({ jsonrpc: "2.0", id, error: { code: -32603, message: "cleanup failed" } });
+        return;
+      }
+      respond(id, {});
+      return;
 
     default:
       if (id !== undefined) respond(id, {});

--- a/src/supervisor/agents/acp/probe.stress.test.ts
+++ b/src/supervisor/agents/acp/probe.stress.test.ts
@@ -7,6 +7,9 @@
  * Each test asserts the correct behavior for timing and process-failure paths
  * that are difficult to exercise reliably against a live provider.
  */
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { probeAcpCapabilities, type AcpProbeResult } from "./probe";
@@ -24,6 +27,19 @@ function probeWith(
   });
 }
 
+async function waitForFile(path: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    try {
+      await access(path);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
 describe("probeAcpCapabilities live-process paths", () => {
   it("uses initialize._meta.modelState after a successful session handshake", async () => {
     const result = await probeWith({ FAKE_INIT_MODELS: "grok-4.5" }, 3_000);
@@ -34,6 +50,102 @@ describe("probeAcpCapabilities live-process paths", () => {
     });
     expect(result?.authState).toBe("authenticated");
   });
+
+  it.each(["delete", "close"] as const)(
+    "cleans up its disposable session with session/%s",
+    async (capability) => {
+      const root = await mkdtemp(join(tmpdir(), "poracode-acp-probe-"));
+      const marker = join(root, "cleanup.txt");
+      try {
+        const result = await probeWith(
+          {
+            FAKE_SESSION_CLEANUP_CAPABILITY: capability,
+            FAKE_SESSION_CLEANUP_MARKER: marker,
+          },
+          5_000,
+        );
+
+        expect(result?.sessionEstablished).toBe(true);
+        expect(await readFile(marker, "utf8")).toBe(`session/${capability}`);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("falls back to session/close when session/delete is null", async () => {
+    const root = await mkdtemp(join(tmpdir(), "poracode-acp-probe-"));
+    const marker = join(root, "cleanup.txt");
+    try {
+      await probeWith(
+        {
+          FAKE_SESSION_CLEANUP_CAPABILITY: "null-delete-close",
+          FAKE_SESSION_CLEANUP_MARKER: marker,
+        },
+        5_000,
+      );
+
+      expect(await readFile(marker, "utf8")).toBe("session/close");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not call a null session cleanup capability", async () => {
+    const root = await mkdtemp(join(tmpdir(), "poracode-acp-probe-"));
+    const marker = join(root, "cleanup.txt");
+    try {
+      await probeWith(
+        {
+          FAKE_SESSION_CLEANUP_CAPABILITY: "null",
+          FAKE_SESSION_CLEANUP_MARKER: marker,
+        },
+        3_000,
+      );
+
+      await expect(access(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reserves enough of a short probe deadline to delete the session", async () => {
+    const root = await mkdtemp(join(tmpdir(), "poracode-acp-probe-"));
+    const marker = join(root, "cleanup.txt");
+    const started = Date.now();
+    try {
+      const result = await probeWith(
+        {
+          FAKE_SESSION_CLEANUP_CAPABILITY: "delete",
+          FAKE_SESSION_CLEANUP_MARKER: marker,
+        },
+        800,
+      );
+
+      expect(result?.sessionEstablished).toBe(true);
+      expect(await readFile(marker, "utf8")).toBe("session/delete");
+      expect(Date.now() - started).toBeLessThan(1_300);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["error", "hang"] as const)(
+    "keeps the detection result when session cleanup returns %s",
+    async (behavior) => {
+      const started = Date.now();
+      const result = await probeWith(
+        {
+          FAKE_SESSION_CLEANUP_CAPABILITY: "delete",
+          FAKE_SESSION_CLEANUP_BEHAVIOR: behavior,
+        },
+        1_200,
+      );
+
+      expect(result?.sessionEstablished).toBe(true);
+      expect(Date.now() - started).toBeLessThan(1_700);
+    },
+  );
 
   it("does not expose initialize models when the session requires authentication", async () => {
     const result = await probeWith(
@@ -147,5 +259,35 @@ describe("probeAcpCapabilities live-process paths", () => {
     await pending;
 
     expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  it("cleans up a created session before reaping an aborted probe", async () => {
+    const root = await mkdtemp(join(tmpdir(), "poracode-acp-probe-"));
+    const sessionMarker = join(root, "session.txt");
+    const cleanupMarker = join(root, "cleanup.txt");
+    const abort = new AbortController();
+    const started = Date.now();
+    try {
+      const pending = probeAcpCapabilities(process.execPath, [FIXTURE], process.cwd(), {
+        env: {
+          FAKE_SESSION_CLEANUP_CAPABILITY: "delete",
+          FAKE_SESSION_CLEANUP_MARKER: cleanupMarker,
+          FAKE_SESSION_NEW_MARKER: sessionMarker,
+        },
+        timeoutMs: 5_000,
+        label: "cancelled-after-session",
+        signal: abort.signal,
+      });
+      await waitForFile(sessionMarker);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      abort.abort();
+
+      await pending;
+
+      expect(await readFile(cleanupMarker, "utf8")).toBe("session/delete");
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/supervisor/agents/acp/probe.ts
+++ b/src/supervisor/agents/acp/probe.ts
@@ -403,7 +403,8 @@ function nextConfigOptionsUpdate(
 // ── Probe ────────────────────────────────────────────────────────
 
 /**
- * Spawn an ACP agent, discover its capabilities, then kill it.
+ * Spawn an ACP agent, discover its capabilities, clean up the probe session,
+ * then stop the process.
  *
  * Returns `undefined` on any failure (timeout, missing --acp support,
  * protocol error, etc.).
@@ -434,6 +435,10 @@ export async function probeAcpCapabilities(
   const tag = options?.label ? `[acp-probe:${options.label}]` : "[acp-probe]";
   let child: ReturnType<typeof spawn> | undefined;
   let abortProbe: (() => void) | undefined;
+  let connection: ClientSideConnection | undefined;
+  let probeSessionId: string | undefined;
+  let probeSessionCleanup: "delete" | "close" | undefined;
+  let cleanupReserveMs = 0;
   const ownedProcessGroup = process.platform !== "win32";
   const probeResult: AcpProbeResult = {};
 
@@ -465,17 +470,18 @@ export async function probeAcpCapabilities(
       child!.once("error", markClosed);
       child!.once("exit", markClosed);
     });
+    let resolveProbeAborted: (() => void) | undefined;
+    let probeWasAborted = false;
+    const probeAborted = new Promise<void>((resolve) => {
+      resolveProbeAborted = resolve;
+    });
     abortProbe = () => {
-      try {
-        child?.stdin?.destroy();
-      } catch {
-        // Ignore cleanup races.
-      }
-      if (child) terminateChildProcessTree(child, { ownedProcessGroup });
+      probeWasAborted = true;
+      resolveProbeAborted?.();
     };
     options?.signal?.addEventListener("abort", abortProbe, { once: true });
     if (options?.signal?.aborted) abortProbe();
-    const remainingBudgetMs = () => Math.max(0, deadline - Date.now());
+    const remainingBudgetMs = () => Math.max(0, deadline - Date.now() - cleanupReserveMs);
     const waitForProbeWindow = async (maxMs: number): Promise<void> => {
       const waitMs = Math.min(maxMs, remainingBudgetMs());
       if (waitMs <= 0 || childExited) return;
@@ -486,6 +492,9 @@ export async function probeAcpCapabilities(
             timer = setTimeout(resolve, waitMs);
           }),
           childClosed,
+          probeAborted.then<never>(() => {
+            throw new Error("ACP probe aborted");
+          }),
         ]);
       } finally {
         if (timer) clearTimeout(timer);
@@ -494,6 +503,7 @@ export async function probeAcpCapabilities(
     const runWithinProbeBudget = async <T>(operation: Promise<T>, maxMs?: number): Promise<T> => {
       const budgetMs = Math.min(maxMs ?? Number.POSITIVE_INFINITY, remainingBudgetMs());
       if (budgetMs <= 0) throw new Error("ACP probe timed out");
+      if (probeWasAborted) throw new Error("ACP probe aborted");
       if (childExited) throw new Error("ACP agent exited during capability probe");
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -504,6 +514,9 @@ export async function probeAcpCapabilities(
           }),
           childClosed.then<never>(() => {
             throw new Error("ACP agent exited during capability probe");
+          }),
+          probeAborted.then<never>(() => {
+            throw new Error("ACP probe aborted");
           }),
         ]);
       } finally {
@@ -526,7 +539,7 @@ export async function probeAcpCapabilities(
     const fromAgent = Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>;
     const stream = ndJsonStream(toAgent, filterAcpStdoutNonJsonLines(fromAgent));
 
-    const connection = new ClientSideConnection(
+    connection = new ClientSideConnection(
       () => ({
         requestPermission: () => Promise.resolve({ outcome: { outcome: "cancelled" as const } }),
         sessionUpdate: (params: SessionNotification) => {
@@ -547,70 +560,82 @@ export async function probeAcpCapabilities(
       stream,
     );
 
-    const result = await runWithinProbeBudget(
-      (async () => {
-        const initResult = await connection.initialize({
-          protocolVersion: PROTOCOL_VERSION,
-          clientInfo: { name: "poracode-probe", version: "0.1.0" },
-          clientCapabilities: { auth: { terminal: true } },
-        });
-        if (initResult.authMethods?.length) {
-          probeResult.authMethods = initResult.authMethods;
-        }
-        if (initResult.agentCapabilities?.auth?.logout !== undefined) {
-          probeResult.authLogoutSupported = true;
-        }
-        if (initResult._meta && typeof initResult._meta === "object") {
-          probeResult.acpMeta = initResult._meta as Record<string, unknown>;
-          initializeModels = readUnstableInitializeModels(initResult._meta);
-        }
-
-        // Non-spec compatibility fallback for agents that still expose
-        // commands during initialize instead of session/update.
-        const rawCommands = (initResult as { commands?: AcpAvailableCommandLike[] }).commands;
-        if (Array.isArray(rawCommands) && rawCommands.length > 0) {
-          latestSlashCommands = mapAcpSlashCommands(rawCommands);
-        }
-
-        const preferredAuthMethodId = options?.authenticateMethodIds?.find((id) =>
-          initResult.authMethods?.some((method) => method.id === id),
-        );
-        if (preferredAuthMethodId) {
-          try {
-            const authResult = (await connection.authenticate({
-              methodId: preferredAuthMethodId,
-            })) as { _meta?: unknown } | undefined;
-            const authMeta = authResult?._meta;
-            if (authMeta && typeof authMeta === "object") {
-              probeResult.acpMeta = {
-                ...(probeResult.acpMeta ?? {}),
-                ...(authMeta as Record<string, unknown>),
-              };
-            }
-          } catch (err) {
-            console.log(
-              "%s authenticate(%s) failed: %s",
-              tag,
-              preferredAuthMethodId,
-              err instanceof Error ? err.message : String(err),
-            );
-          }
-        }
-
-        try {
-          return await connection.newSession({ cwd: sessionCwd, mcpServers: [] });
-        } catch (err) {
-          // ACP's spec-compliant signal that the agent is not signed in.
-          // Propagate it as a distinct authState so the detection layer can
-          // surface "missing" without falling back to env-var / file probes
-          // that don't reflect post-logout state.
-          if (isAcpAuthRequiredError(err)) {
-            probeResult.authState = "missing";
-          }
-          throw err;
-        }
-      })(),
+    const initResult = await runWithinProbeBudget(
+      connection.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientInfo: { name: "poracode-probe", version: "0.1.0" },
+        clientCapabilities: { auth: { terminal: true } },
+      }),
     );
+    if (initResult.authMethods?.length) {
+      probeResult.authMethods = initResult.authMethods;
+    }
+    if (initResult.agentCapabilities?.auth?.logout !== undefined) {
+      probeResult.authLogoutSupported = true;
+    }
+    const sessionCapabilities = initResult.agentCapabilities?.sessionCapabilities;
+    probeSessionCleanup =
+      sessionCapabilities?.delete != null
+        ? "delete"
+        : sessionCapabilities?.close != null
+          ? "close"
+          : undefined;
+    if (probeSessionCleanup) {
+      cleanupReserveMs = Math.min(1_000, Math.floor(timeoutMs / 4));
+    }
+    if (initResult._meta && typeof initResult._meta === "object") {
+      probeResult.acpMeta = initResult._meta as Record<string, unknown>;
+      initializeModels = readUnstableInitializeModels(initResult._meta);
+    }
+
+    // Non-spec compatibility fallback for agents that still expose
+    // commands during initialize instead of session/update.
+    const rawCommands = (initResult as { commands?: AcpAvailableCommandLike[] }).commands;
+    if (Array.isArray(rawCommands) && rawCommands.length > 0) {
+      latestSlashCommands = mapAcpSlashCommands(rawCommands);
+    }
+
+    const preferredAuthMethodId = options?.authenticateMethodIds?.find((id) =>
+      initResult.authMethods?.some((method) => method.id === id),
+    );
+    if (preferredAuthMethodId) {
+      try {
+        const authResult = (await runWithinProbeBudget(
+          connection.authenticate({ methodId: preferredAuthMethodId }),
+        )) as { _meta?: unknown } | undefined;
+        const authMeta = authResult?._meta;
+        if (authMeta && typeof authMeta === "object") {
+          probeResult.acpMeta = {
+            ...(probeResult.acpMeta ?? {}),
+            ...(authMeta as Record<string, unknown>),
+          };
+        }
+      } catch (err) {
+        console.log(
+          "%s authenticate(%s) failed: %s",
+          tag,
+          preferredAuthMethodId,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+
+    let result;
+    try {
+      result = await runWithinProbeBudget(
+        connection.newSession({ cwd: sessionCwd, mcpServers: [] }),
+      );
+    } catch (err) {
+      // ACP's spec-compliant signal that the agent is not signed in.
+      // Propagate it as a distinct authState so the detection layer can
+      // surface "missing" without falling back to env-var / file probes
+      // that don't reflect post-logout state.
+      if (isAcpAuthRequiredError(err)) {
+        probeResult.authState = "missing";
+      }
+      throw err;
+    }
+    probeSessionId = result.sessionId;
     // An available-commands update is a full snapshot. Keep the latest one
     // throughout the grace window because agents may publish built-ins first
     // and append skills after their async discovery completes.
@@ -752,6 +777,41 @@ export async function probeAcpCapabilities(
     return undefined;
   } finally {
     if (abortProbe) options?.signal?.removeEventListener("abort", abortProbe);
+    const cleanupBudgetMs = Math.max(0, deadline - Date.now());
+    if (
+      connection &&
+      probeSessionId &&
+      probeSessionCleanup &&
+      child &&
+      !child.killed &&
+      cleanupBudgetMs > 0
+    ) {
+      let cleanupTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const cleanup =
+          probeSessionCleanup === "delete"
+            ? connection.deleteSession({ sessionId: probeSessionId })
+            : connection.closeSession({ sessionId: probeSessionId });
+        await Promise.race([
+          cleanup,
+          new Promise<never>((_, reject) => {
+            cleanupTimer = setTimeout(
+              () => reject(new Error("ACP probe session cleanup timed out")),
+              cleanupBudgetMs,
+            );
+          }),
+        ]);
+      } catch (error) {
+        console.log(
+          "%s session/%s cleanup failed: %s",
+          tag,
+          probeSessionCleanup,
+          error instanceof Error ? error.message : String(error),
+        );
+      } finally {
+        if (cleanupTimer) clearTimeout(cleanupTimer);
+      }
+    }
     if (child && !child.killed) {
       // Destroy stdin before killing to prevent the ACP SDK from writing
       // to a dead pipe (which causes noisy "ACP write error" logs).


### PR DESCRIPTION
- Clean up created ACP sessions prior to stopping probed agents to prevent dangling resources
- Update ACP probe lifecycle logic to guarantee session termination before agent shutdown
- Adjust fake ACP agent test fixtures and stress tests to validate clean session teardown