### PR TITLE
Fix inactive chat runtime memory growth

### DIFF
--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -42,6 +42,7 @@ import { applyAgentStatusSupervisorEvent, useAgentStatusesStore } from "./state/
 import { useProviderUsageStore } from "./state/providerUsageStore";
 import { useUpdateStore } from "./state/updateStore";
 import { clearRuntimeItemStoreSelectorCacheForThread } from "./components/thread/ChatPane/chatPaneSelectors";
+import { evictOversizedInactiveThreadRuntimeItems } from "./state/chatRuntimePersister";
 
 import { useAppHydration } from "@/renderer/hooks/useAppHydration";
 import { usePrWatchAgentSync } from "@/renderer/hooks/usePrWatchAgentSync";
@@ -113,6 +114,7 @@ function flushPendingRuntimeEvents(shouldFlush: (threadId: string) => boolean): 
   // One Zustand set for all concurrent streams — avoids N selector passes when
   // several chats are working in the background / being switched between.
   store.applyRuntimeEventBatches(batches);
+  evictOversizedInactiveThreadRuntimeItems(batches.map((batch) => batch.threadId));
   for (const { threadId, events } of batches) {
     // Durable usage capture at the canonical layer (all providers normalized).
     // Thread metadata is resolved lazily inside, so pure-delta frames are free.

--- a/src/renderer/components/find/ChatFindBar.tsx
+++ b/src/renderer/components/find/ChatFindBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent, useMemo, useRef } from "react";
 import { useLingui } from "@lingui/react/macro";
+import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/renderer/state/appStore";
 import { useChatFindStore } from "@/renderer/state/chatFindStore";
 import { selectVisibleThreadTimelineEntries } from "@/renderer/components/thread/ChatPane/chatPaneSelectors";
