### PR TITLE
Fence one-shot output from shell startup banners

### DIFF
--- a/src/supervisor/contextExtractor.ts
+++ b/src/supervisor/contextExtractor.ts
@@ -70,6 +70,7 @@ export async function extractContext(
         extractionCommand.command,
         extractionCommand.args,
         {
+          markOutput: true,
           ...(extractionCommand.env ? { env: extractionCommand.env } : {}),
         },
       );

--- a/src/supervisor/oneShotOutputMarker.test.ts
+++ b/src/supervisor/oneShotOutputMarker.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  ONE_SHOT_OUTPUT_MARKER,
+  markOneShotOutput,
+  stripOneShotBanner,
+} from "./oneShotOutputMarker";
+
+const WSL_SPEC = {
+  command: "C:\\Windows\\System32\\wsl.exe",
+  args: [
+    "-d",
+    "Ubuntu",
+    "--cd",
+    "/home/demo/project",
+    "--exec",
+    "/bin/bash",
+    "-l",
+    "-i",
+    "-c",
+    "exec 'claude' '-p' 'title this'",
+  ],
+};
+
+describe("markOneShotOutput", () => {
+  it("prints the sentinel before the login-shell script runs", () => {
+    const marked = markOneShotOutput(WSL_SPEC);
+    expect(marked.args.at(-1)).toBe(
+      `printf '%s\n' '${ONE_SHOT_OUTPUT_MARKER}'; exec 'claude' '-p' 'title this'`,
+    );
+    expect(marked.args.slice(0, -1)).toEqual(WSL_SPEC.args.slice(0, -1));
+  });
+
+  it("leaves non-shell specs untouched", () => {
+    const spec = { command: "claude", args: ["-p", "title this"] };
+    expect(markOneShotOutput(spec)).toEqual(spec);
+  });
+});
+
+describe("stripOneShotBanner", () => {
+  it("drops a cold-boot WSL MOTD printed before the command output", () => {
+    const raw = [
+      "Welcome to Ubuntu 24.04.1 LTS (GNU/Linux 6.18.3-microsoft-standard-WSL2 x86_64)",
+      "",
+      " * Documentation:  https://help.ubuntu.com",
+      "Last login: Wed Aug 27 09:12:03 2026",
+      ONE_SHOT_OUTPUT_MARKER,
+      "Fix WSL cold-boot thread titles",
+      "",
+    ].join("\n");
+    expect(stripOneShotBanner(raw).trim()).toBe("Fix WSL cold-boot thread titles");
+  });
+
+  it("keeps output that echoes the sentinel earlier than the real one", () => {
+    const raw = `noise ${ONE_SHOT_OUTPUT_MARKER} noise\n${ONE_SHOT_OUTPUT_MARKER}\nreal title`;
+    expect(stripOneShotBanner(raw)).toBe("real title");
+  });
+
+  it("returns unmarked output unchanged", () => {
+    expect(stripOneShotBanner("Fix the thing")).toBe("Fix the thing");
+  });
+});

--- a/src/supervisor/oneShotOutputMarker.ts
+++ b/src/supervisor/oneShotOutputMarker.ts
@@ -1,0 +1,45 @@
+import { quotePosixShellArg, type CommandSpec } from "./agents/base";
+
+/**
+ * Sentinel echoed as the first thing our one-shot script runs, so login-shell
+ * noise emitted *before* it can be discarded when the output is parsed.
+ */
+export const ONE_SHOT_OUTPUT_MARKER = "__PORACODE_ONESHOT_OUTPUT__";
+
+/**
+ * One-shot generation (titles, commit messages, PR summaries, context
+ * extraction) runs the agent CLI through a login+interactive shell — `bash -l
+ * -i -c` inside WSL, `$SHELL -l [-i] -c` on POSIX — so rc files (nvm/fnm/asdf,
+ * PATH overrides) are sourced. Those startup files also print banners: a WSL
+ * distro that was powered off emits Ubuntu's full MOTD ("Welcome to Ubuntu
+ * 24.04.1 LTS (GNU/Linux …)") on the first shell after boot, which lands on
+ * stdout ahead of the CLI's answer and gets parsed as the result — e.g. a new
+ * thread titled "Welcome to Ubuntu 24.04.1 LTS".
+ *
+ * Printing a sentinel as the script's first statement separates shell startup
+ * noise from the command's real output; {@link stripOneShotBanner} drops
+ * everything up to it. No-op for specs that aren't shell-script invocations
+ * (native Windows/PowerShell, or a direct absolute-path exec).
+ */
+export function markOneShotOutput(spec: CommandSpec): CommandSpec {
+  const scriptIndex = spec.args.length - 1;
+  if (scriptIndex < 1 || spec.args[scriptIndex - 1] !== "-c") return spec;
+  const script = spec.args[scriptIndex];
+  if (typeof script !== "string") return spec;
+
+  const args = [...spec.args];
+  const marker = quotePosixShellArg(ONE_SHOT_OUTPUT_MARKER);
+  args[scriptIndex] = `printf '%s\n' ${marker}; ${script}`;
+  return { ...spec, args };
+}
+
+/**
+ * Drop shell-startup banner output that precedes the sentinel from
+ * {@link markOneShotOutput}. Returns the text unchanged when no sentinel is
+ * present (unmarked spec, or the shell died before running the script).
+ */
+export function stripOneShotBanner(output: string): string {
+  const index = output.lastIndexOf(ONE_SHOT_OUTPUT_MARKER);
+  if (index < 0) return output;
+  return output.slice(index + ONE_SHOT_OUTPUT_MARKER.length).replace(/^\r?\n/, "");
+}

