### PR TITLE
Persist streamed runtime output in bounded SQLite chunks

### DIFF
--- a/src/main/db.schema.ts
+++ b/src/main/db.schema.ts
@@ -133,11 +133,54 @@ export const threadRuntimeItems = sqliteTable(
     type: text("type").notNull(),
     state: text("state").notNull(),
     payload: text("payload"), // JSON, nullable
+    // Head of each stream. Content past the head lives in
+    // `threadRuntimeItemStreamChunks` so appends never rewrite this blob.
     streams: text("streams"), // JSON of Partial<Record<RuntimeContentStreamKind, string>>
     parentItemId: text("parent_item_id"), // sub-agent parent tool_call id, nullable
   },
   (table) => ({
     pk: primaryKey({ columns: [table.threadId, table.itemId] }),
+  }),
+);
+
+/**
+ * Append-only tail of a runtime item's streamed content. One row per appended
+ * chunk, assembled in `seq` order on read. Keeps the cost of a streamed chunk
+ * proportional to that chunk instead of to everything the item has produced.
+ */
+export const threadRuntimeItemStreamChunks = sqliteTable(
+  "thread_runtime_item_stream_chunks",
+  {
+    threadId: text("thread_id").notNull(),
+    itemId: text("item_id").notNull(),
+    stream: text("stream").notNull(),
+    seq: integer("seq").notNull(),
+    // Declared before `text` so size lookups read record headers, not contents.
+    chars: integer("chars").notNull(),
+    text: text("text").notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.threadId, table.itemId, table.stream, table.seq] }),
+  }),
+);
+
+/**
+ * Per-stream bookkeeping for the append-only tail: the next sequence number,
+ * how many characters are retained and how many have been dropped. Keeps the
+ * append path free of aggregate queries over the chunk rows.
+ */
+export const threadRuntimeItemStreamState = sqliteTable(
+  "thread_runtime_item_stream_state",
+  {
+    threadId: text("thread_id").notNull(),
+    itemId: text("item_id").notNull(),
+    stream: text("stream").notNull(),
+    nextSeq: integer("next_seq").notNull(),
+    tailChars: integer("tail_chars").notNull(),
+    elidedChars: integer("elided_chars").notNull().default(0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.threadId, table.itemId, table.stream] }),
   }),
 );
 

--- a/src/main/db/connection.ts
+++ b/src/main/db/connection.ts
@@ -157,6 +157,28 @@ export function initDatabase(dbPath: string) {
     );
     CREATE INDEX IF NOT EXISTS idx_runtime_items_thread_pos
       ON thread_runtime_items (thread_id, position);
+    CREATE TABLE IF NOT EXISTS thread_runtime_item_stream_chunks (
+      thread_id TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      stream TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      chars INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      PRIMARY KEY (thread_id, item_id, stream, seq),
+      FOREIGN KEY (thread_id, item_id)
+        REFERENCES thread_runtime_items (thread_id, item_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS thread_runtime_item_stream_state (
+      thread_id TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      stream TEXT NOT NULL,
+      next_seq INTEGER NOT NULL,
+      tail_chars INTEGER NOT NULL,
+      elided_chars INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (thread_id, item_id, stream),
+      FOREIGN KEY (thread_id, item_id)
+        REFERENCES thread_runtime_items (thread_id, item_id) ON DELETE CASCADE
+    );
     CREATE TABLE IF NOT EXISTS thread_completed_turns (
       thread_id TEXT NOT NULL REFERENCES threads(id) ON DELETE CASCADE,
       idx INTEGER NOT NULL,
@@ -302,9 +324,22 @@ export function getSqlite(): InstanceType<typeof Database> {
   return _sqlite;
 }
 
+/**
+ * Hooks run while the database is still open, before it closes. Registered by
+ * modules that buffer writes (see `runtimeItems.ts`) so nothing queued is lost
+ * on shutdown. Registration order is preserved; a failed hook leaves the
+ * database open so its buffered writes can be retried instead of discarded.
+ */
+const beforeCloseHooks: Array<() => void> = [];
+
+export function registerBeforeDatabaseClose(hook: () => void): void {
+  beforeCloseHooks.push(hook);
+}
+
 export function closeDatabase() {
   const sqlite = _sqlite;
   if (sqlite) {
+    for (const hook of beforeCloseHooks) hook();
     // With journal_mode=WAL + synchronous=NORMAL, committed transactions live
     // in the -wal file and only become durable across an OS crash/power loss
     // after a checkpoint. Fold the WAL back into the main db on shutdown so the

--- a/src/main/db/migrations.test.ts
+++ b/src/main/db/migrations.test.ts
@@ -40,8 +40,9 @@ describe("database migration registry", () => {
       [33, "project GitHub account"],
       [34, "projects.icon"],
       [35, "threads.archived_at"],
+      [36, "runtime item stream chunks"],
     ]);
-    expect(LATEST_SCHEMA_VERSION).toBe(35);
+    expect(LATEST_SCHEMA_VERSION).toBe(36);
     expect(() => validateMigrationRegistry()).not.toThrow();
   });
 

--- a/src/main/db/migrations.ts
+++ b/src/main/db/migrations.ts
@@ -1,4 +1,6 @@
 import Database from "better-sqlite3";
+import { HEAD_CHARS } from "./runtimeStreamCap";
+import { writeItemStreams } from "./runtimeStreamStore";
 
 type SqliteDatabase = InstanceType<typeof Database>;
 
@@ -47,6 +49,36 @@ function foldContextSuffix(sqlite: SqliteDatabase, table: string, column: string
       config.contextSize = match[1]!.toLowerCase();
     }
     update.run(JSON.stringify(config), row.rowid);
+  }
+}
+
+function normalizeRuntimeStreams(sqlite: SqliteDatabase): void {
+  const nextRow = sqlite.prepare(
+    `SELECT rowid, thread_id, item_id, streams FROM thread_runtime_items
+     WHERE rowid > ? AND streams IS NOT NULL AND LENGTH(CAST(streams AS BLOB)) > ?
+     ORDER BY rowid ASC LIMIT 1`,
+  );
+  let rowid = 0;
+  for (;;) {
+    const row = nextRow.get(rowid, HEAD_CHARS) as
+      | { rowid: number; thread_id: string; item_id: string; streams: string }
+      | undefined;
+    if (!row) return;
+    rowid = row.rowid;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.streams);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+    const streams = parsed as Record<string, string>;
+    if (
+      !Object.values(streams).some((text) => typeof text === "string" && text.length > HEAD_CHARS)
+    ) {
+      continue;
+    }
+    writeItemStreams(sqlite, row.thread_id, row.item_id, streams);
   }
 }
 
@@ -392,6 +424,37 @@ export const DATABASE_MIGRATIONS = [
       );
     },
   },
+  {
+    version: 36,
+    name: "runtime item stream chunks",
+    migrate: (sqlite) => {
+      sqlite.exec(`
+        CREATE TABLE IF NOT EXISTS thread_runtime_item_stream_chunks (
+          thread_id TEXT NOT NULL,
+          item_id TEXT NOT NULL,
+          stream TEXT NOT NULL,
+          seq INTEGER NOT NULL,
+          chars INTEGER NOT NULL,
+          text TEXT NOT NULL,
+          PRIMARY KEY (thread_id, item_id, stream, seq),
+          FOREIGN KEY (thread_id, item_id)
+            REFERENCES thread_runtime_items (thread_id, item_id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS thread_runtime_item_stream_state (
+          thread_id TEXT NOT NULL,
+          item_id TEXT NOT NULL,
+          stream TEXT NOT NULL,
+          next_seq INTEGER NOT NULL,
+          tail_chars INTEGER NOT NULL,
+          elided_chars INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (thread_id, item_id, stream),
+          FOREIGN KEY (thread_id, item_id)
+            REFERENCES thread_runtime_items (thread_id, item_id) ON DELETE CASCADE
+        );
+      `);
+      normalizeRuntimeStreams(sqlite);
+    },
+  },
 ] as const satisfies readonly DatabaseMigration[];
 
 export const LATEST_SCHEMA_VERSION = DATABASE_MIGRATIONS[DATABASE_MIGRATIONS.length - 1]!.version;
