### PR TITLE
Fix Command Code live model discovery and one-shot defaults

### DIFF
--- a/src/renderer/components/providers/commandcode/index.tsx
+++ b/src/renderer/components/providers/commandcode/index.tsx
@@ -12,32 +12,8 @@ import { registerTitleGenDefaults } from "../titleGen";
 const PROVIDER_KIND = providerManifest.kind;
 
 registerProviderIcon(PROVIDER_KIND, CommandCodeIcon);
-// Command Code is usage-priced and gates Claude/GPT models behind paid plans:
-// the previous defaults (gpt-5.4-mini, claude-sonnet-4-6, google/gemini-3.1-flash-
-// lite) all return "403 MODEL_NOT_IN_PLAN" on the base plan, so Auto generation
-// failed outright. Picks below are open-source models available on every plan.
-// `deepseek-v4-flash` is Command Code's own default — the cheap, ungated baseline
-// that a local benchmark confirmed is fast and types commits correctly; the
-// "-Fast"/"-Highspeed" tiers (e.g. GLM-5.2-Fast) are quicker but cost more, so
-// they're not worth it for frequent title/commit runs. `deepseek-v4-pro` adds
-// reasoning for the rarer, heavier conflict resolver. Pro users can override.
-registerCommitGenDefaults(PROVIDER_KIND, {
-  label: "Command Code",
-  hint: "DeepSeek V4 Flash",
-  model: "deepseek/deepseek-v4-flash",
-  effort: "",
-});
-registerTitleGenDefaults(PROVIDER_KIND, {
-  label: "Command Code",
-  hint: "DeepSeek V4 Flash",
-  model: "deepseek/deepseek-v4-flash",
-  effort: "",
-});
-registerConflictResolverDefaults(PROVIDER_KIND, {
-  label: "Command Code",
-  hint: "DeepSeek V4 Pro",
-  model: "deepseek/deepseek-v4-pro",
-  effort: "",
-});
-
+const liveDefaults = { label: "Command Code", model: "", effort: "" };
+registerCommitGenDefaults(PROVIDER_KIND, liveDefaults);
+registerTitleGenDefaults(PROVIDER_KIND, liveDefaults);
+registerConflictResolverDefaults(PROVIDER_KIND, liveDefaults);
 registerComposerControls(PROVIDER_KIND, (input) => standardPlanApprovalControls(input));

