### PR TITLE
Integrate shared settings and update thread model picker controls

### DIFF
--- a/src/main/sharedSettingsFile.test.ts
+++ b/src/main/sharedSettingsFile.test.ts
@@ -156,6 +156,7 @@ describe("sharedSettingsFile", () => {
       prMergeMethod: "squash",
       commitDefaultAction: "commit-push",
       providerConfigs: {},
+      providerModelPreferences: {},
       lastPresentationModeByAgent: {},
       lastUsedProjectDirs: {},
       editorLspEnabled: false,
@@ -290,6 +291,7 @@ describe("sharedSettingsFile", () => {
       prMergeMethod: "squash",
       commitDefaultAction: "commit-push",
       providerConfigs: {},
+      providerModelPreferences: {},
       lastPresentationModeByAgent: {},
       lastUsedProjectDirs: {},
       editorLspEnabled: false,
@@ -416,6 +418,26 @@ describe("sharedSettingsFile", () => {
     const raw = readFileSync(settingsPath, "utf8");
     expect(raw.endsWith("\n")).toBe(true);
     expect(raw).toContain("\n  "); // two-space indent
+  });
+
+  it("round-trips app-wide provider model preferences", () => {
+    const settingsPath = join(makeTempDir(), "settings.json");
+    writeSharedSettingsFile(settingsPath, {
+      ...defaultSharedSettings,
+      providerModelPreferences: {
+        codex: {
+          "gpt-5.6-luna": { effort: "max", fast: true },
+          "gpt-5.6-sol": { effort: "high", fast: false },
+        },
+      },
+    });
+
+    expect(readSharedSettingsFile(settingsPath).providerModelPreferences).toEqual({
+      codex: {
+        "gpt-5.6-luna": { effort: "max", fast: true },
+        "gpt-5.6-sol": { effort: "high", fast: false },
+      },
+    });
   });
 
   it("preserves valid settings when provider configs contain invalid entries", () => {

--- a/src/renderer/components/thread/ThreadComposerSection.tsx
+++ b/src/renderer/components/thread/ThreadComposerSection.tsx
@@ -416,8 +416,15 @@ function ThreadComposerSectionInner(props: ThreadComposerSectionProps & { thread
         )
       ],
   );
-  const controls = buildControls(thread, effectiveAgentStatus, hiddenModelIds, (config) =>
-    changeThreadConfig(thread.id, config),
+  const modelPreferences = useSharedSettings((s) => s.providerModelPreferences[thread.agentKind]);
+  const setProviderModelPreference = useSharedSettings((s) => s.setProviderModelPreference);
+  const controls = buildControls(
+    thread,
+    effectiveAgentStatus,
+    hiddenModelIds,
+    (config) => changeThreadConfig(thread.id, config),
+    modelPreferences,
+    (model, preference) => setProviderModelPreference(thread.agentKind, model, preference),
   );
   const controlsWithOpenSignal = controls.map((control): ComposerControl => {
     if (controlOpenRequest?.target === "model" && control.kind === "provider-model") {

--- a/src/renderer/components/thread/ThreadDraftView.test.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.test.tsx
@@ -136,6 +136,23 @@ const codexStatus: AgentStatus = {
   },
 };
 
+const rememberedCodexStatus: AgentStatus = {
+  ...codexStatus,
+  capabilities: {
+    ...codexStatus.capabilities,
+    models: [
+      { id: "gpt-5.6-luna", label: "Luna" },
+      { id: "gpt-5.6-sol", label: "Sol" },
+    ],
+    efforts: ["low", "medium", "high", "max"],
+    modelEfforts: {
+      "gpt-5.6-luna": ["low", "medium", "high", "max"],
+      "gpt-5.6-sol": ["low", "medium", "high"],
+    },
+    fastModels: ["gpt-5.6-luna", "gpt-5.6-sol"],
+  },
+};
+
 const dualModeCodexStatus: AgentStatus = {
   ...codexStatus,
   capabilities: {
@@ -480,6 +497,7 @@ describe("ThreadDraftView", () => {
     });
     useSharedSettings.setState({
       providerConfigs: {},
+      providerModelPreferences: {},
       hiddenModels: {},
       disabledAgents: [],
       lastPresentationModeByAgent: {},
@@ -1269,6 +1287,9 @@ describe("ThreadDraftView", () => {
 
   it("submits an explicit Fast-off selection in the launch config", async () => {
     const onStart = vi.fn<(input: unknown) => void>();
+    useSharedSettings.setState({
+      providerModelPreferences: { cursor: { "composer-2": { fast: false } } },
+    });
 
     render(
       <ThreadDraftView
@@ -1750,6 +1771,7 @@ describe("ThreadDraftView", () => {
             sandboxMode: "danger-full-access",
           },
         },
+        providerModelPreferences: {},
         sharedSettingsHydrated: true,
       });
     });
@@ -1763,6 +1785,81 @@ describe("ThreadDraftView", () => {
       expect(providerModel?.currentModel).toBe("gpt-5.4");
       expect(effortContext?.effortValue).toBe("medium");
     });
+  });
+
+  it("recalls app-wide effort and Fast choices when switching between Codex models", async () => {
+    useSharedSettings.setState({
+      providerConfigs: {
+        codex: {
+          model: "gpt-5.6-luna",
+          effort: "max",
+          fast: true,
+          mode: "agent",
+          approvalPolicy: "on-request",
+          sandboxMode: "workspace-write",
+        },
+      },
+      providerModelPreferences: {
+        codex: {
+          "gpt-5.6-luna": { effort: "max", fast: true },
+          "gpt-5.6-sol": { effort: "high", fast: false },
+        },
+      },
+    });
+
+    render(
+      <ThreadDraftView
+        project={project}
+        agentStatuses={[rememberedCodexStatus]}
+        lastDraftConfig={{
+          agentKind: "codex",
+          model: "gpt-5.6-luna",
+          effort: "low",
+          fast: false,
+        }}
+        onStart={vi.fn<(input: unknown) => void>()}
+      />,
+    );
+
+    type ModelControl = {
+      kind?: string;
+      currentModel?: string;
+      effortValue?: string;
+      label?: string;
+      isSelected?: boolean;
+      onChange?: (next: { agentKind: string; model: string }) => void;
+    };
+    const currentControls = () => {
+      const call = composerSpy.mock.lastCall;
+      if (!call) throw new Error("Composer has not rendered");
+      return (call[0] as { controls: ModelControl[] }).controls;
+    };
+    const expectSelection = async (model: string, effort: string, fast: boolean) => {
+      await waitFor(() => {
+        const controls = currentControls();
+        expect(controls.find((control) => control.kind === "provider-model")?.currentModel).toBe(
+          model,
+        );
+        expect(controls.find((control) => control.kind === "effort-context")?.effortValue).toBe(
+          effort,
+        );
+        expect(controls.find((control) => control.label === "Fast")?.isSelected).toBe(fast);
+      });
+    };
+
+    await expectSelection("gpt-5.6-luna", "max", true);
+    act(() => {
+      currentControls()
+        .find((control) => control.kind === "provider-model")
+        ?.onChange?.({ agentKind: "codex", model: "gpt-5.6-sol" });
+    });
+    await expectSelection("gpt-5.6-sol", "high", false);
+    act(() => {
+      currentControls()
+        .find((control) => control.kind === "provider-model")
+        ?.onChange?.({ agentKind: "codex", model: "gpt-5.6-luna" });
+    });
+    await expectSelection("gpt-5.6-luna", "max", true);
   });
 
   it("keeps simultaneously open draft configs independent while saving defaults for later drafts", async () => {

--- a/src/renderer/components/thread/ThreadDraftView.tsx
+++ b/src/renderer/components/thread/ThreadDraftView.tsx
@@ -26,6 +26,7 @@ import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { capabilitiesForPresentation, filterHiddenModels } from "@/shared/agentSelection";
+import type { ProviderModelPreference } from "@/shared/settings";
 import {
   appendProviderComposerControls,
   buildModelPickerControls,
@@ -42,6 +43,7 @@ import {
   resolveModelValue,
   resolvePreferredAgentKind,
   resolveProviderDraftConfig,
+  resolveProviderModelPreference,
   resolveSavedProviderDraftConfig,
   supportsUsableFastMode,
   resolveThinkingValue,
@@ -323,8 +325,12 @@ export function ThreadDraftView(props: {
   // --- Per-provider config memory (app-wide via shared settings) ---
   const updateProjectDraftConfig = useAppStore((s) => s.updateProjectDraftConfig);
   const setProviderConfig = useSharedSettings((s) => s.setProviderConfig);
+  const setProviderModelPreference = useSharedSettings((s) => s.setProviderModelPreference);
   const effectiveAgentKindRef = useRef(effectiveAgentKind);
   const providerConfigsRef = useRef<Record<string, ProviderDraftConfig>>({});
+  const providerModelPreferencesRef = useRef<
+    Record<string, Record<string, ProviderModelPreference>>
+  >({});
   const initialLastDraftConfigRef = useRef(lastDraftConfig);
   const hasLocalConfigEditRef = useRef(false);
   const hasLocalContextEditRef = useRef(false);
@@ -333,17 +339,41 @@ export function ThreadDraftView(props: {
   // in place to keep effort/model selections in sync mid-render. Assigning the
   // store reference directly would mutate Zustand state and skip subscribers.
   providerConfigsRef.current = { ...useSharedSettings.getState().providerConfigs };
+  providerModelPreferencesRef.current = {
+    ...useSharedSettings.getState().providerModelPreferences,
+  };
+
+  function persistProviderModelPreference(providerKind: string, config: ProviderDraftConfig) {
+    const preference: ProviderModelPreference = {
+      ...(config.effort ? { effort: config.effort } : {}),
+      ...(config.fast !== undefined ? { fast: config.fast } : {}),
+    };
+    providerModelPreferencesRef.current = {
+      ...providerModelPreferencesRef.current,
+      [providerKind]: {
+        ...providerModelPreferencesRef.current[providerKind],
+        [config.model]: preference,
+      },
+    };
+    setProviderModelPreference(providerKind, config.model, preference);
+  }
 
   function persistProviderConfig(providerKind: string, config: ProviderDraftConfig) {
     providerConfigsRef.current[providerKind] = config;
     if (!isHomeScope) {
       setProviderConfig(providerKind, config);
     }
+    persistProviderModelPreference(providerKind, config);
   }
 
   function persistProjectDraftConfig(draftConfig: ProjectDraftConfig) {
     updateProjectDraftConfig(project.id, draftConfig);
   }
+
+  const persistProviderConfigRef = useRef(persistProviderConfig);
+  const persistProjectDraftConfigRef = useRef(persistProjectDraftConfig);
+  persistProviderConfigRef.current = persistProviderConfig;
+  persistProjectDraftConfigRef.current = persistProjectDraftConfig;
 
   function handleSwitchBranch(branch: string, createNew: boolean) {
     readBridge()
@@ -392,6 +422,7 @@ export function ThreadDraftView(props: {
       effectiveAgentKind,
       lastDraftConfig,
       isHomeScope ? {} : providerConfigsRef.current,
+      providerModelPreferencesRef.current,
     );
     const resolved = resolveProviderDraftConfig(selectedAgentForConfig, saved);
     const nextModel = resolved.model;
@@ -416,10 +447,7 @@ export function ThreadDraftView(props: {
     lastAppliedAgentKindRef.current = effectiveAgentKind;
 
     // Persist per-provider config app-wide, last-used provider per project.
-    providerConfigsRef.current[effectiveAgentKind] = resolved;
-    if (!isHomeScope) {
-      setProviderConfig(effectiveAgentKind, resolved);
-    }
+    persistProviderConfigRef.current(effectiveAgentKind, resolved);
     updateProjectDraftConfig(project.id, {
       agentKind: effectiveAgentKind,
       model: nextModel,
@@ -479,10 +507,7 @@ export function ThreadDraftView(props: {
         fast: nextFast,
         thinking: nextThinking,
       };
-      providerConfigsRef.current[effectiveAgentKind] = corrected;
-      if (!isHomeScope) {
-        setProviderConfig(effectiveAgentKind, corrected);
-      }
+      persistProviderConfigRef.current(effectiveAgentKind, corrected);
       updateProjectDraftConfig(project.id, {
         agentKind: effectiveAgentKind,
         model: nextModel,
@@ -517,6 +542,73 @@ export function ThreadDraftView(props: {
   ]);
 
   useEffect(() => {
+    if (!sharedSettingsHydrated || !selectedAgentForConfig || !effectiveAgentKind || !model) {
+      return;
+    }
+    if (hasLocalConfigEditRef.current) return;
+
+    const settings = useSharedSettings.getState();
+    providerConfigsRef.current = { ...settings.providerConfigs };
+    providerModelPreferencesRef.current = { ...settings.providerModelPreferences };
+    const preference = resolveProviderModelPreference(
+      effectiveAgentKind,
+      model,
+      settings.providerConfigs,
+      settings.providerModelPreferences,
+    );
+    if (!preference) return;
+
+    const resolved = resolveProviderDraftConfig(selectedAgentForConfig, {
+      model,
+      ...(preference.effort !== undefined ? { effort: preference.effort } : {}),
+      ...(contextSize ? { contextSize } : {}),
+      ...(preference.fast !== undefined ? { fast: preference.fast } : {}),
+      thinking,
+      mode,
+      approvalPolicy,
+      approvalsReviewer,
+      sandboxMode,
+    });
+    const nextEffort = resolved.effort ?? "";
+    const nextFast = resolved.fast ?? false;
+    if (nextEffort === effort && nextFast === fast) return;
+
+    setEffort(nextEffort);
+    setFast(nextFast);
+    const corrected: ProviderDraftConfig = {
+      model,
+      effort: nextEffort,
+      ...(contextSize ? { contextSize } : {}),
+      ...(resolved.fast !== undefined ? { fast: resolved.fast } : {}),
+      ...(resolved.thinking !== undefined ? { thinking: resolved.thinking } : {}),
+      mode,
+      approvalPolicy,
+      approvalsReviewer,
+      sandboxMode,
+    };
+    persistProviderConfigRef.current(effectiveAgentKind, corrected);
+    persistProjectDraftConfigRef.current({
+      agentKind: effectiveAgentKind,
+      ...corrected,
+      worktreeMode: effectiveWorktreeMode,
+    });
+  }, [
+    sharedSettingsHydrated,
+    selectedAgentForConfig,
+    effectiveAgentKind,
+    model,
+    effort,
+    contextSize,
+    fast,
+    thinking,
+    mode,
+    approvalPolicy,
+    approvalsReviewer,
+    sandboxMode,
+    effectiveWorktreeMode,
+  ]);
+
+  useEffect(() => {
     if (isHomeScope || !sharedSettingsHydrated) {
       return;
     }
@@ -537,11 +629,13 @@ export function ThreadDraftView(props: {
     }
 
     const providerConfigs = useSharedSettings.getState().providerConfigs;
+    const providerModelPreferences = useSharedSettings.getState().providerModelPreferences;
     const providerConfig = providerConfigs[effectiveAgentKind];
     if (!providerConfig) {
       return;
     }
     providerConfigsRef.current = { ...providerConfigs };
+    providerModelPreferencesRef.current = { ...providerModelPreferences };
 
     if (hasLocalConfigEditRef.current) {
       const nextContext = resolveContextSizeValue(
@@ -571,9 +665,12 @@ export function ThreadDraftView(props: {
       return;
     }
 
-    const saved = hasInitialProjectDraft
-      ? resolveSavedProviderDraftConfig(effectiveAgentKind, initialLastDraftConfig, providerConfigs)
-      : providerConfig;
+    const saved = resolveSavedProviderDraftConfig(
+      effectiveAgentKind,
+      hasInitialProjectDraft ? initialLastDraftConfig : undefined,
+      providerConfigs,
+      providerModelPreferences,
+    );
     const resolved = resolveProviderDraftConfig(selectedAgentForConfig, saved);
     const nextModel = resolved.model;
     const nextEffort = resolved.effort ?? "";
@@ -622,8 +719,7 @@ export function ThreadDraftView(props: {
         providerConfig.approvalsReviewer !== nextReviewer ||
         providerConfig.sandboxMode !== nextSandbox)
     ) {
-      providerConfigsRef.current[effectiveAgentKind] = resolved;
-      setProviderConfig(effectiveAgentKind, resolved);
+      persistProviderConfigRef.current(effectiveAgentKind, resolved);
     }
 
     updateProjectDraftConfig(project.id, {
@@ -803,9 +899,20 @@ export function ThreadDraftView(props: {
         persistProviderConfig(effectiveAgentKind, snapshot);
       }
       const targetSaved = isHomeScope ? undefined : providerConfigsRef.current[nextKind];
+      const targetPreference = resolveProviderModelPreference(
+        nextKind as AgentStatus["kind"],
+        nextModel,
+        providerConfigsRef.current,
+        providerModelPreferencesRef.current,
+      );
+      const targetBase = { ...targetSaved };
+      delete targetBase.effort;
+      delete targetBase.fast;
       const resolved = resolveProviderDraftConfig(targetAgentForConfig, {
-        ...(targetSaved ?? {}),
+        ...targetBase,
         model: nextModel,
+        ...(targetPreference?.effort !== undefined ? { effort: targetPreference.effort } : {}),
+        ...(targetPreference?.fast !== undefined ? { fast: targetPreference.fast } : {}),
       });
       persistProviderConfig(nextKind, resolved);
       setModel(resolved.model);
@@ -833,10 +940,17 @@ export function ThreadDraftView(props: {
         worktreeMode: effectiveWorktreeMode,
       });
     } else {
+      const modelPreference = resolveProviderModelPreference(
+        effectiveAgentKind as AgentStatus["kind"],
+        nextModel,
+        providerConfigsRef.current,
+        providerModelPreferencesRef.current,
+      );
       latestConfigPatchRef.current(
         patchConfigForModelChange(selectedAgentForConfig.capabilities, nextModel, {
-          ...(effort ? { effort } : {}),
+          ...(modelPreference?.effort !== undefined ? { effort: modelPreference.effort } : {}),
           ...(contextSize ? { contextSize } : {}),
+          ...(modelPreference?.fast !== undefined ? { fast: modelPreference.fast } : {}),
         }),
       );
     }

--- a/src/renderer/components/thread/buildModelPickerControls.test.ts
+++ b/src/renderer/components/thread/buildModelPickerControls.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
-import { describe, expect, it } from "vitest";
-import type { AgentCapability, AgentStatus } from "@/shared/contracts";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentCapability, AgentStatus, Thread } from "@/shared/contracts";
 import {
+  buildControls,
   buildModelPickerControls,
   buildProviderModelMenuProviders,
   expandAgentToVisibilityProviders,
@@ -51,6 +52,7 @@ describe("patchConfigForModelChange", () => {
       }),
     ).toEqual({
       model: "b",
+      effort: "high",
       contextSize: "128k",
       fast: false,
       thinking: true,
@@ -104,6 +106,66 @@ describe("patchConfigForModelChange", () => {
       model: "a",
       fast: false,
     });
+  });
+});
+
+describe("buildControls model preferences", () => {
+  it("restores and records per-model effort and Fast choices for active threads", () => {
+    const activeCapabilities = {
+      ...capabilities,
+      modelEfforts: { a: ["low", "high"], b: ["low", "high"] },
+      fastModels: ["a", "b"],
+    } as AgentCapability;
+    const agent = {
+      kind: "codex",
+      label: "Codex",
+      installed: true,
+      authState: "authenticated",
+      capabilities: activeCapabilities,
+    } as AgentStatus;
+    const thread = {
+      id: "thread-1",
+      projectId: "project-1",
+      title: "Thread",
+      agentKind: "codex",
+      config: { model: "a", effort: "low", fast: false },
+      status: "idle",
+      attention: "none",
+      canResumeWithConfig: true,
+      archived: false,
+      done: false,
+      starred: false,
+      presentationMode: "gui",
+      createdAt: "2026-08-20T00:00:00.000Z",
+      updatedAt: "2026-08-20T00:00:00.000Z",
+    } as Thread;
+    const onConfigChange = vi.fn<(config: Thread["config"]) => void>();
+    const onPreferenceChange =
+      vi.fn<
+        (
+          model: string,
+          preference: { effort?: string | undefined; fast?: boolean | undefined },
+        ) => void
+      >();
+    const controls = buildControls(
+      thread,
+      agent,
+      undefined,
+      onConfigChange,
+      {
+        b: { effort: "high", fast: true },
+      },
+      onPreferenceChange,
+    );
+
+    controls
+      .find((control) => control.kind === "provider-model")
+      ?.onChange({ agentKind: "codex", model: "b" });
+
+    expect(onConfigChange).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "b", effort: "high", fast: true }),
+    );
+    expect(onPreferenceChange).toHaveBeenCalledWith("b", { effort: "high", fast: true });
   });
 });
 

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/shared/agentSelection";
 import type { ComposerControl } from "./ThreadComposer";
 import { formatEffortLabel, supportsUsableFastMode } from "./threadDraftViewHelpers";
+import type { ProviderModelPreference } from "@/shared/settings";
 
 export type ModelPickerConfigPatch = {
   model?: string;
@@ -176,13 +177,9 @@ export function patchConfigForModelChange(
   const nextContextDefault = nextContextIds?.[0] ?? capabilities.defaultContextSize;
   return {
     model,
-    // Reset to the new model's declared default, not the first tier in its
-    // list. A model with no tiers at all clears the effort rather than
-    // inheriting the previous model's — an effort it does not support would
-    // otherwise be sent to the agent, which is free to apply its own default.
-    ...(effortValid ? {} : { effort: nextReasoning.default ?? "" }),
+    effort: effortValid && current.effort ? current.effort : (nextReasoning.default ?? ""),
     ...(nextContextDefault ? { contextSize: nextContextDefault } : {}),
-    ...(supportsUsableFastMode(capabilities, model) ? {} : { fast: false }),
+    fast: supportsUsableFastMode(capabilities, model) ? (current.fast ?? true) : false,
     thinking: capabilities.thinkingModels?.includes(model) ?? false,
   };
 }
@@ -363,6 +360,8 @@ export function buildControls(
   agentStatus: AgentStatus | undefined,
   hiddenModelIds: readonly string[] | undefined,
   onConfigChange: (config: ThreadConfig) => void,
+  modelPreferences?: Record<string, ProviderModelPreference>,
+  onModelPreferenceChange?: (model: string, preference: ProviderModelPreference) => void,
 ): ComposerControl[] {
   const presentationMode =
     thread.presentationMode ?? agentStatus?.capabilities.presentationMode ?? "terminal";
@@ -380,8 +379,14 @@ export function buildControls(
     filteredCaps,
   );
   const isDisabled = !thread.canResumeWithConfig && thread.status !== "launching";
-  const onPatch = (patch: Partial<ThreadConfig>) =>
-    onConfigChange({ ...thread.config, ...effectiveConfig, ...patch });
+  const onPatch = (patch: Partial<ThreadConfig>) => {
+    const config = { ...thread.config, ...effectiveConfig, ...patch };
+    onConfigChange(config);
+    onModelPreferenceChange?.(config.model, {
+      ...(config.effort ? { effort: config.effort } : {}),
+      ...(config.fast !== undefined ? { fast: config.fast } : {}),
+    });
+  };
   const provider: ProviderModelMenuProvider = {
     kind: thread.agentKind,
     label: agentStatus.label,
@@ -403,11 +408,12 @@ export function buildControls(
       presentationMode,
       isDisabled,
       onProviderModelChange: ({ model }) => {
+        const preference = modelPreferences?.[model];
         onPatch(
           patchConfigForModelChange(filteredCaps, model, {
-            ...(effectiveConfig.effort ? { effort: effectiveConfig.effort } : {}),
+            ...(preference?.effort !== undefined ? { effort: preference.effort } : {}),
             ...(effectiveConfig.contextSize ? { contextSize: effectiveConfig.contextSize } : {}),
-            ...(effectiveConfig.fast ? { fast: effectiveConfig.fast } : {}),
+            ...(preference?.fast !== undefined ? { fast: preference.fast } : {}),
             ...(effectiveConfig.thinking ? { thinking: effectiveConfig.thinking } : {}),
           }),
         );

--- a/src/renderer/components/thread/threadDraftViewHelpers.test.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.test.ts
@@ -102,7 +102,7 @@ describe("resolveThinkingValue", () => {
 });
 
 describe("resolveSavedProviderDraftConfig", () => {
-  it("fills an omitted context window from the app-wide provider preset", () => {
+  it("fills an omitted context window and model controls from app-wide preferences", () => {
     const resolved = resolveSavedProviderDraftConfig(
       "codex",
       { agentKind: "codex", model: "gpt-5.6-sol", effort: "high" },
@@ -118,10 +118,31 @@ describe("resolveSavedProviderDraftConfig", () => {
 
     expect(resolved).toMatchObject({
       model: "gpt-5.6-sol",
-      effort: "high",
+      effort: "medium",
       contextSize: "400k",
+      fast: false,
     });
-    expect(resolved?.fast).toBeUndefined();
+  });
+
+  it("uses global model preferences instead of a different project's effort and Fast", () => {
+    expect(
+      resolveSavedProviderDraftConfig(
+        "codex",
+        {
+          agentKind: "codex",
+          model: "gpt-5.6-luna",
+          effort: "low",
+          fast: false,
+        },
+        { codex: { model: "gpt-5.6-sol", effort: "high", fast: false } },
+        {
+          codex: {
+            "gpt-5.6-luna": { effort: "max", fast: true },
+            "gpt-5.6-sol": { effort: "high", fast: false },
+          },
+        },
+      ),
+    ).toMatchObject({ model: "gpt-5.6-luna", effort: "max", fast: true });
   });
 
   it("keeps an explicit last-draft context size over the provider preset", () => {

--- a/src/renderer/components/thread/threadDraftViewHelpers.ts
+++ b/src/renderer/components/thread/threadDraftViewHelpers.ts
@@ -14,6 +14,24 @@ import {
   resolveReasoningSelection,
 } from "@/shared/agentSelection";
 import { i18n } from "@/renderer/i18n/i18n";
+import type { ProviderModelPreference } from "@/shared/settings";
+
+export function resolveProviderModelPreference(
+  agentKind: AgentStatus["kind"],
+  model: string,
+  providerConfigs: Record<string, ProviderDraftConfig>,
+  providerModelPreferences: Record<string, Record<string, ProviderModelPreference>>,
+): ProviderModelPreference | undefined {
+  const saved = providerModelPreferences[agentKind]?.[model];
+  if (saved) return saved;
+
+  const legacy = providerConfigs[agentKind];
+  if (legacy?.model !== model) return undefined;
+  return {
+    ...(legacy.effort ? { effort: legacy.effort } : {}),
+    ...(legacy.fast !== undefined ? { fast: legacy.fast } : {}),
+  };
+}
 
 export function resolvePreferredAgentKind(
   installedAgents: AgentStatus[],
@@ -33,17 +51,44 @@ export function resolveSavedProviderDraftConfig(
   agentKind: AgentStatus["kind"],
   lastDraftConfig: ProjectDraftConfig | undefined,
   providerConfigs: Record<string, ProviderDraftConfig>,
+  providerModelPreferences: Record<string, Record<string, ProviderModelPreference>> = {},
 ): Partial<ProviderDraftConfig> | undefined {
   const providerConfig = providerConfigs[agentKind];
   if (lastDraftConfig?.agentKind === agentKind && lastDraftConfig.model.trim()) {
+    const projectConfig = { ...lastDraftConfig };
+    delete projectConfig.effort;
+    delete projectConfig.fast;
+    const modelPreference = resolveProviderModelPreference(
+      agentKind,
+      lastDraftConfig.model,
+      providerConfigs,
+      providerModelPreferences,
+    );
     // Older project drafts predate context-window persistence. Preserve their
     // other choices while filling only that missing field from the provider preset.
-    return !lastDraftConfig.contextSize && providerConfig?.contextSize
-      ? { ...lastDraftConfig, contextSize: providerConfig.contextSize }
-      : lastDraftConfig;
+    // Effort and Fast are app-wide model preferences rather than project state.
+    return {
+      ...projectConfig,
+      ...(!lastDraftConfig.contextSize && providerConfig?.contextSize
+        ? { contextSize: providerConfig.contextSize }
+        : {}),
+      ...(modelPreference?.effort !== undefined ? { effort: modelPreference.effort } : {}),
+      ...(modelPreference?.fast !== undefined ? { fast: modelPreference.fast } : {}),
+    };
   }
 
-  return providerConfig;
+  if (!providerConfig) return undefined;
+  const modelPreference = resolveProviderModelPreference(
+    agentKind,
+    providerConfig.model,
+    providerConfigs,
+    providerModelPreferences,
+  );
+  return {
+    ...providerConfig,
+    ...(modelPreference?.effort !== undefined ? { effort: modelPreference.effort } : {}),
+    ...(modelPreference?.fast !== undefined ? { fast: modelPreference.fast } : {}),
+  };
 }
 
 export function resolveModelValue(agent: AgentStatus, preferred?: string): string {

--- a/src/renderer/state/sharedSettingsStore.test.ts
+++ b/src/renderer/state/sharedSettingsStore.test.ts
@@ -24,6 +24,7 @@ describe("sharedSettingsStore", () => {
         useWebGpu: true,
       },
       providerConfigs: {},
+      providerModelPreferences: {},
       agentInstances: {},
       hiddenModels: {},
       agentSettings: {},
@@ -161,6 +162,35 @@ describe("sharedSettingsStore", () => {
       contextSize: "200k",
       fast: true,
       thinking: true,
+    });
+  });
+
+  it("keeps effort and Fast preferences independent for subprovider model ids", () => {
+    const state = useSharedSettings.getState();
+    state.setProviderModelPreference("opencode", "openai/gpt-5.6-sol", {
+      effort: "high",
+      fast: false,
+    });
+    state.setProviderModelPreference("opencode", "openai/gpt-5.6-luna", {
+      effort: "max",
+      fast: true,
+    });
+    state.setProviderModelPreference("opencode", "github-copilot/gpt-5.6-luna", {
+      effort: "medium",
+      fast: false,
+    });
+    state.setProviderModelPreference("codex", "openai/gpt-5.6-luna", {
+      effort: "low",
+      fast: false,
+    });
+
+    expect(useSharedSettings.getState().providerModelPreferences.opencode).toEqual({
+      "openai/gpt-5.6-sol": { effort: "high", fast: false },
+      "openai/gpt-5.6-luna": { effort: "max", fast: true },
+      "github-copilot/gpt-5.6-luna": { effort: "medium", fast: false },
+    });
+    expect(useSharedSettings.getState().providerModelPreferences.codex).toEqual({
+      "openai/gpt-5.6-luna": { effort: "low", fast: false },
     });
   });
 

--- a/src/renderer/state/sharedSettingsStore.ts
+++ b/src/renderer/state/sharedSettingsStore.ts
@@ -7,6 +7,7 @@ import {
   WINDOWS_SHELL_ARGUMENTS_MAX,
   type CliPickerTarget,
   type PreventSleep,
+  type ProviderModelPreference,
   type SidebarShortcutId,
   type SharedSettings,
   type SharedSettingsInput,
@@ -148,6 +149,11 @@ interface SharedSettingsState extends SharedSettings {
     value: SharedSettings["usage"][K],
   ) => void;
   setProviderConfig: (agentKind: string, config: ProviderDraftConfig) => void;
+  setProviderModelPreference: (
+    agentKind: string,
+    modelId: string,
+    preference: ProviderModelPreference,
+  ) => void;
   setLastPresentationMode: (agentKind: string, mode: ThreadPresentationMode) => void;
   setLastUsedProjectDir: (runtimeKey: string, dir: string) => void;
   setNotificationsEnabled: (value: boolean) => void;
@@ -730,6 +736,24 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({ providerConfigs: { ...current, [agentKind]: config } });
     persistSettings(selectSharedSettings(get()));
   },
+  setProviderModelPreference: (agentKind, modelId, preference) => {
+    if (!modelId.trim()) return;
+    const current = get().providerModelPreferences;
+    const currentPreference = current[agentKind]?.[modelId];
+    if (
+      currentPreference?.effort === preference.effort &&
+      currentPreference?.fast === preference.fast
+    ) {
+      return;
+    }
+    set({
+      providerModelPreferences: {
+        ...current,
+        [agentKind]: { ...current[agentKind], [modelId]: preference },
+      },
+    });
+    persistSettings(selectSharedSettings(get()));
+  },
   setLastPresentationMode: (agentKind, mode) => {
     const current = get().lastPresentationModeByAgent;
     if (current[agentKind] === mode) return;
@@ -809,6 +833,9 @@ export const useSharedSettings = create<SharedSettingsState>()((set, get) => ({
     set({
       agentInstances,
       providerConfigs: removeProfileKey(get().providerConfigs) as SharedSettings["providerConfigs"],
+      providerModelPreferences: removeProfileKey(
+        get().providerModelPreferences,
+      ) as SharedSettings["providerModelPreferences"],
       hiddenModels: removeProfileKey(get().hiddenModels) as SharedSettings["hiddenModels"],
       agentSettings: removeProfileKey(get().agentSettings) as SharedSettings["agentSettings"],
       lastPresentationModeByAgent: removeProfileKey(
@@ -1016,6 +1043,7 @@ function selectSharedSettings(state: SharedSettingsState): SharedSettingsInput {
     prMergeMethod: state.prMergeMethod,
     commitDefaultAction: state.commitDefaultAction,
     providerConfigs: state.providerConfigs,
+    providerModelPreferences: state.providerModelPreferences,
     lastPresentationModeByAgent: state.lastPresentationModeByAgent,
     lastUsedProjectDirs: state.lastUsedProjectDirs,
     editorLspEnabled: state.editorLspEnabled,

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -25,6 +25,32 @@ describe("shared settings defaults", () => {
     expect(normalizeSharedSettings({}).preventSleep).toBe("while-remote-access");
   });
 
+  it("preserves global provider and model effort/Fast preferences", () => {
+    expect(
+      normalizeSharedSettings({
+        providerModelPreferences: {
+          codex: {
+            "gpt-5.6-luna": { effort: "max", fast: true },
+            "gpt-5.6-sol": { effort: "high", fast: false },
+          },
+        },
+      }).providerModelPreferences,
+    ).toEqual({
+      codex: {
+        "gpt-5.6-luna": { effort: "max", fast: true },
+        "gpt-5.6-sol": { effort: "high", fast: false },
+      },
+    });
+  });
+
+  it("adds an empty model preference map to the previous shared-settings shape", () => {
+    expect(
+      normalizeSharedSettings({
+        providerConfigs: { codex: { model: "gpt-5.6-sol", effort: "high", fast: false } },
+      }).providerModelPreferences,
+    ).toEqual({});
+  });
+
   it("adds automatic Windows shell settings to a previous settings shape", () => {
     const normalized = normalizeSharedSettings({ terminalPosition: "right" });
     expect(normalized).toMatchObject({
@@ -132,6 +158,10 @@ describe("shared settings defaults", () => {
         qwen: { model: "qwen3.8-max-preview", mode: "agent", approvalPolicy: "auto" },
         "claude:qwen": { model: "qwen3.8-max-preview" },
       },
+      providerModelPreferences: {
+        qwen: { "qwen3.8-max-preview": { effort: "xhigh", fast: false } },
+        "claude:qwen": { "qwen3.8-max-preview": { effort: "high", fast: true } },
+      },
       commitGenProvider: "qwen",
       commitGenModel: "qwen3.8-max-preview",
       favoriteModels: [
@@ -172,6 +202,10 @@ describe("shared settings defaults", () => {
 
     expect(migrated.providerConfigs.qwen?.model).toBe("qwen3.8-max");
     expect(migrated.providerConfigs["claude:qwen"]?.model).toBe("qwen3.8-max-preview");
+    expect(migrated.providerModelPreferences).toMatchObject({
+      qwen: { "qwen3.8-max": { effort: "xhigh", fast: false } },
+      "claude:qwen": { "qwen3.8-max-preview": { effort: "high", fast: true } },
+    });
     expect(migrated.commitGenModel).toBe("qwen3.8-max");
     expect(migrated.favoriteModels).toEqual([
       { agentKind: "qwen", modelId: "qwen3.8-max", presentationMode: "gui" },

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -53,6 +53,12 @@ export const agentSelectionUsageEntrySchema = z.object({
 });
 export type AgentSelectionUsageEntry = z.infer<typeof agentSelectionUsageEntrySchema>;
 
+export const providerModelPreferenceSchema = z.object({
+  effort: z.string().optional(),
+  fast: z.boolean().optional(),
+});
+export type ProviderModelPreference = z.infer<typeof providerModelPreferenceSchema>;
+
 export const MAX_CROSSAGENT_ROUTING_OVERRIDES = 100;
 export const MAX_CROSSAGENT_SELECTION_VALUE_LENGTH = 256;
 
@@ -446,6 +452,11 @@ export const sharedSettingsSchema = z.object({
   commitDefaultAction: commitDefaultActionSchema,
   /** Per-provider last-used draft config (model, effort, mode, etc.). App-wide. */
   providerConfigs: z.record(z.string(), providerDraftConfigSchema),
+  /** Per-provider and model effort/Fast choices. App-wide. */
+  providerModelPreferences: z.record(
+    z.string(),
+    z.record(z.string(), providerModelPreferenceSchema),
+  ),
   /**
    * Per-provider last-picked thread presentation mode (terminal vs gui chat).
    * Read by ThreadDraftView so a provider that supports both modes remembers
@@ -688,6 +699,7 @@ export const defaultSharedSettings: SharedSettings = {
   prMergeMethod: "squash",
   commitDefaultAction: "commit-push",
   providerConfigs: {},
+  providerModelPreferences: {},
   lastPresentationModeByAgent: {},
   lastUsedProjectDirs: {},
   editorLspEnabled: false,
@@ -778,6 +790,21 @@ function migrateRetiredQwenPreviewModel(settings: SharedSettings): SharedSetting
           qwen: { ...qwenProviderConfig, model: QWEN_DEFAULT_MODEL_ID },
         }
       : settings.providerConfigs;
+  const qwenModelPreferences = settings.providerModelPreferences.qwen;
+  const retiredQwenModelPreference = qwenModelPreferences?.[QWEN_RETIRED_PREVIEW_MODEL_ID];
+  let providerModelPreferences = settings.providerModelPreferences;
+  if (qwenModelPreferences && retiredQwenModelPreference) {
+    const currentQwenModelPreferences = { ...qwenModelPreferences };
+    delete currentQwenModelPreferences[QWEN_RETIRED_PREVIEW_MODEL_ID];
+    providerModelPreferences = {
+      ...settings.providerModelPreferences,
+      qwen: {
+        ...currentQwenModelPreferences,
+        [QWEN_DEFAULT_MODEL_ID]:
+          currentQwenModelPreferences[QWEN_DEFAULT_MODEL_ID] ?? retiredQwenModelPreference,
+      },
+    };
+  }
 
   const seenFavorites = new Set<string>();
   const favoriteModels = settings.favoriteModels
@@ -807,6 +834,7 @@ function migrateRetiredQwenPreviewModel(settings: SharedSettings): SharedSetting
   return {
     ...settings,
     providerConfigs,
+    providerModelPreferences,
     hiddenModels,
     commitGenModel: migrateUtilityModel(settings.commitGenProvider, settings.commitGenModel),
     titleGenModel: migrateUtilityModel(settings.titleGenProvider, settings.titleGenModel),


### PR DESCRIPTION
- Introduce shared settings schema, store, and file persistence across main and renderer processes to support unified configuration management.
- Update model picker controls and helper utilities to improve model selection workflows in thread drafts.
- Connect shared settings and model picker state to `ThreadComposerSection` and `ThreadDraftView` UI components.
- Add comprehensive unit tests covering settings persistence, store state management, helper utilities, and thread draft views.