### PR TITLE
Resolve bare Windows executables before spawning

### DIFF
--- a/src/supervisor/agents/base.windows-shell.test.ts
+++ b/src/supervisor/agents/base.windows-shell.test.ts
@@ -52,6 +52,7 @@ describe("quotePosixShellArg", () => {
 
 describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
   const originalPlatform = process.platform;
+  const originalPath = process.env.PATH;
   const tempDirs: string[] = [];
 
   beforeEach(() => {
@@ -60,6 +61,7 @@ describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    process.env.PATH = originalPath;
     vi.restoreAllMocks();
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
@@ -88,6 +90,21 @@ describe.skipIf(process.platform !== "win32")("buildWindowsCommand", () => {
       args: ["app-server"],
       cwd: "C:\\repo",
     });
+  });
+
+  it("resolves bare Windows executables before spawning them", () => {
+    const dir = mkdtempSync(join(tmpdir(), "poracode-direct-exe-"));
+    tempDirs.push(dir);
+    const executablePath = join(dir, "poracode-test-agent.exe");
+    writeFileSync(executablePath, "", "utf8");
+    process.env.PATH = `${dir};${originalPath ?? ""}`;
+
+    const spec = buildAgentCommand({ kind: "windows", path: "C:\\repo" }, "poracode-test-agent", [
+      "--version",
+    ]);
+
+    expect(spec.command).toBe(executablePath);
+    expect(spec.args).toEqual(["--version"]);
   });
 
   it("falls back to powershell.exe (PS 5.1) when pwsh is missing", () => {

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -365,7 +365,7 @@ export function buildAgentCommand(
   }
 
   if (location.kind === "windows") {
-    const commandPath = resolvedExecPath ?? command;
+    const commandPath = resolvedExecPath ?? resolveExecutablePath(command) ?? command;
     const shim = resolveWindowsNodeCmdShim(commandPath);
     const spec = shim
       ? buildWindowsCommand(location.path, shim.command, [...shim.argsPrefix, ...args])


### PR DESCRIPTION
- **Bugfix**: Resolve bare executable names to their full paths on Windows so agent processes spawn reliably when invoking binaries on PATH.
- Add test coverage in the supervisor Windows shell suite to verify bare executable resolution behavior.