### PR TITLE
Preserve goals across paged runtime snapshots

### DIFF
--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -37,6 +37,7 @@ export {
   dbReadThreadRuntimeSummaries,
   dbGetThreadRuntimeSummaries,
   dbGetThreadRuntimeItem,
+  dbGetLatestThreadGoalItem,
   dbGetThreadRuntimeItems,
   dbGetThreadRuntimeItemsPage,
   dbTruncateThreadRuntimeAfter,

--- a/src/main/db/runtimeItems.test.ts
+++ b/src/main/db/runtimeItems.test.ts
@@ -8,6 +8,7 @@ import { closeDatabase, initDatabase } from "./connection";
 import { dbUpsertProject, dbUpsertThread } from "./projectsThreads";
 import {
   dbApplyThreadRuntimeEvents,
+  dbGetLatestThreadGoalItem,
   dbGetThreadContextUsage,
   dbGetLatestThreadRuntimeAnchorItemId,
   dbGetThreadRuntimeItems,
@@ -475,5 +476,40 @@ describe.skipIf(!sqliteAvailable)("runtimeItems incremental persistence", () => 
       "assistant-1",
     ]);
     expect(page.nextCursor).toBe(1);
+  });
+
+  it("returns the latest goal even when its position is before the tail window", () => {
+    dbReplaceThreadRuntimeItems("thread-1", [
+      {
+        id: "goal-outside-tail",
+        type: "goal",
+        state: "updated",
+        payload: { action: "set", objective: "outside-tail goal" },
+        streams: {},
+      },
+      ...Array.from({ length: 90 }, (_, index) => ({
+        id: `assistant-${index}`,
+        type: "assistant_message" as const,
+        state: "completed" as const,
+        streams: {},
+      })),
+    ]);
+
+    const tail = dbGetThreadRuntimeItemsPage("thread-1", undefined, 500, 40);
+    expect(tail.items.some((item) => item.id === "goal-outside-tail")).toBe(false);
+    expect(tail.items.at(-1)?.id).toBe("assistant-89");
+
+    expect(dbGetLatestThreadGoalItem("thread-1")?.id).toBe("goal-outside-tail");
+
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "goal-new",
+        itemType: "goal",
+        payload: { action: "updated", objective: "new goal" },
+      },
+    ]);
+    expect(dbGetLatestThreadGoalItem("thread-1")?.id).toBe("goal-new");
   });
 });

--- a/src/main/db/runtimeItems.ts
+++ b/src/main/db/runtimeItems.ts
@@ -209,6 +209,21 @@ export function dbGetThreadRuntimeItem(
   return row ? mapRuntimeItemRow(row) : null;
 }
 
