### PR TITLE
Add project-aware thread creation controls

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Neuer Thread — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Neuer Thread von dieser Aufgabe"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Neuer Thread in {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "Keine Threads in diesem Projekt"
 msgid "No threads yet"
 msgstr "Noch keine Threads"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Noch keine Threads."
@@ -9226,6 +9232,7 @@ msgstr "Projektspezifische Überschreibungen zusätzlich zu den globalen Suchein
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -7514,6 +7514,11 @@ msgstr "New thread — {projectName}"
 msgid "New thread from this to-do"
 msgstr "New thread from this to-do"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "New thread in {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "No threads in this project"
 msgid "No threads yet"
 msgstr "No threads yet"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "No threads yet."
@@ -9226,6 +9232,7 @@ msgstr "Project-specific overrides on top of the global search settings."
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Nuevo hilo — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Nuevo hilo a partir de esta tarea"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Nuevo hilo en {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "No hay hilos en este proyecto"
 msgid "No threads yet"
 msgstr "Aún no hay hilos"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Aún no hay hilos."
@@ -9226,6 +9232,7 @@ msgstr "Anulaciones específicas del proyecto sobre los ajustes de búsqueda glo
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -7513,6 +7513,11 @@ msgstr "Nouveau fil de discussion — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Nouveau fil de cette tâche"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Nouveau fil dans {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7988,6 +7993,7 @@ msgstr "Aucun fil dans ce projet"
 msgid "No threads yet"
 msgstr "Aucun fil pour le moment"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Aucun fil pour l'instant."
@@ -9225,6 +9231,7 @@ msgstr "Remplacements spécifiques au projet en plus des paramètres de recherch
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -7512,6 +7512,11 @@ msgstr "新しいスレッド —{projectName}"
 msgid "New thread from this to-do"
 msgstr "この ToDo からの新しいスレッド"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "{0} で新規スレッド"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7987,6 +7992,7 @@ msgstr "このプロジェクトにはスレッドがありません"
 msgid "No threads yet"
 msgstr "まだスレッドはありません"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "まだスレッドがありません。"
@@ -9224,6 +9230,7 @@ msgstr "グローバル検索設定に加えてプロジェクト固有のオー
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -7514,6 +7514,11 @@ msgstr "새 스레드 — {projectName}"
 msgid "New thread from this to-do"
 msgstr "이 할 일의 새 스레드"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "{0}에서 새 스레드"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "이 프로젝트에 스레드가 없음"
 msgid "No threads yet"
 msgstr "아직 스레드 없음"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "아직 스레드가 없습니다."
@@ -9226,6 +9232,7 @@ msgstr "전역 검색 설정 위에 프로젝트별 재정의가 적용됩니다
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Nowy wątek — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Nowy wątek z tego zadania"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Nowy wątek w {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "Brak wątków w tym projekcie"
 msgid "No threads yet"
 msgstr "Nie ma jeszcze wątków"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Brak wątków."
@@ -9226,6 +9232,7 @@ msgstr "Zastąpienia specyficzne dla projektu ponad globalnymi ustawieniami wysz
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Novo tópico —{projectName}"
 msgid "New thread from this to-do"
 msgstr "Novo tópico desta tarefa"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Nova thread em {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "Nenhuma thread neste projeto"
 msgid "No threads yet"
 msgstr "Ainda não há threads"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Nenhuma thread ainda."
@@ -9226,6 +9232,7 @@ msgstr "Substituições específicas do projeto nas configurações de pesquisa 
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Новый тред — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Новый тред из этой задачи"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Новый поток в {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "В этом проекте нет потоков"
 msgid "No threads yet"
 msgstr "Пока нет потоков"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Тредов пока нет."
@@ -9226,6 +9232,7 @@ msgstr "Переопределения для конкретного проек�
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Yeni konu — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Bu yapılacaklardan yeni konu"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "{0} içinde yeni iş parçacığı"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "Bu projede iş parçacığı yok"
 msgid "No threads yet"
 msgstr "Henüz iş parçacığı yok"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Henüz konuşma yok."
@@ -9226,6 +9232,7 @@ msgstr "Genel arama ayarlarının yanı sıra projeye özel geçersiz kılmalar.
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Новий тред — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Новий тред із цієї задачі"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Новий потік у {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "У цьому проєкті немає потоків"
 msgid "No threads yet"
 msgstr "Потоків ще немає"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Гілок ще немає."
@@ -9226,6 +9232,7 @@ msgstr "Перевизначення для конкретного проєкт�
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -7514,6 +7514,11 @@ msgstr "Luồng mới — {projectName}"
 msgid "New thread from this to-do"
 msgstr "Luồng mới từ việc cần làm này"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "Luồng mới trong {0}"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7989,6 +7994,7 @@ msgstr "Không có luồng trong dự án này"
 msgid "No threads yet"
 msgstr "Chưa có luồng nào"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "Chưa có luồng nào."
@@ -9226,6 +9232,7 @@ msgstr "Ghi đè dành riêng cho dự án ở đầu cài đặt tìm kiếm ch
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -7513,6 +7513,11 @@ msgstr "新线程 —{projectName}"
 msgid "New thread from this to-do"
 msgstr "基于此待办事项的新线程"
 
+#. placeholder {0}: project.name
+#: src/renderer/views/HomeView.tsx
+msgid "New thread in {0}"
+msgstr "在 {0} 中新建线程"
+
 #: src/mobile/ThreadTitleRow.tsx
 #: src/mobile/views/threadActionSurfaces.tsx
 #: src/mobile/views/threadContextMenus.tsx
@@ -7988,6 +7993,7 @@ msgstr "此项目中没有线程"
 msgid "No threads yet"
 msgstr "还没有线程"
 
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/SettingsOverlay/parts/ProfileSettings.tsx
 msgid "No threads yet."
 msgstr "暂无对话。"
@@ -9225,6 +9231,7 @@ msgstr "在全局搜索设置基础上的项目特定覆盖。"
 #: src/mobile/views/ManageProjectsView.tsx
 #: src/mobile/WideShell.tsx
 #: src/renderer/components/mcp/McpProjectDestinationDropdown.tsx
+#: src/renderer/views/HomeView.tsx
 #: src/renderer/views/MainView/parts/Sidebar/parts/SidebarProjectFilter.tsx
 #: src/renderer/views/PullRequestsView/PullRequestsView.tsx
 #: src/renderer/views/SettingsOverlay/parts/WorkspacesSettings.tsx

--- a/src/renderer/views/HomeView.test.tsx
+++ b/src/renderer/views/HomeView.test.tsx
@@ -1,9 +1,10 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { renderWithI18n as render } from "@/renderer/testUtils/i18n";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { AgentStatus, Project, Thread } from "@/shared/contracts";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useAgentStatusesStore } from "@/renderer/state/agentStatusesStore";
+import { useRemoteServersStore } from "@/renderer/state/remoteServersStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { HomeView } from "./HomeView";
 
@@ -26,6 +27,7 @@ describe("HomeView", () => {
       discoveryScope: undefined,
       discoveredAgents: [],
     });
+    useRemoteServersStore.setState({ servers: [], runtime: {} });
   });
 
   it("does not show archived threads in recent threads", () => {
@@ -67,14 +69,92 @@ describe("HomeView", () => {
     expect(container.querySelector(".poracode-provider-icon--external")).toBeInTheDocument();
     expect(container.querySelector(".poracode-provider-icon__generic")).not.toBeInTheDocument();
   });
+
+  it("filters recent threads to the selected workspace and clears on second click", () => {
+    useAppStore.setState({
+      projects: [makeProject(), makeProject({ id: "project-2", name: "side-app" })],
+      threads: [
+        makeThread({ id: "t1", title: "First project thread", projectId: "project-1" }),
+        makeThread({ id: "t2", title: "Second project thread", projectId: "project-2" }),
+      ],
+    });
+
+    render(<HomeView />);
+
+    expect(screen.getByText("First project thread")).toBeInTheDocument();
+    expect(screen.getByText("Second project thread")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "side-app" }));
+
+    expect(screen.queryByText("First project thread")).not.toBeInTheDocument();
+    expect(screen.getByText("Second project thread")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "side-app" }));
+
+    expect(screen.getByText("First project thread")).toBeInTheDocument();
+    expect(screen.getByText("Second project thread")).toBeInTheDocument();
+  });
+
+  it("opens a draft from the workspace row's new-thread button", () => {
+    render(<HomeView />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New thread in todo-app" }));
+
+    expect(useAppStore.getState().view).toEqual({ kind: "draft", projectId: "project-1" });
+  });
+
+  it("marks WSL and remote workspaces and their thread tags", () => {
+    useRemoteServersStore.setState({
+      servers: [{ desktopId: "desktop-1", label: "Poracode on MacBook 16" }],
+      runtime: {},
+    } as never);
+    useAppStore.setState({
+      projects: [
+        makeProject({
+          id: "wsl-1",
+          name: "Ubuntu Repo",
+          location: {
+            kind: "wsl",
+            distro: "Ubuntu",
+            linuxPath: "/home/me/repo",
+            uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\me\\repo",
+          },
+        }),
+        makeProject({
+          id: "remote-1",
+          name: "Mac Repo",
+          location: { kind: "posix", path: "/repo", remoteServerId: "desktop-1" },
+        }),
+      ],
+      threads: [
+        makeThread({ id: "w1", title: "WSL thread", projectId: "wsl-1" }),
+        makeThread({ id: "r1", title: "Remote thread", projectId: "remote-1" }),
+      ],
+    });
+
+    render(<HomeView />);
+
+    // Only the workspace select buttons carry aria-pressed.
+    const workspaceRows = screen.getAllByRole("button", { pressed: false });
+    const wslRow = workspaceRows.find((row) => row.textContent?.includes("Ubuntu Repo"));
+    expect(wslRow).toHaveTextContent("WSL");
+    const remoteRow = workspaceRows.find((row) => row.textContent?.includes("Mac Repo"));
+    expect(remoteRow).toHaveTextContent("MacBook 16");
+
+    const wslThread = screen.getByText("WSL thread").closest("button");
+    expect(wslThread).toHaveTextContent("WSL");
+    const remoteThread = screen.getByText("Remote thread").closest("button");
+    expect(remoteThread).toHaveTextContent("MacBook 16");
+  });
 });
 