--- a/src/supervisor/oneShotSpawn.test.ts
+++ b/src/supervisor/oneShotSpawn.test.ts
@@ -8,11 +8,15 @@ const buildAgentCommandMock = vi.hoisted(() =>
 const terminateProcessTreeMock = vi.hoisted(() => vi.fn<(pid: number) => void>());
 const spawnPtyMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => unknown>());
 
-vi.mock("./agents/base", () => ({ buildAgentCommand: buildAgentCommandMock }));
+vi.mock("./agents/base", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agents/base")>()),
+  buildAgentCommand: buildAgentCommandMock,
+}));
 vi.mock("@/shared/processTree", () => ({ terminateProcessTree: terminateProcessTreeMock }));
 vi.mock("node-pty", () => ({ spawn: spawnPtyMock }));
 
-import { buildOneShotSpec, spawnAgentPty } from "./oneShotSpawn";
+import { ONE_SHOT_OUTPUT_MARKER } from "./oneShotOutputMarker";
+import { buildOneShotSpec, prepareOneShot, spawnAgent, spawnAgentPty } from "./oneShotSpawn";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -90,6 +94,34 @@ describe("spawnAgentPty", () => {
     );
   });
 
+  it("strips a login-shell banner preceding the sentinel", async () => {
+    let onData: ((data: string) => void) | undefined;
+    let onExit: ((event: { exitCode: number }) => void) | undefined;
+    spawnPtyMock.mockReturnValue({
+      pid: 4321,
+      kill: vi.fn<() => void>(),
+      write: vi.fn<() => void>(),
+      onData: vi.fn<(callback: (data: string) => void) => { dispose: () => void }>((callback) => {
+        onData = callback;
+        return { dispose: vi.fn<() => void>() };
+      }),
+      onExit: vi.fn<(callback: (event: { exitCode: number }) => void) => { dispose: () => void }>(
+        (callback) => {
+          onExit = callback;
+          return { dispose: vi.fn<() => void>() };
+        },
+      ),
+    });
+
+    const result = spawnAgentPty({ command: "agy", args: ["-p"] }, "", 10_000);
+    onData?.(
+      `Welcome to Ubuntu 24.04.1 LTS (GNU/Linux 6.18.3 x86_64)\r\n${ONE_SHOT_OUTPUT_MARKER}\r\nFix WSL cold-boot thread titles\r\n`,
+    );
+    onExit?.({ exitCode: 0 });
+
+    await expect(result).resolves.toBe("Fix WSL cold-boot thread titles");
+  });
+
   it("terminates the process tree on Windows instead of invoking node-pty's console helper", async () => {
     vi.useFakeTimers();
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
@@ -123,5 +155,34 @@ describe("spawnAgentPty", () => {
       platform.mockRestore();
       vi.useRealTimers();
     }
+  });
+});
+
+describe("one-shot banner fencing", () => {
+  const wslProject: ProjectLocation = {
+    kind: "wsl",
+    distro: "Ubuntu",
+    linuxPath: "/home/demo/project",
+    uncPath: "\\\\wsl.localhost\\Ubuntu\\home\\demo\\project",
+  };
+
+  it("marks one-shot login-shell scripts so startup banners can be dropped", () => {
+    buildAgentCommandMock.mockReturnValue({
+      command: "wsl.exe",
+      args: ["-d", "Ubuntu", "--exec", "/bin/bash", "-l", "-i", "-c", "exec 'claude' '-p'"],
+    });
+    const { spec } = prepareOneShot(wslProject, { command: "claude", args: ["-p"] });
+    expect(spec.args.at(-1)).toBe(`printf '%s\n' '${ONE_SHOT_OUTPUT_MARKER}'; exec 'claude' '-p'`);
+  });
+
+  it("resolves only the output that follows the sentinel", async () => {
+    const script = [
+      `console.log("Welcome to Ubuntu 24.04.1 LTS (GNU/Linux 6.18.3 x86_64)")`,
+      `console.log(${JSON.stringify(ONE_SHOT_OUTPUT_MARKER)})`,
+      `console.log("Fix WSL cold-boot thread titles")`,
+    ].join(";");
+    await expect(
+      spawnAgent({ command: process.execPath, args: ["-e", script] }, "", 30_000),
+    ).resolves.toBe("Fix WSL cold-boot thread titles");
   });
 });

