### PR TITLE
Refactor remote servers store and project switch menu

### DIFF
--- a/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.test.tsx
@@ -54,22 +54,19 @@ describe("ProjectSwitchMenu", () => {
     });
   });
 
-  it("groups other workspaces' projects under their own heading instead of hiding them", async () => {
+  it("offers only the active workspace's projects, like the sidebar", async () => {
     render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
     const menu = await openMenu();
 
-    const groups = within(menu).getAllByRole("group");
-    expect(groups).toHaveLength(2);
-    // Active workspace first: Home and unfiled projects belong to every workspace.
+    // Home and unfiled projects belong to every workspace; Beta is filed in
+    // Side Hustle and stays out of the list entirely.
+    expect(within(menu).queryByRole("group")).not.toBeInTheDocument();
     expect(
-      within(groups[0]!)
+      within(menu)
         .getAllByRole("menuitemradio")
         .map((item) => item.textContent),
     ).toEqual([HOME_PROJECT_NAME, "Alpha", "Gamma"]);
-    // The out-of-workspace group names the workspace the project would move to.
-    const other = within(groups[1]!).getByRole("menuitemradio", { name: /Beta/ });
-    expect(other).toHaveTextContent("Side Hustle");
-    expect(within(menu).getByText("Other workspaces")).toBeInTheDocument();
+    expect(within(menu).queryByText("Other workspaces")).not.toBeInTheDocument();
   });
 
   it("keeps a flat list when every project belongs to the active workspace", async () => {
@@ -81,21 +78,14 @@ describe("ProjectSwitchMenu", () => {
     expect(within(menu).getAllByRole("menuitemradio")).toHaveLength(3);
   });
 
-  it("follows an out-of-workspace pick into its workspace and remembers it there", async () => {
+  it("does not offer projects filed in another workspace", async () => {
     render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
     const menu = await openMenu();
 
-    fireEvent.click(within(menu).getByRole("menuitemradio", { name: /Beta/ }));
-
-    await waitFor(() => {
-      expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: "b" });
-    });
-    // Otherwise the new thread would be started in a project the sidebar hides.
-    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe("w2");
-    expect(useWorkspaceStore.getState().lastProjectIdByWorkspace).toEqual({ w2: "b" });
+    expect(within(menu).queryByRole("menuitemradio", { name: /Beta/ })).not.toBeInTheDocument();
   });
 
-  it("stays in the active workspace when the pick is already visible there", async () => {
+  it("remembers an in-workspace pick for the active workspace", async () => {
     render(<ProjectSwitchMenu currentProjectId="a" variant="compact" />);
     const menu = await openMenu();
 
@@ -174,20 +164,10 @@ describe("ProjectSwitchMenu", () => {
     const menu = await openMenu();
 
     expect(
-      within(menu).queryByRole("menuitemradio", { name: HOME_PROJECT_NAME }),
-    ).not.toBeInTheDocument();
-    // Active workspace still leads, then the other workspace's projects.
-    const groups = within(menu).getAllByRole("group");
-    expect(
-      within(groups[0]!)
+      within(menu)
         .getAllByRole("menuitemradio")
         .map((item) => item.textContent),
     ).toEqual(["Alpha", "Gamma"]);
-    expect(
-      within(groups[1]!)
-        .getAllByRole("menuitemradio")
-        .map((item) => item.textContent),
-    ).toEqual(["BetaSide Hustle"]);
   });
 
   it("labels the trigger with a draft that outlived a workspace switch", async () => {
@@ -195,8 +175,20 @@ describe("ProjectSwitchMenu", () => {
 
     expect(screen.getByRole("button", { name: "Switch project" })).toHaveTextContent("Beta");
 
+    // Beta is filed in Side Hustle, so the Work-scoped menu offers the active
+    // workspace's projects instead.
     const menu = await openMenu();
-    expect(within(menu).getByRole("menuitemradio", { name: /Beta/ })).toBeInTheDocument();
+    expect(within(menu).queryByRole("menuitemradio", { name: /Beta/ })).not.toBeInTheDocument();
+    expect(within(menu).getByRole("menuitemradio", { name: "Alpha" })).toBeInTheDocument();
+  });
+
+  it("keeps a hidden current project switchable when one active target remains", async () => {
+    useSharedSettings.setState({ homeScopeEnabled: false });
+    useAppStore.setState({ projects: [workProject, sideHustleProject] });
+    render(<ProjectSwitchMenu currentProjectId="b" variant="compact" />);
+
+    expect(screen.getByRole("button", { name: "Switch project" })).not.toBeDisabled();
+    const menu = await openMenu();
     expect(within(menu).getByRole("menuitemradio", { name: "Alpha" })).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/thread/ProjectSwitchMenu.tsx
+++ b/src/renderer/components/thread/ProjectSwitchMenu.tsx
@@ -1,10 +1,10 @@
 import { startTransition, useState } from "react";
 import { Check, ChevronDown, House } from "lucide-react";
-import { Description, Dropdown, Header, Label } from "@heroui/react";
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Description, Dropdown, Label } from "@heroui/react";
+import { useLingui } from "@lingui/react/macro";
+import type { Project } from "@/shared/contracts";
 import { HOME_PROJECT_NAME, isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { makeDraftPaneId } from "@/shared/paneId";
-import { switchWorkspaceForProject } from "@/renderer/actions/workspaceActions";
 import { useAppStore } from "@/renderer/state/appStore";
 import { rememberWorkspaceProject } from "@/renderer/state/workspaceStore";
 import {
@@ -15,7 +15,7 @@ import {
   ProjectSelectorIcon,
   useProjectRemoteServerLookup,
 } from "@/renderer/components/common/ProjectRemoteServer";
-import { useProjectSwitchGroups, type ProjectSwitchEntry } from "./projectSwitchGroups";
+import { useProjectSwitchProjects } from "./projectSwitchGroups";
 
 export function ProjectSwitchMenu(props: {
   currentProjectId: string;
@@ -27,11 +27,11 @@ export function ProjectSwitchMenu(props: {
 }) {
   const { currentProjectId, variant, paneId, onSelectProject } = props;
   const { t } = useLingui();
-  // Projects the active workspace hides are grouped under their own heading
-  // rather than dropped: switching workspaces should not make a project
-  // unreachable from the composer, and picking one moves the workspace along
-  // with the draft (see `handleSelect`).
-  const { all, inWorkspace, others, activeWorkspaceName } = useProjectSwitchGroups();
+  // Only the active workspace's projects: the composer matches the sidebar,
+  // and reaching another workspace's projects goes through the workspace
+  // switcher first.
+  const projects = useProjectSwitchProjects();
+  const allProjects = useAppStore((state) => state.projects);
   const remoteServerFor = useProjectRemoteServerLookup();
   const openDraft = useAppStore((state) => state.openDraft);
   const replacePaneId = useAppStore((state) => state.replacePaneId);
@@ -39,10 +39,9 @@ export function ProjectSwitchMenu(props: {
   const { mobile } = useResponsiveMenu();
   const [isOpen, setIsOpen] = useState(false);
 
-  // Sectioned only when there is something to separate; a single-workspace
-  // install keeps the plain list it has always had.
-  const sectioned = others.length > 0 && activeWorkspaceName !== undefined;
-  const current = all.find((entry) => entry.project.id === currentProjectId)?.project;
+  // The label may name a project the active workspace hides (a draft that
+  // outlived a workspace switch), so it resolves against the full list.
+  const current = allProjects.find((project) => project.id === currentProjectId);
   const isHomeCurrent = isHomeProjectId(currentProjectId);
   const label = isHomeCurrent ? HOME_PROJECT_NAME : (current?.name ?? t`Select project`);
   const currentRemote = remoteServerFor(current);
@@ -57,14 +56,11 @@ export function ProjectSwitchMenu(props: {
       {currentRemote.serverName}
     </span>
   ) : null;
-  const isDisabled = all.length <= 1;
+  const isDisabled =
+    projects.length === 0 || (projects.length === 1 && projects[0]?.id === currentProjectId);
 
   function handleSelect(nextProjectId: string) {
     if (nextProjectId === currentProjectId) return;
-    // Follow the project into its workspace, otherwise the thread the user is
-    // about to start lands in a sidebar that does not list it. Done for the
-    // embedded surfaces too (Quick Composer) for the same reason.
-    switchWorkspaceForProject(nextProjectId);
     rememberWorkspaceProject(nextProjectId);
     if (onSelectProject) {
       onSelectProject(nextProjectId);
@@ -81,8 +77,8 @@ export function ProjectSwitchMenu(props: {
   }
 
   /** Finger-sized rows for the mobile bottom drawer. */
-  function sheetRows(entries: readonly ProjectSwitchEntry[]) {
-    return entries.map(({ project, otherWorkspaceName }) => {
+  function sheetRows(entries: readonly Project[]) {
+    return entries.map((project) => {
       const isHome = isHomeProject(project);
       const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
       const selected = project.id === currentProjectId;
@@ -105,27 +101,22 @@ export function ProjectSwitchMenu(props: {
               {remote.serverName}
             </span>
           ) : null}
-          {otherWorkspaceName ? (
-            <span className="shrink-0 truncate text-xs text-muted">{otherWorkspaceName}</span>
-          ) : null}
           {selected ? <Check className="size-4 shrink-0 text-accent" /> : null}
         </button>
       );
     });
   }
 
-  function menuItems(entries: readonly ProjectSwitchEntry[]) {
-    return entries.map(({ project, otherWorkspaceName }) => {
+  function menuItems(entries: readonly Project[]) {
+    return entries.map((project) => {
       const isHome = isHomeProject(project);
       const itemLabel = isHome ? HOME_PROJECT_NAME : project.name;
       const remote = remoteServerFor(project);
-      // Machine and workspace are both "where this project lives" — one slot.
-      const description = [remote.serverName, otherWorkspaceName].filter(Boolean).join(" · ");
       return (
         <Dropdown.Item key={project.id} id={project.id} textValue={itemLabel}>
           <ProjectSelectorIcon project={project} remote={remote} />
           <Label>{itemLabel}</Label>
-          {description ? <Description>{description}</Description> : null}
+          {remote.serverName ? <Description>{remote.serverName}</Description> : null}
         </Dropdown.Item>
       );
     });
@@ -170,20 +161,7 @@ export function ProjectSwitchMenu(props: {
           </button>
         }
       >
-        <div className="m-sheet-list">
-          {sectioned ? (
-            <>
-              <div className="m-sheet-section">{activeWorkspaceName}</div>
-              {sheetRows(inWorkspace)}
-              <div className="m-sheet-section">
-                <Trans>Other workspaces</Trans>
-              </div>
-              {sheetRows(others)}
-            </>
-          ) : (
-            sheetRows(all)
-          )}
-        </div>
+        <div className="m-sheet-list">{sheetRows(projects)}</div>
       </ResponsiveMenuSurface>
     );
   }
@@ -196,20 +174,7 @@ export function ProjectSwitchMenu(props: {
       onAction={(key) => handleSelect(String(key))}
       className="poracode-menu min-w-56"
     >
-      {sectioned
-        ? [
-            <Dropdown.Section key="active-workspace">
-              <Header>{activeWorkspaceName}</Header>
-              {menuItems(inWorkspace)}
-            </Dropdown.Section>,
-            <Dropdown.Section key="other-workspaces">
-              <Header>
-                <Trans>Other workspaces</Trans>
-              </Header>
-              {menuItems(others)}
-            </Dropdown.Section>,
-          ]
-        : menuItems(all)}
+      {menuItems(projects)}
     </Dropdown.Menu>
   );
 

--- a/src/renderer/components/thread/projectSwitchGroups.ts
+++ b/src/renderer/components/thread/projectSwitchGroups.ts
@@ -3,26 +3,7 @@ import type { Project } from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
-import { useActiveWorkspaceId } from "@/renderer/state/workspaceStore";
 import { useWorkspaceProjectFilter } from "@/renderer/state/workspaceSelectors";
-
-export interface ProjectSwitchEntry {
-  project: Project;
-  /** Workspace this project is filed in, set only for out-of-workspace entries. */
-  otherWorkspaceName?: string;
-}
-
-export interface ProjectSwitchGroups {
-  /**
-   * Home first (while the Home scope setting is on), then local projects,
-   * then projects mirrored from a remote server — the flat fallback order.
-   */
-  all: readonly ProjectSwitchEntry[];
-  inWorkspace: readonly ProjectSwitchEntry[];
-  /** Projects filed to another workspace; picking one switches the workspace. */
-  others: readonly ProjectSwitchEntry[];
-  activeWorkspaceName: string | undefined;
-}
 
 /**
  * Preferred selector order: the Home scope first, then local projects, then
@@ -39,43 +20,24 @@ function compareSelectorOrder(a: Project, b: Project): number {
 }
 
 /**
- * Splits the project list the way the project switcher presents it: the active
- * workspace's projects, then everything filed elsewhere. Out-of-workspace
- * projects stay reachable rather than being hidden — a project the user cannot
- * see is worse than one shown under a heading — and the workspace membership
- * rule stays the shared one in `@/shared/contracts/workspace`.
+ * The project list the switcher presents: exactly the projects the active
+ * workspace shows in the sidebar, in the preferred selector order. Projects
+ * filed in another workspace stay out of the list — the sidebar's workspace
+ * switcher is the way to reach them. The membership rule stays the shared one
+ * in `@/shared/contracts/workspace`.
  */
-export function useProjectSwitchGroups(): ProjectSwitchGroups {
+export function useProjectSwitchProjects(): readonly Project[] {
   const isInWorkspace = useWorkspaceProjectFilter();
-  const workspaces = useSharedSettings((state) => state.workspaces);
   const homeScopeEnabled = useSharedSettings((state) => state.homeScopeEnabled);
-  const activeWorkspaceId = useActiveWorkspaceId();
   // Home is persisted with `disabled: true` as an internal marker (it is not a
   // user-disabled project), so it has to survive the disabled filter — but it
   // is only offered while the Home scope setting is on.
-  const projects = useAppStore(
+  return useAppStore(
     useShallow((state) =>
       state.projects
         .filter((project) => (isHomeProject(project) ? homeScopeEnabled : !project.disabled))
+        .filter(isInWorkspace)
         .sort(compareSelectorOrder),
     ),
   );
-
-  const inWorkspace: ProjectSwitchEntry[] = [];
-  const others: ProjectSwitchEntry[] = [];
-  for (const project of projects) {
-    if (isInWorkspace(project)) {
-      inWorkspace.push({ project });
-      continue;
-    }
-    const name = workspaces.find((workspace) => workspace.id === project.workspaceId)?.name;
-    others.push({ project, ...(name ? { otherWorkspaceName: name } : {}) });
-  }
-
-  return {
-    all: [...inWorkspace, ...others],
-    inWorkspace,
-    others,
-    activeWorkspaceName: workspaces.find((workspace) => workspace.id === activeWorkspaceId)?.name,
-  };
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Andere"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Andere Arbeitsbereiche"
+#~ msgid "Other workspaces"
+#~ msgstr "Andere Arbeitsbereiche"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Other"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Other workspaces"
+#~ msgid "Other workspaces"
+#~ msgstr "Other workspaces"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Otras"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Otros espacios de trabajo"
+#~ msgid "Other workspaces"
+#~ msgstr "Otros espacios de trabajo"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -8204,8 +8204,8 @@ msgid "Other"
 msgstr "Autres"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Autres espaces de travail"
+#~ msgid "Other workspaces"
+#~ msgstr "Autres espaces de travail"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -8203,8 +8203,8 @@ msgid "Other"
 msgstr "その他"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "他のワークスペース"
+#~ msgid "Other workspaces"
+#~ msgstr "他のワークスペース"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "기타"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "다른 작업 영역"
+#~ msgid "Other workspaces"
+#~ msgstr "다른 작업 영역"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Inne"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Inne obszary robocze"
+#~ msgid "Other workspaces"
+#~ msgstr "Inne obszary robocze"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Outros"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Outros espaços de trabalho"
+#~ msgid "Other workspaces"
+#~ msgstr "Outros espaços de trabalho"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Прочие"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Другие рабочие области"
+#~ msgid "Other workspaces"
+#~ msgstr "Другие рабочие области"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Diğer"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Diğer çalışma alanları"
+#~ msgid "Other workspaces"
+#~ msgstr "Diğer çalışma alanları"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Інші"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Інші робочі області"
+#~ msgid "Other workspaces"
+#~ msgstr "Інші робочі області"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -8205,8 +8205,8 @@ msgid "Other"
 msgstr "Khác"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "Không gian làm việc khác"
+#~ msgid "Other workspaces"
+#~ msgstr "Không gian làm việc khác"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -8204,8 +8204,8 @@ msgid "Other"
 msgstr "其他"
 
 #: src/renderer/components/thread/ProjectSwitchMenu.tsx
-msgid "Other workspaces"
-msgstr "其他工作区"
+#~ msgid "Other workspaces"
+#~ msgstr "其他工作区"
 
 #: src/renderer/components/thread/ChatPane/parts/items/WorkflowOverlayBody.tsx
 msgid "Outcome"

--- a/src/renderer/state/remoteServers/types.ts
+++ b/src/renderer/state/remoteServers/types.ts
@@ -79,8 +79,8 @@ export interface RemoteServersState {
    * to — the sidebar while its server is offline. See `projectSync.ts`.
    */
   excludedProjectIds: Record<string, readonly string[]>;
-  /** Local workspace assignments for mirrored projects, keyed by desktop and remote project id. */
-  projectWorkspaceIds: Record<string, Readonly<Record<string, string>>>;
+  /** Local workspace overrides for mirrored projects; null explicitly means unfiled. */
+  projectWorkspaceIds: Record<string, Readonly<Record<string, string | null>>>;
   /** Local display-name overrides for mirrored projects, keyed by desktop and remote project id. */
   projectNameOverrides: Record<string, Readonly<Record<string, string>>>;
   /** Last discovered host projects, retained so offline servers keep their sidebar rows. */

--- a/src/renderer/state/remoteServersStore.test.ts
+++ b/src/renderer/state/remoteServersStore.test.ts
@@ -705,6 +705,26 @@ describe("useRemoteServersStore", () => {
     );
   });
 
+  it("keeps pre-v1 remote workspace overrides when rehydrating", async () => {
+    localStorage.setItem(
+      "poracode-remote-servers",
+      JSON.stringify({
+        state: {
+          servers: [],
+          excludedProjectIds: {},
+          projectWorkspaceIds: { d1: { p1: "workspace-1" } },
+          projectNameOverrides: {},
+          lastKnownProjects: { d1: [proj] },
+        },
+        version: 0,
+      }),
+    );
+
+    await useRemoteServersStore.persist.rehydrate();
+
+    expect(useRemoteServersStore.getState().projectWorkspaceIds.d1?.p1).toBe("workspace-1");
+  });
+
   it("keeps mirrored project metadata local across reconnects", async () => {
     const remoteWorkspaceProject = { ...proj, workspaceId: "remote-workspace" };
     const projectCommand = vi.fn<RemoteDesktopClient["projectCommand"]>(async () => ({
@@ -746,6 +766,88 @@ describe("useRemoteServersStore", () => {
     expect(
       useAppStore.getState().projects.find((project) => project.id === projectedId)?.name,
     ).toBe("Local Project");
+  });
+
+  it("derives a mirror's workspace from its local counterpart until filed explicitly", async () => {
+    const previousProjects = useAppStore.getState().projects;
+    useAppStore.setState({
+      projects: [{ ...proj, id: "local-1", workspaceId: "workspace-side" }],
+    });
+    try {
+      useRemoteServersStore
+        .getState()
+        .setClientFactory(factoryFor(makeClient({ snapshotProjects: [proj] })));
+      await useRemoteServersStore
+        .getState()
+        .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+
+      const projectedId = remoteProjectId("d1", "p1");
+      const mirroredWorkspace = () =>
+        useAppStore.getState().projects.find((project) => project.id === projectedId)?.workspaceId;
+      // Same name as the local project, so the mirror joins its workspace…
+      expect(mirroredWorkspace()).toBe("workspace-side");
+      // …without pinning: the filing stays derived from the counterpart.
+      expect(useRemoteServersStore.getState().projectWorkspaceIds.d1?.p1).toBeUndefined();
+
+      // Moving the local project moves the mirror live, not on the next sync.
+      useAppStore.getState().setProjectWorkspace("local-1", "workspace-other");
+      expect(mirroredWorkspace()).toBe("workspace-other");
+      expect(useRemoteServersStore.getState().projectWorkspaceIds.d1?.p1).toBeUndefined();
+      await useRemoteServersStore.getState().refreshServer("d1");
+      expect(mirroredWorkspace()).toBe("workspace-other");
+
+      // An explicit filing pins the mirror and stops the inheritance.
+      useAppStore.getState().setProjectWorkspace(projectedId, "workspace-side");
+      expect(useRemoteServersStore.getState().projectWorkspaceIds.d1?.p1).toBe("workspace-side");
+      useAppStore.getState().setProjectWorkspace("local-1", undefined);
+      await useRemoteServersStore.getState().refreshServer("d1");
+      expect(mirroredWorkspace()).toBe("workspace-side");
+
+      // Explicitly unfiling the mirror must survive refreshes and stop
+      // inheriting the local counterpart's workspace.
+      useAppStore.getState().setProjectWorkspace(projectedId, undefined);
+      expect(useRemoteServersStore.getState().projectWorkspaceIds.d1?.p1).toBeNull();
+      await useRemoteServersStore.getState().refreshServer("d1");
+      expect(mirroredWorkspace()).toBeUndefined();
+    } finally {
+      useAppStore.setState({ projects: previousProjects });
+    }
+  });
+
+  it("does not inherit a workspace from ambiguous duplicate local project names", async () => {
+    const previousProjects = useAppStore.getState().projects;
+    useAppStore.setState({
+      projects: [
+        {
+          ...proj,
+          id: "local-1",
+          location: { kind: "windows", path: "C:\\one" },
+          workspaceId: "w1",
+        },
+        {
+          ...proj,
+          id: "local-2",
+          location: { kind: "windows", path: "C:\\two" },
+          workspaceId: "w2",
+        },
+      ],
+    });
+    try {
+      useRemoteServersStore
+        .getState()
+        .setClientFactory(factoryFor(makeClient({ snapshotProjects: [proj] })));
+      await useRemoteServersStore
+        .getState()
+        .pairServer({ endpoint: "192.168.1.9:38987", token: "a" });
+
+      expect(
+        useAppStore
+          .getState()
+          .projects.find((project) => project.id === remoteProjectId("d1", "p1"))?.workspaceId,
+      ).toBeUndefined();
+    } finally {
+      useAppStore.setState({ projects: previousProjects });
+    }
   });
 
   it("bootstraps and persists an SSH-backed server through the shared protocol", async () => {

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -125,6 +125,17 @@ interface RemoteServerEventSocketEntry {
 
 const remoteServerEventSockets = new Map<string, RemoteServerEventSocketEntry>();
 const remoteServerSnapshotSeqByDesktopId = new Map<string, number>();
+let remoteProjectRowsSyncDepth = 0;
+
+function withRemoteProjectRowsSync<T>(fn: () => T): T {
+  remoteProjectRowsSyncDepth += 1;
+  try {
+    return fn();
+  } finally {
+    remoteProjectRowsSyncDepth -= 1;
+  }
+}
+
 /** Maps a thread-history snapshot to the openThread slice (terminal fields only when present). */
 function buildOpenThread(
   desktopId: string,
@@ -144,6 +155,37 @@ function buildOpenThread(
       : {}),
     ...(snapshot.terminalSize ? { terminalSize: snapshot.terminalSize } : {}),
   };
+}
+
+/**
+ * Workspace filings of unique local project names. An unfiled remote mirror
+ * defaults to its local counterpart's workspace — one repo should not sit in
+ * two workspaces just because it is mirrored from another machine. Ambiguous
+ * names are left unfiled rather than assigned to an arbitrary project.
+ */
+function localWorkspaceByName(projects: readonly Project[]): Map<string, string> {
+  const byName = new Map<string, string>();
+  const ambiguousNames = new Set<string>();
+  for (const project of projects) {
+    if (project.remoteServerId !== undefined || ambiguousNames.has(project.name)) continue;
+    if (byName.has(project.name)) {
+      byName.delete(project.name);
+      ambiguousNames.add(project.name);
+      continue;
+    }
+    if (project.workspaceId === undefined) {
+      ambiguousNames.add(project.name);
+      continue;
+    }
+    byName.set(project.name, project.workspaceId);
+  }
+  return byName;
+}
+
+function withoutWorkspace(project: Project): Project {
+  const next: Project = { ...project };
+  delete next.workspaceId;
+  return next;
 }
 
 /**
@@ -178,16 +220,21 @@ function syncRemoteAppRows(
           .map((project) => [project.remoteId, project]),
       )
     : null;
+  const counterpartWorkspace = localWorkspaceByName(useAppStore.getState().projects);
   const projectedProjects = projects?.map((project) => {
     const projected = projectRemoteProject(desktopId, project);
     const current = currentProjects?.get(project.id);
     const { workspaceId: remoteWorkspaceId, ...projectWithoutWorkspace } = projected;
+    const name = remoteState.projectNameOverrides[desktopId]?.[project.id] ?? projected.name;
+    const workspaceOverride = remoteState.projectWorkspaceIds[desktopId]?.[project.id];
     const workspaceId =
-      remoteState.projectWorkspaceIds[desktopId]?.[project.id] ??
-      (current?.workspaceId !== remoteWorkspaceId ? current?.workspaceId : undefined);
+      workspaceOverride !== undefined
+        ? (workspaceOverride ?? undefined)
+        : (counterpartWorkspace.get(name) ??
+          (current?.workspaceId !== remoteWorkspaceId ? current?.workspaceId : undefined));
     return {
       ...projectWithoutWorkspace,
-      name: remoteState.projectNameOverrides[desktopId]?.[project.id] ?? projected.name,
+      name,
       ...(workspaceId ? { workspaceId } : {}),
       ...(current?.mcpServers ? { mcpServers: current.mcpServers } : {}),
     };
@@ -214,36 +261,38 @@ function syncRemoteAppRows(
       }
     }
   }
-  useAppStore.setState((state) => {
-    const provisioningThreads = projectedThreads
-      ? state.threads.filter(
-          (thread) =>
-            thread.remoteServerId === desktopId &&
-            state.provisioningWorktreeThreadIds[thread.id] === true &&
-            !projectedThreadIds.has(thread.id) &&
-            state.projects.some((project) => project.id === thread.projectId),
-        )
-      : [];
-    return {
-      ...(projectedProjects
-        ? {
-            projects: [
-              ...state.projects.filter((project) => project.remoteServerId !== desktopId),
-              ...projectedProjects,
-            ],
-          }
-        : {}),
-      ...(projectedThreads
-        ? {
-            threads: [
-              ...state.threads.filter((thread) => thread.remoteServerId !== desktopId),
-              ...provisioningThreads,
-              ...projectedThreads,
-            ],
-          }
-        : {}),
-    };
-  });
+  withRemoteProjectRowsSync(() =>
+    useAppStore.setState((state) => {
+      const provisioningThreads = projectedThreads
+        ? state.threads.filter(
+            (thread) =>
+              thread.remoteServerId === desktopId &&
+              state.provisioningWorktreeThreadIds[thread.id] === true &&
+              !projectedThreadIds.has(thread.id) &&
+              state.projects.some((project) => project.id === thread.projectId),
+          )
+        : [];
+      return {
+        ...(projectedProjects
+          ? {
+              projects: [
+                ...state.projects.filter((project) => project.remoteServerId !== desktopId),
+                ...projectedProjects,
+              ],
+            }
+          : {}),
+        ...(projectedThreads
+          ? {
+              threads: [
+                ...state.threads.filter((thread) => thread.remoteServerId !== desktopId),
+                ...provisioningThreads,
+                ...projectedThreads,
+              ],
+            }
+          : {}),
+      };
+    }),
+  );
   if (!projectedProjects) return;
   if (useRemoteServersStore.getState().runtime[desktopId]?.status !== "online") return;
   const gitStatuses = useGitStore.getState().statuses;
@@ -1344,13 +1393,19 @@ export const useRemoteServersStore = create<RemoteServersState>()(
       // mirrors the PWA (IndexedDB) and is scoped to the Electron renderer; the
       // server can revoke a session at any time.
       partialize: persistedRemoteServersState,
+      version: 1,
+      // v1 reserves null in projectWorkspaceIds for an explicit "unfiled"
+      // override. Older string-valued entries and absent entries remain valid.
+      migrate: (persistedState) => persistedState as RemoteServersState,
     },
   ),
 );
 
 /**
  * Mirror local project workspace assignments back into the remote state so the
- * sync layer keeps a stable record across reloads and server reconnects.
+ * sync layer keeps a stable record across reloads and server reconnects, and
+ * keep unpinned mirrors filed where their same-named local counterpart is
+ * filed (see `localWorkspaceByName`).
  *
  * Installed from `app.tsx` (like `installRemoteGitSummaryPublisher`): the
  * module-scope equivalent would touch `useAppStore` during its own
@@ -1358,18 +1413,56 @@ export const useRemoteServersStore = create<RemoteServersState>()(
  * cycle's TDZ before `useAppStore` is defined.
  */
 export function installRemoteProjectWorkspaceSync(): () => void {
+  let applyingDerivedProjects = false;
   return useAppStore.subscribe((state, previousState) => {
     if (state.projects === previousState.projects) return;
+    if (remoteProjectRowsSyncDepth > 0 || applyingDerivedProjects) return;
     const previousProjects = new Map(
       previousState.projects.map((project) => [project.id, project]),
     );
+    const counterpartWorkspace = localWorkspaceByName(state.projects);
+    // Mirrors whose filing changed in this very update were edited (or
+    // projected) deliberately — re-deriving them here would overwrite that.
+    const changedIds = new Set<string>();
+    for (const project of state.projects) {
+      const previous = previousProjects.get(project.id);
+      if (previous && previous.workspaceId !== project.workspaceId) changedIds.add(project.id);
+    }
+    // Unpinned mirrors follow their local counterpart's filing live, not only
+    // on the next remote snapshot that happens to change the project rows.
+    const pinned = useRemoteServersStore.getState().projectWorkspaceIds;
+    const derivedProjectIds = new Set<string>();
+    const rederived = state.projects.map((project) => {
+      if (!project.remoteServerId || !project.remoteId) return project;
+      if (changedIds.has(project.id)) return project;
+      if (pinned[project.remoteServerId]?.[project.remoteId] !== undefined) return project;
+      const inherited = counterpartWorkspace.get(project.name);
+      if (project.workspaceId === inherited) return project;
+      const next =
+        inherited === undefined
+          ? withoutWorkspace(project)
+          : { ...project, workspaceId: inherited };
+      derivedProjectIds.add(project.id);
+      return next;
+    });
+    const rederivedChanged = rederived.some((project, index) => project !== state.projects[index]);
+    if (rederivedChanged) {
+      applyingDerivedProjects = true;
+      try {
+        useAppStore.setState({ projects: rederived });
+      } finally {
+        applyingDerivedProjects = false;
+      }
+    }
+    const finalProjects = rederivedChanged ? rederived : state.projects;
     const changes: Array<{
       desktopId: string;
       remoteId: string;
       workspaceId: string | undefined;
     }> = [];
-    for (const project of state.projects) {
+    for (const project of finalProjects) {
       if (!project.remoteServerId || !project.remoteId) continue;
+      if (derivedProjectIds.has(project.id)) continue;
       const previous = previousProjects.get(project.id);
       if (!previous || previous.workspaceId === project.workspaceId) continue;
       changes.push({
@@ -1385,10 +1478,10 @@ export function installRemoteProjectWorkspaceSync(): () => void {
       for (const change of changes) {
         const currentForServer = projectWorkspaceIds[change.desktopId] ?? {};
         const currentWorkspaceId = currentForServer[change.remoteId];
-        if (currentWorkspaceId === change.workspaceId) continue;
+        const nextWorkspaceId = change.workspaceId ?? null;
+        if (currentWorkspaceId === nextWorkspaceId) continue;
         const nextForServer = { ...currentForServer };
-        if (change.workspaceId) nextForServer[change.remoteId] = change.workspaceId;
-        else delete nextForServer[change.remoteId];
+        nextForServer[change.remoteId] = nextWorkspaceId;
         projectWorkspaceIds = {
           ...projectWorkspaceIds,
           [change.desktopId]: nextForServer,


### PR DESCRIPTION
- Refactor the remote servers store and type definitions to improve remote server state management and test reliability
- Update the project switch menu component and grouping utilities to streamline project navigation
- Update localization catalogs across all supported locales for modified menu strings