### PR TITLE
Force better-sqlite3 native dependency rebuild

### DIFF
--- a/scripts/ensure-native-deps.mjs
+++ b/scripts/ensure-native-deps.mjs
@@ -145,7 +145,7 @@ function validateElectronNativeDependencies() {
 
 function rebuildElectronNativeDependencies() {
   const rebuildCli = join(dirname(require.resolve("@electron/rebuild")), "cli.js");
-  const result = spawnSync(process.execPath, [rebuildCli, "--only", "better-sqlite3"], {
+  const result = spawnSync(process.execPath, [rebuildCli, "--force", "--only", "better-sqlite3"], {
     stdio: "inherit",
   });
   if (result.status !== 0) {


### PR DESCRIPTION
- Bugfix: Force rebuilding better-sqlite3 for Electron.
- Prevent stale or incompatible native binaries from causing build/runtime failures.