### PR TITLE
Keep polling after staging an update

### DIFF
--- a/src/main/updates/autoUpdater.test.ts
+++ b/src/main/updates/autoUpdater.test.ts
@@ -256,20 +256,68 @@ describe("createAutoUpdaterController", () => {
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1);
   });
 
-  it("stops checking once an update is downloaded and after install", async () => {
-    const controller = createAutoUpdaterController(vi.fn(), "stable", false);
+  it("keeps checking after an update is downloaded and supersedes it with a newer release", async () => {
+    const sendStatus = vi.fn<(status: UpdateStatus) => void>();
+    const controller = createAutoUpdaterController(sendStatus, "stable", false);
+    controller.initialize();
+
+    await vi.advanceTimersByTimeAsync(INITIAL_CHECK_DELAY_MS);
+    autoUpdaterMock.emit("update-downloaded", { version: "1.2.3" });
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    // A staged update must not stop polling: the next interval check runs and
+    // finds a newer release, which is downloaded in place of the staged one.
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("update-available", { version: "1.2.4" });
+    });
+    await vi.advanceTimersByTimeAsync(PERIODIC_CHECK_INTERVAL_MS);
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2);
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledOnce();
+
+    autoUpdaterMock.emit("update-downloaded", { version: "1.2.4" });
+    expect(sendStatus).toHaveBeenLastCalledWith({ type: "downloaded", version: "1.2.4" });
+
+    // Installing clears the interval, so advancing time does nothing more.
+    controller.installUpdate();
+    await vi.advanceTimersByTimeAsync(PERIODIC_CHECK_INTERVAL_MS);
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not re-download when a check re-finds the staged version", async () => {
+    const sendStatus = vi.fn<(status: UpdateStatus) => void>();
+    const controller = createAutoUpdaterController(sendStatus, "stable", false);
     controller.initialize();
 
     await vi.advanceTimersByTimeAsync(INITIAL_CHECK_DELAY_MS);
     autoUpdaterMock.emit("update-downloaded", { version: "1.2.3" });
 
-    // An update is staged for install — no point polling further.
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("update-available", { version: "1.2.3" });
+    });
     await vi.advanceTimersByTimeAsync(PERIODIC_CHECK_INTERVAL_MS);
-    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1);
 
-    // Installing clears the interval, so advancing time does nothing more.
-    controller.installUpdate();
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2);
+    expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled();
+    // The staged install affordance stays visible after the redundant check.
+    expect(sendStatus).toHaveBeenLastCalledWith({ type: "downloaded", version: "1.2.3" });
+  });
+
+  it("keeps the staged install visible when a background check finds nothing newer", async () => {
+    const sendStatus = vi.fn<(status: UpdateStatus) => void>();
+    const controller = createAutoUpdaterController(sendStatus, "stable", false);
+    controller.initialize();
+
+    await vi.advanceTimersByTimeAsync(INITIAL_CHECK_DELAY_MS);
+    autoUpdaterMock.emit("update-downloaded", { version: "1.2.3" });
+
+    autoUpdaterMock.checkForUpdates.mockImplementationOnce(async () => {
+      autoUpdaterMock.emit("checking-for-update");
+      autoUpdaterMock.emit("update-not-available");
+    });
     await vi.advanceTimersByTimeAsync(PERIODIC_CHECK_INTERVAL_MS);
-    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1);
+
+    expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(2);
+    expect(sendStatus).toHaveBeenLastCalledWith({ type: "downloaded", version: "1.2.3" });
   });
 });