--- a/src/supervisor/oneShotSpawn.ts
+++ b/src/supervisor/oneShotSpawn.ts
@@ -6,6 +6,7 @@ import type { ProjectLocation } from "@/shared/contracts";
 import { terminateProcessTree } from "@/shared/processTree";
 import { buildAgentCommand, type CommandSpec } from "./agents/base";
 import { ensureNodePtySpawnHelperExecutable } from "./nodePty";
+import { markOneShotOutput, stripOneShotBanner } from "./oneShotOutputMarker";
 import { processEnvRecord } from "./processEnv";
 
 export interface OneShotSpecOptions {
@@ -19,6 +20,13 @@ export interface OneShotSpecOptions {
    */
   isolateCwd?: boolean | undefined;
   env?: Record<string, string> | undefined;
+  /**
+   * Fence the command's output with a sentinel so login-shell banners (WSL
+   * MOTD, rc-file notices) can be stripped before the output is parsed. Only
+   * for one-shots whose stdout is parsed as a whole; leave it off for callers
+   * that stream stdout to the user. See {@link markOneShotOutput}.
+   */
+  markOutput?: boolean | undefined;
 }
 
 /**
@@ -40,7 +48,8 @@ export function buildOneShotSpec(
   options?: OneShotSpecOptions,
 ): CommandSpec {
   const effectiveLocation = options?.isolateCwd ? isolatedCwdLocation(location) : location;
-  return buildAgentCommand(effectiveLocation, command, args, undefined, options?.env);
+  const spec = buildAgentCommand(effectiveLocation, command, args, undefined, options?.env);
+  return options?.markOutput ? markOneShotOutput(spec) : spec;
 }
 
 /**
@@ -48,7 +57,9 @@ export function buildOneShotSpec(
  * result in one place, so every one-shot caller honors the two command flags
  * identically: `isolateCwd` neutralizes the working directory (see
  * `OneShotSpecOptions`) and `pty` selects the terminal-backed spawner for CLIs
- * that only emit their answer when attached to a tty (e.g. `agy -p`).
+ * that only emit their answer when attached to a tty (e.g. `agy -p`). Output
+ * is always sentinel-fenced (`markOutput: true`) so login-shell banners are
+ * stripped before the spawner resolves — see `markOneShotOutput`.
  */
 export function prepareOneShot(
   location: ProjectLocation,
@@ -62,6 +73,7 @@ export function prepareOneShot(
 ): { spec: CommandSpec; spawn: typeof spawnAgent } {
   const spec = buildOneShotSpec(location, cmd.command, cmd.args, {
     isolateCwd: cmd.isolateCwd,
+    markOutput: true,
     ...(cmd.env ? { env: cmd.env } : {}),
   });
   return { spec, spawn: cmd.pty ? spawnAgentPty : spawnAgent };
@@ -108,10 +120,11 @@ export function spawnAgent(
     });
     child.on("close", (code) => {
       signal?.removeEventListener("abort", onAbort);
+      const output = stripOneShotBanner(stdout).trim();
       if (signal?.aborted) {
         reject(new Error("Aborted"));
-      } else if (code === 0 && stdout.trim()) {
-        resolve(stdout.trim());
+      } else if (code === 0 && output) {
+        resolve(output);
       } else if (code === null && child.killed) {
         reject(new Error("Agent timed out"));
       } else {
@@ -178,7 +191,7 @@ export function spawnAgentPty(
       dataDisposable.dispose();
       exitDisposable.dispose();
 
-      const text = stripAnsiPreservingLayout(output).trim();
+      const text = stripOneShotBanner(stripAnsiPreservingLayout(output)).trim();
       if (signal?.aborted) {
         reject(new Error("Aborted"));
       } else if (timedOut) {


### PR DESCRIPTION
- Bugfix: prevent WSL login-shell banners from contaminating parsed one-shot output.
- Apply sentinel fencing to context extraction and other one-shot commands.
- Add coverage for marker handling, banner stripping, and PTY/process output resolution.