### PR TITLE
Add Cursor SDK usage profiles and account identity

### DIFF
--- a/packages/agents-usage/src/collectors/cursor.test.ts
+++ b/packages/agents-usage/src/collectors/cursor.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { HostPort, OAuthToken } from "../host";
-import { collectCursor, parseCursorUsage } from "./cursor";
+import {
+  collectCursor,
+  collectCursorFromApiKey,
+  CURSOR_API_KEY_EXCHANGE_ENDPOINT,
+  CURSOR_PERIOD_USAGE_ENDPOINT,
+  CURSOR_PLAN_INFO_ENDPOINT,
+  parseCursorPeriodUsage,
+  parseCursorUsage,
+} from "./cursor";
 
 const NOW = 1_717_000_000_000;
 
@@ -164,5 +172,142 @@ describe("parseCursorUsage", () => {
     const snap = parseCursorUsage({}, {}, NOW);
     expect(snap.status).toBe("ok");
     expect(snap.windows).toHaveLength(0);
+  });
+});
+
+describe("parseCursorPeriodUsage", () => {
+  it("maps GetCurrentPeriodUsage onto Auto / API windows", () => {
+    const snap = parseCursorPeriodUsage(
+      {
+        billingCycleEnd: "1719600000000",
+        planUsage: {
+          totalSpend: 2875,
+          includedSpend: 2000,
+          limit: 2000,
+          autoPercentUsed: 2.65,
+          apiPercentUsed: 55.07,
+        },
+      },
+      { plan: "Cursor Pro+", email: "work@example.com" },
+      NOW,
+      "cursor:work",
+    );
+
+    expect(snap.providerId).toBe("cursor:work");
+    expect(snap.plan).toBe("Cursor Pro+");
+    expect(snap.authenticatedAs).toBe("work@example.com");
+    const auto = snap.windows.find((w) => w.id === "cursor-auto")!;
+    expect(auto.usedPercent).toBeCloseTo(2.65);
+    const api = snap.windows.find((w) => w.id === "cursor-api")!;
+    expect(api.usedPercent).toBeCloseTo(55.07);
+    expect(api.used).toBeCloseTo(28.75);
+    expect(api.limit).toBeCloseTo(20);
+  });
+});
+
+describe("collectCursorFromApiKey", () => {
+  function jwtWithEmail(email: string): string {
+    const payload = Buffer.from(JSON.stringify({ email })).toString("base64url");
+    return `header.${payload}.sig`;
+  }
+
+  it("exchanges the user API key then reads period usage for that account", async () => {
+    const urls: string[] = [];
+    const authorizations: Array<string | undefined> = [];
+    const host: HostPort = {
+      now: () => NOW,
+      credentials: {
+        getOAuthToken: async () => undefined,
+        getSecret: async () => undefined,
+      },
+      http: {
+        request: async (req) => {
+          urls.push(req.url);
+          authorizations.push(req.headers?.Authorization);
+          if (req.url === CURSOR_API_KEY_EXCHANGE_ENDPOINT) {
+            return {
+              status: 200,
+              headers: {},
+              body: JSON.stringify({ accessToken: jwtWithEmail("work@example.com") }),
+            };
+          }
+          if (req.url === CURSOR_PERIOD_USAGE_ENDPOINT) {
+            return {
+              status: 200,
+              headers: {},
+              body: JSON.stringify({
+                billingCycleEnd: "1719600000000",
+                planUsage: {
+                  totalSpend: 9347,
+                  limit: 25000,
+                  autoPercentUsed: 34,
+                  apiPercentUsed: 37.4,
+                },
+              }),
+            };
+          }
+          if (req.url === CURSOR_PLAN_INFO_ENDPOINT) {
+            return {
+              status: 200,
+              headers: {},
+              body: JSON.stringify({ planInfo: { planName: "enterprise" } }),
+            };
+          }
+          throw new Error(`unexpected url ${req.url}`);
+        },
+      },
+    };
+
+    const snap = await collectCursorFromApiKey(host, " crsr_work ", "cursor:work");
+    expect(urls).toEqual([
+      CURSOR_API_KEY_EXCHANGE_ENDPOINT,
+      CURSOR_PERIOD_USAGE_ENDPOINT,
+      CURSOR_PLAN_INFO_ENDPOINT,
+    ]);
+    expect(authorizations[0]).toBe("Bearer crsr_work");
+    expect(snap.providerId).toBe("cursor:work");
+    expect(snap.status).toBe("ok");
+    expect(snap.plan).toBe("Cursor Enterprise");
+    expect(snap.authenticatedAs).toBe("work@example.com");
+    expect(snap.windows.find((w) => w.id === "cursor-auto")?.usedPercent).toBe(34);
+  });
+
+  it("maps a thrown usage request to an error snapshot", async () => {
+    const host: HostPort = {
+      now: () => NOW,
+      credentials: {
+        getOAuthToken: async () => undefined,
+        getSecret: async () => undefined,
+      },
+      http: {
+        request: async () => {
+          throw new Error("network down");
+        },
+      },
+    };
+    const snap = await collectCursorFromApiKey(host, "crsr_work", "cursor:work");
+    expect(snap).toMatchObject({
+      providerId: "cursor:work",
+      status: "error",
+      error: "network down",
+    });
+  });
+
+  it("treats a rejected API key as auth-missing", async () => {
+    const host: HostPort = {
+      now: () => NOW,
+      credentials: {
+        getOAuthToken: async () => undefined,
+        getSecret: async () => undefined,
+      },
+      http: {
+        request: async () => ({ status: 401, headers: {}, body: '{"message":"Invalid"}' }),
+      },
+    };
+    const snap = await collectCursorFromApiKey(host, "crsr_bad", "cursor:work");
+    expect(snap).toMatchObject({
+      providerId: "cursor:work",
+      status: "auth-missing",
+    });
   });
 });

--- a/packages/agents-usage/src/collectors/cursor.ts
+++ b/packages/agents-usage/src/collectors/cursor.ts
@@ -17,6 +17,17 @@ import type { UsageSnapshot, UsageWindow } from "../types";
  */
 
 export const CURSOR_USAGE_ENDPOINT = "https://cursor.com/api/usage-summary";