--- a/src/renderer/state/agentStatusesStore.test.ts
+++ b/src/renderer/state/agentStatusesStore.test.ts
@@ -45,9 +45,41 @@ function reset() {
 beforeEach(reset);
 
 describe("persisted agent status cache", () => {
+  it("invalidates v15 statuses cached before Command Code's live-only model discovery", async () => {
+    const options = useAgentStatusesStore.persist.getOptions();
+    expect(options.version).toBe(16);
+    const staleCommandCode = makeStatus({
+      kind: "commandcode",
+      label: "Command Code",
+      capabilities: {
+        ...makeStatus().capabilities,
+        models: [
+          { id: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+          { id: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+        ],
+        modelSubProvider: { "deepseek/deepseek-v4-pro": "deepseek" },
+      },
+    });
+    const migrated = await options.migrate!(
+      {
+        agentStatuses: [staleCommandCode],
+        wslAgentStatuses: [],
+        windowsLoaded: true,
+        wslLoaded: true,
+      },
+      15,
+    );
+    expect(migrated).toMatchObject({
+      agentStatuses: [],
+      wslAgentStatuses: [],
+      windowsLoaded: false,
+      wslLoaded: false,
+    });
+  });
+
   it("invalidates v10 statuses whose terminal auth methods lack baseSpawnEnv-derived env", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(15);
+    expect(options.version).toBe(16);
     const staleLogin = makeStatus({
       kind: "antigravity",
       label: "Antigravity",
@@ -74,7 +106,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v14 statuses that grouped Cursor Grok under Other models", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(15);
+    expect(options.version).toBe(16);
     const staleCursor = makeStatus({
       kind: "cursor",
       label: "Cursor",
@@ -107,7 +139,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v8 statuses cached before successful ACP sessions established auth", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(15);
+    expect(options.version).toBe(16);
     const staleAcp = makeStatus({
       kind: "acp-generic:example",
       label: "Example ACP",
@@ -134,7 +166,7 @@ describe("persisted agent status cache", () => {
 
   it("invalidates v6 statuses produced without the Grok login-shell environment", async () => {
     const options = useAgentStatusesStore.persist.getOptions();
-    expect(options.version).toBe(15);
+    expect(options.version).toBe(16);
     expect(options.migrate).toBeTypeOf("function");
 
     const grok = makeStatus({

--- a/src/renderer/state/agentStatusesStore.ts
+++ b/src/renderer/state/agentStatusesStore.ts
@@ -263,9 +263,10 @@ export const useAgentStatusesStore = create<AgentStatusesStore>()(
     }),
     {
       name: "poracode-agent-statuses-v1",
-      version: 15,
-      // v15 mirrors supervisor STATUS_CACHE_VERSION=18 so this localStorage
-      // copy does not keep Cursor Grok grouped under Other models.
+      version: 16,
+      // v16 mirrors supervisor STATUS_CACHE_VERSION=19 so this localStorage
+      // copy does not keep Command Code's pre-live-discovery curated model
+      // table (deepseek fallbacks, static `defaultEffort`) on first paint.
       migrate: (persisted) => {
         const prev = (persisted ?? {}) as Partial<AgentStatusesStore>;
         return {

--- a/src/supervisor/agents/base/index.ts
+++ b/src/supervisor/agents/base/index.ts
@@ -91,6 +91,7 @@ export type {
 } from "./types";
 export * from "./terminalHints";
 export * from "./expectedRuntimeError";
+export * from "./oneShotModel";
 export * from "./promptSession";
 export * from "./processRuntime";
 export * from "./shellBasics";

--- a/src/supervisor/agents/base/oneShotModel.ts
+++ b/src/supervisor/agents/base/oneShotModel.ts
@@ -1,0 +1,21 @@
+import type { AgentAdapter } from "./types";
+
+/**
+ * Resolve the model a utility one-shot should run with: the caller's explicit
+ * pick, else the adapter's default. An empty result is only allowed when the
+ * adapter opted into implicit models (`allowsImplicitOneShotModel`) — CLI
+ * adapters may then omit `--model` and use the target environment's own live
+ * default. `makeNoModelError` supplies the caller-facing error so each
+ * generator keeps its own localized message.
+ */
+export function resolveOneShotEffectiveModel(
+  adapter: Pick<AgentAdapter, "defaultOneShotModel" | "allowsImplicitOneShotModel" | "label">,
+  model: string | undefined,
+  makeNoModelError: () => Error,
+): string {
+  const effectiveModel = model ?? adapter.defaultOneShotModel ?? "";
+  if (!effectiveModel && !adapter.allowsImplicitOneShotModel) {
+    throw makeNoModelError();
+  }
+  return effectiveModel;
+}

--- a/src/supervisor/agents/base/types.ts
+++ b/src/supervisor/agents/base/types.ts
@@ -581,6 +581,8 @@ export interface OneShotGenerationOptions {
 
 export interface AgentOneShotRunner {
   defaultOneShotModel?: string;
+  /** Allow CLI adapters to omit `--model` and use the target environment's own live default. */
+  allowsImplicitOneShotModel?: boolean;
   /**
    * Build a bypass-permissions CLI invocation so an agent WITHOUT a structured
    * (GUI) runtime can still be spawned as a one-shot subagent child. Implemented

--- a/src/supervisor/agents/commandcode/commandcode.test.ts
+++ b/src/supervisor/agents/commandcode/commandcode.test.ts
@@ -1,13 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ProjectLocation, ThreadConfig } from "@/shared/contracts";
 import { createCommandCodeAdapter } from ".";
 import { buildCommandCodeArgs } from "./argv";
 import {
   buildCommandCodeModelPickerCapabilities,
-  COMMANDCODE_DEFAULT_MODEL_ID,
+  collectCommandCodeModelEfforts,
   commandCodeDetectionSpec,
+  createCommandCodeEffortProbeCache,
+  createCommandCodeModelNameLoader,
   defaultCommandCodeCapabilities,
+  parseCommandCodeModelEfforts,
+  parseCommandCodeModelNames,
   parseCommandCodeModels,
+  resolveCommandCodeModelName,
 } from "./detection";
 import { authJsonHasApiKey, detectCommandCodeInvalidSessionRef } from "./session";
 import {
@@ -130,12 +135,12 @@ describe("buildCommandCodeArgs", () => {
 describe("createCommandCodeAdapter", () => {
   const project: ProjectLocation = { kind: "windows", path: "C:\\demo" };
 
-  it("declares the command-code binary, default-first models, and bypass default", () => {
+  it("declares the command-code binary, live-only models, and bypass default", () => {
     const adapter = createCommandCodeAdapter();
 
     expect(adapter.kind).toBe("commandcode");
     expect(adapter.binary).toBe("command-code");
-    expect(adapter.capabilities.models[0]?.id).toBe(COMMANDCODE_DEFAULT_MODEL_ID);
+    expect(adapter.capabilities.models).toEqual([]);
     expect(adapter.capabilities.approvalPolicies.map((p) => p.id)).toEqual([
       "default",
       "auto_edit",
@@ -143,10 +148,9 @@ describe("createCommandCodeAdapter", () => {
       "yolo",
     ]);
     expect(adapter.capabilities.defaultApprovalPolicy).toBe("yolo");
-    expect(adapter.capabilities.defaultEffort).toBe("high");
-    expect(adapter.capabilities.models).toHaveLength(50);
     expect(defaultCommandCodeCapabilities.presentationModes).toEqual(["terminal"]);
-    expect(adapter.defaultOneShotModel).toBe(COMMANDCODE_DEFAULT_MODEL_ID);
+    expect(adapter.defaultOneShotModel).toBeUndefined();
+    expect(adapter.allowsImplicitOneShotModel).toBe(true);
   });
 
   it("builds a bypass-permissions one-shot subagent command with --yolo", () => {
@@ -248,6 +252,19 @@ describe("createCommandCodeAdapter", () => {
       ],
       stdin: "",
     });
+  });
+
+  it("lets each CLI location choose its own default for an empty one-shot model", () => {
+    const adapter = createCommandCodeAdapter();
+    const command = adapter.buildOneShotCommand?.("", undefined, "summarize");
+    expect(command?.args).not.toContain("--model");
+
+    const subagent = adapter.buildSubagentOneShotCommand?.({
+      model: "",
+      prompt: "do the work",
+      location: project,
+    });
+    expect(subagent?.args).not.toContain("--model");
   });
 });
 
@@ -406,11 +423,33 @@ describe("parseCommandCodeModels", () => {
     expect(parsed.find((m) => m.id === "claude-sonnet-4-6")?.description).toBe(
       "best combo of speed & intelligence",
     );
+    expect(parsed.find((m) => m.id === "claude-sonnet-4-6")).toMatchObject({
+      providerId: "anthropic",
+      providerLabel: "Anthropic",
+    });
   });
 
   it("returns an empty list for unparseable output", () => {
     expect(parseCommandCodeModels("")).toEqual([]);
     expect(parseCommandCodeModels("totally unrelated text\nno models here")).toEqual([]);
+  });
+
+  it("keeps a dropped or wrapped id-like line from redefining the provider section", () => {
+    const parsed = parseCommandCodeModels(
+      [
+        "Anthropic",
+        "",
+        "claude-sonnet-5  smart",
+        // A row printed without its tagline gap (or a wrapped continuation
+        // starting with an id family) must be skipped, not promoted to a
+        // header that would regroup every following row.
+        "moonshotai/kimi-k2",
+        "claude-fable-5  balanced",
+      ].join("\n"),
+    );
+    expect(parsed.map((m) => m.id)).toEqual(["claude-sonnet-5", "claude-fable-5"]);
+    expect(parsed.every((m) => m.providerId === "anthropic")).toBe(true);
+    expect(parsed.some((m) => m.providerLabel?.toLowerCase().includes("kimi"))).toBe(false);
   });
 });
 
@@ -418,13 +457,21 @@ describe("buildCommandCodeModelPickerCapabilities", () => {
   it("labels models, hoists the default first, and groups by sub-provider", () => {
     const caps = buildCommandCodeModelPickerCapabilities(
       parseCommandCodeModels(LIST_MODELS_FIXTURE),
+      {
+        "deepseek/deepseek-v4-flash": ["high", "max"],
+        "gpt-5.5": ["low", "medium", "high", "xhigh"],
+      },
+      {
+        "moonshotai/kimi-k2.7-code": "Kimi K2.7 Code",
+        "gpt-5.5": "GPT-5.5",
+      },
     );
 
     // Default is surfaced first so a fresh thread mirrors the CLI default.
     expect(caps.models[0]?.id).toBe("deepseek/deepseek-v4-flash");
 
     const byId = new Map(caps.models.map((m) => [m.id, m]));
-    // Curated label override wins; humanize is only the fallback.
+    // Labels derive from the live model ids; taglines remain descriptions.
     expect(byId.get("moonshotai/kimi-k2.7-code")?.label).toBe("Kimi K2.7 Code");
     expect(byId.get("gpt-5.5")?.label).toBe("GPT-5.5");
     // The CLI tagline rides along as the (search/tooltip) description.
@@ -432,24 +479,245 @@ describe("buildCommandCodeModelPickerCapabilities", () => {
       "improved long-horizon coding with vision",
     );
 
-    // Un-namespaced ids map explicitly; slash-namespaced ids derive from prefix.
+    // Grouping follows the live CLI sections, independent of id namespaces.
     expect(caps.modelSubProvider?.["claude-fable-5"]).toBe("anthropic");
     expect(caps.modelSubProvider?.["gpt-5.5"]).toBe("openai");
-    expect(caps.modelSubProvider?.["nvidia/nemotron-3-ultra-550b-a55b"]).toBe("nvidia");
+    expect(caps.modelSubProvider?.["nvidia/nemotron-3-ultra-550b-a55b"]).toBe("open-source");
     expect(caps.modelEfforts["deepseek/deepseek-v4-flash"]).toEqual(["high", "max"]);
     expect(caps.modelEfforts["gpt-5.5"]).toEqual(["low", "medium", "high", "xhigh"]);
 
-    // Curated label for a known sub-provider; humanized fallback for nvidia.
+    // Section labels and order come directly from the CLI output.
     const subById = new Map((caps.subProviders ?? []).map((s) => [s.id, s.label]));
-    expect(subById.get("deepseek")).toBe("DeepSeek");
-    expect(subById.get("nvidia")).toBe("NVIDIA");
+    expect(subById.get("open-source")).toBe("Open Source");
+    expect(subById.get("anthropic")).toBe("Anthropic");
   });
 
-  it("falls back to a humanized label for an uncurated id", () => {
-    const caps = buildCommandCodeModelPickerCapabilities([{ id: "acme/new-shiny-model" }]);
-    expect(caps.models[0]?.label).toBe("New Shiny Model");
-    expect(caps.modelSubProvider?.["acme/new-shiny-model"]).toBe("acme");
-    expect((caps.subProviders ?? []).find((s) => s.id === "acme")?.label).toBe("Acme");
+  it("uses stable live BYOK ids despite repeated spaces or duplicate display names", () => {
+    const parsed = parseCommandCodeModels(`Available models  ·  2 models
+
+Available  AI (byok)
+
+audit-local/internal-id  Audit Reasoner
+
+Available  AI (byok)
+
+other-local/other-id  Other Reasoner
+`);
+    const caps = buildCommandCodeModelPickerCapabilities(
+      parsed,
+      { "audit-local/internal-id": ["low", "medium", "xhigh"] },
+      { "audit-local/internal-id": "Wrong Built-in Name" },
+    );
+    expect(caps.models).toEqual([
+      { id: "audit-local/internal-id", label: "Audit Reasoner" },
+      { id: "other-local/other-id", label: "Other Reasoner" },
+    ]);
+    expect(caps.subProviders).toEqual([
+      { id: "audit-local", label: "Available  AI" },
+      { id: "other-local", label: "Available  AI" },
+    ]);
+    expect(caps.modelSubProvider?.["audit-local/internal-id"]).toBe("audit-local");
+    expect(caps.modelSubProvider?.["other-local/other-id"]).toBe("other-local");
+    expect(caps.modelEfforts["audit-local/internal-id"]).toEqual(["low", "medium", "xhigh"]);
+  });
+});
+
+describe("dynamic Command Code effort discovery", () => {
+  it("parses live built-in display names case-insensitively", () => {
+    expect(
+      parseCommandCodeModelNames({
+        object: "list",
+        data: [
+          { id: "moonshotai/Kimi-K3", name: "Kimi K3" },
+          { id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+          { id: "", name: "Missing" },
+          { id: "bad" },
+        ],
+      }),
+    ).toEqual({
+      "moonshotai/kimi-k3": "Kimi K3",
+      "gpt-5.6-sol": "GPT-5.6 Sol",
+    });
+    expect(parseCommandCodeModelNames({ data: "invalid" })).toEqual({});
+  });
+
+  it("resolves a unique dated canonical model id without a static alias table", () => {
+    const names = {
+      "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+      "gpt-5.6-sol": "GPT-5.6 Sol",
+    };
+    expect(resolveCommandCodeModelName("gpt-5.6-sol", names)).toBe("GPT-5.6 Sol");
+    expect(resolveCommandCodeModelName("claude-haiku-4-5", names)).toBe("Claude Haiku 4.5");
+    expect(
+      resolveCommandCodeModelName("claude-haiku-4-5", {
+        ...names,
+        "claude-haiku-4-5-20260101": "Different Haiku",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("coalesces and briefly caches live model-name requests", async () => {
+    let now = 1_000;
+    let releaseFetch: (() => void) | undefined;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      await fetchGate;
+      return new Response(JSON.stringify({ data: [{ id: "gpt-5.6-sol", name: "GPT-5.6 Sol" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const load = createCommandCodeModelNameLoader({ fetchImpl, now: () => now, ttlMs: 100 });
+
+    const first = load();
+    const second = load();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    releaseFetch?.();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { "gpt-5.6-sol": "GPT-5.6 Sol" },
+      { "gpt-5.6-sol": "GPT-5.6 Sol" },
+    ]);
+
+    await load();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    now += 101;
+    await load();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps coalesced model-name fetches independent from each caller's cancellation", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const fetchImpl = vi.fn<typeof fetch>(async () => {
+      await firstGate;
+      return new Response(JSON.stringify({ data: [{ id: "gpt", name: "GPT" }] }));
+    });
+    const load = createCommandCodeModelNameLoader({ fetchImpl });
+    const ownerController = new AbortController();
+    const liveController = new AbortController();
+    const cancelledOwner = load(ownerController.signal);
+    const liveWaiter = load(liveController.signal);
+    ownerController.abort();
+    await expect(cancelledOwner).rejects.toMatchObject({ name: "AbortError" });
+    releaseFirst?.();
+    await expect(liveWaiter).resolves.toEqual({ gpt: "GPT" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    let releaseSecond: (() => void) | undefined;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const secondFetch = vi.fn<typeof fetch>(async () => {
+      await secondGate;
+      return new Response(JSON.stringify({ data: [{ id: "glm", name: "GLM" }] }));
+    });
+    const secondLoad = createCommandCodeModelNameLoader({ fetchImpl: secondFetch });
+    const cancelledWaiterController = new AbortController();
+    const liveOwner = secondLoad();
+    const cancelledWaiter = secondLoad(cancelledWaiterController.signal);
+    cancelledWaiterController.abort();
+    await expect(cancelledWaiter).rejects.toMatchObject({ name: "AbortError" });
+    releaseSecond?.();
+    await expect(liveOwner).resolves.toEqual({ glm: "GLM" });
+    expect(secondFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses supported efforts and models without adjustable effort", () => {
+    expect(
+      parseCommandCodeModelEfforts(
+        'Unknown effort "__poracode_capability_probe__". Supported: low, medium, xhigh.',
+      ),
+    ).toEqual(["low", "medium", "xhigh"]);
+    expect(parseCommandCodeModelEfforts("Kimi K3 has no adjustable reasoning effort.")).toEqual([]);
+    expect(parseCommandCodeModelEfforts("unexpected failure")).toBeUndefined();
+  });
+
+  it("collects efforts with bounded concurrency and reports unresolved probes", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const result = await collectCommandCodeModelEfforts(
+      ["reasoning-a", "plain", "reasoning-b", "failed"],
+      async (modelId) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await Promise.resolve();
+        active -= 1;
+        if (modelId === "plain") return "Plain has no adjustable reasoning effort.";
+        if (modelId === "failed") return "probe failed";
+        return `Unknown effort. Supported: low, high${modelId === "reasoning-b" ? ", max" : ""}.`;
+      },
+      2,
+    );
+    expect(maxActive).toBe(2);
+    expect(result).toEqual({
+      "reasoning-a": ["low", "high"],
+      plain: [],
+      "reasoning-b": ["low", "high", "max"],
+    });
+  });
+
+  it("refuses the fan-out when neither leader probe gets a parseable rejection reply", async () => {
+    const probed: string[] = [];
+    const result = await collectCommandCodeModelEfforts(
+      ["first", "second", "third"],
+      async (modelId) => {
+        probed.push(modelId);
+        return modelId === "first" ? "signed out - run command-code login" : "";
+      },
+      24,
+    );
+    // Only the two serial leaders fire; a real `-p` turn storm is never launched.
+    expect(probed).toEqual(["first", "second"]);
+    expect(result).toEqual({});
+  });
+
+  it("keeps a persistently unparseable first model from vetoing the rest of the list", async () => {
+    const probed: string[] = [];
+    const result = await collectCommandCodeModelEfforts(
+      ["poison", "good-a", "good-b"],
+      async (modelId) => {
+        probed.push(modelId);
+        return modelId === "poison"
+          ? "endpoint rejected the request"
+          : "Unknown effort. Supported: low, high.";
+      },
+      24,
+    );
+    expect(result).toEqual({
+      "good-a": ["low", "high"],
+      "good-b": ["low", "high"],
+    });
+    expect(new Set(probed)).toEqual(new Set(["poison", "good-a", "good-b"]));
+  });
+
+  it("coalesces same-key probes and retains resolved models across cache keys", async () => {
+    const cache = createCommandCodeEffortProbeCache(2);
+    const calls = new Map<string, number>();
+    const probe = async (modelId: string) => {
+      calls.set(modelId, (calls.get(modelId) ?? 0) + 1);
+      await Promise.resolve();
+      return modelId === "flaky" ? "temporary failure" : `Unknown effort. Supported: low, high.`;
+    };
+
+    await Promise.all([
+      cache("native-v1", ["stable", "flaky"], probe),
+      cache("native-v1", ["stable", "flaky"], probe),
+    ]);
+    expect(calls).toEqual(
+      new Map([
+        ["stable", 1],
+        ["flaky", 1],
+      ]),
+    );
+
+    await cache("wsl-v1", ["stable"], probe);
+    await cache("native-v1", ["stable", "flaky"], probe);
+    expect(calls.get("stable")).toBe(2);
+    expect(calls.get("flaky")).toBe(2);
   });
 });
 

--- a/src/supervisor/agents/commandcode/detection.ts
+++ b/src/supervisor/agents/commandcode/detection.ts
@@ -3,6 +3,7 @@ import type { AgentCapability, AgentTerminalAuthMethod, LabeledOption } from "@/
 import {
   envVarAuthProbe,
   type AuthProbe,
+  type DetectProbeCtx,
   type DetectionSpec,
   readAgentCommandOutput,
 } from "../base";
@@ -23,206 +24,20 @@ const COMMANDCODE_SKIP_UPDATES_ENV: Record<string, string> = {
   COMMANDCODE_SKIP_UPDATES: "1",
 };
 
-// Command Code's CLI default (used with no `-m`). We surface it first so a
-// fresh thread mirrors what running `command-code` directly would pick.
-// Source: https://commandcode.ai/docs/reference/cli/models (also `command-code
-// --list-models` for the live, copy-pasteable set). `--model` matching is
-// case-insensitive and accepts either the full id or the part after the `/`.
-export const COMMANDCODE_DEFAULT_MODEL_ID = "deepseek/deepseek-v4-flash";
-
-// Curated sub-provider labels + canonical display order for the model picker.
-// The slash-namespaced ids (`google/…`, `moonshotai/…`) auto-derive a
-// sub-provider from their prefix; the un-namespaced Anthropic/OpenAI ids map
-// explicitly (see `commandCodeModelSubProviderId`). Any namespace the CLI
-// surfaces that isn't listed here still groups — it just falls back to a
-// humanized label and sorts after the curated ones.
-const COMMANDCODE_SUB_PROVIDER_LABELS: Record<string, string> = {
-  anthropic: "Anthropic",
-  openai: "OpenAI",
-  google: "Google",
-  moonshotai: "Moonshot",
-  deepseek: "DeepSeek",
-  "zai-org": "Z.ai",
-  minimaxai: "MiniMax",
-  qwen: "Qwen",
-  stepfun: "StepFun",
-  xiaomi: "Xiaomi",
-  tencent: "Tencent",
-  nvidia: "NVIDIA",
-  thinkingmachines: "Thinking Machines",
-  poolside: "Poolside",
-  inclusionai: "InclusionAI",
-  sakana: "Sakana AI",
-  meta: "Meta",
-  xai: "xAI",
-};
-
-const COMMANDCODE_SUB_PROVIDER_ORDER = [
-  "anthropic",
-  "openai",
-  "google",
-  "moonshotai",
-  "deepseek",
-  "zai-org",
-  "minimaxai",
-  "qwen",
-  "stepfun",
-  "xiaomi",
-  "tencent",
-  "nvidia",
-  "thinkingmachines",
-  "poolside",
-  "inclusionai",
-  "sakana",
-  "meta",
-  "xai",
-];
-
-// Hand-tuned display labels keyed by model id. These exist only to render known
-// ids prettily (correct casing, `4.6` vs `4-6`, dropping a noisy param suffix
-// like `nemotron-3-ultra-550b-a55b`). They are NOT the source of truth for
-// which models exist — that comes from `command-code --list-models` at
-// detection time. A brand-new id we haven't curated still appears, labeled by
-// `humanizeCommandCodeModelLabel` until an override is added here.
-const COMMANDCODE_MODEL_LABELS: Record<string, string> = {
-  "deepseek/deepseek-v4-pro": "DeepSeek V4 Pro",
-  "deepseek/deepseek-v4-flash": "DeepSeek V4 Flash",
-  "moonshotai/kimi-k3": "Kimi K3",
-  "moonshotai/kimi-k2.7-code": "Kimi K2.7 Code",
-  "moonshotai/kimi-k2.7-code-highspeed": "Kimi K2.7 Code Highspeed",
-  "moonshotai/kimi-k2.6": "Kimi K2.6",
-  "moonshotai/kimi-k2.5": "Kimi K2.5",
-  "zai-org/glm-5.2": "GLM-5.2",
-  "zai-org/glm-5.2-fast": "GLM-5.2 Fast",
-  "zai-org/glm-5.1": "GLM-5.1",
-  "zai-org/glm-5": "GLM-5",
-  "minimaxai/minimax-m3": "MiniMax M3",
-  "minimaxai/minimax-m2.7": "MiniMax M2.7",
-  "minimaxai/minimax-m2.5": "MiniMax M2.5",
-  "xiaomi/mimo-v2.5-pro": "MiMo v2.5 Pro",
-  "xiaomi/mimo-v2.5": "MiMo v2.5",
-  "qwen/qwen3.6-max-preview": "Qwen3.6 Max Preview",
-  "qwen/qwen3.6-plus": "Qwen3.6 Plus",
-  "qwen/qwen3.7-max": "Qwen3.7 Max",
-  "qwen/qwen3.7-plus": "Qwen3.7 Plus",
-  "qwen/qwen3.7-flash": "Qwen3.7 Flash",
-  "stepfun/step-3.7-flash": "Step 3.7 Flash",
-  "stepfun/step-3.5-flash": "Step 3.5 Flash",
-  "tencent/hy3-paid": "Hunyuan 3",
-  "nvidia/nemotron-3-ultra-550b-a55b": "Nemotron 3 Ultra",
-  "thinkingmachines/inkling": "Inkling",
-  "thinkingmachines/inkling-small": "Inkling Small",
-  "poolside/laguna-s-2.1-free": "Laguna S 2.1",
-  "inclusionai/ling-3.0-flash-free": "Ling 3.0 Flash",
-  "claude-sonnet-5": "Claude Sonnet 5",
-  "claude-sonnet-4-6": "Claude Sonnet 4.6",
-  "claude-fable-5": "Claude Fable 5",
-  "claude-opus-5": "Claude Opus 5",
-  "claude-opus-4-8": "Claude Opus 4.8",
-  "claude-opus-4-7": "Claude Opus 4.7",
-  "claude-haiku-4-5": "Claude Haiku 4.5",
-  "gpt-5.6-sol": "GPT-5.6 Sol",
-  "gpt-5.6-terra": "GPT-5.6 Terra",
-  "gpt-5.6-luna": "GPT-5.6 Luna",
-  "gpt-5.5": "GPT-5.5",
-  "gpt-5.4": "GPT-5.4",
-  "gpt-5.3-codex": "GPT-5.3 Codex",
-  "gpt-5.4-mini": "GPT-5.4 Mini",
-  "google/gemini-3.6-flash": "Gemini 3.6 Flash",
-  "google/gemini-3.5-flash": "Gemini 3.5 Flash",
-  "google/gemini-3.5-flash-lite": "Gemini 3.5 Flash Lite",
-  "google/gemini-3.1-flash-lite": "Gemini 3.1 Flash Lite",
-  "sakana/fugu-ultra": "Fugu Ultra",
-  "meta/muse-spark-1.1": "Muse Spark 1.1",
-  "xai/grok-4.5": "Grok 4.5",
-};
-
-// Offline fallback model ids (a known-good snapshot of `--list-models`). Used to
-// build `defaultCommandCodeCapabilities` so the picker still has a sensible set
-// before/without a successful probe. The live probe replaces this whenever
-// `command-code --list-models` succeeds, so it never has to stay current.
-const COMMANDCODE_FALLBACK_MODEL_IDS = [
-  "deepseek/deepseek-v4-pro",
-  COMMANDCODE_DEFAULT_MODEL_ID,
-  "moonshotai/kimi-k3",
-  "moonshotai/kimi-k2.7-code",
-  "moonshotai/kimi-k2.7-code-highspeed",
-  "moonshotai/kimi-k2.6",
-  "moonshotai/kimi-k2.5",
-  "zai-org/glm-5.2",
-  "zai-org/glm-5.2-fast",
-  "zai-org/glm-5.1",
-  "zai-org/glm-5",
-  "minimaxai/minimax-m3",
-  "minimaxai/minimax-m2.7",
-  "minimaxai/minimax-m2.5",
-  "xiaomi/mimo-v2.5-pro",
-  "xiaomi/mimo-v2.5",
-  "qwen/qwen3.6-max-preview",
-  "qwen/qwen3.6-plus",
-  "qwen/qwen3.7-max",
-  "qwen/qwen3.7-plus",
-  "qwen/qwen3.7-flash",
-  "stepfun/step-3.7-flash",
-  "stepfun/step-3.5-flash",
-  "tencent/hy3-paid",
-  "nvidia/nemotron-3-ultra-550b-a55b",
-  "thinkingmachines/inkling",
-  "thinkingmachines/inkling-small",
-  "poolside/laguna-s-2.1-free",
-  "inclusionai/ling-3.0-flash-free",
-  "claude-sonnet-5",
-  "claude-sonnet-4-6",
-  "claude-fable-5",
-  "claude-opus-5",
-  "claude-opus-4-8",
-  "claude-opus-4-7",
-  "claude-haiku-4-5",
-  "gpt-5.6-sol",
-  "gpt-5.6-terra",
-  "gpt-5.6-luna",
-  "gpt-5.5",
-  "gpt-5.4",
-  "gpt-5.3-codex",
-  "gpt-5.4-mini",
-  "google/gemini-3.6-flash",
-  "google/gemini-3.5-flash",
-  "google/gemini-3.5-flash-lite",
-  "google/gemini-3.1-flash-lite",
-  "sakana/fugu-ultra",
-  "meta/muse-spark-1.1",
-  "xai/grok-4.5",
-];
-
-const COMMANDCODE_MODEL_EFFORTS: Record<string, string[]> = {
-  "claude-sonnet-5": ["low", "medium", "high", "xhigh", "max"],
-  "claude-sonnet-4-6": ["low", "medium", "high", "xhigh", "max"],
-  "claude-fable-5": ["low", "medium", "high", "xhigh", "max"],
-  "claude-opus-5": ["low", "medium", "high", "xhigh", "max"],
-  "claude-opus-4-8": ["low", "medium", "high", "xhigh", "max"],
-  "claude-opus-4-7": ["low", "medium", "high", "xhigh", "max"],
-  "gpt-5.6-sol": ["low", "medium", "high", "xhigh", "max"],
-  "gpt-5.6-terra": ["low", "medium", "high", "xhigh", "max"],
-  "gpt-5.6-luna": ["low", "medium", "high", "xhigh", "max"],
-  "gpt-5.5": ["low", "medium", "high", "xhigh"],
-  "gpt-5.4": ["low", "medium", "high", "xhigh"],
-  "gpt-5.3-codex": ["low", "medium", "high", "xhigh"],
-  "gpt-5.4-mini": ["low", "medium", "high"],
-  "deepseek/deepseek-v4-pro": ["high", "max"],
-  "deepseek/deepseek-v4-flash": ["high", "max"],
-  "zai-org/glm-5.2": ["high", "max"],
-  "google/gemini-3.6-flash": ["low", "medium", "high"],
-  "google/gemini-3.5-flash": ["low", "medium", "high"],
-  "google/gemini-3.5-flash-lite": ["low", "medium", "high"],
-  "google/gemini-3.1-flash-lite": ["low", "medium", "high"],
-  "sakana/fugu-ultra": ["high", "xhigh"],
-  "xai/grok-4.5": ["low", "medium", "high"],
-};
+const COMMANDCODE_EFFORT_PROBE_VALUE = "__poracode_capability_probe__";
+const COMMANDCODE_EFFORT_SENTINEL_ATTEMPTS = 2;
+const COMMANDCODE_EFFORT_PROBE_CONCURRENCY = 24;
+const COMMANDCODE_EFFORT_CACHE_SIZE = 8;
+const COMMANDCODE_MODELS_ENDPOINT = "https://api.commandcode.ai/provider/v1/models";
+const COMMANDCODE_MODEL_NAMES_TTL_MS = 5 * 60_000;
 
 export interface ParsedCommandCodeModel {
   id: string;
   description?: string;
   isDefault?: boolean;
+  providerId?: string;
+  providerLabel?: string;
+  isByok?: boolean;
 }
 
 // A model row is `<id><2+ spaces><tagline>`; section headers ("Open Source",
@@ -241,15 +56,44 @@ const COMMANDCODE_NOISE_LINE_RE = /^(?:Available\b|Pass\b|cmd\b|Docs:|Tip:|Loadi
 export function parseCommandCodeModels(output: string): ParsedCommandCodeModel[] {
   const parsed: ParsedCommandCodeModel[] = [];
   const seen = new Set<string>();
+  let providerId: string | undefined;
+  let providerLabel: string | undefined;
+  let isByok = false;
   for (const rawLine of stripAnsi(output).split(/\r?\n/)) {
     const line = rawLine.trim();
-    if (!line || COMMANDCODE_NOISE_LINE_RE.test(line)) continue;
+    if (!line) continue;
+
+    const byokHeader = /^(.*?)\s+\(byok\)$/i.exec(line);
+    if (byokHeader) {
+      providerLabel = byokHeader[1]!.trim();
+      providerId = undefined;
+      isByok = true;
+      continue;
+    }
+    if (COMMANDCODE_NOISE_LINE_RE.test(line)) continue;
 
     const match = COMMANDCODE_MODEL_LINE_RE.exec(line);
-    if (!match) continue;
+    if (!match) {
+      // Only display-name section headers may redefine the provider context.
+      // A lone id-shaped token is a dropped model row (tagline missing), not a
+      // header — promoting it would regroup every later row under a garbage
+      // sub-provider. Multiword headers never contain the id `/` separator.
+      if (!line.includes(" ") && line.includes("/") && COMMANDCODE_MODEL_ID_RE.test(line)) {
+        continue;
+      }
+      isByok = false;
+      providerLabel = line;
+      providerId = providerLabel
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "");
+      continue;
+    }
     const id = match[1]!;
     if (!COMMANDCODE_MODEL_ID_RE.test(id) || seen.has(id)) continue;
     seen.add(id);
+    const modelProviderId =
+      isByok && id.includes("/") ? id.slice(0, id.indexOf("/")).toLowerCase() : providerId;
 
     const rawDescription = match[2]!.trim();
     const isDefault = /\(default\)/i.test(rawDescription);
@@ -261,14 +105,220 @@ export function parseCommandCodeModels(output: string): ParsedCommandCodeModel[]
       id,
       ...(description ? { description } : {}),
       ...(isDefault ? { isDefault: true } : {}),
+      ...(modelProviderId ? { providerId: modelProviderId } : {}),
+      ...(providerLabel ? { providerLabel } : {}),
+      ...(isByok ? { isByok: true } : {}),
     });
   }
   return parsed;
 }
 
+export function parseCommandCodeModelEfforts(output: string): string[] | undefined {
+  const cleaned = stripAnsi(output);
+  const supported = /Supported:\s*([^\r\n.]+)\.?/i.exec(cleaned)?.[1];
+  if (supported) {
+    return supported
+      .split(",")
+      .map((effort) => effort.trim())
+      .filter(Boolean);
+  }
+  return /has no adjustable reasoning effort/i.test(cleaned) ? [] : undefined;
+}
+
+export function parseCommandCodeModelNames(body: unknown): Record<string, string> {
+  if (!body || typeof body !== "object" || !Array.isArray((body as { data?: unknown }).data)) {
+    return {};
+  }
+  const names: Record<string, string> = {};
+  for (const item of (body as { data: unknown[] }).data) {
+    if (!item || typeof item !== "object") continue;
+    const { id, name } = item as { id?: unknown; name?: unknown };
+    if (typeof id !== "string" || typeof name !== "string") continue;
+    const normalizedId = id.trim().toLowerCase();
+    const normalizedName = name.trim();
+    if (normalizedId && normalizedName) names[normalizedId] = normalizedName;
+  }
+  return names;
+}
+
+export function resolveCommandCodeModelName(
+  id: string,
+  liveModelNames: Readonly<Record<string, string>>,
+): string | undefined {
+  const normalizedId = id.toLowerCase();
+  const exact = liveModelNames[normalizedId];
+  if (exact) return exact;
+
+  const datedPrefix = `${normalizedId}-`;
+  const datedMatches = Object.entries(liveModelNames).filter(
+    ([candidate]) =>
+      candidate.startsWith(datedPrefix) && /^\d{8}$/.test(candidate.slice(datedPrefix.length)),
+  );
+  return datedMatches.length === 1 ? datedMatches[0]![1] : undefined;
+}
+
+export function createCommandCodeModelNameLoader(
+  options: {
+    fetchImpl?: typeof fetch;
+    now?: () => number;
+    ttlMs?: number;
+  } = {},
+) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? COMMANDCODE_MODEL_NAMES_TTL_MS;
+  let cached: { names: Record<string, string>; expiresAt: number } | undefined;
+  let pending: Promise<Record<string, string>> | undefined;
+
+  const waitForPending = (
+    request: Promise<Record<string, string>>,
+    signal: AbortSignal | undefined,
+  ): Promise<Record<string, string>> => {
+    if (!signal) return request;
+    signal.throwIfAborted();
+    return new Promise((resolve, reject) => {
+      const onAbort = () => reject(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
+      request.then(
+        (names) => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(names);
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(error);
+        },
+      );
+    });
+  };
+
+  return async (signal?: AbortSignal): Promise<Record<string, string>> => {
+    if (cached && cached.expiresAt > now()) return cached.names;
+    if (pending) return waitForPending(pending, signal);
+
+    const staleNames = cached?.names ?? {};
+    pending = (async () => {
+      try {
+        const response = await fetchImpl(COMMANDCODE_MODELS_ENDPOINT, {
+          headers: { Accept: "application/json" },
+          signal: AbortSignal.timeout(4_000),
+        });
+        if (!response.ok) return staleNames;
+        const names = parseCommandCodeModelNames(await response.json());
+        if (Object.keys(names).length > 0) {
+          cached = { names, expiresAt: now() + ttlMs };
+          return names;
+        }
+        return staleNames;
+      } catch {
+        return staleNames;
+      } finally {
+        pending = undefined;
+      }
+    })();
+    return waitForPending(pending, signal);
+  };
+}
+
+export async function collectCommandCodeModelEfforts(
+  modelIds: readonly string[],
+  probe: (modelId: string) => Promise<string>,
+  concurrency = COMMANDCODE_EFFORT_PROBE_CONCURRENCY,
+): Promise<Record<string, string[]>> {
+  const modelEfforts: Record<string, string[]> = {};
+  if (modelIds.length === 0) return modelEfforts;
+
+  // Sentinel gate: effort discovery relies on the CLI rejecting an unknown
+  // `--effort` with a parseable reply ("Supported: …" / "has no adjustable
+  // reasoning effort"). Up to two leaders are probed serially until one
+  // produces such a reply; if neither does — older CLI builds may ignore the
+  // flag and run real `-p` turns instead — refuse the fan-out so a couple of
+  // invocations replace N. Trying a second leader keeps one persistently
+  // broken id (auth-walled BYOK endpoint, transient timeout) from vetoing the
+  // rest of the list forever, while models that merely fail stay retryable on
+  // later passes because they remain absent from the returned map.
+  const probed = new Set<string>();
+  let cursor = 0;
+  const runLeader = async (): Promise<boolean> => {
+    const modelId = modelIds[cursor++]!;
+    probed.add(modelId);
+    const efforts = parseCommandCodeModelEfforts(await probe(modelId));
+    if (efforts === undefined) return false;
+    modelEfforts[modelId] = efforts;
+    return true;
+  };
+  let sawParseableReply = false;
+  while (cursor < Math.min(COMMANDCODE_EFFORT_SENTINEL_ATTEMPTS, modelIds.length)) {
+    sawParseableReply = await runLeader();
+    if (sawParseableReply) break;
+  }
+  if (!sawParseableReply) return modelEfforts;
+
+  const takeNext = (): string | undefined => {
+    while (cursor < modelIds.length && probed.has(modelIds[cursor]!)) cursor++;
+    return cursor < modelIds.length ? modelIds[cursor++] : undefined;
+  };
+  const workers = Array.from(
+    { length: Math.min(Math.max(1, concurrency), modelIds.length - probed.size) },
+    async () => {
+      for (;;) {
+        const modelId = takeNext();
+        if (modelId === undefined) return;
+        const efforts = parseCommandCodeModelEfforts(await probe(modelId));
+        if (efforts !== undefined) modelEfforts[modelId] = efforts;
+      }
+    },
+  );
+  await Promise.all(workers);
+  return modelEfforts;
+}
+
+export function createCommandCodeEffortProbeCache(maxEntries = COMMANDCODE_EFFORT_CACHE_SIZE) {
+  const entries = new Map<
+    string,
+    { modelEfforts: Record<string, string[]>; pending?: Promise<void> }
+  >();
+
+  return async (
+    key: string,
+    modelIds: readonly string[],
+    probe: (modelId: string) => Promise<string>,
+  ): Promise<Record<string, string[]>> => {
+    let entry = entries.get(key);
+    if (entry) {
+      entries.delete(key);
+      entries.set(key, entry);
+    } else {
+      entry = { modelEfforts: {} };
+      entries.set(key, entry);
+      if (entries.size > Math.max(1, maxEntries)) {
+        entries.delete(entries.keys().next().value!);
+      }
+    }
+
+    if (entry.pending) {
+      await entry.pending;
+      return { ...entry.modelEfforts };
+    }
+
+    const missing = modelIds.filter((modelId) => !(modelId in entry.modelEfforts));
+    if (missing.length > 0) {
+      entry.pending = collectCommandCodeModelEfforts(missing, probe)
+        .then((modelEfforts) => {
+          Object.assign(entry.modelEfforts, modelEfforts);
+        })
+        .finally(() => {
+          delete entry.pending;
+        });
+      await entry.pending;
+    }
+    return { ...entry.modelEfforts };
+  };
+}
+
 function humanizeCommandCodeModelLabel(id: string): string {
   // Drop any namespace prefix, then turn `-` separators into spaces and
-  // title-case each segment. Fallback only — curated ids use the override map.
+  // title-case each segment without keeping a provider-owned name table.
   const tail = id.includes("/") ? id.slice(id.lastIndexOf("/") + 1) : id;
   return tail
     .split("-")
@@ -277,49 +327,47 @@ function humanizeCommandCodeModelLabel(id: string): string {
     .join(" ");
 }
 
-function commandCodeModelSubProviderId(id: string): string | undefined {
-  const slash = id.indexOf("/");
-  if (slash > 0) return id.slice(0, slash).toLowerCase();
-  if (/^claude/i.test(id)) return "anthropic";
-  if (/^(?:gpt|o\d|codex)/i.test(id)) return "openai";
-  return undefined;
-}
-
 /**
  * Turn parsed models into the picker's model capabilities: the labeled model
- * list plus the sub-provider grouping (labels + per-model mapping). Shared by
- * the static fallback and the live `--list-models` probe so labels and grouping
- * stay consistent across both paths.
+ * list plus the provider sections emitted by the live `--list-models` probe.
  */
 export function buildCommandCodeModelPickerCapabilities(
   parsed: ParsedCommandCodeModel[],
+  probedModelEfforts: Readonly<Record<string, string[]>> = {},
+  liveModelNames: Readonly<Record<string, string>> = {},
 ): Pick<AgentCapability, "models" | "subProviders" | "modelSubProvider" | "modelEfforts"> {
   const models: LabeledOption[] = [];
   const modelSubProvider: Record<string, string> = {};
   const modelEfforts: Record<string, string[]> = {};
-  const usedSubProviders = new Set<string>();
+  const subProviders: LabeledOption[] = [];
+  const seenSubProviders = new Set<string>();
   const seen = new Set<string>();
   let defaultId: string | undefined;
 
-  for (const { id, description, isDefault } of parsed) {
+  for (const { id, description, isDefault, providerId, providerLabel, isByok } of parsed) {
     if (!id || seen.has(id)) continue;
     seen.add(id);
     if (isDefault && !defaultId) defaultId = id;
 
     const model: LabeledOption = {
       id,
-      label: COMMANDCODE_MODEL_LABELS[id.toLowerCase()] ?? humanizeCommandCodeModelLabel(id),
+      label:
+        isByok && description
+          ? description
+          : (resolveCommandCodeModelName(id, liveModelNames) ?? humanizeCommandCodeModelLabel(id)),
     };
     const desc = description?.trim();
-    if (desc) model.description = desc;
+    if (desc && !isByok) model.description = desc;
     models.push(model);
-    const efforts = COMMANDCODE_MODEL_EFFORTS[id.toLowerCase()];
+    const efforts = probedModelEfforts[id];
     if (efforts) modelEfforts[id] = efforts;
 
-    const sub = commandCodeModelSubProviderId(id);
-    if (sub) {
-      modelSubProvider[id] = sub;
-      usedSubProviders.add(sub);
+    if (providerId && providerLabel) {
+      modelSubProvider[id] = providerId;
+      if (!seenSubProviders.has(providerId)) {
+        seenSubProviders.add(providerId);
+        subProviders.push({ id: providerId, label: providerLabel });
+      }
     }
   }
 
@@ -331,34 +379,15 @@ export function buildCommandCodeModelPickerCapabilities(
     if (idx > 0) models.unshift(models.splice(idx, 1)[0]!);
   }
 
-  const subProviders: LabeledOption[] = [];
-  const emitted = new Set<string>();
-  const pushSubProvider = (subId: string) => {
-    if (emitted.has(subId)) return;
-    emitted.add(subId);
-    subProviders.push({
-      id: subId,
-      label: COMMANDCODE_SUB_PROVIDER_LABELS[subId] ?? humanizeCommandCodeModelLabel(subId),
-    });
-  };
-  for (const subId of COMMANDCODE_SUB_PROVIDER_ORDER) {
-    if (usedSubProviders.has(subId)) pushSubProvider(subId);
-  }
-  // Any namespace the CLI introduced that we don't have a curated order for.
-  for (const subId of usedSubProviders) pushSubProvider(subId);
-
   return { models, subProviders, modelSubProvider, modelEfforts };
 }
 
 export const defaultCommandCodeCapabilities: AgentCapability = {
-  ...buildCommandCodeModelPickerCapabilities(
-    COMMANDCODE_FALLBACK_MODEL_IDS.map((id) => ({
-      id,
-      ...(id === COMMANDCODE_DEFAULT_MODEL_ID ? { isDefault: true } : {}),
-    })),
-  ),
+  models: [],
+  subProviders: [],
+  modelSubProvider: {},
+  modelEfforts: {},
   efforts: [],
-  defaultEffort: "high",
   modes: ["agent", "plan"],
   approvalPolicies: [
     { id: "default", label: "Default" },
@@ -406,6 +435,40 @@ const COMMANDCODE_TERMINAL_AUTH: AgentTerminalAuthMethod = {
   // terminal auth method as it assembles the status.
 };
 
+const readCachedCommandCodeModelEfforts = createCommandCodeEffortProbeCache();
+const loadCommandCodeModelNames = createCommandCodeModelNameLoader();
+
+async function probeCommandCodeModelEfforts(
+  ctx: DetectProbeCtx & { executablePath: string },
+  modelsOutput: string,
+  modelIds: readonly string[],
+): Promise<Record<string, string[]>> {
+  const cacheKey = JSON.stringify([ctx.location, ctx.executablePath, ctx.version, modelsOutput]);
+  return readCachedCommandCodeModelEfforts(cacheKey, modelIds, async (modelId) => {
+    const probe = await readAgentCommandOutput(
+      ctx.location,
+      ctx.executablePath,
+      [
+        "--model",
+        modelId,
+        "--effort",
+        COMMANDCODE_EFFORT_PROBE_VALUE,
+        "--no-session",
+        "-p",
+        "capability probe",
+      ],
+      {
+        timeoutMs: 4_000,
+        wslLinuxCwd: "/tmp",
+        posixCwd: getAgentProbeCwd(ctx.location),
+        ...(ctx.probeEnv ? { env: ctx.probeEnv } : {}),
+        ...(ctx.signal ? { signal: ctx.signal } : {}),
+      },
+    ).catch(() => undefined);
+    return probe ? `${probe.stdout}\n${probe.stderr}` : "";
+  });
+}
+
 export const commandCodeDetectionSpec: DetectionSpec = {
   kind: "commandcode",
   label: "Command Code",
@@ -414,12 +477,13 @@ export const commandCodeDetectionSpec: DetectionSpec = {
   capabilities: defaultCommandCodeCapabilities,
   versionArgs: ["--version"],
   authProbes: [envVarAuthProbe(["COMMAND_CODE_API_KEY"]), storedCredentialsAuthProbe],
-  // Two cheap, no-TUI jobs in one probe: advertise the terminal login method so
-  // the Settings Login button appears, and refresh the model list from
-  // `command-code --list-models` (instant, no auth needed) so newly shipped
-  // models show up without an app release. If the list call fails or parses to
-  // nothing we return auth only, leaving the static fallback models in place
-  // (detectAgentInstall shallow-merges this partial over spec.capabilities).
+  // One probe, three jobs: advertise the terminal login method so the Settings
+  // Login button appears; refresh models from `command-code --list-models`
+  // (instant, no auth needed) so newly shipped ones show up without an app
+  // release; then discover per-model efforts (sentinel-gated CLI probes — see
+  // collectCommandCodeModelEfforts) and pretty display names (HTTP fetch with a
+  // short TTL). If the list call fails or parses to nothing we return auth only
+  // and expose no stale model choices.
   async capabilitiesProbe(ctx) {
     if (!ctx.executablePath) return undefined;
     const result = await readAgentCommandOutput(
@@ -440,8 +504,20 @@ export const commandCodeDetectionSpec: DetectionSpec = {
       return undefined;
     });
     const parsed = result?.ok ? parseCommandCodeModels(result.stdout) : [];
+    const [modelEfforts, modelNames] = await Promise.all([
+      parsed.length > 0
+        ? probeCommandCodeModelEfforts(
+            { ...ctx, executablePath: ctx.executablePath },
+            result?.stdout ?? "",
+            parsed.map((model) => model.id),
+          )
+        : {},
+      parsed.length > 0 ? loadCommandCodeModelNames(ctx.signal) : {},
+    ]);
     const modelCapabilities =
-      parsed.length > 0 ? buildCommandCodeModelPickerCapabilities(parsed) : undefined;
+      parsed.length > 0
+        ? buildCommandCodeModelPickerCapabilities(parsed, modelEfforts, modelNames)
+        : undefined;
     return { authMethods: [COMMANDCODE_TERMINAL_AUTH], ...modelCapabilities };
   },
   // `command-code update` is the documented self-updater (preferred). `npm`

--- a/src/supervisor/agents/commandcode/index.ts
+++ b/src/supervisor/agents/commandcode/index.ts
@@ -8,11 +8,7 @@ import {
 } from "../base";
 import { resolveInstallNodePath, warnIfPluginManifestMissing } from "../plugin/installerBase";
 import { buildCommandCodeArgs } from "./argv";
-import {
-  COMMANDCODE_DEFAULT_MODEL_ID,
-  commandCodeDetectionSpec,
-  defaultCommandCodeCapabilities,
-} from "./detection";
+import { commandCodeDetectionSpec, defaultCommandCodeCapabilities } from "./detection";
 import {
   installCommandCodePlugin,
   isCommandCodePluginInstalled,
@@ -184,7 +180,7 @@ export function createCommandCodeAdapter(): AgentAdapter {
     optimisticWorkingOnSubmit: true,
     detectInvalidSessionRef: detectCommandCodeInvalidSessionRef,
 
-    defaultOneShotModel: COMMANDCODE_DEFAULT_MODEL_ID,
+    allowsImplicitOneShotModel: true,
 
     buildOneShotCommand(model, effort, prompt) {
       if (!prompt) return undefined;
@@ -194,8 +190,7 @@ export function createCommandCodeAdapter(): AgentAdapter {
           "--trust",
           "--skip-onboarding",
           "--no-session",
-          "--model",
-          model || COMMANDCODE_DEFAULT_MODEL_ID,
+          ...(model ? ["--model", model] : []),
           ...(effort ? ["--effort", effort] : []),
           "-p",
           prompt,
@@ -216,8 +211,7 @@ export function createCommandCodeAdapter(): AgentAdapter {
           "--skip-onboarding",
           "--no-session",
           "--yolo",
-          "--model",
-          model || COMMANDCODE_DEFAULT_MODEL_ID,
+          ...(model ? ["--model", model] : []),
           ...(effort ? ["--effort", effort] : []),
           "-p",
           prompt,

--- a/src/supervisor/commitMessageGenerator.ts
+++ b/src/supervisor/commitMessageGenerator.ts
@@ -1,5 +1,5 @@
 import type { GitFileChange, ProjectLocation } from "@/shared/contracts";
-import type { AgentAdapter } from "./agents/base";
+import { resolveOneShotEffectiveModel, type AgentAdapter } from "./agents/base";
 import { buildDiffPromptContext } from "./diffPromptContext";
 import { GitService } from "./git";
 import { runOneShotPromptWithFallback } from "./oneShotPromptRunner";
@@ -98,10 +98,9 @@ export async function generateCommitMessage(
   language?: string,
   fast?: boolean,
 ): Promise<string> {
-  const effectiveModel = model ?? adapter.defaultOneShotModel;
-  if (!effectiveModel) {
-    throw new Error(`No default one-shot model configured for ${adapter.label}`);
-  }
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(`No default one-shot model configured for ${adapter.label}`);
+  });
 
   if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
     throw new Error(`${adapter.label} does not support one-shot generation`);

--- a/src/supervisor/contextExtractor.ts
+++ b/src/supervisor/contextExtractor.ts
@@ -1,5 +1,9 @@
 import type { ExtractContextResult, ProjectLocation, SessionRef } from "@/shared/contracts";
-import { withCommandBaseSpawnEnv, type AgentAdapter } from "./agents/base";
+import {
+  resolveOneShotEffectiveModel,
+  withCommandBaseSpawnEnv,
+  type AgentAdapter,
+} from "./agents/base";
 import { runOneShotPromptWithFallback } from "./oneShotPromptRunner";
 import { buildOneShotSpec, spawnAgent } from "./oneShotSpawn";
 
@@ -114,10 +118,9 @@ export async function extractContextFromScrollback(
     );
   }
 
-  const effectiveModel = model ?? adapter.defaultOneShotModel;
-  if (!effectiveModel) {
-    throw new Error(`No default one-shot model configured for ${adapter.label}`);
-  }
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(`No default one-shot model configured for ${adapter.label}`);
+  });
 
   const buildPromptForCap = (maxChars: number): string => {
     const trimmed =

--- a/src/supervisor/experimentJudge.ts
+++ b/src/supervisor/experimentJudge.ts
@@ -6,7 +6,7 @@ import type {
   JudgeExperimentResult,
   ProjectLocation,
 } from "@/shared/contracts";
-import type { AgentAdapter } from "./agents/base";
+import { resolveOneShotEffectiveModel, type AgentAdapter } from "./agents/base";
 import type { UnifiedDiffStats } from "@/shared/lineUnifiedDiff";
 import { msg } from "@/shared/messages";
 import { createExperimentJudgeWorkspace } from "./experimentJudgeWorkspace";
@@ -217,10 +217,9 @@ export async function judgeExperiment(
     throw new Error(msg("experiment.judge.uniqueThreadIds"));
   }
 
-  const effectiveModel = model ?? adapter.defaultOneShotModel;
-  if (!effectiveModel) {
-    throw new Error(msg("experiment.judge.noDefaultModel", { provider: adapter.label }));
-  }
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(msg("experiment.judge.noDefaultModel", { provider: adapter.label }));
+  });
   if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
     throw new Error(msg("experiment.judge.oneShotUnsupported", { provider: adapter.label }));
   }

--- a/src/supervisor/prSummaryGenerator.ts
+++ b/src/supervisor/prSummaryGenerator.ts
@@ -1,5 +1,5 @@
 import type { ProjectLocation } from "@/shared/contracts";
-import type { AgentAdapter } from "./agents/base";
+import { resolveOneShotEffectiveModel, type AgentAdapter } from "./agents/base";
 import { buildDiffPromptContext, getFilesFromDiff } from "./diffPromptContext";
 import { GitService } from "./git";
 import { runOneShotPromptWithFallback } from "./oneShotPromptRunner";
@@ -83,10 +83,9 @@ export async function generatePrSummary(
   effort?: string,
   language?: string,
 ): Promise<{ title: string; description: string }> {
-  const effectiveModel = model ?? adapter.defaultOneShotModel;
-  if (!effectiveModel) {
-    throw new Error(`No default one-shot model configured for ${adapter.label}`);
-  }
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(`No default one-shot model configured for ${adapter.label}`);
+  });
 
   if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
     throw new Error(`${adapter.label} does not support one-shot generation`);

--- a/src/supervisor/runtime/agentStatusCache.test.ts
+++ b/src/supervisor/runtime/agentStatusCache.test.ts
@@ -227,7 +227,51 @@ describe("agent status cache", () => {
       }
     ).readCachedStatuses([]);
 
-    expect(STATUS_CACHE_VERSION).toBe(18);
+    expect(STATUS_CACHE_VERSION).toBe(19);
+    expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
+  });
+
+  it("invalidates v18 caches holding Command Code's curated fallback models", () => {
+    const dataDir = makeTempDir();
+    process.env.PORACODE_DATA_DIR = dataDir;
+
+    const { cacheDir, statusCachePath } = resolvePoracodePaths(dataDir);
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      statusCachePath,
+      JSON.stringify({
+        version: 18,
+        windows: [
+          {
+            kind: "commandcode",
+            label: "Command Code",
+            installed: true,
+            authState: "authenticated",
+            capabilities: {
+              models: [
+                { id: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+                { id: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+              ],
+              modelEfforts: { "deepseek/deepseek-v4-flash": ["high", "max"] },
+              defaultEffort: "high",
+            },
+          },
+        ],
+      }),
+    );
+
+    const runtime = makeRuntime(() => {});
+    const cached = (
+      runtime.agentStatusService as unknown as {
+        readCachedStatuses: (wslDistros: readonly string[]) => {
+          windows: AgentStatus[];
+          wsl: AgentStatus[];
+          fromCache: boolean;
+        };
+      }
+    ).readCachedStatuses([]);
+
+    expect(STATUS_CACHE_VERSION).toBe(19);
     expect(cached).toEqual({ windows: [], wsl: [], fromCache: false });
   });
 

--- a/src/supervisor/runtime/agentStatusService.ts
+++ b/src/supervisor/runtime/agentStatusService.ts
@@ -69,8 +69,11 @@ const execFileAsync = promisify(execFile);
  * v18 regroups Cursor first-party models (Grok, Composer, future Cursor ids)
  * into the Cursor Models pool by denylisting known third-party vendor prefixes
  * instead of allowlisting first-party families.
+ * v19 replaces Command Code's curated fallback model tables/static efforts
+ * (and its `defaultEffort`) with live-only discovery, so cached statuses from
+ * before the switch would keep serving a stale deepseek-era picker.
  */
-export const STATUS_CACHE_VERSION = 18;
+export const STATUS_CACHE_VERSION = 19;
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 60_000;
 const WSL_LXSS_REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
 

--- a/src/supervisor/titleGenerator.test.ts
+++ b/src/supervisor/titleGenerator.test.ts
@@ -77,4 +77,24 @@ describe("generateTitle CLI spawn", () => {
       }),
     );
   });
+
+  it("allows a CLI adapter to use its target environment's implicit model", async () => {
+    const buildOneShotCommand = vi.fn<NonNullable<AgentAdapter["buildOneShotCommand"]>>(
+      (_model: string) => ({
+        command: "command-code",
+        args: ["--no-session", "-p", "prompt"],
+      }),
+    );
+    const adapter = cliAdapter({ allowsImplicitOneShotModel: true, buildOneShotCommand });
+    delete adapter.defaultOneShotModel;
+    await generateTitle(windowsProject, adapter, "the login times out");
+
+    expect(buildOneShotCommand).toHaveBeenCalledWith(
+      "",
+      undefined,
+      expect.any(String),
+      windowsProject,
+      undefined,
+    );
+  });
 });

--- a/src/supervisor/titleGenerator.ts
+++ b/src/supervisor/titleGenerator.ts
@@ -1,5 +1,9 @@
 import type { ProjectLocation } from "@/shared/contracts";
-import { withCommandBaseSpawnEnv, type AgentAdapter } from "./agents/base";
+import {
+  resolveOneShotEffectiveModel,
+  withCommandBaseSpawnEnv,
+  type AgentAdapter,
+} from "./agents/base";
 import { prepareOneShot } from "./oneShotSpawn";
 
 /**
@@ -79,10 +83,9 @@ export async function generateTitle(
   language?: string,
   fast?: boolean,
 ): Promise<string> {
-  const effectiveModel = model ?? adapter.defaultOneShotModel;
-  if (!effectiveModel) {
-    throw new Error(`No default one-shot model configured for ${adapter.label}`);
-  }
+  const effectiveModel = resolveOneShotEffectiveModel(adapter, model, () => {
+    return new Error(`No default one-shot model configured for ${adapter.label}`);
+  });
 
   if (!adapter.runOneShot && !adapter.buildOneShotCommand) {
     throw new Error(`${adapter.label} does not support one-shot generation`);


### PR DESCRIPTION
- Replace curated Command Code models with live model and effort discovery.
- Allow Command Code one-shot generators to use implicit environment defaults.
- Invalidate stale cached model capabilities and update related status handling.
- Add coverage for discovery caching, cache invalidation, and implicit models.