@@ -54,16 +55,25 @@ function ActiveChatFind({ threadId, scrollToIndexRef, scrollElement }: ChatFindB
   const setMatchCount = useChatFindStore((state) => state.setMatchCount);
 
   const entries = useAppStore((state) => selectVisibleThreadTimelineEntries(state, threadId));
-  const itemsById = useAppStore((state) => state.runtimeItemsByIdByThread[threadId]);
+  const itemSnapshot = useAppStore(
+    useShallow(
+      (state) =>
+        [
+          state.runtimeItemsByIdByThread[threadId],
+          state.runtimeStructuralVersionByThread[threadId] ?? 0,
+        ] as const,
+    ),
+  );
+  const [itemsById, structuralVersion] = itemSnapshot;
 
   // `entries`/`itemsById` are reference-stable across navigation, so memoizing
   // keeps `matches` stable when only `currentIndex` changes — avoiding a full
   // transcript re-scan (and a spurious re-fire of the scroll/highlight effect)
   // on every next/prev press.
-  const matches = useMemo(
-    () => collectChatMatches(itemsById, entries, query, caseSensitive),
-    [itemsById, entries, query, caseSensitive],
-  );
+  const matches = useMemo(() => {
+    void structuralVersion;
+    return collectChatMatches(itemsById, entries, query, caseSensitive);
+  }, [itemsById, structuralVersion, entries, query, caseSensitive]);
 
   // Re-resolve highlight ranges from the live (virtualized) DOM. Reads the latest
   // render's values so the scroll listener and nav effect can share it.

--- a/src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
+++ b/src/renderer/components/thread/ChatPane/ChatRuntimeDebugPanel.tsx
@@ -121,15 +121,16 @@ function OpenRequestDebug(props: { index: number; request: OpenRuntimeRequest })
 export function ChatRuntimeDebugPanel({ threadId }: ChatRuntimeDebugPanelProps) {
   const { t } = useLingui();
   const itemIds = useAppStore((s) => s.runtimeItemIdsByThread[threadId] ?? EMPTY_IDS);
-  const itemsById = useAppStore((s) => s.runtimeItemsByIdByThread[threadId] ?? EMPTY_ITEMS_BY_ID);
+  // Development-only inspector: subscribe to every store update so pure
+  // streaming deltas refresh without adding a production-path revision.
+  const runtimeState = useAppStore((state) => state);
+  const itemsById = runtimeState.runtimeItemsByIdByThread[threadId] ?? EMPTY_ITEMS_BY_ID;
   const requests = useAppStore((s) => s.runtimeRequestsByThread[threadId] ?? EMPTY_REQ);
   const [query, setQuery] = useState("");
 
-  const items = useMemo(
-    () =>
-      itemIds.map((itemId) => itemsById[itemId]).filter((item): item is RuntimeChatItem => !!item),
-    [itemIds, itemsById],
-  );
+  const items = itemIds
+    .map((itemId) => itemsById[itemId])
+    .filter((item): item is RuntimeChatItem => !!item);
 
   const trimmed = query.trim().toLowerCase();
   const filteredItems = useMemo(() => {

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Thread } from "@/shared/contracts";
 import type { AppStoreState } from "@/renderer/state/appStore";
+import { applyRuntimeEventsToState } from "@/renderer/state/slices/runtimeEventReducer";
+import { readRuntimeStructuralChangeHint } from "@/renderer/state/runtimeStructuralChanges";
 import {
   selectActiveNativeSubAgentThreadIds,
   selectActiveSubAgentParentItemIds,
@@ -474,6 +476,246 @@ describe("chatPaneSelectors", () => {
       },
       { kind: "item", id: "assistant-2" },
       { kind: "item", id: "tool-3" },
+    ]);
+  });
+
+  it("rebuilds only the live timeline tail across an item lifecycle", () => {
+    const threadId = "incremental-tail";
+    const itemIds = Array.from({ length: 256 }, (_, index) => `assistant-${index}`);
+    const items = Object.fromEntries(
+      itemIds.map((id) => [
+        id,
+        {
+          id,
+          type: "assistant_message",
+          state: "completed",
+          streams: { assistant_text: id },
+        },
+      ]),
+    );
+    let state = {
+      runtimeItemIdsByThread: { [threadId]: itemIds },
+      runtimeItemsByIdByThread: { [threadId]: items },
+      runtimeRequestsByThread: {},
+      runtimeContextByThread: {},
+      runtimeStructuralVersionByThread: { [threadId]: 1 },
+      runtimeCompletedTurnsByThread: {},
+      runtimeOpenTurnByThread: {},
+      threads: [],
+    } as unknown as AppStoreState;
+    const initial = selectVisibleThreadTimelineEntries(state, threadId);
+
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        {
+          type: "item.started",
+          threadId,
+          itemId: "tool-live",
+          itemType: "tool_call",
+          payload: { name: "Read", status: "running" },
+        },
+      ]),
+    } as AppStoreState;
+    const started = selectVisibleThreadTimelineEntries(state, threadId);
+    expect(started[0]).toBe(initial[0]);
+    expect(started.at(-1)).toEqual({ kind: "item", id: "tool-live" });
+
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        {
+          type: "item.updated",
+          threadId,
+          itemId: "tool-live",
+          payload: { name: "Read src/app.ts", status: "running" },
+        },
+      ]),
+    } as AppStoreState;
+    const updated = selectVisibleThreadTimelineEntries(state, threadId);
+    expect(updated[0]).toBe(initial[0]);
+    expect(updated.at(-1)).toEqual({ kind: "item", id: "tool-live" });
+
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        {
+          type: "item.completed",
+          threadId,
+          itemId: "tool-live",
+          payload: { status: "success" },
+        },
+      ]),
+    } as AppStoreState;
+    const completed = selectVisibleThreadTimelineEntries(state, threadId);
+    expect(completed[0]).toBe(initial[0]);
+    expect(completed.at(-1)).toEqual({ kind: "item", id: "tool-live" });
+  });
+
+  it("rebuilds a live parent row when an appended subagent child nests under it", () => {
+    const threadId = "incremental-child";
+    let state = {
+      runtimeItemIdsByThread: { [threadId]: ["tool-1", "parent"] },
+      runtimeItemsByIdByThread: {
+        [threadId]: {
+          "tool-1": {
+            id: "tool-1",
+            type: "tool_call",
+            state: "completed",
+            payload: { name: "Read", status: "success" },
+            streams: {},
+          },
+          parent: {
+            id: "parent",
+            type: "tool_call",
+            state: "started",
+            payload: { name: "Custom tool", status: "running" },
+            streams: {},
+          },
+        },
+      },
+      runtimeRequestsByThread: {},
+      runtimeContextByThread: {},
+      runtimeStructuralVersionByThread: { [threadId]: 1 },
+      runtimeCompletedTurnsByThread: {},
+      runtimeOpenTurnByThread: {},
+      threads: [],
+    } as unknown as AppStoreState;
+    expect(selectVisibleThreadTimelineEntries(state, threadId)).toEqual([
+      {
+        kind: "tool_call_group",
+        id: "tool-call-group:tool-1",
+        itemIds: ["tool-1", "parent"],
+      },
+    ]);
+
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        {
+          type: "item.started",
+          threadId,
+          itemId: "child",
+          itemType: "assistant_message",
+          parentItemId: "parent",
+        },
+      ]),
+    } as AppStoreState;
+
+    expect(selectVisibleThreadTimelineEntries(state, threadId)).toEqual([
+      { kind: "item", id: "tool-1" },
+      { kind: "item", id: "parent" },
+    ]);
+  });
+
+  it("falls back to a full projection after skipping structural versions", () => {
+    const threadId = "skipped-versions";
+    const itemIds = Array.from({ length: 256 }, (_, index) => `assistant-${index}`);
+    const items = Object.fromEntries(
+      itemIds.map((id, index) => [
+        id,
+        {
+          id,
+          type: "assistant_message",
+          state: "completed",
+          streams: { assistant_text: index === 0 ? "" : id },
+        },
+      ]),
+    );
+    let state = {
+      runtimeItemIdsByThread: { [threadId]: itemIds },
+      runtimeItemsByIdByThread: { [threadId]: items },
+      runtimeRequestsByThread: {},
+      runtimeContextByThread: {},
+      runtimeStructuralVersionByThread: { [threadId]: 1 },
+      runtimeCompletedTurnsByThread: {},
+      runtimeOpenTurnByThread: {},
+      threads: [],
+    } as unknown as AppStoreState;
+    expect(selectVisibleThreadRuntimeItemIds(state, threadId)).not.toContain("assistant-0");
+
+    for (const [itemId, text] of [
+      ["assistant-0", "now visible"],
+      ["assistant-255", "tail changed"],
+    ] as const) {
+      state = {
+        ...state,
+        ...applyRuntimeEventsToState(state, threadId, [
+          {
+            type: "item.updated",
+            threadId,
+            itemId,
+            payload: { content: [{ kind: "text", text }] },
+          },
+        ]),
+      } as AppStoreState;
+    }
+
+    expect(selectVisibleThreadRuntimeItemIds(state, threadId)).toContain("assistant-0");
+  });
+
+  it("recomputes child parents when an empty child is removed", () => {
+    const threadId = "removed-child";
+    let state = {
+      runtimeItemIdsByThread: { [threadId]: ["tool-1", "parent"] },
+      runtimeItemsByIdByThread: {
+        [threadId]: {
+          "tool-1": {
+            id: "tool-1",
+            type: "tool_call",
+            state: "completed",
+            payload: { name: "Read", status: "success" },
+            streams: {},
+          },
+          parent: {
+            id: "parent",
+            type: "tool_call",
+            state: "completed",
+            payload: { name: "Custom tool", status: "success" },
+            streams: {},
+          },
+        },
+      },
+      runtimeRequestsByThread: {},
+      runtimeContextByThread: {},
+      runtimeStructuralVersionByThread: { [threadId]: 1 },
+      runtimeCompletedTurnsByThread: {},
+      runtimeOpenTurnByThread: {},
+      threads: [],
+    } as unknown as AppStoreState;
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        {
+          type: "item.started",
+          threadId,
+          itemId: "child",
+          itemType: "reasoning",
+          parentItemId: "parent",
+        },
+      ]),
+    } as AppStoreState;
+    expect(selectVisibleThreadTimelineEntries(state, threadId)).toEqual([
+      { kind: "item", id: "tool-1" },
+      { kind: "item", id: "parent" },
+    ]);
+
+    state = {
+      ...state,
+      ...applyRuntimeEventsToState(state, threadId, [
+        { type: "item.completed", threadId, itemId: "child" },
+      ]),
+    } as AppStoreState;
+    expect(state.runtimeItemIdsByThread[threadId]).not.toContain("child");
+    expect(state.runtimeItemsByIdByThread[threadId]?.child).toBeUndefined();
+    expect(state.runtimeStructuralVersionByThread[threadId]).toBe(3);
+    expect(readRuntimeStructuralChangeHint(threadId, 3)?.itemIds).toBeNull();
+    expect(selectVisibleThreadTimelineEntries(state, threadId)).toEqual([
+      {
+        kind: "tool_call_group",
+        id: "tool-call-group:tool-1",
+        itemIds: ["tool-1", "parent"],
+      },
     ]);
   });
 

--- a/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
+++ b/src/renderer/components/thread/ChatPane/chatPaneSelectors.ts
@@ -4,6 +4,10 @@ import {
   type RuntimeChatItem,
 } from "@/renderer/state/slices/runtimeEventSlice";
 import type { AppStoreState } from "@/renderer/state/slices/shared";
