### PR TITLE
Add push and create PR action

### DIFF
--- a/src/renderer/locales/de/messages.po
+++ b/src/renderer/locales/de/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push & PR erstellen"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/en/messages.po
+++ b/src/renderer/locales/en/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push & Create PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/es/messages.po
+++ b/src/renderer/locales/es/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push y crear PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/fr/messages.po
+++ b/src/renderer/locales/fr/messages.po
@@ -9416,6 +9416,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push et créer une PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/ja/messages.po
+++ b/src/renderer/locales/ja/messages.po
@@ -9415,6 +9415,10 @@ msgstr "プッシュ ({0})"
 msgid "Push ({ahead})"
 msgstr "プッシュ ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "プッシュして PR を作成"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "プッシュ ↑{ahead}"

--- a/src/renderer/locales/ko/messages.po
+++ b/src/renderer/locales/ko/messages.po
@@ -9417,6 +9417,10 @@ msgstr "푸시({0})"
 msgid "Push ({ahead})"
 msgstr "푸시({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "푸시 및 PR 작성"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "푸시 ↑{ahead}"

--- a/src/renderer/locales/pl/messages.po
+++ b/src/renderer/locales/pl/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push i utwórz PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/pt-BR/messages.po
+++ b/src/renderer/locales/pt-BR/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push e criar PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/ru/messages.po
+++ b/src/renderer/locales/ru/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push и создать PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/tr/messages.po
+++ b/src/renderer/locales/tr/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push Et ve PR Oluştur"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/uk/messages.po
+++ b/src/renderer/locales/uk/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Push ({0})"
 msgid "Push ({ahead})"
 msgstr "Push ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push і створити PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Push ↑{ahead}"

--- a/src/renderer/locales/vi/messages.po
+++ b/src/renderer/locales/vi/messages.po
@@ -9417,6 +9417,10 @@ msgstr "Đẩy ({0})"
 msgid "Push ({ahead})"
 msgstr "Đẩy ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "Push & Tạo PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "Đẩy ↑{ahead}"

--- a/src/renderer/locales/zh-CN/messages.po
+++ b/src/renderer/locales/zh-CN/messages.po
@@ -9416,6 +9416,10 @@ msgstr "推 ({0})"
 msgid "Push ({ahead})"
 msgstr "推 ({ahead})"
 