+/** Reads the latest goal even when it precedes the paged transcript window. */
+export function dbGetLatestThreadGoalItem(threadId: string): PersistedRuntimeItem | null {
+  const sqlite = getSqlite();
+  const row = sqlite
+    .prepare(
+      `SELECT item_id, type, state, payload, streams, parent_item_id
+       FROM thread_runtime_items
+       WHERE thread_id = ? AND type = 'goal'
+       ORDER BY position DESC
+       LIMIT 1`,
+    )
+    .get(threadId) as PersistedRuntimeItemRow | undefined;
+  return row ? mapRuntimeItemRow(row) : null;
+}
+
 export function dbGetThreadRuntimeItemsPage(
   threadId: string,
   beforePosition: number | undefined,

--- a/src/main/ipc/localHandlers.ts
+++ b/src/main/ipc/localHandlers.ts
@@ -14,6 +14,7 @@ import {
   dbGetThreadContextUsage,
   dbGetThreadRuntimeItems,
   dbGetThreadRuntimeItemsPage,
+  dbGetLatestThreadGoalItem,
   dbTruncateThreadRuntimeAfter,
   dbGetThreads,
   dbPersistExperimentState,
@@ -527,6 +528,7 @@ export function createLocalIpcHandlers(
     dbGetThreadRuntimeItems: ({ threadId }) => dbGetThreadRuntimeItems(threadId),
     dbGetThreadRuntimeItemsPage: ({ threadId, beforePosition, limit, targetTimelineEntryCount }) =>
       dbGetThreadRuntimeItemsPage(threadId, beforePosition, limit, targetTimelineEntryCount),
+    dbGetLatestThreadGoalItem: ({ threadId }) => dbGetLatestThreadGoalItem(threadId),
     dbTruncateThreadRuntimeAfter: ({ threadId, itemId }) =>
       dbTruncateThreadRuntimeAfter(threadId, itemId),
     dbReplaceThreadRuntimeItems: ({ threadId, items }) =>

--- a/src/main/remote/RemoteAccessServer.test.ts
+++ b/src/main/remote/RemoteAccessServer.test.ts
@@ -47,6 +47,7 @@ import {
   dbGetProjects,
   dbGetThread,
   dbGetThreadContextUsage,
+  dbGetLatestThreadGoalItem,
   dbGetLatestThreadRuntimeAnchorItemId,
   dbGetThreadRuntimeItems,
   dbGetThreadRuntimeItemsPage,
@@ -90,6 +91,7 @@ vi.mock("../db", () => {
     dbGetProjects: vi.fn<() => unknown[]>(() => []),
     dbGetThreadCompletedTurns: vi.fn<() => unknown[]>(() => []),
     dbGetThreadContextUsage: vi.fn<() => null>(() => null),
+    dbGetLatestThreadGoalItem: vi.fn<() => unknown>(() => null),
     dbGetLatestThreadRuntimeAnchorItemId: vi.fn<() => null>(() => null),
     dbGetThreadRuntimeItems: vi.fn<() => unknown[]>(() => []),
     dbGetThreadRuntimeItemsPage: vi.fn<() => { items: unknown[]; nextCursor: number | null }>(
@@ -158,6 +160,7 @@ afterEach(async () => {
   vi.mocked(dbGetProjectNotes).mockReset().mockReturnValue(null);
   vi.mocked(dbGetProjects).mockReset().mockReturnValue([]);
   vi.mocked(dbGetThreadContextUsage).mockReset().mockReturnValue(null);
+  vi.mocked(dbGetLatestThreadGoalItem).mockReset().mockReturnValue(null);
   vi.mocked(dbGetLatestThreadRuntimeAnchorItemId).mockReset().mockReturnValue(null);
   vi.mocked(dbGetThreadRuntimeItems).mockReset().mockReturnValue([]);
   vi.mocked(dbGetThreadRuntimeItemsPage)
@@ -919,8 +922,16 @@ describe("RemoteAccessServer", () => {
         streams: {},
       },
     ];
+    const goalItem = {
+      id: "goal-outside-tail",
+      type: "goal",
+      state: "updated" as const,
+      payload: { action: "set", objective: "Keep the remote dock visible" },
+      streams: {},
+    };
     const tailPage = { items: [fullItems[1]!], nextCursor: 41 };
     vi.mocked(dbGetThread).mockReturnValue(thread);
+    vi.mocked(dbGetLatestThreadGoalItem).mockReturnValue(goalItem);
     vi.mocked(dbGetThreadRuntimeItems).mockReturnValue(fullItems);
     vi.mocked(dbGetThreadRuntimeItemsPage).mockReturnValue(tailPage);
 
@@ -949,7 +960,7 @@ describe("RemoteAccessServer", () => {
     );
     expect(tailResponse.status).toBe(200);
     await expect(tailResponse.json()).resolves.toMatchObject({
-      runtimeItems: tailPage.items,
+      runtimeItems: [goalItem, ...tailPage.items],
       runtimeNextCursor: 41,
     });
     expect(dbGetThreadRuntimeItemsPage).toHaveBeenLastCalledWith(
@@ -959,6 +970,8 @@ describe("RemoteAccessServer", () => {
       40,
     );
 
+    const tailWithGoal = { items: [goalItem, ...tailPage.items], nextCursor: 41 };
+    vi.mocked(dbGetThreadRuntimeItemsPage).mockReturnValue(tailWithGoal);
     const narrowTailResponse = await fetch(
       new URL(
         "/api/threads/thread-paged/history?runtimePage=1&targetTimelineEntryCount=20",
@@ -968,7 +981,7 @@ describe("RemoteAccessServer", () => {
     );
     expect(narrowTailResponse.status).toBe(200);
     await expect(narrowTailResponse.json()).resolves.toMatchObject({
-      runtimeItems: tailPage.items,
+      runtimeItems: tailWithGoal.items,
       runtimeNextCursor: 41,
     });
     expect(dbGetThreadRuntimeItemsPage).toHaveBeenLastCalledWith(
@@ -978,6 +991,7 @@ describe("RemoteAccessServer", () => {
       20,
     );
 
+    vi.mocked(dbGetThreadRuntimeItemsPage).mockReturnValue(tailPage);
     const olderResponse = await fetch(
       new URL(
         "/api/threads/thread-paged/history/items?beforePosition=41&limit=500&targetTimelineEntryCount=40",

--- a/src/main/remote/server/snapshots.ts
+++ b/src/main/remote/server/snapshots.ts
@@ -19,6 +19,7 @@ import {
   dbGetThread,
   dbGetThreadCompletedTurns,
   dbGetThreadContextUsage,
+  dbGetLatestThreadGoalItem,
   dbGetThreadRuntimeItems,
   dbGetThreadRuntimeItemsPage,
   dbGetThreadRuntimeSummaries,
@@ -148,16 +149,19 @@ export async function buildThreadSnapshot(
   const runtimePage = options.runtimePage
     ? dbGetThreadRuntimeItemsPage(threadId, undefined, 500, options.targetTimelineEntryCount ?? 40)
     : null;
+  const runtimeItems = runtimePage?.items ?? dbGetThreadRuntimeItems(threadId);
+  const latestGoal = runtimePage ? dbGetLatestThreadGoalItem(threadId) : null;
+  const runtimeItemsWithGoal =
+    latestGoal && !runtimeItems.some((item) => item.id === latestGoal.id)
+      ? [latestGoal, ...runtimeItems]
+      : runtimeItems;
   return remoteThreadSnapshotSchema.parse(
     withStableUpdatedAt(`thread:${threadId}`, {
       snapshotSeq: ctx.seq,
       thread,
       // Inline image bytes are replaced by host-minted references: they are ~89%
       // of runtime payload bytes and the client fetches each one on demand.
-      runtimeItems: projectRuntimeItemsImageRefs(
-        threadId,
-        runtimePage?.items ?? dbGetThreadRuntimeItems(threadId),
-      ),
+      runtimeItems: projectRuntimeItemsImageRefs(threadId, runtimeItemsWithGoal),
       ...(runtimePage ? { runtimeNextCursor: runtimePage.nextCursor } : {}),
       completedTurns: dbGetThreadCompletedTurns(threadId),
       contextUsage: dbGetThreadContextUsage(threadId),

--- a/src/mobile/bridge.ts
+++ b/src/mobile/bridge.ts
@@ -289,6 +289,7 @@ const remoteBridgeOverrides = {
     payload.beforePosition === undefined
       ? Promise.resolve({ items: [], nextCursor: null })
       : invokeRemoteIpcProcedure(requireClient(), "dbGetThreadRuntimeItemsPage", payload),
+  dbGetLatestThreadGoalItem: () => Promise.resolve(null),
   dbGetThreadCompletedTurns: () => Promise.resolve([]),
   dbGetThreadContextUsage: () => Promise.resolve(null),
 

--- a/src/mobile/storeSync.applyThreadSnapshot.test.tsx
+++ b/src/mobile/storeSync.applyThreadSnapshot.test.tsx
@@ -374,6 +374,58 @@ describe("applyThreadSnapshot", () => {
     expect(assistantStreamText("tail-a")).toBe("updated");
   });
 
+  it("catches up an active paged snapshot while preserving a pinned goal's order", () => {
+    const goal: PersistedRuntimeItem = {
+      id: "goal-1",
+      type: "goal",
+      state: "updated",
+      payload: { action: "set", objective: "Finish the task" },
+      streams: {},
+    };
+    applyThreadSnapshot(
+      makeSnapshot({
+        status: "working",
+        items: [goal, makeItem({ id: "tail-a" })],
+        runtimeNextCursor: 10,
+      }),
+    );
+
+    useAppStore.getState().applyRuntimeEvents(THREAD_ID, [
+      {
+        type: "item.started",
+        threadId: THREAD_ID,
+        itemId: "live-message",
+        itemType: "assistant_message",
+      },
+      {
+        type: "content.delta",
+        threadId: THREAD_ID,
+        itemId: "live-message",
+        stream: "assistant_text",
+        delta: "partial",
+      },
+    ]);
+
+    applyThreadSnapshot(
+      makeSnapshot({
+        status: "working",
+        items: [
+          goal,
+          makeItem({ id: "tail-a" }),
+          makeItem({ id: "live-message", assistantText: "partial complete" }),
+        ],
+        runtimeNextCursor: 10,
+      }),
+    );
+
+    expect(useAppStore.getState().runtimeItemIdsByThread[THREAD_ID]).toEqual([
+      "goal-1",
+      "tail-a",
+      "live-message",
+    ]);
+    expect(assistantStreamText("live-message")).toBe("partial complete");
+  });
+
   it("splices a missed initial user_message ahead of a fresher live transcript", () => {
     // Launch race: the thread's first events broadcast before this client's
     // mirrored thread list contained the id, so the live filter dropped the

--- a/src/mobile/useRemoteDesktop.test.tsx
+++ b/src/mobile/useRemoteDesktop.test.tsx
@@ -255,7 +255,8 @@ vi.mock("./storeSync", () => ({
   resetRemoteStores: (...a: unknown[]) => h.resetRemoteStores(...a),
 }));
 
-vi.mock("@/renderer/state/chatRuntimePersister", () => ({
+vi.mock("@/renderer/state/chatRuntimePersister", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/renderer/state/chatRuntimePersister")>()),
   seedOlderThreadRuntimeItemsCursor: (...a: unknown[]) => h.seedOlderThreadRuntimeItemsCursor(...a),
 }));
 vi.mock("@/renderer/state/fileCheckpointActions", () => ({
@@ -1279,11 +1280,16 @@ describe("useRemoteDesktop", () => {
   it("preserves an advanced page cursor when a fresh tail overlaps local history", async () => {
     const desktop = makeDesktop("d1");
     const client = clientFor("d1");
-    useAppStore.setState({ runtimeItemIdsByThread: { t1: ["shared-tail-start"] } });
+    useAppStore.setState({
+      runtimeItemIdsByThread: { t1: ["pinned-goal", "shared-tail-start"] },
+    });
     client.threadHistory.mockResolvedValueOnce({
       snapshotSeq: 2,
       thread: { id: "t1", status: "idle", presentationMode: "gui" },
-      runtimeItems: [{ id: "shared-tail-start" }],
+      runtimeItems: [
+        { id: "pinned-goal", type: "goal" },
+        { id: "shared-tail-start", type: "assistant_message" },
+      ],
       runtimeNextCursor: 80,
       completedTurns: [],
       contextUsage: null,
@@ -1303,11 +1309,16 @@ describe("useRemoteDesktop", () => {
   it("replaces the page cursor when a fresh tail is disjoint from local history", async () => {
     const desktop = makeDesktop("d1");
     const client = clientFor("d1");
-    useAppStore.setState({ runtimeItemIdsByThread: { t1: ["cached-tail-start"] } });
+    useAppStore.setState({
+      runtimeItemIdsByThread: { t1: ["pinned-goal", "cached-tail-start"] },
+    });
     client.threadHistory.mockResolvedValueOnce({
       snapshotSeq: 2,
       thread: { id: "t1", status: "idle", presentationMode: "gui" },
-      runtimeItems: [{ id: "fresh-tail-start" }],
+      runtimeItems: [
+        { id: "pinned-goal", type: "goal" },
+        { id: "fresh-tail-start", type: "assistant_message" },
+      ],
       runtimeNextCursor: 120,
       completedTurns: [],
       contextUsage: null,

--- a/src/mobile/useRemoteDesktop.ts
+++ b/src/mobile/useRemoteDesktop.ts
@@ -28,7 +28,10 @@ import { performThreadInputSubmit } from "@/renderer/actions/threadRuntimeAction
 import { worktreePlacementPayload } from "@/renderer/actions/worktreePlacement";
 import { captureFileCheckpoint } from "@/renderer/state/fileCheckpointActions";
 import { useAppStore } from "@/renderer/state/appStore";
-import { seedOlderThreadRuntimeItemsCursor } from "@/renderer/state/chatRuntimePersister";
+import {
+  runtimePageOverlapsExistingTranscript,
+  seedOlderThreadRuntimeItemsCursor,
+} from "@/renderer/state/chatRuntimePersister";
 import { readBridge } from "@/renderer/bridge";
 import type { DraftStartInput } from "@/renderer/components/thread/ThreadDraftComposerArea";
 import { i18n } from "@/renderer/i18n/i18n";
@@ -679,10 +682,11 @@ export function useRemoteDesktop() {
       // Bail if the user opened another thread while the fetch was in flight.
       if (isStaleSelection()) return latest;
       latest = { snapshot: next, fromServer: true };
-      const firstSnapshotItemId = next.runtimeItems[0]?.id;
       const existingRuntimeItemIds = useAppStore.getState().runtimeItemIdsByThread[threadId] ?? [];
-      const tailOverlapsExistingTranscript =
-        firstSnapshotItemId !== undefined && existingRuntimeItemIds.includes(firstSnapshotItemId);
+      const tailOverlapsExistingTranscript = runtimePageOverlapsExistingTranscript(
+        next.runtimeItems,
+        existingRuntimeItemIds,
+      );
       seedOlderThreadRuntimeItemsCursor(threadId, next.runtimeNextCursor ?? null, {
         preserveExistingCursor: tailOverlapsExistingTranscript,
       });

--- a/src/renderer/remoteProcedureRoutes.ts
+++ b/src/renderer/remoteProcedureRoutes.ts
@@ -82,6 +82,7 @@ export const NON_ROUTER_PROJECT_PROCEDURES = {
   dbDeleteThread: "remote-mirrors-not-persisted",
   dbSyncAll: "remote-mirrors-not-persisted",
   dbGetThreadRuntimeItems: "remote-runtime-mirror-local",
+  dbGetLatestThreadGoalItem: "remote-runtime-snapshot-provided",
   dbReplaceThreadRuntimeItems: "remote-runtime-mirror-local",
   dbGetThreadCompletedTurns: "remote-runtime-mirror-local",
   dbReplaceThreadCompletedTurns: "remote-runtime-mirror-local",

--- a/src/renderer/state/chatRuntimePersister.test.ts
+++ b/src/renderer/state/chatRuntimePersister.test.ts
@@ -29,6 +29,18 @@ const { bridge } = vi.hoisted(() => ({
       .fn<(threadId: string) => Promise<never[]>>()
       .mockResolvedValue([]),
     dbGetThreadContextUsage: vi.fn<(threadId: string) => Promise<null>>().mockResolvedValue(null),
+    dbGetLatestThreadGoalItem: vi
+      .fn<
+        (input: { threadId: string }) => Promise<{
+          id: string;
+          type: string;
+          state: "started" | "updated" | "completed";
+          payload?: unknown;
+          streams: Record<string, string>;
+          parentItemId?: string;
+        } | null>
+      >()
+      .mockResolvedValue(null),
   },
 }));
 
@@ -160,6 +172,7 @@ describe("paged runtime hydration", () => {
     vi.clearAllMocks();
     bridge.dbGetThreadCompletedTurns.mockResolvedValue([]);
     bridge.dbGetThreadContextUsage.mockResolvedValue(null);
+    bridge.dbGetLatestThreadGoalItem.mockResolvedValue(null);
     useAppStore.setState((state) => ({
       ...state,
       runtimeItemIdsByThread: {},
@@ -535,5 +548,67 @@ describe("paged runtime hydration", () => {
     );
     evictOversizedInactiveThreadRuntimeItems([threadId]);
     expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toBeUndefined();
+  });
+
+  it("re-pins an out-of-window goal item when the paged tail has none", async () => {
+    const threadId = "long-goal-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [makeItem({ id: "assistant-recent", type: "assistant_message" })],
+      nextCursor: 50,
+    });
+    bridge.dbGetLatestThreadGoalItem.mockResolvedValueOnce({
+      id: "goal-old",
+      type: "goal",
+      state: "updated",
+      payload: { action: "set", objective: "ship coverage", status: "active" },
+      streams: {},
+    });
+
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual([
+      "goal-old",
+      "assistant-recent",
+    ]);
+    const goal = useAppStore.getState().runtimeItemsByIdByThread[threadId]?.["goal-old"];
+    expect(goal?.type).toBe("goal");
+  });
+
+  it("does not duplicate a goal item already present in the tail", async () => {
+    const threadId = "goal-in-tail-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [
+        makeItem({ id: "goal-in-tail", type: "goal", payload: { objective: "keep me" } }),
+        makeItem({ id: "assistant-recent", type: "assistant_message" }),
+      ],
+      nextCursor: 50,
+    });
+    bridge.dbGetLatestThreadGoalItem.mockResolvedValueOnce({
+      id: "goal-in-tail",
+      type: "goal",
+      state: "updated",
+      payload: { objective: "keep me" },
+      streams: {},
+    });
+
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual([
+      "goal-in-tail",
+      "assistant-recent",
+    ]);
+  });
+
+  it("does not pin when no persisted goal exists", async () => {
+    const threadId = "no-goal-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({
+      items: [makeItem({ id: "assistant-recent", type: "assistant_message" })],
+      nextCursor: null,
+    });
+    bridge.dbGetLatestThreadGoalItem.mockResolvedValueOnce(null);
+
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual(["assistant-recent"]);
   });
 });

--- a/src/renderer/state/chatRuntimePersister.test.ts
+++ b/src/renderer/state/chatRuntimePersister.test.ts
@@ -574,6 +574,32 @@ describe("paged runtime hydration", () => {
     expect(goal?.type).toBe("goal");
   });
 
+  it("retries hydration after the latest goal lookup fails", async () => {
+    const threadId = "goal-retry-thread";
+    bridge.dbGetThreadRuntimeItemsPage.mockResolvedValue({
+      items: [makeItem({ id: "assistant-recent", type: "assistant_message" })],
+      nextCursor: 50,
+    });
+    bridge.dbGetLatestThreadGoalItem
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockResolvedValueOnce({
+        id: "goal-old",
+        type: "goal",
+        state: "updated",
+        payload: { action: "set", objective: "retry coverage", status: "active" },
+        streams: {},
+      });
+
+    await hydrateThreadRuntimeItems(threadId);
+    await hydrateThreadRuntimeItems(threadId);
+
+    expect(bridge.dbGetLatestThreadGoalItem).toHaveBeenCalledTimes(2);
+    expect(useAppStore.getState().runtimeItemIdsByThread[threadId]).toEqual([
+      "goal-old",
+      "assistant-recent",
+    ]);
+  });
+
   it("does not duplicate a goal item already present in the tail", async () => {
     const threadId = "goal-in-tail-thread";
     bridge.dbGetThreadRuntimeItemsPage.mockResolvedValueOnce({

--- a/src/renderer/state/chatRuntimePersister.ts
+++ b/src/renderer/state/chatRuntimePersister.ts
@@ -247,7 +247,8 @@ async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolea
   return (
     itemsResult.status !== "rejected" &&
     turnsResult.status !== "rejected" &&
-    contextResult.status !== "rejected"
+    contextResult.status !== "rejected" &&
+    latestGoalResult.status !== "rejected"
   );
 }
 

--- a/src/renderer/state/chatRuntimePersister.ts
+++ b/src/renderer/state/chatRuntimePersister.ts
@@ -1,4 +1,5 @@
 import type { ToolCallPayload } from "@/shared/contracts";
+import type { PersistedRuntimeItem } from "@/shared/ipc";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
 import { captureRendererException } from "../diagnostics/sentry";
 import { imageViewRendersInline } from "../components/thread/ChatPane/parts/items/imageViewSource";
@@ -54,6 +55,14 @@ export function seedOlderThreadRuntimeItemsCursor(
   }
   if (currentCursor === null) return;
   olderRuntimePageCursorByThread.set(threadId, Math.min(currentCursor, cursor));
+}
+
+export function runtimePageOverlapsExistingTranscript(
+  runtimeItems: readonly Pick<PersistedRuntimeItem, "id" | "type">[],
+  existingItemIds: readonly string[],
+): boolean {
+  const existingIds = new Set(existingItemIds);
+  return runtimeItems.some((item) => item.type !== "goal" && existingIds.has(item.id));
 }
 
 export function hasHydratedThreadRuntimeItems(threadId: string): boolean {
@@ -148,7 +157,7 @@ export async function hydrateThreadRuntimeItems(threadId: string): Promise<void>
 
 async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolean> {
   const bridge = readBridge();
-  const [itemsResult, turnsResult, contextResult] = await Promise.allSettled([
+  const [itemsResult, turnsResult, contextResult, latestGoalResult] = await Promise.allSettled([
     Promise.resolve().then(() =>
       bridge.dbGetThreadRuntimeItemsPage({
         threadId,
@@ -158,6 +167,7 @@ async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolea
     ),
     Promise.resolve().then(() => bridge.dbGetThreadCompletedTurns(threadId)),
     Promise.resolve().then(() => bridge.dbGetThreadContextUsage(threadId)),
+    Promise.resolve().then(() => bridge.dbGetLatestThreadGoalItem({ threadId })),
   ]);
 
   if (itemsResult.status === "fulfilled") {
@@ -193,6 +203,19 @@ async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolea
     captureRendererException(itemsResult.reason, { featureArea: "runtime-persistence" });
   }
 
+  // Goal rows are hidden from the timeline but still drive the composer dock.
+  // Re-pin the latest one when paged hydration omits it.
+  if (latestGoalResult.status === "fulfilled" && latestGoalResult.value) {
+    pinOutOfWindowGoalItem(threadId, latestGoalResult.value);
+  } else if (latestGoalResult.status === "rejected") {
+    console.warn(
+      "[chat] failed to read the latest goal item for thread %s",
+      threadId,
+      latestGoalResult.reason,
+    );
+    captureRendererException(latestGoalResult.reason, { featureArea: "runtime-persistence" });
+  }
+
   if (turnsResult.status === "fulfilled" && turnsResult.value.length > 0) {
     const records: CompletedTurnRecord[] = turnsResult.value.flatMap((row) => {
       const startedAt = new Date(row.startedAt).getTime();
@@ -226,6 +249,22 @@ async function hydrateThreadRuntimeItemsFromDb(threadId: string): Promise<boolea
     turnsResult.status !== "rejected" &&
     contextResult.status !== "rejected"
   );
+}
+
+/**
+ * Prepends the thread's latest persisted goal item when the loaded window has
+ * none. The item is older than everything in the tail window, so prepending
+ * keeps insertion order; later older-page loads that contain the same item id
+ * are deduped by `prependThreadRuntimeItems`, and live `item.updated` events
+ * for the goal keep landing on the pinned row.
+ */
+function pinOutOfWindowGoalItem(threadId: string, goalItem: PersistedRuntimeItem): void {
+  const state = useAppStore.getState();
+  const itemIds = state.runtimeItemIdsByThread[threadId];
+  if (!itemIds) return;
+  const itemsById = state.runtimeItemsByIdByThread[threadId];
+  if (itemIds.some((itemId) => itemsById?.[itemId]?.type === "goal")) return;
+  state.prependThreadRuntimeItems(threadId, [toRuntimeChatItem(goalItem)]);
 }
 
 function evictInactiveThreadRuntimeItems(): void {

--- a/src/renderer/state/remoteServersStore.ts
+++ b/src/renderer/state/remoteServersStore.ts
@@ -28,7 +28,10 @@ import {
 } from "@/renderer/remoteProcedureRouter";
 import { applyThreadSnapshot, dispatchRemoteSupervisorEvent } from "@/renderer/state/remote";
 import { useAppStore } from "@/renderer/state/appStore";
-import { seedOlderThreadRuntimeItemsCursor } from "@/renderer/state/chatRuntimePersister";
+import {
+  runtimePageOverlapsExistingTranscript,
+  seedOlderThreadRuntimeItemsCursor,
+} from "@/renderer/state/chatRuntimePersister";
 import {
   projectRemoteProject,
   projectRemoteThread,
@@ -1132,16 +1135,16 @@ export const useRemoteServersStore = create<RemoteServersState>()(
           if (requestSeq !== openRemoteThreadRequestSeq) return false;
           const projectedSnapshot = projectRemoteThreadSnapshot(desktopId, snapshot);
           const viewThreadId = projectedSnapshot.thread.id;
-          const firstSnapshotItemId = projectedSnapshot.runtimeItems[0]?.id;
           const existingRuntimeItemIds =
             useAppStore.getState().runtimeItemIdsByThread[viewThreadId] ?? [];
           seedOlderThreadRuntimeItemsCursor(
             viewThreadId,
             projectedSnapshot.runtimeNextCursor ?? null,
             {
-              preserveExistingCursor:
-                firstSnapshotItemId !== undefined &&
-                existingRuntimeItemIds.includes(firstSnapshotItemId),
+              preserveExistingCursor: runtimePageOverlapsExistingTranscript(
+                projectedSnapshot.runtimeItems,
+                existingRuntimeItemIds,
+              ),
             },
           );
           applyThreadSnapshot(projectedSnapshot);

--- a/src/shared/ipc/procedureMap.ts
+++ b/src/shared/ipc/procedureMap.ts
@@ -130,6 +130,7 @@ export const MAIN_LOCAL_PROCEDURE_NAMES = [
   "dbPersistExperimentState",
   "dbGetThreadRuntimeItems",
   "dbGetThreadRuntimeItemsPage",
+  "dbGetLatestThreadGoalItem",
   "dbTruncateThreadRuntimeAfter",
   "dbReplaceThreadRuntimeItems",
   "dbGetThreadCompletedTurns",

--- a/src/shared/ipc/procedures/db.ts
+++ b/src/shared/ipc/procedures/db.ts
@@ -95,6 +95,11 @@ export const dbProcedures = {
     PersistedRuntimePage,
     "main-local"
   >("dbGetThreadRuntimeItemsPage", "main-local", dbGetRuntimeItemsPagePayloadSchema),
+  dbGetLatestThreadGoalItem: definePayloadProcedure<
+    z.infer<typeof dbGetRuntimeItemsPayloadSchema>,
+    PersistedRuntimeItem | null,
+    "main-local"
+  >("dbGetLatestThreadGoalItem", "main-local", dbGetRuntimeItemsPayloadSchema),
   dbTruncateThreadRuntimeAfter: definePayloadProcedure<
     z.infer<typeof dbTruncateRuntimeItemsPayloadSchema>,
     void,

--- a/src/shared/remote/client.test.ts
+++ b/src/shared/remote/client.test.ts
@@ -655,6 +655,16 @@ describe("RemoteDesktopClient", () => {
     });
   });
 
+  it("rejects a v5 host whose paged snapshots use the old goal anchor semantics", async () => {
+    const client = new RemoteDesktopClient("http://127.0.0.1:38987/", undefined, async () =>
+      descriptorResponse(5, ["session:read"]),
+    );
+
+    await expect(client.environment()).rejects.toMatchObject({
+      code: "protocol_version_mismatch",
+    });
+  });
+
   it("falls back to the legacy environment endpoint when the Poracode endpoint is unavailable", async () => {
     const requestedPaths: string[] = [];
     const client = new RemoteDesktopClient("http://127.0.0.1:38987/", undefined, async (url) => {

--- a/src/shared/remote/protocol.ts
+++ b/src/shared/remote/protocol.ts
@@ -15,9 +15,9 @@ import { persistedCompletedTurnSchema, persistedRuntimeItemSchema } from "../ipc
 import { gitStateInterestSchema, gitStatePatchSchema, gitStateSnapshotSchema } from "../gitState";
 import { sharedSettingsSchema } from "../settings";
 
-// v5 carries the persisted thread archive timestamp. Older hosts cannot retain
-// or report it accurately across archive, snapshot, and reconnect boundaries.
-export const PORACODE_REMOTE_PROTOCOL_VERSION = 5;
+// v6 pins an out-of-window goal before paged runtime history. Older clients
+// mistake that goal for the page anchor and can preserve a disjoint cursor.
+export const PORACODE_REMOTE_PROTOCOL_VERSION = 6;
 export const REMOTE_COMMAND_ID_HEADER = "x-poracode-command-id";
 
 export const remoteAccessScopeSchema = z.enum([


### PR DESCRIPTION
- Keep the latest goal visible when it falls outside the paged transcript window.
- Preserve transcript ordering and cursor behavior across remote desktop and mobile clients.
- Version the remote protocol to reject incompatible goal-anchor semantics.
- Add database, IPC, snapshot, synchronization, and compatibility regression coverage.