-function makeProject(): Project {
+function makeProject(overrides?: Partial<Project>): Project {
   return {
     id: "project-1",
     name: "todo-app",
     location: { kind: "windows", path: "C:\\repo" },
     createdAt: "2026-05-26T00:00:00.000Z",
+    ...overrides,
   };
 }
 

--- a/src/renderer/views/HomeView.tsx
+++ b/src/renderer/views/HomeView.tsx
@@ -1,14 +1,24 @@
-import { ArrowRight, FolderOpen, House, Plus } from "lucide-react";
+import { useState } from "react";
+import { ArrowRight, Plus } from "lucide-react";
 import { useShallow } from "zustand/shallow";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
+import type { Project } from "@/shared/contracts";
 import { isHomeProject, isHomeProjectId } from "@/shared/homeScope";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useSharedSettings } from "@/renderer/state/sharedSettingsStore";
 import { openThread } from "@/renderer/actions/threadActions";
 import { ThreadProviderIcon } from "@/renderer/components/providers/ThreadProviderIcon";
 import { RelativeTime } from "@/renderer/components/common/RelativeTime";
+import {
+  ProjectRemoteServerChip,
+  ProjectSelectorIcon,
+  useProjectRemoteServerLookup,
+  type ProjectRemoteServerInfo,
+} from "@/renderer/components/common/ProjectRemoteServer";
+import { TuxIcon } from "@/renderer/components/common/TuxIcon";
 
 export function HomeView() {
+  const { t } = useLingui();
   const homeScopeEnabled = useSharedSettings((state) => state.homeScopeEnabled);
   const homeProject = useAppStore((state) => state.projects.find(isHomeProject));
   const projects = useAppStore(
@@ -16,97 +26,149 @@ export function HomeView() {
       state.projects.filter((project) => !project.disabled && !isHomeProject(project)),
     ),
   );
-  const recentThreads = useAppStore(
-    useShallow((state) =>
-      state.threads
-        .filter(
-          (t) => !t.done && !t.archived && (homeScopeEnabled || !isHomeProjectId(t.projectId)),
-        )
-        .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-        .slice(0, 8),
-    ),
-  );
+  const [filterProjectId, setFilterProjectId] = useState<string | null>(null);
+  const remoteServerFor = useProjectRemoteServerLookup();
   const openDraft = useAppStore((state) => state.openDraft);
 
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex h-full min-h-0 flex-col px-8 py-8">
-        <div className="mx-auto flex h-full w-full max-w-[560px] flex-col">
-          <div className="flex flex-1 flex-col justify-center">
-            <div className="flex w-full flex-col gap-8">
-              {(homeScopeEnabled && homeProject) || projects.length > 0 ? (
-                <section>
-                  <div className="flex flex-col gap-1">
-                    {homeScopeEnabled && homeProject ? (
-                      <button
-                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
-                        onClick={() => openDraft(homeProject.id)}
-                        type="button"
-                      >
-                        <House className="size-4 shrink-0 text-muted" />
-                        <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                          <Trans>Home</Trans>
-                        </p>
-                        <Plus className="size-4 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
-                      </button>
-                    ) : null}
-                    {projects.map((project) => (
-                      <button
-                        key={project.id}
-                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
-                        onClick={() => openDraft(project.id)}
-                        type="button"
-                      >
-                        <FolderOpen className="size-4 shrink-0 text-muted" />
-                        <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                          {project.name}
-                        </p>
-                        <Plus className="size-4 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
-                      </button>
-                    ))}
-                  </div>
-                </section>
-              ) : null}
+  const workspaces = homeScopeEnabled && homeProject ? [homeProject, ...projects] : projects;
+  const activeFilter =
+    filterProjectId !== null && workspaces.some((project) => project.id === filterProjectId)
+      ? filterProjectId
+      : null;
 
+  const recentThreads = useAppStore(
+    useShallow((state) => {
+      const sorted = state.threads
+        .filter(
+          (thread) =>
+            !thread.done &&
+            !thread.archived &&
+            (homeScopeEnabled || !isHomeProjectId(thread.projectId)) &&
+            (activeFilter === null || thread.projectId === activeFilter),
+        )
+        .toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      return activeFilter === null ? sorted.slice(0, 8) : sorted;
+    }),
+  );
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="flex min-h-full flex-col px-8 py-8">
+        <div className="m-auto grid w-full max-w-[960px] items-start gap-10 md:grid-cols-[minmax(0,17rem)_minmax(0,1fr)]">
+          {workspaces.length > 0 ? (
+            <section>
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-muted">
+                <Trans>Projects</Trans>
+              </h2>
+              <div className="flex flex-col gap-1">
+                {workspaces.map((project) => (
+                  <WorkspaceRow
+                    key={project.id}
+                    project={project}
+                    remote={remoteServerFor(project)}
+                    selected={activeFilter === project.id}
+                    onSelect={() =>
+                      setFilterProjectId((current) => (current === project.id ? null : project.id))
+                    }
+                    onNewThread={() => openDraft(project.id)}
+                    newThreadLabel={t`New thread in ${project.name}`}
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {recentThreads.length > 0 || activeFilter !== null ? (
+            <section className="min-w-0">
+              <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-muted">
+                <Trans>Recent threads</Trans>
+              </h2>
               {recentThreads.length > 0 ? (
-                <section>
-                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-muted">
-                    <Trans>Recent threads</Trans>
-                  </h2>
-                  <div className="flex flex-col gap-1">
-                    {recentThreads.map((thread) => {
-                      const project = isHomeProjectId(thread.projectId)
-                        ? homeProject
-                        : projects.find((p) => p.id === thread.projectId);
-                      return (
-                        <button
-                          key={thread.id}
-                          className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
-                          onClick={() => openThread(thread.id)}
-                          type="button"
-                        >
-                          <ThreadProviderIcon thread={thread} className="size-4 shrink-0" />
-                          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                            {thread.title}
-                          </p>
-                          {project ? (
-                            <span className="ml-3 shrink-0 text-xs text-muted">{project.name}</span>
-                          ) : null}
-                          <RelativeTime
-                            iso={thread.updatedAt}
-                            className="ml-3 w-[3ch] shrink-0 text-right font-mono text-xs tabular-nums text-muted"
-                          />
-                          <ArrowRight className="size-3.5 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
-                        </button>
-                      );
-                    })}
-                  </div>
-                </section>
-              ) : null}
-            </div>
-          </div>
+                <div className="flex flex-col gap-1">
+                  {recentThreads.map((thread) => {
+                    const project = isHomeProjectId(thread.projectId)
+                      ? homeProject
+                      : projects.find((p) => p.id === thread.projectId);
+                    return (
+                      <button
+                        key={thread.id}
+                        className="group flex items-center gap-3 rounded-2xl px-3 py-2 text-left transition-colors hover:bg-[var(--row-hover)]"
+                        onClick={() => openThread(thread.id)}
+                        type="button"
+                      >
+                        <ThreadProviderIcon thread={thread} className="size-4 shrink-0" />
+                        <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                          {thread.title}
+                        </p>
+                        {activeFilter === null && project ? (
+                          <span className="ml-3 flex shrink-0 items-center gap-1 text-xs text-muted">
+                            <span className="max-w-40 truncate">{project.name}</span>
+                            <ProjectRemoteServerChip info={remoteServerFor(project)} size="xs" />
+                            {project.location.kind === "wsl" ? (
+                              <TuxIcon className="h-2.5 w-auto shrink-0 text-muted/60" />
+                            ) : null}
+                          </span>
+                        ) : null}
+                        <RelativeTime
+                          iso={thread.updatedAt}
+                          className="ml-3 w-[3ch] shrink-0 text-right font-mono text-xs tabular-nums text-muted"
+                        />
+                        <ArrowRight className="size-3.5 shrink-0 text-muted opacity-0 transition-opacity group-hover:opacity-100" />
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="px-3 py-2 text-sm text-muted">
+                  <Trans>No threads yet.</Trans>
+                </p>
+              )}
+            </section>
+          ) : null}
         </div>
       </div>
+    </div>
+  );
+}
+
+function WorkspaceRow(props: {
+  project: Project;
+  remote: ProjectRemoteServerInfo;
+  selected: boolean;
+  onSelect: () => void;
+  onNewThread: () => void;
+  newThreadLabel: string;
+}) {
+  const { project, remote, selected } = props;
+  return (
+    <div
+      className={`group relative flex items-center rounded-2xl transition-colors ${
+        selected ? "bg-[var(--row-active)]" : "hover:bg-[var(--row-hover)]"
+      }`}
+    >
+      <button
+        aria-pressed={selected}
+        className="flex min-w-0 flex-1 items-center gap-3 py-2 pr-9 pl-3 text-left"
+        onClick={props.onSelect}
+        type="button"
+      >
+        <ProjectSelectorIcon project={project} remote={remote} className="size-4" />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          {isHomeProject(project) ? <Trans>Home</Trans> : project.name}
+        </span>
+        <ProjectRemoteServerChip info={remote} size="sm" />
+        {project.location.kind === "wsl" ? (
+          <TuxIcon className="h-3 w-auto shrink-0 text-muted/60" />
+        ) : null}
+      </button>
+      <button
+        aria-label={props.newThreadLabel}
+        className="absolute top-1/2 right-2 -translate-y-1/2 rounded-md p-1 text-muted opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100"
+        onClick={props.onNewThread}
+        type="button"
+      >
+        <Plus className="size-4" />
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
- Add project-scoped thread creation controls on the Home view.
- Display project, remote server, and WSL context for workspaces and threads.
- Expand Home view coverage with interaction and context tests.
- Localize the new project-aware UI strings across supported languages.