### PR TITLE
Show saved Fast preferences per model

### DIFF
--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.test.tsx
@@ -122,6 +122,8 @@ describe("ProviderModelMenu", () => {
       favoriteModels: [],
       recentModels: [],
       hiddenModels: {},
+      providerConfigs: {},
+      providerModelPreferences: {},
     });
   });
 
@@ -194,6 +196,57 @@ describe("ProviderModelMenu", () => {
     fireEvent.click(screen.getByRole("button", { name: "Select model" }));
 
     expect(await screen.findByRole("option", { name: /Opus/u })).toHaveTextContent("· 2x");
+  });
+
+  it("shows each fast-capable model's saved Fast preference", async () => {
+    const provider = makeProvider(2);
+    provider.capabilities.fastModels = ["model-1", "model-2"];
+    useSharedSettings.setState({
+      providerModelPreferences: {
+        codex: {
+          "model-1": { fast: false },
+          "model-2": { fast: true },
+        },
+      },
+    });
+
+    render(
+      <ProviderModelMenu
+        providers={[provider]}
+        currentAgentKind="codex"
+        currentModel="model-1"
+        onChange={vi.fn<(next: { agentKind: string; model: string }) => void>()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const listbox = await screen.findByRole("listbox", { name: "Models" });
+    expect(within(listbox).getByRole("img", { name: "Supports Fast mode" })).toBeInTheDocument();
+    expect(within(listbox).getByRole("img", { name: "Fast mode" })).toBeInTheDocument();
+  });
+
+  it("uses the model default when a saved preference omits Fast", async () => {
+    const provider = makeProvider(1);
+    provider.capabilities.fastModels = ["model-1"];
+    useSharedSettings.setState({
+      providerConfigs: { codex: { model: "model-1", fast: false } },
+      providerModelPreferences: { codex: { "model-1": { effort: "high" } } },
+    });
+
+    render(
+      <ProviderModelMenu
+        providers={[provider]}
+        currentAgentKind="codex"
+        currentModel="model-1"
+        onChange={vi.fn<(next: { agentKind: string; model: string }) => void>()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const listbox = await screen.findByRole("listbox", { name: "Models" });
+    expect(within(listbox).getByRole("img", { name: "Fast mode" })).toBeInTheDocument();
   });
 
   it("ignores provider prose model descriptions", async () => {

--- a/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
+++ b/src/renderer/components/common/ProviderModelMenu/ProviderModelMenu.tsx
@@ -66,8 +66,6 @@ export interface ProviderModelMenuProps {
   lockedAgentKind?: string;
   presentationMode?: ThreadPresentationMode;
   isDisabled?: boolean;
-  /** Fast mode is on for the current draft, so supported rows mark it filled. */
-  isFastEnabled?: boolean;
   hideLabelOnWrap?: boolean;
   forceHideLabel?: boolean;
   collapseTier?: number;
@@ -261,7 +259,6 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
     lockedAgentKind,
     presentationMode,
     isDisabled,
-    isFastEnabled = false,
     hideLabelOnWrap,
     forceHideLabel = false,
     collapseTier,
@@ -287,6 +284,8 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
   const recents = useSharedSettings((s) => s.recentModels);
   const providerOrder = useSharedSettings((s) => s.providerOrder);
   const hiddenModels = useSharedSettings((s) => s.hiddenModels);
+  const providerModelPreferences = useSharedSettings((s) => s.providerModelPreferences);
+  const providerConfigs = useSharedSettings((s) => s.providerConfigs);
   const toggleFavoriteModel = useSharedSettings((s) => s.toggleFavoriteModel);
   const latestFavoritesRef = useRef(favorites);
   const latestRecentsRef = useRef(recents);
@@ -371,6 +370,18 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
     `recent:${currentAgentKind}:${effectiveCurrentModel}`,
     `model:${currentProviderKey}:${effectiveCurrentModel}`,
   ]);
+
+  // Rows mirror the Fast preference saved per model — an explicitly saved value
+  // wins, otherwise the app default keeps Fast on for models that support it.
+  // This is intentionally not the current draft's toggle: the icon answers
+  // "what will selecting this model do", so every row resolves independently.
+  function modelFastEnabled(providerKind: string, modelId: string): boolean {
+    const saved = providerModelPreferences[providerKind]?.[modelId];
+    if (saved) return saved.fast ?? true;
+    const legacy = providerConfigs[providerKind];
+    if (legacy?.model === modelId && legacy.fast !== undefined) return legacy.fast;
+    return true;
+  }
 
   function handleSelect(itemId: string) {
     const selected = items.find((item) => item.id === itemId);
@@ -475,7 +486,7 @@ export function ProviderModelMenu(props: ProviderModelMenuProps) {
           modelRowHeight={mobile ? MODEL_MENU_ROW_HEIGHT_MOBILE : MODEL_MENU_ROW_HEIGHT}
           mobile={mobile}
           mobileExpanded={mobile && expanded}
-          isFastEnabled={isFastEnabled}
+          modelFastEnabled={modelFastEnabled}
           toggleFavorite={(providerKind, modelId, rowPresentationMode) =>
             toggleFavoriteModel(
               providerKind,
@@ -524,7 +535,7 @@ function WindowedProviderModelList(props: {
   modelRowHeight: number;
   mobile: boolean;
   mobileExpanded: boolean;
-  isFastEnabled: boolean;
+  modelFastEnabled: (providerKind: string, modelId: string) => boolean;
   toggleFavorite: (
     providerKind: string,
     modelId: string,
@@ -540,7 +551,7 @@ function WindowedProviderModelList(props: {
     modelRowHeight,
     mobile,
     mobileExpanded,
-    isFastEnabled,
+    modelFastEnabled,
     toggleFavorite,
     onSelect,
   } = props;
@@ -820,17 +831,18 @@ function WindowedProviderModelList(props: {
               // Render the head as the model name and the tail as muted hint.
               const { name, hint } = splitModelLabel(item.label);
               const mutedHint = [hint, item.contextDescription].filter(Boolean).join(" · ");
+              const rowFastEnabled = modelFastEnabled(item.providerKind, item.modelId);
               const content = (
                 <span className="flex min-w-0 flex-1 items-center gap-1.5">
                   <span className="min-w-0 truncate">{name}</span>
                   {item.supportsFast ? (
-                    // Filled while Fast mode is on, outlined when the model
-                    // merely supports it.
+                    // Filled when Fast mode is saved on for this model,
+                    // outlined when it merely supports it or Fast was saved off.
                     <Zap
                       role="img"
-                      aria-label={isFastEnabled ? t`Fast mode` : t`Supports Fast mode`}
+                      aria-label={rowFastEnabled ? t`Fast mode` : t`Supports Fast mode`}
                       className={
-                        isFastEnabled
+                        rowFastEnabled
                           ? "size-3 shrink-0 fill-current text-muted"
                           : "size-3 shrink-0 text-muted/60"
                       }

--- a/src/renderer/components/thread/ThreadComposer.tsx
+++ b/src/renderer/components/thread/ThreadComposer.tsx
@@ -85,7 +85,6 @@ export type ComposerControl =
       lockedAgentKind?: string;
       presentationMode?: ThreadPresentationMode;
       isDisabled?: boolean;
-      isFastEnabled?: boolean;
       hideLabelOnWrap?: boolean;
       openSignal?: number;
       onChange: (next: {
@@ -443,7 +442,6 @@ export function ThreadComposer(props: {
           {...(control.lockedAgentKind ? { lockedAgentKind: control.lockedAgentKind } : {})}
           {...(control.presentationMode ? { presentationMode: control.presentationMode } : {})}
           {...(control.isDisabled !== undefined ? { isDisabled: control.isDisabled } : {})}
-          {...(control.isFastEnabled !== undefined ? { isFastEnabled: control.isFastEnabled } : {})}
           {...(control.openSignal !== undefined ? { openSignal: control.openSignal } : {})}
           {...(hideOnWrap || shouldHideLabel
             ? {

--- a/src/renderer/components/thread/buildModelPickerControls.tsx
+++ b/src/renderer/components/thread/buildModelPickerControls.tsx
@@ -240,8 +240,6 @@ export function buildModelPickerControls(input: BuildModelPickerControlsInput): 
       ...(lockedAgentKind ? { lockedAgentKind } : {}),
       ...(presentationMode ? { presentationMode } : {}),
       ...(isDisabled !== undefined ? { isDisabled } : {}),
-      // Rows mark Fast mode filled while it is on for this draft.
-      ...(fast === true ? { isFastEnabled: true } : {}),
       hideLabelOnWrap,
       tier: 5,
       onChange: onProviderModelChange,


### PR DESCRIPTION
- Bugfix: display each model’s saved Fast-mode state in the model picker.
- Fall back to the provider’s model default when no saved preference exists.
- Remove draft-level Fast-mode propagation and add coverage for preference handling.