### PR TITLE
Handle unreachable remote projects in sidebar menus

### DIFF
--- a/src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsSidebar.tsx
@@ -15,6 +15,7 @@ import {
   ProjectSelectorIcon,
   useProjectRemoteServerLookup,
 } from "@/renderer/components/common/ProjectRemoteServer";
+import { isRemoteProjectStatusUnreachable } from "@/renderer/state/remoteServers/reachability";
 import {
   overlaySidebarColumnClass,
   overlaySidebarSurfaceClass,
@@ -120,7 +121,14 @@ export function GitHubActionsSidebar(props: {
                     {props.projects.map((project) => {
                       const remote = remoteServerFor(project);
                       return (
-                        <Dropdown.Item key={project.id} id={project.id} textValue={project.name}>
+                        <Dropdown.Item
+                          key={project.id}
+                          id={project.id}
+                          textValue={project.name}
+                          // An offline machine can't serve workflows, so its
+                          // projects stay visible but unpickable.
+                          isDisabled={isRemoteProjectStatusUnreachable(project, remote.status)}
+                        >
                           <ProjectSelectorIcon project={project} remote={remote} />
                           <Label>{project.name}</Label>
                           {remote.serverName ? (

--- a/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
+++ b/src/renderer/views/GitHubActionsView/GitHubActionsView.test.tsx
@@ -240,6 +240,31 @@ describe("GitHubActionsView", () => {
     expect(document.querySelector('[class~="min-w-[--trigger-width]"]')).toBeInTheDocument();
   });
 
+  it("disables menu rows for projects on unreachable servers", async () => {
+    const mirrored: Project = {
+      ...project,
+      id: "remote:desktop-1:project:project-1",
+      remoteServerId: "desktop-1",
+      remoteId: project.id,
+      location: { ...project.location, remoteServerId: "desktop-1" },
+    };
+    useRemoteServersStore.setState({
+      servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+      runtime: { "desktop-1": { status: "offline", projects: [], threads: [] } },
+    } as never);
+    useAppStore.setState({ projects: [project, mirrored] });
+
+    render(<GitHubActionsView projectId={project.id} onClose={() => {}} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Project" }));
+    const remoteRow = await screen.findByRole("menuitemradio", { name: /MacBook 16/ });
+    expect(remoteRow).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("menuitemradio", { name: "Poracode" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
   it("selects the first pinned workflow by default", async () => {
     bridge.ghListWorkflows.mockResolvedValue({
       workflows: [

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.test.tsx
@@ -318,6 +318,46 @@ describe("SidebarProjectFilter", () => {
       );
     });
 
+    it("right-aligns the overflow button on unavailable rows like the selectable ones", async () => {
+      const mirrored = {
+        ...projects[1]!,
+        remoteServerId: "desktop-1",
+        remoteId: "remote-b",
+      } as Project;
+      useRemoteServersStore.setState({
+        servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+        runtime: { "desktop-1": { status: "offline", projects: [], threads: [] } },
+      } as never);
+      useAppStore.setState({ projects: [projects[0]!, mirrored], threads: [] });
+      render(
+        <SidebarProjectFilter
+          projects={[projects[0]!, mirrored]}
+          filterableProjectIds={new Set(["a"])}
+          threadCounts={threadCounts}
+          value={null}
+          onChange={vi.fn<(next: string[] | null) => void>()}
+        />,
+      );
+      await openMenu();
+
+      // The unavailable row pushes its overflow button to the right edge…
+      const unavailableButton = screen.getByRole("button", {
+        name: "Project actions for Beta",
+      });
+      expect(unavailableButton).toHaveClass("ms-auto");
+      // …and keeps the indicator so the row gets the same left inset
+      // (:has(.menu-item__indicator) → ps-7) as the selectable rows.
+      expect(
+        unavailableButton
+          .closest('[data-slot="menu-item"]')
+          ?.querySelector('[data-slot="menu-item-indicator"]'),
+      ).not.toBeNull();
+      // Selectable rows right-align through the thread-count hint instead.
+      expect(screen.getByRole("button", { name: "Project actions for Alpha" })).not.toHaveClass(
+        "ms-auto",
+      );
+    });
+
     it("closes both menus once an action is picked", async () => {
       renderFilter(null);
       await openMenu();

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
@@ -112,6 +112,7 @@ function useFilterDismissal(args: {
  */
 function ProjectRowMenuButton(props: {
   project: Project;
+  className?: string;
   onOpenMenu: (anchor: { x: number; y: number }) => void;
 }) {
   const { t } = useLingui();
@@ -126,7 +127,7 @@ function ProjectRowMenuButton(props: {
       role="button"
       tabIndex={0}
       aria-label={t`Project actions for ${props.project.name}`}
-      className="-mr-1 flex size-5 shrink-0 items-center justify-center rounded text-muted/60 hover:bg-[var(--row-hover)] hover:text-foreground"
+      className={`${props.className ?? ""} -mr-1 flex size-5 shrink-0 items-center justify-center rounded text-muted/60 hover:bg-[var(--row-hover)] hover:text-foreground`}
       onPointerDown={(event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -530,9 +531,15 @@ export function SidebarProjectFilter(props: {
                   {isHomeProject(project) ? null : (
                     <ProjectRowMenuButton
                       project={project}
+                      className="ms-auto"
                       onOpenMenu={(anchor) => setOverflowTarget({ project, anchor })}
                     />
                   )}
+                  {/* Invisible while unselected; marks the row as having an
+                     indicator so `.menu-item` picks up the same left inset
+                     (ps-7) the selectable rows have. The button itself is
+                     right-aligned by `ms-auto`, not by this spacer. */}
+                  <Dropdown.ItemIndicator />
                 </Dropdown.Item>
               );
             })}


### PR DESCRIPTION
- **Type**: Bugfix
- Disable project selection in the GitHub Actions sidebar for offline remote servers so users cannot trigger operations on unreachable hosts.
- Fix alignment and spacing for unavailable project rows in the sidebar project filter to maintain visual consistency with selectable items.
- Add unit tests verifying disabled states in the GitHub Actions menu and layout styling in the project filter.