@@ -549,6 +612,15 @@ const REQUIRED_COLUMNS = {
     "payload",
     "streams",
     "parent_item_id",
+  ],
+  thread_runtime_item_stream_chunks: ["thread_id", "item_id", "stream", "seq", "chars", "text"],
+  thread_runtime_item_stream_state: [
+    "thread_id",
+    "item_id",
+    "stream",
+    "next_seq",
+    "tail_chars",
+    "elided_chars",
   ],
   scheduled_tasks: [
     "id",

--- a/src/main/db/projectsThreads.test.ts
+++ b/src/main/db/projectsThreads.test.ts
@@ -294,7 +294,7 @@ describe("projectsThreads (real sqlite round-trip)", () => {
 
     initDatabase(databasePath);
 
-    expect(dbGetState("schema_version")).toBe("35");
+    expect(dbGetState("schema_version")).toBe(String(LATEST_SCHEMA_VERSION));
     const legacyProject = dbGetProject("legacy-project");
     expect(legacyProject).toMatchObject({
       id: "legacy-project",
@@ -480,7 +480,7 @@ describe("projectsThreads (real sqlite round-trip)", () => {
     initDatabase(databasePath);
 
     expect(dbGetThread("legacy-archived")?.archivedAt).toBe("2026-02-03T04:05:06.000Z");
-    expect(dbGetState("schema_version")).toBe("35");
+    expect(dbGetState("schema_version")).toBe(String(LATEST_SCHEMA_VERSION));
   });
 
   it("repairs blank legacy thread models from schema v29 without changing valid configs", () => {

--- a/src/main/db/projectsThreads.ts
+++ b/src/main/db/projectsThreads.ts
@@ -5,6 +5,7 @@ import { getDb } from "./connection";
 import { forgetMainCreatedThread, noteMainCreatedThread } from "./mainCreatedThreads";
 import { notifyProjectThreadDataChanged } from "./projectThreadChanges";
 import { projectMutableRow, rowToProject, rowToThread } from "./rowMappers";
+import { dbDiscardThreadRuntimeWrites } from "./runtimeItems";
 
 // ── Public query functions (called from IPC handlers) ───────────────
 
@@ -195,13 +196,21 @@ export function dbMarkLiveThreadsInactive(): void {
 export function dbDeleteThread(threadId: string): void {
   const db = getDb();
   db.delete(schema.threads).where(eq(schema.threads.id, threadId)).run();
+  dbDiscardThreadRuntimeWrites(threadId);
   forgetMainCreatedThread(threadId);
   notifyProjectThreadDataChanged();
 }
 
 export function dbDeleteProject(projectId: string): void {
   const db = getDb();
+  const threadIds = db
+    .select({ id: schema.threads.id })
+    .from(schema.threads)
+    .where(eq(schema.threads.projectId, projectId))
+    .all()
+    .map((row) => row.id);
   db.delete(schema.projects).where(eq(schema.projects.id, projectId)).run();
   db.delete(schema.projectNotes).where(eq(schema.projectNotes.projectId, projectId)).run();
+  for (const threadId of threadIds) dbDiscardThreadRuntimeWrites(threadId);
   notifyProjectThreadDataChanged();
 }

--- a/src/main/db/runtimeItems.test.ts
+++ b/src/main/db/runtimeItems.test.ts
@@ -4,10 +4,11 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Thread } from "@/shared/contracts";
-import { closeDatabase, initDatabase } from "./connection";
-import { dbUpsertProject, dbUpsertThread } from "./projectsThreads";
+import { closeDatabase, getSqlite, initDatabase } from "./connection";
+import { dbDeleteThread, dbUpsertProject, dbUpsertThread } from "./projectsThreads";
 import {
   dbApplyThreadRuntimeEvents,
+  dbFlushThreadRuntimeWrites,
   dbGetThreadContextUsage,
   dbGetLatestThreadRuntimeAnchorItemId,
   dbGetThreadRuntimeItems,
@@ -15,6 +16,7 @@ import {
   dbReplaceThreadRuntimeItems,
   dbTruncateThreadRuntimeAfter,
 } from "./runtimeItems";
+import { HEAD_CHARS, TAIL_CHARS } from "./runtimeStreamCap";
 
 const serverNativeBinding = join(process.cwd(), "dist", "server-native", "better_sqlite3.node");
 let nativeBindingEnv: string | undefined;
@@ -475,5 +477,309 @@ describe.skipIf(!sqliteAvailable)("runtimeItems incremental persistence", () => 
       "assistant-1",
     ]);
     expect(page.nextCursor).toBe(1);
+  });
+
+  it("keeps buffered stream writes readable before the flush window elapses", () => {
+    // Writes are queued to keep streaming off the per-chunk rewrite path, so
+    // every reader must drain the queue or hydration would serve a stale
+    // transcript.
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        itemType: "command_execution",
+        payload: { command: "pnpm test" },
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: "line one ",
+      },
+    ]);
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: "line two",
+      },
+      { type: "item.completed", threadId: "thread-1", itemId: "cmd-1" },
+    ]);
+
+    const items = dbGetThreadRuntimeItems("thread-1");
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "cmd-1",
+      state: "completed",
+      streams: { command_output: "line one line two" },
+    });
+    expect(dbGetThreadRuntimeItemsPage("thread-1", undefined, 50, 40).items).toHaveLength(1);
+  });
+
+  it("applies queued events in order across separate batches", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "msg-1",
+        itemType: "assistant_message",
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "msg-1",
+        stream: "assistant_text",
+        delta: "a",
+      },
+    ]);
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "msg-1",
+        stream: "assistant_text",
+        delta: "b",
+      },
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "msg-2",
+        itemType: "assistant_message",
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "msg-1",
+        stream: "assistant_text",
+        delta: "c",
+      },
+    ]);
+
+    const items = dbGetThreadRuntimeItems("thread-1");
+
+    expect(items.map((item) => item.id)).toEqual(["msg-1", "msg-2"]);
+    expect(items[0]!.streams.assistant_text).toBe("abc");
+  });
+
+  it("keeps a multi-megabyte stream whole while it fits the retained window", () => {
+    const megabyte = "y".repeat(1_000_000);
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        itemType: "command_execution",
+        payload: { command: "pnpm test" },
+      },
+    ]);
+    for (let i = 0; i < 3; i += 1) {
+      dbApplyThreadRuntimeEvents("thread-1", [
+        {
+          type: "content.delta",
+          threadId: "thread-1",
+          itemId: "cmd-1",
+          stream: "command_output",
+          delta: megabyte,
+        },
+      ]);
+      dbFlushThreadRuntimeWrites("thread-1");
+    }
+
+    const output = dbGetThreadRuntimeItems("thread-1")[0]!.streams.command_output!;
+
+    expect(output).toBe(megabyte.repeat(3));
+    expect(output).not.toContain("poracode elided");
+  });
+
+  it("bounds a runaway command output while keeping its head and tail", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        itemType: "command_execution",
+        payload: { command: "pnpm run dev" },
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: "FIRST-LINE ",
+      },
+    ]);
+    dbFlushThreadRuntimeWrites("thread-1");
+    for (let i = 0; i < 6; i += 1) {
+      dbApplyThreadRuntimeEvents("thread-1", [
+        {
+          type: "content.delta",
+          threadId: "thread-1",
+          itemId: "cmd-1",
+          stream: "command_output",
+          delta: "x".repeat(1_000_000),
+        },
+      ]);
+      dbFlushThreadRuntimeWrites("thread-1");
+    }
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: " LAST-LINE",
+      },
+    ]);
+
+    const output = dbGetThreadRuntimeItems("thread-1")[0]!.streams.command_output!;
+
+    // Whole chunks are dropped, so the retained window can overshoot by at most
+    // the newest chunk; it must never grow without bound.
+    expect(output.length).toBeLessThanOrEqual(HEAD_CHARS + TAIL_CHARS + 600_000);
+    expect(output.length).toBeGreaterThan(HEAD_CHARS + TAIL_CHARS - 600_000);
+    expect(output.startsWith("FIRST-LINE ")).toBe(true);
+    expect(output.endsWith(" LAST-LINE")).toBe(true);
+    expect(output).toContain("poracode elided");
+  });
+
+  it("drops a completed reasoning item whose text only ever arrived as chunks", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "think-1",
+        itemType: "reasoning",
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "think-1",
+        stream: "reasoning_text",
+        delta: "   ",
+      },
+      { type: "item.completed", threadId: "thread-1", itemId: "think-1" },
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "think-2",
+        itemType: "reasoning",
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "think-2",
+        stream: "reasoning_text",
+        delta: "a real thought",
+      },
+      { type: "item.completed", threadId: "thread-1", itemId: "think-2" },
+    ]);
+
+    const items = dbGetThreadRuntimeItems("thread-1");
+
+    expect(items.map((item) => item.id)).toEqual(["think-2"]);
+    expect(items[0]!.streams.reasoning_text).toBe("a real thought");
+  });
+
+  it("counts completed reasoning whose non-whitespace text is only in the chunk tail", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "think-tail",
+        itemType: "reasoning",
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "think-tail",
+        stream: "reasoning_text",
+        delta: `${" ".repeat(HEAD_CHARS)}visible tail`,
+      },
+      { type: "item.completed", threadId: "thread-1", itemId: "think-tail" },
+    ]);
+
+    expect(dbGetThreadRuntimeItemsPage("thread-1", undefined, 50, 40).items).toHaveLength(1);
+  });
+
+  it("removes the appended stream tail when the thread is deleted", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        itemType: "command_execution",
+        payload: { command: "pnpm run dev" },
+      },
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: "z".repeat(HEAD_CHARS + 50_000),
+      },
+    ]);
+    dbFlushThreadRuntimeWrites("thread-1");
+    const chunkCount = () =>
+      (
+        getSqlite()
+          .prepare("SELECT COUNT(*) AS n FROM thread_runtime_item_stream_chunks")
+          .get() as { n: number }
+      ).n;
+    const stateCount = () =>
+      (
+        getSqlite().prepare("SELECT COUNT(*) AS n FROM thread_runtime_item_stream_state").get() as {
+          n: number;
+        }
+      ).n;
+    expect(chunkCount()).toBeGreaterThan(0);
+    expect(stateCount()).toBeGreaterThan(0);
+
+    dbDeleteThread("thread-1");
+
+    expect(chunkCount()).toBe(0);
+    expect(stateCount()).toBe(0);
+  });
+
+  it("does not resurrect queued writes for a transcript that was replaced", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "stale-1",
+        itemType: "assistant_message",
+      },
+    ]);
+
+    dbReplaceThreadRuntimeItems("thread-1", [
+      {
+        id: "fresh-1",
+        type: "assistant_message",
+        state: "completed",
+        streams: { assistant_text: "hi" },
+      },
+    ]);
+
+    expect(dbGetThreadRuntimeItems("thread-1").map((item) => item.id)).toEqual(["fresh-1"]);
+  });
+
+  it("does not apply queued writes after a thread id is deleted and reused", () => {
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "item.started",
+        threadId: "thread-1",
+        itemId: "stale-1",
+        itemType: "assistant_message",
+      },
+    ]);
+
+    dbDeleteThread("thread-1");
+    dbUpsertThread(testThread(), 0);
+
+    expect(dbGetThreadRuntimeItems("thread-1")).toEqual([]);
   });
 });

--- a/src/main/db/runtimeItems.ts
+++ b/src/main/db/runtimeItems.ts
@@ -4,8 +4,18 @@ import { RUNTIME_REQUEST_ITEM_TYPE } from "@/shared/contracts";
 import { inlineImagePayloadRenders } from "@/shared/inlineImagePayload";
 import type { PersistedRuntimePage } from "@/shared/ipc/schemas";
 import { isSubAgentTool } from "@/shared/toolCallClassification";
-import { getSqlite } from "./connection";
+import { getSqlite, registerBeforeDatabaseClose } from "./connection";
 import { safeParse } from "./rowMappers";
