### PR TITLE
Show WSL markers in flat thread list

### DIFF
--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.test.tsx
@@ -225,6 +225,40 @@ describe("SidebarFlatThreadList", () => {
     expect(glyph?.getAttribute("class")).toContain("size-3");
   });
 
+  it("tags WSL project rows with the WSL marker; native rows carry none", () => {
+    useAppStore.setState({
+      projects: [
+        homeProject,
+        localProject,
+        {
+          ...localProject,
+          id: "wsl-1",
+          name: "Ubuntu Repo",
+          location: {
+            kind: "wsl",
+            distro: "Ubuntu",
+            linuxPath: "/home/me/repo",
+            uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\repo",
+          },
+        },
+      ],
+      threads: [
+        makeThread("p1", "local-1", "2026-08-01T10:00:00.000Z"),
+        makeThread("w1", "wsl-1", "2026-08-02T10:00:00.000Z"),
+      ],
+    });
+
+    render(<SidebarFlatThreadList sortMode="updated" />);
+
+    const wslRow = screen.getByText(/thread:w1 in Ubuntu Repo/).closest("[data-testid=row]");
+    expect(wslRow).toHaveTextContent("WSL");
+    expect(wslRow?.querySelector('svg[viewBox="0 0 40 16"]')?.getAttribute("class")).toContain(
+      "h-2.5",
+    );
+    const localRow = screen.getByText(/thread:p1 in Poracode/).closest("[data-testid=row]");
+    expect(localRow).not.toHaveTextContent("WSL");
+  });
+
   it("hides Home threads when home scope is disabled", () => {
     useSharedSettings.setState({ homeScopeEnabled: false } as never);
     useAppStore.setState({

--- a/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
+++ b/src/renderer/views/MainView/parts/Sidebar/parts/SidebarFlatThreadList.tsx
@@ -2,6 +2,7 @@ import { useShallow } from "zustand/shallow";
 import type { Project } from "@/shared/contracts";
 import { isHomeProject } from "@/shared/homeScope";
 import { ProjectIcon } from "@/renderer/components/common/ProjectIcon";
+import { TuxIcon } from "@/renderer/components/common/TuxIcon";
 import {
   ProjectRemoteServerChip,
   ProjectSelectorIcon,
@@ -244,6 +245,10 @@ export function SidebarFlatThreadList(props: { sortMode: ThreadSortMode }) {
                           <ProjectIcon project={project} className="size-3 text-muted/70" />
                           <span className="truncate">{project.name}</span>
                           <ProjectRemoteServerChip info={remote} size="xs" />
+                          {/* Mirrors the grouped header's trailing WSL marker. */}
+                          {project.location.kind === "wsl" ? (
+                            <TuxIcon className="h-2.5 w-auto shrink-0 text-muted/60" />
+                          ) : null}
                         </span>
                       ),
                     }


### PR DESCRIPTION
- Add WSL markers to WSL project rows in the flat thread sidebar.
- Keep native project rows free of WSL markers.
- Add coverage verifying both behaviors.