--- a/src/main/updates/autoUpdater.ts
+++ b/src/main/updates/autoUpdater.ts
@@ -43,9 +43,15 @@ export function createAutoUpdaterController(
   // True while a check or download is in flight; gates the periodic timer so a
   // scheduled tick never stacks a redundant check on top of an active one.
   let checkInFlight = false;
-  // True once an update is downloaded and waiting to install; we stop polling
-  // until the user restarts to apply it.
+  // True once an update is downloaded and waiting to install. Checks keep
+  // running so a newer release can supersede the staged one before the user
+  // ever restarts.
   let updateReady = false;
+  // Version of the staged download, and of the release the in-flight check
+  // found. Compared so a check that re-discovers the staged version doesn't
+  // trigger a redundant re-download.
+  let downloadedVersion: string | null = null;
+  let availableVersion: string | null = null;
   let periodicTimer: ReturnType<typeof setInterval> | null = null;
   let checkPromise: Promise<void> | null = null;
   let downloadPromise: Promise<void> | null = null;
@@ -99,17 +105,22 @@ export function createAutoUpdaterController(
           continue;
         }
         reportClassifiedFailure(operation, failure.kind);
-        if (failure.kind === "optional-manifest-missing") {
+        if (updateReady) {
+          // A background check/download failed while an update is staged; keep
+          // the install affordance instead of replacing it with an error state.
+          sendStagedStatus();
+        } else if (failure.kind === "optional-manifest-missing") {
           sendStatus({ type: "update-not-available" });
           return;
+        } else {
+          sendStatus({
+            type: "error",
+            messageKey:
+              failure.kind === "transient-network"
+                ? "update.serviceUnavailable"
+                : "update.operationFailed",
+          });
         }
-        sendStatus({
-          type: "error",
-          messageKey:
-            failure.kind === "transient-network"
-              ? "update.serviceUnavailable"
-              : "update.operationFailed",
-        });
         throw error;
       } finally {
         if (activeAttempt === attemptState) {
@@ -124,7 +135,11 @@ export function createAutoUpdaterController(
     checkInFlight = true;
     downloadPromise = runOperation("download", () => autoUpdater.downloadUpdate()).finally(() => {
       downloadPromise = null;
-      if (!updateReady) checkInFlight = false;
+      // downloadUpdate resolves after update-downloaded fired (which already
+      // cleared the flag); on failure nothing else will, so reset here either
+      // way. updateReady may still hold for a previously staged version, so it
+      // can't be used to tell whether this download finished.
+      checkInFlight = false;
     });
     return downloadPromise;
   }
@@ -133,12 +148,20 @@ export function createAutoUpdaterController(
     if (checkPromise) return checkPromise;
     checkInFlight = true;
     updateAvailable = false;
+    availableVersion = null;
     checkPromise = runOperation("check", () => autoUpdater.checkForUpdates())
       .then(() => {
-        if (updateAvailable && !updateReady) {
+        if (updateAvailable && availableVersion !== downloadedVersion) {
+          // A newer (or first) release — download it. When an older update is
+          // already staged, electron-updater supersedes it, so the pending
+          // install is discarded in favor of the fresh one.
           void beginDownload().catch(() => {});
         } else {
           checkInFlight = false;
+          // The check re-found the version that is already staged: no new
+          // download, but restore the staged status so the install affordance
+          // stays visible.
+          sendStagedStatus();
         }
       })
       .catch(() => {
@@ -150,10 +173,21 @@ export function createAutoUpdaterController(
     return checkPromise;
   }
 
+  // Re-emit the staged-update status after a background check finishes without
+  // a newer release, so the renderer's install affordance is not clobbered by
+  // the intermediate "checking"/"update-not-available" states.
+  function sendStagedStatus(): void {
+    if (updateReady && downloadedVersion) {
+      sendStatus({ type: "downloaded", version: downloadedVersion });
+    }
+  }
+
   // Fire a background check, but only when the updater is otherwise idle. Used
-  // by both the initial launch check and the recurring interval.
+  // by both the initial launch check and the recurring interval. A staged
+  // update does not block checks: a newer release must still be discovered and
+  // downloaded, superseding the pending install.
   function runScheduledCheck(): void {
-    if (checkInFlight || updateReady) {
+    if (checkInFlight) {
       return;
     }
     void beginCheck();
@@ -193,12 +227,18 @@ export function createAutoUpdaterController(
     });
     autoUpdater.on("update-available", (info) => {
       updateAvailable = true;
+      availableVersion = info.version;
       checkInFlight = true;
       sendStatus({ type: "update-available", version: info.version });
     });
     autoUpdater.on("update-not-available", () => {
       checkInFlight = false;
-      sendStatus({ type: "update-not-available" });
+      if (updateReady) {
+        // Nothing newer than the staged download — keep it visible.
+        sendStagedStatus();
+      } else {
+        sendStatus({ type: "update-not-available" });
+      }
     });
     autoUpdater.on("download-progress", (progress) => {
       checkInFlight = true;
@@ -213,6 +253,7 @@ export function createAutoUpdaterController(
     autoUpdater.on("update-downloaded", (info) => {
       checkInFlight = false;
       updateReady = true;
+      downloadedVersion = info.version;
       sendStatus({ type: "downloaded", version: info.version });
     });
     autoUpdater.on("error", (error) => {
@@ -224,7 +265,9 @@ export function createAutoUpdaterController(
       const failure = classifyUpdateFailure(error, operation, channel);
       reportClassifiedFailure(operation, failure.kind);
       checkInFlight = false;
-      if (failure.kind === "optional-manifest-missing") {
+      if (updateReady) {
+        sendStagedStatus();
+      } else if (failure.kind === "optional-manifest-missing") {
         sendStatus({ type: "update-not-available" });
       } else {
         sendStatus({


### PR DESCRIPTION
- Bugfix: Continue checking for newer releases after an update is downloaded.
- Avoid redundant downloads when checks rediscover the staged version.
- Preserve the staged install status when no newer update is available.
- Add coverage for superseding and retaining staged updates.