+#: src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+msgid "Push & Create PR"
+msgstr "推送并创建 PR"
+
 #: src/renderer/views/MainView/parts/Sidebar/parts/SyncBadge.tsx
 msgid "Push ↑{ahead}"
 msgstr "推送 ↑{ahead}"

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/GitReviewSidebar.tsx
@@ -185,6 +185,7 @@ export function GitReviewSidebar(props: {
     handleGenerateMessage,
     handleSyncOrPush,
     handleSyncAction,
+    handlePushAndCreatePr,
     handleMergeOnly,
     handleMergeAndRemove,
     handlePullFromSource,
@@ -559,6 +560,7 @@ export function GitReviewSidebar(props: {
               handleGenerateMessage={handleGenerateMessage}
               handleSyncOrPush={handleSyncOrPush}
               handleSyncAction={handleSyncAction}
+              handlePushAndCreatePr={handlePushAndCreatePr}
               hasTracking={hasTracking}
               handlePullFromSource={handlePullFromSource}
             />

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.test.tsx
@@ -71,6 +71,7 @@ function renderPanel(overrides?: Partial<Parameters<typeof CommitSyncPanel>[0]>)
     handleGenerateMessage: vi.fn<() => Promise<void>>(),
     handleSyncOrPush: vi.fn<() => Promise<void>>(),
     handleSyncAction: vi.fn<() => Promise<void>>(),
+    handlePushAndCreatePr: vi.fn<() => Promise<void>>(),
     handlePullFromSource: vi.fn<() => Promise<void>>(),
   };
   renderWithI18n(<CommitSyncPanel {...props} {...overrides} />);
@@ -158,5 +159,28 @@ describe("CommitSyncPanel in-button step status", () => {
     });
 
     expect(screen.getByRole("button", { name: "Commit" })).toBeDisabled();
+  });
+});
+
+// Committed-but-not-pushed is the gap between the commit split-button (which
+// offers "Commit & Create PR") and the PR section (which offers "Create PR"
+// once pushed): the push row has to carry the chained action there.
+describe("CommitSyncPanel push options", () => {
+  const pushedAhead = {
+    hasRemote: true,
+    hasTracking: true,
+    needsPush: true,
+    ahead: 2,
+  } as const;
+
+  it("offers Push & Create PR while a pushable branch can still open a PR", () => {
+    renderPanel({ ...pushedAhead, canCreatePr: true });
+    expect(screen.getByText("Push & Create PR")).toBeInTheDocument();
+  });
+
+  it("omits Push & Create PR when no PR can be opened", () => {
+    renderPanel({ ...pushedAhead, canCreatePr: false });
+    expect(screen.queryByText("Push & Create PR")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Push (2)").length).toBeGreaterThan(0);
   });
 });

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/CommitSyncPanel.tsx
@@ -60,6 +60,7 @@ export function CommitSyncPanel(props: {
   handleGenerateMessage: () => Promise<void>;
   handleSyncOrPush: () => Promise<void>;
   handleSyncAction: (key: GitSyncCommand) => Promise<void>;
+  handlePushAndCreatePr: () => Promise<void>;
   handlePullFromSource: () => Promise<void>;
 }) {
   const {
@@ -92,6 +93,7 @@ export function CommitSyncPanel(props: {
     handleGenerateMessage,
     handleSyncOrPush,
     handleSyncAction,
+    handlePushAndCreatePr,
     handlePullFromSource,
   } = props;
   const { t } = useLingui();
@@ -323,10 +325,15 @@ export function CommitSyncPanel(props: {
           const showPull = hasTracking && behind > 0;
           const showPush = ahead > 0 || !hasTracking;
           const showSyncBoth = hasTracking && ahead > 0 && behind > 0;
+          // Committed but not pushed yet: offer the chained push + PR here too,
+          // so the flow the commit split-button offers before committing (and
+          // the PR section offers after pushing) stays reachable in between.
+          const showPushPr = showPush && canCreatePr;
           const showPullFromSourceItem = Boolean(
             showPullFromSource && sourceBranch && sourceAhead > 0,
           );
-          const hasSyncOptions = showPull || showPush || showSyncBoth || showPullFromSourceItem;
+          const hasSyncOptions =
+            showPull || showPush || showPushPr || showSyncBoth || showPullFromSourceItem;
 
           const primaryButton = (
             <Button
@@ -389,6 +396,10 @@ export function CommitSyncPanel(props: {
                         void handlePullFromSource();
                         return;
                       }
+                      if (key === "push-pr") {
+                        void handlePushAndCreatePr();
+                        return;
+                      }
                       void handleSyncAction(key as GitSyncCommand);
                     }}
                   >
@@ -420,6 +431,16 @@ export function CommitSyncPanel(props: {
                       >
                         <ArrowUp className="size-3.5" />
                         <Label>{ahead > 0 ? t`Push (${ahead})` : t`Push`}</Label>
+                      </Dropdown.Item>
+                    ) : null}
+                    {showPushPr ? (
+                      <Dropdown.Item
+                        id="push-pr"
+                        textValue={t`Push & Create PR`}
+                        isDisabled={actionInFlight}
+                      >
+                        <GitPullRequest className="size-3.5" />
+                        <Label>{t`Push & Create PR`}</Label>
                       </Dropdown.Item>
                     ) : null}
                     {showSyncBoth ? (

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.test.tsx
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.test.tsx
@@ -196,6 +196,35 @@ describe("useGitReviewActions action phase", () => {
     expect(bridgeMock.ghCreatePr).not.toHaveBeenCalled();
   });
 
+  // "Push & Create PR" is the same single-user-action chain for an
+  // already-committed branch: one continuous status walk, and never a PR
+  // attempt after a failed push.
+  it("keeps one continuous phase across push and PR creation", async () => {
+    const actions = renderActions();
+    const { seen, stop } = recordPhases();
+
+    await act(async () => {
+      await actions.current.handlePushAndCreatePr();
+    });
+    stop();
+
+    expect(seen).toEqual(["pushing", "creating-pr", null]);
+    expect(bridgeMock.ghCreatePr).toHaveBeenCalledTimes(1);
+  });
+
+  // A failed push must release the slot and hold off on creating the PR.
+  it("clears the phase when the chained flow fails at the push step", async () => {
+    runGitSyncCommandMock.mockRejectedValueOnce(new Error("push failed"));
+    const actions = renderActions();
+
+    await act(async () => {
+      await actions.current.handlePushAndCreatePr();
+    });
+
+    expect(useGitReviewActionStore.getState().panels[STORE_KEY]?.actionPhase).toBeNull();
+    expect(bridgeMock.ghCreatePr).not.toHaveBeenCalled();
+  });
+
   // Every sync-menu entry reports a phase, so none of them can race a commit.
   it.each([
     ["pull", "pulling"],

--- a/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
+++ b/src/renderer/views/GitReviewOverlay/parts/GitReviewSidebar/parts/useGitReviewActions.ts
@@ -275,6 +275,39 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     });
   }
 
+  // Push arm shared by the plain push entries and both "…& Create PR" chains:
+  // run the command, report it, flip the cached status optimistically, and let
+  // a plain push schedule the delayed refresh (GitHub takes a beat to register
+  // the new commits, so an immediate fetch sees stale PR state). Chains pass
+  // skipDelayedRefresh instead: the delayed refresh would race with
+  // handleCreatePr's setPrData and overwrite it with a stale snapshot.
+  async function pushBranch(options: {
+    // The commit flow reports the whole commit+push as git.commit_created and
+    // must not emit a second sync event.
+    emitSyncEvent: boolean;
+    skipDelayedRefresh: boolean;
+  }): Promise<void> {
+    await runGitSyncCommand({
+      command: "push",
+      projectLocation: project.location,
+      setUpstream: !hasTracking,
+    });
+    if (options.emitSyncEvent) {
+      captureProductEvent("git.sync_action", {
+        action: "push",
+        has_remote: hasRemote,
+        has_tracking: hasTracking,
+        has_worktree: Boolean(worktreePath),
+      });
+    }
+    refreshPrAfterPush();
+    // Optimistic: a successful push clears `ahead`.
+    applyStatusOptimistic((s) => ({ ...s, ahead: 0 }));
+    if (!options.skipDelayedRefresh) {
+      setTimeout(() => onRefresh(), 2000);
+    }
+  }
+
   async function generateMessage(): Promise<GeneratedCommitMessageWithProvider> {
     return generateCommitMessageWithFallbackDetails({
       projectLocation: project.location,
@@ -356,22 +389,7 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
         setIsSyncing(true);
         phase.advance("pushing");
         try {
-          await runGitSyncCommand({
-            command: "push",
-            projectLocation: project.location,
-            setUpstream: !hasTracking,
-          });
-          refreshPrAfterPush();
-          applyStatusOptimistic((s) => ({ ...s, ahead: 0 }));
-          // GitHub takes a beat to register the new commits — refreshing
-          // immediately fetches a stale PR snapshot. Delay so the post-push
-          // refresh picks up fresh state.
-          // When the caller chains a PR creation (skipDelayedRefresh), the
-          // delayed refresh would race with handleCreatePr's setPrData and
-          // overwrite it with a stale null from ghGetPrForBranch.
-          if (!skipDelayedRefresh) {
-            setTimeout(() => onRefresh(), 2000);
-          }
+          await pushBranch({ emitSyncEvent: false, skipDelayedRefresh });
         } finally {
           setIsSyncing(false);
         }
@@ -451,25 +469,7 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     setIsSyncing(true);
     try {
       if (needsPush) {
-        await runGitSyncCommand({
-          command: "push",
-          projectLocation: project.location,
-          setUpstream: !hasTracking,
-        });
-        captureProductEvent("git.sync_action", {
-          action: "push",
-          has_remote: hasRemote,
-          has_tracking: hasTracking,
-          has_worktree: Boolean(worktreePath),
-        });
-        refreshPrAfterPush();
-        // Optimistic: a successful push clears `ahead`. The refresh below
-        // confirms it a moment later.
-        applyStatusOptimistic((s) => ({ ...s, ahead: 0 }));
-        // GitHub takes a beat to register the new commits — refreshing
-        // immediately fetches a stale PR snapshot (mergeable/checks not
-        // yet updated). Delay so the post-push refresh picks up fresh state.
-        setTimeout(() => onRefresh(), 2000);
+        await pushBranch({ emitSyncEvent: true, skipDelayedRefresh: false });
       } else {
         await runGitSyncCommand({ command: "sync", projectLocation: project.location });
         captureProductEvent("git.sync_action", {
@@ -505,10 +505,13 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     if (!phase) return;
     setIsSyncing(true);
     try {
+      if (key === "push") {
+        await pushBranch({ emitSyncEvent: true, skipDelayedRefresh: false });
+        return;
+      }
       await runGitSyncCommand({
         command: key,
         projectLocation: project.location,
-        ...(key === "push" ? { setUpstream: !hasTracking } : {}),
       });
       captureProductEvent("git.sync_action", {
         action: key,
@@ -516,12 +519,6 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
         has_tracking: hasTracking,
         has_worktree: Boolean(worktreePath),
       });
-      if (key === "push") {
-        refreshPrAfterPush();
-        applyStatusOptimistic((s) => ({ ...s, ahead: 0 }));
-        setTimeout(() => onRefresh(), 2000);
-        return;
-      }
       onRefresh();
     } catch (err) {
       showGitActionError(err, {
@@ -784,6 +781,32 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     }
   }
 
+  // One-click "Push & Create PR" for an already-committed branch: push, then —
+  // only if that succeeded — auto-create the PR. Both steps share one phase
+  // cursor so the status line walks pushing → creating PR without blinking off
+  // (and without re-enabling the other buttons) in between. The PR step always
+  // auto-generates, mirroring handleCommitAndCreatePr.
+  async function handlePushAndCreatePr(): Promise<void> {
+    const phase = claimActionPhase("pushing");
+    if (!phase) return;
+    // Stay "syncing" for the whole chain: the push button owns the flow, so it
+    // must keep reporting the live step through the PR step too.
+    setIsSyncing(true);
+    try {
+      try {
+        await pushBranch({ emitSyncEvent: true, skipDelayedRefresh: true });
+      } catch (err) {
+        showGitActionError(err, { logPrefix: "[git] push failed" });
+        return;
+      }
+      await handleCreatePr(false, phase);
+      onRefresh();
+    } finally {
+      setIsSyncing(false);
+      phase.release();
+    }
+  }
+
   // One-click "Commit & Create PR": commit + push, then — only if that
   // succeeded — auto-create the PR. The PR step always auto-generates (never
   // opens the dialog), so this stays a single uninterrupted action regardless
@@ -875,6 +898,7 @@ export function useGitReviewActions(args: UseGitReviewActionsArgs) {
     handleFinishMerge,
     handleCreatePr,
     handleCommitAndCreatePr,
+    handlePushAndCreatePr,
     handleMergePr: writeActions.handleMergePr,
     handleClosePr: writeActions.handleClosePr,
     handleMarkPrReady: writeActions.handleMarkPrReady,


### PR DESCRIPTION
- Add a one-click Git Review action to push changes and create a pull request.
- Wire the action through the sidebar and preserve action state during failures.
- Add UI and action-flow coverage for availability, success, and push failure cases.
- Localize the new action label across all supported languages.