+import {
+  clearRuntimeStructuralChangeHint,
+  readRuntimeStructuralChangeHint,
+} from "@/renderer/state/runtimeStructuralChanges";
 import type { MessageItemPayload, ToolCallPayload } from "@/shared/contracts";
 import { RUNTIME_REQUEST_ITEM_TYPE } from "@/shared/contracts";
 import {
@@ -25,6 +29,8 @@ export type ChatTimelineEntry =
   | { kind: "item"; id: string }
   | { kind: "tool_call_group"; id: string; itemIds: readonly string[] };
 
+const MAX_INCREMENTAL_TAIL_ITEMS = 128;
+
 /**
  * Cache for `selectVisibleThreadTimelineEntries`. Keyed by
  * `${threadId}\0${hiddenItemId ?? ""}` (a small constant-size string) and
@@ -44,6 +50,8 @@ const timelineEntryCache = new Map<
     itemIds: readonly string[];
     structuralVersion: number;
     entries: readonly ChatTimelineEntry[];
+    entryStartIndices: readonly number[];
+    childParentIds: ReadonlySet<string>;
   }
 >();
 
@@ -60,6 +68,8 @@ const visibleItemIdsCache = new Map<
     sourceItemIds: readonly string[];
     structuralVersion: number;
     result: readonly string[];
+    sourceIndices: readonly number[];
+    stablePrefixLength: number;
   }
 >();
 
@@ -90,25 +100,102 @@ export function selectVisibleThreadRuntimeItemIds(
   }
 
   const items = state.runtimeItemsByIdByThread[threadId];
-  const visible = itemIds.filter((itemId) => {
-    if (itemId === hiddenItemId) return false;
-    const item = items?.[itemId];
-    if (!item) return true;
-    // Sub-agent children render embedded under their parent tool_call row, not
-    // as siblings at the top of the timeline.
-    if (item.parentItemId) return false;
-    return isVisibleRuntimeItem(item);
-  });
-  const result =
-    visible.length === 0
-      ? EMPTY_THREAD_ITEM_IDS
-      : visible.length === itemIds.length
-        ? itemIds
-        : visible;
+  const hint = readRuntimeStructuralChangeHint(threadId, structuralVersion);
+  const tailStartIndex =
+    cached && cached.structuralVersion + 1 === structuralVersion && hint?.itemIds
+      ? findIncrementalTailStart(cached.sourceItemIds, itemIds, hint.itemIds)
+      : null;
+  let result: readonly string[];
+  let sourceIndices: readonly number[];
+  let stablePrefixLength = 0;
+  if (cached && tailStartIndex !== null) {
+    stablePrefixLength = lowerBound(cached.sourceIndices, tailStartIndex);
+    const visible = cached.result.slice(0, stablePrefixLength);
+    const nextSourceIndices = cached.sourceIndices.slice(0, stablePrefixLength);
+    appendVisibleItems(visible, nextSourceIndices, itemIds, items, hiddenItemId, tailStartIndex);
+    result = visible.length === 0 ? EMPTY_THREAD_ITEM_IDS : visible;
+    sourceIndices = nextSourceIndices;
+  } else {
+    const visible: string[] = [];
+    const nextSourceIndices: number[] = [];
+    appendVisibleItems(visible, nextSourceIndices, itemIds, items, hiddenItemId, 0);
+    result =
+      visible.length === 0
+        ? EMPTY_THREAD_ITEM_IDS
+        : visible.length === itemIds.length
+          ? itemIds
+          : visible;
+    sourceIndices = nextSourceIndices;
+  }
 
   if (visibleItemIdsCache.size > 500) visibleItemIdsCache.clear();
-  visibleItemIdsCache.set(cacheKey, { sourceItemIds: itemIds, structuralVersion, result });
+  visibleItemIdsCache.set(cacheKey, {
+    sourceItemIds: itemIds,
+    structuralVersion,
+    result,
+    sourceIndices,
+    stablePrefixLength,
+  });
   return result;
+}
+
+function appendVisibleItems(
+  visible: string[],
+  sourceIndices: number[],
+  itemIds: readonly string[],
+  items: Record<string, RuntimeChatItem> | undefined,
+  hiddenItemId: string | undefined,
+  startIndex: number,
+): void {
+  for (let index = startIndex; index < itemIds.length; index += 1) {
+    const itemId = itemIds[index]!;
+    if (itemId === hiddenItemId) continue;
+    const item = items?.[itemId];
+    if (item?.parentItemId || (item && !isVisibleRuntimeItem(item))) continue;
+    visible.push(itemId);
+    sourceIndices.push(index);
+  }
+}
+
+function findIncrementalTailStart(
+  previousItemIds: readonly string[],
+  itemIds: readonly string[],
+  changedItemIds: readonly string[],
+): number | null {
+  if (changedItemIds.length === 0 || changedItemIds.length > MAX_INCREMENTAL_TAIL_ITEMS)
+    return null;
+  const remaining = new Set(changedItemIds);
+  let earliestIndex = Number.POSITIVE_INFINITY;
+  const currentStart = Math.max(0, itemIds.length - MAX_INCREMENTAL_TAIL_ITEMS);
+  for (let index = itemIds.length - 1; index >= currentStart && remaining.size > 0; index -= 1) {
+    if (!remaining.delete(itemIds[index]!)) continue;
+    earliestIndex = Math.min(earliestIndex, index);
+  }
+  const previousStart = Math.max(0, previousItemIds.length - MAX_INCREMENTAL_TAIL_ITEMS);
+  for (
+    let index = previousItemIds.length - 1;
+    index >= previousStart && remaining.size > 0;
+    index -= 1
+  ) {
+    if (!remaining.delete(previousItemIds[index]!)) continue;
+    earliestIndex = Math.min(earliestIndex, index);
+  }
+  if (remaining.size > 0 || !Number.isFinite(earliestIndex)) return null;
+  if (earliestIndex > 0 && previousItemIds[earliestIndex - 1] !== itemIds[earliestIndex - 1]) {
+    return null;
+  }
+  return Math.min(earliestIndex, itemIds.length);
+}
+
+function lowerBound(values: readonly number[], target: number): number {
+  let low = 0;
+  let high = values.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (values[middle]! < target) low = middle + 1;
+    else high = middle;
+  }
+  return low;
 }
 
 export function selectVisibleThreadTimelineEntries(
@@ -126,10 +213,86 @@ export function selectVisibleThreadTimelineEntries(
     return cached.entries;
   }
 
-  const entries = buildTimelineEntries(state, threadId, itemIds);
+  const visibleProjection = visibleItemIdsCache.get(cacheKey);
+  const hint = readRuntimeStructuralChangeHint(threadId, structuralVersion);
+  let entries: readonly ChatTimelineEntry[];
+  let entryStartIndices: readonly number[];
+  let childParentIds: ReadonlySet<string>;
+  if (
+    cached &&
+    cached.structuralVersion + 1 === structuralVersion &&
+    visibleProjection &&
+    visibleProjection.structuralVersion === structuralVersion &&
+    hint?.itemIds
+  ) {
+    childParentIds = updateChildParentIds(
+      cached.childParentIds,
+      state.runtimeItemsByIdByThread[threadId],
+      hint.itemIds,
+    );
+    const stablePrefixLength = visibleProjection.stablePrefixLength;
+    if (stablePrefixLength === itemIds.length && cached.itemIds.length === itemIds.length) {
+      entries = cached.entries;
+      entryStartIndices = cached.entryStartIndices;
+    } else {
+      let firstChangedEntry = lowerBound(cached.entryStartIndices, stablePrefixLength);
+      if (firstChangedEntry > 0) firstChangedEntry -= 1;
+      const itemStartIndex = cached.entryStartIndices[firstChangedEntry] ?? 0;
+      const tail = buildTimelineEntryProjection(
+        state.runtimeItemsByIdByThread[threadId],
+        itemIds.slice(itemStartIndex),
+        childParentIds,
+      );
+      entries = [...cached.entries.slice(0, firstChangedEntry), ...tail.entries];
+      entryStartIndices = [
+        ...cached.entryStartIndices.slice(0, firstChangedEntry),
+        ...tail.entryStartIndices.map((index) => index + itemStartIndex),
+      ];
+    }
+  } else {
+    childParentIds = collectChildParentIds(state, threadId);
+    const projection = buildTimelineEntryProjection(
+      state.runtimeItemsByIdByThread[threadId],
+      itemIds,
+      childParentIds,
+    );
+    entries = projection.entries;
+    entryStartIndices = projection.entryStartIndices;
+  }
   if (timelineEntryCache.size > 500) timelineEntryCache.clear();
-  timelineEntryCache.set(cacheKey, { itemIds, structuralVersion, entries });
+  timelineEntryCache.set(cacheKey, {
+    itemIds,
+    structuralVersion,
+    entries,
+    entryStartIndices,
+    childParentIds,
+  });
   return entries;
+}
+
+function collectChildParentIds(state: AppStoreState, threadId: string): ReadonlySet<string> {
+  const items = state.runtimeItemsByIdByThread[threadId];
+  const childParentIds = new Set<string>();
+  for (const itemId of state.runtimeItemIdsByThread[threadId] ?? EMPTY_THREAD_ITEM_IDS) {
+    const parentItemId = items?.[itemId]?.parentItemId;
+    if (parentItemId) childParentIds.add(parentItemId);
+  }
+  return childParentIds;
+}
+
+function updateChildParentIds(
+  previous: ReadonlySet<string>,
+  items: Record<string, RuntimeChatItem> | undefined,
+  changedItemIds: readonly string[],
+): ReadonlySet<string> {
+  let childParentIds: Set<string> | undefined;
+  for (const itemId of changedItemIds) {
+    const parentItemId = items?.[itemId]?.parentItemId;
+    if (!parentItemId || previous.has(parentItemId)) continue;
+    childParentIds ??= new Set(previous);
+    childParentIds.add(parentItemId);
+  }
+  return childParentIds ?? previous;
 }
 
 function buildTimelineEntries(
@@ -138,18 +301,24 @@ function buildTimelineEntries(
   sourceItemIds: readonly string[],
 ): readonly ChatTimelineEntry[] {
   const items = state.runtimeItemsByIdByThread[threadId];
-  const childParentIds = new Set(
-    (state.runtimeItemIdsByThread[threadId] ?? [])
-      .map((itemId) => items?.[itemId]?.parentItemId)
-      .filter((parentItemId): parentItemId is string => parentItemId !== undefined),
-  );
+  const childParentIds = collectChildParentIds(state, threadId);
   const itemIds = sourceItemIds.filter((itemId) => {
     const item = items?.[itemId];
     return !item || isVisibleRuntimeItem(item);
   });
+  return buildTimelineEntryProjection(items, itemIds, childParentIds).entries;
+}
+
+function buildTimelineEntryProjection(
+  items: Record<string, RuntimeChatItem> | undefined,
+  itemIds: readonly string[],
+  childParentIds: ReadonlySet<string>,
+): { entries: readonly ChatTimelineEntry[]; entryStartIndices: readonly number[] } {
   const entries: ChatTimelineEntry[] = [];
+  const entryStartIndices: number[] = [];
   let idx = 0;
   while (idx < itemIds.length) {
+    entryStartIndices.push(idx);
     const itemId = itemIds[idx]!;
     const item = items?.[itemId];
     if (!item || !isToolGroupItem(item) || childParentIds.has(itemId)) {
@@ -182,7 +351,7 @@ function buildTimelineEntries(
       });
     }
   }
-  return entries;
+  return { entries, entryStartIndices };
 }
 
 function isToolGroupItem(item: RuntimeChatItem): boolean {
@@ -611,6 +780,7 @@ export function selectCompletedTurnForEntry(
 }
 
 export function clearRuntimeItemStoreSelectorCacheForThread(threadId: string): void {
+  clearRuntimeStructuralChangeHint(threadId);
   const prefix = `${threadId}\0`;
   for (const key of runtimeItemStoreSelectorCache.keys()) {
     if (key.startsWith(prefix)) {

--- a/src/renderer/state/chatRuntimePersister.test.ts
+++ b/src/renderer/state/chatRuntimePersister.test.ts
@@ -3,6 +3,8 @@ import { useAppStore } from "./appStore";
 import type { RuntimeChatItem } from "./slices/runtimeEventSlice";
 import {
   compactRuntimeItemsForHydration,
+  evictOversizedInactiveThreadRuntimeItems,
+  hasHydratedThreadRuntimeItems,
   hydrateThreadRuntimeItems,
   loadOlderThreadRuntimeItems,
   releaseThreadRuntimeItems,
@@ -42,6 +44,7 @@ function makeItem(
     streams: input.streams ?? {},
     ...(input.payload !== undefined ? { payload: input.payload } : {}),
     ...(input.parentItemId ? { parentItemId: input.parentItemId } : {}),
+    ...(input.observedLive === true ? { observedLive: true } : {}),
   };
 }
 
@@ -316,5 +319,221 @@ describe("paged runtime hydration", () => {
     expect(useAppStore.getState().runtimeItemIdsByThread[threadIds[0]!]).toEqual([
       `${threadIds[0]}-item`,
     ]);
+  });
+
+  it("evicts an oversized transcript as soon as it becomes inactive", async () => {
+    const threadId = "oversized-cached-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: Array.from({ length: 5_001 }, (_, index) =>
+        makeItem({ id: `message-${index}`, type: "assistant_message" }),
+      ),
+      nextCursor: 1,
+    });
+
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toHaveLength(5_001);
+
+    releaseThreadRuntimeItems(threadId);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toBeUndefined();
+
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [makeItem({ id: "tail-message", type: "assistant_message" })],
+      nextCursor: 5_000,
+    });
+    await hydrateThreadRuntimeItems(threadId);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual(["tail-message"]);
+  });
+
+  it("merges the persisted tail with live items received after eviction", async () => {
+    const threadId = "evicted-live-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: Array.from({ length: 5_001 }, (_, index) =>
+        makeItem({ id: `history-${index}`, type: "assistant_message" }),
+      ),
+      nextCursor: 1,
+    });
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+    releaseThreadRuntimeItems(threadId);
+
+    useAppStore.getState().applyRuntimeEvent(threadId, {
+      type: "item.started",
+      threadId,
+      itemId: "live-message",
+      itemType: "tool_call",
+      payload: {
+        name: "Active agent",
+        status: "running",
+        isSubAgent: true,
+      },
+    });
+    expect(hasHydratedThreadRuntimeItems(threadId)).toBe(false);
+
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [
+        makeItem({ id: "tail-message", type: "assistant_message" }),
+        makeItem({
+          id: "live-message",
+          type: "tool_call",
+          state: "started",
+          payload: { name: "Active agent", status: "running", isSubAgent: true },
+        }),
+      ],
+      nextCursor: 5_000,
+    });
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual([
+      "tail-message",
+      "live-message",
+    ]);
+    expect(
+      useAppStore.getState().runtimeItemsByIdByThread[threadId]?.["live-message"],
+    ).toMatchObject({
+      state: "started",
+      payload: { status: "running" },
+    });
+  });
+
+  it("reconciles persisted stale agents without terminating merged live agents", async () => {
+    const threadId = "mixed-stale-live-thread";
+    useAppStore.getState().applyRuntimeEvent(threadId, {
+      type: "item.started",
+      threadId,
+      itemId: "live-agent",
+      itemType: "tool_call",
+      payload: { name: "Live agent", status: "running", isSubAgent: true },
+    });
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [
+        makeItem({
+          id: "stale-agent",
+          type: "tool_call",
+          state: "started",
+          payload: { name: "Stale agent", status: "running", isSubAgent: true },
+        }),
+      ],
+      nextCursor: null,
+    });
+
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(
+      useAppStore.getState().runtimeItemsByIdByThread[threadId]?.["stale-agent"],
+    ).toMatchObject({ state: "completed", payload: { status: "error" } });
+    expect(useAppStore.getState().runtimeItemsByIdByThread[threadId]?.["live-agent"]).toMatchObject(
+      {
+        state: "started",
+        payload: { status: "running" },
+        observedLive: true,
+      },
+    );
+  });
+
+  it("discards an older page that resolves after eviction and rehydration", async () => {
+    const threadId = "stale-page-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: Array.from({ length: 5_001 }, (_, index) =>
+        makeItem({ id: `history-${index}`, type: "assistant_message" }),
+      ),
+      nextCursor: 1_000,
+    });
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+
+    let resolveStalePage: (page: {
+      items: RuntimeChatItem[];
+      nextCursor: number | null;
+    }) => void = () => undefined;
+    bridge.dbGetThreadRuntimeItemsPage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStalePage = resolve;
+      }),
+    );
+    const staleLoad = loadOlderThreadRuntimeItems(threadId);
+    releaseThreadRuntimeItems(threadId);
+
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [makeItem({ id: "fresh-tail", type: "assistant_message" })],
+      nextCursor: 2_000,
+    });
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [makeItem({ id: "fresh-older", type: "assistant_message" })],
+      nextCursor: null,
+    });
+    const freshLoad = loadOlderThreadRuntimeItems(threadId);
+
+    resolveStalePage({
+      items: [makeItem({ id: "stale-page", type: "assistant_message" })],
+      nextCursor: 500,
+    });
+    await expect(staleLoad).resolves.toBe(false);
+    await expect(freshLoad).resolves.toBe(true);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual([
+      "fresh-older",
+      "fresh-tail",
+    ]);
+    expect(bridge.dbGetThreadRuntimeItemsPage).toHaveBeenNthCalledWith(4, {
+      threadId,
+      beforePosition: 2_000,
+      limit: 500,
+      targetTimelineEntryCount: 40,
+    });
+  });
+
+  it("invalidates a pending older page when a remote cursor becomes exhausted", async () => {
+    const threadId = "remote-exhausted-thread";
+    seedOlderThreadRuntimeItemsCursor(threadId, 100);
+
+    let resolveStalePage: (page: {
+      items: RuntimeChatItem[];
+      nextCursor: number | null;
+    }) => void = () => undefined;
+    bridge.dbGetThreadRuntimeItemsPage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStalePage = resolve;
+      }),
+    );
+    const staleLoad = loadOlderThreadRuntimeItems(threadId);
+
+    seedOlderThreadRuntimeItemsCursor(threadId, null, { preserveExistingCursor: true });
+    resolveStalePage({
+      items: [makeItem({ id: "stale-remote-page", type: "assistant_message" })],
+      nextCursor: 50,
+    });
+
+    await expect(staleLoad).resolves.toBe(false);
+    await expect(loadOlderThreadRuntimeItems(threadId)).resolves.toBe(false);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toBeUndefined();
+  });
+
+  it("re-evicts an inactive transcript that regrows from background events", async () => {
+    const threadId = "regrown-background-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: Array.from({ length: 5_001 }, (_, index) =>
+        makeItem({ id: `history-${index}`, type: "assistant_message" }),
+      ),
+      nextCursor: 1,
+    });
+    retainThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+    releaseThreadRuntimeItems(threadId);
+
+    useAppStore.getState().applyRuntimeEvents(
+      threadId,
+      Array.from({ length: 5_001 }, (_, index) => ({
+        type: "item.started" as const,
+        threadId,
+        itemId: `background-${index}`,
+        itemType: "assistant_message" as const,
+      })),
+    );
+    evictOversizedInactiveThreadRuntimeItems([threadId]);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toBeUndefined();
   });
 });

--- a/src/renderer/state/chatRuntimePersister.ts
+++ b/src/renderer/state/chatRuntimePersister.ts
@@ -2,6 +2,7 @@ import type { ToolCallPayload } from "@/shared/contracts";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
 import { captureRendererException } from "../diagnostics/sentry";
 import { imageViewRendersInline } from "../components/thread/ChatPane/parts/items/imageViewSource";
+import { clearRuntimeItemStoreSelectorCacheForThread } from "../components/thread/ChatPane/chatPaneSelectors";
 import { readBridge } from "../bridge";
 import { useAppStore } from "./appStore";
 import {
@@ -13,10 +14,14 @@ import {
 const RUNTIME_PAGE_SCAN_SIZE = 500;
 const RUNTIME_TIMELINE_PAGE_SIZE = 40;
 const MAX_CACHED_THREAD_TRANSCRIPTS = 10;
+const MAX_CACHED_THREAD_RUNTIME_ITEMS = 5_000;
 const hydratedThreadRuntimeIds = new Set<string>();
 const pendingThreadRuntimeHydrations = new Map<string, Promise<boolean>>();
 const olderRuntimePageCursorByThread = new Map<string, number | null>();
-const pendingOlderRuntimePages = new Map<string, Promise<boolean>>();
+const pendingOlderRuntimePages = new Map<
+  string,
+  { cancelled: boolean; readonly promise: Promise<boolean> }
+>();
 const retainedThreadRuntimeCounts = new Map<string, number>();
 const inactiveThreadRuntimeLru = new Set<string>();
 
@@ -36,8 +41,13 @@ export function seedOlderThreadRuntimeItemsCursor(
   cursor: number | null,
   options: { readonly preserveExistingCursor?: boolean } = {},
 ): void {
-  hydratedThreadRuntimeIds.add(threadId);
   const currentCursor = olderRuntimePageCursorByThread.get(threadId);
+  if (
+    options.preserveExistingCursor !== true ||
+    (cursor === null && currentCursor !== undefined && currentCursor !== null)
+  )
+    cancelPendingOlderRuntimePage(threadId);
+  hydratedThreadRuntimeIds.add(threadId);
   if (options.preserveExistingCursor !== true || currentCursor === undefined || cursor === null) {
     olderRuntimePageCursorByThread.set(threadId, cursor);
     return;
@@ -47,10 +57,7 @@ export function seedOlderThreadRuntimeItemsCursor(
 }
 
 export function hasHydratedThreadRuntimeItems(threadId: string): boolean {
-  return (
-    hydratedThreadRuntimeIds.has(threadId) ||
-    Object.prototype.hasOwnProperty.call(useAppStore.getState().runtimeItemIdsByThread, threadId)
-  );
+  return hydratedThreadRuntimeIds.has(threadId);
 }
 
 export function retainThreadRuntimeItems(threadId: string): void {
@@ -67,6 +74,7 @@ export function releaseThreadRuntimeItems(threadId: string): void {
   retainedThreadRuntimeCounts.delete(threadId);
   inactiveThreadRuntimeLru.delete(threadId);
   inactiveThreadRuntimeLru.add(threadId);
+  evictOversizedInactiveThreadRuntimeItems([threadId]);
   evictInactiveThreadRuntimeItems();
 }
 
@@ -74,8 +82,9 @@ export async function loadOlderThreadRuntimeItems(threadId: string): Promise<boo
   const cursor = olderRuntimePageCursorByThread.get(threadId);
   if (cursor === undefined || cursor === null) return false;
   const pending = pendingOlderRuntimePages.get(threadId);
-  if (pending) return pending;
+  if (pending && !pending.cancelled) return pending.promise;
 
+  const request = { cancelled: false, promise: Promise.resolve(false) };
   const load = (async () => {
     const page = await readBridge().dbGetThreadRuntimeItemsPage({
       threadId,
@@ -83,22 +92,30 @@ export async function loadOlderThreadRuntimeItems(threadId: string): Promise<boo
       limit: RUNTIME_PAGE_SCAN_SIZE,
       targetTimelineEntryCount: RUNTIME_TIMELINE_PAGE_SIZE,
     });
+    if (request.cancelled || !hydratedThreadRuntimeIds.has(threadId)) {
+      return false;
+    }
     olderRuntimePageCursorByThread.set(threadId, page.nextCursor);
     if (page.items.length === 0) return false;
     const items = compactRuntimeItemsForHydration(page.items.map(toRuntimeChatItem));
     useAppStore.getState().prependThreadRuntimeItems(threadId, items);
-    useAppStore.getState().reconcileStaleSubAgents(threadId);
+    useAppStore.getState().reconcileStaleSubAgents(threadId, { preserveObservedLive: true });
+    evictOversizedInactiveThreadRuntimeItems([threadId]);
+    evictInactiveThreadRuntimeItems();
     return true;
   })().catch((error: unknown) => {
     console.warn("[chat] failed to load older runtime items for thread %s", threadId, error);
     captureRendererException(error, { featureArea: "runtime-persistence" });
     return false;
   });
-  pendingOlderRuntimePages.set(threadId, load);
+  request.promise = load;
+  pendingOlderRuntimePages.set(threadId, request);
   try {
     return await load;
   } finally {
-    pendingOlderRuntimePages.delete(threadId);
+    if (pendingOlderRuntimePages.get(threadId) === request) {
+      pendingOlderRuntimePages.delete(threadId);
+    }
   }
 }
 
@@ -121,6 +138,8 @@ export async function hydrateThreadRuntimeItems(threadId: string): Promise<void>
     const completed = await hydration;
     if (completed) {
       hydratedThreadRuntimeIds.add(threadId);
+      evictOversizedInactiveThreadRuntimeItems([threadId]);
+      evictInactiveThreadRuntimeItems();
     }
   } finally {
     pendingThreadRuntimeHydrations.delete(threadId);
@@ -147,14 +166,24 @@ async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolea
   if (itemsResult.status === "fulfilled" && itemsResult.value.items.length > 0) {
     // Persisted rows can contain raw tool runs or legacy synthetic summaries;
     // normalize both forms during hydration.
-    const items = compactRuntimeItemsForHydration(itemsResult.value.items.map(toRuntimeChatItem));
-    useAppStore.getState().hydrateThreadRuntimeItems(threadId, items);
+    const persistedItems = itemsResult.value.items.map(toRuntimeChatItem);
+    const state = useAppStore.getState();
+    const existingItemIds = state.runtimeItemIdsByThread[threadId] ?? [];
+    if (existingItemIds.length === 0) {
+      state.hydrateThreadRuntimeItems(threadId, compactRuntimeItemsForHydration(persistedItems));
+    } else {
+      const existingItemIdSet = new Set(existingItemIds);
+      const overlapIndex = persistedItems.findIndex((item) => existingItemIdSet.has(item.id));
+      const persistedPrefix =
+        overlapIndex < 0 ? persistedItems : persistedItems.slice(0, overlapIndex);
+      state.prependThreadRuntimeItems(threadId, compactRuntimeItemsForHydration(persistedPrefix));
+    }
     // Any sub-agent tool_call that was mid-flight when the prior session
     // ended will hydrate here as still "running" and show up in the active
     // sub-agent dock forever. Reconcile in place so those rows render as
     // terminated immediately instead of waiting for a live event that will
     // never come.
-    useAppStore.getState().reconcileStaleSubAgents(threadId);
+    useAppStore.getState().reconcileStaleSubAgents(threadId, { preserveObservedLive: true });
   } else if (itemsResult.status === "rejected") {
     console.warn(
       "[chat] failed to hydrate runtime items for thread %s",
@@ -203,10 +232,29 @@ function evictInactiveThreadRuntimeItems(): void {
   while (inactiveThreadRuntimeLru.size > MAX_CACHED_THREAD_TRANSCRIPTS) {
     const threadId = inactiveThreadRuntimeLru.keys().next().value as string | undefined;
     if (!threadId) return;
-    inactiveThreadRuntimeLru.delete(threadId);
-    hydratedThreadRuntimeIds.delete(threadId);
-    olderRuntimePageCursorByThread.delete(threadId);
-    useAppStore.getState().evictThreadRuntimeItems(threadId);
+    evictThreadRuntimeItems(threadId);
+  }
+}
+
+function evictThreadRuntimeItems(threadId: string): void {
+  inactiveThreadRuntimeLru.delete(threadId);
+  hydratedThreadRuntimeIds.delete(threadId);
+  olderRuntimePageCursorByThread.delete(threadId);
+  cancelPendingOlderRuntimePage(threadId);
+  clearRuntimeItemStoreSelectorCacheForThread(threadId);
+  useAppStore.getState().evictThreadRuntimeItems(threadId);
+}
+
+function cancelPendingOlderRuntimePage(threadId: string): void {
+  const pending = pendingOlderRuntimePages.get(threadId);
+  if (pending) pending.cancelled = true;
+}
+
+export function evictOversizedInactiveThreadRuntimeItems(threadIds: readonly string[]): void {
+  for (const threadId of threadIds) {
+    if (retainedThreadRuntimeCounts.has(threadId)) continue;
+    const itemCount = useAppStore.getState().runtimeItemIdsByThread[threadId]?.length ?? 0;
+    if (itemCount > MAX_CACHED_THREAD_RUNTIME_ITEMS) evictThreadRuntimeItems(threadId);
   }
 }
 

--- a/src/renderer/state/remote/sync.ts
+++ b/src/renderer/state/remote/sync.ts
@@ -18,6 +18,7 @@ import {
   requestsFromRuntimeItems,
 } from "./runtimeRequests";
 import { shouldReplaceRuntimeItemsFromSnapshot } from "./guards";
+import { evictOversizedInactiveThreadRuntimeItems } from "../chatRuntimePersister";
 
 /**
  * Feeds remote snapshots and live WebSocket events into the same Zustand
@@ -366,6 +367,7 @@ function flushPendingRuntimeEvents(shouldFlush: (threadId: string) => boolean): 
   }
   if (batches.length === 0) return;
   store.applyRuntimeEventBatches(batches);
+  evictOversizedInactiveThreadRuntimeItems(batches.map((batch) => batch.threadId));
 }
 
 function schedulePendingRuntimeEvents(): void {

--- a/src/renderer/state/runtimeStructuralChanges.ts
+++ b/src/renderer/state/runtimeStructuralChanges.ts
@@ -1,0 +1,29 @@
+export type RuntimeStructuralChangeHint = {
+  readonly version: number;
+  readonly itemIds: readonly string[] | null;
+};
+
+const runtimeStructuralChangeHints = new Map<string, RuntimeStructuralChangeHint>();
+
+export function recordRuntimeStructuralChangeHint(
+  threadId: string,
+  version: number,
+  itemIds: ReadonlySet<string> | null,
+): void {
+  runtimeStructuralChangeHints.set(threadId, {
+    version,
+    itemIds: itemIds === null ? null : [...itemIds],
+  });
+}
+
+export function readRuntimeStructuralChangeHint(
+  threadId: string,
+  version: number,
+): RuntimeStructuralChangeHint | null {
+  const hint = runtimeStructuralChangeHints.get(threadId);
+  return hint?.version === version ? hint : null;
+}
+
+export function clearRuntimeStructuralChangeHint(threadId: string): void {
+  runtimeStructuralChangeHints.delete(threadId);
+}

--- a/src/renderer/state/slices/runtimeEventReducer.ts
+++ b/src/renderer/state/slices/runtimeEventReducer.ts
@@ -1,5 +1,6 @@
 import type { RuntimeEvent, ThreadContextUsage, ToolCallPayload } from "@/shared/contracts";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
+import { recordRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import type { AppStoreState } from "./shared";
 import {
   type CompletedTurnRecord,
@@ -51,6 +52,7 @@ export function applyRuntimeEventBatchesToState(
   };
   let changed = false;
   const structuralBumpThreadIds = new Set<string>();
+  const structuralChangedItemIdsByThread = new Map<string, Set<string> | null>();
 
   for (const batch of batches) {
     if (batch.events.length === 0) continue;
@@ -77,7 +79,18 @@ export function applyRuntimeEventBatchesToState(
           if (itemBatch) {
             nextState = itemBatch.state;
             batchChanged = true;
-            if (itemBatch.structuralChanged) structuralBumpThreadIds.add(threadId);
+            if (itemBatch.structuralItemIds === null || itemBatch.structuralItemIds.size > 0) {
+              structuralBumpThreadIds.add(threadId);
+              if (itemBatch.structuralItemIds === null) {
+                structuralChangedItemIdsByThread.set(threadId, null);
+              } else {
+                mergeStructuralChangedItemIds(
+                  structuralChangedItemIdsByThread,
+                  threadId,
+                  itemBatch.structuralItemIds,
+                );
+              }
+            }
           }
           eventIndex = itemRunEnd;
           continue;
@@ -92,7 +105,17 @@ export function applyRuntimeEventBatchesToState(
         nextState = { ...nextState, ...reopenPatch };
       }
       batchChanged = true;
-      if (eventAffectsStructuralVersion(event)) structuralBumpThreadIds.add(threadId);
+      if (eventAffectsStructuralVersion(event)) {
+        structuralBumpThreadIds.add(threadId);
+        if (
+          event.type === "item.completed" &&
+          !nextState.runtimeItemsByIdByThread[threadId]?.[event.itemId]
+        ) {
+          structuralChangedItemIdsByThread.set(threadId, null);
+        } else {
+          noteStructuralChangedEvent(structuralChangedItemIdsByThread, threadId, event);
+        }
+      }
     }
     if (batchChanged) {
       changed = true;
@@ -103,10 +126,16 @@ export function applyRuntimeEventBatchesToState(
   if (structuralBumpThreadIds.size > 0) {
     let runtimeStructuralVersionByThread = nextState.runtimeStructuralVersionByThread;
     for (const threadId of structuralBumpThreadIds) {
+      const nextVersion = (runtimeStructuralVersionByThread[threadId] ?? 0) + 1;
       runtimeStructuralVersionByThread = {
         ...runtimeStructuralVersionByThread,
-        [threadId]: (runtimeStructuralVersionByThread[threadId] ?? 0) + 1,
+        [threadId]: nextVersion,
       };
+      recordRuntimeStructuralChangeHint(
+        threadId,
+        nextVersion,
+        structuralChangedItemIdsByThread.get(threadId) ?? null,
+      );
     }
     nextState = { ...nextState, runtimeStructuralVersionByThread };
   }
@@ -117,25 +146,28 @@ export function applyRuntimeEventBatchesToState(
 
 /**
  * Buffered sub-agent history is delivered as one batch containing hundreds of
- * item lifecycle events. Clone the thread collections once for that replay;
- * cloning the growing id array and item map for every event makes hydration
- * quadratic and blocks the panel's first paint.
+ * item lifecycle events. Reuse the thread's item index and clone its id array
+ * only if membership changes; copying a large index for every live batch makes
+ * active long threads progressively slower.
  */
 function applyRuntimeItemEvents(
   state: RuntimeEventState,
   threadId: string,
   events: RuntimeEvent[],
   applyReopen: boolean,
-): { state: RuntimeEventState; structuralChanged: boolean } | null {
+): { state: RuntimeEventState; structuralItemIds: ReadonlySet<string> | null } | null {
   if (!events.every(isRuntimeItemEvent)) return null;
 
   const existingIds = state.runtimeItemIdsByThread[threadId] ?? [];
   const existingItems = state.runtimeItemsByIdByThread[threadId] ?? {};
-  const preserveItemsMap = events.length === 1 && events[0]?.type === "content.delta";
   const draft: RuntimeItemDraft = {
     itemIds: existingIds,
     itemIdsChanged: false,
-    items: preserveItemsMap ? existingItems : { ...existingItems },
+    // The outer per-thread map is replaced below, so item selectors are still
+    // notified when their item object changes. Keep the inner index mutable:
+    // cloning every entry for each structural batch makes active long threads
+    // progressively slower even though a batch only touches its tail items.
+    items: existingItems,
   };
   let nextState: RuntimeEventState = {
     ...state,
@@ -145,14 +177,24 @@ function applyRuntimeItemEvents(
     },
   };
   let changed = false;
-  let structuralChanged = false;
+  let structuralItemIds: Set<string> | null = new Set<string>();
 
   for (const event of events) {
     const itemIdsChangedBefore = draft.itemIdsChanged;
+    const itemBefore = draft.items[event.itemId];
     const eventChanged = applyRuntimeItemEvent(draft, event);
     if (!eventChanged) continue;
     changed = true;
-    if (eventAffectsStructuralVersion(event)) structuralChanged = true;
+    if (eventAffectsStructuralVersion(event)) {
+      if (itemBefore && !draft.items[event.itemId]) {
+        structuralItemIds = null;
+      } else if (structuralItemIds) {
+        structuralItemIds.add(event.itemId);
+        if (event.type === "item.started" && event.parentItemId) {
+          structuralItemIds.add(event.parentItemId);
+        }
+      }
+    }
     if (!itemIdsChangedBefore && draft.itemIdsChanged) {
       nextState = {
         ...nextState,
@@ -170,7 +212,38 @@ function applyRuntimeItemEvents(
     }
   }
 
-  return changed ? { state: nextState, structuralChanged } : null;
+  return changed ? { state: nextState, structuralItemIds } : null;
+}
+
+function noteStructuralChangedEvent(
+  changes: Map<string, Set<string> | null>,
+  threadId: string,
+  event: RuntimeEvent,
+): void {
+  if (!isRuntimeItemEvent(event)) {
+    changes.set(threadId, null);
+    return;
+  }
+  const itemIds = changes.get(threadId);
+  if (itemIds === null) return;
+  const nextItemIds = itemIds ?? new Set<string>();
+  nextItemIds.add(event.itemId);
+  if (event.type === "item.started" && event.parentItemId) {
+    nextItemIds.add(event.parentItemId);
+  }
+  changes.set(threadId, nextItemIds);
+}
+
+function mergeStructuralChangedItemIds(
+  changes: Map<string, Set<string> | null>,
+  threadId: string,
+  itemIds: ReadonlySet<string>,
+): void {
+  const existing = changes.get(threadId);
+  if (existing === null) return;
+  const merged = existing ?? new Set<string>();
+  for (const itemId of itemIds) merged.add(itemId);
+  changes.set(threadId, merged);
 }
 
 interface RuntimeItemDraft {

--- a/src/renderer/state/slices/runtimeEventSlice.test.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
 import type { RuntimeEvent } from "@/shared/contracts";
 import {
   createRuntimeEventSlice,
@@ -12,10 +13,12 @@ import {
  * Zustand store so the rest of the app store doesn't have to be wired up.
  */
 function makeStore() {
-  return create<RuntimeEventSlice>()((set, get, store) =>
-    // Cast — the slice's `SliceCreator<T>` parameter expects the full app
-    // state, but the slice itself only touches its own keys. Safe in tests.
-    createRuntimeEventSlice(set as never, get as never, store as never),
+  return create<RuntimeEventSlice>()(
+    subscribeWithSelector((set, get, store) =>
+      // Cast — the slice's `SliceCreator<T>` parameter expects the full app
+      // state, but the slice itself only touches its own keys. Safe in tests.
+      createRuntimeEventSlice(set as never, get as never, store as never),
+    ),
   );
 }
 
@@ -138,6 +141,68 @@ describe("runtimeEventSlice.applyRuntimeEvent", () => {
     expect(afterItems).toBe(beforeItems);
     expect(afterItems?.["i1"]).not.toBe(beforeItem);
     expect(afterItems?.["i1"]?.streams.assistant_text).toBe("Hello");
+  });
+
+  it("applies structural item events without cloning the whole thread item map", () => {
+    apply("t1", {
+      type: "item.started",
+      threadId: "t1",
+      itemId: "i1",
+      itemType: "assistant_message",
+    });
+    const beforeItems = store.getState().runtimeItemsByIdByThread["t1"];
+    const beforeItem = beforeItems?.["i1"];
+
+    apply("t1", {
+      type: "item.started",
+      threadId: "t1",
+      itemId: "i2",
+      itemType: "assistant_message",
+    });
+    expect(store.getState().runtimeItemsByIdByThread["t1"]).toBe(beforeItems);
+
+    apply("t1", {
+      type: "item.updated",
+      threadId: "t1",
+      itemId: "i1",
+      payload: { content: [] },
+    });
+    const updatedItems = store.getState().runtimeItemsByIdByThread["t1"];
+    expect(updatedItems).toBe(beforeItems);
+    expect(updatedItems?.["i1"]).not.toBe(beforeItem);
+
+    apply("t1", {
+      type: "item.completed",
+      threadId: "t1",
+      itemId: "i1",
+    });
+    expect(store.getState().runtimeItemsByIdByThread["t1"]).toBe(beforeItems);
+    expect(store.getState().runtimeItemsByIdByThread["t1"]?.["i1"]?.state).toBe("completed");
+  });
+
+  it("notifies item selectors while preserving the thread item map", () => {
+    apply("t1", {
+      type: "item.started",
+      threadId: "t1",
+      itemId: "i1",
+      itemType: "assistant_message",
+    });
+    const beforeItems = store.getState().runtimeItemsByIdByThread["t1"];
+    const observed: string[] = [];
+    const unsubscribe = store.subscribe(
+      (state) => state.runtimeItemsByIdByThread["t1"]?.["i1"],
+      (item) => observed.push(item?.state ?? "missing"),
+    );
+
+    apply("t1", {
+      type: "item.completed",
+      threadId: "t1",
+      itemId: "i1",
+    });
+
+    unsubscribe();
+    expect(store.getState().runtimeItemsByIdByThread["t1"]).toBe(beforeItems);
+    expect(observed).toEqual(["completed"]);
   });
 
   it("stores context usage updates", () => {

--- a/src/renderer/state/slices/runtimeEventSlice.ts
+++ b/src/renderer/state/slices/runtimeEventSlice.ts
@@ -14,6 +14,7 @@ import type { PersistedRuntimeItem } from "@/shared/ipc";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
 import { i18n } from "@/renderer/i18n/i18n";
 import type { SliceCreator } from "./shared";
+import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import {
   applyRuntimeEventsToState,
   applyRuntimeEventBatchesToState,
@@ -139,7 +140,10 @@ export interface RuntimeEventSlice {
    * this, parents that never completed (denied permissions, crashes, abrupt
    * exits) keep appearing in the active sub-agent dock forever.
    */
-  reconcileStaleSubAgents(threadId: string): void;
+  reconcileStaleSubAgents(
+    threadId: string,
+    options?: { readonly preserveObservedLive?: boolean },
+  ): void;
   /**
    * Revert the visible chat transcript to a checkpoint item, preserving that
    * item and everything before it. Used by GUI chat checkpoints.
@@ -226,6 +230,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
 
   clearThreadRuntimeEvents: (threadId) =>
     set((state) => {
+      clearRuntimeStructuralChangeHint(threadId);
       if (
         !(threadId in state.runtimeItemIdsByThread) &&
         !(threadId in state.runtimeItemsByIdByThread) &&
@@ -262,12 +267,13 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
       };
     }),
 
-  reconcileStaleSubAgents: (threadId) =>
+  reconcileStaleSubAgents: (threadId, options) =>
     set((state) => {
       const items = state.runtimeItemsByIdByThread[threadId];
       if (!items) return {};
       let nextItems: Record<string, RuntimeChatItem> | undefined;
       for (const [id, item] of Object.entries(items)) {
+        if (options?.preserveObservedLive === true && item.observedLive === true) continue;
         if (!isStaleSubAgentItem(item)) continue;
         nextItems ??= { ...items };
         nextItems[id] = terminateSubAgentItem(item);
@@ -381,6 +387,7 @@ export const createRuntimeEventSlice: SliceCreator<RuntimeEventSlice> = (set) =>
 
   evictThreadRuntimeItems: (threadId) =>
     set((state) => {
+      clearRuntimeStructuralChangeHint(threadId);
       if (!(threadId in state.runtimeItemIdsByThread)) return {};
       const { [threadId]: _itemIds, ...runtimeItemIdsByThread } = state.runtimeItemIdsByThread;
       const { [threadId]: _items, ...runtimeItemsByIdByThread } = state.runtimeItemsByIdByThread;

--- a/src/renderer/state/slices/threadSlice.ts
+++ b/src/renderer/state/slices/threadSlice.ts
@@ -27,6 +27,7 @@ import {
 import { recordThreadStarted } from "../usageRecorder";
 import { removeKeepAliveId } from "./paneCacheSlice";
 import type { SliceCreator } from "./shared";
+import { clearRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 
 export interface ThreadSlice {
   threads: Thread[];
@@ -252,6 +253,7 @@ export const createThreadSlice: SliceCreator<ThreadSlice> = (set) => ({
   },
   deleteThread: (threadId) =>
     set((state) => {
+      clearRuntimeStructuralChangeHint(threadId);
       const nextThreads = state.threads.filter((thread) => thread.id !== threadId);
 
       if (nextThreads.length === state.threads.length) {


### PR DESCRIPTION
- Bound cached runtime items for inactive chat threads to prevent unbounded memory use.
- Refresh timeline and find selectors when runtime structure changes without unnecessary rescans.
- Keep debug views responsive to streaming item updates.
- Add regression coverage for eviction, selector invalidation, and runtime event subscriptions.