+/**
+ * cursor-agent exchanges a User API key (`crsr_…`) for a short-lived session
+ * JWT through this endpoint, then reads DashboardService over api2. Cursor
+ * profiles have no isolated CLI login, so this is the documented-for-CLI path
+ * that can collect a second account's usage from its key.
+ */
+export const CURSOR_API_KEY_EXCHANGE_ENDPOINT = "https://api2.cursor.sh/auth/exchange_user_api_key";
+export const CURSOR_PERIOD_USAGE_ENDPOINT =
+  "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage";
+export const CURSOR_PLAN_INFO_ENDPOINT =
+  "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo";
 
 interface CursorPlanUsage {
   used?: number;
@@ -45,6 +56,7 @@ const MEMBERSHIP_LABELS: Record<string, string> = {
   free_trial: "Cursor Free Trial",
   pro: "Cursor Pro",
   pro_plus: "Cursor Pro+",
+  "pro+": "Cursor Pro+",
   ultra: "Cursor Ultra",
   business: "Cursor Business",
   team: "Cursor Team",
@@ -243,4 +255,227 @@ export async function collectCursor(
     ...(typeof token.raw?.email === "string" ? { email: token.raw.email } : {}),
   };
   return parseCursorUsage(parsed, account, now);
+}
+
+interface CursorPeriodPlanUsage {
+  totalSpend?: number;
+  includedSpend?: number;
+  remaining?: number;
+  limit?: number;
+  autoPercentUsed?: number;
+  apiPercentUsed?: number;
+  totalPercentUsed?: number;
+}
+
+interface CursorPeriodUsage {
+  billingCycleStart?: string;
+  billingCycleEnd?: string;
+  membershipType?: string;
+  planUsage?: CursorPeriodPlanUsage;
+}
+
+interface CursorPlanInfo {
+  planInfo?: { planName?: string };
+}
+
+/** Map api2 `GetCurrentPeriodUsage` onto the dashboard usage-summary parser. */
+export function parseCursorPeriodUsage(
+  body: unknown,
+  account: { plan?: string; email?: string },
+  nowMs: number,
+  providerId = "cursor",
+): UsageSnapshot {
+  const period = (body ?? {}) as CursorPeriodUsage;
+  const plan = period.planUsage ?? {};
+  const snapshot = parseCursorUsage(
+    {
+      billingCycleEnd: period.billingCycleEnd,
+      membershipType: period.membershipType,
+      individualUsage: {
+        plan: {
+          used: plan.totalSpend,
+          limit: plan.limit,
+          autoPercentUsed: plan.autoPercentUsed,
+          apiPercentUsed: plan.apiPercentUsed,
+          totalPercentUsed: plan.totalPercentUsed,
+          breakdown: {
+            included: plan.includedSpend,
+            total: plan.totalSpend,
+          },
+        },
+      },
+    },
+    account,
+    nowMs,
+  );
+  return { ...snapshot, providerId };
+}
+
+function emailFromJwt(accessToken: string): string | undefined {
+  const payload = accessToken.split(".")[1];
+  if (!payload) return undefined;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      email?: unknown;
+    };
+    return typeof claims.email === "string" && claims.email.trim()
+      ? claims.email.trim()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function cursorDashboardHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    "Connect-Protocol-Version": "1",
+  };
+}
+
+async function postCursorJson(
+  host: HostPort,
+  url: string,
+  headers: Record<string, string>,
+): Promise<HttpResponse> {
+  return host.http.request({
+    method: "POST",
+    url,
+    headers,
+    body: "{}",
+    timeoutMs: 15_000,
+  });
+}
+
+function httpFailureSnapshot(
+  providerId: string,
+  now: number,
+  status: number,
+): UsageSnapshot | undefined {
+  if (status === 401 || status === 403) {
+    return {
+      providerId,
+      status: "auth-missing",
+      windows: [],
+      fetchedAt: now,
+      error: `session rejected (${status})`,
+    };
+  }
+  if (status === 429) {
+    return { providerId, status: "rate-limited", windows: [], fetchedAt: now };
+  }
+  if (status < 200 || status >= 300) {
+    return {
+      providerId,
+      status: "error",
+      windows: [],
+      fetchedAt: now,
+      error: `HTTP ${status}`,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Collect Cursor usage for an account that authenticates with a User API key
+ * (Cursor profiles). Exchanges the key the same way `cursor-agent` does, then
+ * reads the current billing-period summary. Failures never throw.
+ */
+export async function collectCursorFromApiKey(
+  host: HostPort,
+  apiKey: string,
+  providerId = "cursor",
+): Promise<UsageSnapshot> {
+  const now = host.now();
+  try {
+    return await collectCursorFromApiKeyUnchecked(host, apiKey, providerId, now);
+  } catch (error) {
+    return {
+      providerId,
+      status: "error",
+      windows: [],
+      fetchedAt: now,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function collectCursorFromApiKeyUnchecked(
+  host: HostPort,
+  apiKey: string,
+  providerId: string,
+  now: number,
+): Promise<UsageSnapshot> {
+  const key = apiKey.trim();
+  if (!key) {
+    return { providerId, status: "auth-missing", windows: [], fetchedAt: now };
+  }
+
+  const exchanged = await postCursorJson(host, CURSOR_API_KEY_EXCHANGE_ENDPOINT, {
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+  });
+  const exchangeFailure = httpFailureSnapshot(providerId, now, exchanged.status);
+  if (exchangeFailure) return exchangeFailure;
+
+  let accessToken: string | undefined;
+  try {
+    const parsed = JSON.parse(exchanged.body) as { accessToken?: unknown };
+    accessToken = typeof parsed.accessToken === "string" ? parsed.accessToken.trim() : undefined;
+  } catch {
+    return {
+      providerId,
+      status: "error",
+      windows: [],
+      fetchedAt: now,
+      error: "invalid JSON response",
+    };
+  }
+  if (!accessToken) {
+    return { providerId, status: "auth-missing", windows: [], fetchedAt: now };
+  }
+
+  const headers = cursorDashboardHeaders(accessToken);
+  const [usageRes, planRes] = await Promise.all([
+    postCursorJson(host, CURSOR_PERIOD_USAGE_ENDPOINT, headers),
+    postCursorJson(host, CURSOR_PLAN_INFO_ENDPOINT, headers).catch(() => undefined),
+  ]);
+  const usageFailure = httpFailureSnapshot(providerId, now, usageRes.status);
+  if (usageFailure) return usageFailure;
+
+  let usageBody: unknown;
+  try {
+    usageBody = JSON.parse(usageRes.body);
+  } catch {
+    return {
+      providerId,
+      status: "error",
+      windows: [],
+      fetchedAt: now,
+      error: "invalid JSON response",
+    };
+  }
+
+  let planName: string | undefined;
+  if (planRes && planRes.status >= 200 && planRes.status < 300) {
+    try {
+      const planBody = JSON.parse(planRes.body) as CursorPlanInfo;
+      const name = planBody.planInfo?.planName?.trim();
+      planName = name ? (MEMBERSHIP_LABELS[name.toLowerCase()] ?? name) : undefined;
+    } catch {
+      planName = undefined;
+    }
+  }
+
+  const email = emailFromJwt(accessToken);
+  return parseCursorPeriodUsage(
+    usageBody,
+    {
+      ...(planName ? { plan: planName } : {}),
+      ...(email ? { email } : {}),
+    },
+    now,
+    providerId,
+  );
 }

--- a/packages/agents-usage/src/index.ts
+++ b/packages/agents-usage/src/index.ts
@@ -59,7 +59,16 @@ export {
   CODEX_USAGE_ENDPOINT,
 } from "./collectors/codex";
 export { collectCopilot, parseCopilotUsage, COPILOT_USER_ENDPOINT } from "./collectors/copilot";
-export { collectCursor, parseCursorUsage, CURSOR_USAGE_ENDPOINT } from "./collectors/cursor";
+export {
+  collectCursor,
+  collectCursorFromApiKey,
+  parseCursorUsage,
+  parseCursorPeriodUsage,
+  CURSOR_USAGE_ENDPOINT,
+  CURSOR_API_KEY_EXCHANGE_ENDPOINT,
+  CURSOR_PERIOD_USAGE_ENDPOINT,
+  CURSOR_PLAN_INFO_ENDPOINT,
+} from "./collectors/cursor";
 export {
   collectCommandCode,
   formatCommandCodePlanLabel,

--- a/src/renderer/components/providers/usageProviders.test.ts
+++ b/src/renderer/components/providers/usageProviders.test.ts
@@ -33,6 +33,12 @@ const agentInstances: AgentInstanceConfigMap = {
     enabled: false,
     config: { configDir: "~/.poracode/claude-profiles/disabled" },
   },
+  yieldmo: {
+    id: "yieldmo",
+    driver: "cursor",
+    displayName: "Work",
+    environment: { CURSOR_API_KEY: { value: "lc-safe:encrypted", sensitive: true } },
+  },
 };
 
 describe("usageProviders", () => {
@@ -65,6 +71,22 @@ describe("usageProviders", () => {
       "claude:work",
     ]);
     expect(providers.find((provider) => provider.id === "claude:home")?.label).toBe("Claude Home");
+  });
+
+  it("adds Cursor profile providers after the base Cursor provider", () => {
+    const providers = usageProvidersForAgentInstances(agentInstances);
+    const cursorIndex = providers.findIndex((provider) => provider.id === "cursor");
+
+    expect(providers.slice(cursorIndex, cursorIndex + 2).map((provider) => provider.id)).toEqual([
+      "cursor",
+      "cursor:yieldmo",
+    ]);
+    expect(providers.find((provider) => provider.id === "cursor:yieldmo")?.label).toBe(
+      "Cursor Work",
+    );
+    expect(providers.find((provider) => provider.id === "cursor:yieldmo")?.sharedWindowReset).toBe(
+      true,
+    );
   });
 
   it("orders, disables, and rings Claude profiles like Claude", () => {

--- a/src/renderer/components/providers/usageProviders.ts
+++ b/src/renderer/components/providers/usageProviders.ts
@@ -4,6 +4,7 @@ import type { UsageSnapshot, UsageWindow } from "@poracode/agents-usage/types";
 import {
   baseAgentKind,
   claudeProfileKind,
+  cursorProfileKind,
   parseClaudeProfileInstanceConfig,
   type AgentInstanceConfigMap,
 } from "@/shared/contracts";
@@ -161,17 +162,39 @@ function claudeProfileUsageProviders(
   return profiles;
 }
 
+function cursorProfileUsageProviders(
+  agentInstances: AgentInstanceConfigMap | undefined,
+): UsageProvider[] {
+  if (!agentInstances) return [];
+  const profiles: UsageProvider[] = [];
+  for (const instance of Object.values(agentInstances)) {
+    if (instance.enabled === false || instance.driver !== "cursor") continue;
+    const apiKey = instance.environment?.CURSOR_API_KEY?.value;
+    if (typeof apiKey !== "string" || apiKey.length === 0) continue;
+    const label = instance.displayName ?? instance.id;
+    profiles.push({
+      id: cursorProfileKind(instance.id),
+      label: `Cursor ${label}`,
+      ...rendererMeta("cursor"),
+    });
+  }
+  profiles.sort((a, b) => a.label.localeCompare(b.label));
+  return profiles;
+}
+
 export function usageProvidersForAgentInstances(
   agentInstances: AgentInstanceConfigMap | undefined,
 ): UsageProvider[] {
-  const profiles = claudeProfileUsageProviders(agentInstances);
-  if (profiles.length === 0) return [...STATIC_USAGE_PROVIDERS];
+  const claudeProfiles = claudeProfileUsageProviders(agentInstances);
+  const cursorProfiles = cursorProfileUsageProviders(agentInstances);
+  if (claudeProfiles.length === 0 && cursorProfiles.length === 0) {
+    return [...STATIC_USAGE_PROVIDERS];
+  }
   const out: UsageProvider[] = [];
   for (const provider of STATIC_USAGE_PROVIDERS) {
     out.push(provider);
-    if (provider.id === "claude") {
-      out.push(...profiles);
-    }
+    if (provider.id === "claude") out.push(...claudeProfiles);
+    if (provider.id === "cursor") out.push(...cursorProfiles);
   }
   return out;
 }

--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Erstellen"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Pull Request für Kandidat {0} ({label}) erstellen"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Erstelle ein zweites Cursor-Konto mit einem eigenen User-API-Schlüssel. Cursor CLI und ACP teilen sich eine Anmeldung auf dem Rechner, daher bleiben sie auf der Hauptkachel von Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Erstelle mit einem Klick eine nützliche Routine und passe sie jederzeit an."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Geplante Aufgabe erstellen"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Erstellen Sie separate Cursor-Profile mit eigenen API-Schlüsseln."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Erstellen Sie separate Cursor-Profile mit eigenen API-Schlüsseln."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Von Cursor ACP abgemeldet."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Wähle die Laufzeit für neue Cursor-GUI-Chats. Jede Laufzeit wird eigenständig installiert und authentifiziert; offene Chats behalten die Laufzeit, mit der sie gestartet wurden."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Wählen Sie die Laufzeitumgebung für neue Cursor-GUI-Chats. Der Profil-API-Schlüssel gilt für beide Laufzeitumgebungen."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Wählen Sie die Laufzeitumgebung für neue Cursor-GUI-Chats. Der Profil-API-Schlüssel gilt für beide Laufzeitumgebungen."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Der Agent"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Der API-Schlüssel unten wird von Cursor CLI, ACP und SDK für dieses Profil verwendet."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Der API-Schlüssel unten wird von Cursor CLI, ACP und SDK für dieses Profil verwendet."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Denkt …"
 msgid "This agent is not installed."
 msgstr "Dieser Agent ist nicht installiert."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Dieser API-Schlüssel authentifiziert die SDK-Chats dieses Profils und seine Nutzungskarte. Er ändert nicht die CLI-Anmeldung der Haupt-Cursor-Kachel."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Diese App wird über HTTPS bereitgestellt, aber der Desktop nutzt einfaches HTTP, das Browser blockieren. Öffne den Kopplungslink direkt vom Desktop (LAN), oder stelle den Desktop über HTTPS bereit."
@@ -12351,6 +12358,10 @@ msgstr "Die Poracode-Einstellungen dieses Plugins wurden ignoriert, weil sie ung
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Die Skills dieses Plugins konnten nicht gelesen werden."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Dieses Profil läuft auf dem Cursor SDK. Cursor CLI und ACP teilen sich eine Anmeldung auf dem Rechner, daher bleiben sie auf der Hauptkachel von Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Create"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Create a pull request for candidate {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Create a useful routine with one click, then adjust it anytime."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Create scheduled task"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Create separate Cursor profiles with their own API keys."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Create separate Cursor profiles with their own API keys."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Cursor ACP logged out."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Pick the runtime that backs new Cursor GUI chats. Each runtime installs and authenticates on its own; open chats keep the runtime they started with."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "The agent"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Thinking"
 msgid "This agent is not installed."
 msgstr "This agent is not installed."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "This plugin's Poracode settings were ignored because they are not valid.
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "This plugin's skills could not be read."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Crear"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Crear una pull request para el candidato {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Crea una segunda cuenta de Cursor con su propia clave de API de usuario. Cursor CLI y ACP comparten un único inicio de sesión en la máquina, así que se quedan en la ficha principal de Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Crea una rutina útil con un clic y ajústala cuando quieras."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Crear tarea programada"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Crea perfiles de Cursor separados con sus propias claves de API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Crea perfiles de Cursor separados con sus propias claves de API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Se cerró la sesión de Cursor ACP."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Elige el runtime que respalda los nuevos chats de la GUI de Cursor. Cada runtime se instala y se autentica por separado; los chats abiertos conservan el runtime con el que se iniciaron."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Elige el entorno que respalda los nuevos chats de la interfaz de Cursor. La clave de API del perfil se aplica a ambos entornos."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Elige el entorno que respalda los nuevos chats de la interfaz de Cursor. La clave de API del perfil se aplica a ambos entornos."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "El agente"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "La clave de API de abajo se usa en Cursor CLI, ACP y SDK para este perfil."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "La clave de API de abajo se usa en Cursor CLI, ACP y SDK para este perfil."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Pensando"
 msgid "This agent is not installed."
 msgstr "Este agente no está instalado."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Esta clave de API autentica los chats SDK de este perfil y su tarjeta de uso. No cambia el inicio de sesión de CLI de la ficha principal de Cursor."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Esta app se sirve por HTTPS, pero el escritorio usa HTTP sin cifrar, que los navegadores bloquean. Abre el enlace de emparejamiento directamente desde el escritorio (LAN) o expón el escritorio por HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "Se ignoraron los ajustes de Poracode de este plugin porque no son válid
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "No se pudieron leer las skills de este plugin."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Este perfil se ejecuta en el Cursor SDK. Cursor CLI y ACP comparten un único inicio de sesión en la máquina, así que se quedan en la ficha principal de Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Créer"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Créer une pull request pour le candidat {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Créez un second compte Cursor avec sa propre clé API utilisateur. Cursor CLI et ACP partagent une seule connexion sur la machine, ils restent donc sur la tuile Cursor principale."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Créez une routine utile en un clic, puis ajustez-la à tout moment."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Créer une tâche planifiée"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Créez des profils Cursor distincts avec leurs propres clés API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Créez des profils Cursor distincts avec leurs propres clés API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Déconnexion de Cursor ACP effectuée."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8735,8 +8738,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Choisissez la durée d'exécution qui alimente les nouveaux chats GUI Cursor. Chaque durée d'exécution s'installe et s'authentifie séparément ; les chats ouverts conservent celle avec laquelle ils ont démarré."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Choisissez l’environnement d’exécution des nouveaux chats Cursor. La clé API du profil s’applique aux deux environnements."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Choisissez l’environnement d’exécution des nouveaux chats Cursor. La clé API du profil s’applique aux deux environnements."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12048,8 +12051,8 @@ msgid "The agent"
 msgstr "L'agent"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "La clé API ci-dessous est utilisée par Cursor CLI, ACP et le SDK pour ce profil."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "La clé API ci-dessous est utilisée par Cursor CLI, ACP et le SDK pour ce profil."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12249,6 +12252,10 @@ msgstr "Réflexion"
 msgid "This agent is not installed."
 msgstr "Cet agent n'est pas installé."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Cette clé API authentifie les chats SDK de ce profil et sa carte d'utilisation. Elle ne modifie pas la connexion CLI de la tuile Cursor principale."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Cette app est servie en HTTPS, mais l'ordinateur est en HTTP simple, ce que les navigateurs bloquent. Ouvrez le lien d'association directement depuis l'ordinateur (LAN) ou exposez l'ordinateur en HTTPS."
@@ -12350,6 +12357,10 @@ msgstr "Les réglages Poracode de ce plugin ont été ignorés car ils ne sont p
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Les compétences de ce plugin n'ont pas pu être lues."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Ce profil s'exécute sur le Cursor SDK. Cursor CLI et ACP partagent une seule connexion sur la machine, ils restent donc sur la tuile Cursor principale."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -3491,6 +3491,10 @@ msgstr "作成"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "候補 {0}（{label}）のプルリクエストを作成"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "独自のユーザー API キーで 2 つ目の Cursor アカウントを作成します。Cursor CLI と ACP はマシンで 1 つのログインを共有するため、メインの Cursor タイルに残ります。"
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "ワンクリックで便利なルーティンを作成し、いつでも調整できます。"
@@ -3551,8 +3555,8 @@ msgid "Create scheduled task"
 msgstr "スケジュールタスクを作成"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "それぞれ独自のAPIキーを持つCursorプロファイルを作成します。"
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "それぞれ独自のAPIキーを持つCursorプロファイルを作成します。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3724,7 +3728,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Cursor ACP からログアウトしました。"
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8734,8 +8737,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "新しい Cursor GUI チャットで使用するランタイムを選択します。各ランタイムは個別にインストールおよび認証されます。開いているチャットは開始時のランタイムを維持します。"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "新しいCursor GUIチャットで使用するランタイムを選択します。プロファイルのAPIキーは両方のランタイムに適用されます。"
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "新しいCursor GUIチャットで使用するランタイムを選択します。プロファイルのAPIキーは両方のランタイムに適用されます。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12047,8 +12050,8 @@ msgid "The agent"
 msgstr "エージェント"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "以下のAPIキーは、このプロファイルのCursor CLI、ACP、SDKで使用されます。"
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "以下のAPIキーは、このプロファイルのCursor CLI、ACP、SDKで使用されます。"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12248,6 +12251,10 @@ msgstr "思考中"
 msgid "This agent is not installed."
 msgstr "このエージェントはインストールされていません。"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "この API キーは、このプロファイルの SDK チャットと使用量カードを認証します。メインの Cursor CLI ログインは変更しません。"
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "このアプリは HTTPS で配信されていますが、デスクトップはブラウザがブロックする通常の HTTP です。デスクトップ（LAN）からペアリングリンクを直接開くか、デスクトップを HTTPS で公開してください。"
@@ -12349,6 +12356,10 @@ msgstr "このプラグインの Poracode 設定は無効なため無視され�
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "このプラグインのスキルを読み取れませんでした。"
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "このプロファイルは Cursor SDK 上で動作します。Cursor CLI と ACP はマシンで 1 つのログインを共有するため、メインの Cursor タイルに残ります。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -3492,6 +3492,10 @@ msgstr "생성"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "후보 {0}({label})의 풀 리퀘스트 생성"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "고유한 사용자 API 키로 두 번째 Cursor 계정을 만듭니다. Cursor CLI와 ACP는 기기에서 로그인을 하나 공유하므로 기본 Cursor 타일에 남습니다."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "한 번의 클릭으로 유용한 루틴을 만들고 언제든지 조정하세요."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "예약 작업 만들기"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "각각 고유한 API 키를 사용하는 별도의 Cursor 프로필을 만드세요."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "각각 고유한 API 키를 사용하는 별도의 Cursor 프로필을 만드세요."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Cursor ACP에서 로그아웃했습니다."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "새 Cursor GUI 채팅에 사용할 런타임을 선택하세요. 각 런타임은 개별적으로 설치되고 인증됩니다. 열려 있는 채팅은 시작할 때의 런타임을 유지합니다."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "새 Cursor GUI 채팅을 지원할 런타임을 선택하세요. 프로필 API 키는 두 런타임 모두에 적용됩니다."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "새 Cursor GUI 채팅을 지원할 런타임을 선택하세요. 프로필 API 키는 두 런타임 모두에 적용됩니다."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "에이전트"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "아래 API 키는 이 프로필의 Cursor CLI, ACP, SDK에서 사용됩니다."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "아래 API 키는 이 프로필의 Cursor CLI, ACP, SDK에서 사용됩니다."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "생각 중"
 msgid "This agent is not installed."
 msgstr "이 에이전트는 설치되지 않았습니다."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "이 API 키는 이 프로필의 SDK 채팅과 사용량 카드를 인증합니다. 기본 Cursor CLI 로그인은 바꾸지 않습니다."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "이 앱은 HTTPS로 제공되지만 데스크톱은 브라우저가 차단하는 일반 HTTP를 사용합니다. 데스크톱(LAN)에서 페어링 링크를 직접 열거나 데스크톱을 HTTPS로 노출하세요."
@@ -12351,6 +12358,10 @@ msgstr "이 플러그인의 Poracode 설정이 유효하지 않아 무시되었�
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "이 플러그인의 스킬을 읽을 수 없습니다."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "이 프로필은 Cursor SDK에서 실행됩니다. Cursor CLI와 ACP는 기기에서 로그인을 하나 공유하므로 기본 Cursor 타일에 남습니다."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Utwórz"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Utwórz pull request dla kandydata {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Utwórz drugie konto Cursor z własnym kluczem API użytkownika. Cursor CLI i ACP współdzielą jedno logowanie na komputerze, więc pozostają na głównej kafelce Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Utwórz przydatną rutynę jednym kliknięciem i dostosuj ją w dowolnym momencie."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Utwórz zaplanowane zadanie"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Utwórz osobne profile Cursor z własnymi kluczami API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Utwórz osobne profile Cursor z własnymi kluczami API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Wylogowano z Cursor ACP."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Wybierz czas wykonania dla nowych czatów GUI Cursor. Każdy instaluje się i uwierzytelnia oddzielnie; otwarte czaty zachowują ten, z którym zostały uruchomione."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Wybierz środowisko dla nowych czatów GUI Cursor. Klucz API profilu dotyczy obu środowisk."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Wybierz środowisko dla nowych czatów GUI Cursor. Klucz API profilu dotyczy obu środowisk."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Agent"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Poniższy klucz API jest używany przez Cursor CLI, ACP i SDK dla tego profilu."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Poniższy klucz API jest używany przez Cursor CLI, ACP i SDK dla tego profilu."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Myślenie"
 msgid "This agent is not installed."
 msgstr "Ten agent nie jest zainstalowany."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Ten klucz API uwierzytelnia czaty SDK tego profilu i jego kartę użycia. Nie zmienia logowania CLI głównej kafelki Cursor."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Ta aplikacja jest serwowana przez HTTPS, ale desktop używa zwykłego HTTP, które przeglądarki blokują. Otwórz link parowania bezpośrednio z desktopa (LAN) albo udostępnij desktop przez HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "Ustawienia Poracode tej wtyczki zostały zignorowane, ponieważ są niep
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Nie udało się odczytać umiejętności tej wtyczki."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Ten profil działa na Cursor SDK. Cursor CLI i ACP współdzielą jedno logowanie na komputerze, więc pozostają na głównej kafelce Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Criar"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Criar uma pull request para o candidato {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Crie uma segunda conta Cursor com sua própria chave de API de usuário. Cursor CLI e ACP compartilham um único login na máquina, então eles ficam no cartão principal do Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Crie uma rotina útil com um clique e ajuste-a quando quiser."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Criar tarefa agendada"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Crie perfis separados do Cursor com suas próprias chaves de API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Crie perfis separados do Cursor com suas próprias chaves de API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Sessão do Cursor ACP encerrada."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Escolha o tempo de execução usado pelos novos chats de GUI do Cursor. Cada um é instalado e autenticado separadamente; chats abertos mantêm aquele com que foram iniciados."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Escolha o runtime para novos chats da interface do Cursor. A chave de API do perfil se aplica aos dois runtimes."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Escolha o runtime para novos chats da interface do Cursor. A chave de API do perfil se aplica aos dois runtimes."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "o agente"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "A chave de API abaixo é usada pelo Cursor CLI, ACP e SDK para este perfil."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "A chave de API abaixo é usada pelo Cursor CLI, ACP e SDK para este perfil."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Pensando"
 msgid "This agent is not installed."
 msgstr "Este agente não está instalado."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Esta chave de API autentica os chats SDK deste perfil e o cartão de uso. Ela não altera o login CLI do cartão principal do Cursor."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Este app é servido por HTTPS, mas o desktop está em HTTP simples, que os navegadores bloqueiam. Abra o link de pareamento diretamente no desktop (LAN) ou exponha o desktop por HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "As configurações do Poracode deste plugin foram ignoradas porque não 
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Não foi possível ler as skills deste plugin."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Este perfil é executado no Cursor SDK. Cursor CLI e ACP compartilham um único login na máquina, então eles ficam no cartão principal do Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Создать"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Создать pull request для кандидата {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Создайте второй аккаунт Cursor с собственным пользовательским API-ключом. Cursor CLI и ACP используют один вход на машине, поэтому они остаются на основной плитке Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Создайте полезный распорядок одним щелчком и изменяйте его в любое время."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Создать запланированную задачу"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Создавайте отдельные профили Cursor со своими ключами API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Создавайте отдельные профили Cursor со своими ключами API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Выполнен выход из Cursor ACP."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Выберите среду выполнения для новых GUI-чатов Cursor. Каждая среда выполнения устанавливается и аутентифицируется отдельно; открытые чаты сохраняют ту, с которой были запущены."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Выберите среду для новых GUI-чатов Cursor. Ключ API профиля применяется к обеим средам."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Выберите среду для новых GUI-чатов Cursor. Ключ API профиля применяется к обеим средам."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Агент"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Указанный ниже API-ключ используется в Cursor CLI, ACP и SDK для этого профиля."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Указанный ниже API-ключ используется в Cursor CLI, ACP и SDK для этого профиля."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Размышление"
 msgid "This agent is not installed."
 msgstr "Этот агент не установлен."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Этот API-ключ аутентифицирует SDK-чаты этого профиля и его карточку использования. Он не меняет вход CLI основной плитки Cursor."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Это приложение открыто по HTTPS, но десктоп использует обычный HTTP, который блокируется браузерами. Откройте ссылку привязки напрямую с десктопа (LAN) или предоставьте доступ к десктопу через HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "Настройки Poracode этого плагина проигнори
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Не удалось прочитать навыки этого плагина."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Этот профиль работает на Cursor SDK. Cursor CLI и ACP используют один вход на машине, поэтому они остаются на основной плитке Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Oluştur"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Aday {0} ({label}) için pull request oluştur"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Kendi Kullanıcı API anahtarıyla ikinci bir Cursor hesabı oluşturun. Cursor CLI ve ACP makinede tek bir oturumu paylaşır, bu yüzden ana Cursor kartında kalırlar."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Tek tıklamayla yararlı bir rutin oluşturun ve istediğiniz zaman ayarlayın."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Zamanlanmış görev oluştur"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Kendi API anahtarlarına sahip ayrı Cursor profilleri oluşturun."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Kendi API anahtarlarına sahip ayrı Cursor profilleri oluşturun."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Cursor ACP oturumu kapatıldı."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Yeni Cursor GUI sohbetlerinde kullanılacak çalışma zamanını seçin. Her çalışma zamanı ayrı ayrı yüklenir ve kimlik doğrulaması yapar; açık sohbetler başladıkları çalışma zamanını korur."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Yeni Cursor GUI sohbetlerini destekleyen çalışma zamanını seçin. Profil API anahtarı her iki çalışma zamanı için de geçerlidir."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Yeni Cursor GUI sohbetlerini destekleyen çalışma zamanını seçin. Profil API anahtarı her iki çalışma zamanı için de geçerlidir."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Temsilci"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Aşağıdaki API anahtarı bu profil için Cursor CLI, ACP ve SDK tarafından kullanılır."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Aşağıdaki API anahtarı bu profil için Cursor CLI, ACP ve SDK tarafından kullanılır."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Düşünme"
 msgid "This agent is not installed."
 msgstr "Bu aracı yüklü değil."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Bu API anahtarı, bu profilin SDK sohbetlerini ve kullanım kartını kimlik doğrular. Ana Cursor CLI oturumunu değiştirmez."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Bu uygulama HTTPS üzerinden sunuluyor, ancak masaüstü tarayıcıların engellediği düz HTTP kullanıyor. Eşleştirme bağlantısını doğrudan masaüstünden (LAN) açın veya masaüstünü HTTPS üzerinden yayımlayın."
@@ -12351,6 +12358,10 @@ msgstr "Bu eklentinin Poracode ayarları geçersiz olduğu için yok sayıldı."
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Bu eklentinin becerileri okunamadı."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Bu profil Cursor SDK üzerinde çalışır. Cursor CLI ve ACP makinede tek bir oturumu paylaşır, bu yüzden ana Cursor kartında kalırlar."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Створити"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Створити pull request для кандидата {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Створіть другий обліковий запис Cursor із власним користувацьким API-ключем. Cursor CLI і ACP мають один вхід на машині, тому вони лишаються на основній плитці Cursor."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Створіть корисний розпорядок одним клацанням і змінюйте його будь-коли."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Створити заплановане завдання"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Створюйте окремі профілі Cursor із власними ключами API."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Створюйте окремі профілі Cursor із власними ключами API."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Виконано вихід із Cursor ACP."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Виберіть середовище виконання для нових GUI-чатів Cursor. Кожне середовище встановлюється та автентифікується окремо; відкриті чати зберігають те, з яким були запущені."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Виберіть середовище для нових GUI-чатів Cursor. Ключ API профілю застосовується до обох середовищ."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Виберіть середовище для нових GUI-чатів Cursor. Ключ API профілю застосовується до обох середовищ."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Агент"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Наведений нижче API-ключ використовується в Cursor CLI, ACP і SDK для цього профілю."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Наведений нижче API-ключ використовується в Cursor CLI, ACP і SDK для цього профілю."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Міркування"
 msgid "This agent is not installed."
 msgstr "Цей агент не встановлено."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Цей API-ключ автентифікує SDK-чати цього профілю та його картку використання. Він не змінює вхід CLI основної плитки Cursor."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Цей застосунок відкрито через HTTPS, але десктоп використовує звичайний HTTP, який браузери блокують. Відкрийте посилання підключення безпосередньо з десктопа (LAN) або надайте доступ до десктопа через HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "Налаштування Poracode цього плагіна проігн
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Не вдалося прочитати навички цього плагіна."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Цей профіль працює на Cursor SDK. Cursor CLI і ACP мають один вхід на машині, тому вони лишаються на основній плитці Cursor."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -3492,6 +3492,10 @@ msgstr "Tạo"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "Tạo pull request cho ứng viên {0} ({label})"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Tạo tài khoản Cursor thứ hai với khóa API người dùng riêng. Cursor CLI và ACP dùng chung một lần đăng nhập trên máy, nên chúng ở lại ô Cursor chính."
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "Tạo một quy trình hữu ích chỉ với một lần nhấp, sau đó điều chỉnh bất cứ lúc nào."
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "Tạo tác vụ theo lịch"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "Tạo các hồ sơ Cursor riêng với khóa API riêng."
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "Tạo các hồ sơ Cursor riêng với khóa API riêng."
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "Đã đăng xuất khỏi Cursor ACP."
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8736,8 +8739,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "Chọn thời gian chạy cho các cuộc trò chuyện GUI Cursor mới. Mỗi thời gian chạy được cài đặt và xác thực riêng; các cuộc trò chuyện đang mở giữ nguyên thời gian chạy khi bắt đầu."
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "Chọn runtime hỗ trợ các cuộc trò chuyện GUI Cursor mới. Khóa API của hồ sơ áp dụng cho cả hai runtime."
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "Chọn runtime hỗ trợ các cuộc trò chuyện GUI Cursor mới. Khóa API của hồ sơ áp dụng cho cả hai runtime."
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12049,8 +12052,8 @@ msgid "The agent"
 msgstr "Tác nhân"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "Khóa API bên dưới được Cursor CLI, ACP và SDK dùng cho hồ sơ này."
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "Khóa API bên dưới được Cursor CLI, ACP và SDK dùng cho hồ sơ này."
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12250,6 +12253,10 @@ msgstr "Đang suy nghĩ"
 msgid "This agent is not installed."
 msgstr "Tác nhân này chưa được cài đặt."
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "Khóa API này xác thực các cuộc trò chuyện SDK của hồ sơ này và thẻ mức dùng. Nó không thay đổi đăng nhập CLI của ô Cursor chính."
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "Ứng dụng này được phục vụ qua HTTPS nhưng desktop dùng HTTP thường, bị trình duyệt chặn. Mở liên kết ghép đôi trực tiếp từ desktop (LAN), hoặc cung cấp desktop qua HTTPS."
@@ -12351,6 +12358,10 @@ msgstr "Cài đặt Poracode của plugin này bị bỏ qua vì không hợp l�
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "Không đọc được các skill của plugin này."
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "Hồ sơ này chạy trên Cursor SDK. Cursor CLI và ACP dùng chung một lần đăng nhập trên máy, nên chúng ở lại ô Cursor chính."
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -3492,6 +3492,10 @@ msgstr "创建"
 msgid "Create a pull request for candidate {0} ({label})"
 msgstr "为候选 {0}（{label}）创建拉取请求"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+msgid "Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "使用独立的用户 API 密钥创建第二个 Cursor 账号。Cursor CLI 和 ACP 在本机共享一次登录，因此它们留在主 Cursor 卡片上。"
+
 #: src/renderer/views/SchedulesView/SchedulesView.tsx
 msgid "Create a useful routine with one click, then adjust it anytime."
 msgstr "一键创建实用例程，之后可随时调整。"
@@ -3552,8 +3556,8 @@ msgid "Create scheduled task"
 msgstr "创建计划任务"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
-msgid "Create separate Cursor profiles with their own API keys."
-msgstr "创建使用各自 API 密钥的独立 Cursor 配置文件。"
+#~ msgid "Create separate Cursor profiles with their own API keys."
+#~ msgstr "创建使用各自 API 密钥的独立 Cursor 配置文件。"
 
 #: src/renderer/components/thread/ChatPane/parts/items/toolDisplay.ts
 msgid "Create task"
@@ -3725,7 +3729,6 @@ msgstr "Cursor"
 #~ msgid "Cursor ACP logged out."
 #~ msgstr "已退出 Cursor ACP。"
 
-#: src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
 msgid "Cursor CLI (ACP)"
 msgstr "Cursor CLI (ACP)"
@@ -8735,8 +8738,8 @@ msgid "Pick the runtime that backs new Cursor GUI chats. Each runtime installs a
 msgstr "选择用于新建 Cursor GUI 聊天的运行时。每个运行时单独安装并单独进行身份验证；已打开的聊天会保留启动时使用的运行时。"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
-msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
-msgstr "选择用于新 Cursor GUI 聊天的运行时。配置文件 API 密钥适用于两个运行时。"
+#~ msgid "Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both runtimes."
+#~ msgstr "选择用于新 Cursor GUI 聊天的运行时。配置文件 API 密钥适用于两个运行时。"
 
 #: src/renderer/views/MainView/parts/RightPanel/parts/BrowserPanel/hooks/useElementPicker.ts
 msgid "Picker failed"
@@ -12048,8 +12051,8 @@ msgid "The agent"
 msgstr "代理"
 
 #: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
-msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
-msgstr "下面的 API 密钥用于该配置文件的 Cursor CLI、ACP 和 SDK。"
+#~ msgid "The API key below is used by Cursor CLI, ACP, and SDK for this profile."
+#~ msgstr "下面的 API 密钥用于该配置文件的 Cursor CLI、ACP 和 SDK。"
 
 #: src/renderer/components/providers/usageFormat.ts
 msgid "the app"
@@ -12249,6 +12252,10 @@ msgstr "思考"
 msgid "This agent is not installed."
 msgstr "未安装此代理。"
 
+#: src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+msgid "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login."
+msgstr "此 API 密钥用于验证该配置文件的 SDK 对话及其用量卡片。它不会更改主 Cursor CLI 登录。"
+
 #: src/mobile/routeComponents.tsx
 #~ msgid "This app is served over HTTPS but the desktop is on plain HTTP, which browsers block. Open the pairing link directly from the desktop (LAN), or expose the desktop over HTTPS."
 #~ msgstr "此应用通过 HTTPS 提供，但桌面使用浏览器会阻止的普通 HTTP。请直接从桌面（LAN）打开配对链接，或通过 HTTPS 暴露桌面。"
@@ -12350,6 +12357,10 @@ msgstr "此插件的 Poracode 设置无效，已被忽略。"
 #: src/renderer/components/plugins/pluginCopy.ts
 msgid "This plugin's skills could not be read."
 msgstr "无法读取此插件的技能。"
+
+#: src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+msgid "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile."
+msgstr "此配置文件在 Cursor SDK 上运行。Cursor CLI 和 ACP 在本机共享一次登录，因此它们留在主 Cursor 卡片上。"
 
 #: src/renderer/components/skills/SkillsManager.tsx
 msgid "this project"

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -47,8 +47,8 @@ beforeEach(reset);
 describe("persisted agent status cache", () => {
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(12);
-    // Mirrors supervisor STATUS_CACHE_VERSION=15: a persisted antigravity
+    expect(options.version).toBe(14);
+    // Mirrors supervisor STATUS_CACHE_VERSION=16: a persisted antigravity
     // status from before the derivation would build the `agy` login command
     // without `AGY_CLI_DISABLE_AUTO_UPDATE`.
     const staleLogin = makeStatus({
@@ -77,7 +77,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(12);
+    expect(options.version).toBe(14);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -104,7 +104,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(12);
+    expect(options.version).toBe(14);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -263,16 +263,12 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 12,
-      // v12 mirrors the supervisor STATUS_CACHE_VERSION=15 bump: ACP-derived
-      // thinking toggles and normalized per-model capability maps now need a
-      // fresh detection. v11 covered terminal auth methods now carrying
-      // baseSpawnEnv-derived `env`, and a persisted status
-      // from before that derivation would build a login command without the
-      // provider's base env. This mirrors the supervisor cache invalidation,
-      // which only covers the supervisor's on-disk cache, not this localStorage
-      // copy. (v10 added ACP session readiness separately from authentication
-      // and normalized ACP approval-policy labels.)
+      version: 14,
+      // v14 mirrors the supervisor STATUS_CACHE_VERSION=17 bump: Cursor SDK
+      // runtime variants now carry their own account email. v13 covered
+      // Cursor profiles becoming SDK-only. This mirrors the supervisor cache
+      // invalidation, which only covers the supervisor's on-disk cache, not
+      // this localStorage copy.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
+++ b/src/renderer/views/SettingsOverlay/SettingsOverlay.tsx
@@ -8,6 +8,7 @@ import { usePanelStore } from "@/renderer/state/panelStore";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
 import { buildWslProjectDistrosKey } from "@/renderer/state/projectKeys";
 import { PageLayout } from "@/renderer/components/layout/PageLayout";
+import { agentStatusNeedsAuthAttention } from "@/shared/agentSelection";
 import { getSettingsInstalledAgents } from "@/shared/agentStatus";
 import { normalizeAnalyticsProvider } from "@/shared/analytics/posthogPrivacy";
 import { ProfileSettings } from "./parts/ProfileSettings";
@@ -184,7 +185,7 @@ export function SettingsOverlay(props: { onClose: () => void }) {
   const installedAgents = getSettingsInstalledAgents(agentStatuses, wslAgentStatuses);
   const attentionAgentKinds = new Set(
     [...agentStatuses, ...wslAgentStatuses]
-      .filter((status) => status.installed && status.authState === "missing")
+      .filter(agentStatusNeedsAuthAttention)
       .map((status) => status.kind),
   );
   const isAgentsSectionActive = activeSection === "agents" || activeSection.startsWith("agents:");

--- a/src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CursorProfileIdentity.tsx
@@ -72,7 +72,10 @@ export function CursorProfileIdentity(props: {
         <Trans>Profile</Trans>
       </p>
       <p className="mb-2 text-xs text-muted">
-        <Trans>The API key below is used by Cursor CLI, ACP, and SDK for this profile.</Trans>
+        <Trans>
+          This API key authenticates this profile's SDK chats and its usage card. It does not change
+          the main Cursor CLI login.
+        </Trans>
       </p>
       <div className="space-y-1.5">
         <CursorRuntimeCardRow

--- a/src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CursorProfileSettings.tsx
@@ -1,31 +1,31 @@
 import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
-import type { AgentInstanceConfig, AgentStatus } from "@/shared/contracts";
-import { cursorProfileKind } from "@/shared/contracts";
+import type { AgentInstanceConfig } from "@/shared/contracts";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import type { NativeAgentProfileSupport } from "./agentRegistryNative";
-import { cursorRuntimeInstallState } from "./cursorRuntimeInstall";
 
 /**
- * Every Cursor profile has its own key, so naming that in the list would say
- * nothing; the runtime it launches on is what differs. A profile with no saved
- * choice runs on the SDK — the supervisor's default.
+ * Cursor CLI cannot isolate a second login, so every profile is an SDK
+ * account. The list subtitle names that runtime rather than repeating the key.
  */
-function CursorProfileRuntimeLabel(props: { instance: AgentInstanceConfig }) {
+function CursorProfileRuntimeLabel(_props: { instance: AgentInstanceConfig }) {
   const { t } = useLingui();
-  const saved = useSharedSettings(
-    (state) => state.agentSettings[cursorProfileKind(props.instance.id)],
-  );
-  return saved?.structuredRuntime === "acp" ? t`Cursor CLI (ACP)` : t`Cursor SDK`;
+  return t`Cursor SDK`;
 }
 
 /**
- * Cursor's profile descriptor: one API key per profile, carried into the CLI,
- * ACP and SDK runtimes. Everything structural lives in `AgentProfileList`.
+ * Cursor's profile descriptor: a second account via User API key, running on
+ * the SDK. CLI/ACP stay on the main Cursor tile. Everything structural lives
+ * in `AgentProfileList`.
  */
 export const cursorProfileSupport: NativeAgentProfileSupport = {
   driver: "cursor",
-  description: <Trans>Create separate Cursor profiles with their own API keys.</Trans>,
+  description: (
+    <Trans>
+      Create a second Cursor account with its own User API key. Cursor CLI and ACP share one machine
+      login, so they stay on the main Cursor tile.
+    </Trans>
+  ),
   field: {
     ariaLabel: msg`New Cursor profile API key`,
     placeholder: msg`Paste Cursor API key`,
@@ -45,17 +45,7 @@ export const cursorProfileSupport: NativeAgentProfileSupport = {
     displayName,
     environment: { CURSOR_API_KEY: { value: field, sensitive: true } },
   }),
-  onCreated: ({ profileKind, statuses }) => {
-    // Pin the runtime rather than leaning on the implicit SDK default: on a
-    // machine without `@cursor/sdk` that default leaves the profile pointing at
-    // a runtime it cannot start, with nothing in the UI explaining why. The
-    // package is shared by every Cursor kind, so the base provider's detection
-    // answers whether the SDK is available.
-    const sdkInstalled = statuses.some(
-      (status: AgentStatus) => cursorRuntimeInstallState(status).sdkInstalled,
-    );
-    useSharedSettings
-      .getState()
-      .setAgentSetting(profileKind, "structuredRuntime", sdkInstalled ? "sdk" : "acp");
+  onCreated: ({ profileKind }) => {
+    useSharedSettings.getState().setAgentSetting(profileKind, "structuredRuntime", "sdk");
   },
 };

--- a/src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.test.tsx
@@ -601,11 +601,12 @@ describe("CursorProviderSettings", () => {
     const field = screen.getByLabelText("Cursor profile API key");
     expect(field).toHaveValue("***********");
     expect(
-      screen.getByText("The API key below is used by Cursor CLI, ACP, and SDK for this profile."),
+      screen.getByText(
+        "This API key authenticates this profile's SDK chats and its usage card. It does not change the main Cursor CLI login.",
+      ),
     ).toBeTruthy();
-    expect(screen.getByRole("radiogroup", { name: "Structured runtime" }).contains(field)).toBe(
-      false,
-    );
+    expect(screen.queryByRole("radiogroup", { name: "Structured runtime" })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /ACP/ })).toBeNull();
     fireEvent.focus(field);
     fireEvent.change(field, { target: { value: " replacement-key " } });
     fireEvent.click(screen.getByRole("button", { name: "Save Cursor profile API key" }));
@@ -683,6 +684,57 @@ describe("CursorProviderSettings", () => {
     ).toHaveLength(2);
     // The SDK card carries its own API key state; ACP auth lives with the CLI.
     expect(screen.getByText("Authenticated")).toBeInTheDocument();
+  });
+
+  it("shows the SDK account email on the main SDK card", () => {
+    const withEmail: AgentStatus = {
+      ...runtimeStatus,
+      runtimeVariants: {
+        ...runtimeStatus.runtimeVariants,
+        sdk: {
+          ...runtimeStatus.runtimeVariants!.sdk!,
+          providerMetadata: { authenticatedAs: "sdk@example.com" },
+        },
+      },
+    };
+    render(<CursorProviderSettings agentKind="cursor" statuses={[withEmail]} wslDistros={[]} />);
+
+    expect(screen.getByText("Installed · Authenticated · sdk@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Authenticated · sdk@example.com")).toBeInTheDocument();
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === "Installed · Authenticated"),
+    ).toHaveLength(1);
+  });
+
+  it("shows the SDK account email on a Cursor profile", () => {
+    useSharedSettings.setState({
+      agentInstances: {
+        work: {
+          id: "work",
+          driver: "cursor",
+          displayName: "Work",
+          environment: { CURSOR_API_KEY: { value: "lc-safe:encrypted", sensitive: true } },
+        },
+      },
+    });
+    const withEmail: AgentStatus = {
+      ...runtimeStatus,
+      kind: "cursor:work",
+      label: "Cursor Work",
+      runtimeVariants: {
+        ...runtimeStatus.runtimeVariants,
+        sdk: {
+          ...runtimeStatus.runtimeVariants!.sdk!,
+          providerMetadata: { authenticatedAs: "work@yieldmo.com" },
+        },
+      },
+    };
+    render(
+      <CursorProviderSettings agentKind="cursor:work" statuses={[withEmail]} wslDistros={[]} />,
+    );
+
+    expect(screen.getAllByText("Authenticated · work@yieldmo.com").length).toBeGreaterThan(0);
+    expect(screen.getByText("Installed · Authenticated · work@yieldmo.com")).toBeInTheDocument();
   });
 
   it("combines runtime availability detected in different environments", () => {
@@ -857,7 +909,7 @@ describe("CursorProviderSettings", () => {
     expect(setAgentSettingMock).toHaveBeenLastCalledWith("cursor", "structuredRuntime", "acp");
   });
 
-  it("persists a profile runtime choice under the profile kind", async () => {
+  it("does not offer CLI or ACP on a Cursor profile", () => {
     render(
       <CursorProviderSettings
         agentKind="cursor:work"
@@ -866,36 +918,14 @@ describe("CursorProviderSettings", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: /ACP/ }));
-
-    await vi.waitFor(() => {
-      expect(bridgeMock.refreshAgentStatuses).toHaveBeenCalledWith([], {
-        agentKinds: ["cursor:work"],
-      });
-    });
-    expect(setAgentSettingMock).toHaveBeenCalledWith("cursor:work", "structuredRuntime", "acp");
-    expect(flushSharedSettingsMock.mock.invocationCallOrder[0]).toBeLessThan(
-      bridgeMock.refreshAgentStatuses.mock.invocationCallOrder[0]!,
-    );
-  });
-
-  it("restores a profile runtime choice when the settings flush fails", async () => {
-    flushSharedSettingsMock.mockRejectedValueOnce(new Error("write failed"));
-    render(
-      <CursorProviderSettings
-        agentKind="cursor:work"
-        statuses={[{ ...runtimeStatus, kind: "cursor:work", label: "Cursor Work" }]}
-        wslDistros={[]}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("radio", { name: /ACP/ }));
-
-    await act(async () => {
-      await vi.waitFor(() => expect(toastMock.danger).toHaveBeenCalled());
-    });
-    expect(bridgeMock.refreshAgentStatuses).not.toHaveBeenCalled();
-    expect(setAgentSettingMock).toHaveBeenLastCalledWith("cursor:work", "structuredRuntime", "sdk");
+    expect(screen.queryByRole("radiogroup", { name: "Structured runtime" })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /ACP/ })).toBeNull();
+    expect(screen.getByText("Cursor SDK")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so they stay on the main Cursor tile.",
+      ),
+    ).toBeTruthy();
   });
 
   it("saves an SDK API key through the encrypted setting path and refreshes detection", async () => {
@@ -975,7 +1005,7 @@ describe("CursorProviderSettings", () => {
     expect(bridgeMock.createProfile).not.toHaveBeenCalled();
   });
 
-  it("pins the ACP runtime for a new profile when @cursor/sdk is missing", async () => {
+  it("pins the SDK runtime for a new profile even when @cursor/sdk is missing", async () => {
     const withoutSdk: AgentStatus = {
       ...runtimeStatus,
       runtimeVariants: {
@@ -995,7 +1025,7 @@ describe("CursorProviderSettings", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create profile" }));
 
     await vi.waitFor(() =>
-      expect(setAgentSettingMock).toHaveBeenCalledWith("cursor:work", "structuredRuntime", "acp"),
+      expect(setAgentSettingMock).toHaveBeenCalledWith("cursor:work", "structuredRuntime", "sdk"),
     );
   });
 
@@ -1016,7 +1046,7 @@ describe("CursorProviderSettings", () => {
     expect(screen.getByRole("button", { name: "Remove profile Work" })).toBeTruthy();
   });
 
-  it("labels each profile row with the runtime it launches on", () => {
+  it("labels each profile row as Cursor SDK", () => {
     useSharedSettings.setState({
       agentInstances: {
         work: { id: "work", driver: "cursor", displayName: "Work" },
@@ -1028,10 +1058,8 @@ describe("CursorProviderSettings", () => {
       <CursorProviderSettings agentKind="cursor" statuses={[runtimeStatus]} wslDistros={[]} />,
     );
 
-    // "Personal" pinned ACP; "Work" has no saved choice and follows the
-    // supervisor's SDK default.
     const rowText = screen.getAllByRole("button").map((button) => button.textContent);
-    expect(rowText).toContain("PersonalCursor CLI (ACP)");
+    expect(rowText).toContain("PersonalCursor SDK");
     expect(rowText).toContain("WorkCursor SDK");
   });
 

--- a/src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/CursorProviderSettings.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { RadioGroup, toast } from "@heroui/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { readBridge } from "@/renderer/bridge";
+import { useProviderUsage } from "@/renderer/state/providerUsageStore";
 import { flushSharedSettings, useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import {
   cursorProfileKind,
@@ -70,16 +71,35 @@ export function CursorProviderSettings(props: {
   const sdkVariant = sdkStatus?.runtimeVariants?.sdk;
   const acpAuthState = acpVariant?.authState ?? acpStatus?.authState ?? "unknown";
   const sdkAuthState = sdkVariant?.authState ?? "unknown";
+  const providerUsage = useProviderUsage(agentKind);
+  const sdkAccountEmail =
+    sdkVariant?.providerMetadata?.authenticatedAs?.trim() ||
+    (profileInstanceId && providerUsage?.status === "ok"
+      ? providerUsage.authenticatedAs?.trim()
+      : undefined);
 
-  const authLabel = (authState: AuthState, runtime: CursorStructuredRuntime) => {
-    if (authState === "authenticated") return t`Authenticated`;
+  const authLabel = (
+    authState: AuthState,
+    runtime: CursorStructuredRuntime,
+    accountEmail?: string,
+  ) => {
+    if (authState === "authenticated") {
+      return accountEmail ? `${t`Authenticated`} · ${accountEmail}` : t`Authenticated`;
+    }
     if (authState === "missing") {
       return runtime === "sdk" ? t`API key required` : t`Sign in required`;
     }
     return t`Authentication unavailable`;
   };
-  const statusLine = (installed: boolean, authState: AuthState, runtime: CursorStructuredRuntime) =>
-    installed ? `${t`Installed`} · ${authLabel(authState, runtime)}` : t`Not installed`;
+  const statusLine = (
+    installed: boolean,
+    authState: AuthState,
+    runtime: CursorStructuredRuntime,
+    accountEmail?: string,
+  ) =>
+    installed
+      ? `${t`Installed`} · ${authLabel(authState, runtime, accountEmail)}`
+      : t`Not installed`;
   const detailLine = (capabilities: AgentCapability | undefined) => {
     if (!capabilities?.models.length) return undefined;
     const modes = capabilities.modes.map((mode) =>
@@ -121,35 +141,64 @@ export function CursorProviderSettings(props: {
     await flushSharedSettings();
   };
 
-  return (
-    <div className="border-t border-border/10 pt-3">
-      {profileInstanceId ? (
+  const sdkSetup = (
+    <CursorSdkRuntimeSetup
+      agentKind={agentKind}
+      {...(profileInstanceId ? { profileInstanceId } : {})}
+      status={sdkStatus}
+      authDescription={authLabel(sdkAuthState, "sdk", sdkAccountEmail)}
+      refreshStatus={refreshStatus}
+      refreshPackageStatus={refreshPackageStatus}
+      onApiKeyCleared={fallBackToAcp}
+    />
+  );
+
+  if (profileInstanceId) {
+    return (
+      <div className="border-t border-border/10 pt-3">
         <CursorProfileIdentity
           agentKind={agentKind}
           profileInstanceId={profileInstanceId}
-          // The SDK probe authenticates with the key itself, so it is the only
-          // runtime whose state answers "is this key good?" — ACP runs through
-          // the CLI and can report success from an ambient machine login.
-          authDescription={authLabel(sdkAuthState, "sdk")}
+          authDescription={authLabel(sdkAuthState, "sdk", sdkAccountEmail)}
           refreshStatus={refreshStatus}
         />
-      ) : null}
+        <div className="mb-2">
+          <p className="text-sm font-medium text-foreground">
+            <Trans>Cursor SDK</Trans>
+          </p>
+          <p className="text-xs text-muted">
+            <Trans>
+              This profile runs on the Cursor SDK. Cursor CLI and ACP share one machine login, so
+              they stay on the main Cursor tile.
+            </Trans>
+          </p>
+        </div>
+        <div className="rounded-lg border border-border/40 bg-surface-secondary/35">
+          <div className="px-3 py-2">
+            <p className="text-xs text-muted">
+              {statusLine(sdkInstallState.sdkInstalled, sdkAuthState, "sdk", sdkAccountEmail)}
+            </p>
+            {sdkDetailLine ? (
+              <p className="mt-0.5 text-[11px] text-muted/80">{sdkDetailLine}</p>
+            ) : null}
+          </div>
+          <div className="space-y-1.5 border-t border-border/10 px-3 py-2">{sdkSetup}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border/10 pt-3">
       <div className="mb-2">
         <p className="text-sm font-medium text-foreground">
           <Trans>GUI runtime</Trans>
         </p>
         <p className="text-xs text-muted">
-          {profileInstanceId ? (
-            <Trans>
-              Pick the runtime that backs new Cursor GUI chats. The profile API key applies to both
-              runtimes.
-            </Trans>
-          ) : (
-            <Trans>
-              Pick the runtime that backs new Cursor GUI chats. Each runtime installs and
-              authenticates on its own; open chats keep the runtime they started with.
-            </Trans>
-          )}
+          <Trans>
+            Pick the runtime that backs new Cursor GUI chats. Each runtime installs and
+            authenticates on its own; open chats keep the runtime they started with.
+          </Trans>
         </p>
       </div>
 
@@ -178,27 +227,22 @@ export function CursorProviderSettings(props: {
           label={t`Cursor SDK`}
           isSelected={selectedRuntime === "sdk"}
           isSelectable={sdkInstallState.sdkInstalled && sdkAuthState === "authenticated"}
-          statusLine={statusLine(sdkInstallState.sdkInstalled, sdkAuthState, "sdk")}
+          statusLine={statusLine(
+            sdkInstallState.sdkInstalled,
+            sdkAuthState,
+            "sdk",
+            sdkAccountEmail,
+          )}
           {...(sdkDetailLine ? { detailLine: sdkDetailLine } : {})}
         >
-          <CursorSdkRuntimeSetup
-            agentKind={agentKind}
-            {...(profileInstanceId ? { profileInstanceId } : {})}
-            status={sdkStatus}
-            authDescription={authLabel(sdkAuthState, "sdk")}
-            refreshStatus={refreshStatus}
-            refreshPackageStatus={refreshPackageStatus}
-            onApiKeyCleared={fallBackToAcp}
-          />
+          {sdkSetup}
         </CursorRuntimeCard>
       </RadioGroup>
-      {profileInstanceId === undefined ? (
-        <AgentProfileList
-          profiles={cursorProfileSupport}
-          {...(statuses ? { statuses } : {})}
-          onOpenProfile={props.onOpenProfile}
-        />
-      ) : null}
+      <AgentProfileList
+        profiles={cursorProfileSupport}
+        {...(statuses ? { statuses } : {})}
+        onOpenProfile={props.onOpenProfile}
+      />
     </div>
   );
 }

--- a/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/SingleAgentSettings/SingleAgentSettings.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   baseAgentKind,
   extractAcpGenericInstanceId,
+  isCursorProfileKind,
   parseAgentProfileKind,
 } from "@/shared/contracts";
 import { friendlyError } from "@/shared/messages";
@@ -999,11 +1000,13 @@ export function SingleAgentSettings(props: {
         )}
       </div>
 
-      <HookPluginSettings
-        agentKind={agent.kind}
-        agentLabel={agent.label}
-        statuses={installedStatuses}
-      />
+      {isCursorProfileKind(agent.kind) ? null : (
+        <HookPluginSettings
+          agentKind={agent.kind}
+          agentLabel={agent.label}
+          statuses={installedStatuses}
+        />
+      )}
     </div>
   );
 }

--- a/src/shared/agentSelection.test.ts
+++ b/src/shared/agentSelection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentCapability, AgentStatus, SessionRef } from "./contracts";
 import {
   agentStatusForPresentation,
+  agentStatusNeedsAuthAttention,
   authStatusForPresentation,
   authStateForPresentation,
   capabilitiesForPresentation,
@@ -302,5 +303,75 @@ describe("agent selection", () => {
     const terminal = agentStatusForPresentation(status, "terminal", sessionRef("run:sdk:123"));
     expect(terminal.installed).toBe(true);
     expect(terminal.capabilities.models[0]?.id).toBe("terminal-model");
+  });
+
+  it("does not flag Cursor as needing login when the SDK runtime is authenticated", () => {
+    expect(
+      agentStatusNeedsAuthAttention({
+        installed: true,
+        authState: "missing",
+        runtimeVariants: {
+          acp: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "missing",
+            authUsesProviderLogin: true,
+            capabilities,
+          },
+          sdk: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "authenticated",
+            authUsesProviderLogin: false,
+            capabilities,
+          },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      agentStatusNeedsAuthAttention({
+        installed: true,
+        authState: "missing",
+        runtimeVariants: {
+          acp: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "missing",
+            authUsesProviderLogin: true,
+            capabilities,
+          },
+          sdk: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "missing",
+            authUsesProviderLogin: false,
+            capabilities,
+          },
+        },
+      }),
+    ).toBe(true);
+    expect(agentStatusNeedsAuthAttention({ installed: true, authState: "missing" })).toBe(true);
+    expect(
+      agentStatusNeedsAuthAttention({
+        installed: true,
+        authState: "missing",
+        runtimeVariants: {
+          acp: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "missing",
+            authUsesProviderLogin: true,
+            capabilities,
+          },
+          sdk: {
+            presentationMode: "gui",
+            installed: true,
+            authState: "unknown",
+            authUsesProviderLogin: false,
+            capabilities,
+          },
+        },
+      }),
+    ).toBe(true);
   });
 });

--- a/src/shared/agentSelection.ts
+++ b/src/shared/agentSelection.ts
@@ -26,6 +26,25 @@ export function authStateForPresentation(
   return status.presentationAuthStates?.[presentationMode] ?? status.authState;
 }
 
+/**
+ * Whether Settings should flag this provider as needing sign-in. Providers with
+ * independently authenticated runtimes (Cursor CLI vs SDK) are ready when any
+ * installed runtime is signed in — picking SDK on the main tile must not look
+ * like a CLI logout.
+ */
+export function agentStatusNeedsAuthAttention(
+  status: Pick<AgentStatus, "installed" | "authState" | "runtimeVariants">,
+): boolean {
+  if (!status.installed) return false;
+  const variants = status.runtimeVariants;
+  if (variants && Object.keys(variants).length > 0) {
+    const installed = Object.values(variants).filter((variant) => variant.installed);
+    if (installed.length === 0) return status.authState === "missing";
+    return !installed.some((variant) => variant.authState === "authenticated");
+  }
+  return status.authState === "missing";
+}
+
 export function authStatusForPresentation(
   status: AgentStatus,
   presentationMode: ThreadPresentationMode,

--- a/src/shared/contracts/agent.ts
+++ b/src/shared/contracts/agent.ts
@@ -385,6 +385,11 @@ export const agentRuntimeVariantSchema = z.object({
   authState: authStateSchema,
   authUsesProviderLogin: z.boolean(),
   capabilities: agentCapabilitySchema,
+  /**
+   * Runtime-specific account identity. Cursor's SDK key is a different login
+   * from the CLI/ACP session, so the SDK card must not reuse root metadata.
+   */
+  providerMetadata: agentProviderMetadataSchema.optional(),
 });
 export type AgentRuntimeVariant = z.infer<typeof agentRuntimeVariantSchema>;
 

--- a/src/supervisor/agents/cursor/cursor.test.ts
+++ b/src/supervisor/agents/cursor/cursor.test.ts
@@ -60,7 +60,7 @@ describe("createCursorAdapter capabilities", () => {
     expect(adapter.createStructuredSession).toBeTypeOf("function");
   });
 
-  it("creates a profile adapter whose key applies to every process lane", () => {
+  it("creates a profile adapter that does not inject its key into CLI/ACP spawns", () => {
     const adapter = createCursorProfileAdapter({
       id: "work",
       driver: "cursor",
@@ -70,7 +70,8 @@ describe("createCursorAdapter capabilities", () => {
 
     expect(adapter.kind).toBe("cursor:work");
     expect(adapter.label).toBe("Cursor Work");
-    expect(adapter.baseSpawnEnv).toEqual({ CURSOR_API_KEY: "profile-key" });
+    expect(adapter.baseSpawnEnv).toBeUndefined();
+    expect(adapter.capabilities.presentationModes).toEqual(["gui"]);
   });
 
   it("defaults new Cursor profile GUI sessions to the SDK runtime", async () => {
@@ -85,7 +86,7 @@ describe("createCursorAdapter capabilities", () => {
       projectLocation: { kind: "posix", path: "/repo" },
       config: { model: "composer-2.5" },
       presentationMode: "gui",
-      ...(adapter.baseSpawnEnv ? { baseSpawnEnv: adapter.baseSpawnEnv } : {}),
+      agentSettings: { structuredRuntime: "acp" },
     });
 
     expect(session).toBeInstanceOf(CursorSdkSession);

--- a/src/supervisor/agents/cursor/cursorUsageProfiles.ts
+++ b/src/supervisor/agents/cursor/cursorUsageProfiles.ts
@@ -1,0 +1,51 @@
+import { collectCursorFromApiKey, type HostPort, type UsageSnapshot } from "@poracode/agents-usage";
+import { cursorProfileKind } from "@/shared/contracts";
+import type { SharedSettings } from "@/shared/settings";
+
+/**
+ * Cursor profiles cannot isolate `cursor-agent login`, so each profile's usage
+ * is the User API key's own billing period — the same exchange cursor-agent
+ * performs when `CURSOR_API_KEY` is set.
+ */
+
+export interface CursorUsageProfile {
+  providerId: string;
+  apiKey: string;
+}
+
+/** Enabled Cursor profile instances as usage providers, keyed by provider id. */
+export function readCursorUsageProfiles(settings: SharedSettings): Map<string, CursorUsageProfile> {
+  const profiles = new Map<string, CursorUsageProfile>();
+  for (const instance of Object.values(settings.agentInstances)) {
+    if (instance.enabled === false || instance.driver !== "cursor") continue;
+    const apiKey = instance.environment?.CURSOR_API_KEY?.value.trim();
+    if (!apiKey) continue;
+    profiles.set(cursorProfileKind(instance.id), {
+      providerId: cursorProfileKind(instance.id),
+      apiKey,
+    });
+  }
+  return profiles;
+}
+
+/**
+ * Collect usage for one Cursor profile from its User API key. Never throws
+ * into the refresh — failures come back as an error / auth-missing snapshot.
+ */
+export async function collectCursorProfile(
+  profile: CursorUsageProfile,
+  host: HostPort,
+): Promise<UsageSnapshot> {
+  const now = host.now();
+  try {
+    return await collectCursorFromApiKey(host, profile.apiKey, profile.providerId);
+  } catch (error) {
+    return {
+      providerId: profile.providerId,
+      status: "error",
+      windows: [],
+      fetchedAt: now,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/supervisor/agents/cursor/index.ts
+++ b/src/supervisor/agents/cursor/index.ts
@@ -1,4 +1,4 @@
-import type { AgentInstanceConfig, PromptSegment } from "@/shared/contracts";
+import type { AgentInstanceConfig, AgentStatus, PromptSegment } from "@/shared/contracts";
 import { cursorProfileKind } from "@/shared/contracts";
 import { inlinePromptSegmentText } from "@/shared/promptContent";
 import { createAcpStructuredSession } from "../acp";
@@ -82,15 +82,20 @@ function cursorHookActiveTerminalFallback(hint: TerminalStatusHint): boolean {
   return hint.status === "needs_approval";
 }
 
-function withoutCursorProfileLogin(status: Awaited<ReturnType<typeof detectAgentInstall>>) {
-  const {
-    authLogoutSupported: _authLogoutSupported,
-    authMethods: _authMethods,
-    loginCommand: _loginCommand,
-    preferTerminalLogin: _preferTerminalLogin,
-    ...profileStatus
-  } = status;
-  return profileStatus;
+function cursorProfileCliStub(kind: string, label: string): AgentStatus {
+  return {
+    kind,
+    label,
+    installed: false,
+    authState: "unknown",
+    capabilities: {
+      ...cursorDefaultCapabilities,
+      presentationMode: "gui",
+      presentationModes: ["gui"],
+      liveInputMode: "server",
+      supportsOneShot: false,
+    },
+  };
 }
 
 /**
@@ -108,17 +113,9 @@ export function rewriteCursorLoadSessionError(error: unknown, _sessionId: string
 export function createCursorAdapter(options: CursorAdapterOptions = {}): AgentAdapter {
   const kind = options.kind ?? cursorDetectionSpec.kind;
   const label = options.label ?? cursorDetectionSpec.label;
-  const detectionSpec = options.apiKey
-    ? {
-        ...cursorDetectionSpec,
-        kind,
-        label,
-        baseSpawnEnv: {
-          ...cursorDetectionSpec.baseSpawnEnv,
-          CURSOR_API_KEY: options.apiKey,
-        },
-      }
-    : cursorDetectionSpec;
+  const isProfile = Boolean(options.apiKey);
+  const detectionSpec = isProfile ? { ...cursorDetectionSpec, kind, label } : cursorDetectionSpec;
+  const profileKeyEnv = options.apiKey ? { CURSOR_API_KEY: options.apiKey } : undefined;
   return {
     kind,
     label,
@@ -165,13 +162,21 @@ export function createCursorAdapter(options: CursorAdapterOptions = {}): AgentAd
         project: ["cursor", "agents", "claude", "codex"],
       },
     },
-    ...(detectionSpec.update ? { update: detectionSpec.update } : {}),
+    ...(isProfile || !detectionSpec.update ? {} : { update: detectionSpec.update }),
     ...inheritBaseSpawnEnv(detectionSpec),
     // Detection returns environment-scoped capabilities through AgentStatus.
     // Keep the adapter's process-wide fallback immutable: native and WSL
     // probes run concurrently, and a mutable singleton lets the last probe
     // change routing for every other environment.
-    capabilities: cursorDefaultCapabilities,
+    capabilities: isProfile
+      ? {
+          ...cursorDefaultCapabilities,
+          presentationMode: "gui",
+          presentationModes: ["gui"],
+          liveInputMode: "server",
+          supportsOneShot: false,
+        }
+      : cursorDefaultCapabilities,
     spawnEnv: { wsl: { BROWSER: "/bin/true" } },
     pluginId: "poracode-status@cursor",
     pluginVersion: CURSOR_PLUGIN_VERSION,
@@ -195,25 +200,21 @@ export function createCursorAdapter(options: CursorAdapterOptions = {}): AgentAd
     },
 
     detectInstall: async (ctx) => {
+      // Cursor CLI stores one machine-wide login. Profiles are a second
+      // account via User API key, so they never probe or spawn `cursor-agent`
+      // — that would share (or overwrite) the main tile's CLI/ACP session.
+      if (options.apiKey) {
+        const sdkProbe = await probeCursorSdkRuntime(ctx, {}, options.apiKey);
+        return applyCursorSdkProbe(cursorProfileCliStub(kind, label), sdkProbe, "sdk");
+      }
       const [detectedCliStatus, sdkProbe] = await Promise.all([
         detectAgentInstall(ctx, detectionSpec),
-        options.apiKey
-          ? probeCursorSdkRuntime(ctx, {}, options.apiKey)
-          : probeCursorSdkRuntime(ctx),
+        probeCursorSdkRuntime(ctx),
       ]);
-      // `baseSpawnEnv` intentionally carries the profile key into every real
-      // provider process. Detection also uses it to decorate renderer-driven
-      // terminal login methods, so remove those methods for profiles before
-      // the status crosses IPC; the encrypted profile editor owns auth.
-      const cliStatus = options.apiKey
-        ? withoutCursorProfileLogin(detectedCliStatus)
-        : detectedCliStatus;
       return applyCursorSdkProbe(
-        cliStatus,
+        detectedCliStatus,
         sdkProbe,
-        options.apiKey && ctx?.agentSettings?.structuredRuntime === undefined
-          ? "sdk"
-          : configuredCursorStructuredRuntime(ctx?.agentSettings),
+        configuredCursorStructuredRuntime(ctx?.agentSettings),
       );
     },
     // Cursor CLI has no documented per-launch MCP config or isolated config
@@ -240,14 +241,12 @@ export function createCursorAdapter(options: CursorAdapterOptions = {}): AgentAd
           ? {
               ...input.agentSettings,
               sdkApiKey: options.apiKey,
-              ...(input.agentSettings?.structuredRuntime === undefined
-                ? { structuredRuntime: "sdk" }
-                : {}),
+              ...(input.sessionRef ? {} : { structuredRuntime: "sdk" as const }),
             }
           : input.agentSettings;
         const resolved = resolveCursorStructuredRuntime(agentSettings, input.sessionRef);
         if (resolved.runtime === "sdk") {
-          const env = mergeSpawnEnv(input.env, input.baseSpawnEnv);
+          const env = mergeSpawnEnv(input.env, mergeSpawnEnv(input.baseSpawnEnv, profileKeyEnv));
           return CursorSdkSession.create({
             ...input,
             ...(agentSettings ? { agentSettings } : {}),
@@ -256,8 +255,10 @@ export function createCursorAdapter(options: CursorAdapterOptions = {}): AgentAd
         }
       }
       const command = buildCursorAgentCommand(input.projectLocation, ["acp"]);
+      const acpEnv = mergeSpawnEnv(input.baseSpawnEnv, profileKeyEnv);
       return createAcpStructuredSession(command, {
         ...input,
+        ...(acpEnv ? { baseSpawnEnv: acpEnv } : {}),
         loadSessionErrorRewriter: rewriteCursorLoadSessionError,
         acpSessionUpdateTransform: transformCursorAcpSessionUpdate,
         acpExtensionNotificationHandler: handleCursorAcpExtensionNotification,

--- a/src/supervisor/agents/cursor/sdkAccount.test.ts
+++ b/src/supervisor/agents/cursor/sdkAccount.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { probeCursorSdkAccountEmail, readCursorSdkAccountEmail } from "./sdkAccount";
+
+describe("readCursorSdkAccountEmail", () => {
+  it("reads Cursor.me() SDKUser.userEmail", () => {
+    expect(readCursorSdkAccountEmail({ userEmail: " work@example.com " })).toBe("work@example.com");
+  });
+
+  it("falls back to email on auth.status-shaped payloads", () => {
+    expect(readCursorSdkAccountEmail({ status: "logged-in", email: "me@cursor.com" })).toBe(
+      "me@cursor.com",
+    );
+  });
+
+  it("ignores blank or non-object payloads", () => {
+    expect(readCursorSdkAccountEmail(undefined)).toBeUndefined();
+    expect(readCursorSdkAccountEmail({ userEmail: "  " })).toBeUndefined();
+    expect(readCursorSdkAccountEmail("work@example.com")).toBeUndefined();
+  });
+});
+
+describe("probeCursorSdkAccountEmail", () => {
+  it("calls Cursor.me with the same apiKey used for catalog reads", async () => {
+    const seen: unknown[] = [];
+    const email = await probeCursorSdkAccountEmail(
+      {
+        me: async (options: unknown) => {
+          seen.push(options);
+          return { userEmail: "work@example.com", apiKeyName: "cli" };
+        },
+      },
+      "crsr_work",
+    );
+    expect(seen).toEqual([{ apiKey: "crsr_work" }]);
+    expect(email).toBe("work@example.com");
+  });
+
+  it("does not fail the probe when Cursor.me is missing or rejects", async () => {
+    await expect(probeCursorSdkAccountEmail(undefined)).resolves.toBeUndefined();
+    await expect(probeCursorSdkAccountEmail({})).resolves.toBeUndefined();
+    await expect(
+      probeCursorSdkAccountEmail({
+        me: async () => {
+          throw new Error("network");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/supervisor/agents/cursor/sdkAccount.ts
+++ b/src/supervisor/agents/cursor/sdkAccount.ts
@@ -1,0 +1,30 @@
+/**
+ * Best-effort identity from `@cursor/sdk`. `Cursor.me({ apiKey })` returns
+ * `SDKUser`; older / partial payloads may only have `email`. Account identity
+ * is supplemental — a missing or failing `me()` must not fail model probing.
+ */
+
+export function readCursorSdkAccountEmail(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  for (const key of ["userEmail", "email"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return undefined;
+}
+
+export async function probeCursorSdkAccountEmail(
+  cursor: unknown,
+  apiKey?: string,
+): Promise<string | undefined> {
+  if (!cursor || typeof cursor !== "object") return undefined;
+  const me = (cursor as { me?: unknown }).me;
+  if (typeof me !== "function") return undefined;
+  try {
+    const account = await me(apiKey ? { apiKey } : undefined);
+    return readCursorSdkAccountEmail(account);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/supervisor/agents/cursor/sdkAdapterDetection.test.ts
+++ b/src/supervisor/agents/cursor/sdkAdapterDetection.test.ts
@@ -112,22 +112,12 @@ describe("Cursor adapter SDK detection selection", () => {
     );
   });
 
-  it("keeps a profile key out of renderer-visible login metadata", async () => {
-    mocks.detectAgentInstall.mockResolvedValue({
-      ...cliStatus,
-      loginCommand: "cursor-agent login",
-      authLogoutSupported: true,
-      authMethods: [
-        {
-          type: "terminal",
-          id: "cursor-login",
-          name: "Cursor login",
-          args: ["login"],
-          env: { CURSOR_API_KEY: "profile-key" },
-        },
-      ],
-    });
-    mocks.applyCursorSdkProbe.mockImplementation((status) => status);
+  it("probes a profile through the SDK only and never runs cursor-agent", async () => {
+    mocks.applyCursorSdkProbe.mockImplementation((status, probe) => ({
+      ...status,
+      installed: probe.installed,
+      authState: probe.authState,
+    }));
     const adapter = createCursorProfileAdapter({
       id: "work",
       driver: "cursor",
@@ -136,14 +126,22 @@ describe("Cursor adapter SDK detection selection", () => {
 
     const result = await adapter.detectInstall({ envKind: "posix" });
 
-    expect(result).not.toHaveProperty("loginCommand");
-    expect(result).not.toHaveProperty("authMethods");
-    expect(result).not.toHaveProperty("authLogoutSupported");
+    expect(mocks.detectAgentInstall).not.toHaveBeenCalled();
     expect(mocks.probeCursorSdkRuntime).toHaveBeenCalledWith(
       expect.objectContaining({ envKind: "posix" }),
       {},
       "profile-key",
     );
+    expect(mocks.applyCursorSdkProbe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "cursor:work",
+        installed: false,
+        capabilities: expect.objectContaining({ presentationModes: ["gui"] }),
+      }),
+      expect.objectContaining({ models: [{ id: "sdk-model", displayName: "SDK Model" }] }),
+      "sdk",
+    );
+    expect(result.authState).toBe("authenticated");
   });
 
   it("keeps process-wide routing immutable across divergent environment probes", async () => {

--- a/src/supervisor/agents/cursor/sdkDetection.test.ts
+++ b/src/supervisor/agents/cursor/sdkDetection.test.ts
@@ -9,6 +9,7 @@ function worker(input: {
     models: Array<{ id: string; displayName: string }>;
     sdkVersion: string;
     source: "configured" | "global-npm";
+    authenticatedAs?: string;
   }>;
 }) {
   return {
@@ -53,6 +54,24 @@ describe("probeCursorSdkRuntime", () => {
     });
     expect(handle.probe).toHaveBeenCalledWith("stored-key");
     expect(handle.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("forwards the SDK account email from Cursor.me()", async () => {
+    const handle = worker({
+      probe: async () => ({
+        models: [],
+        sdkVersion: "1.0.24",
+        source: "global-npm",
+        authenticatedAs: "work@example.com",
+      }),
+    });
+
+    await expect(
+      probeCursorSdkRuntime({ envKind: "posix" }, { spawnWorker: async () => handle }, "crsr_work"),
+    ).resolves.toMatchObject({
+      authState: "authenticated",
+      authenticatedAs: "work@example.com",
+    });
   });
 
   it("uses an explicit profile key instead of the base Cursor setting", async () => {
@@ -439,6 +458,23 @@ describe("applyCursorSdkProbe", () => {
         },
       },
     });
+  });
+
+  it("attaches the SDK account email to the SDK runtime, not the CLI login", () => {
+    const merged = applyCursorSdkProbe(
+      { ...cliStatus, providerMetadata: { authenticatedAs: "cli@example.com" } },
+      {
+        installed: true,
+        authState: "authenticated",
+        authenticatedAs: "sdk@example.com",
+        models: [{ id: "sdk-model", displayName: "SDK Model" }],
+      },
+      "sdk",
+    );
+
+    expect(merged.providerMetadata?.authenticatedAs).toBe("cli@example.com");
+    expect(merged.runtimeVariants?.sdk?.providerMetadata?.authenticatedAs).toBe("sdk@example.com");
+    expect(merged.runtimeVariants?.acp?.providerMetadata).toBeUndefined();
   });
 
   it("hides SDK GUI when the external package is unavailable", () => {

--- a/src/supervisor/agents/cursor/sdkDetection.ts
+++ b/src/supervisor/agents/cursor/sdkDetection.ts
@@ -41,6 +41,7 @@ export interface CursorSdkRuntimeProbe {
   source?: string;
   diagnosticCode?: string;
   diagnosticMessage?: string;
+  authenticatedAs?: string;
 }
 
 export interface CursorSdkDetectionDependencies {
@@ -88,6 +89,9 @@ export function applyCursorSdkProbe(
       authState: probe.authState,
       authUsesProviderLogin: false,
       capabilities: sdkCapabilities,
+      ...(probe.authenticatedAs
+        ? { providerMetadata: { authenticatedAs: probe.authenticatedAs } }
+        : {}),
     },
   };
   const runtimeRouting: NonNullable<AgentStatus["sessionRuntimeRouting"]> = {
@@ -257,6 +261,7 @@ export async function probeCursorSdkRuntime(
       models: result.models,
       version: result.sdkVersion,
       source: result.source,
+      ...(result.authenticatedAs ? { authenticatedAs: result.authenticatedAs } : {}),
     };
   } catch (error) {
     const code = cursorSdkProbeErrorCode(error);

--- a/src/supervisor/agents/cursor/sdkWorker.ts
+++ b/src/supervisor/agents/cursor/sdkWorker.ts
@@ -41,6 +41,7 @@ import {
   type RuntimeAgent,
   type RuntimeRun,
 } from "./sdkWorkerRuntime";
+import { probeCursorSdkAccountEmail } from "./sdkAccount";
 
 // stdout is a protocol channel, while provider-native console output can carry
 // credentials or arbitrary non-JSON text. SDK failures are returned through
@@ -310,9 +311,11 @@ async function listModels(
   const models = await loaded.Cursor.models.list(
     input.apiKey ? { apiKey: input.apiKey } : undefined,
   );
+  const authenticatedAs = await probeCursorSdkAccountEmail(loaded.Cursor, input.apiKey);
   return {
     models,
     ...sdkRuntime.metadata,
+    ...(authenticatedAs ? { authenticatedAs } : {}),
   };
 }
 

--- a/src/supervisor/agents/cursor/sdkWorkerProtocol.ts
+++ b/src/supervisor/agents/cursor/sdkWorkerProtocol.ts
@@ -50,6 +50,8 @@ export interface CursorSdkWorkerProbeResult {
     | "global-npm"
     | "global-pnpm"
     | "explicit-entry";
+  /** Account the probed API key belongs to, from `Cursor.me()`. */
+  authenticatedAs?: string;
 }
 
 export type CursorSdkWorkerMcpServer =

--- a/src/supervisor/agents/registry.test.ts
+++ b/src/supervisor/agents/registry.test.ts
@@ -135,7 +135,9 @@ describe("profile agent registry", () => {
 
     expect(adapters.find((adapter) => adapter.kind === "cursor:work")).toMatchObject({
       label: "Cursor Work",
-      baseSpawnEnv: { CURSOR_API_KEY: "profile-key" },
     });
+    expect(
+      adapters.find((adapter) => adapter.kind === "cursor:work")?.baseSpawnEnv,
+    ).toBeUndefined();
   });
 });

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -62,8 +62,12 @@ const execFileAsync = promisify(execFile);
  * v15 adds ACP-derived per-model thinking toggles and normalizes provider model
  * capability maps, so statuses cached before those capability semantics changed
  * must be re-probed.
+ * v16 makes Cursor profiles SDK-only (no CLI/ACP probe or shared login), so
+ * statuses that advertised profile CLI login/ACP variants must be re-probed.
+ * v17 adds per-runtime `providerMetadata` so Cursor SDK can show the API-key
+ * account email without overwriting the CLI login identity.
  */
-export const STATUS_CACHE_VERSION = 15;
+export const STATUS_CACHE_VERSION = 17;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 

--- a/src/supervisor/runtime/usageService.test.ts
+++ b/src/supervisor/runtime/usageService.test.ts
@@ -2,7 +2,14 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { HostPort, OAuthToken, UsageSnapshot } from "@poracode/agents-usage";
+import {
+  CURSOR_API_KEY_EXCHANGE_ENDPOINT,
+  CURSOR_PERIOD_USAGE_ENDPOINT,
+  CURSOR_PLAN_INFO_ENDPOINT,
+  type HostPort,
+  type OAuthToken,
+  type UsageSnapshot,
+} from "@poracode/agents-usage";
 import type { SupervisorEvent } from "@/shared/ipc";
 import type { LocalUsageCollector } from "./localUsageCollectors";
 import { UsageService } from "./usageService";
@@ -417,6 +424,88 @@ describe("UsageService", () => {
       plan: "Team Subscription",
     });
     expect(result.snapshots[0]?.windows.find((w) => w.id === "session-5h")?.usedPercent).toBe(0.4);
+  });
+
+  it("collects Cursor profile usage from the profile API key", async () => {
+    const settingsPath = tempCachePath();
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        agentInstances: {
+          work: {
+            id: "work",
+            driver: "cursor",
+            displayName: "Work",
+            environment: { CURSOR_API_KEY: { value: "crsr_work", sensitive: true } },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const urls: string[] = [];
+    const authorizations: Array<string | undefined> = [];
+    const host: HostPort = {
+      now: () => NOW,
+      credentials: {
+        getOAuthToken: () => Promise.resolve(undefined),
+        getSecret: () => Promise.resolve(undefined),
+      },
+      http: {
+        request: (request) => {
+          urls.push(request.url);
+          authorizations.push(request.headers?.Authorization);
+          if (request.url === CURSOR_API_KEY_EXCHANGE_ENDPOINT) {
+            return Promise.resolve({
+              status: 200,
+              headers: {},
+              body: JSON.stringify({ accessToken: "session-jwt" }),
+            });
+          }
+          if (request.url === CURSOR_PERIOD_USAGE_ENDPOINT) {
+            return Promise.resolve({
+              status: 200,
+              headers: {},
+              body: JSON.stringify({
+                planUsage: {
+                  totalSpend: 2000,
+                  limit: 2000,
+                  autoPercentUsed: 10,
+                  apiPercentUsed: 40,
+                },
+              }),
+            });
+          }
+          if (request.url === CURSOR_PLAN_INFO_ENDPOINT) {
+            return Promise.resolve({
+              status: 200,
+              headers: {},
+              body: JSON.stringify({ planInfo: { planName: "pro" } }),
+            });
+          }
+          return Promise.resolve({ status: 404, headers: {}, body: "" });
+        },
+      },
+    };
+    const service = new UsageService({
+      emit: () => {},
+      cachePath: tempCachePath(),
+      settingsPath,
+      host,
+      localCollectors: stubLocalCollectors(),
+    });
+
+    const result = await service.refreshProviderUsage({ providerIds: ["cursor:work"] });
+
+    expect(urls[0]).toBe(CURSOR_API_KEY_EXCHANGE_ENDPOINT);
+    expect(authorizations[0]).toBe("Bearer crsr_work");
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0]).toMatchObject({
+      providerId: "cursor:work",
+      status: "ok",
+      plan: "Cursor Pro",
+    });
+    expect(result.snapshots[0]?.windows.find((w) => w.id === "cursor-auto")?.usedPercent).toBe(10);
   });
 
   it("does not re-poll a rate-limited provider until its Retry-After backoff clears", async () => {

--- a/src/supervisor/runtime/usageService.ts
+++ b/src/supervisor/runtime/usageService.ts
@@ -9,12 +9,7 @@ import {
 import { coalesceByKey } from "@/shared/coalesce";
 import type { ProviderUsagePayload, ProviderUsageResponse } from "@/shared/contracts";
 import type { SupervisorEvent } from "@/shared/ipc";
-import {
-  defaultSharedSettings,
-  normalizeSharedSettings,
-  type SharedSettings,
-  type UsageSettings,
-} from "@/shared/settings";
+import { defaultSharedSettings, type SharedSettings, type UsageSettings } from "@/shared/settings";
 import {
   collectClaudeProfile,
   readClaudeUsageProfiles,
@@ -22,8 +17,14 @@ import {
   withClaudeEstimatedCost,
   type ClaudeUsageProfile,
 } from "../agents/claude/claudeUsageProfiles";
+import {
+  collectCursorProfile,
+  readCursorUsageProfiles,
+  type CursorUsageProfile,
+} from "../agents/cursor/cursorUsageProfiles";
 import { createLocalUsageCollectors, type LocalUsageCollector } from "./localUsageCollectors";
 import { createNodeUsageHost } from "./usageHost";
+import { readSupervisorSharedSettings } from "./supervisorSharedSettings";
 
 /**
  * Periodic/on-demand provider usage collection, modeled on AgentStatusService:
@@ -99,17 +100,13 @@ export class UsageService {
   private defaultProviderIds(): string[] {
     const baseIds = [...(this.options.providerIds ?? DEFAULT_PROVIDER_IDS)];
     if (this.options.providerIds) return baseIds;
-    return [...baseIds, ...this.claudeUsageProfiles().keys()];
+    return [...baseIds, ...this.claudeUsageProfiles().keys(), ...this.cursorUsageProfiles().keys()];
   }
 
-  /** Read shared settings from disk (defaults if absent). */
+  /** Read shared settings from disk (defaults if absent). Decrypts profile keys. */
   private readSharedSettings(): SharedSettings {
     if (!this.options.settingsPath) return defaultSharedSettings;
-    try {
-      return normalizeSharedSettings(JSON.parse(readFileSync(this.options.settingsPath, "utf8")));
-    } catch {
-      return defaultSharedSettings;
-    }
+    return readSupervisorSharedSettings(this.options.settingsPath);
   }
 
   /** Read the usage policy from the shared settings file (defaults if absent). */
@@ -121,10 +118,17 @@ export class UsageService {
     return readClaudeUsageProfiles(this.readSharedSettings());
   }
 
+  private cursorUsageProfiles(): Map<string, CursorUsageProfile> {
+    return readCursorUsageProfiles(this.readSharedSettings());
+  }
+
   /** A provider id this service can collect (package registry or supervisor-local). */
   private isSupported(id: string): boolean {
     return (
-      this.registry.has(id) || this.localCollectors.has(id) || this.claudeUsageProfiles().has(id)
+      this.registry.has(id) ||
+      this.localCollectors.has(id) ||
+      this.claudeUsageProfiles().has(id) ||
+      this.cursorUsageProfiles().has(id)
     );
   }
 
@@ -219,13 +223,15 @@ export class UsageService {
 
   private async runRefresh(ids: string[]): Promise<ProviderUsageResponse> {
     const claudeProfiles = this.claudeUsageProfiles();
+    const cursorProfiles = this.cursorUsageProfiles();
     const registryIds = ids.filter((id) => this.registry.has(id));
     const localIds = ids.filter((id) => this.localCollectors.has(id));
     const claudeProfileIds = ids.filter((id) => claudeProfiles.has(id));
+    const cursorProfileIds = ids.filter((id) => cursorProfiles.has(id));
     // The registry HTTP batch and the supervisor-local collectors are independent
     // of each other, so run both groups concurrently rather than waiting out the
     // (rate-limited, slow) HTTP batch before starting the local scans.
-    const [registrySnaps, localSnaps, claudeProfileSnaps] = await Promise.all([
+    const [registrySnaps, localSnaps, claudeProfileSnaps, cursorProfileSnaps] = await Promise.all([
       this.registry.collectAll(registryIds, this.host),
       Promise.all(localIds.map((id) => this.collectLocal(id))),
       Promise.all(
@@ -234,10 +240,19 @@ export class UsageService {
           return profile ? [collectClaudeProfile(profile, this.host)] : [];
         }),
       ),
+      Promise.all(
+        cursorProfileIds.flatMap((id) => {
+          const profile = cursorProfiles.get(id);
+          return profile ? [collectCursorProfile(profile, this.host)] : [];
+        }),
+      ),
     ]);
-    let snapshots = [...registrySnaps, ...localSnaps, ...claudeProfileSnaps].map((snap) =>
-      this.preserveOnTransientFailure(snap),
-    );
+    let snapshots = [
+      ...registrySnaps,
+      ...localSnaps,
+      ...claudeProfileSnaps,
+      ...cursorProfileSnaps,
+    ].map((snap) => this.preserveOnTransientFailure(snap));
     if (this.readUsageSettings().showEstimatedCost) {
       snapshots = await this.withEstimatedCost(snapshots, claudeProfiles);
     }


### PR DESCRIPTION
- Add Cursor SDK usage collection with profile-specific usage windows and API-key authentication.
- Expose SDK account identity and separate it from Cursor CLI/ACP login state.
- Update Cursor settings, provider selection, status persistence, and localized UI messaging.
- Expand coverage with supervisor, renderer, usage, migration, and authentication tests.