+import {
+  appendStreamDelta,
+  assembleItemStreams,
+  clearThreadStreamChunks,
+  readStreamTails,
+  streamHasContent,
+  type ItemStreamTails,
+  writeItemStreams,
+} from "./runtimeStreamStore";
+import { RuntimeWriteQueue } from "./runtimeWriteQueue";
 
 /**
  * Persisted canonical chat items per thread. Stored as a flat table keyed by
@@ -80,15 +90,37 @@ function runtimeItemState(state: string): PersistedRuntimeItem["state"] {
   return state === "completed" || state === "updated" ? state : "started";
 }
 
-function mapRuntimeItemRow(row: PersistedRuntimeItemRow): PersistedRuntimeItem {
+function mapRuntimeItemRow(
+  row: PersistedRuntimeItemRow,
+  tails?: ItemStreamTails,
+): PersistedRuntimeItem {
+  const head = row.streams ? (safeParse(row.streams) as Record<string, string>) : {};
   return {
     id: row.item_id,
     type: row.type,
     state: runtimeItemState(row.state),
     payload: row.payload ? safeParse(row.payload) : undefined,
-    streams: row.streams ? (safeParse(row.streams) as Record<string, string>) : {},
+    streams: assembleItemStreams(head, tails),
     ...(row.parent_item_id ? { parentItemId: row.parent_item_id } : {}),
   };
+}
+
+/**
+ * Map rows to items with their appended stream tails. Chunks are fetched for
+ * the whole batch at once so a 500-row page costs one extra query, not 500.
+ */
+function mapRuntimeItemRows(
+  sqlite: InstanceType<typeof Database>,
+  threadId: string,
+  rows: readonly PersistedRuntimeItemRow[],
+): PersistedRuntimeItem[] {
+  if (rows.length === 0) return [];
+  const tails = readStreamTails(
+    sqlite,
+    threadId,
+    rows.map((row) => row.item_id),
+  );
+  return rows.map((row) => mapRuntimeItemRow(row, tails.get(row.item_id)));
 }
 
 function chunkValues<T>(values: readonly T[], size: number): T[][] {
@@ -177,17 +209,19 @@ export function dbReadThreadRuntimeSummaries(
 export function dbGetThreadRuntimeSummaries(
   threadIds: readonly string[],
 ): Record<string, ThreadRuntimeSummary> {
+  for (const threadId of threadIds) runtimeWriteQueue.flush(threadId);
   return dbReadThreadRuntimeSummaries(getSqlite(), threadIds);
 }
 
 export function dbGetThreadRuntimeItems(threadId: string): PersistedRuntimeItem[] {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   const rows = sqlite
     .prepare(
       "SELECT item_id, type, state, payload, streams, parent_item_id FROM thread_runtime_items WHERE thread_id = ? ORDER BY position ASC",
     )
     .all(threadId) as PersistedRuntimeItemRow[];
-  return rows.map(mapRuntimeItemRow);
+  return mapRuntimeItemRows(sqlite, threadId, rows);
 }
 
 /**
@@ -200,13 +234,14 @@ export function dbGetThreadRuntimeItem(
   threadId: string,
   itemId: string,
 ): PersistedRuntimeItem | null {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   const row = sqlite
     .prepare(
       "SELECT item_id, type, state, payload, streams, parent_item_id FROM thread_runtime_items WHERE thread_id = ? AND item_id = ?",
     )
     .get(threadId, itemId) as PersistedRuntimeItemRow | undefined;
-  return row ? mapRuntimeItemRow(row) : null;
+  return row ? mapRuntimeItemRows(sqlite, threadId, [row])[0]! : null;
 }
 
 export function dbGetThreadRuntimeItemsPage(
@@ -215,6 +250,7 @@ export function dbGetThreadRuntimeItemsPage(
   limit: number,
   targetTimelineEntryCount?: number,
 ): PersistedRuntimePage {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   const childParentIds = new Set(
     (
@@ -254,12 +290,12 @@ export function dbGetThreadRuntimeItemsPage(
     // contents of the first already-visible tool/reasoning group.
     while (
       segmentRows.length > 0 &&
-      isRuntimePageGroupItem(segmentRows.at(-1)!, childParentIds) &&
+      isRuntimePageGroupItem(sqlite, threadId, segmentRows.at(-1)!, childParentIds) &&
       lookaheadRows[0] &&
-      isRuntimePageGroupItem(lookaheadRows[0], childParentIds)
+      isRuntimePageGroupItem(sqlite, threadId, lookaheadRows[0], childParentIds)
     ) {
       const boundaryIndex = lookaheadRows.findIndex(
-        (row) => !isRuntimePageGroupItem(row, childParentIds),
+        (row) => !isRuntimePageGroupItem(sqlite, threadId, row, childParentIds),
       );
       if (boundaryIndex >= 0) {
         segmentRows.push(...lookaheadRows.slice(0, boundaryIndex));
@@ -276,7 +312,7 @@ export function dbGetThreadRuntimeItemsPage(
   if (targetTimelineEntryCount === undefined) {
     const page = readPageRows(beforePosition);
     return {
-      items: page.rows.reverse().map(mapRuntimeItemRow),
+      items: mapRuntimeItemRows(sqlite, threadId, page.rows.reverse()),
       nextCursor: page.hasMore ? (page.rows[0]?.position ?? null) : null,
     };
   }
@@ -296,7 +332,7 @@ export function dbGetThreadRuntimeItemsPage(
 
     for (let index = 0; index < scanRows.length; index += 1) {
       const row = scanRows[index]!;
-      if (completingTargetGroup && !isRuntimePageGroupItem(row, childParentIds)) {
+      if (completingTargetGroup && !isRuntimePageGroupItem(sqlite, threadId, row, childParentIds)) {
         hasMore = true;
         break pageScan;
       }
@@ -304,7 +340,7 @@ export function dbGetThreadRuntimeItemsPage(
       pageRows.push(row);
       cursor = row.position;
       if (!completingTargetGroup) {
-        accumulateRuntimeTimelineEntryCount(row, childParentIds, timelineCount);
+        accumulateRuntimeTimelineEntryCount(sqlite, threadId, row, childParentIds, timelineCount);
         if (timelineCount.entries >= targetTimelineEntryCount) {
           completingTargetGroup = timelineCount.insideGroup;
           if (!completingTargetGroup) {
@@ -322,25 +358,29 @@ export function dbGetThreadRuntimeItemsPage(
 
   const nextCursor = hasMore ? (pageRows.at(-1)?.position ?? null) : null;
   return {
-    items: pageRows.reverse().map(mapRuntimeItemRow),
+    items: mapRuntimeItemRows(sqlite, threadId, pageRows.reverse()),
     nextCursor,
   };
 }
 
 function isRuntimePageGroupItem(
+  sqlite: InstanceType<typeof Database>,
+  threadId: string,
   row: PositionedPersistedRuntimeItemRow,
   childParentIds: ReadonlySet<string>,
 ): boolean {
   // Rows omitted from the top-level timeline do not break a visible tool run.
-  return classifyRuntimeTimelineRow(row, childParentIds) !== "item";
+  return classifyRuntimeTimelineRow(sqlite, threadId, row, childParentIds) !== "item";
 }
 
 function accumulateRuntimeTimelineEntryCount(
+  sqlite: InstanceType<typeof Database>,
+  threadId: string,
   row: PositionedPersistedRuntimeItemRow,
   childParentIds: ReadonlySet<string>,
   state: { entries: number; insideGroup: boolean },
 ): void {
-  const kind = classifyRuntimeTimelineRow(row, childParentIds);
+  const kind = classifyRuntimeTimelineRow(sqlite, threadId, row, childParentIds);
   if (kind === "hidden") return;
   if (kind === "group") {
     if (!state.insideGroup) state.entries += 1;
@@ -352,6 +392,8 @@ function accumulateRuntimeTimelineEntryCount(
 }
 
 function classifyRuntimeTimelineRow(
+  sqlite: InstanceType<typeof Database>,
+  threadId: string,
   row: PositionedPersistedRuntimeItemRow,
   childParentIds: ReadonlySet<string>,
 ): "hidden" | "group" | "item" {
@@ -362,7 +404,17 @@ function classifyRuntimeTimelineRow(
       streams && typeof streams === "object"
         ? (streams as Record<string, unknown>).reasoning_text
         : undefined;
-    if (typeof reasoningText !== "string" || reasoningText.trim().length === 0) return "hidden";
+    if (
+      !streamHasContent(
+        sqlite,
+        threadId,
+        row.item_id,
+        "reasoning_text",
+        typeof reasoningText === "string" ? reasoningText : undefined,
+      )
+    ) {
+      return "hidden";
+    }
   }
   let payload: Record<string, unknown> | undefined;
   if (RUNTIME_PAGE_NAMED_TOOL_TYPES.has(row.type)) {
@@ -386,14 +438,45 @@ function classifyRuntimeTimelineRow(
 }
 
 /**
- * Applies the supervisor's canonical runtime events directly to SQLite. This
- * keeps the main process as the durability owner without rewriting a thread's
- * complete transcript for every streaming batch.
+ * Buffered runtime writes. `dbApplyThreadRuntimeEvents` queues; the queue
+ * coalesces each item's consecutive deltas and writes once per window, so a
+ * streaming item costs a few row rewrites per second instead of one per chunk.
+ * Every reader below drains the queue first, so nothing observes a stale
+ * transcript.
+ */
+const runtimeWriteQueue = new RuntimeWriteQueue((threadId, events) =>
+  applyThreadRuntimeEventsNow(threadId, events),
+);
+
+registerBeforeDatabaseClose(() => runtimeWriteQueue.flush());
+
+/**
+ * Applies the supervisor's canonical runtime events to SQLite. This keeps the
+ * main process as the durability owner without rewriting a thread's complete
+ * transcript for every streaming batch.
  */
 export function dbApplyThreadRuntimeEvents(
   threadId: string,
   events: readonly RuntimeEvent[],
 ): void {
+  if (events.length === 0) return;
+  runtimeWriteQueue.enqueue(threadId, events);
+}
+
+/**
+ * Flush buffered runtime writes so a subsequent read sees them. Callers that
+ * read or rewrite `thread_runtime_items` outside this module must go through
+ * one of the exported readers, which already do this.
+ */
+export function dbFlushThreadRuntimeWrites(threadId?: string): void {
+  runtimeWriteQueue.flush(threadId);
+}
+
+export function dbDiscardThreadRuntimeWrites(threadId: string): void {
+  runtimeWriteQueue.discard(threadId);
+}
+
+function applyThreadRuntimeEventsNow(threadId: string, events: readonly RuntimeEvent[]): void {
   if (events.length === 0) return;
   const sqlite = getSqlite();
   sqlite.transaction(() => {
@@ -414,6 +497,9 @@ export function dbApplyThreadRuntimeEvents(
       `UPDATE thread_runtime_items
        SET state = ?, payload = ?, streams = ?
        WHERE thread_id = ? AND item_id = ?`,
+    );
+    const setItemState = sqlite.prepare(
+      "UPDATE thread_runtime_items SET state = ? WHERE thread_id = ? AND item_id = ?",
     );
     const deleteItem = sqlite.prepare(
       "DELETE FROM thread_runtime_items WHERE thread_id = ? AND item_id = ?",
@@ -475,7 +561,16 @@ export function dbApplyThreadRuntimeEvents(
           const row = readItem(event.itemId);
           if (!row) break;
           const streams = row.streams ? (safeParse(row.streams) as Record<string, string>) : {};
-          if (row.type === "reasoning" && !(streams.reasoning_text ?? "").trim()) {
+          if (
+            row.type === "reasoning" &&
+            !streamHasContent(
+              sqlite,
+              threadId,
+              event.itemId,
+              "reasoning_text",
+              streams.reasoning_text,
+            )
+          ) {
             deleteItem.run(threadId, event.itemId);
             break;
           }
@@ -497,12 +592,25 @@ export function dbApplyThreadRuntimeEvents(
         case "content.delta": {
           const row = readItem(event.itemId);
           if (!row) break;
-          const streams = row.streams ? (safeParse(row.streams) as Record<string, string>) : {};
-          streams[event.stream] = `${streams[event.stream] ?? ""}${event.delta}`;
+          const head = row.streams ? (safeParse(row.streams) as Record<string, string>) : {};
+          const appended = appendStreamDelta(sqlite, {
+            threadId,
+            itemId: event.itemId,
+            stream: event.stream,
+            delta: event.delta,
+            head: head[event.stream] ?? "",
+          });
+          const nextState = row.state === "completed" ? "completed" : "updated";
+          if (appended.head === undefined) {
+            // Content went entirely into the append-only tail, so the item row
+            // only needs its lifecycle state refreshed — no blob rewrite.
+            setItemState.run(nextState, threadId, event.itemId);
+            break;
+          }
           updateItem.run(
-            row.state === "completed" ? "completed" : "updated",
+            nextState,
             row.payload,
-            JSON.stringify(streams),
+            JSON.stringify({ ...head, [event.stream]: appended.head }),
             threadId,
             event.itemId,
           );
@@ -582,6 +690,7 @@ export function dbApplyThreadRuntimeEvents(
 }
 
 export function dbReplaceThreadRuntimeItems(threadId: string, items: PersistedRuntimeItem[]): void {
+  runtimeWriteQueue.discard(threadId);
   const sqlite = getSqlite();
   sqlite.transaction(() => {
     if (!threadExistsInSqlite(sqlite, threadId)) return;
@@ -602,6 +711,8 @@ function replaceThreadRuntimeItemsInSqlite(
   threadId: string,
   items: PersistedRuntimeItem[],
 ): void {
+  // A wholesale replace supplies each item's complete stream text, so any
+  // append-only tail left from streaming is stale and must go with it.
   const replace = sqlite.prepare(
     `INSERT INTO thread_runtime_items (thread_id, item_id, position, type, state, payload, streams, parent_item_id)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -613,6 +724,7 @@ function replaceThreadRuntimeItemsInSqlite(
        streams = excluded.streams,
        parent_item_id = excluded.parent_item_id`,
   );
+  clearThreadStreamChunks(sqlite, threadId);
   const incomingIds = new Set(items.map((it) => it.id));
   const existing = sqlite
     .prepare("SELECT item_id FROM thread_runtime_items WHERE thread_id = ?")
@@ -634,17 +746,20 @@ function replaceThreadRuntimeItemsInSqlite(
       it.type,
       it.state,
       it.payload === undefined ? null : JSON.stringify(it.payload),
-      JSON.stringify(it.streams ?? {}),
+      "{}",
       it.parentItemId ?? null,
     );
+    writeItemStreams(sqlite, threadId, it.id, it.streams ?? {});
   }
 }
 
 export function dbClearThreadRuntimeItems(threadId: string): void {
+  runtimeWriteQueue.discard(threadId);
   getSqlite().prepare("DELETE FROM thread_runtime_items WHERE thread_id = ?").run(threadId);
 }
 
 export function dbTruncateThreadRuntimeAfter(threadId: string, itemId: string): void {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   sqlite.transaction(() => {
     const checkpoint = sqlite
@@ -681,6 +796,7 @@ export interface PersistedCompletedTurn {
 }
 
 export function dbGetThreadCompletedTurns(threadId: string): PersistedCompletedTurn[] {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   const rows = sqlite
     .prepare(
@@ -699,6 +815,7 @@ export function dbGetThreadCompletedTurns(threadId: string): PersistedCompletedT
 }
 
 export function dbAppendThreadCompletedTurn(threadId: string, turn: PersistedCompletedTurn): void {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   sqlite.transaction(() => {
     if (!threadExistsInSqlite(sqlite, threadId)) return;
@@ -718,6 +835,7 @@ export function dbAppendThreadCompletedTurn(threadId: string, turn: PersistedCom
 }
 
 export function dbGetLatestThreadRuntimeAnchorItemId(threadId: string): string | null {
+  runtimeWriteQueue.flush(threadId);
   const row = getSqlite()
     .prepare(
       `SELECT item_id
@@ -736,6 +854,7 @@ export function dbReplaceThreadCompletedTurns(
   threadId: string,
   turns: PersistedCompletedTurn[],
 ): void {
+  runtimeWriteQueue.flush(threadId);
   const sqlite = getSqlite();
   sqlite.transaction(() => {
     if (!threadExistsInSqlite(sqlite, threadId)) return;
@@ -749,6 +868,7 @@ export function dbReplaceThreadRuntimeSnapshot(
   turns: PersistedCompletedTurn[],
   contextUsage: ThreadContextUsage | null | undefined,
 ): void {
+  runtimeWriteQueue.discard(threadId);
   const sqlite = getSqlite();
   sqlite.transaction(() => {
     if (!threadExistsInSqlite(sqlite, threadId)) return;
@@ -761,6 +881,7 @@ export function dbReplaceThreadRuntimeSnapshot(
 }
 
 export function dbGetThreadContextUsage(threadId: string): ThreadContextUsage | null {
+  runtimeWriteQueue.flush(threadId);
   return dbGetThreadContextUsageFromSqlite(getSqlite(), threadId);
 }
 

--- a/src/main/db/runtimeStreamCap.test.ts
+++ b/src/main/db/runtimeStreamCap.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { joinWithElision } from "./runtimeStreamCap";
+
+describe("joinWithElision", () => {
+  const NL_CHAR = String.fromCharCode(10);
+
+  it("returns head and tail untouched when nothing was elided", () => {
+    expect(joinWithElision("a", "b", 0)).toBe("ab");
+  });
+
+  it("gives the notice its own line between whole lines", () => {
+    const head = `first${NL_CHAR}second${NL_CHAR}partial-he`;
+    const tail = `ad-cut${NL_CHAR}ninth${NL_CHAR}tenth`;
+
+    const lines = joinWithElision(head, tail, 1234).split(NL_CHAR);
+
+    expect(lines[0]).toBe("first");
+    expect(lines[1]).toBe("second");
+    // The partial lines on both sides of the gap are dropped, not shown broken.
+    expect(lines[2]).toBe("[... poracode elided 1234 characters of earlier output ...]");
+    expect(lines[3]).toBe("ninth");
+    expect(lines[4]).toBe("tenth");
+  });
+
+  it("keeps content that has no line breaks at all", () => {
+    const joined = joinWithElision("AAA", "ZZZ", 10);
+
+    expect(joined.startsWith("AAA")).toBe(true);
+    expect(joined.endsWith("ZZZ")).toBe(true);
+  });
+});

--- a/src/main/db/runtimeStreamCap.ts
+++ b/src/main/db/runtimeStreamCap.ts
@@ -1,0 +1,80 @@
+/**
+ * How much of a runtime item's streamed content is retained, and how the
+ * retained head and tail are joined back together for readers.
+ *
+ * Streamed content is stored append-only (see `runtimeStreamStore.ts`): a head
+ * on the item row plus chunk rows for everything after it.
+ *
+ * What is kept is the head (the command echo, how the run started) and the tail
+ * (what it is doing now, how it ended). Those are what a transcript is read
+ * for; the middle of a 45 MB build log is not.
+ */
+
+/**
+ * Characters kept from the start of a stream. Streamed content stores this head
+ * on the item row and freezes it, so it is written at most once.
+ */
+export const HEAD_CHARS = 256_000;
+
+/**
+ * Characters kept after the head. Streamed content keeps this window as
+ * append-only chunk rows, where trimming is a row delete rather than a blob
+ * rewrite — so the bound here is about what is reasonable to hydrate into the
+ * renderer, not about what is affordable to write.
+ */
+export const TAIL_CHARS = 4_000_000;
+
+const NOTICE_PREFIX = "[... poracode elided ";
+const NOTICE_SUFFIX = " characters of earlier output ...]";
+
+export function utf16SafeSliceEnd(text: string, end: number): number {
+  if (
+    end > 0 &&
+    end < text.length &&
+    text.charCodeAt(end - 1) >= 0xd800 &&
+    text.charCodeAt(end - 1) <= 0xdbff &&
+    text.charCodeAt(end) >= 0xdc00 &&
+    text.charCodeAt(end) <= 0xdfff
+  ) {
+    return end - 1;
+  }
+  return end;
+}
+
+/** The notice shown in place of dropped output, with no surrounding line breaks. */
+export function elisionNotice(elidedChars: number): string {
+  return `${NOTICE_PREFIX}${elidedChars}${NOTICE_SUFFIX}`;
+}
+
+/** Drop a trailing partial line so the notice can start on its own line. */
+function withoutTrailingPartialLine(text: string): string {
+  if (text.length === 0 || text.endsWith("\n")) return text;
+  const lastBreak = text.lastIndexOf("\n");
+  return lastBreak < 0 ? text : text.slice(0, lastBreak + 1);
+}
+
+/** Drop a leading partial line so retained output resumes at a line start. */
+function withoutLeadingPartialLine(text: string): string {
+  if (text.length === 0) return text;
+  const firstBreak = text.indexOf("\n");
+  return firstBreak < 0 ? text : text.slice(firstBreak + 1);
+}
+
+/**
+ * Join a retained head and tail with the elision notice between them.
+ *
+ * The window is measured in characters, so both ends can land mid-line. Snap to
+ * line boundaries and give the notice a line of its own: a notice wedged inside
+ * a log line reads like corrupted output. Text with no line breaks at all (one
+ * enormous line) is joined as-is rather than thrown away.
+ *
+ * Shared by the append-only store and the whole-value cap so a transcript reads
+ * the same however its middle was dropped.
+ */
+export function joinWithElision(head: string, tail: string, elidedChars: number): string {
+  if (elidedChars <= 0) return `${head}${tail}`;
+  const alignedHead = withoutTrailingPartialLine(head);
+  const alignedTail = withoutLeadingPartialLine(tail);
+  const lead = alignedHead.length === 0 || alignedHead.endsWith("\n") ? "" : "\n";
+  return `${alignedHead}${lead}${elisionNotice(elidedChars)}\n${alignedTail}`;
+}

--- a/src/main/db/runtimeStreamCapMigration.test.ts
+++ b/src/main/db/runtimeStreamCapMigration.test.ts
@@ -1,0 +1,187 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDatabase, initDatabase } from "./connection";
+import { dbUpsertProject, dbUpsertThread } from "./projectsThreads";
+import { dbApplyThreadRuntimeEvents, dbGetThreadRuntimeItems } from "./runtimeItems";
+import { HEAD_CHARS, TAIL_CHARS } from "./runtimeStreamCap";
+
+const MAX_PERSISTED_STREAM_CHARS = HEAD_CHARS + TAIL_CHARS;
+
+const serverNativeBinding = join(process.cwd(), "dist", "server-native", "better_sqlite3.node");
+let nativeBindingEnv: string | undefined;
+let sqliteAvailable = true;
+try {
+  new Database(":memory:").close();
+} catch {
+  if (existsSync(serverNativeBinding)) nativeBindingEnv = serverNativeBinding;
+  else sqliteAvailable = false;
+}
+
+/**
+ * Rows written before the stream cap shipped can hold tens of megabytes, and
+ * they stay slow forever unless the upgrade compacts them: every later append
+ * re-reads and rewrites the whole blob. This is the pre-upgrade regression
+ * guard for that migration — it builds a database at the previous schema
+ * version and opens it with the current code.
+ */
+describe.skipIf(!sqliteAvailable)("runtime stream chunks migration", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    if (nativeBindingEnv) process.env.PORACODE_BETTER_SQLITE3_NATIVE_BINDING = nativeBindingEnv;
+    dir = mkdtempSync(join(tmpdir(), "poracode-stream-cap-migration-"));
+    dbPath = join(dir, "state.sqlite");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Windows can still hold the -wal handle briefly; the temp dir is disposable.
+    }
+    delete process.env.PORACODE_BETTER_SQLITE3_NATIVE_BINDING;
+  });
+
+  function seedPreCapDatabase(streams: Record<string, string>): void {
+    // Build the last released schema with the normal writers, then remove the
+    // new tables before seeding the legacy runtime row.
+    initDatabase(dbPath);
+    dbUpsertProject(
+      {
+        id: "project-1",
+        name: "Legacy",
+        location: { kind: "posix", path: "/tmp/p" },
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      0,
+    );
+    dbUpsertThread(
+      {
+        id: "thread-1",
+        projectId: "project-1",
+        title: "Legacy",
+        agentKind: "claude",
+        config: { model: "opus" },
+        status: "idle",
+        attention: "none",
+        canResumeWithConfig: false,
+        archived: false,
+        done: false,
+        starred: false,
+        presentationMode: "gui",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      0,
+    );
+    closeDatabase();
+
+    const sqlite = new Database(dbPath, {
+      ...(nativeBindingEnv ? { nativeBinding: nativeBindingEnv } : {}),
+    });
+    sqlite.exec(`
+      DROP TABLE thread_runtime_item_stream_state;
+      DROP TABLE thread_runtime_item_stream_chunks;
+    `);
+    sqlite
+      .prepare(
+        `INSERT INTO thread_runtime_items
+           (thread_id, item_id, position, type, state, payload, streams, parent_item_id)
+         VALUES ('thread-1', 'cmd-1', 0, 'command_execution', 'completed', NULL, ?, NULL)`,
+      )
+      .run(JSON.stringify(streams));
+    sqlite
+      .prepare(
+        "INSERT INTO app_state (key, value) VALUES ('schema_version', '35') " +
+          "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+      )
+      .run();
+    sqlite.close();
+  }
+
+  it("compacts an oversized stream on upgrade, keeping head and tail", () => {
+    const head = "FIRST-LINE";
+    const tail = "LAST-LINE";
+    const oversized = `${head}${"x".repeat(MAX_PERSISTED_STREAM_CHARS * 2)}${tail}`;
+    seedPreCapDatabase({ command_output: oversized, assistant_text: "kept" });
+
+    initDatabase(dbPath);
+
+    const item = dbGetThreadRuntimeItems("thread-1")[0]!;
+    const output = item.streams.command_output!;
+    expect(output.length).toBeLessThanOrEqual(MAX_PERSISTED_STREAM_CHARS);
+    expect(output.startsWith(head)).toBe(true);
+    expect(output.endsWith(tail)).toBe(true);
+    expect(output).toContain("poracode elided");
+    // Streams that already fit are untouched.
+    expect(item.streams.assistant_text).toBe("kept");
+    const tables = getTables();
+    expect(tables).toContain("thread_runtime_item_stream_chunks");
+    expect(tables).toContain("thread_runtime_item_stream_state");
+  });
+
+  function getTables(): string[] {
+    const sqlite = new Database(dbPath, {
+      ...(nativeBindingEnv ? { nativeBinding: nativeBindingEnv } : {}),
+      readonly: true,
+    });
+    try {
+      return (
+        sqlite.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all() as Array<{
+          name: string;
+        }>
+      ).map((row) => row.name);
+    } finally {
+      sqlite.close();
+    }
+  }
+
+  it("leaves transcripts that already fit byte for byte", () => {
+    seedPreCapDatabase({ command_output: "small output" });
+
+    initDatabase(dbPath);
+
+    expect(dbGetThreadRuntimeItems("thread-1")[0]!.streams).toEqual({
+      command_output: "small output",
+    });
+  });
+
+  it("migrates astral text measured as oversized UTF-16", () => {
+    const oversized = "😀".repeat(MAX_PERSISTED_STREAM_CHARS / 2 + 10);
+    seedPreCapDatabase({ command_output: oversized });
+
+    initDatabase(dbPath);
+
+    const output = dbGetThreadRuntimeItems("thread-1")[0]!.streams.command_output!;
+    expect(output.length).toBeLessThanOrEqual(MAX_PERSISTED_STREAM_CHARS + 256_000);
+    expect(output).not.toContain("�");
+  });
+
+  it("keeps one bounded stream layout when a large legacy item resumes", () => {
+    seedPreCapDatabase({
+      command_output: `LEGACY-HEAD ${"x".repeat(MAX_PERSISTED_STREAM_CHARS * 2)}`,
+    });
+
+    initDatabase(dbPath);
+    dbApplyThreadRuntimeEvents("thread-1", [
+      {
+        type: "content.delta",
+        threadId: "thread-1",
+        itemId: "cmd-1",
+        stream: "command_output",
+        delta: `${"y".repeat(TAIL_CHARS + 500_000)} APPENDED-TAIL`,
+      },
+    ]);
+
+    const output = dbGetThreadRuntimeItems("thread-1")[0]!.streams.command_output!;
+    expect(output.startsWith("LEGACY-HEAD ")).toBe(true);
+    expect(output.endsWith(" APPENDED-TAIL")).toBe(true);
+    expect(output.match(/poracode elided/g)).toHaveLength(1);
+    expect(output.length).toBeLessThanOrEqual(HEAD_CHARS + TAIL_CHARS + 256_000);
+  });
+});

--- a/src/main/db/runtimeStreamStore.test.ts
+++ b/src/main/db/runtimeStreamStore.test.ts
@@ -1,0 +1,277 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { beforeEach, describe, expect, it } from "vitest";
+import { HEAD_CHARS, TAIL_CHARS } from "./runtimeStreamCap";
+import {
+  appendStreamDelta,
+  assembleItemStreams,
+  readStreamTails,
+  streamHasContent,
+} from "./runtimeStreamStore";
+
+const serverNativeBinding = join(process.cwd(), "dist", "server-native", "better_sqlite3.node");
+let nativeBinding: string | undefined;
+let sqliteAvailable = true;
+try {
+  new Database(":memory:").close();
+} catch {
+  if (existsSync(serverNativeBinding)) nativeBinding = serverNativeBinding;
+  else sqliteAvailable = false;
+}
+
+const THREAD = "t1";
+const ITEM = "cmd-1";
+const STREAM = "command_output";
+const NL = String.fromCharCode(10);
+
+describe.skipIf(!sqliteAvailable)("runtime stream chunk store", () => {
+  let sqlite: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:", { ...(nativeBinding ? { nativeBinding } : {}) });
+    sqlite.exec(`
+      CREATE TABLE thread_runtime_item_stream_chunks (
+        thread_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        stream TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        chars INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        PRIMARY KEY (thread_id, item_id, stream, seq)
+      );
+      CREATE TABLE thread_runtime_item_stream_state (
+        thread_id TEXT NOT NULL,
+        item_id TEXT NOT NULL,
+        stream TEXT NOT NULL,
+        next_seq INTEGER NOT NULL,
+        tail_chars INTEGER NOT NULL,
+        elided_chars INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (thread_id, item_id, stream)
+      );
+    `);
+  });
+
+  /** Drive a whole stream through the store the way the writer does. */
+  function stream(deltas: readonly string[], itemId = ITEM, streamName = STREAM): string {
+    let head = "";
+    for (const delta of deltas) {
+      const result = appendStreamDelta(sqlite, {
+        threadId: THREAD,
+        itemId,
+        stream: streamName,
+        delta,
+        head,
+      });
+      if (result.head !== undefined) head = result.head;
+    }
+    return head;
+  }
+
+  function assemble(head: string, itemId = ITEM, streamName = STREAM): string {
+    const tails = readStreamTails(sqlite, THREAD, [itemId]).get(itemId);
+    return assembleItemStreams({ [streamName]: head }, tails)[streamName] ?? "";
+  }
+
+  function elidedChars(itemId = ITEM, streamName = STREAM): number {
+    const row = sqlite
+      .prepare(
+        `SELECT elided_chars FROM thread_runtime_item_stream_state
+         WHERE thread_id = ? AND item_id = ? AND stream = ?`,
+      )
+      .get(THREAD, itemId, streamName) as { elided_chars: number } | undefined;
+    return row ? Number(row.elided_chars) : 0;
+  }
+
+  it("keeps short output entirely in the head, with no chunk rows", () => {
+    const head = stream(["hello ", "world"]);
+
+    expect(head).toBe("hello world");
+    expect(readStreamTails(sqlite, THREAD, [ITEM]).size).toBe(0);
+    expect(assemble(head)).toBe("hello world");
+  });
+
+  it("reassembles head and tail into the exact original text", () => {
+    const parts = Array.from({ length: 40 }, (_, i) => `line ${i} `.repeat(1_000));
+    const head = stream(parts);
+
+    expect(head).toHaveLength(HEAD_CHARS);
+    expect(elidedChars()).toBe(0);
+    expect(assemble(head)).toBe(parts.join(""));
+  });
+
+  it("freezes the head once it is full", () => {
+    const first = appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: "z".repeat(HEAD_CHARS + 10),
+      head: "",
+    });
+    expect(first.head).toHaveLength(HEAD_CHARS);
+
+    const second = appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: "more",
+      head: first.head!,
+    });
+    // No head returned means no item-row rewrite from here on.
+    expect(second.head).toBeUndefined();
+  });
+
+  it("freezes the head after an astral character crosses its final slot", () => {
+    const first = appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: `${"a".repeat(HEAD_CHARS - 1)}😀`,
+      head: "",
+    });
+    const second = appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: "more",
+      head: first.head!,
+    });
+
+    expect(first.head).toHaveLength(HEAD_CHARS + 1);
+    expect(second.head).toBeUndefined();
+  });
+
+  it("trims the oldest chunks and reports what was dropped", () => {
+    const head = stream(["START", "q".repeat(TAIL_CHARS + HEAD_CHARS + 500_000), "END"]);
+
+    const text = assemble(head);
+    expect(text.startsWith("START")).toBe(true);
+    expect(text.endsWith("END")).toBe(true);
+    expect(text).toContain("poracode elided");
+    expect(text.length).toBeLessThanOrEqual(HEAD_CHARS + TAIL_CHARS + 300_000);
+    expect(elidedChars()).toBeGreaterThan(0);
+  });
+
+  it("puts the elision notice on its own line between whole lines", () => {
+    const logLine = (i: number) =>
+      `2026-08-27T07:00:00.000Z INFO build step ${String(i).padStart(6, "0")} ok`;
+    const log = Array.from({ length: 200_000 }, (_, i) => logLine(i)).join(NL) + NL;
+    const head = stream([log]);
+
+    const text = assemble(head);
+    const lines = text.split(NL);
+    const noticeIndex = lines.findIndex((l) => l.includes("poracode elided"));
+
+    expect(noticeIndex).toBeGreaterThan(0);
+    // The notice occupies a whole line, and its neighbours are intact log lines.
+    expect(lines[noticeIndex]!.startsWith("[... poracode elided")).toBe(true);
+    expect(lines[noticeIndex]!.endsWith("...]")).toBe(true);
+    expect(lines[noticeIndex - 1]).toMatch(/^2026-08-27T07:00:00\.000Z INFO build step \d{6} ok$/);
+    expect(lines[noticeIndex + 1]).toMatch(/^2026-08-27T07:00:00\.000Z INFO build step \d{6} ok$/);
+  });
+
+  it("keeps single-line output readable when it has to be trimmed", () => {
+    // No line breaks anywhere: alignment must not throw the content away.
+    const head = stream(["A".repeat(HEAD_CHARS + TAIL_CHARS + 400_000) + "Z"]);
+
+    const text = assemble(head);
+
+    expect(text.startsWith("A")).toBe(true);
+    expect(text.endsWith("Z")).toBe(true);
+    expect(text).toContain("poracode elided");
+  });
+
+  it("keeps its bookkeeping consistent with the rows it retains", () => {
+    stream(["p".repeat(HEAD_CHARS + TAIL_CHARS + 700_000)]);
+
+    const state = sqlite
+      .prepare(
+        `SELECT next_seq, tail_chars, elided_chars FROM thread_runtime_item_stream_state
+         WHERE thread_id = ? AND item_id = ? AND stream = ?`,
+      )
+      .get(THREAD, ITEM, STREAM) as {
+      next_seq: number;
+      tail_chars: number;
+      elided_chars: number;
+    };
+    const actual = sqlite
+      .prepare(
+        `SELECT COUNT(*) AS rows, COALESCE(SUM(chars), 0) AS chars, COALESCE(SUM(LENGTH(text)), 0) AS textChars
+         FROM thread_runtime_item_stream_chunks WHERE thread_id = ? AND item_id = ? AND stream = ?`,
+      )
+      .get(THREAD, ITEM, STREAM) as { rows: number; chars: number; textChars: number };
+
+    expect(Number(actual.chars)).toBe(Number(actual.textChars));
+    expect(state.tail_chars).toBe(Number(actual.chars));
+    expect(state.elided_chars + state.tail_chars + HEAD_CHARS).toBe(
+      HEAD_CHARS + TAIL_CHARS + 700_000,
+    );
+  });
+
+  it("splits one oversized delta so the retention window still applies", () => {
+    const head = stream(["x".repeat(HEAD_CHARS + TAIL_CHARS * 2)]);
+
+    const rows = sqlite
+      .prepare("SELECT chars FROM thread_runtime_item_stream_chunks")
+      .all() as Array<{ chars: number }>;
+    expect(rows.length).toBeGreaterThan(1);
+    expect(Math.max(...rows.map((r) => Number(r.chars)))).toBeLessThanOrEqual(256_000);
+    expect(assemble(head).length).toBeLessThanOrEqual(HEAD_CHARS + TAIL_CHARS + 300_000);
+  });
+
+  it("does not split surrogate pairs at head or chunk boundaries", () => {
+    const source = `${"a".repeat(HEAD_CHARS - 1)}😀${"b".repeat(256_000 - 1)}😀tail`;
+    const head = stream([source]);
+
+    expect(assemble(head)).toBe(source);
+    expect(assemble(head)).not.toContain("�");
+  });
+
+  it("keeps separate streams on the same item independent", () => {
+    stream(["a".repeat(HEAD_CHARS + 1_000)], ITEM, "command_output");
+    stream(["thinking"], ITEM, "reasoning_text");
+
+    const tails = readStreamTails(sqlite, THREAD, [ITEM]).get(ITEM)!;
+    expect(tails.text.command_output).toHaveLength(1_000);
+    expect(tails.text.reasoning_text).toBeUndefined();
+  });
+
+  it("reports whether a stream holds content across head and chunks", () => {
+    const blankHead = " ".repeat(HEAD_CHARS);
+    appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: blankHead + "   ",
+      head: "",
+    });
+    expect(streamHasContent(sqlite, THREAD, ITEM, STREAM, blankHead)).toBe(false);
+
+    appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: "real output",
+      head: blankHead,
+    });
+    expect(streamHasContent(sqlite, THREAD, ITEM, STREAM, blankHead)).toBe(true);
+  });
+
+  it("treats all JavaScript whitespace in chunks as blank", () => {
+    const blankHead = " ".repeat(HEAD_CHARS);
+    appendStreamDelta(sqlite, {
+      threadId: THREAD,
+      itemId: ITEM,
+      stream: STREAM,
+      delta: `${blankHead}\t\n\u00a0`,
+      head: "",
+    });
+
+    expect(streamHasContent(sqlite, THREAD, ITEM, STREAM, blankHead)).toBe(false);
+  });
+
+  it("returns the head unchanged when there is nothing appended", () => {
+    const head = { assistant_text: "done" };
+    expect(assembleItemStreams(head, undefined)).toBe(head);
+  });
+});

--- a/src/main/db/runtimeStreamStore.ts
+++ b/src/main/db/runtimeStreamStore.ts
@@ -1,0 +1,317 @@
+import type Database from "better-sqlite3";
+import { HEAD_CHARS, joinWithElision, TAIL_CHARS, utf16SafeSliceEnd } from "./runtimeStreamCap";
+
+type SqliteDatabase = InstanceType<typeof Database>;
+
+/**
+ * Append-only storage for a runtime item's streamed content.
+ *
+ * A `content.delta` used to rewrite the item's whole `streams` JSON blob, so the
+ * cost of one chunk grew with everything the item had already produced: a
+ * long-running command reached hundreds of milliseconds per chunk, synchronously,
+ * on the main process. Here an append is a small INSERT plus a small UPDATE, so
+ * it costs the same whether the item has produced a kilobyte or a gigabyte.
+ *
+ * Layout per (item, stream):
+ *   - the head lives in `thread_runtime_items.streams` and freezes once it
+ *     reaches {@link HEAD_CHARS} — after that, streaming never rewrites the
+ *     item row again;
+ *   - everything past the head is a row in `thread_runtime_item_stream_chunks`;
+ *   - `thread_runtime_item_stream_state` carries the next sequence number, the
+ *     retained character count and how much has been dropped, so the append
+ *     path needs no aggregate query;
+ *   - trimming the retained window deletes the oldest chunk rows, which costs
+ *     the same no matter how much the item has produced.
+ *
+ * Reads reassemble `head + elision marker + tail`, so callers still see one
+ * string per stream and nothing outside this module knows about chunking.
+ */
+
+/**
+ * Largest chunk row written. A provider that delivers a whole command result as
+ * one delta would otherwise create a single unbounded row, which both defeats
+ * the retention window (whole rows are the unit of trimming) and puts a huge
+ * value back on the write path.
+ */
+const CHUNK_MAX_CHARS = 256_000;
+
+/** Oldest chunks inspected per trim pass. */
+const TRIM_SCAN_LIMIT = 64;
+
+/** Item ids per tail lookup; SQLite caps how many parameters one statement takes. */
+const TAIL_QUERY_BATCH = 400;
+
+interface StreamStateRow {
+  next_seq: number;
+  tail_chars: number;
+  elided_chars: number;
+}
+
+export interface AppendStreamDeltaInput {
+  readonly threadId: string;
+  readonly itemId: string;
+  readonly stream: string;
+  readonly delta: string;
+  /** The item's current head text for this stream, as stored on the item row. */
+  readonly head: string;
+}
+
+export interface AppendStreamDeltaResult {
+  /** New head text when the head grew, or `undefined` when it is already frozen. */
+  readonly head?: string;
+}
+
+function readStreamState(
+  sqlite: SqliteDatabase,
+  threadId: string,
+  itemId: string,
+  stream: string,
+): StreamStateRow {
+  const row = sqlite
+    .prepare(
+      `SELECT next_seq, tail_chars, elided_chars FROM thread_runtime_item_stream_state
+       WHERE thread_id = ? AND item_id = ? AND stream = ?`,
+    )
+    .get(threadId, itemId, stream) as StreamStateRow | undefined;
+  return row ?? { next_seq: 0, tail_chars: 0, elided_chars: 0 };
+}
+
+function writeStreamState(
+  sqlite: SqliteDatabase,
+  threadId: string,
+  itemId: string,
+  stream: string,
+  state: StreamStateRow,
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO thread_runtime_item_stream_state
+         (thread_id, item_id, stream, next_seq, tail_chars, elided_chars)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(thread_id, item_id, stream) DO UPDATE SET
+         next_seq = excluded.next_seq,
+         tail_chars = excluded.tail_chars,
+         elided_chars = excluded.elided_chars`,
+    )
+    .run(threadId, itemId, stream, state.next_seq, state.tail_chars, state.elided_chars);
+}
+
+/**
+ * Append one delta. Returns the item-row fields that changed so the caller can
+ * fold them into the UPDATE it already performs — usually nothing, because the
+ * head is frozen and the tail lives in its own rows.
+ */
+export function appendStreamDelta(
+  sqlite: SqliteDatabase,
+  input: AppendStreamDeltaInput,
+): AppendStreamDeltaResult {
+  const { threadId, itemId, stream, delta, head } = input;
+  if (delta.length === 0) return {};
+
+  // Fill the head first; it freezes at HEAD_CHARS and is never rewritten after.
+  let nextHead: string | undefined;
+  let remainder = delta;
+  if (head.length < HEAD_CHARS) {
+    const room = HEAD_CHARS - head.length;
+    const safeEnd = utf16SafeSliceEnd(delta, room);
+    const headEnd = safeEnd < Math.min(delta.length, room) ? safeEnd + 2 : safeEnd;
+    nextHead = head + delta.slice(0, headEnd);
+    remainder = delta.slice(headEnd);
+    if (remainder.length === 0) return { head: nextHead };
+  }
+
+  const state = readStreamState(sqlite, threadId, itemId, stream);
+  const insert = sqlite.prepare(
+    `INSERT INTO thread_runtime_item_stream_chunks (thread_id, item_id, stream, seq, chars, text)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  let nextSeq = state.next_seq;
+  let tailChars = state.tail_chars;
+  for (let offset = 0; offset < remainder.length;) {
+    const end = utf16SafeSliceEnd(remainder, Math.min(remainder.length, offset + CHUNK_MAX_CHARS));
+    const text = remainder.slice(offset, end);
+    insert.run(threadId, itemId, stream, nextSeq, text.length, text);
+    nextSeq += 1;
+    tailChars += text.length;
+    offset = end;
+  }
+  const newestSeq = nextSeq - 1;
+
+  let elidedChars = state.elided_chars;
+  if (tailChars > TAIL_CHARS) {
+    // Over budget: drop whole chunks from the oldest end. `chars` is declared
+    // before `text` so this reads record headers, not chunk contents.
+    const oldest = sqlite.prepare(
+      `SELECT seq, chars FROM thread_runtime_item_stream_chunks
+       WHERE thread_id = ? AND item_id = ? AND stream = ?
+       ORDER BY seq ASC LIMIT ${TRIM_SCAN_LIMIT}`,
+    );
+    const remove = sqlite.prepare(
+      `DELETE FROM thread_runtime_item_stream_chunks
+       WHERE thread_id = ? AND item_id = ? AND stream = ? AND seq = ?`,
+    );
+    while (tailChars > TAIL_CHARS) {
+      const candidates = oldest.all(threadId, itemId, stream) as Array<{
+        seq: number;
+        chars: number;
+      }>;
+      let removedAny = false;
+      for (const candidate of candidates) {
+        if (tailChars <= TAIL_CHARS) break;
+        // Never drop the newest chunk: it is what just arrived.
+        if (candidate.seq >= newestSeq) break;
+        remove.run(threadId, itemId, stream, candidate.seq);
+        tailChars -= Number(candidate.chars);
+        elidedChars += Number(candidate.chars);
+        removedAny = true;
+      }
+      if (!removedAny) break;
+    }
+  }
+
+  writeStreamState(sqlite, threadId, itemId, stream, {
+    next_seq: nextSeq,
+    tail_chars: tailChars,
+    elided_chars: elidedChars,
+  });
+  return nextHead === undefined ? {} : { head: nextHead };
+}
+
+/** Remove every appended tail in a thread. */
+export function clearThreadStreamChunks(sqlite: SqliteDatabase, threadId: string): void {
+  sqlite.prepare("DELETE FROM thread_runtime_item_stream_chunks WHERE thread_id = ?").run(threadId);
+  sqlite.prepare("DELETE FROM thread_runtime_item_stream_state WHERE thread_id = ?").run(threadId);
+}
+
+/** Store complete stream values in the same head/chunk layout used by live deltas. */
+export function writeItemStreams(
+  sqlite: SqliteDatabase,
+  threadId: string,
+  itemId: string,
+  streams: Record<string, string>,
+): void {
+  const heads: Record<string, string> = {};
+  for (const [stream, text] of Object.entries(streams)) {
+    if (typeof text !== "string") continue;
+    const result = appendStreamDelta(sqlite, { threadId, itemId, stream, delta: text, head: "" });
+    heads[stream] = result.head ?? "";
+  }
+  sqlite
+    .prepare("UPDATE thread_runtime_items SET streams = ? WHERE thread_id = ? AND item_id = ?")
+    .run(JSON.stringify(heads), threadId, itemId);
+}
+
+/** A stream's appended tail text and how much of it has been dropped. */
+export interface ItemStreamTails {
+  text: Record<string, string>;
+  elided: Record<string, number>;
+}
+
+/**
+ * Load the appended tails for a set of items, concatenated in sequence order.
+ * Items with nothing appended are absent from the result.
+ */
+export function readStreamTails(
+  sqlite: SqliteDatabase,
+  threadId: string,
+  itemIds: readonly string[],
+): Map<string, ItemStreamTails> {
+  const byItem = new Map<string, ItemStreamTails>();
+  const textParts = new Map<string, Record<string, string[]>>();
+  const ids = [...new Set(itemIds)];
+  if (ids.length === 0) return byItem;
+  const entryFor = (itemId: string): ItemStreamTails => {
+    const existing = byItem.get(itemId);
+    if (existing) return existing;
+    const created: ItemStreamTails = { text: {}, elided: {} };
+    byItem.set(itemId, created);
+    return created;
+  };
+
+  // Restricted to the requested items: a transcript can hold several megabytes
+  // of retained tail, and a page must not pay for items it is not returning.
+  for (let start = 0; start < ids.length; start += TAIL_QUERY_BATCH) {
+    const batch = ids.slice(start, start + TAIL_QUERY_BATCH);
+    const marks = batch.map(() => "?").join(", ");
+    const stateRows = sqlite
+      .prepare(
+        `SELECT item_id, stream, elided_chars FROM thread_runtime_item_stream_state
+         WHERE thread_id = ? AND elided_chars > 0 AND item_id IN (${marks})`,
+      )
+      .all(threadId, ...batch) as Array<{
+      item_id: string;
+      stream: string;
+      elided_chars: number;
+    }>;
+    for (const row of stateRows) {
+      entryFor(row.item_id).elided[row.stream] = Number(row.elided_chars);
+    }
+
+    const chunkRows = sqlite
+      .prepare(
+        `SELECT item_id, stream, text FROM thread_runtime_item_stream_chunks
+         WHERE thread_id = ? AND item_id IN (${marks})
+         ORDER BY item_id ASC, stream ASC, seq ASC`,
+      )
+      .all(threadId, ...batch) as Array<{ item_id: string; stream: string; text: string }>;
+    for (const row of chunkRows) {
+      entryFor(row.item_id);
+      let itemParts = textParts.get(row.item_id);
+      if (!itemParts) {
+        itemParts = {};
+        textParts.set(row.item_id, itemParts);
+      }
+      (itemParts[row.stream] ??= []).push(row.text);
+    }
+  }
+  for (const [itemId, streams] of textParts) {
+    const target = byItem.get(itemId)!.text;
+    for (const [stream, parts] of Object.entries(streams)) target[stream] = parts.join("");
+  }
+  return byItem;
+}
+
+/**
+ * Rebuild one item's streams from its stored head and its appended tail.
+ * Returns the head object itself when there is nothing to add.
+ */
+export function assembleItemStreams(
+  head: Record<string, string>,
+  tails: ItemStreamTails | undefined,
+): Record<string, string> {
+  if (!tails) return head;
+  const assembled: Record<string, string> = { ...head };
+  const streams = new Set([
+    ...Object.keys(assembled),
+    ...Object.keys(tails.text),
+    ...Object.keys(tails.elided),
+  ]);
+  for (const stream of streams) {
+    const headText = assembled[stream] ?? "";
+    const elidedChars = tails.elided[stream] ?? 0;
+    const tailText = tails.text[stream] ?? "";
+    assembled[stream] = joinWithElision(headText, tailText, elidedChars);
+  }
+  return assembled;
+}
+
+/** Whether a stream holds any non-whitespace content, without assembling it. */
+export function streamHasContent(
+  sqlite: SqliteDatabase,
+  threadId: string,
+  itemId: string,
+  stream: string,
+  head: string | undefined,
+): boolean {
+  if ((head ?? "").trim().length > 0) return true;
+  const rows = sqlite
+    .prepare(
+      `SELECT text FROM thread_runtime_item_stream_chunks
+       WHERE thread_id = ? AND item_id = ? AND stream = ?`,
+    )
+    .iterate(threadId, itemId, stream) as Iterable<{ text: string }>;
+  for (const row of rows) {
+    if (row.text.trim().length > 0) return true;
+  }
+  return false;
+}

--- a/src/main/db/runtimeWriteQueue.test.ts
+++ b/src/main/db/runtimeWriteQueue.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import { coalesceRuntimeEvents } from "@/shared/coalesce";
+import type { RuntimeEvent } from "@/shared/contracts";
+import { RuntimeWriteQueue } from "./runtimeWriteQueue";
+
+function delta(itemId: string, text: string, stream = "command_output"): RuntimeEvent {
+  return { type: "content.delta", threadId: "t1", itemId, stream, delta: text } as RuntimeEvent;
+}
+
+function started(itemId: string): RuntimeEvent {
+  return {
+    type: "item.started",
+    threadId: "t1",
+    itemId,
+    itemType: "command_execution",
+  } as RuntimeEvent;
+}
+
+function completed(itemId: string): RuntimeEvent {
+  return { type: "item.completed", threadId: "t1", itemId } as RuntimeEvent;
+}
+
+describe("coalesceRuntimeEvents", () => {
+  it("merges consecutive deltas for the same item and stream", () => {
+    const merged = coalesceRuntimeEvents([
+      delta("a", "one "),
+      delta("a", "two "),
+      delta("a", "three"),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toMatchObject({ type: "content.delta", itemId: "a", delta: "one two three" });
+  });
+
+  it("keeps lifecycle events between deltas in order", () => {
+    const merged = coalesceRuntimeEvents([
+      started("a"),
+      delta("a", "x"),
+      delta("a", "y"),
+      completed("a"),
+      delta("a", "z"),
+    ]);
+
+    expect(merged.map((e) => e.type)).toEqual([
+      "item.started",
+      "content.delta",
+      "item.completed",
+      "content.delta",
+    ]);
+    expect(merged[1]).toMatchObject({ delta: "xy" });
+    expect(merged[3]).toMatchObject({ delta: "z" });
+  });
+
+  it("does not merge across items or streams", () => {
+    const merged = coalesceRuntimeEvents([
+      delta("a", "1"),
+      delta("b", "2"),
+      delta("a", "3"),
+      delta("a", "4", "assistant_text"),
+    ]);
+
+    expect(merged).toHaveLength(4);
+    expect(merged.map((e) => (e as { itemId: string }).itemId)).toEqual(["a", "b", "a", "a"]);
+  });
+
+  it("preserves interleaved output exactly when two items stream at once", () => {
+    const merged = coalesceRuntimeEvents([
+      delta("a", "a1"),
+      delta("a", "a2"),
+      delta("b", "b1"),
+      delta("a", "a3"),
+    ]);
+
+    const perItem = merged.reduce<Record<string, string>>((acc, event) => {
+      const e = event as unknown as { itemId: string; delta: string };
+      acc[e.itemId] = (acc[e.itemId] ?? "") + e.delta;
+      return acc;
+    }, {});
+    expect(perItem).toEqual({ a: "a1a2a3", b: "b1" });
+  });
+});
+
+describe("RuntimeWriteQueue", () => {
+  it("defers writes until the flush window elapses, then writes once", () => {
+    vi.useFakeTimers();
+    try {
+      const writes: Array<{ threadId: string; events: RuntimeEvent[] }> = [];
+      const queue = new RuntimeWriteQueue(
+        (threadId, events) => writes.push({ threadId, events }),
+        250,
+      );
+
+      queue.enqueue("t1", [started("a")]);
+      for (let i = 0; i < 40; i += 1) queue.enqueue("t1", [delta("a", `chunk${i} `)]);
+      expect(writes).toHaveLength(0);
+
+      vi.advanceTimersByTime(250);
+
+      expect(writes).toHaveLength(1);
+      expect(writes[0]!.events).toHaveLength(2);
+      expect(writes[0]!.events[1]).toMatchObject({ delta: expect.stringContaining("chunk39 ") });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes one thread on demand and leaves the others queued", () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const queue = new RuntimeWriteQueue((threadId) => writes.push(threadId), 250);
+      queue.enqueue("t1", [delta("a", "x")]);
+      queue.enqueue("t2", [delta("b", "y")]);
+
+      queue.flush("t1");
+
+      expect(writes).toEqual(["t1"]);
+      vi.advanceTimersByTime(250);
+      expect(writes).toEqual(["t1", "t2"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a thread's queued writes when its rows are being replaced", () => {
+    vi.useFakeTimers();
+    try {
+      const writes: string[] = [];
+      const queue = new RuntimeWriteQueue((threadId) => writes.push(threadId), 250);
+      queue.enqueue("t1", [delta("a", "stale")]);
+
+      queue.discard("t1");
+      vi.advanceTimersByTime(250);
+
+      expect(writes).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains queued writes when a flush fails so they can be retried", () => {
+    let fail = true;
+    const writes: string[] = [];
+    const queue = new RuntimeWriteQueue((threadId) => {
+      if (fail) throw new Error("busy");
+      writes.push(threadId);
+    });
+    queue.enqueue("t1", [delta("a", "x")]);
+
+    expect(() => queue.flush()).toThrow("busy");
+    fail = false;
+    queue.flush();
+
+    expect(writes).toEqual(["t1"]);
+  });
+
+  it("retries a failed timer-driven flush", () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      let fail = true;
+      const writes: string[] = [];
+      const queue = new RuntimeWriteQueue((threadId) => {
+        if (fail) throw new Error("busy");
+        writes.push(threadId);
+      }, 250);
+      queue.enqueue("t1", [delta("a", "x")]);
+
+      vi.advanceTimersByTime(250);
+      fail = false;
+      vi.advanceTimersByTime(250);
+
+      expect(writes).toEqual(["t1"]);
+      expect(error).toHaveBeenCalledOnce();
+    } finally {
+      error.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/main/db/runtimeWriteQueue.ts
+++ b/src/main/db/runtimeWriteQueue.ts
@@ -1,0 +1,86 @@
+import type { RuntimeEvent } from "@/shared/contracts";
+import { coalesceRuntimeEvents } from "@/shared/coalesce";
+
+/**
+ * Buffers canonical runtime events per thread so streamed output reaches SQLite
+ * in a few coalesced writes per second instead of one full-row rewrite per
+ * chunk.
+ *
+ * The supervisor already batches events on a 16 ms tick, which still leaves ~60
+ * writes per second per streaming item, and each of those rewrites the item's
+ * entire accumulated `streams` blob synchronously on the main process. Holding
+ * events for a short window and merging each item's consecutive deltas collapses
+ * that into one write per window.
+ *
+ * Ordering is preserved: a thread's queue is a single ordered list, and deltas
+ * merge only with the immediately preceding delta for the same item and stream,
+ * so an `item.started` / `item.completed` between them still lands in order.
+ *
+ * Reads must not observe a stale transcript, so every reader flushes first (see
+ * `runtimeItems.ts`). Buffered events survive at most one window; the queue is
+ * also drained before the database closes.
+ */
+const RUNTIME_WRITE_FLUSH_MS = 250;
+
+type RuntimeWriteFlush = (threadId: string, events: RuntimeEvent[]) => void;
+
+export class RuntimeWriteQueue {
+  private readonly pending = new Map<string, RuntimeEvent[]>();
+  private timer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(
+    private readonly write: RuntimeWriteFlush,
+    private readonly flushMs: number = RUNTIME_WRITE_FLUSH_MS,
+  ) {}
+
+  enqueue(threadId: string, events: readonly RuntimeEvent[]): void {
+    if (events.length === 0) return;
+    const pending = this.pending.get(threadId);
+    // Appended one by one: a replayed sub-agent history can be thousands of
+    // events, and spreading that into `push` risks an argument-count limit.
+    if (pending) for (const event of events) pending.push(event);
+    else this.pending.set(threadId, [...events]);
+    this.scheduleFlush();
+  }
+
+  /** Drain one thread's queue, or every thread when `threadId` is omitted. */
+  flush(threadId?: string): void {
+    if (this.pending.size === 0) return;
+    if (threadId !== undefined) {
+      const events = this.pending.get(threadId);
+      if (!events) return;
+      this.write(threadId, coalesceRuntimeEvents(events));
+      this.pending.delete(threadId);
+      return;
+    }
+    const drained = [...this.pending];
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    for (const [id, events] of drained) {
+      this.write(id, coalesceRuntimeEvents(events));
+      this.pending.delete(id);
+    }
+  }
+
+  /** Discard a thread's buffered writes (its rows are going away anyway). */
+  discard(threadId: string): void {
+    this.pending.delete(threadId);
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer !== undefined || this.pending.size === 0) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      try {
+        this.flush();
+      } catch (error) {
+        console.error("[db] runtime write flush failed; retrying:", error);
+        this.scheduleFlush();
+      }
+    }, this.flushMs);
+    // A pending write must never hold the process open on its own.
+    this.timer.unref?.();
+  }
+}

--- a/src/main/db/sync.ts
+++ b/src/main/db/sync.ts
@@ -10,6 +10,7 @@ import { getSqlite } from "./connection";
 import { acknowledgeMirroredThreadIds, isMainCreatedThreadUnmirrored } from "./mainCreatedThreads";
 import { notifyProjectThreadDataChanged } from "./projectThreadChanges";
 import { projectMutableRow } from "./rowMappers";
+import { dbDiscardThreadRuntimeWrites } from "./runtimeItems";
 
 /**
  * Bulk-sync the full project and thread lists from the renderer store.
@@ -17,12 +18,20 @@ import { projectMutableRow } from "./rowMappers";
  */
 export function dbSyncAll(projectsData: Project[], threadsData: Thread[], viewJson: string): void {
   const sqlite = getSqlite();
+  const deletedThreadIds = new Set<string>();
 
   sqlite.transaction(() => {
+    const existingThreads = sqlite.prepare("SELECT id, project_id FROM threads").all() as Array<{
+      id: string;
+      project_id: string;
+    }>;
     const existingProjectIds = new Set(
       (sqlite.prepare("SELECT id FROM projects").all() as Array<{ id: string }>).map((r) => r.id),
     );
     const incomingProjectIds = new Set(projectsData.map((p) => p.id));
+    const deletedProjectIds = new Set(
+      [...existingProjectIds].filter((projectId) => !incomingProjectIds.has(projectId)),
+    );
     const deleteProject = sqlite.prepare("DELETE FROM projects WHERE id = ?");
     const deleteProjectNotes = sqlite.prepare("DELETE FROM project_notes WHERE project_id = ?");
     const upsertProject = prepareProjectSyncStatement(sqlite);
@@ -37,21 +46,19 @@ export function dbSyncAll(projectsData: Project[], threadsData: Thread[], viewJs
       runProjectSync(upsertProject, projectsData[i]!, i);
     }
 
-    const existingThreadIds = new Set(
-      (sqlite.prepare("SELECT id FROM threads").all() as Array<{ id: string }>).map((r) => r.id),
-    );
     const incomingThreadIds = new Set(threadsData.map((t) => t.id));
     const deleteThread = sqlite.prepare("DELETE FROM threads WHERE id = ?");
     const upsertThread = prepareThreadSyncStatement(sqlite);
 
-    for (const tid of existingThreadIds) {
+    for (const { id: tid, project_id: projectId } of existingThreads) {
       if (incomingThreadIds.has(tid)) continue;
       // A thread main just created (remote `start`, schedule, orchestrator) is
       // absent from this snapshot only because the renderer has not applied the
       // forwarded command yet. Deleting it would cascade away the launch turn's
       // runtime items — most visibly the initial `user_message`.
-      if (isMainCreatedThreadUnmirrored(tid)) continue;
+      if (!deletedProjectIds.has(projectId) && isMainCreatedThreadUnmirrored(tid)) continue;
       deleteThread.run(tid);
+      deletedThreadIds.add(tid);
     }
     for (let i = 0; i < threadsData.length; i++) {
       runThreadSync(upsertThread, threadsData[i]!, i);
@@ -66,6 +73,7 @@ export function dbSyncAll(projectsData: Project[], threadsData: Thread[], viewJs
       )
       .run(viewJson);
   })();
+  for (const threadId of deletedThreadIds) dbDiscardThreadRuntimeWrites(threadId);
   notifyProjectThreadDataChanged();
 }
 
@@ -92,6 +100,7 @@ export function dbPersistExperimentState(payload: DbPersistExperimentStatePayloa
         }),
       );
   })();
+  for (const threadId of payload.deletedThreadIds) dbDiscardThreadRuntimeWrites(threadId);
 }
 
 type SqliteStatement = ReturnType<InstanceType<typeof Database>["prepare"]>;

--- a/src/renderer/state/slices/runtimeEventReducer.ts
+++ b/src/renderer/state/slices/runtimeEventReducer.ts
@@ -1,4 +1,5 @@
 import type { RuntimeEvent, ThreadContextUsage, ToolCallPayload } from "@/shared/contracts";
+import { coalesceRuntimeEvents } from "@/shared/coalesce";
 import { isDelegatedAgentTool } from "@/shared/toolCallClassification";
 import { recordRuntimeStructuralChangeHint } from "../runtimeStructuralChanges";
 import type { AppStoreState } from "./shared";
@@ -607,41 +608,6 @@ function areContextUsagesEqual(
     const other = rightBreakdown[index];
     return other?.id === entry.id && other.label === entry.label && other.tokens === entry.tokens;
   });
-}
-
-function coalesceRuntimeEvents(events: RuntimeEvent[]): RuntimeEvent[] {
-  const coalesced: RuntimeEvent[] = [];
-  let pendingDelta: Extract<RuntimeEvent, { type: "content.delta" }> | undefined;
-
-  const flushPendingDelta = () => {
-    if (!pendingDelta) return;
-    coalesced.push(pendingDelta);
-    pendingDelta = undefined;
-  };
-
-  for (const event of events) {
-    if (event.type !== "content.delta") {
-      flushPendingDelta();
-      coalesced.push(event);
-      continue;
-    }
-    if (
-      pendingDelta &&
-      pendingDelta.itemId === event.itemId &&
-      pendingDelta.stream === event.stream
-    ) {
-      pendingDelta = {
-        ...pendingDelta,
-        delta: pendingDelta.delta + event.delta,
-      };
-      continue;
-    }
-    flushPendingDelta();
-    pendingDelta = event;
-  }
-
-  flushPendingDelta();
-  return coalesced;
 }
 
 function pruneTrailingInterruptedReasoningItems(

--- a/src/shared/coalesce.ts
+++ b/src/shared/coalesce.ts
@@ -1,3 +1,5 @@
+import type { RuntimeEvent } from "./contracts";
+
 /**
  * Coalesce concurrent async work by key: callers with the same key share one
  * in-flight promise instead of each starting the work. The entry clears itself
@@ -17,4 +19,25 @@ export function coalesceByKey<K, V>(
   });
   inFlight.set(key, tracked);
   return tracked;
+}
+
+/** Append one runtime event, merging only an immediately preceding matching delta. */
+export function appendCoalescedRuntimeEvent(target: RuntimeEvent[], event: RuntimeEvent): void {
+  const previous = target.at(-1);
+  if (
+    event.type === "content.delta" &&
+    previous?.type === "content.delta" &&
+    previous.itemId === event.itemId &&
+    previous.stream === event.stream
+  ) {
+    target[target.length - 1] = { ...previous, delta: previous.delta + event.delta };
+    return;
+  }
+  target.push(event);
+}
+
+export function coalesceRuntimeEvents(events: readonly RuntimeEvent[]): RuntimeEvent[] {
+  const coalesced: RuntimeEvent[] = [];
+  for (const event of events) appendCoalescedRuntimeEvent(coalesced, event);
+  return coalesced;
 }

--- a/src/supervisor/runtime/threadSession/subAgentRegistry.ts
+++ b/src/supervisor/runtime/threadSession/subAgentRegistry.ts
@@ -1,4 +1,5 @@
 import type { RuntimeEvent } from "@/shared/contracts";
+import { appendCoalescedRuntimeEvent } from "@/shared/coalesce";
 import { childKey, subAgentKey } from "./helpers";
 
 /**
@@ -60,17 +61,7 @@ export class SubAgentRegistry {
       this.buffers.set(key, [event]);
       return;
     }
-    const previous = buffer.at(-1);
-    if (
-      event.type === "content.delta" &&
-      previous?.type === "content.delta" &&
-      previous.itemId === event.itemId &&
-      previous.stream === event.stream
-    ) {
-      buffer[buffer.length - 1] = { ...previous, delta: previous.delta + event.delta };
-      return;
-    }
-    buffer.push(event);
+    appendCoalescedRuntimeEvent(buffer, event);
   }
 
   /** Drain and remove the buffer for `parentItemId`. Returns `[]` if none. */


### PR DESCRIPTION
- Add append-only, bounded stream storage with head/tail elision and migration support.
- Batch and coalesce runtime writes to reduce SQLite rewrites during streaming.
- Flush and discard queued writes safely across shutdown, deletion, sync, and thread reuse.
- Share runtime event coalescing across renderer and supervisor paths.