### PR TITLE
Update the GLM preset to 5.3

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Gitignorierte Dateien zum Kopieren aus dem Hauptprojekt in jeden neuen Arbeitsbaum. Muster im Gitignore-Stil, eines pro Zeile (z. B. <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (optionale Beschriftung)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (optionale Beschriftung)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Gitignored files to copy from the main project into each new worktree. Gitignore-style patterns, one per line (e.g., <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (optional label)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (optional label)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Archivos ignorados por Git para copiar del proyecto principal a cada nuevo worktree. Patrones estilo gitignore, uno por línea (p. ej., <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (etiqueta opcional)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (etiqueta opcional)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Fichiers Gitignorés à copier du projet principal dans chaque nouvel arbre de travail. Modèles de style Gitignore, un par ligne (par exemple, <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (libellé optionnel)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (libellé optionnel)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -5576,8 +5576,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "メイン プロジェクトから各新しいワークツリーにコピーする、Gitignored ファイル。 Gitignore スタイルのパターン、1 行に 1 つ (例: <0>.env.*</0>)。"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2（任意のラベル）"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3（任意のラベル）"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "기본 프로젝트에서 각각의 새 작업 트리로 복사할 Gitignored 파일입니다. Gitignore 스타일 패턴, 한 줄에 하나씩(예: <0>.env.*</0>)"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (선택 레이블)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (선택 레이블)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Pliki ignorowane przez Git do skopiowania z głównego projektu do każdego nowego drzewa roboczego. Wzorce w stylu Gitignore, po jednym w wierszu (np. <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (etykieta opcjonalna)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (etykieta opcjonalna)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Arquivos gitignorados para copiar do projeto principal para cada nova árvore de trabalho. Padrões estilo Gitignore, um por linha (por exemplo, <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (rótulo opcional)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (rótulo opcional)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Игнорируемые Git файлы для копирования из основного проекта в каждый новый worktree. Шаблоны в стиле gitignore, по одному на строку (напр., <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (необязательная метка)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (необязательная метка)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Ana projeden her yeni çalışma ağacına kopyalanacak Git yok sayılan dosyalar. Gitignore tarzı desenler, her satıra bir tane (ör. <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (isteğe bağlı etiket)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (isteğe bağlı etiket)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Ігноровані Git файли для копіювання з основного проєкту до кожного нового worktree. Шаблони у стилі gitignore, по одному на рядок (напр., <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (необов'язкова мітка)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (необов'язкова мітка)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Các tệp được Gitignored để sao chép từ dự án chính vào từng cây làm việc mới. Các mẫu kiểu Gitignore, mỗi mẫu một dòng (ví dụ: <0>.env.*</0>)."
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2 (nhãn tùy chọn)"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3 (nhãn tùy chọn)"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -5577,8 +5577,8 @@ msgid "Gitignored files to copy from the main project into each new worktree. Gi
 msgstr "Gitignored 文件从主项目复制到每个新工作树中。 Gitignore 风格的模式，每行一个（例如 <0>.env.*</0>）。"
 
 #: src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
-msgid "GLM 5.2 (optional label)"
-msgstr "GLM 5.2（可选标签）"
+msgid "GLM 5.3 (optional label)"
+msgstr "GLM 5.3（可选标签）"
 
 #: src/renderer/views/SettingsOverlay/parts/cursorRuntimeInstall.ts
 msgid "global"

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.test.tsx
@@ -357,14 +357,17 @@ describe("ClaudeProfileProviderSettings", () => {
     expect(screen.getByDisplayValue("https://api.z.ai/api/anthropic")).toBeInTheDocument();
     expect(screen.getByDisplayValue("ANTHROPIC_AUTH_TOKEN")).toBeInTheDocument();
     expect(screen.getByDisplayValue("CLAUDE_CODE_AUTO_COMPACT_WINDOW")).toBeInTheDocument();
-    // The preset's GLM 5.2 picker model id keeps its [1m] suffix verbatim.
-    expect(screen.getByLabelText("Model id")).toHaveValue("glm-5.2[1m]");
+    // The preset's GLM 5.3 picker model ids keep their [1m] suffix verbatim.
+    expect(
+      screen.getAllByLabelText("Model id").map((input) => input.getAttribute("value")),
+    ).toEqual(["glm-5.3[1m]", "glm-5.3-flash[1m]"]);
     expect(settingsState.setHiddenModels).toHaveBeenCalledWith("claude:glm", [
       "claude-opus-4-8",
       "claude-opus-4-7",
       "claude-opus-4-6",
       "sonnet",
       "haiku",
+      "glm-5.2[1m]",
     ]);
   });
 

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettings.tsx
@@ -535,14 +535,14 @@ function ClaudeProfileEditor(props: {
               <Input
                 aria-label={t`Model id`}
                 className="min-w-48 flex-[1_1_12rem] font-mono text-xs"
-                placeholder="glm-5.2[1m]"
+                placeholder="glm-5.3[1m]"
                 value={row.id}
                 onChange={(event) => updateModelRow(row.rowId, { id: event.target.value })}
               />
               <Input
                 aria-label={t`Model label`}
                 className="min-w-48 flex-[1_1_12rem] text-xs"
-                placeholder={t`GLM 5.2 (optional label)`}
+                placeholder={t`GLM 5.3 (optional label)`}
                 value={row.label}
                 onChange={(event) => updateModelRow(row.rowId, { label: event.target.value })}
               />

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.test.ts
@@ -94,9 +94,9 @@ describe("ClaudeProfileSettingsModel", () => {
         applyPresetEnvRows(ZAI_PRESET_ROWS, [], nextRowId).map((row) => [row.key, row.value]),
       );
       expect(byKey.ANTHROPIC_BASE_URL).toBe("https://api.z.ai/api/anthropic");
-      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("glm-5.2[1m]");
-      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("glm-5.2[1m]");
-      expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("glm-4.5-air");
+      expect(byKey.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("glm-5.3[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("glm-5.3-flash[1m]");
+      expect(byKey.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("glm-5.3-flash[1m]");
       expect(byKey.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1000000");
     });
 
@@ -212,7 +212,7 @@ describe("ClaudeProfileSettingsModel", () => {
         applyPresetEnvRows(ZAI_PRESET_ROWS, existing, nextRowId).map((r) => [r.key, r]),
       );
 
-      expect(byKey.get("ANTHROPIC_DEFAULT_OPUS_MODEL")?.value).toBe("glm-5.2[1m]");
+      expect(byKey.get("ANTHROPIC_DEFAULT_OPUS_MODEL")?.value).toBe("glm-5.3[1m]");
       expect(byKey.get("ANTHROPIC_AUTH_TOKEN")?.value).toBe("lc-safe:v1:sealed");
       expect(byKey.get("MY_CUSTOM")?.value).toBe("keep");
     });

--- a/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
+++ b/src/renderer/views/SettingsOverlay/parts/ClaudeProfileSettingsModel.ts
@@ -21,16 +21,19 @@ export type PresetEnvRow = { key: string; value: string; sensitive: boolean };
 
 /**
  * Canonical z.ai (GLM) environment, per https://docs.z.ai/devpack/tool/claude.
- * `glm-5.2[1m]` is z.ai's real model name for the 1M-context GLM 5.2 — the `[1m]`
+ * `glm-5.3[1m]` is z.ai's real model name for the 1M-context GLM 5.3 — the `[1m]`
  * is part of the id, not Poracode's context selector, so it is sent verbatim.
+ * `glm-5.3-flash[1m]` is the cheaper tier; z.ai lists Flash as its default
+ * mapping for the Sonnet/Haiku slots (its manual-config example keeps the full
+ * model on Sonnet) — we follow the default mapping.
  * `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is required for the 1M context to be usable.
  */
 export const ZAI_PRESET_ROWS: ReadonlyArray<PresetEnvRow> = [
   { key: "ANTHROPIC_BASE_URL", value: "https://api.z.ai/api/anthropic", sensitive: false },
   { key: "ANTHROPIC_AUTH_TOKEN", value: "", sensitive: true },
-  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "glm-5.2[1m]", sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "glm-5.2[1m]", sensitive: false },
-  { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "glm-4.5-air", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_OPUS_MODEL", value: "glm-5.3[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_SONNET_MODEL", value: "glm-5.3-flash[1m]", sensitive: false },
+  { key: "ANTHROPIC_DEFAULT_HAIKU_MODEL", value: "glm-5.3-flash[1m]", sensitive: false },
   { key: "API_TIMEOUT_MS", value: "3000000", sensitive: false },
   { key: "CLAUDE_CODE_AUTO_COMPACT_WINDOW", value: "1000000", sensitive: false },
 ];
@@ -154,11 +157,17 @@ export const PROFILE_PRESETS: readonly ProfilePreset[] = [
     id: "zai",
     label: msg`z.ai`,
     envRows: ZAI_PRESET_ROWS,
-    // glm-5.2[1m] is z.ai's 1M-context GLM 5.2 (the `[1m]` is part of the id).
-    models: [{ id: "glm-5.2[1m]", label: "GLM 5.2" }],
-    efforts: ["high", "max", "ultracode"],
+    // glm-5.3[1m] is z.ai's 1M-context GLM 5.3 (the `[1m]` is part of the id).
+    models: [
+      { id: "glm-5.3[1m]", label: "GLM 5.3" },
+      { id: "glm-5.3-flash[1m]", label: "GLM 5.3 Flash" },
+    ],
+    efforts: ["low", "high", "max", "ultracode"],
     defaultEffort: "high",
-    modelEfforts: { "glm-5.2[1m]": ["high", "max", "ultracode"] },
+    modelEfforts: {
+      "glm-5.3[1m]": ["low", "high", "max", "ultracode"],
+      "glm-5.3-flash[1m]": ["low", "high", "max", "ultracode"],
+    },
   },
   {
     id: "deepseek",


### PR DESCRIPTION
- Update the z.ai Claude preset with GLM 5.3 and GLM 5.3 Flash models.
- Add low-effort support for both new models.
- Refresh Claude settings placeholders and localized labels.
- Update preset and UI tests for the new model IDs and legacy model retention.